### PR TITLE
gh: update code owners for github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
-*                          alex@vectorized.io noah@vectorized.io
-cmake/*                    ivo@vectorized.io
-infra/*                    david@vectorized.io ivo@vectorized.io
-packaging/*                david@vectorized.io michal@vectorized.io
-tools/*                    ivo@vectorized.io michal@vectorized.io david@vectorized.io
-conf/*                     david@vectorized.io
-src/go/*                   michal@vectorized.io david@vectorized.io
-src/v/prometheus           michal@vectorized.io
-src/consistency-testing/*  denis@vectorized.io
+*                          @senior7515 @dotnwat
+/cmake/                    @benpope @ivotron
+/conf/                     @0x5d
+/src/go/                   @0x5d @mmaslankaprv
+/src/consistency-testing/  @rystsov
+/src/v/bytes/              @senior7515 @dotnwat
+/src/v/cluster/            @senior7515 @dotnwat @mmaslankaprv
+/src/v/coproc/             @graphcareful @dotnwat
+/src/v/pandaproxy/         @benpope @dotnwat
+/src/v/raft/               @senior7515 @dotnwat @mmaslankaprv


### PR DESCRIPTION
Uses github syntax and removes personal emails in the code owners file. This also influences which reviewers are automatically requested. Most specific takes precedence.