### PR TITLE
Fixes Raft nodes not to erase their votes on leader step down v2

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -159,6 +159,7 @@ public:
             // term backward
             if (term > _term) {
                 _term = term;
+                _voted_for = {};
                 do_step_down();
             }
         });


### PR DESCRIPTION
do_step_down function used to erase voted_for information on every replicated batch. This behaviour is prone to the split brain problem.

The patch updates do_step_down not to erase the votes and updates consensus to erase the votes only when they become obsolete (after the term increases)

Changed since v1:
  - removed _last_election
  - simplified vote_stm