### PR TITLE
k/fetch_request: limit max fetch_request version to 6

### DIFF
--- a/src/v/kafka/requests/fetch_request.h
+++ b/src/v/kafka/requests/fetch_request.h
@@ -19,7 +19,7 @@ struct fetch_api final {
     static constexpr const char* name = "fetch";
     static constexpr api_key key = api_key(1);
     static constexpr api_version min_supported = api_version(4);
-    static constexpr api_version max_supported = api_version(10);
+    static constexpr api_version max_supported = api_version(6);
 
     static ss::future<response_ptr>
     process(request_context&&, ss::smp_service_group);


### PR DESCRIPTION
In redpanda we do not yet support incremental fetch requests. The
incremental fetches are there to minimize overhead of sending
request/responses for partitions that didn't change since previous
fetch.

For more details:

[KIP-227](https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability)

Signed-off-by: Michal Maslanka <michal@vectorized.io>