### PR TITLE
gh: adds initial pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Checklist
+- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
+- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant
+
+When referencing a related issue, remember to migrate duplicate stories from the
+external tracker. This is not relevant for most users.


### PR DESCRIPTION
Initial content of a pull request. As we develop more of a procedure we
can expand this template. For now it contains reminders for referencing
issues and updating docuemntation.