### PR TITLE
Raft error metrics

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -197,6 +197,8 @@ public:
 
     model::offset read_last_applied() const;
 
+    probe& get_probe() { return _probe; };
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -185,6 +185,7 @@ void heartbeat_manager::process_reply(
                 continue;
             }
             // propagate error
+            (*it)->get_probe().heartbeat_request_error();
             (*it)->process_append_entries_reply(
               n, result<append_entries_reply>(r.error()), seq_id);
         }

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -79,6 +79,21 @@ void probe::setup_metrics(const model::ntp& ntp) {
          "leadership_changes",
          [this] { return _leadership_changes; },
          sm::description("Number of leadership changes"),
+         labels),
+       sm::make_derive(
+         "replicate_request_errors",
+         [this] { return _replicate_request_error; },
+         sm::description("Number of failed replicate requests"),
+         labels),
+       sm::make_derive(
+         "heartbeat_requests_errors",
+         [this] { return _heartbeat_request_error; },
+         sm::description("Number of failed heartbeat requests"),
+         labels),
+       sm::make_derive(
+         "recovery_requests_errors",
+         [this] { return _recovery_request_error; },
+         sm::description("Number of failed recovery requests"),
          labels)});
 }
 

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -31,6 +31,10 @@ public:
 
     void setup_metrics(const model::ntp& ntp);
 
+    void heartbeat_request_error() { ++_heartbeat_request_error; };
+    void replicate_request_error() { ++_replicate_request_error; };
+    void recovery_request_error() { ++_recovery_request_error; };
+
 private:
     uint64_t _vote_requests = 0;
     uint64_t _append_requests = 0;
@@ -45,6 +49,9 @@ private:
     uint32_t _configuration_updates = 0;
     uint64_t _recovery_requests = 0;
     uint64_t _leadership_changes = 0;
+    uint64_t _heartbeat_request_error = 0;
+    uint64_t _replicate_request_error = 0;
+    uint64_t _recovery_request_error = 0;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -270,6 +270,7 @@ ss::future<> recovery_stm::replicate(model::record_batch_reader&& reader) {
               r,
               r.error().message());
             _stop_requested = true;
+            _ptr->get_probe().recovery_request_error();
         }
         _ptr->process_append_entries_reply(_node_id, r.value(), seq);
         // If request was reordered we have to stop recovery as follower state

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -90,6 +90,9 @@ ss::future<> replicate_entries_stm::dispatch_one(
                        auto seq = it == _followers_seq.end()
                                     ? follower_req_seq(0)
                                     : it->second;
+                       if (!reply) {
+                           _ptr->get_probe().replicate_request_error();
+                       }
                        _ptr->process_append_entries_reply(id, reply, seq);
                    });
              })


### PR DESCRIPTION
Added more detailed error metrics to raft module to diagnose which requests timeout. 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
