### PR TITLE
r/consensus: update max_consumable offset on commit index updates

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -675,6 +675,7 @@ ss::future<> consensus::start() {
               auto last_applied = read_last_applied();
               if (last_applied > _commit_index) {
                   _commit_index = last_applied;
+                  _max_consumable_offset = last_applied;
                   vlog(
                     _ctxlog.trace, "Recovered commit_index: {}", _commit_index);
               }
@@ -1131,6 +1132,8 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
 
         // TODO: add applying snapshot content to state machine
         _commit_index = std::max(_last_snapshot_index, _commit_index);
+        _max_consumable_offset = std::max(
+          _commit_index, _max_consumable_offset);
 
         update_follower_stats(metadata.latest_configuration);
         return _configuration_manager


### PR DESCRIPTION
Every time the commit index is updated we must try updating max consumable offset. Otherwise raft will not be able to make progress

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
