### PR TITLE
operator/configurator: fallback on the internal IP

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -283,6 +283,12 @@ func getExternalIP(node *corev1.Node) string {
 			return address.Address
 		}
 	}
+	// If no external IP is found, fallback on the internal IP. This is mainly useful for Kind.
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeInternalIP {
+			return address.Address
+		}
+	}
 	return ""
 }
 


### PR DESCRIPTION
## Cover letter

My motivation was to deploy the whole application inside of `kind`, yet still make the backend services available on the host. This is useful for quick turnaround during development where the app is executed on the host and connects to redpanda. And having an environment that is relatively close to production at the same time.

In that scenario, all the developers are using Linux, so we can rely on them having access to the kind worker node internal IP directly from the host.

In the redpanda/configurator, if the node external IP is unset, it returns an empty string. This PR changes that to fallback on the internal IP.

This is a draft PR because I am looking for initial feedback. Is it worth pursuing this further in principle? Is it ok to make this a heuristic or should that behavior be turned into a flag? What other changes need to be added to the code base?

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
