### PR TITLE
Expose Redpanda behind a single NLB

### DIFF
--- a/src/go/.dockerignore
+++ b/src/go/.dockerignore
@@ -1,0 +1,3 @@
+*/bin/*
+*/testbin/*
+*/tests/*

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -154,11 +154,28 @@ type StorageSpec struct {
 type ExternalConnectivityConfig struct {
 	// Enabled enables the external connectivity feature
 	Enabled bool `json:"enabled,omitempty"`
+	// Hostname Only takes effect if Subdomain is defined and advertises the
+	// same hostname for all brokers i.e. HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+	// Combined with OrdinalNodePorts it would generate advertised
+	// listeners as HOSTNAME.SUBDOMAIN:30001, HOSTNAME.SUBDOMAIN:30002 etc.
+	Hostname string `json:"hostname,omitempty"`
+	// BaseNodePort is the bootstrap port as defined by the user.
+	// If omitted a random port would be chosen by Kubernetes.
+	BaseNodePort int `json:"baseNodePort,omitempty"`
+	// OrdinalNodePorts enables generating an increasing dedicated
+	// NodePort per broker, e.g. each of those NodePorts would have
+	// a selector that points to a single broker.
+	// Each broker would use that NodePort as it's advertized port.
+	OrdinalNodePorts bool `json:"ordinalNodePorts,omitempty"`
 	// Subdomain can be used to change the behavior of an advertised
 	// KafkaAPI. Each broker advertises Kafka API as follows
 	// BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
 	// If Subdomain is empty then each broker advertises Kafka
 	// API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
+	// If Hostname is defined in addition to Subdomain then each broker
+	// advertises Kafka API as HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+	// If OrdinalNodePorts is enabled then each broker advertises
+	// Kafka API as HOSTNAME.SUBDOMAIN:(EXTERNAL_KAFKA_API_PORT + brokerID).
 	// If TLS is enabled then this subdomain will be requested
 	// as a subject alternative name.
 	Subdomain string `json:"subdomain,omitempty"`

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -148,9 +148,29 @@ spec:
                             API outside of a Kubernetes cluster. For more information
                             please go to ExternalConnectivityConfig
                           properties:
+                            baseNodePort:
+                              description: BaseNodePort is the bootstrap port as defined
+                                by the user. If omitted a random port would be chosen
+                                by Kubernetes.
+                              type: integer
                             enabled:
                               description: Enabled enables the external connectivity
                                 feature
+                              type: boolean
+                            hostname:
+                              description: Hostname Only takes effect if Subdomain
+                                is defined and advertises the same hostname for all
+                                brokers i.e. HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Combined with OrdinalNodePorts it would generate advertised
+                                listeners as HOSTNAME.SUBDOMAIN:30001, HOSTNAME.SUBDOMAIN:30002
+                                etc.
+                              type: string
+                            ordinalNodePorts:
+                              description: OrdinalNodePorts enables generating an
+                                increasing dedicated NodePort per broker, e.g. each
+                                of those NodePorts would have a selector that points
+                                to a single broker. Each broker would use that NodePort
+                                as it's advertized port.
                               type: boolean
                             subdomain:
                               description: Subdomain can be used to change the behavior
@@ -158,8 +178,12 @@ spec:
                                 Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
-                                If TLS is enabled then this subdomain will be requested
-                                as a subject alternative name.
+                                If Hostname is defined in addition to Subdomain then
+                                each broker advertises Kafka API as HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                If OrdinalNodePorts is enabled then each broker advertises
+                                Kafka API as HOSTNAME.SUBDOMAIN:(EXTERNAL_KAFKA_API_PORT
+                                + brokerID). If TLS is enabled then this subdomain
+                                will be requested as a subject alternative name.
                               type: string
                           type: object
                         port:
@@ -192,9 +216,29 @@ spec:
                             outside of a Kubernetes cluster. For more information
                             please go to ExternalConnectivityConfig
                           properties:
+                            baseNodePort:
+                              description: BaseNodePort is the bootstrap port as defined
+                                by the user. If omitted a random port would be chosen
+                                by Kubernetes.
+                              type: integer
                             enabled:
                               description: Enabled enables the external connectivity
                                 feature
+                              type: boolean
+                            hostname:
+                              description: Hostname Only takes effect if Subdomain
+                                is defined and advertises the same hostname for all
+                                brokers i.e. HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Combined with OrdinalNodePorts it would generate advertised
+                                listeners as HOSTNAME.SUBDOMAIN:30001, HOSTNAME.SUBDOMAIN:30002
+                                etc.
+                              type: string
+                            ordinalNodePorts:
+                              description: OrdinalNodePorts enables generating an
+                                increasing dedicated NodePort per broker, e.g. each
+                                of those NodePorts would have a selector that points
+                                to a single broker. Each broker would use that NodePort
+                                as it's advertized port.
                               type: boolean
                             subdomain:
                               description: Subdomain can be used to change the behavior
@@ -202,8 +246,12 @@ spec:
                                 Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
-                                If TLS is enabled then this subdomain will be requested
-                                as a subject alternative name.
+                                If Hostname is defined in addition to Subdomain then
+                                each broker advertises Kafka API as HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                If OrdinalNodePorts is enabled then each broker advertises
+                                Kafka API as HOSTNAME.SUBDOMAIN:(EXTERNAL_KAFKA_API_PORT
+                                + brokerID). If TLS is enabled then this subdomain
+                                will be requested as a subject alternative name.
                               type: string
                           type: object
                         port:
@@ -300,9 +348,29 @@ spec:
                             outside of a Kubernetes cluster. For more information
                             please go to ExternalConnectivityConfig
                           properties:
+                            baseNodePort:
+                              description: BaseNodePort is the bootstrap port as defined
+                                by the user. If omitted a random port would be chosen
+                                by Kubernetes.
+                              type: integer
                             enabled:
                               description: Enabled enables the external connectivity
                                 feature
+                              type: boolean
+                            hostname:
+                              description: Hostname Only takes effect if Subdomain
+                                is defined and advertises the same hostname for all
+                                brokers i.e. HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Combined with OrdinalNodePorts it would generate advertised
+                                listeners as HOSTNAME.SUBDOMAIN:30001, HOSTNAME.SUBDOMAIN:30002
+                                etc.
+                              type: string
+                            ordinalNodePorts:
+                              description: OrdinalNodePorts enables generating an
+                                increasing dedicated NodePort per broker, e.g. each
+                                of those NodePorts would have a selector that points
+                                to a single broker. Each broker would use that NodePort
+                                as it's advertized port.
                               type: boolean
                             subdomain:
                               description: Subdomain can be used to change the behavior
@@ -310,8 +378,12 @@ spec:
                                 Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
-                                If TLS is enabled then this subdomain will be requested
-                                as a subject alternative name.
+                                If Hostname is defined in addition to Subdomain then
+                                each broker advertises Kafka API as HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                If OrdinalNodePorts is enabled then each broker advertises
+                                Kafka API as HOSTNAME.SUBDOMAIN:(EXTERNAL_KAFKA_API_PORT
+                                + brokerID). If TLS is enabled then this subdomain
+                                will be requested as a subject alternative name.
                               type: string
                           type: object
                         port:
@@ -341,18 +413,42 @@ spec:
                           outside of a Kubernetes cluster. For more information please
                           go to ExternalConnectivityConfig
                         properties:
+                          baseNodePort:
+                            description: BaseNodePort is the bootstrap port as defined
+                              by the user. If omitted a random port would be chosen
+                              by Kubernetes.
+                            type: integer
                           enabled:
                             description: Enabled enables the external connectivity
                               feature
+                            type: boolean
+                          hostname:
+                            description: Hostname Only takes effect if Subdomain is
+                              defined and advertises the same hostname for all brokers
+                              i.e. HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT. Combined
+                              with OrdinalNodePorts it would generate advertised listeners
+                              as HOSTNAME.SUBDOMAIN:30001, HOSTNAME.SUBDOMAIN:30002
+                              etc.
+                            type: string
+                          ordinalNodePorts:
+                            description: OrdinalNodePorts enables generating an increasing
+                              dedicated NodePort per broker, e.g. each of those NodePorts
+                              would have a selector that points to a single broker.
+                              Each broker would use that NodePort as it's advertized
+                              port.
                             type: boolean
                           subdomain:
                             description: Subdomain can be used to change the behavior
                               of an advertised KafkaAPI. Each broker advertises Kafka
                               API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                               If Subdomain is empty then each broker advertises Kafka
-                              API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT. If TLS
-                              is enabled then this subdomain will be requested as
-                              a subject alternative name.
+                              API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT. If Hostname
+                              is defined in addition to Subdomain then each broker
+                              advertises Kafka API as HOSTNAME.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                              If OrdinalNodePorts is enabled then each broker advertises
+                              Kafka API as HOSTNAME.SUBDOMAIN:(EXTERNAL_KAFKA_API_PORT
+                              + brokerID). If TLS is enabled then this subdomain will
+                              be requested as a subject alternative name.
                             type: string
                         type: object
                       port:

--- a/src/go/k8s/config/samples/external_connectivity_single_nlb.yaml
+++ b/src/go/k8s/config/samples/external_connectivity_single_nlb.yaml
@@ -1,0 +1,35 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: external-connectivity-single-nlb
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+     - port: 9092
+     - external:
+         enabled: true
+         hostname: redpanda
+         subdomain: example.com
+         ordinalNodePorts: true
+         baseNodePort: 32000
+    pandaproxyApi:
+     - port: 8082
+     - external:
+         enabled: true
+         ordinalNodePorts: true
+         subdomain: example.com
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -417,7 +417,10 @@ func (r *ClusterReconciler) createExternalNodesList(
 
 	for i := range pods {
 		prefixLen := len(pods[i].GenerateName)
-		podName := pods[i].Name[prefixLen:]
+		hostName := pods[i].Name[prefixLen:]
+		if externalKafkaListener != nil && externalKafkaListener.External.Hostname != "" {
+			hostName = externalKafkaListener.External.Hostname
+		}
 
 		if externalKafkaListener != nil && needExternalIP(externalKafkaListener.External) ||
 			externalAdminListener != nil && needExternalIP(externalAdminListener.External) ||
@@ -429,7 +432,7 @@ func (r *ClusterReconciler) createExternalNodesList(
 		}
 
 		if externalKafkaListener != nil && len(externalKafkaListener.External.Subdomain) > 0 {
-			address := subdomainAddress(podName, externalKafkaListener.External.Subdomain, getNodePort(&nodePortSvc, resources.ExternalListenerName))
+			address := subdomainAddress(hostName, externalKafkaListener.External.Subdomain, getNodePort(&nodePortSvc, resources.ExternalListenerName))
 			result.External = append(result.External, address)
 		} else if externalKafkaListener != nil {
 			result.External = append(result.External,
@@ -439,8 +442,12 @@ func (r *ClusterReconciler) createExternalNodesList(
 				))
 		}
 
-		if externalAdminListener != nil && len(externalAdminListener.External.Subdomain) > 0 {
-			address := subdomainAddress(podName, externalAdminListener.External.Subdomain, getNodePort(&nodePortSvc, resources.AdminPortExternalName))
+		hostName = pods[i].Name[prefixLen:]
+		if externalAdminListener != nil && externalAdminListener.External.Hostname != "" {
+			hostName = externalAdminListener.External.Hostname
+		}
+		if externalAdminListener != nil && len(externalKafkaListener.External.Subdomain) > 0 {
+			address := subdomainAddress(hostName, externalAdminListener.External.Subdomain, getNodePort(&nodePortSvc, resources.AdminPortExternalName))
 			result.ExternalAdmin = append(result.ExternalAdmin, address)
 		} else if externalAdminListener != nil {
 			result.ExternalAdmin = append(result.ExternalAdmin,
@@ -450,8 +457,12 @@ func (r *ClusterReconciler) createExternalNodesList(
 				))
 		}
 
-		if externalProxyListener != nil && len(externalProxyListener.External.Subdomain) > 0 {
-			address := subdomainAddress(podName, externalProxyListener.External.Subdomain, getNodePort(&nodePortSvc, resources.PandaproxyPortExternalName))
+		hostName = pods[i].Name[prefixLen:]
+		if externalProxyListener != nil && externalProxyListener.External.Hostname != "" {
+			hostName = externalProxyListener.External.Hostname
+		}
+		if externalProxyListener != nil && len(externalKafkaListener.External.Subdomain) > 0 {
+			address := subdomainAddress(hostName, externalProxyListener.External.Subdomain, getNodePort(&nodePortSvc, resources.PandaproxyPortExternalName))
 			result.ExternalPandaproxy = append(result.ExternalPandaproxy, address)
 		} else if externalProxyListener != nil {
 			result.ExternalPandaproxy = append(result.ExternalPandaproxy,

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -49,8 +49,9 @@ const (
 
 // NamedServicePort allows to pass name ports, e.g., to service resources
 type NamedServicePort struct {
-	Name string
-	Port int
+	Name     string
+	NodePort int
+	Port     int
 }
 
 // Resource decompose the reconciliation loop to specific kubernetes objects
@@ -81,7 +82,9 @@ func CreateIfNotExists(
 	}
 	err := c.Create(ctx, obj)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return false, fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+		if obj.GetObjectKind().GroupVersionKind().Kind == "Service" && !errors.IsInvalid(err) {
+			return false, fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+		}
 	}
 	if err == nil {
 		l.Info(fmt.Sprintf("%s %s did not exist, was created", gvk.Kind, obj.GetName()))

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -307,6 +307,7 @@ func TestEnsure_NodePortService(t *testing.T) {
 		c,
 		cluster,
 		scheme.Scheme,
+		-1,
 		[]res.NamedServicePort{
 			{Port: 123},
 		},
@@ -339,6 +340,7 @@ func TestEnsure_NodePortService(t *testing.T) {
 		c,
 		cluster,
 		scheme.Scheme,
+		-1,
 		[]res.NamedServicePort{
 			{Port: 1111},
 		},

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -235,8 +235,16 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 
 	externalListener := r.pandaCluster.ExternalListener()
 	externalSubdomain := ""
+	advertisedHostname := ""
 	if externalListener != nil {
+		advertisedHostname = externalListener.External.Hostname
 		externalSubdomain = externalListener.External.Subdomain
+	}
+
+	proxyAPIExternal := r.pandaCluster.PandaproxyAPIExternal()
+	advertisedProxyHostname := ""
+	if proxyAPIExternal != nil {
+		advertisedProxyHostname = proxyAPIExternal.External.Hostname
 	}
 
 	ss := &appsv1.StatefulSet{
@@ -337,6 +345,14 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								{
 									Name:  "HOST_PORT",
 									Value: r.getNodePort(ExternalListenerName),
+								},
+								{
+									Name:  "ADVERTISED_HOSTNAME",
+									Value: advertisedHostname,
+								},
+								{
+									Name:  "ADVERTISED_PROXY_HOSTNAME",
+									Value: advertisedProxyHostname,
 								},
 							}, r.pandaproxyEnvVars()...),
 							SecurityContext: &corev1.SecurityContext{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -236,15 +236,19 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 	externalListener := r.pandaCluster.ExternalListener()
 	externalSubdomain := ""
 	advertisedHostname := ""
+	ordinalNodePorts := false
 	if externalListener != nil {
 		advertisedHostname = externalListener.External.Hostname
 		externalSubdomain = externalListener.External.Subdomain
+		ordinalNodePorts = externalListener.External.OrdinalNodePorts
 	}
 
 	proxyAPIExternal := r.pandaCluster.PandaproxyAPIExternal()
 	advertisedProxyHostname := ""
+	proxyOrdinalNodePorts := false
 	if proxyAPIExternal != nil {
 		advertisedProxyHostname = proxyAPIExternal.External.Hostname
+		proxyOrdinalNodePorts = proxyAPIExternal.External.OrdinalNodePorts
 	}
 
 	ss := &appsv1.StatefulSet{
@@ -351,8 +355,16 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 									Value: advertisedHostname,
 								},
 								{
+									Name:  "ORDINAL_NODE_PORTS",
+									Value: strconv.FormatBool(ordinalNodePorts),
+								},
+								{
 									Name:  "ADVERTISED_PROXY_HOSTNAME",
 									Value: advertisedProxyHostname,
+								},
+								{
+									Name:  "PROXY_ORDINAL_NODE_PORTS",
+									Value: strconv.FormatBool(proxyOrdinalNodePorts),
 								},
 							}, r.pandaproxyEnvVars()...),
 							SecurityContext: &corev1.SecurityContext{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -799,9 +799,6 @@ func (r *StatefulSetResource) getPorts() []corev1.ContainerPort {
 				// port. The routing in the Kubernetes will forward all traffic from
 				// HostPort to the ContainerPort.
 				ContainerPort: port.TargetPort.IntVal,
-				// The host port is set to the service node port that doesn't have
-				// any endpoints.
-				HostPort: port.NodePort,
 			})
 		}
 		return ports

--- a/src/go/k8s/tests/e2e/external-connectivity/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/01-assert.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: base-nodeport
+status:
+  readyReplicas: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: base-nodeport
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: base-nodeport-external
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+    nodePort: 30000
+  type: NodePort
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: base-nodeport
+status:
+  replicas: 2
+  nodes:
+    external:
+    - 0.subdomain.com:30000
+    - 1.subdomain.com:30000

--- a/src/go/k8s/tests/e2e/external-connectivity/01-base-nodeport.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/01-base-nodeport.yaml
@@ -1,0 +1,27 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: base-nodeport
+spec:
+  image: "vectorized/redpanda"
+  version: "dev"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    - external:
+        enabled: true
+        subdomain: "subdomain.com"
+        baseNodePort: 30000
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/external-connectivity/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/02-assert.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ordinal-nodeports-extended
+status:
+  readyReplicas: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-extended
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+    - name: proxy
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-extended-external
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+    nodePort: 32000
+  - name: proxy-external
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+    nodePort: 31000
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-extended-0
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+    nodePort: 32001
+  - name: proxy-external
+    nodePort: 31001
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-extended-1
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+    nodePort: 32002
+  - name: proxy-external
+    nodePort: 31002
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  type: NodePort
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ordinal-nodeports-extended
+status:
+  replicas: 2
+  nodes:
+    external:
+    - hostname.subdomain.com:32001
+    - hostname.subdomain.com:32002
+    externalPandaproxy:
+    - hostname.subdomain.com:31001
+    - hostname.subdomain.com:31002

--- a/src/go/k8s/tests/e2e/external-connectivity/02-ordinal-nodeports-extended.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/02-ordinal-nodeports-extended.yaml
@@ -1,0 +1,37 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ordinal-nodeports-extended
+spec:
+  image: "vectorized/redpanda"
+  version: "dev"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    - external:
+        enabled: true
+        subdomain: "subdomain.com"
+        hostname: hostname
+        baseNodePort: 32000
+        ordinalNodePorts: true
+    pandaproxyApi:
+    - port: 8082
+    - external:
+        enabled: true
+        subdomain: "subdomain.com"
+        hostname: hostname
+        baseNodePort: 31000
+        ordinalNodePorts: true
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/external-connectivity/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/03-assert.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ordinal-nodeports
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-external
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ordinal-nodeports-0
+spec:
+  ports:
+  - name: kafka-external
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  type: NodePort

--- a/src/go/k8s/tests/e2e/external-connectivity/03-ordinal-nodeports.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/03-ordinal-nodeports.yaml
@@ -1,0 +1,27 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ordinal-nodeports
+spec:
+  image: "vectorized/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    - external:
+        enabled: true
+        subdomain: "subdomain.com"
+        ordinalNodePorts: true
+    adminApi:
+    - port: 9644
+    developerMode: true


### PR DESCRIPTION
## Cover letter

This PR tries to add Redpanda operator the capability of exposing Redpanda cluster behind a single NLB
It is very opinionated, placed here for initial feedback, and I am more than happy discussing changes
Once I'll get the initial approval I'll add unit/integration tests

Closes:
- [#1543](https://github.com/vectorizedio/redpanda/discussions/1543)
- [#1777](https://github.com/vectorizedio/redpanda/issues/1777)
- [#1199](https://github.com/vectorizedio/redpanda/issues/1199)
## Release notes

Making the default bootstrap NodePort service route traffic to all brokers
Adding the capabilities for:
- Choosing custom base NodePort per external listener
- Adjusting the way advertised external listeners are being generated
- Creating a NodePort service per broker
