### PR TITLE
admin_server: Add /v1/status/started

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -31,6 +31,7 @@ rpcgen(
 v_cc_library(
   NAME cluster
   SRCS
+    errc.cc
     metadata_cache.cc
     partition_manager.cc
     scheduling/partition_allocator.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -103,6 +103,7 @@ ss::future<> controller::start() {
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),
+            std::ref(_partition_manager),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -59,6 +59,11 @@
             "name": "finish_reallocation",
             "input_type": "finish_reallocation_request",
             "output_type": "finish_reallocation_reply"
+        },
+        {
+            "name": "get_under_replicated",
+            "input_type": "get_under_replicated_request",
+            "output_type": "get_under_replicated_reply"
         }
     ]
 }

--- a/src/v/cluster/errc.cc
+++ b/src/v/cluster/errc.cc
@@ -1,0 +1,52 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/errc.h"
+
+#include "raft/errc.h"
+#include "rpc/errc.h"
+
+namespace cluster {
+
+cluster::errc map_errc(std::error_code ec) {
+    if (ec == errc::success) {
+        return errc::success;
+    }
+
+    // raft errors
+    if (ec.category() == raft::error_category()) {
+        switch (static_cast<raft::errc>(ec.value())) {
+        case raft::errc::timeout:
+            return errc::timeout;
+        case raft::errc::not_leader:
+            return errc::not_leader_controller;
+        default:
+            return errc::replication_error;
+        }
+    }
+
+    // from rpc errors
+    if (ec.category() == rpc::error_category()) {
+        switch (static_cast<rpc::errc>(ec.value())) {
+        case rpc::errc::client_request_timeout:
+            return errc::timeout;
+        default:
+            return errc::replication_error;
+        }
+    }
+
+    // cluster errors, just forward
+    if (ec.category() == cluster::error_category()) {
+        return static_cast<errc>(ec.value());
+    }
+
+    return errc::replication_error;
+}
+
+} // namespace cluster

--- a/src/v/cluster/errc.cc
+++ b/src/v/cluster/errc.cc
@@ -15,7 +15,7 @@
 namespace cluster {
 
 cluster::errc map_errc(std::error_code ec) {
-    if (ec == errc::success) {
+    if (!ec) {
         return errc::success;
     }
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -149,6 +149,9 @@ inline const std::error_category& error_category() noexcept {
 inline std::error_code make_error_code(errc e) noexcept {
     return std::error_code(static_cast<int>(e), error_category());
 }
+
+errc map_errc(std::error_code);
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -38,8 +38,6 @@ static ss::future<bool> sleep_abortable(std::chrono::milliseconds dur) {
     }
 }
 
-cluster::errc map_errc_fixme(std::error_code ec);
-
 id_allocator_frontend::id_allocator_frontend(
   ss::smp_service_group ssg,
   ss::sharded<cluster::partition_manager>& partition_manager,

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -48,6 +48,7 @@ public:
         std::error_code error;
     };
     ss::future<get_under_replicated_reply> get_under_replicated(model::node_id);
+    ss::future<std::error_code> abdicate_node(model::node_id);
 
 private:
     template<typename T>

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -34,6 +34,7 @@ public:
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
+      ss::sharded<partition_manager>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -42,6 +43,11 @@ public:
     ss::future<std::error_code> decommission_node(model::node_id);
     ss::future<std::error_code> recommission_node(model::node_id);
     ss::future<std::error_code> finish_node_reallocations(model::node_id);
+    struct get_under_replicated_reply {
+        bool under_replicated{false};
+        std::error_code error;
+    };
+    ss::future<get_under_replicated_reply> get_under_replicated(model::node_id);
 
 private:
     template<typename T>
@@ -58,11 +64,13 @@ private:
                 });
           });
     }
+    ss::future<bool> is_node_under_replicated(model::node_id) const;
     model::node_id _self;
     std::chrono::milliseconds _node_op_timeout;
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<ss::abort_source>& _as;
 };
 } // namespace cluster

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -35,41 +35,6 @@
 
 namespace cluster {
 
-// TODO: possibly generalize with other error mapping routines in cluster::*
-// on the other hand, these mappings may be partially specialized for each case
-// (e.g. topic-creation, or error-creation).
-static inline cluster::errc map_errc(std::error_code ec) {
-    if (ec == errc::success) {
-        return errc::success;
-    }
-
-    if (ec.category() == raft::error_category()) {
-        switch (static_cast<raft::errc>(ec.value())) {
-        case raft::errc::timeout:
-            return errc::timeout;
-        case raft::errc::not_leader:
-            return errc::not_leader_controller;
-        default:
-            return errc::replication_error;
-        }
-    }
-
-    if (ec.category() == rpc::error_category()) {
-        switch (static_cast<rpc::errc>(ec.value())) {
-        case rpc::errc::client_request_timeout:
-            return errc::timeout;
-        default:
-            return errc::replication_error;
-        }
-    }
-
-    if (ec.category() == cluster::error_category()) {
-        return static_cast<errc>(ec.value());
-    }
-
-    return errc::replication_error;
-}
-
 security_frontend::security_frontend(
   model::node_id self,
   ss::sharded<controller_stm>& s,

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -207,14 +207,7 @@ ss::future<decommission_node_reply> service::decommission_node(
       get_scheduling_group(), [this, req]() mutable {
           return _members_frontend.local().decommission_node(req.id).then(
             [](std::error_code ec) {
-                if (!ec) {
-                    return decommission_node_reply{.error = errc::success};
-                }
-                if (ec.category() == cluster::error_category()) {
-                    return decommission_node_reply{.error = errc(ec.value())};
-                }
-                return decommission_node_reply{
-                  .error = errc::replication_error};
+                return decommission_node_reply{.error = map_errc(ec)};
             });
       });
 }
@@ -225,14 +218,7 @@ ss::future<recommission_node_reply> service::recommission_node(
       get_scheduling_group(), [this, req]() mutable {
           return _members_frontend.local().recommission_node(req.id).then(
             [](std::error_code ec) {
-                if (!ec) {
-                    return recommission_node_reply{.error = errc::success};
-                }
-                if (ec.category() == cluster::error_category()) {
-                    return recommission_node_reply{.error = errc(ec.value())};
-                }
-                return recommission_node_reply{
-                  .error = errc::replication_error};
+                return recommission_node_reply{.error = map_errc(ec)};
             });
       });
 }
@@ -248,15 +234,6 @@ ss::future<finish_reallocation_reply>
 service::do_finish_reallocation(finish_reallocation_request req) {
     auto ec = co_await _members_frontend.local().finish_node_reallocations(
       req.id);
-    if (ec) {
-        if (ec.category() == error_category()) {
-            co_return finish_reallocation_reply{.error = errc(ec.value())};
-        } else {
-            co_return finish_reallocation_reply{
-              .error = errc::replication_error};
-        }
-    }
-
-    co_return finish_reallocation_reply{.error = errc::success};
+    co_return finish_reallocation_reply{.error = map_errc(ec)};
 }
 } // namespace cluster

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -236,4 +236,12 @@ service::do_finish_reallocation(finish_reallocation_request req) {
       req.id);
     co_return finish_reallocation_reply{.error = map_errc(ec)};
 }
+
+ss::future<get_under_replicated_reply> service::get_under_replicated(
+  get_under_replicated_request&& req, rpc::streaming_context&) {
+    auto [ur, ec] = co_await _members_frontend.local().get_under_replicated(
+      req.id);
+    co_return get_under_replicated_reply{
+      .under_replicated = ur, .error = map_errc(ec)};
+}
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -64,6 +64,9 @@ public:
     ss::future<finish_reallocation_reply> finish_reallocation(
       finish_reallocation_request&&, rpc::streaming_context&) final;
 
+    ss::future<get_under_replicated_reply> get_under_replicated(
+      get_under_replicated_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -37,7 +37,8 @@ set(srcs
     decommissioning_tests.cc
     replicas_rebalancing_tests.cc
     create_partitions_test.cc
-    id_allocator_stm_test.cc)
+    id_allocator_stm_test.cc
+    startup_tests.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -61,6 +61,12 @@ public:
         set_configuration("disable_metrics", true);
     }
 
+    void remove_node(int id) {
+        auto nid = model::node_id(id);
+        remove_node_application(nid);
+        apps.erase(nid);
+    }
+
     cluster::topic_configuration create_topic_cfg(
       ss::sstring topic, int partitions, int replication_factor) {
         model::topic_namespace tp_ns(
@@ -227,6 +233,16 @@ public:
               std::find(ids.begin(), ids.end(), id) == ids.end());
         });
     }
+
+    ss::future<bool> is_node_under_replicated(
+      model::node_id query_node, model::node_id target_node) {
+        return get_node_application(query_node)
+          ->controller->get_members_frontend()
+          .local()
+          .get_under_replicated(target_node)
+          .then([](auto res) { return res.under_replicated; });
+    }
+
     ss::logger test_logger;
     absl::node_hash_map<model::node_id, application*> apps;
 };

--- a/src/v/cluster/tests/startup_tests.cc
+++ b/src/v/cluster/tests/startup_tests.cc
@@ -1,0 +1,91 @@
+
+#include "cluster/tests/rebalancing_tests_fixture.h"
+#include "model/namespace.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <exception>
+
+FIXTURE_TEST(test_three_node_startup, rebalancing_tests_fixture) {
+    constexpr model::node_id node_0(0);
+    constexpr model::node_id node_1(1);
+    constexpr model::node_id node_2(2);
+    constexpr model::node_id victim(2);
+    const auto any_under_replicated = [this, victim]() -> ss::future<bool> {
+        for (auto [id, _] : apps) {
+            if (id != victim) {
+                if (co_await is_node_under_replicated(id, victim)) {
+                    co_return true;
+                }
+            }
+        }
+        co_return false;
+    };
+    const auto none_under_replicated = [this, victim]() -> ss::future<bool> {
+        for (auto [id, _] : apps) {
+            if (id != victim) {
+                if (co_await is_node_under_replicated(id, victim)) {
+                    co_return false;
+                }
+            }
+        }
+        co_return true;
+    };
+
+    test_logger.info("starting cluster of 3");
+    start_cluster(3);
+
+    test_logger.info("creating 3 topics");
+    create_topic(create_topic_cfg("test-1", 3, 3));
+    create_topic(create_topic_cfg("test-2", 3, 3));
+    create_topic(create_topic_cfg("test-3", 3, 3));
+
+    test_logger.info("populating all topics");
+    populate_all_topics_with_data();
+
+    test_logger.info("abdicating node: {}", victim);
+    node_application(2)
+      ->controller->get_members_frontend()
+      .local()
+      .abdicate_node(node_2)
+      .get();
+
+    test_logger.info("removing node: {}", victim);
+    remove_node(victim);
+
+    test_logger.info(
+      "waiting for node 2 to not be a leader of any partition: {}", victim);
+    tests::cooperative_spin_wait_with_timeout(60s, [this, node_0, victim] {
+        auto md = get_local_cache(node_0).all_topics_metadata();
+        return std::all_of(md.begin(), md.end(), [victim](const auto& tm) {
+            return std::all_of(
+              tm.partitions.begin(),
+              tm.partitions.end(),
+              [victim](const auto& p) { return p.leader_node != victim; });
+        });
+    }).get0();
+
+    test_logger.info("populating all topics");
+    populate_all_topics_with_data();
+
+    test_logger.info("waiting for node {} to be under replicated", victim);
+    tests::cooperative_spin_wait_with_timeout(60s, any_under_replicated).get();
+
+    test_logger.info("Restarting node {}", victim);
+    add_node(2);
+
+    test_logger.info(
+      "Expecting node: {} to self-report under_replicated", victim);
+    BOOST_REQUIRE(is_node_under_replicated(victim, victim).get());
+
+    test_logger.info("waiting for node {} to not be under replicated", victim);
+    tests::cooperative_spin_wait_with_timeout(60s, none_under_replicated).get();
+
+    test_logger.info("Expecting node: {} not under_replicated", 2);
+    BOOST_REQUIRE(!is_node_under_replicated(victim, victim).get());
+}

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -104,39 +104,6 @@ ss::future<std::vector<topic_result>> topics_frontend::create_topics(
       });
 }
 
-cluster::errc map_errc(std::error_code ec) {
-    if (ec == errc::success) {
-        return errc::success;
-    }
-    // error comming from raft
-    if (ec.category() == raft::error_category()) {
-        switch (static_cast<raft::errc>(ec.value())) {
-        case raft::errc::timeout:
-            return errc::timeout;
-        case raft::errc::not_leader:
-            return errc::not_leader_controller;
-        default:
-            return errc::replication_error;
-        }
-    }
-
-    // error comming from raft
-    if (ec.category() == rpc::error_category()) {
-        switch (static_cast<rpc::errc>(ec.value())) {
-        case rpc::errc::client_request_timeout:
-            return errc::timeout;
-        default:
-            return errc::replication_error;
-        }
-    }
-    // cluster errors, just forward
-    if (ec.category() == cluster::error_category()) {
-        return static_cast<errc>(ec.value());
-    }
-
-    return errc::replication_error;
-}
-
 ss::future<std::vector<topic_result>> topics_frontend::update_topic_properties(
   std::vector<topic_properties_update> updates,
   model::timeout_clock::time_point timeout) {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -648,6 +648,15 @@ struct finish_reallocation_reply {
     errc error;
 };
 
+struct get_under_replicated_request {
+    model::node_id id;
+};
+
+struct get_under_replicated_reply {
+    bool under_replicated{false};
+    errc error{errc::success};
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2557,9 +2557,10 @@ std::vector<follower_metrics> consensus::get_follower_metrics() const {
     std::vector<follower_metrics> ret;
     ret.reserve(_fstats.size());
     auto dirty_offset = _log.offsets().dirty_offset;
+    auto now = clock_type::now();
     for (const auto& f : _fstats) {
         auto last_hbeat = f.second.last_hbeat_timestamp;
-        auto is_live = last_hbeat + _jit.base_duration() > clock_type::now();
+        auto is_live = last_hbeat + _jit.base_duration() > now;
         ret.push_back(follower_metrics{
           .id = f.first.id(),
           .is_learner = f.second.is_learner,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -308,6 +308,11 @@ public:
 
     bool should_reconnect_follower(vnode);
 
+    /**
+     * Return whether any partition is under_replicated by the provided node.
+     */
+    result<bool> is_under_replicated(model::node_id) const;
+
     std::vector<follower_metrics> get_follower_metrics() const;
 
     const configuration_manager& get_configuration_manager() const {

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -48,6 +48,28 @@
             ]
         },
         {
+            "path": "/v1/brokers/{id}/abdicate",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Relinquish leadership",
+                    "type": "void",
+                    "nickname": "abdicate",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/brokers/{id}/decommission",
             "operations": [
                 {

--- a/src/v/redpanda/admin/api-doc/status.json
+++ b/src/v/redpanda/admin/api-doc/status.json
@@ -11,4 +11,35 @@
         }
       }
     }
+  },
+  "/v1/status/started": {
+    "get": {
+      "summary": "redpanda started",
+      "operationId": "started",
+      "responses": {
+        "200": {
+          "description": "Redpanda is actively participating in the cluster",
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "code": {
+              "type": "integer"
+            }
+          }
+        },
+        "503": {
+          "description": "Redpanda is booting",
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "code": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
   }

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -20,6 +20,10 @@ class Admin:
         url = f"http://{node.account.hostname}:9644/v1/status/ready"
         return requests.get(url).json()
 
+    def started(node):
+        url = f"http://{node.account.hostname}:9644/v1/status/started"
+        return requests.get(url).status_code == requests.codes.ok
+
     @staticmethod
     def _url(node, path):
         return f"http://{node.account.hostname}:9644/v1/{path}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -41,7 +41,7 @@ class RedpandaService(Service):
     WASM_STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                               "wasm_engine.log")
     CLUSTER_NAME = "my_cluster"
-    READY_TIMEOUT_SEC = 10
+    READY_TIMEOUT_SEC = 20
 
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"
@@ -192,7 +192,7 @@ class RedpandaService(Service):
         node.account.ssh(cmd)
 
         wait_until(
-            lambda: Admin.ready(node).get("status") == "ready",
+            lambda: Admin.started(node),
             timeout_sec=RedpandaService.READY_TIMEOUT_SEC,
             err_msg=f"Redpanda service {node.account.hostname} failed to start",
             retry_on_exc=True)

--- a/tests/rptest/tests/configuration_update_test.py
+++ b/tests/rptest/tests/configuration_update_test.py
@@ -81,28 +81,28 @@ class ConfigurationUpdateTest(RedpandaTest):
         node_2 = self.redpanda.get_node(2)
         node_3 = self.redpanda.get_node(3)
 
-        # stop all nodes
-        self.redpanda.stop_node(node_1)
-        self.redpanda.stop_node(node_2)
-        self.redpanda.stop_node(node_3)
-
         def make_new_address(node, port):
             return dict(address=node.name, port=port)
 
-        # change ports
+        # node 1 - stop, reconfigure port, start
+        self.redpanda.stop_node(node_1)
         altered_cfg_1 = dict(kafka_api=make_new_address(node_1, 10091),
                              advertised_kafka_api=make_new_address(
                                  node_1, 10091))
+        self.redpanda.start_node(node_1, override_cfg_params=altered_cfg_1)
+
+        # node 2 - stop, reconfigure port, start
+        self.redpanda.stop_node(node_2)
         altered_cfg_2 = dict(kafka_api=make_new_address(node_2, 10092),
                              advertised_kafka_api=make_new_address(
                                  node_2, 10092))
+        self.redpanda.start_node(node_2, override_cfg_params=altered_cfg_2)
+
+        # node 3 - stop, reconfigure port, start
+        self.redpanda.stop_node(node_3)
         altered_cfg_3 = dict(kafka_api=make_new_address(node_3, 10093),
                              advertised_kafka_api=make_new_address(
                                  node_3, 10093))
-
-        # start all
-        self.redpanda.start_node(node_1, override_cfg_params=altered_cfg_1)
-        self.redpanda.start_node(node_2, override_cfg_params=altered_cfg_2)
         self.redpanda.start_node(node_3, override_cfg_params=altered_cfg_3)
 
         def metadata_updated():


### PR DESCRIPTION
## Cover letter

Introduce endpoints suitable for Kubernetes lifecycle events.

See #846, https://github.com/vectorizedio/redpanda/pull/1901#issuecomment-889320548

* Introduce: `/v1/status/started` (suitable as a startupProbe):
```
  Success: status_code: `200`, content: `{"message": "started", "code": 200}`
  Failure: status_code: `503`, content: `{"message": "booting", "code": 503}`
```
* Introduce `/v1/brokers/{node_id}/abdicate` (suitable as a `PreStop` hook)
  Relinquishes partition leadership for the given node (must be called on the correct node)

Fix #846
Related: #1901 #1164

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ce14b1a045949e5924996d71070ccf8a1741c342..a3859a493f41631cde022e1663ac08332dbd39e8)
* Reworded the failure case of `status/started`
* Improved `get_under_replicated` implementation
* Fixed the tests

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a3859a493f41631cde022e1663ac08332dbd39e8..365ccca961432c2e44865e2d386d392380f2a28c)
* Rebase past #1937 
* Rebase past #1989 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/365ccca961432c2e44865e2d386d392380f2a28c..ceff1d7fb754eec79a2d729cc4d4ec95ea8dec5b)
* Make synchronization points more strict in the test
* Workaround a coroutine bug

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ceff1d7fb754eec79a2d729cc4d4ec95ea8dec5b..09ee20d5c4f1648daaab79fd580928b859665c61)
* Rebase around conflict in CMakeLists.txt
* Switch Ducktape to use this endpoint (all in the final commit)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/eb99d567fb4410f00f1e6f637465dbd76834d343..ca3cddf642b626376905261258a12aa90c0148c0)
* Change `ConfigurationUpdateTest` to take down nodes one at a time.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

admin_server: Add `/v1/status/started` (suitable for k8s `startupProbe`)
admin_server: Add `/v1/brokers/{node_id}/abdicate` (suitable for k8s `PreStop` hook)
