### PR TITLE
ducktape: Fix rpk output parsing

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -83,7 +83,7 @@ class RpkTool:
 
         def partition_line(line):
             m = re.match(
-                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] + \[.+\] +(?P<hw>\d+) *",
+                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<hw>\d+) *",
                 line)
             if m == None:
                 return None


### PR DESCRIPTION
## Cover letter

The output of the rpk topic describe command has changed and the
existing regex is no longer working. This commit updates the regex.

Sample command output:
```
  Name                panda-topic  
  Internal            false        
  Cleanup policy      delete       
  Config:             
  Name                Value        Read-only  Sensitive  
  partition_count     1            false      false      
  replication_factor  3            false      false      
  cleanup.policy      delete       false      false      
  Partitions          1 - 1 out of 1  
  Partition           Leader          Replicas   High Watermark  
  0                   3               [1 2 3]    0  
```

the client is trying to fetch the last line

## Release notes

N/A