### PR TITLE
rpc: enable setting a limit on the seastar/userspace receive buffer size

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -844,6 +844,16 @@ configuration::configuration()
       {.example = "65536"},
       std::nullopt,
       {.min = 32_KiB, .align = 4_KiB})
+  , kafka_rpc_server_stream_recv_buf(
+      *this,
+      "kafka_rpc_server_stream_recv_buf",
+      "Userspace receive buffer max size in bytes",
+      {.example = "65536", .visibility = visibility::tunable},
+      std::nullopt,
+      // The minimum is set to match seastar's min_buffer_size (i.e. don't
+      // permit setting a max below the min).  The maximum is set to forbid
+      // contiguous allocations beyond that size.
+      {.min = 512, .max = 512_KiB, .align = 4_KiB})
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -184,6 +184,7 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> kafka_connections_max_overrides;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_recv_buf;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_send_buf;
+    bounded_property<std::optional<size_t>> kafka_rpc_server_stream_recv_buf;
 
     // Archival storage
     property<bool> cloud_storage_enabled;

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -56,6 +56,7 @@ connection::connection(
   ss::connected_socket f,
   ss::socket_address a,
   server_probe& p,
+  std::optional<size_t> in_max_buffer_size,
   std::optional<security::tls::principal_mapper> tls_pm)
   : addr(a)
   , _hook(hook)
@@ -65,6 +66,14 @@ connection::connection(
   , _out(_fd.output())
   , _probe(p)
   , _tls_pm(std::move(tls_pm)) {
+    if (in_max_buffer_size.has_value()) {
+        auto in_config = ss::connected_socket_input_stream_config{};
+        in_config.max_buffer_size = in_max_buffer_size.value();
+        _in = _fd.input(std::move(in_config));
+    } else {
+        _in = _fd.input();
+    }
+
     _hook.push_back(*this);
     _probe.connection_established();
 }

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -39,6 +39,7 @@ public:
       ss::connected_socket f,
       ss::socket_address a,
       server_probe& p,
+      std::optional<size_t> in_max_buffer_size,
       std::optional<security::tls::principal_mapper> tls_pm);
     ~connection() noexcept;
     connection(const connection&) = delete;

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -223,6 +223,7 @@ ss::future<> server::accept(listener& s) {
                 std::move(ar.connection),
                 ar.remote_address,
                 _probe,
+                cfg.stream_recv_buf,
                 tls_pm);
               vlog(
                 rpc::rpclog.trace,

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -96,6 +96,7 @@ struct server_configuration {
     std::optional<int> listen_backlog;
     std::optional<int> tcp_recv_buf;
     std::optional<int> tcp_send_buf;
+    std::optional<size_t> stream_recv_buf;
     net::metrics_disabled disable_metrics = net::metrics_disabled::no;
     ss::sstring name;
     std::optional<config_connection_rate_bindings> connection_rate_bindings;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1063,6 +1063,9 @@ void application::wire_up_redpanda_services() {
                   c.tcp_send_buf
                     = config::shard_local_cfg().rpc_server_tcp_send_buf;
               }
+
+              c.stream_recv_buf
+                = config::shard_local_cfg().kafka_rpc_server_stream_recv_buf;
               auto& tls_config = config::node().kafka_api_tls.value();
               for (const auto& ep : config::node().kafka_api()) {
                   ss::shared_ptr<ss::tls::server_credentials> credentails;


### PR DESCRIPTION
## Cover letter

Seastar users a buffer in input_stream which can be as large as 128kB.  We don't necessarily want that on top of what the kernel/network is already keeping in flight for us.  Configuring this to a lower value lets us remove a possible source of queuing latency when tweaking for performance.

## Release notes

### Improvements

A new configuration property `kafka_rpc_server_stream_recv_buf` is added.  Setting a low value (e.g. 8192) reduces the amount of userspace buffering for data received on each TCP connection with a Kafka client.  By default this is unset and does not change behavior.