### PR TITLE
spec.Resources is resources of all containers running by the statefulset

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -622,7 +622,7 @@ func (p PandaproxyAPI) GetTLS() *TLSConfig {
 // all CRDs assigned to all enabled sidecars
 func (r *Cluster) GetRedpandaResources() corev1.ResourceRequirements {
 	assignedResources := *r.Spec.Resources.DeepCopy()
-	if r.Spec.Sidecars.RpkStatus.Enabled && r.Spec.Sidecars.RpkStatus.Resources != nil {
+	if r.Spec.Sidecars.RpkStatus != nil && r.Spec.Sidecars.RpkStatus.Enabled && r.Spec.Sidecars.RpkStatus.Resources != nil {
 		cpuLimit := assignedResources.Limits.Cpu()
 		memoryLimit := assignedResources.Limits.Memory()
 		cpuLimit.Sub(*r.Spec.Sidecars.RpkStatus.Resources.Limits.Cpu())

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -627,6 +627,7 @@ func (r *Cluster) GetRedpandaResources() corev1.ResourceRequirements {
 		memoryLimit := assignedResources.Limits.Memory()
 		cpuLimit.Sub(*r.Spec.Sidecars.RpkStatus.Resources.Limits.Cpu())
 		memoryLimit.Sub(*r.Spec.Sidecars.RpkStatus.Resources.Limits.Memory())
+		_ = memoryLimit.RoundUp(0)
 		assignedResources.Limits[corev1.ResourceCPU] = *cpuLimit
 		assignedResources.Limits[corev1.ResourceMemory] = *memoryLimit
 
@@ -634,6 +635,7 @@ func (r *Cluster) GetRedpandaResources() corev1.ResourceRequirements {
 		memoryRequest := assignedResources.Requests.Memory()
 		cpuRequest.Sub(*r.Spec.Sidecars.RpkStatus.Resources.Requests.Cpu())
 		memoryRequest.Sub(*r.Spec.Sidecars.RpkStatus.Resources.Requests.Memory())
+		_ = memoryRequest.RoundUp(0)
 		assignedResources.Requests[corev1.ResourceCPU] = *cpuRequest
 		assignedResources.Requests[corev1.ResourceMemory] = *memoryRequest
 	}

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
@@ -1,0 +1,48 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetRedpandaResources(t *testing.T) {
+	resources := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+	rpkResources := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("0.5"),
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+	}
+	redpandaCluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			Resources: corev1.ResourceRequirements{
+				Limits:   resources,
+				Requests: resources,
+			},
+			Sidecars: v1alpha1.Sidecars{
+				RpkStatus: &v1alpha1.Sidecar{
+					Enabled: true,
+					Resources: &corev1.ResourceRequirements{
+						Limits:   rpkResources,
+						Requests: rpkResources,
+					},
+				},
+			},
+		},
+	}
+	rpResources := redpandaCluster.GetRedpandaResources()
+	assert.True(t, resource.MustParse("0.5").Equal(*rpResources.Limits.Cpu()), "limits cpu")
+	assert.True(t, resource.MustParse("0.5").Equal(*rpResources.Requests.Cpu()), "requests cpu")
+	assert.True(t, resource.MustParse("1Gi").Equal(*rpResources.Limits.Memory()), "limits memory")
+	assert.True(t, resource.MustParse("1Gi").Equal(*rpResources.Requests.Memory()), "requests memory")
+}

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -44,11 +44,11 @@ var (
 	// DefaultRpkStatusResources is default resources setting for rpk debug
 	DefaultRpkStatusResources = &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10M"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
 			corev1.ResourceCPU:    resource.MustParse("0.2"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10M"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
 			corev1.ResourceCPU:    resource.MustParse("0.2"),
 		},
 	}

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -403,10 +403,11 @@ func (r *Cluster) validateRedpandaMemory() field.ErrorList {
 	var allErrs field.ErrorList
 
 	// Ensure a requested 2GB of memory per core
-	requests := r.Spec.Resources.Requests.DeepCopy()
+	requests := r.GetRedpandaResources().Requests.DeepCopy()
 	requests.Cpu().RoundUp(0)
 	requestedCores := requests.Cpu().Value()
-	if r.Spec.Resources.Requests.Memory().Value() < requestedCores*MinimumMemoryPerCore {
+	originalRequests := r.GetRedpandaResources().Requests
+	if originalRequests.Memory().Value() < requestedCores*MinimumMemoryPerCore {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec").Child("resources").Child("requests").Child("memory"),

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -262,6 +262,10 @@ func TestValidateUpdate_NoError(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
 					corev1.ResourceCPU:    resource.MustParse("1"),
 				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
+				},
 			},
 		},
 	}
@@ -528,12 +532,12 @@ func TestValidateUpdate_NoError(t *testing.T) {
 				Enabled: true,
 				Resources: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("1Gi"),
-						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("0.1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("0.1"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
-						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("0.2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("0.1"),
 					},
 				},
 			},

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -394,12 +394,12 @@ spec:
                 minimum: 0
                 type: integer
               resources:
-                description: Resources used by redpanda process running in container.
-                  Beware that there are multiple containers running in the redpanda
-                  pod and these can be enabled/disabled and configured from the `sidecars`
-                  field. These containers have separate resources settings and the
-                  amount of resources assigned to these containers will be required
-                  on the cluster on top of the resources defined here
+                description: Resources used by all redpanda containers. Beware that
+                  there are multiple containers running in the redpanda pod and these
+                  can be enabled/disabled and configured from the `sidecars` field.
+                  These containers have separate resources settings and the amount
+                  of resources assigned to these containers will be deducted from
+                  the amount assigned here.
                 properties:
                   limits:
                     additionalProperties:

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
@@ -10,10 +10,10 @@ spec:
   replicas: 3
   resources:
     requests:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 200m
+      memory: 110Mi
     limits:
-      cpu: 1
+      cpu: 1.1
       memory: 1.2Gi
   configuration:
     rpcServer:

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -72,10 +72,10 @@ resources: {}
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
 #  limits:
-#   cpu: 100m
+#   cpu: 200m
 #   memory: 30Mi
 #  requests:
-#   cpu: 100m
+#   cpu: 200m
 #   memory: 20Mi
 
 # nodeSelector -- Allows to schedule Redpanda Operator on specific nodes

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -344,8 +344,8 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								RunAsGroup: pointer.Int64Ptr(groupID),
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits:   r.pandaCluster.Spec.Resources.Limits,
-								Requests: r.pandaCluster.Spec.Resources.Requests,
+								Limits:   r.pandaCluster.GetRedpandaResources().Limits,
+								Requests: r.pandaCluster.GetRedpandaResources().Requests,
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -371,7 +371,7 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								r.portsConfiguration(),
 							}, prepareAdditionalArguments(
 								r.pandaCluster.Spec.Configuration.DeveloperMode,
-								r.pandaCluster.Spec.Resources.Requests)...),
+								r.pandaCluster.GetRedpandaResources().Requests)...),
 							Env: []corev1.EnvVar{
 								{
 									Name:  "REDPANDA_ENVIRONMENT",
@@ -412,8 +412,8 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								},
 							}, r.getPorts()...),
 							Resources: corev1.ResourceRequirements{
-								Limits:   r.pandaCluster.Spec.Resources.Limits,
-								Requests: r.pandaCluster.Spec.Resources.Requests,
+								Limits:   r.pandaCluster.GetRedpandaResources().Limits,
+								Requests: r.pandaCluster.GetRedpandaResources().Requests,
 							},
 							VolumeMounts: append([]corev1.VolumeMount{
 								{

--- a/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/admin-api-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-redpanda-cluster.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/external-connectivity/00-external-connectivity.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-external-connectivity.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 3
   resources:
     requests:
-      cpu: 1
-      memory: 2Gi
+      cpu: 1.2
+      memory: 2.02Gi
     limits:
-      cpu: 1
-      memory: 2Gi
+      cpu: 1.2
+      memory: 2.02Gi
   configuration:
     rpcServer:
       port: 33145

--- a/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 2
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
@@ -27,7 +27,7 @@ spec:
   replicas: 2
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 2
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 2
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update/00-one-replica.yaml
+++ b/src/go/k8s/tests/e2e/update/00-one-replica.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 100M
     limits:
       cpu: 1

--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - resources:
             requests:
-              memory: 99M
+              memory: 89M
         - resources:
             requests:
               memory: 10M


### PR DESCRIPTION
## Cover letter

With 21.8.1 we introduced sidecars (rpkstatus) but the chosen implementation was to keep `spec.Resources` as redpanda resources and having sidecars defined on top of that. But this proves to be much harder to upgrade from existing clusters. This PR switches the behavior back to `spec.Resources` being resources of all containers and then when computing redpanda resources, we need to subtract all sidecars from it.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
in k8s, `spec.Resources` is now resources assigned to all containers including sidecars.