### PR TITLE
storage: make alignment strongly typed

### DIFF
--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -28,7 +28,7 @@ public:
      * same device and file system. For convenience we use the fail safe size
      * specified by seastar, and dynamically verify compatibility for each file.
      */
-    static constexpr const size_t alignment = 4_KiB;
+    static constexpr const alignment alignment{4_KiB};
 
     chunk_cache() noexcept
       : _size_target(memory_groups::chunk_cache_min_memory())

--- a/src/v/storage/segment_appender_chunk.h
+++ b/src/v/storage/segment_appender_chunk.h
@@ -23,9 +23,12 @@
 #include <ostream>
 
 namespace storage {
+
+using alignment = named_type<size_t, struct alignment_type>;
+
 class segment_appender_chunk {
 public:
-    explicit segment_appender_chunk(size_t size, size_t alignment)
+    explicit segment_appender_chunk(size_t size, alignment alignment)
       : _chunk_size(size)
       , _alignment(alignment)
       , _buf(ss::allocate_aligned_buffer<char>(_chunk_size, alignment)) {
@@ -43,7 +46,7 @@ public:
 
     bool is_full() const { return _pos == _chunk_size; }
     bool is_empty() const { return _pos == 0; }
-    size_t alignment() const { return _alignment; }
+    alignment alignment() const { return _alignment; }
     size_t space_left() const { return _chunk_size - _pos; }
     size_t size() const { return _pos; }
 
@@ -97,7 +100,7 @@ public:
 
 private:
     size_t _chunk_size{0};
-    size_t _alignment{0};
+    storage::alignment _alignment{0};
     size_t _pos{0};
     size_t _flushed_pos{0};
     std::unique_ptr<char[], ss::free_deleter> _buf;

--- a/src/v/storage/tests/appender_chunk_manipulations.cc
+++ b/src/v/storage/tests/appender_chunk_manipulations.cc
@@ -18,7 +18,7 @@
 #include <cstring>
 
 using chunk = storage::segment_appender::chunk;
-static constexpr size_t alignment = 4096;
+static constexpr storage::alignment alignment{4096};
 
 SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
     const auto b = random_generators::gen_alphanum_string(1024 * 1024);
@@ -53,7 +53,7 @@ SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
         // 10 bytes on the next page
         BOOST_REQUIRE_EQUAL(c.flushed_pos() % alignment, 10);
         BOOST_TEST_MESSAGE("10 bytes spill over: " << c);
-        c.append(b.data() + i, alignment + 10);
+        c.append(b.data() + i, alignment() + 10);
         BOOST_TEST_MESSAGE("Should be full: " << c.is_full() << ", " << c);
         BOOST_REQUIRE(c.is_full());
         // we flushed after 3 pages. so the dma_size() should be 1 page left


### PR DESCRIPTION
## Cover letter

Avoid a repetition of the snafus fixed in
a53ad9861, 2e983af0.

This is an ancient branch that I'm revising because the change is just as valid now as it was then!

## Backports

none

## Release notes

* none