### PR TITLE
tests: reinstate log deletion at end of test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -284,7 +284,7 @@ class RedpandaService(Service):
 
     def clean_node(self, node):
         node.account.kill_process("redpanda", clean_shutdown=False)
-        node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
+        node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/*")
         node.account.remove(f"{RedpandaService.CONFIG_FILE}")
 
     def redpanda_pid(self, node):


### PR DESCRIPTION
## Cover letter

This was changed in f6ade60faf0711c5d1c35ac50440aac2f12405be.

Removing the logs is important, because otherwise multiple tests'
logs are combined, making debugging failures awkward.  ducktape
copies out the logs before it runs clean_node.

## Release notes

None
