### PR TITLE
partition_movement_test: use field 'value', not 'message'

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -312,7 +312,7 @@ class PartitionMovementTest(EndToEndTest):
                     time.sleep(5)
                     for m in consumer.messages:
                         self.logger.info(f"message: {m}")
-                    consumed = set([(m['key'], m['message'])
+                    consumed = set([(m['key'], m['value'])
                                     for m in consumer.messages])
 
             self.logger.info(f"Stopping consumer...")


### PR DESCRIPTION
The PR for this test was created before the franz produce/consume PR was
merged, and merged after that PR was merged.

consuming now uses the json field 'value', not the old format 'message'.
This updates the newly-merged-old-behavior test.
