### PR TITLE
cloud_storage: Modify cache interface

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -26,6 +26,9 @@ struct cache_item {
     size_t size;
 };
 
+enum class cache_element_status { available, not_available, in_progress };
+std::ostream& operator<<(std::ostream& o, cache_element_status);
+
 class cache {
 public:
     /// C-tor.
@@ -40,13 +43,15 @@ public:
     ss::future<> stop();
 
     /// Get cached value as a stream if it exists on disk
-    ss::future<std::optional<cache_item>> get(std::filesystem::path key);
+    ss::future<std::optional<cache_item>>
+    get(std::filesystem::path key, size_t file_pos = 0);
 
     /// Add new value to the cache, overwrite if it's already exist
     ss::future<> put(std::filesystem::path key, ss::input_stream<char>& data);
 
     /// Return true if the following object is already in the cache
-    ss::future<bool> is_cached(const std::filesystem::path& key);
+    ss::future<cache_element_status>
+    is_cached(const std::filesystem::path& key);
 
     /// Remove element from cache by key
     ss::future<> invalidate(const std::filesystem::path& key);

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -75,9 +75,9 @@ FIXTURE_TEST(get_missing_file, cache_test_fixture) {
 }
 
 FIXTURE_TEST(missing_file_not_cached, cache_test_fixture) {
-    bool is_cached = cache_service.is_cached(WRONG_KEY).get();
+    auto is_cached = cache_service.is_cached(WRONG_KEY).get();
 
-    BOOST_CHECK(!is_cached);
+    BOOST_CHECK_EQUAL(is_cached, cache_element_status::not_available);
 }
 
 FIXTURE_TEST(is_cached_after_put_success, cache_test_fixture) {
@@ -85,9 +85,9 @@ FIXTURE_TEST(is_cached_after_put_success, cache_test_fixture) {
     auto input = make_iobuf_input_stream(std::move(buf));
     cache_service.put(KEY, input).get();
 
-    bool is_cached = cache_service.is_cached(KEY).get();
+    auto is_cached = cache_service.is_cached(KEY).get();
 
-    BOOST_CHECK(is_cached);
+    BOOST_CHECK_EQUAL(is_cached, cache_element_status::available);
 }
 
 FIXTURE_TEST(after_invalidate_is_not_cached, cache_test_fixture) {
@@ -96,8 +96,8 @@ FIXTURE_TEST(after_invalidate_is_not_cached, cache_test_fixture) {
 
     cache_service.invalidate(KEY).get();
 
-    bool is_cached = cache_service.is_cached(KEY).get();
-    BOOST_CHECK(!is_cached);
+    auto is_cached = cache_service.is_cached(KEY).get();
+    BOOST_CHECK_EQUAL(is_cached, cache_element_status::not_available);
 }
 
 FIXTURE_TEST(invalidate_missing_file_ok, cache_test_fixture) {


### PR DESCRIPTION
## Cover letter

Change result type of the is_cached method. The returned value is
an enum which can indicate that the value is cached or not or it's
being downloaded.

Add parameter pos to the get method to start reading value starting
from the specific offset.

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/a6c6c0a7b60253ef133c8b3b488651f4259a07e0..60610af09ce68f78121389bad6e36ea068802042)
- Address code review issues
- Fix build

## Release notes

N/A