### PR TITLE
schema_registry: Avoid null pointer during shutdown

### DIFF
--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -55,12 +55,12 @@ ss::future<> api::start() {
 }
 
 ss::future<> api::stop() {
-    // co_await _service.invoke_on_all(&service::stop);
-
     co_await _service.stop();
     co_await _sequencer.stop();
     co_await _client.stop();
-    co_await _store->stop();
+    if (_store) {
+        co_await _store->stop();
+    }
 }
 
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
## Cover letter

During schema registry start-up a failure may occur before the
store is created. however, shutdown assumes the store has been
created and will deference a null pointer in this case.

The bug was found during a startup where bind failed due to
address already in use.

It was introduced in https://github.com/vectorizedio/redpanda/pull/2361 - which made it to v21.10.x

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: schema_registry: Avoid null pointer during shutdown
