### PR TITLE
cluster: is_topic_replicable returning the inverted value

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -146,7 +146,7 @@ void members_backend::calculate_reallocations(update_meta& meta) {
         // reallocate all partitons for which any of replicas is placed on
         // decommissioned node
         for (const auto& [tp_ns, cfg] : _topics.local().topics_map()) {
-            if (cfg.is_topic_replicable()) {
+            if (!cfg.is_topic_replicable()) {
                 continue;
             }
             for (auto& pas : cfg.get_configuration().assignments) {
@@ -257,7 +257,7 @@ void members_backend::calculate_reallocations_after_node_added(
           || tp_ns.ns == model::redpanda_ns) {
             continue;
         }
-        if (metadata.is_topic_replicable()) {
+        if (!metadata.is_topic_replicable()) {
             continue;
         }
         // do not move topics that were created after node was added, they are

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -52,7 +52,7 @@ std::optional<model::topic>
 metadata_cache::get_source_topic(model::topic_namespace_view tp) const {
     auto& topics_map = _topics_state.local().topics_map();
     auto mt = topics_map.find(tp);
-    if (mt == topics_map.end() || !mt->second.is_topic_replicable()) {
+    if (mt == topics_map.end() || mt->second.is_topic_replicable()) {
         return std::nullopt;
     }
     return mt->second.get_source_topic();

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -46,7 +46,7 @@ std::optional<model::node_id> partition_leaders_table::get_leader(
     } else if (auto it = topics_map.find(tp_ns); it != topics_map.end()) {
         // Possible leadership query for materialized topic, search for it
         // in the topics table.
-        if (it->second.is_topic_replicable()) {
+        if (!it->second.is_topic_replicable()) {
             // Leadership properties of non replicated topic are that of its
             // parent
             return get_leader(

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -274,7 +274,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      */
     std::optional<model::ntp> ntp;
     for (const auto& topic : _topics.topics_map()) {
-        if (topic.second.is_topic_replicable()) {
+        if (!topic.second.is_topic_replicable()) {
             continue;
         }
         for (const auto& partition :
@@ -433,7 +433,7 @@ leader_balancer::index_type leader_balancer::build_index() {
 
     // for each ntp in the cluster
     for (const auto& topic : _topics.topics_map()) {
-        if (topic.second.is_topic_replicable()) {
+        if (!topic.second.is_topic_replicable()) {
             continue;
         }
         for (const auto& partition :


### PR DESCRIPTION
the `cluster::topic_table::is_topic_replicable()` method is returning the inverted value then what is expected. However all calls to this method invert the result, so this change should have no effect only to make this method return the correct value of what is expected.