### PR TITLE
Logging state when out of range error is returned from fetch

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -205,6 +205,13 @@ static ss::future<read_result> do_read_from_ntp(
     }
 
     if (ntp_config.cfg.start_offset < kafka_partition->start_offset()) {
+        vlog(
+          klog.warn,
+          "fetch offset out of range for {}, requested offset: {}, partition "
+          "start offset: {}",
+          ntp_config.ntp(),
+          ntp_config.cfg.start_offset,
+          kafka_partition->start_offset());
         return ss::make_ready_future<read_result>(
           error_code::offset_out_of_range);
     }


### PR DESCRIPTION
When out of range error is returned from fetch request handler we should
log this situation to make debugging easier.
