### PR TITLE
rpk container start: print --brokers in start message

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -308,9 +309,13 @@ func startCluster(
 		return err
 	}
 	renderClusterInfo(nodes)
+	var brokers []string
+	for _, node := range nodes {
+		brokers = append(brokers, node.addr)
+	}
 	log.Infof(
-		"\nCluster started! You may use rpk to interact with it." +
-			" E.g:\n\nrpk cluster info\n",
+		"\nCluster started! You may use rpk to interact with it."+
+			" E.g:\n\nrpk cluster info --brokers %s\n", strings.Join(brokers, ","),
 	)
 
 	return nil


### PR DESCRIPTION
container address autodiscovery has been removed, so we need to
reference --brokers in the container start message.

This is a quicker fix; soon we may also add some ability to auto-update
the rpk configuration in place as well if no brokers are in the
configuration yet.

Fixes #2601.