### PR TITLE
docs: Show that rpk commands for rpk container must include brokers

### DIFF
--- a/docs/www/guide-rpk-container.md
+++ b/docs/www/guide-rpk-container.md
@@ -13,31 +13,27 @@ please follow the installation instructions for
 
 It's important to note, however, that you won't need to interact with Docker directly or have experience with it.
 
-To get started, run `rpk container start -n 3`. This will start a 3-node cluster. You should see something like this (the addresses may vary):
+To run Redpanda in a 3-node cluster, run: `rpk container start -n 3`
 
-> `rpk container start` will take a minute the first time you run it, as it will download the latest stable version of Redpanda.
+The first time you run `rpk container start`, it downloads an image matching the rpk version (you can check it by running `rpk version`).
+You now have a 3-node cluster running Redpanda!
+
+The command output shows the addresses of the cluster nodes:
 
 ```
-Downloading latest version of Redpanda
+$ rpk container start -n 3
 Starting cluster
-  NODE ID  ADDRESS
-  0        172.24.1.2:58754
-  2        172.24.1.4:58756
-  1        172.24.1.3:58757
-
-Cluster started! You may use rpk to interact with it. E.g:
-
-rpk cluster info
+Waiting for the cluster to be ready...
+  NODE ID  ADDRESS          
+  0        127.0.0.1:49462  
+  1        127.0.0.1:49468  
+  2        127.0.0.1:49467  
 ```
 
-It says we can check our cluster with `rpk cluster info`
+You can run `rpk` commands to interact with the cluster, for example:
 
-```
-  Redpanda Cluster Info
-
-  0 (127.0.0.1:58754)      (No partitions)
-  1 (127.0.0.1:58757)      (No partitions)
-  2 (127.0.0.1:58756)      (No partitions)
+```bash
+rpk cluster info --brokers 127.0.0.1:49462,127.0.0.1:49468,127.0.0.1:49467
 ```
 
 You can now connect your Kafka compatible applications directly to Redpanda
@@ -49,7 +45,7 @@ Additionally, all of the `rpk topic` subcommands will detect the local cluster a
 For example, you can run `rpk topic create` and it will work!
 
 ```
-$ rpk topic create -p 6 -r 3 new-topic
+$ rpk topic create -p 6 -r 3 new-topic --brokers <broker1_address>,<broker2_address>...
 Created topic 'new-topic'. Partitions: 6, replicas: 3, cleanup policy: 'delete'
 ```
 

--- a/docs/www/quick-start-macos.md
+++ b/docs/www/quick-start-macos.md
@@ -35,10 +35,22 @@ To run Redpanda in a 3-node cluster, run: `rpk container start -n 3`
 The first time you run `rpk container start`, it downloads an image matching the rpk version (you can check it by running `rpk version`).
 You now have a 3-node cluster running Redpanda!
 
+The command output shows the addresses of the cluster nodes:
+
+```
+$ rpk container start -n 3
+Starting cluster
+Waiting for the cluster to be ready...
+  NODE ID  ADDRESS          
+  0        127.0.0.1:49462  
+  1        127.0.0.1:49468  
+  2        127.0.0.1:49467  
+```
+
 You can run `rpk` commands to interact with the cluster, for example:
 
 ```bash
-rpk cluster info
+rpk cluster info --brokers 127.0.0.1:49462,127.0.0.1:49468,127.0.0.1:49467
 ```
 
 ## Do some streaming
@@ -48,13 +60,13 @@ Here are the basic commands to produce and consume streams:
 1. Create a topic. We'll call it "twitch_chat":
 
     ```bash
-    rpk topic create twitch_chat
+    rpk topic create twitch_chat --brokers <broker1_address>,<broker2_address>...
     ```
 
 1. Produce messages to the topic:
 
     ```bash
-    rpk topic produce twitch_chat
+    rpk topic produce twitch_chat --brokers <broker1_address>,<broker2_address>...
     ```
 
     Type text into the topic and press Ctrl + D to seperate between messages.
@@ -64,7 +76,7 @@ Here are the basic commands to produce and consume streams:
 1. Consume (or read) the messages in the topic:
 
     ```bash
-    rpk topic consume twitch_chat
+    rpk topic consume twitch_chat --brokers <broker1_address>,<broker2_address>...
     ```
     
     Each message is shown with its metadata, like this:

--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -301,6 +301,10 @@ Flags:
       --retries uint   The amount of times to check for the cluster before considering it unstable and exiting. (default: 10)
 ```
 
+The command returns the list of broker addresses.
+You must specify the broker addresses with the `--broker` option in `rpk` commands that interact with the cluster,
+such as `rpk topic` and `rpk acl`.
+
 ### container stop 
 
 OS support: ![Linux][linux] ![MacOS][mac]


### PR DESCRIPTION
## Cover letter

The `rpk` command does not auto-detect the brokers in the cluster. This PR adds to the docs that the `rpk` requires the brokers to be explicitly listed and shows the syntax.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
