### PR TITLE
topic produce: disable idempotency for acks==1

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -71,7 +71,7 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 			case 0:
 				opts = append(opts, kgo.RequiredAcks(kgo.NoAck()), kgo.DisableIdempotentWrite())
 			case 1:
-				opts = append(opts, kgo.RequiredAcks(kgo.LeaderAck()))
+				opts = append(opts, kgo.RequiredAcks(kgo.LeaderAck()), kgo.DisableIdempotentWrite())
 			default:
 				out.Die("invalid acks %d, only -1, 0, and 1 are supported", acks)
 			}


### PR DESCRIPTION
Idempotency was already disabled for acks==0. For some reason I thought
it could work with acks==1, but in franz-go I specifically check and
reject this.

Fixes #2605.