### PR TITLE
k8s:fix values being parsed as scientific notation

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -314,7 +314,7 @@ func (r *ConfigMapResource) createConfiguration(
 
 	// Add arbitrary parameters to configuration
 	for k, v := range r.pandaCluster.Spec.AdditionalConfiguration {
-		err = mgr.Set(k, v, "")
+		err = mgr.Set(k, v, "single")
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/deprecated/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureConfigMap(t *testing.T) {
+	panda := pandaCluster().DeepCopy()
+	panda.Spec.AdditionalConfiguration = map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"}
+	c := fake.NewClientBuilder().Build()
+	cfgRes := resources.NewConfigMap(
+		c,
+		panda,
+		scheme.Scheme,
+		"cluster.local",
+		types.NamespacedName{Name: "test", Namespace: "test"},
+		types.NamespacedName{Name: "test", Namespace: "test"},
+		ctrl.Log.WithName("test"))
+	require.NoError(t, cfgRes.Ensure(context.TODO()))
+
+	actual := &v1.ConfigMap{}
+	err := c.Get(context.Background(), cfgRes.Key(), actual)
+	require.NoError(t, err)
+	data := actual.Data["redpanda.yaml"]
+	require.True(t, strings.Contains(data, "transactional_id_expiration_ms: 25920000000"), fmt.Sprintf("expecting transactional_id_expiration_ms: 25920000000 but got %v", data))
+}


### PR DESCRIPTION
## Cover letter

This boils down to how rpk config manager works. If you don't provide
single, it probably treats it as json and in the end viper when setting
the value, converts it to scientific notation (it does that for certain
numbers). Providing single as format resolved this.

In the end it might be a bug in rpk config manager, worth investigating @0x5d @twmb 

rpk config set has single as default, that's why it works and not in the operator https://github.com/vectorizedio/redpanda/blob/0aea298baeca8cfc162bbc5f52db322137d1131f/src/go/rpk/pkg/cli/cmd/redpanda/config.go#L70

Fixes: #2620

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Fixed a bug with passing redpanda.transactional_id_expiration_ms via additionalConfiguration for k8s operator