### PR TITLE
ducky/availability_test: changed desired producer throughput

### DIFF
--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -12,7 +12,6 @@ import random
 import time
 
 from ducktape.mark.resource import cluster
-from ducktape.mark import ignore
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 from rptest.services.failure_injector import FailureInjector, FailureSpec
@@ -38,7 +37,6 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2568
     @cluster(num_nodes=5)
     def test_availability_when_one_node_failed(self):
         self.redpanda = RedpandaService(


### PR DESCRIPTION
Changed producer throughput from 1000 rps to 10000 rps. The availability
test failed sometime since we were waiting for to many messages. Limited
throughput plus failures caused producer to fail reaching a desired
number of messages.