### PR TITLE
Revert "cluster: disable unstable parts of test_cluster_rpunit"

### DIFF
--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -23,8 +23,7 @@ set(srcs
     cluster_tests.cc
     metadata_dissemination_test.cc
     notification_latch_test.cc
-    # Disabled for https://github.com/vectorizedio/redpanda/issues/2175
-    # autocreate_test.cc
+    autocreate_test.cc
     controller_state_test.cc
     commands_serialization_test.cc
     topic_table_test.cc
@@ -37,8 +36,7 @@ set(srcs
     controller_api_tests.cc
     decommissioning_tests.cc
     replicas_rebalancing_tests.cc
-    # Disabled for https://github.com/vectorizedio/redpanda/issues/2175
-    # create_partitions_test.cc
+    create_partitions_test.cc
     id_allocator_stm_test.cc
     data_policy_controller_test.cc
     topic_configuration_compat_test.cc)


### PR DESCRIPTION
Re enabled cluster tests that were flaky. Currently the tests should pass.

Fixes: #2175 
