### PR TITLE
txn: use sleep_abortable with abort_source

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -87,7 +87,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
               "waiting for {} to fill leaders cache, retries left: {}",
               model::id_allocator_ntp,
               retries);
-            aborted = !co_await sleep_abortable(delay_ms);
+            aborted = !co_await sleep_abortable(delay_ms, _as);
             continue;
         }
         auto leader = leader_opt.value();
@@ -116,7 +116,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         error = fmt::format("id allocation failed with {}", r.ec);
         vlog(
           clusterlog.trace, "id allocation failed, retries left: {}", retries);
-        aborted = !co_await sleep_abortable(delay_ms);
+        aborted = !co_await sleep_abortable(delay_ms, _as);
     }
 
     if (error) {
@@ -162,7 +162,7 @@ id_allocator_frontend::do_allocate_id(model::timeout_clock::duration timeout) {
         auto delay_ms = _metadata_dissemination_retry_delay_ms;
         auto aborted = false;
         while (!aborted && !shard && 0 < retries--) {
-            aborted = !co_await sleep_abortable(delay_ms);
+            aborted = !co_await sleep_abortable(delay_ms, _as);
             shard = _shard_table.local().shard_for(model::id_allocator_ntp);
         }
 

--- a/src/v/cluster/id_allocator_frontend.h
+++ b/src/v/cluster/id_allocator_frontend.h
@@ -13,6 +13,7 @@
 #include "cluster/types.h"
 #include "rpc/connection_cache.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/sharded.hh>
 
 #include <vector>
@@ -48,7 +49,13 @@ public:
     ss::future<allocate_id_reply>
     allocate_id(model::timeout_clock::duration timeout);
 
+    ss::future<> stop() {
+        _as.request_abort();
+        return ss::make_ready_future<>();
+    }
+
 private:
+    ss::abort_source _as;
     ss::smp_service_group _ssg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -78,7 +78,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
           "waiting for {} to fill metadata cache, retries left: {}",
           ntp,
           retries);
-        aborted = !co_await sleep_abortable(delay_ms);
+        aborted = !co_await sleep_abortable(delay_ms, _as);
         has_metadata = _metadata_cache.local().contains(nt, ntp.tp.partition);
     }
     if (!has_metadata) {
@@ -96,7 +96,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
           "waiting for {} to fill leaders cache, retries left: {}",
           ntp,
           retries);
-        aborted = !co_await sleep_abortable(delay_ms);
+        aborted = !co_await sleep_abortable(delay_ms, _as);
         leader_opt = _leaders.local().get_leader(ntp);
     }
 
@@ -112,7 +112,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
               "can't find {} in the leaders cache, retries left: {}",
               ntp,
               retries);
-            aborted = !co_await sleep_abortable(delay_ms);
+            aborted = !co_await sleep_abortable(delay_ms, _as);
             leader_opt = _leaders.local().get_leader(ntp);
             continue;
         }
@@ -135,7 +135,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
                   "leader', retries left: {}",
                   ntp,
                   retries);
-                aborted = !co_await sleep_abortable(delay_ms);
+                aborted = !co_await sleep_abortable(delay_ms, _as);
                 leader_opt = _leaders.local().get_leader(ntp);
                 continue;
             }
@@ -170,7 +170,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
               ntp,
               leader,
               retries);
-            aborted = !co_await sleep_abortable(delay_ms);
+            aborted = !co_await sleep_abortable(delay_ms, _as);
             leader_opt = _leaders.local().get_leader(ntp);
             continue;
         }

--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -17,6 +17,8 @@
 #include "rpc/fwd.h"
 #include "seastarx.h"
 
+#include <seastar/core/abort_source.hh>
+
 namespace cluster {
 
 class rm_partition_frontend {
@@ -53,8 +55,13 @@ public:
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
+    ss::future<> stop() {
+        _as.request_abort();
+        return ss::make_ready_future<>();
+    }
 
 private:
+    ss::abort_source _as;
     ss::smp_service_group _ssg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -65,6 +65,7 @@ public:
     ss::future<> stop();
 
 private:
+    ss::abort_source _as;
     ss::gate _gate;
     ss::smp_service_group _ssg;
     ss::sharded<cluster::partition_manager>& _partition_manager;

--- a/src/v/cluster/tx_helpers.cc
+++ b/src/v/cluster/tx_helpers.cc
@@ -1,12 +1,16 @@
 #include "cluster/tx_helpers.h"
 
+#include "cluster/logger.h"
+#include "vlog.h"
+
 #include <seastar/core/coroutine.hh>
 
 namespace cluster {
 
-ss::future<bool> sleep_abortable(std::chrono::milliseconds dur) {
+ss::future<bool>
+sleep_abortable(std::chrono::milliseconds dur, ss::abort_source& as) {
     try {
-        co_await ss::sleep_abortable(dur);
+        co_await ss::sleep_abortable(dur, as);
         co_return true;
     } catch (const ss::sleep_aborted&) {
         co_return false;

--- a/src/v/cluster/tx_helpers.h
+++ b/src/v/cluster/tx_helpers.h
@@ -5,5 +5,6 @@
 #include <seastar/core/sleep.hh>
 
 namespace cluster {
-ss::future<bool> sleep_abortable(std::chrono::milliseconds dur);
+ss::future<bool>
+sleep_abortable(std::chrono::milliseconds dur, ss::abort_source& as);
 }


### PR DESCRIPTION
ss::sleep_abortable has several overloads: one accepts abort source and another doesn't. Transactional subsystem is the only place where we use the latter and it may explain the #2626 issue.

A client creates a topic and immediately starts a transaction. One of the first steps of a transaction is mark a data partition as a participant (begin_tx). Since it's still fresh the quorum isn't established the call fails with tx_errc::leader_not_found.

Usually when it happens Redpanda logs an error, sleeps and retries the operation.

    TRACE 2021-10-12 18:01:14,081 [shard 2] cluster - rm_partition_frontend.cc:238 - processing name:begin_tx, ntp:{kafka/tx-topic/0}, pid:{producer_identity: id=1, epoch=0}, tx_seq:1
    WARN  2021-10-12 18:01:14,081 [shard 1] cluster - rm_partition_frontend.cc:282 - rm_stm::begin_tx({kafka/tx-topic/0},...) failed with cluster::tx_errc:1

But in this case it fails with

    *** stack smashing detected ***: terminated

I failed to retroduced the problem locally so I instrumented the code to return leader_not_found even when the quorum is ready. It doesn't revealed anything but when I checked the log afer:

    TRACE 2021-10-13 17:31:07,412 [shard 2] cluster - rm_partition_frontend.cc:244 - processing name:begin_tx, ntp:{kafka/topic2/0}, pid:{producer_identity: id=1, epoch=0}, tx_seq:1
    WARN  2021-10-13 17:31:07,412 [shard 1] cluster - rm_partition_frontend.cc:288 - rm_stm::begin_tx({kafka/topic2/0},...) failed with cluster::tx_errc:1
    TRACE 2021-10-13 17:31:07,412 [shard 2] cluster - rm_partition_frontend.cc:137 - local execution of begin_tx({kafka/topic2/0},...) failed with 'not a leader', retries left: 12

I saw the following error:

    TRACE 2021-10-13 17:31:07,732 [shard 2] exception - Throw exception at:
    0x34380f4 0x311187a 0x2a1780e0bda7 0xff6656 0x137f977 0x31b2866 0x3237ece 0x323986b 0x31b5a39 0x320551d 0x31631ff /lib/x86_64-linux-gnu/libpthread.so.0+0x944f /lib/x86_64-linux-gnu/libc.so.6+0x117d52
    TRACE 2021-10-13 17:31:07,732 [shard 2] exception - Throw exception at:
    0x34380f4 0x311187a 0x2a1780e0c1d2 /home/denis/vectorized/redpanda/vbuild/release/clang/rp_deps_install/lib/libc++.so.1+0x47e38 0x31266cf 0x31b2214 0x31b56d7 0x320551d 0x31631ff /lib/x86_64-linux-gnu/libpthread.so.0+0x944f /lib/x86_64-linux-gnu/libc.so.6+0x117d52
       --------
       seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void> seastar::future<void>::handle_exception<seastar::future<void> seastar::sleep_abortable<std::__1::chrono::steady_clock>(std::__1::chrono::steady_clock::duration)::'lambda'(std::exception_ptr)>(std::__1::chrono::steady_clock&&)::'lambda'(std::__1::chrono::steady_clock&&), seastar::futurize<std::__1::chrono::steady_clock>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void> seastar::future<void>::handle_exception<seastar::future<void> seastar::sleep_abortable<std::__1::chrono::steady_clock>(std::__1::chrono::steady_clock::duration)::'lambda'(std::exception_ptr)>(std::__1::chrono::steady_clock&&)::'lambda'(std::__1::chrono::steady_clock&&)>(seastar::future<void> seastar::future<void>::handle_exception<seastar::future<void> seastar::sleep_abortable<std::__1::chrono::steady_clock>(std::__1::chrono::steady_clock::duration)::'lambda'(std::exception_ptr)>(std::__1::chrono::steady_clock&&)::'lambda'(std::__1::chrono::steady_clock&&)&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void> seastar::future<void>::handle_exception<seastar::future<void> seastar::sleep_abortable<std::__1::chrono::steady_clock>(std::__1::chrono::steady_clock::duration)::'lambda'(std::exception_ptr)>(std::__1::chrono::steady_clock&&)::'lambda'(std::__1::chrono::steady_clock&&)&, seastar::future_state<seastar::internal::monostate>&&), void>
       --------
       seastar::internal::coroutine_traits_base<bool>::promise_type
       --------
       seastar::internal::coroutine_traits_base<cluster::begin_tx_reply>::promise_type
       ...

An exception happens inside the seastar, the framework logs it but doesn't re-throw it so the flow isn't affected. It's different from the CI-crush but the location of the error is very suspicious. The hypothesis is that it's the same error which manifests itself in a different form.

What cases this exception?

I played with the code and noticed that the error goes away when the [sleep](https://github.com/vectorizedio/redpanda/blob/f4baa8ae797923081b3aec23e67a0673593a8757/src/v/cluster/rm_partition_frontend.cc#L138) is either commented out or when we use another overload (with an abort_source).

The exception is thrown just after:

    TRACE 2021-10-13 17:31:07,412 [shard 2] cluster - rm_partition_frontend.cc:244 - processing name:begin_tx, ntp:{kafka/topic2/0}, pid:{producer_identity: id=1, epoch=0}, tx_seq:1
    WARN  2021-10-13 17:31:07,412 [shard 1] cluster - rm_partition_frontend.cc:288 - rm_stm::begin_tx({kafka/topic2/0},...) failed with cluster::tx_errc:1
    TRACE 2021-10-13 17:31:07,412 [shard 2] cluster - rm_partition_frontend.cc:137 - local execution of begin_tx({kafka/topic2/0},...) failed with 'not a leader', retries left: 12

It's just one log entry more than the original CI error:

    TRACE 2021-10-12 18:01:14,081 [shard 2] cluster - rm_partition_frontend.cc:238 - processing name:begin_tx, ntp:{kafka/tx-topic/0}, pid:{producer_identity: id=1, epoch=0}, tx_seq:1
    WARN  2021-10-12 18:01:14,081 [shard 1] cluster - rm_partition_frontend.cc:282 - rm_stm::begin_tx({kafka/tx-topic/0},...) failed with cluster::tx_errc:1

I guess that when the crash happens it aborts the process before the last entry gets into the log and it explains the difference. The PR switches to another sleep_abortable overload to avoid the exception.

Is it safe?

Yes, we use that overload all over the codebase.

Does it fix the #2626?

I wasn't able to reproduce the CI failure and validate the fix, but there is a higher chance that we're dealing with the same root cause than with two different problems happening at the same place (CI crush and sleep_abortable log noise).