### PR TITLE
Remove `--node-ami auto` from the Kubernetes external connectivity article

### DIFF
--- a/docs/www/kubernetes-external-connect.md
+++ b/docs/www/kubernetes-external-connect.md
@@ -33,8 +33,7 @@ Create a 3-node cluster on the platform of your choice:
   --node-type m5.xlarge \
   --nodes 3 \
   --nodes-min 1 \
-  --nodes-max 4 \
-  --node-ami auto
+  --nodes-max 4 
   ```
 
   It will take about 10-15 minutes for the process to finish.


### PR DESCRIPTION
Using this command
```
--node-ami auto
```
gives an error
```
Error: invalid AMI "auto" (managedNodeGroups[0].ami)
```

According to [this](https://githubmemory.com/repo/weaveworks/eksctl/issues/4039), this part is no longer required, since auto is the default value.
