### PR TITLE
Set enable_coproc to false in root test fixture

### DIFF
--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -31,6 +31,7 @@ coproc_test_fixture::coproc_test_fixture() {
     ss::smp::invoke_on_all([]() {
         auto& config = config::shard_local_cfg();
         config.get("coproc_offset_flush_interval_ms").set_value(500ms);
+        config.get("enable_coproc").set_value(true);
     }).get0();
     _root_fixture = std::make_unique<redpanda_thread_fixture>();
 }

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -164,7 +164,6 @@ public:
             config.get("enable_pid_file").set_value(false);
             config.get("developer_mode").set_value(true);
             config.get("enable_admin_api").set_value(false);
-            config.get("enable_coproc").set_value(true);
             config.get("join_retry_timeout_ms").set_value(100ms);
             config.get("members_backend_retry_ms").set_value(1000ms);
             config.get("coproc_supervisor_server")


### PR DESCRIPTION
Its not necessary to have `enable_coproc` to `true` in the root fixture. The logs will be polluted with many failures as the system attempts to connect to a wasm engine that will never appear.

Only have this variable set to true in the root coproc test fixture. 