### PR TITLE
cloud_storage: Fix resource cleanup and prefetch

### DIFF
--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -95,6 +95,7 @@ private:
     manifest::key _path;
     retry_chain_node _rtc;
     mutable retry_chain_logger _ctxlog;
+    ss::abort_source _as;
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/raft/log_eviction_stm.h
+++ b/src/v/raft/log_eviction_stm.h
@@ -15,9 +15,9 @@
 #include "seastarx.h"
 #include "storage/types.h"
 
-#include <seastar/core/weak_ptr.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/weak_ptr.hh>
 #include <seastar/util/log.hh>
 
 namespace raft {


### PR DESCRIPTION
## Cover letter

- Fix bug in resource cleanup code (that finds old materialized segments
  and offloads them)
- Fix prefetch bug. The prefetch was performed but the reader didn't
  wait until prefetched segment finishes downloading. The reader started
  new parallel download instead. This problem is fixed by adding a code
  that detects that the segment is already hydrating and waiting until
  the hydration is done (or timeout is reached, in which case the new
  download is started).


## Release notes

N/A