### PR TITLE
ducky: unblocks tx_feature_flag_test

### DIFF
--- a/tests/rptest/tests/tx_feature_flag_test.py
+++ b/tests/rptest/tests/tx_feature_flag_test.py
@@ -23,6 +23,8 @@ class TxFeatureFlagTest(EndToEndTest):
         # it unavailable when one of the nodes is down,
         self.start_redpanda(num_nodes=3,
                             extra_rp_conf={
+                                "transaction_coordinator_replication": 3,
+                                "id_allocator_replication": 3,
                                 "enable_idempotence": True,
                                 "enable_transactions": True,
                                 "default_topic_replications": 1,
@@ -46,6 +48,9 @@ class TxFeatureFlagTest(EndToEndTest):
         for n in self.redpanda.nodes:
             self.redpanda.start_node(n,
                                      override_cfg_params={
+                                         "transaction_coordinator_replication":
+                                         3,
+                                         "id_allocator_replication": 3,
                                          "enable_idempotence": False,
                                          "enable_transactions": False,
                                          "transactional_id_expiration_ms":


### PR DESCRIPTION
A transaction coordinator's topic has replication factor 1 and when a node hosting it crushes redpanda can't process transactional requests anymore leading `tx_feature_flag_test` to fail.

Increasing replication factor of the transactional topics to unblock `tx_feature_flag_test`.

Reproduced #2626 on arm64 and checked that this commit fixes it. The crush is tracked by #2662.