### PR TITLE
redpanda: Fix function_handler allocation problem

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -276,11 +276,11 @@ void admin_server::register_config_routes() {
           return "";
       };
 
-    static ss::httpd::function_handler get_config_handler_f{
+    auto get_config_handler_f = new ss::httpd::function_handler{
       get_config_handler, "json"};
 
     ss::httpd::config_json::get_config.set(
-      _server._routes, &get_config_handler_f);
+      _server._routes, get_config_handler_f);
 
     ss::httpd::config_json::set_log_level.set(
       _server._routes, [this](ss::const_req req) {


### PR DESCRIPTION
## Cover letter

Static object was passed to the ss::httpd::routes object which asusmes
ownership of the passed pointer. That caused an attempt to deallocate it
using 'delete' operator and ASan error.

This commit allocates the function_handler instead of making it static.

Fixes: #2664

## Release notes

N/A