### PR TITLE
rpk: add the ability to print offsets for empty groups

### DIFF
--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -672,10 +672,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twmb/franz-go v1.1.2/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
 github.com/twmb/franz-go v1.1.3-0.20211011202156-c82819093251/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211012005532-1508c3b8fa7d/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211017224045-8e793efaef43/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20210914042331-106aef61b693/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211010181717-11efd498dac5/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211011202237-b9b592ed0719/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211017223218-8f7af361b808/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/go-rbtree v1.0.0/go.mod h1:UlIAI8gu3KRPkXSobZnmJfVwCJgEhD/liWzT5ppzIyc=
 github.com/twmb/tlscfg v1.2.0 h1:WCzLHtmnVJ94+veAO4TLTB1ENx7TPYLkTl4Q6WFF4Vo=
 github.com/twmb/tlscfg v1.2.0/go.mod h1:GameEQddljI+8Es373JfQEBvtI4dCTLKWGJbqT2kErs=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.1.0
 	github.com/twmb/franz-go v1.1.3-0.20211011202156-c82819093251
-	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211012005532-1508c3b8fa7d
-	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211011202237-b9b592ed0719
+	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211017224045-8e793efaef43
+	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211017223218-8f7af361b808
 	github.com/twmb/tlscfg v1.2.0
 	github.com/twmb/types v1.1.6
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -339,12 +339,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/twmb/franz-go v1.1.2/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
 github.com/twmb/franz-go v1.1.3-0.20211011202156-c82819093251 h1:kltd+R1cjGt5crzuj5+nKJldjaqYYXn1gDg1oln2qXc=
 github.com/twmb/franz-go v1.1.3-0.20211011202156-c82819093251/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211012005532-1508c3b8fa7d h1:50Z+EY7lsGvIPLxGWUnr87s+dQbWb1w27nsUpf9hymc=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211012005532-1508c3b8fa7d/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211017224045-8e793efaef43 h1:PHGN84oHs7cNuYlS3fShdxV2jQTv60yZ5fNGmj5guz4=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211017224045-8e793efaef43/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20210914042331-106aef61b693/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211010181717-11efd498dac5/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211011202237-b9b592ed0719 h1:WJuYis+5i5sz1GRfGWt7MDTOHHlt6Tm139FbFAvXY98=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211011202237-b9b592ed0719/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211017223218-8f7af361b808 h1:x7OQpMXYB0ch+2vbDxiBk1y2nOHU4t0dM+kbH8CJNXI=
+github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211017223218-8f7af361b808/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/go-rbtree v1.0.0 h1:KxN7dXJ8XaZ4cvmHV1qqXTshxX3EBvX/toG5+UR49Mg=
 github.com/twmb/go-rbtree v1.0.0/go.mod h1:UlIAI8gu3KRPkXSobZnmJfVwCJgEhD/liWzT5ppzIyc=
 github.com/twmb/tlscfg v1.2.0 h1:WCzLHtmnVJ94+veAO4TLTB1ENx7TPYLkTl4Q6WFF4Vo=


### PR DESCRIPTION
If a user is using Redpanda to store committed offsets, but is assigning
partitions outside manually without using consumer groups, then the
group will always be in the empty state.

By pulling in new capabilities from kadm, we can print offsets for these
groups. The only difference is the per-partition lag has no member.

We now print lag for empty groups if the --print-empty (-e) flag is
specified, or if specific groups are asked for individually. The
--print-empty is not the prettiest, flag follows naming conventions of
other commands.

New output example:

```
GROUP        g
COORDINATOR  1
STATE        Empty
BALANCER
MEMBERS      0
TOPIC  PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG     MEMBER-ID  CLIENT-ID  HOST
foo    0          4               128392          128388
foo    1          -               162290          162290
foo    2          -               116938          116938
foo    3          -               127771          127771
foo    4          -               119660          119660
foo    5          -               122214          122214
foo    6          -               79458           79458
foo    7          -               125253          125253
foo    8          -               121137          121137
foo    9          2               112713          112711
foo    10         -               98053           98053
foo    11         5               112741          112736
foo    12         -               103176          103176
foo    13         -               109242          109242
foo    14         1               120808          120807
foo    15         -               104797          104797
foo    16         8               122082          122074
foo    17         -               95447           95447
foo    18         -               114481          114481
foo    19         -               112145          112145
```
