### PR TITLE
Update links to cert-manager docs

### DIFF
--- a/docs/www/quick-start-kubernetes-CN.md
+++ b/docs/www/quick-start-kubernetes-CN.md
@@ -55,8 +55,7 @@ eksctl create cluster \
 --node-type m5.xlarge \
 --nodes 1 \
 --nodes-min 1 \
---nodes-max 4 \
---node-ami auto
+--nodes-max 4
 ```
 
 该过程大约需要10-15分钟。

--- a/docs/www/quick-start-kubernetes.md
+++ b/docs/www/quick-start-kubernetes.md
@@ -62,8 +62,7 @@ You can either create a Kubernetes cluster on your local machine or on a cloud p
   --node-type m5.xlarge \
   --nodes 1 \
   --nodes-min 1 \
-  --nodes-max 4 \
-  --node-ami auto
+  --nodes-max 4
   ```
 
   It will take about 10-15 minutes for the process to finish.


### PR DESCRIPTION
Patching cert-manager link to [this one](https://cert-manager.io/docs/installation/verify/#manual-verification)
The other was probably an old link that doesn't work anymore.

Changing eksctl command to adhere 
https://github.com/vectorizedio/redpanda/pull/2650