### PR TITLE
rpk: fix debug info process hanging forever

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -78,6 +78,7 @@ func NewInfoCommand(fs afero.Fs) *cobra.Command {
 
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				ctx, cancel := context.WithTimeout(context.Background(), timeout)
 				defer cancel()
 				if ts, err := kadm.NewClient(cl).ListTopics(ctx); err != nil {


### PR DESCRIPTION
## Cover letter

With the missing `wg.Done()` call the process was hanging forever and
never exited. In cloud, this caused couple of OOMs because we were
starting new debug command every 10 minutes.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
