### PR TITLE
cloud_storage: Fix offset translation bug

### DIFF
--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -34,7 +34,7 @@ public:
         if (
           _partition->cloud_data_available()
           && (_partition->start_offset() > _partition->start_cloud_offset())) {
-            return _partition->start_cloud_offset(); // TODO: translate offset
+            return _partition->start_cloud_offset();
         }
         return _translator->from_log_offset(_partition->start_offset());
     }


### PR DESCRIPTION
## Cover letter

The segments are stored in the map using max_offset as a key. This
enables segment lookups using std::map::lower_bound. The prolem is
that the remote_partition deals with kafka offsets, and expects
log_reader_config.start_offset to be a kafka offset. To search segments
using kafka offsets we store kafka max_offset. But because we can
only translate base_offset precisely, max_offset is not precise.
Instead of that max_offset is estimated with the guarantee that it
never overshoots (real kafka max_offset is always larger than the one
we use as key).

But there is a part of code that uses precisely translated max_offset
to find segment. This lead to the situation when eviction can't find
the segment that have to be evicted which results in failure.

The commit fixes that among other things.


## Release notes

N/A