### PR TITLE
coproc: disable coproc_fixture_rpunit test

### DIFF
--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -26,5 +26,5 @@ rp_test(
     kafka_api_materialized_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main ${fixture_deps}
-  LABELS coproc
+  LABELS coproc disable_on_ci  # https://github.com/vectorizedio/redpanda/issues/2613
 )


### PR DESCRIPTION


## Cover letter

This is failing about 25% of the time.

Pending https://github.com/vectorizedio/redpanda/issues/2613

## Release notes

None
