### PR TITLE
Dynamic memory usage control for `recovery_stm`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -173,7 +173,23 @@ configuration::configuration()
 
   , min_version(*this, "min_version")
   , max_version(*this, "max_version")
-
+  , raft_max_recovery_memory(
+      *this,
+      "raft_max_recovery_memory",
+      "Max memory that can be used for reads in raft recovery process by "
+      "default 15% of total memory",
+      {.needs_restart = needs_restart::no,
+       .example = "41943040",
+       .visibility = visibility::tunable},
+      std::nullopt,
+      {.min = 32_MiB})
+  , raft_recovery_default_read_size(
+      *this,
+      "raft_recovery_default_read_size",
+      "default size of read issued during raft follower recovery",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      512_KiB,
+      {.min = 128, .max = 5_MiB})
   , use_scheduling_groups(*this, "use_scheduling_groups")
   , enable_admin_api(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -67,6 +67,8 @@ struct configuration final : public config_store {
     property<size_t> raft_heartbeat_disconnect_failures;
     deprecated_property min_version;
     deprecated_property max_version;
+    bounded_property<std::optional<size_t>> raft_max_recovery_memory;
+    bounded_property<size_t> raft_recovery_default_read_size;
     // Kafka
     deprecated_property use_scheduling_groups;
     property<bool> enable_admin_api;

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -33,6 +33,7 @@ v_cc_library(
     append_entries_buffer.cc
     follower_queue.cc
     offset_translator.cc
+    recovery_memory_quota.cc
   DEPS
     v::storage
     raft_rpc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -475,7 +475,7 @@ void consensus::dispatch_recovery(follower_index_metadata& idx) {
     ssx::background
       = ssx::spawn_with_gate_then(_bg, [this, node_id = idx.node_id] {
             auto recovery = std::make_unique<recovery_stm>(
-              this, node_id, _scheduling);
+              this, node_id, _scheduling, _recovery_mem_quota);
             auto ptr = recovery.get();
             return ptr->apply()
               .handle_exception([this, node_id](const std::exception_ptr& e) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -66,7 +66,8 @@ consensus::consensus(
   consensus_client_protocol client,
   consensus::leader_cb_t cb,
   storage::api& storage,
-  std::optional<std::reference_wrapper<recovery_throttle>> recovery_throttle)
+  std::optional<std::reference_wrapper<recovery_throttle>> recovery_throttle,
+  recovery_memory_quota& recovery_mem_quota)
   : _self(nid, initial_cfg.revision_id())
   , _group(group)
   , _jit(std::move(jit))
@@ -95,6 +96,7 @@ consensus::consensus(
       config::shard_local_cfg().raft_heartbeat_disconnect_failures())
   , _storage(storage)
   , _recovery_throttle(recovery_throttle)
+  , _recovery_mem_quota(recovery_mem_quota)
   , _snapshot_mgr(
       std::filesystem::path(_log.config().work_directory()),
       storage::simple_snapshot_manager::default_snapshot_filename,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -26,6 +26,7 @@
 #include "raft/offset_translator.h"
 #include "raft/prevote_stm.h"
 #include "raft/probe.h"
+#include "raft/recovery_memory_quota.h"
 #include "raft/recovery_throttle.h"
 #include "raft/replicate_batcher.h"
 #include "raft/timeout_jitter.h"
@@ -92,7 +93,8 @@ public:
       consensus_client_protocol,
       leader_cb_t,
       storage::api&,
-      std::optional<std::reference_wrapper<recovery_throttle>>);
+      std::optional<std::reference_wrapper<recovery_throttle>>,
+      recovery_memory_quota&);
 
     /// Initial call. Allow for internal state recovery
     ss::future<> start();
@@ -560,6 +562,7 @@ private:
     ss::abort_source _as;
     storage::api& _storage;
     std::optional<std::reference_wrapper<recovery_throttle>> _recovery_throttle;
+    recovery_memory_quota& _recovery_mem_quota;
     storage::simple_snapshot_manager _snapshot_mgr;
     std::optional<storage::snapshot_writer> _snapshot_writer;
     model::offset _last_snapshot_index;

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -14,6 +14,7 @@
 #include "model/metadata.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"
+#include "raft/recovery_memory_quota.h"
 #include "raft/rpc_client_protocol.h"
 #include "raft/types.h"
 #include "storage/fwd.h"
@@ -41,6 +42,7 @@ public:
       ss::scheduling_group raft_scheduling_group,
       std::chrono::milliseconds heartbeat_interval,
       std::chrono::milliseconds heartbeat_timeout,
+      recovery_memory_quota::config_provider_fn recovery_mem_cfg,
       ss::sharded<rpc::connection_cache>& clients,
       ss::sharded<storage::api>& storage,
       ss::sharded<recovery_throttle>&);
@@ -98,6 +100,7 @@ private:
     ss::metrics::metric_groups _metrics;
     storage::api& _storage;
     recovery_throttle& _recovery_throttle;
+    recovery_memory_quota _recovery_mem_quota;
 };
 
 } // namespace raft

--- a/src/v/raft/recovery_memory_quota.cc
+++ b/src/v/raft/recovery_memory_quota.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "raft/recovery_memory_quota.h"
+
+#include "raft/logger.h"
+#include "resource_mgmt/memory_groups.h"
+#include "vlog.h"
+
+#include <seastar/core/memory.hh>
+
+namespace raft {
+
+recovery_memory_quota::recovery_memory_quota(
+  recovery_memory_quota::config_provider_fn config_provider)
+  : _cfg(config_provider())
+  , _current_max_recovery_mem(
+      _cfg.max_recovery_memory().value_or(memory_groups::recovery_max_memory()))
+  , _memory(_current_max_recovery_mem) {
+    _cfg.max_recovery_memory.watch([this] { on_max_memory_changed(); });
+}
+
+ss::future<ss::semaphore_units<>> recovery_memory_quota::acquire_read_memory() {
+    return ss::get_units(
+      _memory,
+      std::min(_current_max_recovery_mem, _cfg.default_read_buffer_size()));
+}
+
+void recovery_memory_quota::on_max_memory_changed() {
+    int64_t new_size = _cfg.max_recovery_memory().value_or(
+      memory_groups::recovery_max_memory());
+
+    vlog(raftlog.info, "max recovery memory changed to {} bytes", new_size);
+
+    int64_t diff = new_size - static_cast<int64_t>(_current_max_recovery_mem);
+    if (diff < 0) {
+        _memory.consume(-diff);
+    } else if (diff > 0) {
+        _memory.signal(diff);
+    }
+    _current_max_recovery_mem = new_size;
+}
+
+} // namespace raft

--- a/src/v/raft/recovery_memory_quota.h
+++ b/src/v/raft/recovery_memory_quota.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "config/property.h"
+#include "seastarx.h"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+namespace raft {
+/**
+ * Thread local memory quota for raft recovery
+ */
+class recovery_memory_quota {
+public:
+    struct configuration {
+        config::binding<std::optional<size_t>> max_recovery_memory;
+        config::binding<size_t> default_read_buffer_size;
+    };
+    using config_provider_fn = ss::noncopyable_function<configuration()>;
+
+    explicit recovery_memory_quota(config_provider_fn);
+
+    ss::future<ss::semaphore_units<>> acquire_read_memory();
+
+private:
+    void on_max_memory_changed();
+
+    configuration _cfg;
+    size_t _current_max_recovery_mem;
+    ss::semaphore _memory;
+};
+
+} // namespace raft

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
@@ -58,6 +59,13 @@ struct mux_state_machine_fixture {
             ss::default_scheduling_group(),
             std::chrono::milliseconds(100),
             std::chrono::milliseconds(2000),
+            [] {
+                return raft::recovery_memory_quota::configuration{
+                  .max_recovery_memory
+                  = config::mock_binding<std::optional<size_t>>(std::nullopt),
+                  .default_read_buffer_size = config::mock_binding(512_KiB),
+                };
+            },
             std::ref(_connections),
             std::ref(_storage),
             std::ref(_recovery_throttle))

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "config/configuration.h"
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -96,7 +97,14 @@ struct raft_node {
       model::cleanup_policy_bitflags cleanup_policy,
       size_t segment_size)
       : broker(std::move(broker))
-      , leader_callback(std::move(l_clb)) {
+      , leader_callback(std::move(l_clb))
+      , recovery_mem_quota([] {
+          return raft::recovery_memory_quota::configuration{
+            .max_recovery_memory = config::mock_binding<std::optional<size_t>>(
+              std::nullopt),
+            .default_read_buffer_size = config::mock_binding(512_KiB),
+          };
+      }) {
         cache.start().get();
 
         storage
@@ -149,7 +157,8 @@ struct raft_node {
           raft::make_rpc_client_protocol(self_id, cache),
           [this](raft::leadership_status st) { leader_callback(st); },
           storage.local(),
-          recovery_throttle.local());
+          recovery_throttle.local(),
+          recovery_mem_quota);
 
         // create connections to initial nodes
         consensus->config().for_each_broker(
@@ -310,6 +319,7 @@ struct raft_node {
     ss::sharded<rpc::connection_cache> cache;
     ss::sharded<net::server> server;
     ss::sharded<test_raft_manager> raft_manager;
+    raft::recovery_memory_quota recovery_mem_quota;
     std::unique_ptr<raft::heartbeat_manager> hbeats;
     consensus_ptr consensus;
     std::unique_ptr<raft::log_eviction_stm> _nop_stm;

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -103,7 +103,14 @@ public:
           raft_heartbeat_interval,
           _consensus_client_protocol,
           self,
-          raft_heartbeat_interval * 20) {}
+          raft_heartbeat_interval * 20)
+      , _recovery_memory_quota([] {
+          return raft::recovery_memory_quota::configuration{
+            .max_recovery_memory = config::mock_binding<std::optional<size_t>>(
+              std::nullopt),
+            .default_read_buffer_size = config::mock_binding(512_KiB),
+          };
+      }) {}
 
     ss::lw_shared_ptr<raft::consensus> consensus_for(raft::group_id) {
         return _consensus;
@@ -144,7 +151,8 @@ public:
                               st.group);
                         },
                         _storage,
-                        std::nullopt);
+                        std::nullopt,
+                        _recovery_memory_quota);
                       return _consensus->start().then(
                         [this] { return _hbeats.register_group(_consensus); });
                   });
@@ -162,6 +170,7 @@ private:
     raft::consensus_client_protocol _consensus_client_protocol;
     storage::api _storage;
     raft::heartbeat_manager _hbeats;
+    raft::recovery_memory_quota _recovery_memory_quota;
     model::ntp _ntp{
       model::ns("master_control_program"),
       model::topic("tron"),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -637,6 +637,15 @@ void application::wire_up_redpanda_services() {
         _scheduling_groups.raft_sg(),
         config::shard_local_cfg().raft_heartbeat_interval_ms(),
         config::shard_local_cfg().raft_heartbeat_timeout_ms(),
+        [] {
+            return raft::recovery_memory_quota::configuration{
+              .max_recovery_memory
+              = config::shard_local_cfg().raft_max_recovery_memory.bind(),
+              .default_read_buffer_size
+              = config::shard_local_cfg()
+                  .raft_recovery_default_read_size.bind(),
+            };
+        },
         std::ref(_connection_cache),
         std::ref(storage),
         std::ref(recovery_throttle))

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -24,7 +24,7 @@ struct memory_groups {
     /// \brief includes raft & all services
     static size_t rpc_total_memory() {
         // 30%
-        return ss::memory::stats().total_memory() * .30;
+        return ss::memory::stats().total_memory() * .20;
     }
 
     /**
@@ -45,5 +45,9 @@ struct memory_groups {
      */
     static size_t chunk_cache_max_memory() {
         return ss::memory::stats().total_memory() * .30; // NOLINT
+    }
+
+    static size_t recovery_max_memory() {
+        return ss::memory::stats().total_memory() * .10;
     }
 };


### PR DESCRIPTION
## Cover letter

Added recovery memory quota to control the max amount of data read during recovery. Using per shard quota allow us to use bigger read chunks without a risk of causing out of memory error when partition number is big.

## Release notes

### Improvements

- faster recovery of partition replicas which are behind the leader