### PR TITLE
docs: Fix broken icon links in rpk commands article

### DIFF
--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -2,6 +2,9 @@
 title: RPK commands
 order: 7
 ---
+<!-- References for links to OS icons -->
+[linux]: https://vectorized.io/images/icon-linux.svg "Available on Linux"
+[mac]: https://vectorized.io/images/icon-mac.svg "Available on Mac"
 
 # What is RPK?
 RPK is a CLI tool that Vectorized created to help you better manage RedPanda.   


### PR DESCRIPTION
## Cover letter

Moves the icon references to the top of the file so they are not accidentally removed and break the icons in the article.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
