### PR TITLE
debug info: return early if not requested to send

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -48,11 +48,15 @@ func NewInfoCommand(fs afero.Fs) *cobra.Command {
 		Aliases: []string{"status"},
 		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
+			if !send {
+				return
+			}
+
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			if !cfg.Rpk.EnableUsageStats && send {
+			if !cfg.Rpk.EnableUsageStats {
 				log.Debug("Usage stats reporting is disabled. To enable, set rpk.enable_usage_stats true")
 				return
 			}


### PR DESCRIPTION
All functionality minus sending metrics has been removed from debug
info. I kept the old conditional (!EnableUsageStats && send), but
restructured the code such that the rest always sent. Thus, if send was
false, we would still try sending.

We now return early if send is false.
