### PR TITLE
rpk container start: publish schema registry port

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -312,7 +312,7 @@ func CreateNode(
 			pPort: []nat.PortBinding{{
 				HostPort: fmt.Sprint(proxyPort),
 			}},
-			pPort: []nat.PortBinding{{
+			sPort: []nat.PortBinding{{
 				HostPort: fmt.Sprint(schemaRegPort),
 			}},
 			metPort: []nat.PortBinding{{


### PR DESCRIPTION
Running `rpk container start` in MacOS does not publish the schema registry port `8081`:
```bash
$ docker container ls
PORTS
9092/tcp, 0.0.0.0:60431->8082/tcp, 0.0.0.0:60430->9093/tcp, 0.0.0.0:60434->9644/tcp, 0.0.0.0:60433->33145/tcp
```
This change fixes a bug that fails to correctly set the schema registry port `sPort` when creating the port bindings.