### PR TITLE
cloud_storage: Fix start_offset handling

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -419,6 +419,9 @@ void remote_partition::gc_stale_materialized_segments() {
 
 model::offset remote_partition::first_uploaded_offset() {
     vlog(_ctxlog.debug, "remote partition first_uploaded_offset");
+    if (_manifest.size() == 0) {
+        return model::offset(0);
+    }
     try {
         if (_first_uploaded_offset) {
             return *_first_uploaded_offset;


### PR DESCRIPTION
## Cover letter


Fix bug in remote_partition that can render shadow indexing unavailable.
It's caused by caching of the model::offset::max() in case when the
manifest is empty.

## Release notes

N/A