### PR TITLE
serde: silence warings about unused result

### DIFF
--- a/src/v/serde/envelope_for_each_field.h
+++ b/src/v/serde/envelope_for_each_field.h
@@ -202,10 +202,12 @@ inline auto envelope_for_each_field(T& t, Fn&& fn) -> std::enable_if_t<
     static_assert(is_envelope_v<std::decay_t<T>>);
     if constexpr (inherits_from_envelope_v<std::decay_t<T>>) {
         std::apply(
-          [&](auto&&... args) { (fn(args) && ...); }, envelope_to_tuple(t));
+          [&](auto&&... args) { (void)(fn(args) && ...); },
+          envelope_to_tuple(t));
     } else {
         std::apply(
-          [&](auto&&... args) { (fn(args) && ...); }, reflection::to_tuple(t));
+          [&](auto&&... args) { (void)(fn(args) && ...); },
+          reflection::to_tuple(t));
     }
 }
 


### PR DESCRIPTION
The version of envelope_for_each_field
that is capable of early return uses (fn(args) && ...)
as a trick to do so because && uses lazy evaluation.

The result is indeed unused. But this is fine here.
Adding "return" prevents the compiler from producing warnings.