### PR TITLE
archival: Upload stability

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -498,8 +498,12 @@ ss::future<> scheduler_service_impl::run_uploads() {
         vlog(_rtclog.debug, "Upload loop aborted (abort requested)");
     } catch (...) {
         vlog(_rtclog.error, "Upload loop error: {}", std::current_exception());
-        throw;
     }
+    // The loop can be stopped by gate or abort_source (if it was waiting inside
+    // sleep_abortable)
+    vassert(
+      _as.abort_requested() || _gate.is_closed(),
+      "Upload loop is not stopped properly");
 }
 
 } // namespace archival::internal


### PR DESCRIPTION
## Cover letter

The archival upload loop invokes different instances of ntp_archiver to
upload segments. If ntp_archiver throws gate_closed_exception the loop
exits because the error handling has a path that for this exception
type. Normally, the gate_closed_exception can be triggered by archival
service itself when it closes. So having different source of this
exception breaks the logic.

As result, when the leadership transfer happens one of the ntp_archiver
instances is stopped and if it's busy at the moment, it can throw
gate_closed_exception. After that the upload loop exits and no more
uploads are triggered on the shard. And because we're no longer able to
evict data which is not uploaded to S3, this eventually leads to crash
(when we run out of disk space).

This commit fixes this problem using two things:
- It adds an assertion to the upload loop which is triggered when the
  loop is exited but the gate or abourt_source of the archival service
are not invoked. This will make redpanda crash in a situation described
above.
- In ntp_archiver the upload no longer throws gate_closed_exception. If
the ntp_archiver is being stopped it won't throw.

## Release notes

N/A