### PR TITLE
Fixed stopping consumer to early in ducktape end to end test

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -110,7 +110,7 @@ class EndToEndTest(Test):
                 if not partition in self.last_consumed_offsets:
                     return False
                 last_commit = self.consumer.last_commit(partition)
-                if not last_commit or last_commit < offset:
+                if not last_commit or last_commit <= offset:
                     return False
             return True
 


### PR DESCRIPTION
Consumer was stopped to early in ducktape end_to_end test leading to
situations in which last message of topic partition wasn't consumed.
Problem was caused by the fact that consumer stop condition incorrectly
compared committed offset with last received offset. Committed offset
stored by consumer is the next offset to fetch i.e. it is equal to
last received offset plus one.