### PR TITLE
k8s/test: add `startKIND: true` to kuttl operator test config

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -1,5 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
+startKIND: true
 kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest


### PR DESCRIPTION
this commit was dropped from #2784. it needs to be merged synchronously with https://github.com/vectorizedio/vtools/pull/304