### PR TITLE
ducky: configure open files limit for ssh logged user

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -43,7 +43,10 @@ RUN apt update && \
       openssh-server \
       python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
-    echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config
+    echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config && \
+    echo 'UsePAM yes' >> /etc/ssh/sshd_config && \
+    echo 'root soft nofile 65535' >> /etc/security/limits.conf && \
+    echo 'root hard nofile 65535' >> /etc/security/limits.conf
 
 # install go
 RUN mkdir -p /usr/local/go/ && \


### PR DESCRIPTION
Ducktape operates on containers through SSH. In order to increase soft
limits for redpanda process (spawned via SSH session) we need to
configure limits for users logged in via SSH.

Fixes: #2321 