### PR TITLE
raft: flush more aggressively in recovery_stm

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -191,8 +191,8 @@ recovery_stm::should_flush(model::offset follower_committed_match_index) const {
      */
 
     const bool is_last_batch = _last_batch_offset == lstats.dirty_offset;
-    const bool follower_has_batches_to_commit
-      = follower_committed_match_index < _ptr->_last_quorum_replicated_index;
+    const bool follower_has_batches_to_commit = follower_committed_match_index
+                                                < _ptr->_flushed_offset;
     const bool last_replicate_with_quorum = _ptr->_last_write_consistency_level
                                             == consistency_level::quorum_ack;
 


### PR DESCRIPTION
Request follower to flush if their committed
index is behind that of the leader, even if
they are not behind the last quorum write.

This helps with situations where the follower
in an acks=1 situation may never end up flushing
explicitly at the raft layer.

Signed-off-by: John Spray <jcs@vectorized.io>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
