### PR TITLE
V21.9.x backport pr2926 v2

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -332,7 +332,7 @@ client::create_consumer(const group_id& group_id, member_id name) {
     return gated_retry_with_mitigation(
              [this, group_id, name, func{std::move(build_request)}]() {
                  return _brokers.any()
-                   .then([func{std::move(func)}](shared_broker_t broker) {
+                   .then([func](shared_broker_t broker) {
                        return broker->dispatch(func());
                    })
                    .then([group_id, name](find_coordinator_response res) {

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -177,9 +177,9 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
         }
     } catch (const ss::gate_closed_exception&) {
         vlog(kclog.debug, "gate_closed_exception");
-    } catch (const std::exception_ptr& ex) {
+    } catch (const std::exception& ex) {
         // TODO(Ben): Probably vassert
-        vlog(kclog.error, "unknown exception");
+        vlog(kclog.error, "unknown exception: {}", ex);
     }
     return ss::make_exception_future(ex);
 }

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -96,10 +96,9 @@ public:
     ss::future<typename std::invoke_result_t<
       Func>::api_type::response_type> dispatch(Func func) {
         return gated_retry_with_mitigation([this, func{std::move(func)}]() {
-            return _brokers.any().then(
-              [func{std::move(func)}](shared_broker_t broker) mutable {
-                  return broker->dispatch(func());
-              });
+            return _brokers.any().then([func](shared_broker_t broker) {
+                return broker->dispatch(func());
+            });
         });
     }
 

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -63,9 +63,6 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
     } catch (const std::exception& ex) {
         vlog(kclog.warn, "std::exception {}", ex);
         error = error_code::unknown_server_error;
-    } catch (const std::exception_ptr&) {
-        vlog(kclog.error, "std::exception_ptr");
-        error = error_code::unknown_server_error;
     }
     fetch_response::partition_response pr{
       .partition_index{tp.partition},

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -59,9 +59,6 @@ make_produce_response(model::partition_id p_id, std::exception_ptr ex) {
     } catch (const std::exception& ex) {
         vlog(kclog.warn, "std::exception {}", ex.what());
         response.error_code = error_code::unknown_server_error;
-    } catch (const std::exception_ptr&) {
-        vlog(kclog.error, "std::exception_ptr");
-        response.error_code = error_code::unknown_server_error;
     }
     return response;
 }

--- a/src/v/kafka/client/retry_with_mitigation.h
+++ b/src/v/kafka/client/retry_with_mitigation.h
@@ -46,7 +46,7 @@ auto retry_with_mitigation(
             [&func, &errFunc, &eptr]() {
                 auto fut = ss::now();
                 if (eptr) {
-                    auto fut = errFunc(eptr).handle_exception(
+                    fut = errFunc(eptr).handle_exception(
                       [](const std::exception_ptr&) {
                           // ignore failed mitigation
                       });

--- a/src/v/kafka/client/retry_with_mitigation.h
+++ b/src/v/kafka/client/retry_with_mitigation.h
@@ -21,6 +21,9 @@ namespace kafka::client {
 /// If the action returns an error, it is retried with a backoff.
 /// There is an attempt to mitigate the error after the backoff and prior
 /// to the retry.
+///
+/// \param func is copied for each iteration
+/// \param errFunc is copied, but held by reference for each iteration
 template<
   typename Func,
   typename ErrFunc,
@@ -37,7 +40,7 @@ auto retry_with_mitigation(
       std::move(errFunc),
       std::exception_ptr(),
       [retries, retry_base_backoff](
-        Func& func, ErrFunc& errFunc, std::exception_ptr& eptr) {
+        const Func& func, ErrFunc& errFunc, std::exception_ptr& eptr) {
           return retry_with_backoff(
             retries,
             [&func, &errFunc, &eptr]() {

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -10,15 +10,15 @@ rp_test(
 
 rp_test(
   UNIT_TEST
-  BINARY_NAME test_kafka_client
+  BINARY_NAME test_kafka_client_single_thread
   SOURCES
     fetch_session.cc
-    partitioners.cc
     produce_batcher.cc
     produce_partition.cc
     retry_with_mitigation.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::kafka_client
+  ARGS "-- -c 1"
   LABELS kafka
 )
 

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -30,6 +30,7 @@ rp_test(
     fetch.cc
     produce.cc
     reconnect.cc
+    retry.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     v::seastar_testing_main

--- a/src/v/kafka/client/test/retry.cc
+++ b/src/v/kafka/client/test/retry.cc
@@ -1,0 +1,51 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/client.h"
+#include "kafka/client/test/fixture.h"
+#include "kafka/client/test/utils.h"
+#include "kafka/protocol/exceptions.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+namespace kc = kafka::client;
+
+inline const model::topic_partition unknown_tp{
+  model::topic{"unknown"}, model::partition_id{0}};
+
+FIXTURE_TEST(test_retry_list_offsets, kafka_client_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(5));
+
+    BOOST_REQUIRE_EXCEPTION(
+      client.list_offsets(unknown_tp).get(),
+      kafka::exception_base,
+      [](kafka::exception_base ex) {
+          return ex.error == kafka::error_code::unknown_topic_or_partition;
+      });
+}
+
+FIXTURE_TEST(test_retry_produce, kafka_client_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(5));
+
+    auto res = client
+                 .produce_record_batch(
+                   unknown_tp, make_batch(model::offset{0}, 12))
+                 .get();
+    BOOST_REQUIRE_EQUAL(
+      res.error_code, kafka::error_code::unknown_topic_or_partition);
+}


### PR DESCRIPTION
## Cover letter

Backport #2926 

Test failures:
* `rptest.tests.wait_for_local_consumer_test` - all configs, this PR seems unrelated.
* `rptest.tests.tx_feature_flag_test` - arm64 - this PR seems unrelated.

## Release notes

kafka/client: Fix retry handling for several operations
