### PR TITLE
Update issue #2879: removing error throwing if less than 1GB

### DIFF
--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -37,7 +37,7 @@ ss::future<> disk(const ss::sstring& path) {
     });
 }
 
-void memory(bool ignore) {
+void memory() {
     static const uint64_t kMinMemory = 1 << 30;
     const auto shard_mem = ss::memory::stats().total_memory();
     if (shard_mem >= kMinMemory) {
@@ -46,9 +46,6 @@ void memory(bool ignore) {
     auto line = fmt::format(
       "Memory: '{}' below recommended: '{}'", shard_mem, kMinMemory);
     checklog.error(line.c_str());
-    if (!ignore) {
-        throw std::runtime_error(line);
-    }
 }
 
 ss::future<> systemd_notify_ready() {

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -51,7 +51,7 @@ static inline void cpu() {
 
 ss::future<> disk(const ss::sstring& path);
 
-void memory(bool ignore);
+void memory();
 
 ss::future<> systemd_raw_message(ss::sstring out);
 


### PR DESCRIPTION
## Cover letter

**Updates**: The user who is not the developer is now not required to use 1GB but recommended.

Fixes: #2879 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]

**1 file:**
_modified:_   src/v/syschecks/syschecks.cc
