### PR TITLE
k8s: fix logger type initialization for superuser

### DIFF
--- a/src/go/k8s/pkg/resources/superusers.go
+++ b/src/go/k8s/pkg/resources/superusers.go
@@ -69,7 +69,9 @@ func NewSuperUsers(
 		username,
 		suffix,
 		logger.WithValues(
-			"Kind", ingressKind(),
+			"Kind", secretKind(),
+			"SecretType", "superuser",
+			"SuperuserSuffix", suffix,
 		),
 	}
 }
@@ -117,4 +119,9 @@ func (r *SuperUsersResource) obj() (k8sclient.Object, error) {
 // Key returns namespace/name object that is used to identify object.
 func (r *SuperUsersResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: resourceNameTrim(r.pandaCluster.Name, r.suffix), Namespace: r.pandaCluster.Namespace}
+}
+
+func secretKind() string {
+	var obj corev1.Secret
+	return obj.Kind
 }


### PR DESCRIPTION
## Cover letter

This is just copy-paste error we made in the past - initializing the logger with incorrect type.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
NONE