### PR TITLE
Fix #3034

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -171,35 +171,6 @@ ss::future<> update_broker_client(
       });
 }
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(topics.size());
-    std::transform(
-      std::cbegin(topics),
-      std::cend(topics),
-      std::back_inserter(results),
-      [error_code](const model::topic_namespace& t) {
-          return topic_result(t, error_code);
-      });
-    return results;
-}
-
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(requests.size());
-    std::transform(
-      requests.cbegin(),
-      requests.cend(),
-      std::back_inserter(results),
-      [error_code](const custom_assignable_topic_configuration& r) {
-          return topic_result(r.cfg.tp_ns, error_code);
-      });
-    return results;
-}
-
 model::broker make_self_broker(const config::node_config& node_cfg) {
     auto kafka_addr = node_cfg.advertised_kafka_api();
     auto rpc_addr = node_cfg.advertised_rpc_api();

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -23,6 +23,7 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <type_traits>
 #include <utility>
 
 namespace config {
@@ -41,29 +42,30 @@ patch<broker_ptr> calculate_changed_brokers(
 /// Creates the same topic_result for all requests
 // clang-format off
 template<typename T>
-CONCEPT(requires requires(const T& req) {
-    { req.tp_ns } -> std::convertible_to<const model::topic_namespace&>;
-})
-// clang-format on
-std::vector<topic_result> create_topic_results(
-  const std::vector<T>& requests, errc error_code) {
+std::vector<topic_result>
+create_topic_results(const std::vector<T>& requests, errc error_code) {
     std::vector<topic_result> results;
     results.reserve(requests.size());
     std::transform(
       std::cbegin(requests),
       std::cend(requests),
       std::back_inserter(results),
-      [error_code](const T& r) { return topic_result(r.tp_ns, error_code); });
+      [error_code](const T& r) {
+          if constexpr (std::is_same_v<T, cluster::non_replicable_topic>)
+              return topic_result(r.name, error_code);
+          else if constexpr (std::is_same_v<T, cluster::topic_configuration> ||
+                   std::is_same_v<T, cluster::topic_properties_update>)
+              return topic_result(r.tp_ns, error_code);
+          else if constexpr (std::is_same_v<T, model::topic_namespace>)
+              return topic_result(r, error_code);
+          else if constexpr (std::is_same_v<T, cluster::custom_assignable_topic_configuration>)
+              return topic_result(r.cfg.tp_ns, error_code);
+          else
+              static_assert(security::details::dependent_false<T>::value, "Unsupported type");
+      });
     return results;
 }
-
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code);
-
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code);
-
+// clang-format on
 ss::future<> update_broker_client(
   model::node_id,
   ss::sharded<rpc::connection_cache>&,

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -22,6 +22,11 @@
             "output_type": "create_topics_reply"
         },
         {
+            "name": "create_non_replicable_topics",
+            "input_type": "create_non_replicable_topics_request",
+            "output_type": "create_topics_reply"
+        },
+        {
             "name": "finish_partition_update",
             "input_type": "finish_partition_update_request",
             "output_type": "finish_partition_update_reply"

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -24,7 +24,7 @@
         {
             "name": "create_non_replicable_topics",
             "input_type": "create_non_replicable_topics_request",
-            "output_type": "create_topics_reply"
+            "output_type": "create_non_replicable_topics_reply"
         },
         {
             "name": "finish_partition_update",

--- a/src/v/cluster/non_replicable_topics_frontend.cc
+++ b/src/v/cluster/non_replicable_topics_frontend.cc
@@ -107,7 +107,7 @@ ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
     }
     if (!todos.empty()) {
         auto f = _topics_frontend.local()
-                   .create_non_replicable_topics(todos, timeout)
+                   .autocreate_non_replicable_topics(todos, timeout)
                    .then(
                      [this](const std::vector<cluster::topic_result>& result) {
                          topic_creation_resolved(result);

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -87,6 +87,20 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
       });
 }
 
+ss::future<create_non_replicable_topics_reply>
+service::create_non_replicable_topics(
+  create_non_replicable_topics_request&& r, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+             get_scheduling_group(),
+             [this, r = std::move(r)]() mutable {
+                 return _topics_frontend.local().create_non_replicable_topics(
+                   std::move(r.topics), rpc::no_timeout);
+             })
+      .then([](std::vector<topic_result> res) {
+          return create_non_replicable_topics_reply{std::move(res)};
+      });
+}
+
 std::pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
 service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
     std::vector<model::topic_metadata> md;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -40,6 +40,9 @@ public:
     virtual ss::future<create_topics_reply>
     create_topics(create_topics_request&&, rpc::streaming_context&) override;
 
+    ss::future<create_non_replicable_topics_reply> create_non_replicable_topics(
+      create_non_replicable_topics_request&&, rpc::streaming_context&) final;
+
     ss::future<configuration_update_reply> update_node_configuration(
       configuration_update_request&&, rpc::streaming_context&) final;
 

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(srcs
     metadata_dissemination_test.cc
     notification_latch_test.cc
     autocreate_test.cc
+    autocreate_non_replicable_test.cc
     controller_state_test.cc
     commands_serialization_test.cc
     topic_table_test.cc

--- a/src/v/cluster/tests/autocreate_non_replicable_test.cc
+++ b/src/v/cluster/tests/autocreate_non_replicable_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/metadata_cache.h"
+#include "cluster/shard_table.h"
+#include "cluster/simple_batch_builder.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+#include <vector>
+
+static const model::ns tp1 = model::ns("tp-1");
+static const model::ns tp2 = model::ns("tp-2");
+static const model::ns tp3 = model::ns("tp-3");
+
+std::vector<cluster::topic_configuration> source_topics_configuration() {
+    return std::vector<cluster::topic_configuration>{
+      cluster::topic_configuration(test_ns, model::topic("test"), 10, 1),
+    };
+}
+
+std::vector<cluster::non_replicable_topic> test_topics() {
+    return std::vector<cluster::non_replicable_topic>{
+      cluster::non_replicable_topic{
+        .source = model::topic_namespace{test_ns, model::topic("test")},
+        .name = model::topic_namespace{tp1, model::topic("tp-1")}},
+      cluster::non_replicable_topic{
+        .source = model::topic_namespace{test_ns, model::topic("test")},
+        .name = model::topic_namespace{tp2, model::topic("tp-2")}},
+      cluster::non_replicable_topic{
+        .source = model::topic_namespace{test_ns, model::topic("test")},
+        .name = model::topic_namespace{tp3, model::topic("tp-3")}},
+    };
+}
+
+FIXTURE_TEST(
+  create_single_non_replicable_topic_test_at_current_broker,
+  cluster_test_fixture) {
+    model::node_id id{0};
+    auto app = create_node_application(id);
+    wait_for_controller_leadership(id).get();
+
+    std::vector<cluster::topic_result> sources;
+    bool success = false;
+    while (!success) {
+        sources = app->controller->get_topics_frontend()
+                    .local()
+                    .autocreate_topics(
+                      source_topics_configuration(), std::chrono::seconds(10))
+                    .get0();
+        success = std::all_of(
+          sources.begin(), sources.end(), [](const cluster::topic_result& r) {
+              return r.ec == cluster::errc::success;
+          });
+    }
+
+    std::vector<cluster::topic_result> results;
+    success = false;
+    while (!success) {
+        results = app->controller->get_topics_frontend()
+                    .local()
+                    .autocreate_non_replicable_topics(
+                      test_topics(),
+                      model::timeout_clock::now() + std::chrono::seconds(10))
+                    .get0();
+        success = std::all_of(
+          results.begin(), results.end(), [](const cluster::topic_result& r) {
+              return r.ec == cluster::errc::success;
+          });
+    }
+
+    BOOST_REQUIRE_EQUAL(results.size(), 3);
+}
+
+FIXTURE_TEST(
+  test_autocreate_non_replicable_on_non_leader, cluster_test_fixture) {
+    // root cluster node
+    model::node_id n_1(0);
+    model::node_id n_2(1);
+
+    // first controller
+    auto app_0 = create_node_application(n_1);
+    auto app_1 = create_node_application(n_2);
+
+    wait_for_controller_leadership(n_1).get();
+
+    // Wait for cluster to reach stable state
+    tests::cooperative_spin_wait_with_timeout(10s, [this] {
+        return get_local_cache(model::node_id(0)).all_brokers().size() == 2
+               && get_local_cache(model::node_id(1)).all_brokers().size() == 2;
+    }).get();
+
+    std::vector<cluster::topic_result> sources;
+    bool success = false;
+    while (!success) {
+        sources = app_0->controller->get_topics_frontend()
+                    .local()
+                    .autocreate_topics(
+                      source_topics_configuration(), std::chrono::seconds(10))
+                    .get0();
+        success = std::all_of(
+          sources.begin(), sources.end(), [](const cluster::topic_result& r) {
+              return r.ec == cluster::errc::success;
+          });
+    }
+
+    std::vector<cluster::topic_result> results;
+    success = false;
+    while (!success) {
+        results = app_0->controller->get_topics_frontend()
+                    .local()
+                    .autocreate_non_replicable_topics(
+                      test_topics(),
+                      model::timeout_clock::now() + std::chrono::seconds(10))
+                    .get0();
+        success = std::all_of(
+          results.begin(), results.end(), [](const cluster::topic_result& r) {
+              return r.ec == cluster::errc::success;
+          });
+    }
+}

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -274,7 +274,10 @@ ss::future<std::vector<topic_result>>
 topics_frontend::create_non_replicable_topics(
   std::vector<non_replicable_topic> topics,
   model::timeout_clock::time_point timeout) {
-    vlog(clusterlog.trace, "Create non_replicable topics {}", topics);
+    vlog(
+      clusterlog.trace,
+      "Create non_replicable topics on controller leader {}",
+      topics);
     std::vector<ss::future<topic_result>> futures;
     futures.reserve(topics.size());
 
@@ -297,6 +300,54 @@ topics_frontend::create_non_replicable_topics(
           return ss::make_ready_future<std::vector<topic_result>>(
             std::move(results));
       });
+}
+
+ss::future<std::vector<topic_result>>
+topics_frontend::dispatch_create_non_replicable_to_leader(
+  model::node_id leader,
+  std::vector<non_replicable_topic> topics,
+  model::timeout_clock::duration timeout) {
+    vlog(clusterlog.trace, "Dispatching create topics to {}", leader);
+    return _connections.local()
+      .with_node_client<cluster::controller_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        leader,
+        timeout,
+        [topics, timeout](controller_client_protocol cp) mutable {
+            return cp.create_non_replicable_topics(
+              create_non_replicable_topics_request{std::move(topics), timeout},
+              rpc::client_opts(model::timeout_clock::now() + timeout));
+        })
+      .then(&rpc::get_ctx_data<create_topics_reply>)
+      .then([topics = std::move(topics)](result<create_topics_reply> r) {
+          if (r.has_error()) {
+              return create_topic_results(topics, map_errc(r.error()));
+          }
+          return std::move(r.value().results);
+      });
+}
+
+ss::future<std::vector<topic_result>>
+topics_frontend::autocreate_non_replicable_topics(
+  std::vector<non_replicable_topic> topics,
+  model::timeout_clock::time_point timeout) {
+    vlog(clusterlog.trace, "Create non_replicable topics {}", topics);
+
+    auto leader = _leaders.local().get_leader(model::controller_ntp);
+
+    // no leader available
+    if (!leader) {
+        return ss::make_ready_future<std::vector<topic_result>>(
+          create_topic_results(topics, errc::no_leader_controller));
+    }
+    // current node is a leader controller
+    if (leader == _self) {
+        return create_non_replicable_topics(std::move(topics), timeout);
+    }
+    // dispatch to leader
+    return dispatch_create_non_replicable_to_leader(
+      leader.value(), std::move(topics), timeout - model::timeout_clock::now());
 }
 
 topic_result

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -317,10 +317,11 @@ topics_frontend::dispatch_create_non_replicable_to_leader(
         [topics, timeout](controller_client_protocol cp) mutable {
             return cp.create_non_replicable_topics(
               create_non_replicable_topics_request{std::move(topics), timeout},
-              rpc::client_opts(model::timeout_clock::now() + timeout));
+              rpc::client_opts(rpc::no_timeout));
         })
-      .then(&rpc::get_ctx_data<create_topics_reply>)
-      .then([topics = std::move(topics)](result<create_topics_reply> r) {
+      .then(&rpc::get_ctx_data<create_non_replicable_topics_reply>)
+      .then([topics = std::move(topics)](
+              result<create_non_replicable_topics_reply> r) {
           if (r.has_error()) {
               return create_topic_results(topics, map_errc(r.error()));
           }

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -47,6 +47,10 @@ public:
       std::vector<custom_assignable_topic_configuration>,
       model::timeout_clock::time_point);
 
+    ss::future<std::vector<topic_result>> create_non_replicable_topics(
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::time_point timeout);
+
     ss::future<std::vector<topic_result>> delete_topics(
       std::vector<model::topic_namespace>, model::timeout_clock::time_point);
 
@@ -70,7 +74,7 @@ public:
       std::vector<create_partititions_configuration>,
       model::timeout_clock::time_point);
 
-    ss::future<std::vector<topic_result>> create_non_replicable_topics(
+    ss::future<std::vector<topic_result>> autocreate_non_replicable_topics(
       std::vector<non_replicable_topic>, model::timeout_clock::time_point);
 
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
@@ -94,6 +98,13 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
+
+    ss::future<std::vector<topic_result>>
+    dispatch_create_non_replicable_to_leader(
+      model::node_id leader,
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::duration timeout);
+
     ss::future<std::error_code> do_update_data_policy(
       topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -478,6 +478,20 @@ adl<cluster::create_topics_request>::from(iobuf_parser& in) {
     return cluster::create_topics_request{std::move(configs), timeout};
 }
 
+void adl<cluster::create_non_replicable_topics_request>::to(
+  iobuf& out, cluster::create_non_replicable_topics_request&& r) {
+    reflection::serialize(out, std::move(r.topics), r.timeout);
+}
+
+cluster::create_non_replicable_topics_request
+adl<cluster::create_non_replicable_topics_request>::from(iobuf_parser& in) {
+    using underlying_t = std::vector<cluster::non_replicable_topic>;
+    auto topics = adl<underlying_t>().from(in);
+    auto timeout = adl<model::timeout_clock::duration>().from(in);
+    return cluster::create_non_replicable_topics_request{
+      std::move(topics), timeout};
+}
+
 void adl<cluster::create_topics_reply>::to(
   iobuf& out, cluster::create_topics_reply&& r) {
     reflection::serialize(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -32,6 +32,12 @@ namespace cluster {
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
+struct non_replicable_topic {
+    static constexpr int8_t current_version = 1;
+    model::topic_namespace source;
+    model::topic_namespace name;
+};
+
 struct allocate_id_request {
     model::timeout_clock::duration timeout;
 };
@@ -507,6 +513,11 @@ struct create_topics_request {
     model::timeout_clock::duration timeout;
 };
 
+struct create_non_replicable_topics_request {
+    std::vector<non_replicable_topic> topics;
+    model::timeout_clock::duration timeout;
+};
+
 struct create_topics_reply {
     std::vector<topic_result> results;
     std::vector<model::topic_metadata> metadata;
@@ -654,11 +665,6 @@ struct create_data_policy_cmd_data {
     v8_engine::data_policy dp;
 };
 
-struct non_replicable_topic {
-    static constexpr int8_t current_version = 1;
-    model::topic_namespace source;
-    model::topic_namespace name;
-};
 std::ostream& operator<<(std::ostream&, const non_replicable_topic&);
 
 using config_version = named_type<int64_t, struct config_version_type>;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -524,6 +524,10 @@ struct create_topics_reply {
     std::vector<topic_configuration> configs;
 };
 
+struct create_non_replicable_topics_reply {
+    std::vector<topic_result> results;
+};
+
 struct finish_partition_update_request {
     model::ntp ntp;
     std::vector<model::broker_shard> new_replica_set;
@@ -797,6 +801,12 @@ struct adl<cluster::topic_configuration> {
 };
 
 template<>
+struct adl<cluster::non_replicable_topic> {
+    void to(iobuf&, cluster::non_replicable_topic&&);
+    cluster::non_replicable_topic from(iobuf_parser&);
+};
+
+template<>
 struct adl<cluster::join_request> {
     void to(iobuf&, cluster::join_request&&);
     cluster::join_request from(iobuf);
@@ -820,6 +830,13 @@ struct adl<cluster::create_topics_request> {
     void to(iobuf&, cluster::create_topics_request&&);
     cluster::create_topics_request from(iobuf);
     cluster::create_topics_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_non_replicable_topics_request> {
+    void to(iobuf&, cluster::create_non_replicable_topics_request&&);
+    cluster::create_non_replicable_topics_request from(iobuf);
+    cluster::create_non_replicable_topics_request from(iobuf_parser&);
 };
 
 template<>
@@ -885,12 +902,6 @@ template<>
 struct adl<cluster::create_data_policy_cmd_data> {
     void to(iobuf&, cluster::create_data_policy_cmd_data&&);
     cluster::create_data_policy_cmd_data from(iobuf_parser&);
-};
-
-template<>
-struct adl<cluster::non_replicable_topic> {
-    void to(iobuf& out, cluster::non_replicable_topic&&);
-    cluster::non_replicable_topic from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -284,7 +284,7 @@ public:
           .source = std::move(tp_ns_src), .name = std::move(tp_ns)};
         return app.controller->get_topics_frontend()
           .local()
-          .create_non_replicable_topics({std::move(nrt)}, model::no_timeout)
+          .autocreate_non_replicable_topics({std::move(nrt)}, model::no_timeout)
           .then([this](std::vector<cluster::topic_result> results) {
               return wait_for_topics(std::move(results));
           });


### PR DESCRIPTION
When creating a materialized topic check if the node is controller
leader. If not, send a create_non_replicable_topic_request to the
controller leader.

## Cover letter

Previous coproc implementation fails to consider the requirement that only the controller leader can create
new non _replicable topics. This patch implements the logic to check, when trying to create a new
non_replicable topic, if the current node is the controller leader. If not, a create_non_replicable topic_request
will be sent to the controller leader.

I will update unitests later.

Fixes: #3034

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
