### PR TITLE
RFC: Add file-level fault injector, full disk unit test

### DIFF
--- a/src/v/config/fixed.h
+++ b/src/v/config/fixed.h
@@ -1,0 +1,18 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+// compile-time configuration
+namespace config::fixed {
+
+    // Static feature flags: short-term compile-time switches for use while
+    // features mature.
+    constexpr bool file_fail_injection = false;
+}

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -33,6 +33,7 @@ v_cc_library(
     readers_cache.cc
     backlog_controller.cc
     compaction_controller.cc
+    fs_finject.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -70,6 +70,7 @@ void disk_log_appender::release_lock() {
 
 ss::future<ss::stop_iteration>
 disk_log_appender::operator()(model::record_batch& batch) {
+    // TODO push up disk failures to this level, at least
     batch.header().base_offset = _idx;
     batch.header().header_crc = model::internal_header_only_crc(batch.header());
     if (_last_term != batch.term()) {

--- a/src/v/storage/fs_finject.cc
+++ b/src/v/storage/fs_finject.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "fs_finject.h"
+
+#include "seastarx.h"
+#include "storage/logger.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/io_priority_class.hh>
+namespace storage {
+
+thread_local fs_failure_probe fs_finject::_probe = {}; // NOLINT
+using methods = fs_failure_probe::methods;
+
+ss::future<size_t> fs_finject::write_dma(
+  uint64_t pos,
+  const void* buffer,
+  size_t len,
+  const ss::io_priority_class& pc) {
+    return _probe.maybe_inject_failure(methods::write_dma, "write_dma")
+      .then([this, pos, buffer, len, pc]() {
+          return get_file_impl(_file)->write_dma(pos, buffer, len, pc);
+      });
+}
+
+ss::future<size_t> fs_finject::write_dma(
+  uint64_t pos, std::vector<iovec> iov, const ss::io_priority_class& pc) {
+    return _probe.maybe_inject_failure(methods::write_dma, "write_dma")
+      .then([this, pos, iov, pc]() {
+          return get_file_impl(_file)->write_dma(pos, iov, pc);
+      });
+}
+
+ss::future<size_t> fs_finject::read_dma(
+  uint64_t pos, void* buffer, size_t len, const ss::io_priority_class& pc) {
+    return get_file_impl(_file)->read_dma(pos, buffer, len, pc);
+}
+
+ss::future<size_t> fs_finject::read_dma(
+  uint64_t pos, std::vector<iovec> iov, const ss::io_priority_class& pc) {
+    return get_file_impl(_file)->read_dma(pos, iov, pc);
+}
+
+ss::future<> fs_finject::flush() { return get_file_impl(_file)->flush(); }
+
+ss::future<struct stat> fs_finject::stat() {
+    return get_file_impl(_file)->stat();
+}
+
+ss::future<> fs_finject::truncate(uint64_t length) {
+    return get_file_impl(_file)->truncate(length);
+}
+
+ss::future<> fs_finject::discard(uint64_t offset, uint64_t length) {
+    return get_file_impl(_file)->discard(offset, length);
+}
+
+ss::future<int> fs_finject::ioctl(uint64_t cmd, void* argp) noexcept {
+    return get_file_impl(_file)->ioctl(cmd, argp);
+}
+
+ss::future<int> fs_finject::ioctl_short(uint64_t cmd, void* argp) noexcept {
+    return get_file_impl(_file)->ioctl_short(cmd, argp);
+}
+
+ss::future<int> fs_finject::fcntl(int op, uintptr_t arg) noexcept {
+    return get_file_impl(_file)->fcntl(op, arg);
+}
+
+ss::future<int> fs_finject::fcntl_short(int op, uintptr_t arg) noexcept {
+    return get_file_impl(_file)->fcntl_short(op, arg);
+}
+
+ss::future<> fs_finject::allocate(uint64_t pos, uint64_t len) {
+    vlog(stlog.info, "fs_finject hooked allocate()");
+    return _probe.maybe_inject_failure(methods::allocate, "allocate")
+      .then([this, pos, len]() {
+          return get_file_impl(_file)->allocate(pos, len);
+      });
+}
+
+ss::future<uint64_t> fs_finject::size() { return get_file_impl(_file)->size(); }
+
+ss::future<> fs_finject::close() { return get_file_impl(_file)->close(); }
+
+std::unique_ptr<ss::file_handle_impl> fs_finject::dup() {
+    return get_file_impl(_file)->dup();
+}
+
+ss::subscription<ss::directory_entry> fs_finject::list_directory(
+  std::function<ss::future<>(ss::directory_entry de)> next) {
+    return get_file_impl(_file)->list_directory(next);
+}
+
+ss::future<ss::temporary_buffer<uint8_t>> fs_finject::dma_read_bulk(
+  uint64_t offset, size_t range_size, const ss::io_priority_class& pc) {
+    return get_file_impl(_file)->dma_read_bulk(offset, range_size, pc);
+}
+} // namespace storage

--- a/src/v/storage/fs_finject.h
+++ b/src/v/storage/fs_finject.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "failure_probes.h"
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/core/file.hh>
+namespace storage {
+/**
+ * Filesystem-layer, per-file fault injection.
+ */
+class fs_finject : public ss::file_impl {
+public:
+    explicit fs_finject(ss::file to_wrap)
+      : _file(std::move(to_wrap)) {}
+    fs_finject(const fs_finject&) = delete;
+    fs_finject& operator=(const fs_finject&) = delete;
+    fs_finject& operator=(fs_finject&&) = default;
+    fs_finject(fs_finject&& o) = default;
+    ~fs_finject() noexcept override = default;
+
+    ss::future<size_t> write_dma(
+      uint64_t pos,
+      const void* buffer,
+      size_t len,
+      const ss::io_priority_class& pc) final;
+
+    ss::future<size_t> write_dma(
+      uint64_t pos,
+      std::vector<iovec> iov,
+      const ss::io_priority_class& pc) final;
+
+    ss::future<size_t> read_dma(
+      uint64_t pos,
+      void* buffer,
+      size_t len,
+      const ss::io_priority_class& pc) final;
+
+    ss::future<size_t> read_dma(
+      uint64_t pos,
+      std::vector<iovec> iov,
+      const ss::io_priority_class& pc) final;
+
+    // TODO wrap ss::open_file_dma, for failure injection when
+    // ss::open_flags::create is set
+
+    ss::future<> flush() final;
+    ss::future<struct stat> stat() final;
+    ss::future<> truncate(uint64_t length) final;
+    ss::future<> discard(uint64_t offset, uint64_t length) final;
+    ss::future<int> ioctl(uint64_t cmd, void* argp) noexcept final;
+    ss::future<int> ioctl_short(uint64_t cmd, void* argp) noexcept final;
+    ss::future<int> fcntl(int op, uintptr_t arg) noexcept final;
+    ss::future<int> fcntl_short(int op, uintptr_t arg) noexcept final;
+    ss::future<> allocate(uint64_t position, uint64_t length) final;
+    ss::future<uint64_t> size() final;
+    ss::future<> close() final;
+    std::unique_ptr<ss::file_handle_impl> dup() final;
+    ss::subscription<ss::directory_entry> list_directory(
+      std::function<ss::future<>(ss::directory_entry de)> next) final;
+    ss::future<ss::temporary_buffer<uint8_t>> dma_read_bulk(
+      uint64_t offset,
+      size_t range_size,
+      const ss::io_priority_class& pc) final;
+
+    static fs_failure_probe& get_probe() { return _probe; }
+
+private:
+    ss::file _file;
+    static thread_local fs_failure_probe _probe; // NOLINT global for now
+};
+} // namespace storage

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -10,6 +10,7 @@
 #include "storage/segment_appender.h"
 
 #include "config/configuration.h"
+#include "config/fixed.h"
 #include "likely.h"
 #include "storage/chunk_cache.h"
 #include "storage/logger.h"
@@ -367,13 +368,17 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
                 *this);
           }
           // TODO propagate error upward when safe
-          vassert(
-            false,
-            "We failed to fallocate file. This usually means we have ran out "
-            "of disk space. Please check your data partition and ensure you "
-            "have enough space. Error: {} - {}",
-            e,
-            *this);
+          if constexpr(config::fixed::file_fail_injection) {
+            std::rethrow_exception(e);
+          } else {
+              vassert(
+                false,
+                "We failed to fallocate file. This usually means we have ran "
+                "out of disk space. Please check your data partition and "
+                "ensure you have enough space. Error: {} - {}",
+                e,
+                *this);
+          }
       });
 }
 

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -31,7 +31,8 @@ using namespace storage; // NOLINT
     BOOST_REQUIRE_EQUAL_COLLECTIONS(                                           \
       actual.begin(), actual.end(), expected.begin(), expected.end());
 
-static ss::circular_buffer<model::record_batch>
+namespace {
+ss::circular_buffer<model::record_batch>
 copy(ss::circular_buffer<model::record_batch>& input) {
     ss::circular_buffer<model::record_batch> ret;
     ret.reserve(input.size());
@@ -50,6 +51,7 @@ void write(
     }
     seg->flush().get();
 }
+} // namespace
 
 SEASTAR_THREAD_TEST_CASE(test_can_read_single_batch_smaller_offset) {
     disk_log_builder b;


### PR DESCRIPTION
## Cover letter
For #2166, being able to inject "disk full" errors in the write/fallocate path makes possible to test changes with a simple unit test.

I introduce a simple file-level fault injector using Honey Badger, and use it to write a unit test of the current behavior. This required changing "current behavior" on full disk error to throw an exception instead of doing an abort(), which would kill the unit test that should be handling the expected error.

## Release notes
n/a
