### PR TITLE
Fix topic recovery

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -26,8 +26,14 @@ namespace cloud_storage {
 /// It consumes information stored in the manifest.
 class offset_translator final {
 public:
-    offset_translator(model::offset initial_delta)
+    explicit offset_translator(model::offset initial_delta)
       : _initial_delta(initial_delta) {}
+
+    struct stream_stats {
+        model::offset min_offset;
+        model::offset max_offset;
+        uint64_t size_bytes{};
+    };
 
     /// Copy source stream into the destination stream
     ///
@@ -35,7 +41,7 @@ public:
     /// record batch offsets/checksums.
     /// The caller is responsible for patching the segement file name and
     /// passing correct base_offset of the original segment.
-    ss::future<uint64_t> copy_stream(
+    ss::future<stream_stats> copy_stream(
       ss::input_stream<char> src,
       ss::output_stream<char> dst,
       retry_chain_node& fib) const;

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -547,14 +547,14 @@ ss::future<> partition_downloader::download_segment_file(
           localpath.string());
         co_await ss::recursive_touch_directory(part.part_prefix.string());
         auto fs = co_await open_output_file_stream(localpath);
-        auto actual_len = co_await otl.copy_stream(
+        auto stream_stats = co_await otl.copy_stream(
           std::move(in), std::move(fs), _rtcnode);
         vlog(
           _ctxlog.debug,
           "Log segment downloaded. {} bytes expected, {} bytes after "
           "pre-processing.",
           len,
-          actual_len);
+          stream_stats.size_bytes);
         co_return len;
     };
 

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -28,7 +28,7 @@ namespace cloud_storage {
 /// download completion status and the offset of the
 /// last record batch being downloaded.
 struct log_recovery_result {
-    bool completed;
+    bool completed{false};
     model::offset min_kafka_offset;
     model::offset max_kafka_offset;
     cloud_storage::partition_manifest manifest;
@@ -58,7 +58,7 @@ public:
     /// The 'ntp_config' should have corresponding override. If override
     /// is not set nothing will happen and the returned future will be
     /// ready (not in failed state).
-    /// \return download result struct that contains 'log_downloaded=true'
+    /// \return download result struct that contains 'completed=true'
     ///         if actual download happened. The 'last_offset' field will
     ///         be set to max offset of the downloaded log.
     ss::future<log_recovery_result>
@@ -111,17 +111,13 @@ private:
     download_manifest(const remote_manifest_path& path);
 
     struct recovery_material {
-        std::vector<remote_manifest_path> paths;
         topic_manifest topic_manifest;
+        partition_manifest partition_manifest;
     };
 
     /// Locate all data needed to recover single partition
     ss::future<recovery_material>
     find_recovery_material(const remote_manifest_path& key);
-
-    /// Find all candidate partition manifests
-    ss::future<std::vector<remote_manifest_path>>
-    find_matching_partition_manifests(topic_manifest& manifest);
 
     struct offset_range {
         model::offset min_offset;

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -22,6 +22,18 @@
 
 namespace cloud_storage {
 
+/// Log download result
+///
+/// The struct contains information about the
+/// download completion status and the offset of the
+/// last record batch being downloaded.
+struct log_recovery_result {
+    bool completed;
+    model::offset min_kafka_offset;
+    model::offset max_kafka_offset;
+    cloud_storage::partition_manifest manifest;
+};
+
 /// Data recovery provider is used to download topic segments from S3 (or
 /// compatible storage) during topic re-creation process
 class partition_recovery_manager {
@@ -46,8 +58,11 @@ public:
     /// The 'ntp_config' should have corresponding override. If override
     /// is not set nothing will happen and the returned future will be
     /// ready (not in failed state).
-    /// \return true if log was actually downloaded, false otherwise
-    ss::future<bool> download_log(const storage::ntp_config& ntp_cfg);
+    /// \return download result struct that contains 'log_downloaded=true'
+    ///         if actual download happened. The 'last_offset' field will
+    ///         be set to max offset of the downloaded log.
+    ss::future<log_recovery_result>
+    download_log(const storage::ntp_config& ntp_cfg);
 
 private:
     s3::bucket_name _bucket;
@@ -79,12 +94,15 @@ public:
     /// The 'ntp_config' should have corresponding override. If override
     /// is not set nothing will happen and the returned future will be
     /// ready (not in failed state).
-    /// \return true if log was actually downloaded, false otherwise
-    ss::future<bool> download_log();
+    /// \return download result struct that contains 'log_completed=true'
+    ///         if actual download happened. The 'last_offset' field will
+    ///         be set to max offset of the downloaded log.
+    ss::future<log_recovery_result> download_log();
 
 private:
     /// Download full log based on manifest data
-    ss::future<> download_log(const remote_manifest_path& key);
+    ss::future<log_recovery_result>
+    download_log(const remote_manifest_path& key);
 
     ss::future<> download_log(
       const partition_manifest& manifest, const std::filesystem::path& prefix);
@@ -105,6 +123,11 @@ private:
     ss::future<std::vector<remote_manifest_path>>
     find_matching_partition_manifests(topic_manifest& manifest);
 
+    struct offset_range {
+        model::offset min_offset;
+        model::offset max_offset;
+    };
+
     /// Represents file path of the downloaded file with
     /// the expected final destination. The caller should move
     /// the file and sync the directory.
@@ -112,6 +135,7 @@ private:
         std::filesystem::path part_prefix;
         std::filesystem::path dest_prefix;
         size_t num_files;
+        offset_range range;
     };
 
     struct segment {
@@ -124,7 +148,7 @@ private:
     /// The downloaded file will have a custom suffix
     /// which has to be changed. The downloaded file path
     /// is returned by the futue.
-    ss::future<>
+    ss::future<offset_range>
     download_segment_file(const segment& segm, const download_part& part);
 
     using offset_map_t = absl::btree_map<model::offset, segment>;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -9,17 +9,26 @@
 
 #include "cluster/partition_manager.h"
 
+#include "cloud_storage/partition_recovery_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
 #include "config/configuration.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
+#include "raft/consensus_utils.h"
+#include "raft/group_configuration.h"
+#include "raft/offset_translator.h"
 #include "raft/rpc_client_protocol.h"
 #include "raft/types.h"
 #include "resource_mgmt/io_priority.h"
+#include "storage/offset_translator_state.h"
+#include "storage/segment_utils.h"
+#include "storage/snapshot.h"
+#include "utils/retry_chain_node.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
@@ -61,13 +70,33 @@ ss::future<consensus_ptr> partition_manager::manage(
   raft::group_id group,
   std::vector<model::broker> initial_nodes) {
     gate_guard guard(_gate);
-    bool logs_recovered = co_await maybe_download_log(ntp_cfg);
+    auto dl_result = co_await maybe_download_log(ntp_cfg);
+    auto [logs_recovered, min_kafka_offset, max_kafka_offset, manifest]
+      = dl_result;
     if (logs_recovered) {
         vlog(
           clusterlog.info,
-          "Log download complete, ntp: {}, rev: {}",
+          "Log download complete, ntp: {}, rev: {}, "
+          "min_kafka_offset: {}, max_kafka_offset: {}",
           ntp_cfg.ntp(),
-          ntp_cfg.get_revision());
+          ntp_cfg.get_revision(),
+          min_kafka_offset,
+          max_kafka_offset);
+
+        // Manifest is not empty since we were able to recovery
+        // some data.
+        vassert(manifest.size() != 0, "Manifest is empty");
+        auto last_segm_it = manifest.rbegin();
+        auto last_included_term = last_segm_it->second.archiver_term;
+
+        co_await raft::details::bootstrap_pre_existing_partition(
+          _storage,
+          ntp_cfg,
+          group,
+          min_kafka_offset,
+          max_kafka_offset,
+          last_included_term,
+          initial_nodes);
     }
     storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
     vlog(
@@ -104,22 +133,36 @@ ss::future<consensus_ptr> partition_manager::manage(
     _manage_watchers.notify(p->ntp(), p);
 
     co_await p->start();
+
+    if (logs_recovered) {
+        // Populate archival snapshot using the generated recovery manifest.
+        // This step is needed to connect the newly created partition with the
+        // data inside the snapshot and to prevent re-uploading of recovered
+        // data.
+        auto timeout = config::shard_local_cfg()
+                         .cloud_storage_segment_upload_timeout_ms.value();
+        auto backoff
+          = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
+        retry_chain_node rtc(timeout, backoff);
+        co_await p->archival_meta_stm()->add_segments(manifest, rtc);
+    }
+
     co_return c;
 }
 
-ss::future<bool>
+ss::future<cloud_storage::log_recovery_result>
 partition_manager::maybe_download_log(storage::ntp_config& ntp_cfg) {
     if (_partition_recovery_mgr.local_is_initialized()) {
         auto res = co_await _partition_recovery_mgr.local().download_log(
           ntp_cfg);
-        co_return res.completed;
+        co_return res;
     }
     vlog(
       clusterlog.debug,
       "Logs can't be downloaded because cloud storage is not configured. "
       "Continue creating {} witout downloading the logs.",
       ntp_cfg);
-    co_return false;
+    co_return cloud_storage::log_recovery_result{};
 }
 
 ss::future<> partition_manager::stop_partitions() {

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -110,8 +110,9 @@ ss::future<consensus_ptr> partition_manager::manage(
 ss::future<bool>
 partition_manager::maybe_download_log(storage::ntp_config& ntp_cfg) {
     if (_partition_recovery_mgr.local_is_initialized()) {
-        co_return co_await _partition_recovery_mgr.local().download_log(
+        auto res = co_await _partition_recovery_mgr.local().download_log(
           ntp_cfg);
+        co_return res.completed;
     }
     vlog(
       clusterlog.debug,

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -170,7 +170,8 @@ private:
     /// In this case this method always returns false.
     /// \param ntp_cfg is an ntp_config instance to recover
     /// \return true if the recovery was invoked, false otherwise
-    ss::future<bool> maybe_download_log(storage::ntp_config& ntp_cfg);
+    ss::future<cloud_storage::log_recovery_result>
+    maybe_download_log(storage::ntp_config& ntp_cfg);
 
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -189,4 +189,20 @@ ss::future<> move_persistent_state(
   ss::shard_id target_shard,
   ss::sharded<storage::api>&);
 
+/// Creates persitent state for pre-existing partition (stored in S3 bucket).
+///
+/// The function is supposed to be called before creating a raft group with the
+/// same group_id. The created group will have 'start_offset' equal to
+/// 'min_rp_offset' and 'highest_known_offset' equal to 'max_rp_offset'.
+/// The function will create the offset translator state in kv-store. The offset
+/// translator state will have the right starting point and delta. It will also
+/// create raft snapshot and raft state in kv-store.
+ss::future<> bootstrap_pre_existing_partition(
+  storage::api& api,
+  const storage::ntp_config& ntp_cfg,
+  raft::group_id group,
+  model::offset min_rp_offset,
+  model::offset max_rp_offset,
+  model::term_id last_included_term,
+  std::vector<model::broker> initial_nodes);
 } // namespace raft::details

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -76,6 +76,15 @@ bytes serialize_kvstore_key(raft::group_id group, kvstore_key_type key_type) {
 
 } // namespace
 
+bytes offset_translator::kvstore_offsetmap_key(raft::group_id group) {
+    return serialize_kvstore_key(group, kvstore_key_type::offsets_map);
+}
+
+bytes offset_translator::kvstore_highest_known_offset_key(
+  raft::group_id group) {
+    return serialize_kvstore_key(group, kvstore_key_type::highest_known_offset);
+}
+
 ss::future<>
 offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
     vassert(
@@ -297,12 +306,11 @@ ss::future<> offset_translator::remove_persistent_state() {
 }
 
 bytes offset_translator::offsets_map_key() const {
-    return serialize_kvstore_key(_group, kvstore_key_type::offsets_map);
+    return kvstore_offsetmap_key(_group);
 }
 
 bytes offset_translator::highest_known_offset_key() const {
-    return serialize_kvstore_key(
-      _group, kvstore_key_type::highest_known_offset);
+    return kvstore_highest_known_offset_key(_group);
 }
 
 ss::future<> offset_translator::maybe_checkpoint() {

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -108,6 +108,12 @@ public:
     bytes offsets_map_key() const;
     bytes highest_known_offset_key() const;
 
+    /// Generate kv-store offset-map key
+    static bytes kvstore_offsetmap_key(raft::group_id group);
+
+    /// Generate kv-store highest-known-offset key
+    static bytes kvstore_highest_known_offset_key(raft::group_id group);
+
 private:
     ss::future<> do_checkpoint();
 

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -332,8 +332,14 @@ class BaseCase:
     def create_initial_topics(self):
         """Create initial set of topics based on class/instance topics variable."""
         for topic in self.topics or []:
-            self._rpk.create_topic(topic.name, topic.partition_count,
-                                   topic.replication_factor)
+            self._rpk.create_topic(
+                topic.name,
+                topic.partition_count,
+                topic.replication_factor,
+                config={
+                    'redpanda.remote.write': 'true',
+                    #'redpanda.remote.read': 'true'
+                })
 
     def generate_baseline(self):
         """Generate initial set of data. The method should be implemented in
@@ -466,6 +472,7 @@ class BaseCase:
             if val:
                 conf[cname] = val
         conf['redpanda.remote.recovery'] = 'true'
+        conf['redpanda.remote.write'] = 'true'
         conf.update(overrides)
         self.logger.info(f"Confg: {conf}")
         self._rpk.create_topic(topic, npart, nrepl, conf)
@@ -1545,7 +1552,6 @@ class TopicRecoveryTest(RedpandaTest):
             time.sleep(20)
             test_case.after_restart_validation()
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_no_data(self):
         """If we're trying to recovery a topic which didn't have any data
@@ -1555,7 +1561,6 @@ class TopicRecoveryTest(RedpandaTest):
                                self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_topic_manifest(self):
         """If we're trying to recovery a topic which didn't have any data
@@ -1565,7 +1570,6 @@ class TopicRecoveryTest(RedpandaTest):
                                          self.rpk, self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_partition(self):
         """Test situation when one of the partition manifests are missing.
@@ -1578,7 +1582,6 @@ class TopicRecoveryTest(RedpandaTest):
                                      self.rpk, self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_segment(self):
         """Test the handling of the missing segment. The segment is
@@ -1588,7 +1591,6 @@ class TopicRecoveryTest(RedpandaTest):
                                    self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_fast1(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1602,7 +1604,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.s3_bucket, self.logger, topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_fast2(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1639,7 +1640,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.s3_bucket, self.logger, topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift1(self):
         """Test handling of situations when the revision of the recovered
@@ -1653,7 +1653,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, 0)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift2(self):
         """Test handling of situations when the revision of the recovered
@@ -1667,7 +1666,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, -1)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift3(self):
         """Test handling of situations when the revision of the recovered
@@ -1681,7 +1679,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, 1)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_size_based_retention(self):
         """Test topic recovery with size based retention policy.
@@ -1697,7 +1694,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention(self):
         """Test topic recovery with time based retention policy.
@@ -1714,7 +1710,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics, False)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention_with_legacy_manifest(self):
         """Test topic recovery with time based retention policy.
@@ -1731,7 +1726,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics, True)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_restore_moved_partition1(self):
         """Test handling of the moved partition (it will have different revision id)."""
@@ -1745,7 +1739,6 @@ class TopicRecoveryTest(RedpandaTest):
                                           self.logger, topics, False)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_restore_moved_partition2(self):
         """Test handling of the moved partition (it will have different revision id)."""


### PR DESCRIPTION
## Cover letter

While the topic-recovery tests was disabled the behaviour of the system changed.
Previously it was enough to just copy log segments with omitted raft-configuration batches and start raft bootstrap. After some point this stopped working due to exception in offset translator.

In order to fix all this this PR
- changes the `partition_recovery_manager` to return all data needed to initialise the snapshots.
- initialises raft snapshot with right offsets before creating a raft group
- initialises raft state in kv-store
- initialises offset translator state in kv-store before creating offset translator
- initialises archival metadata state machine (when the raft group and all state machines are created)

This mechanism can also be used to create fast recovery mode that doesn't downloads any data but creates a partition which is connected to the data in the S3 bucket.

Fixes #3351

## Release notes

* Fix raft bootstrap failure after topic recovery

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.


