### PR TITLE
[v8_engine] Third version of script_dispatcher

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -52,7 +52,7 @@ controller::controller(
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
   ss::sharded<raft::group_manager>& raft_manager,
-  ss::sharded<v8_engine::data_policy_table>& data_policy_table)
+  ss::sharded<v8_engine::api>& v8_api)
   : _config_preload(std::move(config_preload))
   , _connections(ccache)
   , _partition_manager(pm)
@@ -60,7 +60,7 @@ controller::controller(
   , _storage(storage)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state, _partition_leaders)
   , _security_manager(_credentials, _authorizer)
-  , _data_policy_manager(data_policy_table)
+  , _data_policy_manager(v8_api)
   , _raft_manager(raft_manager) {}
 
 ss::future<> controller::wire_up() {

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -40,7 +40,7 @@ public:
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
       ss::sharded<raft::group_manager>&,
-      ss::sharded<v8_engine::data_policy_table>&);
+      ss::sharded<v8_engine::api>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }

--- a/src/v/cluster/data_policy_manager.cc
+++ b/src/v/cluster/data_policy_manager.cc
@@ -13,6 +13,7 @@
 
 #include "cluster/cluster_utils.h"
 #include "cluster/errc.h"
+#include "v8_engine/api.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -25,27 +26,26 @@ namespace cluster {
 namespace {
 
 template<typename Cmd>
-std::error_code do_apply(Cmd cmd, v8_engine::data_policy_table& db) {
+std::error_code do_apply(Cmd cmd, v8_engine::api& v8_api) {
     return ss::visit(
       std::move(cmd),
-      [&db](create_data_policy_cmd cmd) {
-          return db.insert(cmd.key, std::move(cmd.value.dp))
-                   ? std::error_code(errc::success)
-                   : std::error_code(errc::data_policy_already_exists);
+      [&v8_api](const create_data_policy_cmd& cmd) {
+          return v8_api.insert_data_policy(cmd.key, cmd.value.dp);
       },
-      [&db](delete_data_policy_cmd cmd) {
-          return db.erase(cmd.key)
-                   ? std::error_code(errc::success)
-                   : std::error_code(errc::data_policy_not_exists);
+      [&v8_api](const delete_data_policy_cmd& cmd) {
+          return v8_api.remove_data_policy(cmd.key);
       });
 }
 
 template<typename Cmd>
-ss::future<std::error_code> dispatch_updates_to_cores(
-  Cmd cmd, ss::sharded<v8_engine::data_policy_table>& db) {
-    auto res = co_await db.map_reduce0(
-      [cmd](v8_engine::data_policy_table& local_db) {
-          return do_apply(std::move(cmd), local_db);
+ss::future<std::error_code>
+dispatch_updates_to_cores(Cmd cmd, ss::sharded<v8_engine::api>& v8_api) {
+    if (!v8_api.local_is_initialized()) {
+        co_return std::error_code(cluster::errc::data_policy_not_enabled);
+    }
+    auto res = co_await v8_api.map_reduce0(
+      [cmd](v8_engine::api& local_v8_api) {
+          return do_apply(std::move(cmd), local_v8_api);
       },
       std::optional<std::error_code>{},
       [](std::optional<std::error_code> result, std::error_code error_code) {
@@ -69,7 +69,7 @@ ss::future<std::error_code> dispatch_updates_to_cores(
 ss::future<std::error_code>
 data_policy_manager::apply_update(model::record_batch batch) {
     return deserialize(std::move(batch), commands).then([this](auto cmd) {
-        return dispatch_updates_to_cores(std::move(cmd), _dps);
+        return dispatch_updates_to_cores(std::move(cmd), _v8_api);
     });
 }
 

--- a/src/v/cluster/data_policy_manager.h
+++ b/src/v/cluster/data_policy_manager.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "cluster/commands.h"
-#include "v8_engine/data_policy_table.h"
+#include "v8_engine/fwd.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -22,8 +22,8 @@ namespace cluster {
 
 class data_policy_manager {
 public:
-    explicit data_policy_manager(ss::sharded<v8_engine::data_policy_table>& dps)
-      : _dps(dps) {}
+    explicit data_policy_manager(ss::sharded<v8_engine::api>& v8_api)
+      : _v8_api(v8_api) {}
 
     static constexpr auto commands
       = make_commands_list<create_data_policy_cmd, delete_data_policy_cmd>();
@@ -36,7 +36,7 @@ public:
     }
 
 private:
-    ss::sharded<v8_engine::data_policy_table>& _dps;
+    ss::sharded<v8_engine::api>& _v8_api;
 };
 
 } // namespace cluster

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -51,6 +51,7 @@ enum class errc : int16_t {
     partition_configuration_in_joint_mode,
     partition_configuration_leader_config_not_committed,
     partition_configuration_differs,
+    data_policy_not_enabled,
     data_policy_already_exists,
     data_policy_not_exists,
     source_topic_not_exists,
@@ -144,6 +145,8 @@ struct errc_category final : public std::error_category {
             return "Partition configuration wasn't committed on the leader";
         case errc::partition_configuration_differs:
             return "Current and requested partition configuration differs";
+        case errc::data_policy_not_enabled:
+            return "Data-policy is not enabled";
         case errc::data_policy_already_exists:
             return "Data-policy already exists";
         case errc::data_policy_not_exists:

--- a/src/v/cluster/tests/data_policy_controller_test.cc
+++ b/src/v/cluster/tests/data_policy_controller_test.cc
@@ -14,7 +14,7 @@
 #include "model/metadata.h"
 #include "seastarx.h"
 #include "test_utils/fixture.h"
-#include "v8_engine/data_policy.h"
+#include "v8_engine/api.h"
 
 #include <seastar/core/lowres_clock.hh>
 
@@ -29,12 +29,28 @@ FIXTURE_TEST(test_change_data_policy, cluster_test_fixture) {
     model::topic_namespace topic2(test_ns, model::topic("1"));
     model::topic_namespace topic3(test_ns, model::topic("2"));
 
+    auto& v8_api = n1->v8_api.local();
+
     v8_engine::data_policy dp1("1", "2");
     auto res = n1->controller->get_data_policy_frontend()
                  .local()
                  .create_data_policy(
                    topic1, dp1, 3s + model::timeout_clock::now())
                  .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::data_policy_not_exists);
+
+    auto res0 = v8_api.get_data_policy(topic1);
+    BOOST_ASSERT(!res0.has_value());
+
+    std::string name = "2";
+    size_t id(xxhash_64(name.data(), name.size()));
+    iobuf code;
+    v8_api.insert_code(coproc::script_id(id), std::move(code)).get();
+
+    res = n1->controller->get_data_policy_frontend()
+            .local()
+            .create_data_policy(topic1, dp1, 3s + model::timeout_clock::now())
+            .get();
     BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
 
     res = n1->controller->get_data_policy_frontend()
@@ -62,11 +78,13 @@ FIXTURE_TEST(test_change_data_policy, cluster_test_fixture) {
             .get();
     BOOST_REQUIRE_EQUAL(res, cluster::errc::data_policy_not_exists);
 
-    auto dp_table = n1->data_policies.local();
+    auto res1 = v8_api.get_data_policy(topic1);
+    BOOST_ASSERT(res1.has_value());
+    BOOST_REQUIRE_EQUAL(res1.value().function_name(), dp1.function_name());
+    BOOST_REQUIRE_EQUAL(res1.value().script_name(), dp1.script_name());
 
-    BOOST_REQUIRE_EQUAL(dp_table.size(), 1);
-    auto dp = dp_table.get_data_policy(topic1);
-    BOOST_ASSERT(dp.has_value());
-    BOOST_REQUIRE_EQUAL(dp.value().function_name(), dp1.function_name());
-    BOOST_REQUIRE_EQUAL(dp.value().script_name(), dp1.script_name());
+    auto res2 = v8_api.get_data_policy(topic2);
+    BOOST_ASSERT(!res2.has_value());
+    auto res3 = v8_api.get_data_policy(topic3);
+    BOOST_ASSERT(!res3.has_value());
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -120,6 +120,18 @@ configuration::configuration()
       "Interval for which all coprocessor offsets are flushed to disk",
       {.visibility = visibility::tunable},
       300000ms) // five minutes
+  , enable_v8(
+      *this,
+      "enable_v8",
+      "Enable v8 engine for inline transformation or data-policy",
+      required::no,
+      false)
+  , executor_queue_size(
+      *this,
+      "executor_queue_size",
+      "Queue size for waiting tasks in executor",
+      required::no,
+      ss::smp::count)
   , seed_server_meta_topic_partitions(
       *this, "seed_server_meta_topic_partitions")
   , raft_heartbeat_interval_ms(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -54,6 +54,9 @@ struct configuration final : public config_store {
     property<std::size_t> coproc_max_ingest_bytes;
     property<std::size_t> coproc_max_batch_size;
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
+    // V8 stuff
+    property<bool> enable_v8;
+    property<std::size_t> executor_queue_size;
 
     // Raft
     deprecated_property seed_server_meta_topic_partitions;

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -31,7 +31,7 @@ public:
 
     ~api();
 
-    ss::future<> start();
+    ss::future<> start(wasm::event_listener& listener);
 
     ss::future<> stop();
 
@@ -40,8 +40,7 @@ public:
 private:
     net::unresolved_address _engine_addr;
 
-    std::unique_ptr<wasm::event_listener> _listener; /// one instance
-    ss::sharded<pacemaker> _pacemaker;               /// one per core
+    ss::sharded<pacemaker> _pacemaker; /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -14,6 +14,7 @@
 #include "coproc/script_dispatcher.h"
 #include "coproc/wasm_event.h"
 #include "seastarx.h"
+#include "v8_engine/fwd.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -91,6 +92,9 @@ private:
 
 class data_policy_event_handler final : public event_handler {
 public:
+    explicit data_policy_event_handler(ss::sharded<v8_engine::api>& v8_api)
+      : _v8_api(v8_api) {}
+
     ss::future<> start() override;
     ss::future<> stop() override;
 
@@ -105,8 +109,7 @@ public:
     std::optional<iobuf> get_code(std::string_view name);
 
 private:
-    /// Map of known script ids to their code
-    ss::sharded<absl::btree_map<script_id, iobuf>> _scripts;
+    ss::sharded<v8_engine::api>& _v8_api;
 };
 
 } // namespace coproc::wasm

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -65,6 +65,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::partition_configuration_in_joint_mode:
     case cluster::errc::partition_configuration_leader_config_not_committed:
     case cluster::errc::partition_configuration_differs:
+    case cluster::errc::data_policy_not_enabled:
     case cluster::errc::data_policy_already_exists:
     case cluster::errc::data_policy_not_exists:
     case cluster::errc::wating_for_partition_shutdown:

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -24,6 +24,7 @@
 #include "model/validation.h"
 #include "security/acl.h"
 #include "ssx/sformat.h"
+#include "v8_engine/api.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/smp.hh>
@@ -553,13 +554,19 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             // Data-policy property
             ss::sstring property_name = "redpanda.datapolicy";
+            auto& v8_api = ctx.v8_api();
+            std::optional<v8_engine::data_policy> dp;
+            if (v8_api.local_is_initialized()) {
+                dp = v8_api.local().get_data_policy(topic);
+            }
+
             add_topic_config_if_requested(
               resource,
               result,
               property_name,
               v8_engine::data_policy("", ""),
               property_name,
-              ctx.data_policy_table().get_data_policy(topic),
+              dp,
               request.data.include_synonyms,
               &describe_as_string<v8_engine::data_policy>);
 

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -51,7 +51,7 @@ protocol::protocol(
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<coproc::partition_manager>& coproc_partition_manager,
-  ss::sharded<v8_engine::data_policy_table>& data_policy_table,
+  ss::sharded<v8_engine::api>& v8_api,
   std::optional<qdc_monitor::config> qdc_config) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
@@ -73,7 +73,7 @@ protocol::protocol(
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _coproc_partition_manager(coproc_partition_manager)
-  , _data_policy_table(data_policy_table) {
+  , _v8_api(v8_api) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -22,7 +22,7 @@
 #include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "utils/ema.h"
-#include "v8_engine/data_policy_table.h"
+#include "v8_engine/fwd.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
@@ -49,7 +49,7 @@ public:
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<coproc::partition_manager>&,
-      ss::sharded<v8_engine::data_policy_table>&,
+      ss::sharded<v8_engine::api>&,
       std::optional<qdc_monitor::config>) noexcept;
 
     ~protocol() noexcept override = default;
@@ -102,9 +102,9 @@ public:
         return _security_frontend.local();
     }
 
-    v8_engine::data_policy_table& data_policy_table() {
-        return _data_policy_table.local();
-    }
+    // v8_engine::api can be not init. So we need to check it in function when
+    // use this method
+    ss::sharded<v8_engine::api>& v8_api() { return _v8_api; }
 
     void update_produce_latency(std::chrono::steady_clock::duration x) {
         if (_qdc_mon) {
@@ -149,7 +149,7 @@ private:
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     ss::sharded<coproc::partition_manager>& _coproc_partition_manager;
-    ss::sharded<v8_engine::data_policy_table>& _data_policy_table;
+    ss::sharded<v8_engine::api>& _v8_api;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -171,8 +171,8 @@ public:
         return _conn->server().security_frontend();
     }
 
-    v8_engine::data_policy_table& data_policy_table() const {
-        return _conn->server().data_policy_table();
+    ss::sharded<v8_engine::api>& v8_api() const {
+        return _conn->server().v8_api();
     }
 
     security::authorizer& authorizer() { return _conn->server().authorizer(); }

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -69,6 +69,7 @@ v_cc_library(
     v::pandaproxy_rest
     v::pandaproxy_schema_registry
     v::archival
+    v::v8_engine
   )
 
 add_executable(redpanda

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -659,7 +659,7 @@ void application::wire_up_redpanda_services() {
 
     construct_service(cp_partition_manager, std::ref(storage)).get();
 
-    if (coproc_enabled()) {
+    if (coproc_enabled() || v8_enabled()) {
         _wasm_event_listener = std::make_unique<coproc::wasm::event_listener>();
     }
 
@@ -676,6 +676,9 @@ void application::wire_up_redpanda_services() {
             ss::engine().alien(), config::shard_local_cfg().executor_queue_size)
           .get();
         construct_service(v8_api, std::ref(*_v8_executor)).get();
+        _data_policy_handler.emplace(v8_api);
+        _wasm_event_listener->register_handler(
+          coproc::wasm::event_type::data_policy, &_data_policy_handler.value());
     }
 
     // controller

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -687,7 +687,7 @@ void application::wire_up_redpanda_services() {
       shard_table,
       storage,
       std::ref(raft_group_manager),
-      data_policies);
+      v8_api);
 
     controller->wire_up().get0();
     syschecks::systemd_message("Creating kafka metadata cache").get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1189,7 +1189,7 @@ void application::start_redpanda() {
             controller->get_api(),
             tx_gateway_frontend,
             cp_partition_manager,
-            data_policies,
+            v8_api,
             qdc_config);
           s.set_protocol(std::move(proto));
       })

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -31,6 +31,7 @@
 #include "config/node_config.h"
 #include "config/seed_server.h"
 #include "coproc/api.h"
+#include "coproc/event_listener.h"
 #include "coproc/partition_manager.h"
 #include "kafka/client/configuration.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
@@ -658,6 +659,10 @@ void application::wire_up_redpanda_services() {
 
     construct_service(cp_partition_manager, std::ref(storage)).get();
 
+    if (coproc_enabled()) {
+        _wasm_event_listener = std::make_unique<coproc::wasm::event_listener>();
+    }
+
     // Construct v8 stuff
     if (v8_enabled()) {
         syschecks::systemd_message("Creating v8_engine::api").get();
@@ -820,8 +825,19 @@ void application::wire_up_redpanda_services() {
           std::ref(metadata_cache),
           std::ref(partition_manager),
           std::ref(cp_partition_manager));
-        coprocessing->start().get();
+        coprocessing->start(*_wasm_event_listener).get();
     }
+
+    if (_wasm_event_listener.get() != nullptr) {
+        _wasm_event_listener->start().get();
+    }
+
+    // We need to stop event_listener before coproc.
+    _deferred.emplace_back([this] {
+        if (_wasm_event_listener.get() != nullptr) {
+            _wasm_event_listener->stop().get();
+        }
+    });
 
     // metrics and quota management
     syschecks::systemd_message("Adding kafka quota manager").get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -163,6 +163,8 @@ private:
     inline static std::optional<v8_engine::enviroment> _v8_env;
     std::unique_ptr<v8_engine::executor_service> _v8_executor;
 
+    std::unique_ptr<coproc::wasm::event_listener> _wasm_event_listener;
+
     ss::metrics::metric_groups _metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
     // run these first on destruction

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "coproc/event_handler.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
@@ -162,6 +163,7 @@ private:
     // platforme or not?
     inline static std::optional<v8_engine::enviroment> _v8_env;
     std::unique_ptr<v8_engine::executor_service> _v8_executor;
+    std::optional<coproc::wasm::data_policy_event_handler> _data_policy_handler;
 
     std::unique_ptr<coproc::wasm::event_listener> _wasm_event_listener;
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -160,6 +160,7 @@ public:
 
             config.get("enable_pid_file").set_value(false);
             config.get("developer_mode").set_value(true);
+            config.get("enable_v8").set_value(true);
             config.get("enable_admin_api").set_value(false);
             config.get("join_retry_timeout_ms").set_value(100ms);
             config.get("members_backend_retry_ms").set_value(1000ms);

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -102,7 +102,7 @@ public:
           app.controller->get_api(),
           app.tx_gateway_frontend,
           app.cp_partition_manager,
-          app.data_policies,
+          app.v8_api,
           std::nullopt);
     }
 

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME v8_engine
   SRCS
+    api.cc
     environment.cc
     executor.cc
     script.cc

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
     v8_monolith
     absl::node_hash_map
     v::rphashing
-    v::bytes)
+    v::bytes
+    v::model)
 
 add_subdirectory(tests)

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -9,6 +9,8 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v8_monolith
-    v_reflection)
+    absl::node_hash_map
+    v::rphashing
+    v::bytes)
 
 add_subdirectory(tests)

--- a/src/v/v8_engine/api.cc
+++ b/src/v/v8_engine/api.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "v8_engine/api.h"
+
+namespace v8_engine {
+
+ss::future<> api::insert_code(coproc::script_id id, iobuf code) {
+    co_await _executor.insert_or_assign(id, std::move(code));
+}
+
+ss::future<> api::erase_code(coproc::script_id id) {
+    co_await _executor.erase(id);
+}
+
+} // namespace v8_engine

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "v8_engine/data_policy_table.h"
+#include "v8_engine/executor.h"
+#include "v8_engine/script_dispatcher.h"
+
+namespace v8_engine {
+
+// Unit for work with v8_engine stuff
+class api {
+public:
+    explicit api(executor_service& executor)
+      : _executor(executor)
+      , _script_dispatcher(_dp_table, executor) {}
+
+    ss::future<> insert_code(coproc::script_id id, iobuf code);
+    ss::future<> erase_code(coproc::script_id id);
+
+private:
+    executor_service& _executor;
+    data_policy_table _dp_table;
+    script_dispatcher<executor_service> _script_dispatcher;
+};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -26,6 +26,12 @@ public:
     ss::future<> insert_code(coproc::script_id id, iobuf code);
     ss::future<> erase_code(coproc::script_id id);
 
+    std::error_code insert_data_policy(
+      const model::topic_namespace& topic, const data_policy& dp);
+    std::error_code remove_data_policy(const model::topic_namespace& topic);
+    std::optional<data_policy>
+    get_data_policy(const model::topic_namespace& topic);
+
 private:
     executor_service& _executor;
     data_policy_table _dp_table;

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -14,6 +14,8 @@
 #include "v8_engine/executor.h"
 #include "v8_engine/script_dispatcher.h"
 
+#include <seastar/core/shared_ptr.hh>
+
 namespace v8_engine {
 
 // Unit for work with v8_engine stuff
@@ -31,6 +33,11 @@ public:
     std::error_code remove_data_policy(const model::topic_namespace& topic);
     std::optional<data_policy>
     get_data_policy(const model::topic_namespace& topic);
+
+    ss::future<ss::lw_shared_ptr<script>>
+    get_script(const model::topic_namespace& topic) {
+        return _script_dispatcher.get(topic);
+    }
 
 private:
     executor_service& _executor;

--- a/src/v/v8_engine/executor.cc
+++ b/src/v/v8_engine/executor.cc
@@ -148,4 +148,12 @@ void executor::loop() {
     }
 }
 
+ss::future<>
+executor_service::start(ss::alien::instance& instance, int64_t size) {
+    co_await _executor.start_single(
+      std::ref(instance), _core_for_executor_thread, size);
+}
+
+ss::future<> executor_service::stop() { return _executor.stop(); }
+
 } // namespace v8_engine

--- a/src/v/v8_engine/executor.h
+++ b/src/v/v8_engine/executor.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "coproc/types.h"
 #include "seastarx.h"
 #include "utils/concepts-enabled.h"
 #include "utils/gate_guard.h"
@@ -25,6 +26,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/util/later.hh>
 
+#include <absl/container/node_hash_map.h>
 #include <boost/lockfree/spsc_queue.hpp>
 
 #include <atomic>
@@ -251,8 +253,17 @@ public:
           });
     }
 
+    ss::future<> insert_or_assign(coproc::script_id id, iobuf code);
+
+    ss::future<> erase(coproc::script_id id);
+
+    ss::future<std::optional<iobuf>> get_code(std::string_view name);
+
 private:
     ss::sharded<executor> _executor;
+
+    using code_database_t = absl::node_hash_map<coproc::script_id, iobuf>;
+    ss::sharded<code_database_t> _code_database;
 };
 
 } // namespace v8_engine

--- a/src/v/v8_engine/fwd.h
+++ b/src/v/v8_engine/fwd.h
@@ -13,6 +13,9 @@
 
 namespace v8_engine {
 
+class api;
+class enviroment;
+class executor_service;
 class data_policy_table;
 
 } // namespace v8_engine

--- a/src/v/v8_engine/logger.h
+++ b/src/v/v8_engine/logger.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/print.hh>
+#include <seastar/util/log.hh>
+
+namespace v8_engine {
+
+inline ss::logger logger{"v8_engine"};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/script.cc
+++ b/src/v/v8_engine/script.cc
@@ -46,7 +46,7 @@ script::~script() {
     _context.Reset();
 }
 
-void script::compile_script(ss::temporary_buffer<char> js_code) {
+void script::compile_script(iobuf js_code) {
     v8::Locker locker(_isolate.get());
     v8::Isolate::Scope isolate_scope(_isolate.get());
     v8::HandleScope handle_scope(_isolate.get());
@@ -54,12 +54,13 @@ void script::compile_script(ss::temporary_buffer<char> js_code) {
     v8::Local<v8::Context> local_ctx = v8::Context::New(_isolate.get());
     v8::Context::Scope context_scope(local_ctx);
 
-    v8::Local<v8::String> script_code = v8::String::NewFromUtf8(
-                                          _isolate.get(),
-                                          js_code.begin(),
-                                          v8::NewStringType::kNormal,
-                                          js_code.size())
-                                          .ToLocalChecked();
+    auto code = iobuf_const_parser(js_code).read_string(js_code.size_bytes());
+
+    v8::Local<v8::String> script_code
+      = v8::String::NewFromUtf8(
+          _isolate.get(), code.c_str(), v8::NewStringType::kNormal, code.size())
+          .ToLocalChecked();
+
     v8::Local<v8::Script> compiled_script;
     if (!v8::Script::Compile(local_ctx, script_code)
            .ToLocal(&compiled_script)) {

--- a/src/v/v8_engine/script.h
+++ b/src/v/v8_engine/script.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "bytes/iobuf_parser.h"
 #include "seastarx.h"
 #include "units.h"
 #include "v8_engine/environment.h"
@@ -69,10 +70,7 @@ public:
     /// temporary_buffer. Maybe better use iobuf and use non-seastar memory for
     /// data in v8 script. \param executor for compile script
     template<typename Executor>
-    ss::future<> init(
-      ss::sstring name,
-      ss::temporary_buffer<char> js_code,
-      Executor& executor) {
+    ss::future<> init(ss::sstring name, iobuf js_code, Executor& executor) {
         compile_task task(*this, std::move(js_code));
         return add_future_handlers(
                  executor.submit(std::move(task), _first_run_timeout_ms))
@@ -94,7 +92,7 @@ public:
 private:
     // Must be running in executor, because it runs js code
     // in first time for init global vars and e.t.c.
-    void compile_script(ss::temporary_buffer<char> js_code);
+    void compile_script(iobuf js_code);
 
     // Init function from compiled js code.
     void set_function(std::string_view name);
@@ -145,9 +143,8 @@ private:
 
     class task_for_executor {
     public:
-        task_for_executor(script& script, ss::temporary_buffer<char> data)
-          : _script(script)
-          , _data(std::move(data)) {}
+        task_for_executor(script& script)
+          : _script(script) {}
 
         virtual void operator()() = 0;
 
@@ -157,25 +154,32 @@ private:
 
     protected:
         script& _script;
-        ss::temporary_buffer<char> _data;
     };
 
     friend class task_for_executor;
 
     class compile_task : public task_for_executor {
     public:
-        compile_task(script& script, ss::temporary_buffer<char> data)
-          : task_for_executor(script, std::move(data)) {}
+        compile_task(script& script, iobuf data)
+          : task_for_executor(script)
+          , _data(std::move(data)) {}
 
         void operator()() override { _script.compile_script(std::move(_data)); }
+
+    private:
+        iobuf _data;
     };
 
     class run_task : public task_for_executor {
     public:
         run_task(script& script, ss::temporary_buffer<char> data)
-          : task_for_executor(script, std::move(data)) {}
+          : task_for_executor(script)
+          , _data(std::move(data)) {}
 
         void operator()() override { _script.run_internal(std::move(_data)); }
+
+    private:
+        ss::temporary_buffer<char> _data;
     };
 };
 

--- a/src/v/v8_engine/script_dispatcher.h
+++ b/src/v/v8_engine/script_dispatcher.h
@@ -1,0 +1,170 @@
+
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/metadata.h"
+#include "v8_engine/data_policy_table.h"
+#include "v8_engine/logger.h"
+#include "v8_engine/script.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <absl/container/node_hash_map.h>
+
+namespace v8_engine {
+
+// This class implement logic to store v8_engine::script.
+template<typename Executor>
+class script_dispatcher {
+    static constexpr size_t max_heap_size_bytes = 10000;
+    static constexpr size_t run_timeout_ms = 10000;
+
+public:
+    script_dispatcher(data_policy_table& dp_table, Executor& executor)
+      : _dp_table(dp_table)
+      , _executor(executor) {}
+
+    // This method will be ran from fetch request. We need to understand do we
+    // need to compile script or only need to wait compilation and return
+    // pointer to script
+    ss::future<ss::lw_shared_ptr<script>> get(model::topic_namespace topic) {
+        auto it = _scripts.find(topic);
+        if (it != _scripts.end()) {
+            co_return co_await get_internal(it->second);
+        }
+
+        co_return co_await compile(topic);
+    }
+
+    // Only delete script from hash_map and notify waiters about end of
+    // compilation
+    void remove(const model::topic_namespace& topic) {
+        auto it = _scripts.find(topic);
+        if (it != _scripts.end()) {
+            // We need to destory script to signal waiters about removing
+            it->second->destroy();
+            _scripts.erase(it);
+        }
+    }
+
+private:
+    struct script_wrpapper {
+        ss::condition_variable cv;
+        ss::lw_shared_ptr<script> function{nullptr};
+
+        bool is_compiling() { return function.get() == nullptr; }
+
+        // TODO: add stop compilation (Is it possible?))
+        void destroy() {
+            function = nullptr;
+            cv.broadcast();
+        }
+    };
+
+    // Data-policy was deleted if hash_map does not contain script for topic or
+    // pointer from hash_map and our ptr are different
+    bool script_is_deleted(
+      const model::topic_namespace& topic,
+      ss::lw_shared_ptr<script_wrpapper> script_ptr) {
+        auto it = _scripts.find(topic);
+        if (it == _scripts.end()) {
+            return true;
+        }
+
+        return it->second != script_ptr;
+    }
+
+    ss::future<ss::lw_shared_ptr<script>>
+    get_internal(ss::lw_shared_ptr<script_wrpapper> script_ptr) {
+        if (script_ptr->is_compiling()) {
+            co_await script_ptr->cv.wait();
+        }
+
+        // If user delete script it returns nullptr
+        co_return script_ptr->function;
+    }
+
+    ss::future<ss::lw_shared_ptr<script>>
+    compile(model::topic_namespace topic) {
+        auto dp = _dp_table.get_data_policy(topic);
+        if (!dp.has_value()) {
+            co_return nullptr;
+        }
+
+        // Insert information that compilation is starting. After that all
+        // changes for data_policy will be visable. Because we put conditional
+        // variable to script_dispatcher. We can not do any async request
+        // between find for _script and insert.
+        auto new_script_wrapper = ss::make_lw_shared<script_wrpapper>();
+        auto [_, res] = _scripts.emplace(topic, new_script_wrapper);
+        vassert(
+          res,
+          "Can not insert new script wrapper to script_dispatcher for "
+          "topoic({})",
+          topic);
+
+        auto code = co_await _executor.get_code(dp.value().script_name());
+        if (!code.has_value()) {
+            vlog(
+              logger.error,
+              "Can not find js code for dp({}) for topic({})",
+              dp.value(),
+              topic);
+            _scripts.erase(topic);
+            co_return nullptr;
+        }
+
+        auto script_ptr = ss::make_lw_shared<script>(
+          max_heap_size_bytes, run_timeout_ms);
+
+        try {
+            co_await script_ptr->init(
+              dp.value().function_name(), std::move(code.value()), _executor);
+        } catch (const v8_engine::script_exception& ex) {
+            vlog(
+              logger.error,
+              "Error in v8 compilation for dp({}) for topic({}). Error: {}",
+              dp.value(),
+              topic,
+              ex.what());
+            if (!script_is_deleted(topic, new_script_wrapper)) {
+                // Delete information about compilation
+                _scripts.erase(topic);
+            }
+            co_return nullptr;
+        };
+
+        if (script_is_deleted(topic, new_script_wrapper)) {
+            co_return nullptr;
+        }
+
+        new_script_wrapper->function = script_ptr;
+        new_script_wrapper->cv.broadcast();
+
+        co_return script_ptr;
+    }
+
+private:
+    // Hash map from topic to scripts(v8 runtimes). It store compilation
+    // params or shared_ptr to script_wrpapper.
+    absl::
+      node_hash_map<model::topic_namespace, ss::lw_shared_ptr<script_wrpapper>>
+        _scripts;
+
+    // External services to get compilation information
+    data_policy_table& _dp_table;
+    Executor& _executor;
+};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/tests/CMakeLists.txt
+++ b/src/v/v8_engine/tests/CMakeLists.txt
@@ -23,3 +23,17 @@ rp_test(
   ARGS "-- -c 1"
   LABELS v8_engine
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME v8_script_dispatcher
+  SOURCES
+    script_dispatcher_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::v8_engine v::utils
+  INPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/to_upper.js
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/long_compilation.js
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/compile_timeout.js
+  ARGS "-- -c 1"
+  LABELS v8_engine
+)

--- a/src/v/v8_engine/tests/script_dispatcher_test.cc
+++ b/src/v/v8_engine/tests/script_dispatcher_test.cc
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster/errc.h"
+#include "hashing/xx.h"
+#include "model/metadata.h"
+#include "utils/file_io.h"
+#include "v8_engine/api.h"
+#include "v8_engine/data_policy.h"
+#include "v8_engine/environment.h"
+#include "v8_engine/executor.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/algorithm/string/case_conv.hpp>
+
+class executor_wrapper_for_test {
+public:
+    executor_wrapper_for_test() {
+        _executor.start(ss::engine().alien(), ss::smp::count).get();
+    }
+
+    ~executor_wrapper_for_test() { _executor.stop().get(); }
+
+    v8_engine::executor_service& get_executor() { return _executor; }
+
+private:
+    v8_engine::executor_service _executor;
+};
+
+v8_engine::enviroment env;
+
+void insert_code(
+  std::string_view js_file, std::string_view code_name, v8_engine::api& api) {
+    auto js_code = read_fully(js_file).get();
+    size_t id(xxhash_64(code_name.data(), code_name.size()));
+    api.insert_code(coproc::script_id(id), std::move(js_code)).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(simple_test) {
+    executor_wrapper_for_test executor_wrapper;
+    v8_engine::api api(executor_wrapper.get_executor());
+
+    model::topic_namespace topic(model::ns("test"), model::topic("simple"));
+
+    v8_engine::data_policy new_dp("to_upper", "to_upper");
+    insert_code("to_upper.js", new_dp.script_name(), api);
+    BOOST_REQUIRE_EQUAL(
+      api.insert_data_policy(topic, new_dp),
+      std::error_code(cluster::errc::success));
+
+    auto script = api.get_script(topic).get();
+    BOOST_REQUIRE(script.get() != nullptr);
+
+    ss::sstring raw_data = "qwerty";
+    ss::temporary_buffer<char> data(raw_data.data(), raw_data.size());
+    script->run(data.share(), executor_wrapper.get_executor()).get();
+    boost::to_upper(raw_data);
+    auto res = std::string(data.get_write(), data.size());
+    BOOST_REQUIRE_EQUAL(raw_data, res);
+
+    BOOST_REQUIRE_EQUAL(
+      api.remove_data_policy(topic), std::error_code(cluster::errc::success));
+    script = api.get_script(topic).get();
+    BOOST_REQUIRE(script.get() == nullptr);
+}
+
+SEASTAR_THREAD_TEST_CASE(remove_inside_compilation) {
+    executor_wrapper_for_test executor_wrapper;
+    v8_engine::api api(executor_wrapper.get_executor());
+
+    model::topic_namespace topic(model::ns("test"), model::topic("simple"));
+
+    v8_engine::data_policy new_dp("foo", "long_compilation");
+    insert_code("long_compilation.js", new_dp.script_name(), api);
+
+    BOOST_REQUIRE_EQUAL(
+      api.insert_data_policy(topic, new_dp),
+      std::error_code(cluster::errc::success));
+    auto get_script_future = api.get_script(topic);
+    BOOST_REQUIRE_EQUAL(
+      api.remove_data_policy(topic), std::error_code(cluster::errc::success));
+    BOOST_REQUIRE(get_script_future.get().get() == nullptr);
+}
+
+SEASTAR_THREAD_TEST_CASE(error_in_compilation) {
+    executor_wrapper_for_test executor_wrapper;
+    v8_engine::api api(executor_wrapper.get_executor());
+
+    model::topic_namespace topic(model::ns("test"), model::topic("simple"));
+
+    v8_engine::data_policy new_dp("foo", "compile_timeout");
+    insert_code("compile_timeout.js", new_dp.script_name(), api);
+
+    BOOST_REQUIRE_EQUAL(
+      api.insert_data_policy(topic, new_dp),
+      std::error_code(cluster::errc::success));
+
+    auto get_script_future = api.get_script(topic).get();
+    BOOST_REQUIRE(get_script_future.get() == nullptr);
+    // Should try to recompile script;
+    get_script_future = api.get_script(topic).get();
+    BOOST_REQUIRE(get_script_future.get() == nullptr);
+}
+
+SEASTAR_THREAD_TEST_CASE(check_waiting) {
+    executor_wrapper_for_test executor_wrapper;
+    v8_engine::api api(executor_wrapper.get_executor());
+
+    model::topic_namespace topic(model::ns("test"), model::topic("simple"));
+
+    v8_engine::data_policy new_dp("foo", "long_compilation");
+    insert_code("long_compilation.js", new_dp.script_name(), api);
+
+    BOOST_REQUIRE_EQUAL(
+      api.insert_data_policy(topic, new_dp),
+      std::error_code(cluster::errc::success));
+
+    std::vector<ss::future<ss::lw_shared_ptr<v8_engine::script>>> futures;
+    futures.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        futures.emplace_back(api.get_script(topic));
+    }
+
+    ss::when_all_succeed(futures.begin(), futures.end())
+      .then([](std::vector<ss::lw_shared_ptr<v8_engine::script>> res) {
+          for (auto ptr : res) {
+              BOOST_REQUIRE(ptr.get() != nullptr);
+          }
+      })
+      .get();
+    BOOST_REQUIRE_EQUAL(
+      api.remove_data_policy(topic), std::error_code(cluster::errc::success));
+
+    BOOST_REQUIRE_EQUAL(
+      api.insert_data_policy(topic, new_dp),
+      std::error_code(cluster::errc::success));
+
+    futures.clear();
+    futures.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        futures.emplace_back(api.get_script(topic));
+    }
+    BOOST_REQUIRE_EQUAL(
+      api.remove_data_policy(topic), std::error_code(cluster::errc::success));
+
+    ss::when_all_succeed(futures.begin(), futures.end())
+      .then([](std::vector<ss::lw_shared_ptr<v8_engine::script>> res) {
+          for (auto ptr : res) {
+              BOOST_REQUIRE(ptr.get() == nullptr);
+          }
+      })
+      .get();
+}

--- a/src/v/v8_engine/tests/script_test.cc
+++ b/src/v/v8_engine/tests/script_test.cc
@@ -44,7 +44,7 @@ SEASTAR_THREAD_TEST_CASE(to_upper_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("to_upper.js").get();
+    auto js_code = read_fully("to_upper.js").get();
     script.init("to_upper", std::move(js_code), executor_wrapper.get_executor())
       .get();
 
@@ -61,7 +61,7 @@ SEASTAR_THREAD_TEST_CASE(sum_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("sum.js").get();
+    auto js_code = read_fully("sum.js").get();
     script.init("sum", std::move(js_code), executor_wrapper.get_executor())
       .get();
 
@@ -88,8 +88,8 @@ SEASTAR_THREAD_TEST_CASE(exception_in_compile_script_test) {
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
     std::string error_script = "2lkb34poup3q94h";
-    ss::temporary_buffer<char> js_code(
-      error_script.data(), error_script.size());
+    iobuf js_code;
+    js_code.append(error_script.c_str(), error_script.size());
     BOOST_REQUIRE_EXCEPTION(
       script.init("sum", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -106,7 +106,7 @@ SEASTAR_THREAD_TEST_CASE(exception_in_get_script_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("sum.js").get();
+    auto js_code = read_fully("sum.js").get();
     BOOST_REQUIRE_EXCEPTION(
       script.init("foo", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -122,8 +122,7 @@ SEASTAR_THREAD_TEST_CASE(compile_timeout_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code
-      = read_fully_tmpbuf("compile_timeout.js").get();
+    auto js_code = read_fully("compile_timeout.js").get();
     BOOST_REQUIRE_EXCEPTION(
       script.init("foo", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -139,8 +138,7 @@ SEASTAR_THREAD_TEST_CASE(run_timeout_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code
-      = read_fully_tmpbuf("run_timeout.js").get();
+    auto js_code = read_fully("run_timeout.js").get();
     script
       .init("run_timeout", std::move(js_code), executor_wrapper.get_executor())
       .get();

--- a/src/v/v8_engine/tests/scripts/long_compilation.js
+++ b/src/v/v8_engine/tests/scripts/long_compilation.js
@@ -1,0 +1,8 @@
+function sleep(duration) {
+    var now = new Date().getTime();
+    while (new Date().getTime() < now + duration) {}
+}
+
+function foo() {}
+
+sleep(2);

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -10,6 +10,7 @@
 import subprocess
 import socket
 import re
+from enum import Enum
 
 DEFAULT_TIMEOUT = 30
 
@@ -42,6 +43,11 @@ class RpkClusterInfoNode:
     def __init__(self, id, address):
         self.id = id
         self.address = address
+
+
+class CoprocType(Enum):
+    Async = 1,
+    DataPolicy = 2
 
 
 class RpkTool:
@@ -191,11 +197,20 @@ class RpkTool:
         cmd = ["seek", group, "--to-group", to_group]
         self._run_group(cmd)
 
-    def wasm_deploy(self, script, name, description):
+    def wasm_deploy(self,
+                    script,
+                    name,
+                    description,
+                    coproc_type=CoprocType.Async):
+        if coproc_type == CoprocType.Async:
+            type_str = "async"
+        else:
+            type_str = "data-policy"
+
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',
             self._redpanda.brokers(), '--name', name, '--description',
-            description
+            description, '--type', type_str
         ]
         return self._execute(cmd)
 

--- a/tests/rptest/tests/data_policy_scripts/simple.js
+++ b/tests/rptest/tests/data_policy_scripts/simple.js
@@ -1,0 +1,1 @@
+function foo() {}


### PR DESCRIPTION
## Cover letter

New v8_engine services - script_dispatcher and api.
`Api` it the main part of v8_engine. All another services use api to communicate with v8_engine.

* `executor` - is std::thread with spsc queue.
* `executor_service` - is sharded service, which provide some logic to put task from seastar core to `executor`. In v0 it is constructed on 0-core. Each core in apply method run `invoke_on(0...)`.  Also it contains hash_map from script_id to iobuf with code. 
In next iteration logic will be changed. For example each core will have the own executor.
* `data_policy_table` - database for data-policies. It contains mapping from topic to data-policy.
* `script_dispatcher` - the main service which store v8 runtimes for fetch request. `data_policy_fronted` create records in log about data_policy changes. `data_policy_manager` replicates and change script_dispatcher. v8_runtimes need 0,5MB memory, and compilation time can be too long, so we will compile v8 only on `get`. Fetch request will run `get`, creates node with conditional_variable and compiles v8. Another fetch request will be waiting the end of compilation.