### PR TITLE
kafka: drop connections if node is not yet member of cluster

### DIFF
--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -91,6 +91,9 @@ public:
     /// Returns all brokers, returns copy as the content of broker can change
     std::vector<broker_ptr> all_brokers() const;
 
+    /// Indicates whether local node is member of cluster
+    bool am_member() const;
+
     /// Returns all brokers, returns copy as the content of broker can change
     ss::future<std::vector<broker_ptr>> all_alive_brokers() const;
 

--- a/src/v/coproc/tests/partition_movement_tests.cc
+++ b/src/v/coproc/tests/partition_movement_tests.cc
@@ -112,10 +112,13 @@ bool partition_exists_on_node(
 
 FIXTURE_TEST(test_move_topic_across_nodes, coproc_cluster_fixture) {
     const auto n = 3;
+    info("Creating applications");
     for (auto i = 0; i < n; ++i) {
         create_node_application(model::node_id(i));
     }
+    info("Waiting for members");
     wait_for_all_members(5s).get();
+    info("Waiting for controller leadership");
     for (auto i = 0; i < n; ++i) {
         wait_for_controller_leadership(model::node_id(i)).get();
     }
@@ -184,7 +187,7 @@ FIXTURE_TEST(test_move_topic_across_nodes, coproc_cluster_fixture) {
       .node_id = *topic_leader_id, .shard = *origin_shard};
     model::broker_shard new_bs{
       .node_id = model::node_id((*topic_leader_id + 1) % n),
-      .shard = ss::shard_id((*origin_shard + 1) % n)};
+      .shard = (*origin_shard + 1) % ss::smp::count};
 
     info("Old broker_shard {} moving to new broker_shard {}", old_bs, new_bs);
     auto& topics_fe = leader->controller->get_topics_frontend();

--- a/src/v/kafka/server/tests/api_versions_test.cc
+++ b/src/v/kafka/server/tests/api_versions_test.cc
@@ -37,6 +37,7 @@ FIXTURE_TEST(validate_latest_version, redpanda_thread_fixture) {
 #endif
 
 FIXTURE_TEST(validate_v0, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get0();
     auto client = make_kafka_client().get0();
     client.connect().get();
 
@@ -65,6 +66,7 @@ FIXTURE_TEST(validate_v3, redpanda_thread_fixture) {
 #endif
 
 FIXTURE_TEST(unsupported_version, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get0();
     auto client = make_kafka_client().get0();
     client.connect().get();
 

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -18,6 +18,7 @@
 #include <limits>
 
 FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
     auto client = make_kafka_client().get0();
     client.connect().get();
 

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -69,6 +69,7 @@ static kafka::metadata_request no_topics() {
 
 // https://github.com/apache/kafka/blob/8968cdd/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala#L117
 FIXTURE_TEST(test_no_topics_request, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
     // FIXME: Create some topics to make this test meaningfull
     auto req = no_topics();
 
@@ -82,6 +83,7 @@ FIXTURE_TEST(test_no_topics_request, redpanda_thread_fixture) {
 
 // https://github.com/apache/kafka/blob/8968cdd/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala#L52
 FIXTURE_TEST(cluster_id_with_req_v1, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
     auto req = all_topics();
 
     auto client = make_kafka_client().get0();
@@ -96,6 +98,7 @@ FIXTURE_TEST(cluster_id_with_req_v1, redpanda_thread_fixture) {
 // https://app.asana.com/0/1149841353291489/1153248907521420
 FIXTURE_TEST_EXPECTED_FAILURES(
   cluster_id_is_valid, redpanda_thread_fixture, 1) {
+    wait_for_controller_leadership().get();
     auto req = all_topics();
 
     auto client = make_kafka_client().get0();

--- a/src/v/kafka/server/tests/offset_commit_test.cc
+++ b/src/v/kafka/server/tests/offset_commit_test.cc
@@ -19,6 +19,8 @@
 
 FIXTURE_TEST(
   offset_commit_static_membership_not_supported, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+
     auto client = make_kafka_client().get0();
     client.connect().get();
 

--- a/src/v/kafka/server/tests/offset_fetch_test.cc
+++ b/src/v/kafka/server/tests/offset_fetch_test.cc
@@ -18,6 +18,8 @@
 #include <limits>
 
 FIXTURE_TEST(offset_fetch, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get0();
+
     auto client = make_kafka_client().get0();
     client.connect().get();
 

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -44,6 +44,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
                   return pm.get(ntp)->is_leader();
               });
         }).get0();
+        wait_for_controller_leadership().get0();
     }
 
     std::vector<kafka::produce_request::partition> small_batches(size_t count) {


### PR DESCRIPTION
## Cover letter

If a node can't come up with any brokers for internal broken-ness reasons (like being only half-joined to a  cluster) then it should return an error rather than an empty list of brokers.

This is particularly acute in the case of metadata requests, but is also a general issue: we shouldn't really be serving kafka at all until the node is joined to a cluster.    Revising the lifetime of the protocol listener comes later: this is a tactical fix to just drop incoming connections if the node isn't in a ready state.

Related: https://github.com/vectorizedio/redpanda/issues/3289

## Release notes

### Improvements

* If a Redpanda node is sent kafka requests before it has fully joined the cluster, it now returns an error instead of returning potentially incomplete metadata.

