### PR TITLE
k8s: make deploy to use dev tag instead of latest

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,7 +1,7 @@
 
 # Image URL to use all building/pushing image targets
-OPERATOR_IMG_LATEST ?= "vectorized/redpanda-operator:latest"
-CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:latest"
+OPERATOR_IMG_LATEST ?= "vectorized/redpanda-operator:dev"
+CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:dev"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 


### PR DESCRIPTION
## Cover letter

We don't update latest tag for the last 5 months.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->

* none
