### PR TITLE
Introduced per connection gate to control connection life cycle

### DIFF
--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     connection.cc
     server.cc
     probes.cc
+    logger.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -10,8 +10,8 @@
  */
 
 #pragma once
+#include "net/logger.h"
 #include "net/unresolved_address.h"
-#include "rpc/logger.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -52,12 +52,12 @@ public:
     void connection_closed() { --_connections; }
 
     void connection_error(const std::exception_ptr& e) {
-        rpc::rpclog.trace("Connection error: {}", e);
+        logger.trace("Connection error: {}", e);
         ++_connection_errors;
     }
 
     void read_dispatch_error(const std::exception_ptr& e) {
-        rpc::rpclog.error("Error dispatching client reads: {}", e);
+        logger.error("Error dispatching client reads: {}", e);
         ++_read_dispatch_errors;
     }
 

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -44,7 +44,8 @@ void connection::shutdown_input() {
 
 ss::future<> connection::shutdown() {
     _probe.connection_closed();
-    return _out.stop();
+    // wait for all pending requests to finish
+    return _connection_gate.close().then([this] { return _out.stop(); });
 }
 
 ss::future<> connection::write(ss::scattered_message<char> msg) {

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -9,7 +9,7 @@
 
 #include "net/connection.h"
 
-#include "rpc/logger.h"
+#include "net/logger.h"
 
 namespace net {
 
@@ -37,7 +37,7 @@ void connection::shutdown_input() {
         _fd.shutdown_input();
     } catch (...) {
         _probe.connection_close_error();
-        rpc::rpclog.debug(
+        logger.debug(
           "Failed to shutdown connection: {}", std::current_exception());
     }
 }

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -15,6 +15,7 @@
 #include "net/server_probe.h"
 #include "seastarx.h"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
@@ -46,6 +47,7 @@ public:
     ss::future<> write(ss::scattered_message<char> msg);
     ss::future<> shutdown();
     void shutdown_input();
+    ss::gate& gate() { return _connection_gate; }
 
     // NOLINTNEXTLINE
     const ss::socket_address addr;
@@ -56,6 +58,12 @@ private:
     ss::connected_socket _fd;
     ss::input_stream<char> _in;
     net::batched_output_stream _out;
+    /**
+     * connection gate have to be hold until all the connection related writes
+     * are finished, after the gate is released and closed connection output
+     * will be closed
+     */
+    ss::gate _connection_gate;
     server_probe& _probe;
 };
 

--- a/src/v/net/logger.cc
+++ b/src/v/net/logger.cc
@@ -1,0 +1,14 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "net/logger.h"
+
+namespace net {
+ss::logger logger("net");
+} // namespace net

--- a/src/v/net/logger.h
+++ b/src/v/net/logger.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace net {
+extern ss::logger logger;
+} // namespace net

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -11,8 +11,8 @@
 
 #include "config/configuration.h"
 #include "likely.h"
+#include "net/logger.h"
 #include "prometheus/prometheus_sanitize.h"
-#include "rpc/logger.h"
 #include "ssx/sformat.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -82,7 +82,7 @@ static inline void print_exceptional_future(
     }
 
     vlog(
-      rpc::rpclog.error,
+      logger.error,
       "{} - Error[{}] remote address: {} - {}",
       proto->name(),
       ctx,
@@ -139,7 +139,7 @@ ss::future<> server::accept(listener& s) {
                 ar.remote_address,
                 _probe);
               vlog(
-                rpc::rpclog.trace,
+                logger.trace,
                 "{} - Incoming connection from {} on \"{}\"",
                 _proto->name(),
                 ar.remote_address,
@@ -162,16 +162,13 @@ ss::future<> server::accept(listener& s) {
 void server::shutdown_input() {
     ss::sstring proto_name = _proto ? _proto->name() : "protocol not set";
     vlog(
-      rpc::rpclog.info,
-      "{} - Stopping {} listeners",
-      proto_name,
-      _listeners.size());
+      logger.info, "{} - Stopping {} listeners", proto_name, _listeners.size());
     for (auto& l : _listeners) {
         l->socket.abort_accept();
     }
-    vlog(rpc::rpclog.debug, "{} - Service probes {}", proto_name, _probe);
+    vlog(logger.debug, "{} - Service probes {}", proto_name, _probe);
     vlog(
-      rpc::rpclog.info,
+      logger.info,
       "{} - Shutting down {} connections",
       proto_name,
       _connections.size());

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -95,7 +95,7 @@ public:
         server_probe& probe() { return _s->_probe; }
         ss::semaphore& memory() { return _s->_memory; }
         hdr_hist& hist() { return _s->_hist; }
-        ss::gate& conn_gate() { return _s->_conn_gate; }
+        ss::gate& conn_gate() { return conn->gate(); }
         ss::abort_source& abort_source() { return _s->_as; }
         bool abort_requested() const { return _s->_as.abort_requested(); }
 

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -1,7 +1,7 @@
 #include "net/transport.h"
 
 #include "net/dns.h"
-#include "rpc/logger.h"
+#include "net/logger.h"
 #include "vassert.h"
 #include "vlog.h"
 
@@ -17,7 +17,7 @@ ss::future<ss::connected_socket> connect_with_timeout(
     auto f = socket->connect(address).finally([socket] {});
     return ss::with_timeout(timeout, std::move(f))
       .handle_exception([socket, address](const std::exception_ptr& e) {
-          rpc::rpclog.trace("error connecting to {} - {}", address, e);
+          net::logger.trace("error connecting to {} - {}", address, e);
           socket->shutdown();
           return ss::make_exception_future<ss::connected_socket>(e);
       });
@@ -98,7 +98,7 @@ ss::future<> base_transport::stop() {
                 // Closing the output stream can throw bad pipe if
                 // it had unflushed bytes, as we already closed FD.
                 vlog(
-                  rpc::rpclog.debug,
+                  logger.debug,
                   "Exception while stopping transport: {}",
                   std::current_exception());
             }
@@ -116,7 +116,7 @@ void base_transport::shutdown() noexcept {
         }
     } catch (...) {
         vlog(
-          rpc::rpclog.debug,
+          logger.debug,
           "Failed to shutdown transport: {}",
           std::current_exception());
     }

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -74,12 +74,7 @@ send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
     buf.set_correlation_id(ctx->get_header().correlation_id);
 
     auto view = std::move(buf).as_scattered();
-    if (ctx->res.conn_gate().is_closed()) {
-        // do not write if gate is closed
-        rpclog.debug(
-          "Skipping write of {} bytes, connection is closed", view.size());
-        return ss::make_ready_future<>();
-    }
+
     return ctx->res.conn->write(std::move(view))
       .handle_exception([ctx = std::move(ctx)](std::exception_ptr e) {
           vlog(rpclog.info, "Error dispatching method: {}", e);


### PR DESCRIPTION
## Cover letter

Previously in Redpanda `net::server` we used a single gate that controlled life cycle of  all the connections. However when one of the connections input stream is broken or redpanda is shutting down (in other words `protocol::apply` method returns) connection must be closed. In current implementation `connection::shutdown()` member function doesn't wait for all the connection related processing to finish. This may lead to situation in which connection output stream is closed before handler finished processing request and sending a response. This may lead to the situation in which operation was successful but redpanda returned an error or failed to return any answer.

Fixed this problem by introducing a per connection gate that keeps the connection alive until all the pending requests are finished.   

Related: #3277 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
