### PR TITLE
docs: fix typo in data migration doc

### DIFF
--- a/docs/www/data-migration.md
+++ b/docs/www/data-migration.md
@@ -67,8 +67,8 @@ cat << EOF > mm2.properties
 clusters = redpanda1, redpanda2
 
 // Assign IP addresses to the cluster names
-redpanda1.bootstrap.server = <redpanda1_cluster_ip>:9092
-redpanda2.bootstrap.server = <redpanda2_cluster_ip>:9092
+redpanda1.bootstrap.servers = <redpanda1_cluster_ip>:9092
+redpanda2.bootstrap.servers = <redpanda2_cluster_ip>:9092
 
 // Set replication for all topics from Redpanda 1 to Redpanda 2
 redpanda1->redpanda2.enabled = true


### PR DESCRIPTION
Fix config name typo when I tried to execute mirrormaker script.