### PR TITLE
cluster/health: factor out node-local state, make syscall async

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -86,6 +86,7 @@ v_cc_library(
     health_monitor_frontend.cc
     metrics_reporter.cc
     node/types.cc
+    node/local_monitor.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -85,6 +85,7 @@ v_cc_library(
     health_monitor_backend.cc
     health_monitor_frontend.cc
     metrics_reporter.cc
+    node/types.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -605,11 +605,11 @@ health_monitor_backend::collect_topic_status(partitions_filter filters) {
     co_return topics;
 }
 
-std::vector<node_disk_space> health_monitor_backend::get_disk_space() {
+std::vector<node::disk> health_monitor_backend::get_disk_space() {
     auto space_info = std::filesystem::space(
       config::node().data_directory().path);
 
-    return {node_disk_space{
+    return {node::disk{
       .path = config::node().data_directory().as_sstring(),
       .free = space_info.free,
       .total = space_info.capacity,

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -163,7 +163,7 @@ std::optional<node_health_report> health_monitor_backend::build_node_report(
     node_health_report report;
     report.id = id;
 
-    report.local_state.disk_space = it->second.local_state.disk_space;
+    report.local_state.disks = it->second.local_state.disks;
     report.local_state.redpanda_version
       = it->second.local_state.redpanda_version;
     report.local_state.uptime = it->second.local_state.uptime;
@@ -511,7 +511,7 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
     node_health_report ret;
     ret.id = _raft0->self().id();
 
-    ret.local_state.disk_space = get_disk_space();
+    ret.local_state.disks = get_disk_space();
     ret.local_state.redpanda_version = cluster::application_version(
       (std::string)redpanda_version());
 

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -163,9 +163,10 @@ std::optional<node_health_report> health_monitor_backend::build_node_report(
     node_health_report report;
     report.id = id;
 
-    report.disk_space = it->second.disk_space;
-    report.redpanda_version = it->second.redpanda_version;
-    report.uptime = it->second.uptime;
+    report.local_state.disk_space = it->second.local_state.disk_space;
+    report.local_state.redpanda_version
+      = it->second.local_state.redpanda_version;
+    report.local_state.uptime = it->second.local_state.uptime;
 
     if (f.include_partitions) {
         report.topics = filter_topic_status(it->second.topics, f.ntp_filters);
@@ -510,12 +511,13 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
     node_health_report ret;
     ret.id = _raft0->self().id();
 
-    ret.disk_space = get_disk_space();
-    ret.redpanda_version = cluster::application_version(
+    ret.local_state.disk_space = get_disk_space();
+    ret.local_state.redpanda_version = cluster::application_version(
       (std::string)redpanda_version());
 
-    ret.uptime = std::chrono::duration_cast<std::chrono::milliseconds>(
-      ss::engine().uptime());
+    ret.local_state.uptime
+      = std::chrono::duration_cast<std::chrono::milliseconds>(
+        ss::engine().uptime());
 
     if (filter.include_partitions) {
         ret.topics = co_await collect_topic_status(

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -385,7 +385,7 @@ health_monitor_backend::get_current_cluster_health_snapshot(
 void health_monitor_backend::tick() {
     ssx::spawn_with_gate(_gate, [this]() -> ss::future<> {
         co_await _local_monitor.update_state();
-        co_return co_await tick_cluster_health();
+        co_await tick_cluster_health();
     });
 }
 

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -512,7 +512,7 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
     ret.id = _raft0->self().id();
 
     ret.local_state.disks = get_disk_space();
-    ret.local_state.redpanda_version = cluster::application_version(
+    ret.local_state.redpanda_version = cluster::node::application_version(
       (std::string)redpanda_version());
 
     ret.local_state.uptime

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/members_table.h"
+#include "cluster/node/local_monitor.h"
 #include "cluster/partition_manager.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
@@ -110,8 +111,6 @@ private:
     ss::future<std::vector<topic_status>>
       collect_topic_status(partitions_filter);
 
-    std::vector<node::disk> get_disk_space();
-
     void refresh_nodes_status();
 
     result<node_health_report>
@@ -142,5 +141,6 @@ private:
     ss::timer<ss::lowres_clock> _tick_timer;
     ss::gate _gate;
     mutex _refresh_mutex;
+    node::local_monitor _local_monitor;
 };
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -110,7 +110,7 @@ private:
     ss::future<std::vector<topic_status>>
       collect_topic_status(partitions_filter);
 
-    std::vector<node_disk_space> get_disk_space();
+    std::vector<node::disk> get_disk_space();
 
     void refresh_nodes_status();
 

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -93,6 +93,7 @@ private:
       = absl::node_hash_map<model::node_id, reply_status>;
 
     void tick();
+    ss::future<> tick_cluster_health();
     ss::future<> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -11,6 +11,7 @@
 #include "cluster/health_monitor_types.h"
 
 #include "cluster/errc.h"
+#include "cluster/node/types.h"
 #include "model/adl_serde.h"
 #include "utils/human.h"
 #include "utils/to_string.h"
@@ -79,28 +80,6 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {
       r.node_reports);
     return o;
 }
-
-namespace node {
-std::ostream& operator<<(std::ostream& o, const local_state& s) {
-    fmt::print(
-      o,
-      "{{redpanda_version: {}, uptime: {}, disks: {}}}",
-      s.redpanda_version,
-      s.uptime,
-      s.disks);
-    return o;
-}
-
-std::ostream& operator<<(std::ostream& o, const disk& s) {
-    fmt::print(
-      o,
-      "{{path: {}, free: {}, total: {}}}",
-      s.path,
-      human::bytes(s.free),
-      human::bytes(s.total));
-    return o;
-}
-} // namespace node
 
 std::ostream& operator<<(std::ostream& o, const partition_status& pl) {
     fmt::print(
@@ -262,7 +241,7 @@ adl<cluster::node_health_report>::from(iobuf_parser& p) {
       "cluster::node_health_report", p);
 
     auto id = adl<model::node_id>{}.from(p);
-    auto redpanda_version = adl<cluster::application_version>{}.from(p);
+    auto redpanda_version = adl<cluster::node::application_version>{}.from(p);
     auto uptime = adl<std::chrono::milliseconds>{}.from(p);
     auto disks = adl<std::vector<cluster::node::disk>>{}.from(p);
     auto topics = adl<std::vector<cluster::topic_status>>{}.from(p);

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -13,7 +13,6 @@
 #include "cluster/errc.h"
 #include "cluster/node/types.h"
 #include "model/adl_serde.h"
-#include "utils/human.h"
 #include "utils/to_string.h"
 
 #include <fmt/ostream.h>

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -63,10 +63,10 @@ std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
       "{{id: {}, disk_space: {}, topics: {}, redpanda_version: {}, uptime: "
       "{}}}",
       r.id,
-      r.disk_space,
+      r.local_state.disk_space,
       r.topics,
-      r.redpanda_version,
-      r.uptime);
+      r.local_state.redpanda_version,
+      r.local_state.uptime);
     return o;
 }
 
@@ -240,9 +240,9 @@ void adl<cluster::node_health_report>::to(
       out,
       r.current_version,
       r.id,
-      std::move(r.redpanda_version),
-      r.uptime,
-      std::move(r.disk_space),
+      std::move(r.local_state.redpanda_version),
+      r.local_state.uptime,
+      std::move(r.local_state.disk_space),
       std::move(r.topics));
 }
 
@@ -259,9 +259,9 @@ adl<cluster::node_health_report>::from(iobuf_parser& p) {
 
     return cluster::node_health_report{
       .id = id,
-      .redpanda_version = std::move(redpanda_version),
+      .local_state = { .redpanda_version = std::move(redpanda_version),
       .uptime = uptime,
-      .disk_space = std::move(disk_space),
+      .disk_space = std::move(disk_space),},
       .topics = std::move(topics),
     };
 }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -143,24 +143,6 @@ void read_and_assert_version(std::string_view type, iobuf_parser& parser) {
       T::current_version);
 }
 
-void adl<cluster::node::disk>::to(iobuf& out, cluster::node::disk&& s) {
-    serialize(out, s.current_version, s.path, s.free, s.total);
-}
-
-cluster::node::disk adl<cluster::node::disk>::from(iobuf_parser& p) {
-    read_and_assert_version<cluster::node::disk>("cluster::node::disks", p);
-
-    auto path = adl<ss::sstring>{}.from(p);
-    auto free = adl<uint64_t>{}.from(p);
-    auto total = adl<uint64_t>{}.from(p);
-
-    return cluster::node::disk{
-      .path = path,
-      .free = free,
-      .total = total,
-    };
-}
-
 void adl<cluster::node_state>::to(iobuf& out, cluster::node_state&& s) {
     serialize(out, s.current_version, s.id, s.membership_state, s.is_alive);
 }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -60,10 +60,10 @@ std::ostream& operator<<(std::ostream& o, const node_state& s) {
 std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
     fmt::print(
       o,
-      "{{id: {}, disk_space: {}, topics: {}, redpanda_version: {}, uptime: "
+      "{{id: {}, disks: {}, topics: {}, redpanda_version: {}, uptime: "
       "{}}}",
       r.id,
-      r.local_state.disk_space,
+      r.local_state.disks,
       r.topics,
       r.local_state.redpanda_version,
       r.local_state.uptime);
@@ -87,7 +87,7 @@ std::ostream& operator<<(std::ostream& o, const local_state& s) {
       "{{redpanda_version: {}, uptime: {}, disks: {}}}",
       s.redpanda_version,
       s.uptime,
-      s.disk_space);
+      s.disks);
     return o;
 }
 
@@ -170,7 +170,7 @@ void adl<cluster::node::disk>::to(iobuf& out, cluster::node::disk&& s) {
 }
 
 cluster::node::disk adl<cluster::node::disk>::from(iobuf_parser& p) {
-    read_and_assert_version<cluster::node::disk>("cluster::node_disk_space", p);
+    read_and_assert_version<cluster::node::disk>("cluster::node::disks", p);
 
     auto path = adl<ss::sstring>{}.from(p);
     auto free = adl<uint64_t>{}.from(p);
@@ -252,7 +252,7 @@ void adl<cluster::node_health_report>::to(
       r.id,
       std::move(r.local_state.redpanda_version),
       r.local_state.uptime,
-      std::move(r.local_state.disk_space),
+      std::move(r.local_state.disks),
       std::move(r.topics));
 }
 
@@ -264,14 +264,14 @@ adl<cluster::node_health_report>::from(iobuf_parser& p) {
     auto id = adl<model::node_id>{}.from(p);
     auto redpanda_version = adl<cluster::application_version>{}.from(p);
     auto uptime = adl<std::chrono::milliseconds>{}.from(p);
-    auto disk_space = adl<std::vector<cluster::node::disk>>{}.from(p);
+    auto disks = adl<std::vector<cluster::node::disk>>{}.from(p);
     auto topics = adl<std::vector<cluster::topic_status>>{}.from(p);
 
     return cluster::node_health_report{
       .id = id,
       .local_state = { .redpanda_version = std::move(redpanda_version),
       .uptime = uptime,
-      .disk_space = std::move(disk_space),},
+      .disks = std::move(disks),},
       .topics = std::move(topics),
     };
 }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -43,16 +43,17 @@ struct node_state {
     friend std::ostream& operator<<(std::ostream&, const node_state&);
 };
 
-struct node_disk_space {
+namespace node {
+struct disk {
     static constexpr int8_t current_version = 0;
 
     ss::sstring path;
     uint64_t free;
     uint64_t total;
-    friend std::ostream& operator<<(std::ostream&, const node_disk_space&);
-    friend bool operator==(const node_disk_space&, const node_disk_space&)
-      = default;
+    friend std::ostream& operator<<(std::ostream&, const disk&);
+    friend bool operator==(const disk&, const disk&) = default;
 };
+} // namespace node
 
 struct partition_status {
     static constexpr int8_t current_version = 0;
@@ -74,14 +75,18 @@ struct topic_status {
     friend bool operator==(const topic_status&, const topic_status&) = default;
 };
 
-struct node_local_state {
+namespace node {
+struct local_state {
     static constexpr int8_t current_version = 0;
     application_version redpanda_version;
     std::chrono::milliseconds uptime;
     // we store a vector to be ready to operate with multiple data
     // directories
-    std::vector<node_disk_space> disk_space;
+    std::vector<disk> disk_space;
+
+    friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
+} // namespace node
 
 /**
  * Node health report is collected built based on node local state at given
@@ -91,7 +96,7 @@ struct node_health_report {
     static constexpr int8_t current_version = 0;
 
     model::node_id id;
-    node_local_state local_state;
+    node::local_state local_state;
     std::vector<topic_status> topics;
 
     friend std::ostream& operator<<(std::ostream&, const node_health_report&);
@@ -200,10 +205,11 @@ struct adl<cluster::cluster_health_report> {
     void to(iobuf&, cluster::cluster_health_report&&);
     cluster::cluster_health_report from(iobuf_parser&);
 };
+
 template<>
-struct adl<cluster::node_disk_space> {
-    void to(iobuf&, cluster::node_disk_space&&);
-    cluster::node_disk_space from(iobuf_parser&);
+struct adl<cluster::node::disk> {
+    void to(iobuf&, cluster::node::disk&&);
+    cluster::node::disk from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -82,7 +82,7 @@ struct local_state {
     std::chrono::milliseconds uptime;
     // we store a vector to be ready to operate with multiple data
     // directories
-    std::vector<disk> disk_space;
+    std::vector<disk> disks;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -182,12 +182,6 @@ struct adl<cluster::cluster_health_report> {
 };
 
 template<>
-struct adl<cluster::node::disk> {
-    void to(iobuf&, cluster::node::disk&&);
-    cluster::node::disk from(iobuf_parser&);
-};
-
-template<>
 struct adl<cluster::node_state> {
     void to(iobuf&, cluster::node_state&&);
     cluster::node_state from(iobuf_parser&);

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -20,6 +20,8 @@
 #include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
+#include <chrono>
+
 namespace cluster {
 
 /**
@@ -71,6 +73,16 @@ struct topic_status {
     friend std::ostream& operator<<(std::ostream&, const topic_status&);
     friend bool operator==(const topic_status&, const topic_status&) = default;
 };
+
+struct node_local_state {
+    static constexpr int8_t current_version = 0;
+    application_version redpanda_version;
+    std::chrono::milliseconds uptime;
+    // we store a vector to be ready to operate with multiple data
+    // directories
+    std::vector<node_disk_space> disk_space;
+};
+
 /**
  * Node health report is collected built based on node local state at given
  * instance of time
@@ -79,11 +91,7 @@ struct node_health_report {
     static constexpr int8_t current_version = 0;
 
     model::node_id id;
-    application_version redpanda_version;
-    std::chrono::milliseconds uptime;
-    // we store a vector to be ready to operate with multiple data
-    // directories
-    std::vector<node_disk_space> disk_space;
+    node_local_state local_state;
     std::vector<topic_status> topics;
 
     friend std::ostream& operator<<(std::ostream&, const node_health_report&);

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "bytes/iobuf_parser.h"
 #include "cluster/errc.h"
+#include "cluster/node/types.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -29,7 +30,6 @@ namespace cluster {
  */
 
 using alive = ss::bool_class<struct node_alive_tag>;
-using application_version = named_type<ss::sstring, struct version_number_tag>;
 /**
  * node state is determined from controller, and it doesn't require contacting
  * with the node directly
@@ -42,18 +42,6 @@ struct node_state {
     alive is_alive;
     friend std::ostream& operator<<(std::ostream&, const node_state&);
 };
-
-namespace node {
-struct disk {
-    static constexpr int8_t current_version = 0;
-
-    ss::sstring path;
-    uint64_t free;
-    uint64_t total;
-    friend std::ostream& operator<<(std::ostream&, const disk&);
-    friend bool operator==(const disk&, const disk&) = default;
-};
-} // namespace node
 
 struct partition_status {
     static constexpr int8_t current_version = 0;
@@ -74,19 +62,6 @@ struct topic_status {
     friend std::ostream& operator<<(std::ostream&, const topic_status&);
     friend bool operator==(const topic_status&, const topic_status&) = default;
 };
-
-namespace node {
-struct local_state {
-    static constexpr int8_t current_version = 0;
-    application_version redpanda_version;
-    std::chrono::milliseconds uptime;
-    // we store a vector to be ready to operate with multiple data
-    // directories
-    std::vector<disk> disks;
-
-    friend std::ostream& operator<<(std::ostream&, const local_state&);
-};
-} // namespace node
 
 /**
  * Node health report is collected built based on node local state at given

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -193,17 +193,17 @@ metrics_reporter::build_metrics_snapshot() {
         }
         auto& metrics = it->second;
 
-        metrics.version = report.redpanda_version;
-        metrics.disks.reserve(report.disk_space.size());
+        metrics.version = report.local_state.redpanda_version;
+        metrics.disks.reserve(report.local_state.disk_space.size());
         std::transform(
-          report.disk_space.begin(),
-          report.disk_space.end(),
+          report.local_state.disk_space.begin(),
+          report.local_state.disk_space.end(),
           std::back_inserter(metrics.disks),
           [](const cluster::node_disk_space& nds) {
               return node_disk_space{.free = nds.free, .total = nds.total};
           });
 
-        metrics.uptime_ms = report.uptime / 1ms;
+        metrics.uptime_ms = report.local_state.uptime / 1ms;
     }
     auto& topics = _topics.local().topics_map();
     snapshot.topic_count = 0;

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -199,7 +199,7 @@ metrics_reporter::build_metrics_snapshot() {
           report.local_state.disk_space.begin(),
           report.local_state.disk_space.end(),
           std::back_inserter(metrics.disks),
-          [](const cluster::node_disk_space& nds) {
+          [](const cluster::node::disk& nds) {
               return node_disk_space{.free = nds.free, .total = nds.total};
           });
 

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -194,10 +194,10 @@ metrics_reporter::build_metrics_snapshot() {
         auto& metrics = it->second;
 
         metrics.version = report.local_state.redpanda_version;
-        metrics.disks.reserve(report.local_state.disk_space.size());
+        metrics.disks.reserve(report.local_state.disks.size());
         std::transform(
-          report.local_state.disk_space.begin(),
-          report.local_state.disk_space.end(),
+          report.local_state.disks.begin(),
+          report.local_state.disks.end(),
           std::back_inserter(metrics.disks),
           [](const cluster::node::disk& nds) {
               return node_disk_space{.free = nds.free, .total = nds.total};

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/node/local_monitor.h"
+
+#include "cluster/node/types.h"
+#include "config/node_config.h"
+#include "version.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sstring.hh>
+
+#include <chrono>
+#include <seastarx.h>
+
+namespace cluster::node {
+
+// TODO make async
+ss::future<> local_monitor::update_state() {
+    auto disks = get_disks();
+    auto vers = application_version(ss::sstring(redpanda_version()));
+    auto uptime = std::chrono::duration_cast<std::chrono::milliseconds>(
+      ss::engine().uptime());
+
+    _state = {
+      .redpanda_version = vers,
+      .uptime = uptime,
+      .disks = disks,
+    };
+    co_return;
+}
+
+const local_state& local_monitor::get_state_cached() { return _state; }
+
+// TODO make async
+std::vector<disk> local_monitor::get_disks() {
+    auto space_info = std::filesystem::space(
+      config::node().data_directory().path);
+
+    return {disk{
+      .path = config::node().data_directory().as_sstring(),
+      .free = space_info.free,
+      .total = space_info.capacity,
+    }};
+}
+
+} // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -40,7 +40,7 @@ ss::future<> local_monitor::update_state() {
     co_return;
 }
 
-const local_state& local_monitor::get_state_cached() { return _state; }
+const local_state& local_monitor::get_state_cached() const { return _state; }
 
 ss::future<std::vector<disk>> local_monitor::get_disks() {
     auto svfs = co_await ss::engine().statvfs(

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -25,7 +25,7 @@ public:
     local_monitor& operator=(local_monitor&&) = default;
 
     ss::future<> update_state();
-    const local_state& get_state_cached();
+    const local_state& get_state_cached() const;
 
 private:
     static ss::future<std::vector<disk>> get_disks();

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -28,7 +28,7 @@ public:
     const local_state& get_state_cached();
 
 private:
-    static std::vector<disk> get_disks();
+    static ss::future<std::vector<disk>> get_disks();
     local_state _state;
 };
 

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/node/types.h"
+
+// Local node state monitoring is kept separate in case we want to access it
+// pre-quorum formation in the future, etc.
+namespace cluster::node {
+
+class local_monitor {
+public:
+    local_monitor() = default;
+    local_monitor(local_monitor&) = delete;
+    local_monitor(local_monitor&&) = default;
+    ~local_monitor() = default;
+    local_monitor& operator=(local_monitor const&) = delete;
+    local_monitor& operator=(local_monitor&&) = default;
+
+    ss::future<> update_state();
+    const local_state& get_state_cached();
+
+private:
+    static std::vector<disk> get_disks();
+    local_state _state;
+};
+
+} // namespace cluster::node

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "types.h"
+
+#include "utils/human.h"
+#include "utils/to_string.h"
+
+#include <fmt/chrono.h>
+#include <fmt/ostream.h>
+
+#include <chrono>
+
+namespace cluster::node {
+
+std::ostream& operator<<(std::ostream& o, const disk& d) {
+    fmt::print(
+      o,
+      "{{path: {}, free: {}, total: {}}}",
+      d.path,
+      human::bytes(d.free),
+      human::bytes(d.total));
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const local_state& s) {
+    fmt::print(
+      o,
+      "{{redpanda_version: {}, uptime: {}, disks: {}}}",
+      s.redpanda_version,
+      s.uptime,
+      s.disks);
+    return o;
+}
+
+} // namespace cluster::node

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "model/metadata.h"
+#include "reflection/adl.h"
 #include "types.h"
 #include "utils/human.h"
 #include "utils/named_type.h"
@@ -54,5 +55,12 @@ struct local_state {
 
 std::ostream& operator<<(std::ostream& o, const disk& d);
 std::ostream& operator<<(std::ostream& o, const local_state& s);
-
 } // namespace cluster::node
+
+namespace reflection {
+template<>
+struct adl<cluster::node::disk> {
+    void to(iobuf&, cluster::node::disk&&);
+    cluster::node::disk from(iobuf_parser&);
+};
+} // namespace reflection

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/metadata.h"
+#include "types.h"
+#include "utils/human.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/ostream.h>
+
+namespace cluster::node {
+
+//
+//  Node-local state. Includes things like:
+//  - Current free resources (disk).
+//  - Software versions (OS, redpanda, etc.).
+//
+
+using application_version = named_type<ss::sstring, struct version_number_tag>;
+
+struct disk {
+    static constexpr int8_t current_version = 0;
+
+    ss::sstring path;
+    uint64_t free;
+    uint64_t total;
+
+    friend std::ostream& operator<<(std::ostream&, const disk&);
+    friend bool operator==(const disk&, const disk&) = default;
+};
+
+/**
+ * A snapshot of node-local state: i.e. things that don't depend on consensus.
+ */
+struct local_state {
+    application_version redpanda_version;
+    std::chrono::milliseconds uptime;
+    // Eventually support multiple volumes.
+    std::vector<disk> disks;
+
+    friend std::ostream& operator<<(std::ostream&, const local_state&);
+};
+
+std::ostream& operator<<(std::ostream& o, const disk& d);
+std::ostream& operator<<(std::ostream& o, const local_state& s);
+
+} // namespace cluster::node

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -51,9 +51,11 @@ void check_reports_the_same(
     for (auto i = 0; i < lhs.size(); ++i) {
         auto& lr = lhs[i];
         auto& rr = rhs[i];
-        BOOST_TEST_REQUIRE(lr.redpanda_version == rr.redpanda_version);
+        BOOST_TEST_REQUIRE(
+          lr.local_state.redpanda_version == rr.local_state.redpanda_version);
         BOOST_TEST_REQUIRE(lr.topics == rr.topics);
-        BOOST_TEST_REQUIRE(lr.disk_space == rr.disk_space);
+        BOOST_TEST_REQUIRE(
+          lr.local_state.disk_space == rr.local_state.disk_space);
     }
 }
 
@@ -95,7 +97,7 @@ FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disk_space.empty()) {
                   return false;
               }
               return true;
@@ -187,7 +189,7 @@ FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disk_space.empty()) {
                   return false;
               }
               return true;
@@ -315,7 +317,7 @@ FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disk_space.empty()) {
                   return false;
               }
               return true;

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -54,8 +54,7 @@ void check_reports_the_same(
         BOOST_TEST_REQUIRE(
           lr.local_state.redpanda_version == rr.local_state.redpanda_version);
         BOOST_TEST_REQUIRE(lr.topics == rr.topics);
-        BOOST_TEST_REQUIRE(
-          lr.local_state.disk_space == rr.local_state.disk_space);
+        BOOST_TEST_REQUIRE(lr.local_state.disks == rr.local_state.disks);
     }
 }
 
@@ -97,7 +96,7 @@ FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].local_state.disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;
@@ -189,7 +188,7 @@ FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].local_state.disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;
@@ -317,7 +316,7 @@ FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
               if (res.value().node_reports.empty()) {
                   return false;
               }
-              if (res.value().node_reports[0].local_state.disk_space.empty()) {
+              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/health_monitor_types.h"
 #include "cluster/metadata_cache.h"
+#include "cluster/node/types.h"
 #include "cluster/shard_table.h"
 #include "cluster/simple_batch_builder.h"
 #include "cluster/tests/cluster_test_fixture.h"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1247,8 +1247,8 @@ void admin_server::register_broker_routes() {
                           return nhr.id == id;
                       });
                     if (r_it != h_report.value().node_reports.end()) {
-                        b.version = r_it->redpanda_version;
-                        for (auto& ds : r_it->disk_space) {
+                        b.version = r_it->local_state.redpanda_version;
+                        for (auto& ds : r_it->local_state.disk_space) {
                             ss::httpd::broker_json::disk_space_info dsi;
                             dsi.path = ds.path;
                             dsi.free = ds.free;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1183,8 +1183,8 @@ void admin_server::register_broker_routes() {
                           return nhr.id == id;
                       });
                     if (r_it != h_report.value().node_reports.end()) {
-                        it->second.version = r_it->redpanda_version;
-                        for (auto& ds : r_it->disk_space) {
+                        it->second.version = r_it->local_state.redpanda_version;
+                        for (auto& ds : r_it->local_state.disk_space) {
                             ss::httpd::broker_json::disk_space_info dsi;
                             dsi.path = ds.path;
                             dsi.free = ds.free;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1184,7 +1184,7 @@ void admin_server::register_broker_routes() {
                       });
                     if (r_it != h_report.value().node_reports.end()) {
                         it->second.version = r_it->local_state.redpanda_version;
-                        for (auto& ds : r_it->local_state.disk_space) {
+                        for (auto& ds : r_it->local_state.disks) {
                             ss::httpd::broker_json::disk_space_info dsi;
                             dsi.path = ds.path;
                             dsi.free = ds.free;
@@ -1248,7 +1248,7 @@ void admin_server::register_broker_routes() {
                       });
                     if (r_it != h_report.value().node_reports.end()) {
                         b.version = r_it->local_state.redpanda_version;
-                        for (auto& ds : r_it->local_state.disk_space) {
+                        for (auto& ds : r_it->local_state.disks) {
                             ss::httpd::broker_json::disk_space_info dsi;
                             dsi.path = ds.path;
                             dsi.free = ds.free;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -226,7 +226,6 @@ private:
      *        runs inside a seastar thread
      */
     void trigger_housekeeping();
-    void arm_housekeeping();
     ss::future<> housekeeping();
 
     std::optional<batch_cache_index> create_cache(with_cache);


### PR DESCRIPTION
In preparation for adding a new node-local health monitor, which does
its processing as part of health_monitor's tick() callback, this set of
patches separates out node-local state.

Besides supporting new local drive space metrics, this change also
allows us to easily move fetching local node health outside of quorum,
which may be useful for implementing gating features.

We also move invocation of the disk stats syscall off of the reactor
thread, making it async.

Related: Issue #2166 