### PR TITLE
Added caching policies to provide read your own writes semantics in the log

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -16,6 +16,7 @@
 #include "model/timestamp.h"
 #include "reflection/adl.h"
 #include "security/acl.h"
+#include "storage/types.h"
 #include "tristate.h"
 #include "utils/to_string.h"
 
@@ -83,7 +84,8 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .retention_time = properties.retention_duration,
             // we disable cache for internal topics as they are read only once
             // during bootstrap.
-            .cache_enabled = storage::with_cache(!is_internal()),
+            .caching = is_internal() ? storage::caching_policy::pending_writes
+                                     : storage::caching_policy::full,
             .recovery_enabled = storage::topic_recovery_enabled(
               properties.recovery ? *properties.recovery : false),
             .shadow_indexing_mode = properties.shadow_indexing

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -464,6 +464,11 @@ public:
      */
     void truncate(model::offset offset);
 
+    /**
+     * Removes all batches with offset smaller than requested
+     */
+    void prefix_truncate(model::offset offset);
+
     /*
      * Testing interface used to evict a batch from the cache identified by
      * the specified offset. The index range is not removed. The offset must

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -385,7 +385,8 @@ ss::future<> kvstore::recover() {
               [] { return std::nullopt; },
               _as,
               config::shard_local_cfg().storage_read_buffer_size(),
-              config::shard_local_cfg().storage_read_readahead_count())
+              config::shard_local_cfg().storage_read_readahead_count(),
+              caching_policy::none)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -237,7 +237,8 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
                  [this, cache_enabled] { return create_cache(cache_enabled); },
                  _abort_source,
                  config::shard_local_cfg().storage_read_buffer_size(),
-                 config::shard_local_cfg().storage_read_readahead_count())
+                 config::shard_local_cfg().storage_read_readahead_count(),
+                 cfg.caching_policy())
           .then([this, cfg = std::move(cfg)](segment_set segments) mutable {
               auto l = storage::make_disk_backed_log(
                 std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -224,6 +224,10 @@ public:
     absl::flat_hash_set<model::ntp> get_all_ntps() const;
 
     int64_t compaction_backlog() const;
+    /**
+     * Gives an access to batch cache held by log manager - used for testing
+     */
+    const batch_cache& get_batch_cache() const { return _batch_cache; }
 
 private:
     using logs_type = absl::flat_hash_map<model::ntp, log_housekeeping_meta>;

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -12,6 +12,7 @@
 #include "storage/fs_utils.h"
 #include "storage/log_replayer.h"
 #include "storage/logger.h"
+#include "storage/types.h"
 #include "utils/directory_walker.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -341,7 +342,8 @@ static ss::future<segment_set::underlying_t> open_segments(
   std::function<std::optional<batch_cache_index>()> cache_factory,
   ss::abort_source& as,
   size_t buf_size,
-  unsigned read_ahead) {
+  unsigned read_ahead,
+  caching_policy cp) {
     using segs_type = segment_set::underlying_t;
     return ss::do_with(
       segs_type{},
@@ -350,7 +352,8 @@ static ss::future<segment_set::underlying_t> open_segments(
        sanitize_fileops,
        dir = std::move(dir),
        buf_size,
-       read_ahead](segs_type& segs) {
+       read_ahead,
+       cp](segs_type& segs) {
           auto f = directory_walker::walk(
             dir,
             [&as,
@@ -359,7 +362,8 @@ static ss::future<segment_set::underlying_t> open_segments(
              sanitize_fileops,
              &segs,
              buf_size,
-             read_ahead](ss::directory_entry seg) {
+             read_ahead,
+             cp](ss::directory_entry seg) {
                 // abort if requested
                 if (as.abort_requested()) {
                     return ss::now();
@@ -388,7 +392,8 @@ static ss::future<segment_set::underlying_t> open_segments(
                          sanitize_fileops,
                          cache_factory(),
                          buf_size,
-                         read_ahead)
+                         read_ahead,
+                         cp)
                   .then([&segs](ss::lw_shared_ptr<segment> p) {
                       segs.push_back(std::move(p));
                   });
@@ -411,21 +416,24 @@ ss::future<segment_set> recover_segments(
   std::function<std::optional<batch_cache_index>()> cache_factory,
   ss::abort_source& as,
   size_t read_buf_size,
-  unsigned read_readahead_count) {
+  unsigned read_readahead_count,
+  caching_policy cp) {
     return ss::recursive_touch_directory(path.string())
       .then([&as,
              cache_factory,
              sanitize_fileops,
              path = std::move(path),
              read_buf_size,
-             read_readahead_count] {
+             read_readahead_count,
+             cp] {
           return open_segments(
             path.string(),
             sanitize_fileops,
             cache_factory,
             as,
             read_buf_size,
-            read_readahead_count);
+            read_readahead_count,
+            cp);
       })
       .then([&as, is_compaction_enabled](segment_set::underlying_t segs) {
           auto segments = segment_set(std::move(segs));

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -96,7 +96,8 @@ ss::future<segment_set> recover_segments(
   std::function<std::optional<batch_cache_index>()> batch_cache_factory,
   ss::abort_source& as,
   size_t read_buf_size,
-  unsigned read_readahead_count);
+  unsigned read_readahead_count,
+  caching_policy cp);
 
 std::ostream& operator<<(std::ostream&, const segment_set&);
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -659,7 +659,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       std::move(index),
       nullptr,
       std::nullopt,
-      std::nullopt);
+      std::nullopt,
+      storage::caching_policy::none);
 }
 
 ss::future<std::vector<compacted_index_reader>> make_indices_readers(

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -63,7 +63,8 @@ struct context {
           std::move(indexer),
           std::move(appender),
           std::nullopt,
-          std::nullopt);
+          std::nullopt,
+          caching_policy::none);
         replayer_opt = log_replayer(*_seg);
     }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -342,4 +342,19 @@ struct compaction_result {
     size_t size_after;
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
+/**
+ * Enum class describing log desired caching policy. The caching policy controls
+ * that which of the batches written or read from a log are stored in the batch
+ * cache.
+ *
+ * full - all written and read batches are placed in the batch cache
+ * pending_writes - only pending inflight writes are stored in the batch cache
+ * none - ntp doesn't use batch cache at all
+ */
+enum class caching_policy : int8_t {
+    full,
+    pending_writes,
+    none,
+};
+
 } // namespace storage


### PR DESCRIPTION
## Cover letter

Introduced caching policy enum to control which batches will be held in batch cache.
Caching policy has three possible modes:

- `full` - all written and read batches are placed in the batch cache
- `pending_writes` - only pending inflight writes are stored in the batch cache
- `none` - do not use batch cache at all