### PR TITLE
rptest: Add new test for shadow indexing

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -614,9 +614,45 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                          replication_factor=3)
         self.client().create_topic(spec)
         self.topic = spec.name
-        self.start_producer(1)
+        self.start_producer(1, throughput=throughput)
         self.start_consumer(1)
         self.await_startup()
-        for _ in range(25):
+        for _ in range(moves):
             self._move_and_verify()
-        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+        self.run_validation(enable_idempotence=False,
+                            consumer_timeout_sec=45,
+                            min_records=records)
+
+    @cluster(num_nodes=5)
+    def test_cross_shard(self):
+        """
+        Test interaction between the shadow indexing and the partition movement.
+        Move partitions with SI enabled between shards.
+        """
+        throughput, records, moves, partitions = self._get_scale_params()
+
+        self.start_redpanda(num_nodes=3)
+        spec = TopicSpec(name="topic",
+                         partition_count=partitions,
+                         replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(1, throughput=throughput)
+        self.start_consumer(1)
+        self.await_startup()
+
+        admin = Admin(self.redpanda)
+        topic = self.topic
+        partition = 0
+
+        for _ in range(moves):
+            assignments = self._get_assignments(admin, topic, partition)
+            for a in assignments:
+                # Bounce between core 0 and 1
+                a['core'] = (a['core'] + 1) % 2
+            admin.set_partition_replicas(topic, partition, assignments)
+            self._wait_post_move(topic, partition, assignments, 360)
+
+        self.run_validation(enable_idempotence=False,
+                            consumer_timeout_sec=45,
+                            min_records=records)


### PR DESCRIPTION
## Cover letter

Add test that checks that shadow indexing works as expected when the
partition movement is actively performed.

The CI check is not supposed to pass before #3492 is merged.
The PR was extracted from the #3492 because the test is flaky. 
The test sometimes fails to fetch few offsets. This happens only in the release branch.
This is something unrelated to the issue #3316.

```
--------------------------------------------------------------------------------
--
  | test_id:    rptest.tests.partition_movement_test.PartitionMovementTest.test_shadow_indexing
  | status:     FAIL
  | run time:   3 minutes 24.582 seconds
  |  
  |  
  | AssertionError('21 acked message did not make it to the Consumer. They are: 1.17326, 1.17330, 1.17324, 1.17321, 1.17316, 1.17331, 1.17319, 1.17325, 1.17315, 1.17320, 1.17328, 1.17322, 1.17323, 1.17333, 1.17327, 1.17334, 1.17332, 1.17317, 1.17335, 1.17318...plus 1 more. Total Acked: 153175, Total Consumed: 153156. (There are also 42 duplicate messages in the log - but that is an acceptable outcome)\n')
  | Traceback (most recent call last):
  | File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 135, in run
  | data = self.run_test()
  | File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 215, in run_test
  | return self.test_context.function(self.test)
  | File "/root/tests/rptest/tests/partition_movement_test.py", line 569, in test_shadow_indexing
  | self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
  | File "/root/tests/rptest/tests/end_to_end.py", line 163, in run_validation
  | self.validate(enable_idempotence)
  | File "/root/tests/rptest/tests/end_to_end.py", line 201, in validate
  | assert success, msg
  | AssertionError: 21 acked message did not make it to the Consumer. They are: 1.17326, 1.17330, 1.17324, 1.17321, 1.17316, 1.17331, 1.17319, 1.17325, 1.17315, 1.17320, 1.17328, 1.17322, 1.17323, 1.17333, 1.17327, 1.17334, 1.17332, 1.17317, 1.17335, 1.17318...plus 1 more. Total Acked: 153175, Total Consumed: 153156. (There are also 42 duplicate messages in the log - but that is an acceptable outcome)
  |  
  |  
  | --------------------------------------------------------------------------------


```

## Release notes

* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
