### PR TITLE
 Add verifiable franz-go producer/consumer to ducktape

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -111,6 +111,10 @@ RUN git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go &
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/
 
+# Should fork to redpanda repo
+RUN git -C /opt clone https://github.com/jcsp/si-verifier.git && \
+    cd /opt/si-verifier && go mod tidy && go build
+
 # Expose port 8080 for any http examples within clients
 EXPOSE 8080
 

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -68,6 +68,15 @@ class S3Client:
             if err.response['Error']['Code'] != 'BucketAlreadyOwnedByYou':
                 raise err
 
+    def delete_bucket(self, name):
+        try:
+            self._cli.delete_bucket(Bucket=name)
+        except Exception:
+            self.logger.warn("Error deleting bucket, contents:")
+            for o in self.list_objects(name):
+                self.logger.warn(f"  {o.Key}")
+            raise
+
     def empty_bucket(self, name):
         """Empty bucket, return list of keys that wasn't deleted due
         to error"""

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -1,0 +1,184 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import threading
+from ducktape.services.background_thread import BackgroundThreadService
+
+# The franz-go root directory
+TESTS_DIR = os.path.join("/opt", "si-verifier")
+
+from enum import Enum
+
+
+class ServiceStatus(Enum):
+    SETUP = 1
+    RUNNING = 2
+    FINISH = 3
+
+
+class FranzGoVerifiableService(BackgroundThreadService):
+    """
+    FranzGoVerifiableService is si-verifier service.
+    To validate produced record user should run consumer and producer in one node.
+    Use ctx.cluster.alloc(ClusterSpec.simple_linux(1)) to allocate node and pass it to constructor
+    """
+    def __init__(self, context, redpanda, topic, msg_size, custom_node):
+        self.use_custom_node = custom_node is not None
+
+        # We should pass num_nodes to allocate for our service in BackgroundThreadService,
+        # but if user allocate node by themself, BackgroundThreadService should not allocate any nodes
+        nodes_for_allocate = 1
+        if self.use_custom_node:
+            nodes_for_allocate = 0
+
+        super(FranzGoVerifiableService,
+              self).__init__(context, num_nodes=nodes_for_allocate)
+
+        # Should check that BackgroundThreadService did not allocate anything
+        # and store allocated nodes by user to self.nodes
+        if self.use_custom_node:
+            assert not self.nodes
+            self.nodes = custom_node
+
+        self._redpanda = redpanda
+        self._topic = topic
+        self._msg_size = msg_size
+        self._stopping = threading.Event()
+        self._exception = None
+        self.status = ServiceStatus.SETUP
+        self._pid = None
+
+    def _worker(self, idx, node):
+        pass
+
+    def execute_cmd(self, cmd, node):
+        for line in node.account.ssh_capture(cmd):
+            if self._pid is None:
+                self._pid = line.strip()
+
+            self.logger.debug(line.rstrip())
+            if self._stopping.is_set():
+                break
+
+    def save_exception(self, ex):
+        if self._stopping.is_set():
+            pass
+        else:
+            self._exception = ex
+            raise ex
+
+    def stop_node(self, node):
+        self._stopping.set()
+
+        if self.status is ServiceStatus.RUNNING:
+            try:
+                if self._pid is not None:
+                    self.logger.debug("Killing pid %s" % {self._pid})
+                    node.account.signal(self._pid, 9, allow_fail=True)
+                else:
+                    self.logger.debug("Killing si-verifier")
+                    node.account.kill_process("si-verifier",
+                                              clean_shutdown=False)
+            except RemoteCommandError as e:
+                if b"No such process" not in e.msg:
+                    raise
+
+        if self._exception is not None:
+            raise self._exception
+
+    def allocate_nodes(self):
+        if self.use_custom_node:
+            return
+        else:
+            return super(FranzGoVerifiableService, self).allocate_nodes()
+
+    def free_all(self):
+        if self.use_custom_node:
+            return
+        else:
+            return super(FranzGoVerifiableService, self).free_all()
+
+
+class FranzGoVerifiableSeqConsumer(FranzGoVerifiableService):
+    def __init__(self, context, redpanda, topic, msg_size, nodes=None):
+        super(FranzGoVerifiableSeqConsumer,
+              self).__init__(context, redpanda, topic, msg_size, nodes)
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            while not self._stopping.is_set():
+                cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs 0 --seq_read=1' % (
+                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    self._topic, self._msg_size)
+                self.execute_cmd(cmd, node)
+        except Exception as ex:
+            self.save_exception(ex)
+        finally:
+            self.status = ServiceStatus.FINISH
+
+
+class FranzGoVerifiableRandomConsumer(FranzGoVerifiableService):
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 msg_size,
+                 rand_read_msgs,
+                 parallel,
+                 nodes=None):
+        super(FranzGoVerifiableRandomConsumer,
+              self).__init__(context, redpanda, topic, msg_size, nodes)
+        self._rand_read_msgs = rand_read_msgs
+        self._parallel = parallel
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            while not self._stopping.is_set():
+                cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs %s --parallel %s --seq_read=0' % (
+                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    self._topic, self._msg_size, self._rand_read_msgs,
+                    self._parallel)
+
+                self.execute_cmd(cmd, node)
+        except Exception as ex:
+            self.save_exception(ex)
+        finally:
+            self.status = ServiceStatus.FINISH
+
+
+class FranzGoVerifiableProducer(FranzGoVerifiableService):
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 msg_size,
+                 msg_count,
+                 custom_node=None):
+        super(FranzGoVerifiableProducer,
+              self).__init__(context, redpanda, topic, msg_size, custom_node)
+        self._msg_count = msg_count
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs %s --rand_read_msgs 0 --seq_read=0' % (
+                f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                self._topic, self._msg_size, self._msg_count)
+
+            self.execute_cmd(cmd, node)
+        except Exception as ex:
+            self.save_exception(ex)
+        finally:
+            self.status = ServiceStatus.FINISH

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -18,10 +18,12 @@ import random
 import threading
 import collections
 import re
+import uuid
 from typing import Optional
 
 import yaml
 from ducktape.services.service import Service
+from rptest.archival.s3_client import S3Client
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
@@ -176,6 +178,45 @@ class ResourceSettings:
         return preamble, args
 
 
+class SISettings:
+    """
+    Settings for shadow indexing stuff
+    """
+    def __init__(self,
+                 *,
+                 log_segment_size=16 * 1000000,
+                 cloud_storage_access_key="panda-user",
+                 cloud_storage_secret_key="panda-secret",
+                 cloud_storage_region="panda-region",
+                 cloud_storage_bucket=f"panda-bucket-{uuid.uuid1()}",
+                 cloud_storage_api_endpoint="minio-s3",
+                 cloud_storage_api_endpoint_port=9000,
+                 cloud_storage_cache_size=160 * 1000000):
+        self.log_segment_size = log_segment_size
+        self.cloud_storage_access_key = cloud_storage_access_key
+        self.cloud_storage_secret_key = cloud_storage_secret_key
+        self.cloud_storage_region = cloud_storage_region
+        self.cloud_storage_bucket = cloud_storage_bucket
+        self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
+        self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
+        self.cloud_storage_cache_size = cloud_storage_cache_size
+
+    def update_rp_conf(self, conf):
+        conf["log_segment_size"] = self.log_segment_size
+        conf["cloud_storage_access_key"] = self.cloud_storage_access_key
+        conf["cloud_storage_secret_key"] = self.cloud_storage_secret_key
+        conf["cloud_storage_region"] = self.cloud_storage_region
+        conf["cloud_storage_bucket"] = self.cloud_storage_bucket
+        conf["cloud_storage_api_endpoint"] = self.cloud_storage_api_endpoint
+        conf[
+            "cloud_storage_api_endpoint_port"] = self.cloud_storage_api_endpoint_port
+        conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
+        conf["cloud_storage_enabled"] = True
+        conf['cloud_storage_disable_tls'] = True
+
+        return conf
+
+
 class RedpandaService(Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
@@ -232,7 +273,8 @@ class RedpandaService(Service):
                  extra_rp_conf=None,
                  enable_pp=False,
                  enable_sr=False,
-                 resource_settings=None):
+                 resource_settings=None,
+                 si_settings=None):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._enable_rp = enable_rp
@@ -248,6 +290,12 @@ class RedpandaService(Service):
         if resource_settings is None:
             resource_settings = ResourceSettings()
         self._resource_settings = resource_settings
+
+        if si_settings is not None:
+            self._extra_rp_conf = si_settings.update_rp_conf(
+                self._extra_rp_conf)
+        self._si_settings = si_settings
+        self._s3client = None
 
         self.config_file_lock = threading.Lock()
 
@@ -326,6 +374,9 @@ class RedpandaService(Service):
                                          sasl_plain_password=password,
                                          request_timeout_ms=30000,
                                          api_version_auto_timeout_ms=3000)
+
+        if self._si_settings is not None:
+            self.start_si()
 
     def security_config(self):
         return self._security_config
@@ -423,6 +474,31 @@ class RedpandaService(Service):
                 f"Wasm engine didn't finish startup in {RedpandaService.READY_TIMEOUT_SEC} seconds",
             )
 
+    def start_si(self):
+        self._s3client = S3Client(
+            region=self._si_settings.cloud_storage_region,
+            access_key=self._si_settings.cloud_storage_access_key,
+            secret_key=self._si_settings.cloud_storage_secret_key,
+            endpoint=
+            f"http://{self._si_settings.cloud_storage_api_endpoint}:{self._si_settings.cloud_storage_api_endpoint_port}",
+            logger=self.logger,
+        )
+
+        self._s3client.create_bucket(self._si_settings.cloud_storage_bucket)
+
+    def delete_bucket_from_si(self):
+        if self._s3client:
+            failed_deletions = self._s3client.empty_bucket(
+                self._si_settings.cloud_storage_bucket)
+            assert len(failed_deletions) == 0
+            self._s3client.delete_bucket(
+                self._si_settings.cloud_storage_bucket)
+
+    def get_objects_from_si(self):
+        if self._s3client:
+            return self._s3client.list_objects(
+                self._si_settings.cloud_storage_bucket)
+
     def monitor_log(self, node):
         assert node in self._started
         return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
@@ -517,6 +593,10 @@ class RedpandaService(Service):
             err_msg=f"Redpanda node failed to stop in {timeout} seconds")
         if node in self._started:
             self._started.remove(node)
+
+    def clean(self, **kwargs):
+        super().clean(**kwargs)
+        self.delete_bucket_from_si()
 
     def clean_node(self, node, preserve_logs=False):
         node.account.kill_process("redpanda", clean_shutdown=False)

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -11,6 +11,8 @@ from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster_spec import ClusterSpec
 
+import os
+
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -50,6 +52,12 @@ class FranzGoVerifiableTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     def test_with_all_type_of_loads(self):
+        self.logger.info(f"Environment: {os.environ}")
+        if os.environ.get('BUILD_TYPE', None) == 'debug':
+            self.logger.info(
+                "Skipping test in debug mode (requires release build)")
+            return
+
         # Need create json file for consumer at first
         self._create_json_file()
 
@@ -117,6 +125,11 @@ class FranzGoVerifiableWithSiTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     def test_with_all_type_of_loads_and_si(self):
+        self.logger.info(f"Environment: {os.environ}")
+        if os.environ.get('BUILD_TYPE', None) == 'debug':
+            self.logger.info(
+                "Skipping test in debug mode (requires release build)")
+            return
 
         rpk = RpkTool(self.redpanda)
         rpk.alter_topic_config(self.topic, 'redpanda.remote.write', 'true')

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -11,11 +11,10 @@ from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster_spec import ClusterSpec
 
-import time
-import random
-
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
 from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
 
 
@@ -59,3 +58,82 @@ class FranzGoVerifiableTest(RedpandaTest):
         self._rand_consumer.start()
 
         self._producer.wait()
+
+
+class FranzGoVerifiableWithSiTest(RedpandaTest):
+    MSG_SIZE = 1000000
+    segment_size = 5 * 1000000
+
+    topics = (TopicSpec(partition_count=100, replication_factor=3), )
+
+    def __init__(self, ctx):
+        si_settings = SISettings(
+            log_segment_size=FranzGoVerifiableWithSiTest.segment_size,
+            cloud_storage_cache_size=5 *
+            FranzGoVerifiableWithSiTest.segment_size)
+
+        super(FranzGoVerifiableWithSiTest, self).__init__(
+            test_context=ctx,
+            num_brokers=3,
+            extra_rp_conf={
+                # Disable prometheus metrics, because we are doing lots
+                # of restarts with lots of partitions, and current high
+                # metric counts make that sometimes cause reactor stalls
+                # during shutdown on debug builds.
+                'disable_metrics': True,
+
+                # We will run relatively large number of partitions
+                # and want it to work with slow debug builds and
+                # on noisy developer workstations: relax the raft
+                # intervals
+                'election_timeout_ms': 5000,
+                'raft_heartbeat_interval_ms': 500,
+            },
+            si_settings=si_settings)
+
+        self._node_for_franz_go = ctx.cluster.alloc(
+            ClusterSpec.simple_linux(1))
+
+        self._producer = FranzGoVerifiableProducer(
+            ctx, self.redpanda, self.topic,
+            FranzGoVerifiableWithSiTest.MSG_SIZE, 20000,
+            self._node_for_franz_go)
+        self._seq_consumer = FranzGoVerifiableSeqConsumer(
+            ctx, self.redpanda, self.topic,
+            FranzGoVerifiableWithSiTest.MSG_SIZE, self._node_for_franz_go)
+        self._rand_consumer = FranzGoVerifiableRandomConsumer(
+            ctx, self.redpanda, self.topic,
+            FranzGoVerifiableWithSiTest.MSG_SIZE, 1000, 20,
+            self._node_for_franz_go)
+
+    # In the future producer will signal about json creation
+    def _create_json_file(self):
+        small_producer = FranzGoVerifiableProducer(
+            self.test_context, self.redpanda, self.topic,
+            FranzGoVerifiableWithSiTest.MSG_SIZE, 10000,
+            self._node_for_franz_go)
+        small_producer.start()
+        small_producer.wait()
+
+    @cluster(num_nodes=4)
+    def test_with_all_type_of_loads_and_si(self):
+
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(self.topic, 'redpanda.remote.write', 'true')
+        rpk.alter_topic_config(self.topic, 'redpanda.remote.read', 'true')
+        rpk.alter_topic_config(self.topic, 'retention.bytes',
+                               str(self.segment_size))
+
+        # Need create json file for consumer at first
+        self._create_json_file()
+
+        # Verify that we really enabled shadow indexing correctly, such
+        # that some objects were written
+        objects = list(self.redpanda.get_objects_from_si())
+        assert len(objects) > 0
+        for o in objects:
+            self.logger.info(f"S3 object: {o.Key}, {o.ContentLength}")
+
+        self._producer.start()
+        self._seq_consumer.start()
+        self._rand_consumer.start()

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster_spec import ClusterSpec
+
+import time
+import random
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
+
+
+class FranzGoVerifiableTest(RedpandaTest):
+    MSG_SIZE = 120000
+
+    topics = (TopicSpec(partition_count=100, replication_factor=3), )
+
+    def __init__(self, ctx):
+        super(FranzGoVerifiableTest, self).__init__(test_context=ctx,
+                                                    num_brokers=3)
+
+        self._node_for_franz_go = ctx.cluster.alloc(
+            ClusterSpec.simple_linux(1))
+
+        self._producer = FranzGoVerifiableProducer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            100000, self._node_for_franz_go)
+        self._seq_consumer = FranzGoVerifiableSeqConsumer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            self._node_for_franz_go)
+        self._rand_consumer = FranzGoVerifiableRandomConsumer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            1000, 20, self._node_for_franz_go)
+
+    # In the future producer will signal about json creation
+    def _create_json_file(self):
+        small_producer = FranzGoVerifiableProducer(
+            self.test_context, self.redpanda, self.topic,
+            FranzGoVerifiableTest.MSG_SIZE, 1000, self._node_for_franz_go)
+        small_producer.start()
+        small_producer.wait()
+
+    @cluster(num_nodes=4)
+    def test_with_all_type_of_loads(self):
+        # Need create json file for consumer at first
+        self._create_json_file()
+
+        self._producer.start()
+        self._seq_consumer.start()
+        self._rand_consumer.start()
+
+        self._producer.wait()

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -28,7 +28,8 @@ class RedpandaTest(Test):
                  extra_rp_conf=dict(),
                  enable_pp=False,
                  enable_sr=False,
-                 resource_settings=None):
+                 resource_settings=None,
+                 si_settings=None):
         super(RedpandaTest, self).__init__(test_context)
         self.scale = Scale(test_context)
         self.redpanda = RedpandaService(test_context,
@@ -36,7 +37,8 @@ class RedpandaTest(Test):
                                         extra_rp_conf=extra_rp_conf,
                                         enable_pp=enable_pp,
                                         enable_sr=enable_sr,
-                                        resource_settings=resource_settings)
+                                        resource_settings=resource_settings,
+                                        si_settings=si_settings)
         self._client = DefaultClient(self.redpanda)
 
     @property


### PR DESCRIPTION
Add Franz go verifiable consumer/producer (https://github.com/jcsp/si-verifier) services to ducktape.

We should run producer and consumer on the same node, because producer creates json file which consumer uses for validation.

This pt contains 3 new services:

- `FranzGoVerifiableSeqConsumer` - sequential consumer. It reads and validates all data from all partition for topic
- `FranzGoVerifiableRandomConsumer` - random consumer. Reads and validates data from random offset. User can set hpw many random reads will work with `parallel` settings
- `FranzGoVerifiableProducer` - producer. It produce data to redpanda and create json file for validation


---
Fixes: #3685 