### PR TITLE
Re-enable wasm ducktape tests

### DIFF
--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -9,7 +9,6 @@
 
 from kafka import TopicPartition
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
 from rptest.wasm.wasm_test import WasmTest
@@ -43,7 +42,6 @@ class WasmFilterTest(WasmTest):
                                            str(j), [],
                                            partition=i)
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=3)
     def verify_filter_test(self):
         # 1. Fill source topics with test data

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.topic import get_source_topic
 from rptest.wasm.topics_result_set import materialized_result_set_compare, group_fan_in_verifier
@@ -50,7 +49,6 @@ class WasmIdentityTest(WasmTest):
         """
         return {topic: self._num_records for topic in self.wasm_test_output()}
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=4, log_allow_list=WASM_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         self.verify_results(materialized_result_set_compare)
@@ -158,7 +156,6 @@ class WasmMultiInputTopicIdentityTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=6, log_allow_list=WASM_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         self.verify_results(materialized_result_set_compare)
@@ -219,7 +216,6 @@ class WasmAllInputsToAllOutputsIdentityTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=6, log_allow_list=WASM_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         # Cannot compare topics to topics, can only verify # of records

--- a/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
+++ b/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import random
-from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.wasm_test import WasmTest
 from rptest.wasm.topics_result_set import materialized_at_least_once_compare, group_fan_in_verifier
@@ -57,7 +56,6 @@ class WasmRedpandaFailureRecoveryTest(WasmTest):
         """
         return {topic: self._num_records for topic in self.wasm_test_output()}
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=4, log_allow_list=WASM_CHAOS_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         self.verify_results(materialized_at_least_once_compare)
@@ -121,7 +119,6 @@ class WasmRPMultiInputTopicFailureRecoveryTest(WasmRedpandaFailureRecoveryTest
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=6, log_allow_list=WASM_CHAOS_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         self.verify_results(materialized_at_least_once_compare)
@@ -161,7 +158,6 @@ class WasmRPMeshFailureRecoveryTest(WasmRedpandaFailureRecoveryTest):
                 script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=6, log_allow_list=WASM_CHAOS_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         self.start_wasm()

--- a/tests/rptest/wasm/native_kafka_consumer.py
+++ b/tests/rptest/wasm/native_kafka_consumer.py
@@ -19,11 +19,11 @@ class NativeKafkaConsumer(BackgroundTask):
     def __init__(self,
                  brokers,
                  topic_partitions,
-                 max_records_per_partition,
+                 max_records_per_topic,
                  batch_size=4092):
         super(NativeKafkaConsumer, self).__init__()
         self._topic_partitions = topic_partitions
-        self._max_records_per_partition = max_records_per_partition
+        self._max_records_per_topic = max_records_per_topic
         self._brokers = brokers
         self._batch_size = batch_size
         self._max_attempts = 20
@@ -33,7 +33,7 @@ class NativeKafkaConsumer(BackgroundTask):
         return f"consumer-worker-{str(random.randint(0,9999))}"
 
     def total_expected_records(self):
-        return sum(self._max_records_per_partition.values())
+        return sum(self._max_records_per_topic.values())
 
     def _init_consumer(self):
         consumer = KafkaConsumer(client_id=self.task_name(),
@@ -50,7 +50,7 @@ class NativeKafkaConsumer(BackgroundTask):
         return consumer
 
     def _finished_consume(self):
-        for topic, throughput in self._max_records_per_partition.items():
+        for topic, throughput in self._max_records_per_topic.items():
             if self.results.num_records_for_topic(topic) < throughput:
                 return False
         return True


### PR DESCRIPTION
Re-enabling the wasm ducktape tests. Ignore directives removed and `auto_create_topics_enabled` is set to `False` for all wasm tests.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/5481aa2a895d5750097d441c27d5d0f209d9474a..74120fe02526aeb517675602b6bb988cf30ba709)
- Rebase of dev to pickup changes from #3857 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/74120fe02526aeb517675602b6bb988cf30ba709..605746de9cdba6b4057d7d6a5d70262e1333a35d)
- Rebase dev

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/e6e46094415350f91f4f89c8016e6aedd934d4ed..34979da79754424eb4d0e4d7760d3836934837fc)
- Fix incorrect variable name