### PR TITLE
Fixes falsely aborted transacitons

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -211,8 +211,11 @@ ss::future<bool> persisted_stm::do_sync(
               ntp);
             co_return false;
         }
-        _insync_term = term;
-        co_return true;
+        if (_c->term() == term) {
+            _insync_term = term;
+            co_return true;
+        }
+        // we lost leadership during waiting
     }
 
     co_return false;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -250,7 +250,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
     auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
     auto is_new_pid = fence_it == _log_state.fence_pid_epoch.end();
     if (is_new_pid || pid.get_epoch() > fence_it->second) {
-        if (!is_new_pid && pid.get_epoch() > fence_it->second) {
+        if (!is_new_pid) {
             auto old_pid = model::producer_identity{
               .id = pid.get_id(), .epoch = fence_it->second};
             // there is a fence, it might be that tm_stm failed, forget about
@@ -270,6 +270,11 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
                 co_return tx_errc::stale;
             }
             if (ar != tx_errc::none) {
+                co_return tx_errc::unknown_server_error;
+            }
+
+            if (is_known_session(old_pid)) {
+                // can't begin a transaction while previous tx is in progress
                 co_return tx_errc::unknown_server_error;
             }
         }
@@ -684,8 +689,10 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
         _mem_state.last_end_tx = r.value().last_offset;
     }
 
-    // don't need to wait for apply because tx is already aborted on the
-    // coordinator level - nothing can go wrong
+    if (!co_await wait_no_throw(r.value().last_offset, timeout)) {
+        co_return tx_errc::unknown_server_error;
+    }
+
     co_return tx_errc::none;
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -244,6 +244,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
     if (!co_await sync(_sync_timeout)) {
         co_return tx_errc::stale;
     }
+    auto synced_term = _insync_term;
 
     // checking / setting pid fencing
     auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
@@ -277,7 +278,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
           rm_stm::fence_control_record_version, pid);
         auto reader = model::make_memory_record_batch_reader(std::move(batch));
         auto r = co_await _c->replicate(
-          _insync_term,
+          synced_term,
           std::move(reader),
           raft::replicate_options(raft::consistency_level::quorum_ack));
         if (!r) {
@@ -317,7 +318,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
 
     track_tx(pid, transaction_timeout_ms);
 
-    co_return _mem_state.term;
+    co_return synced_term;
 }
 
 ss::future<tx_errc> rm_stm::prepare_tx(
@@ -346,6 +347,7 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
     if (!co_await sync(timeout)) {
         co_return tx_errc::stale;
     }
+    auto synced_term = _insync_term;
 
     auto prepared_it = _log_state.prepared.find(pid);
     if (prepared_it != _log_state.prepared.end()) {
@@ -372,13 +374,13 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
         co_return tx_errc::fenced;
     }
 
-    if (_mem_state.term != etag) {
+    if (synced_term != etag) {
         vlog(
           clusterlog.warn,
           "Can't prepare pid:{} - partition lost leadership current term: {} "
           "expected term: {}",
           pid,
-          _mem_state.term,
+          synced_term,
           etag);
         // current partition changed leadership since a transaction started
         // there is a chance that not all writes were replicated
@@ -457,6 +459,7 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
     if (!co_await sync(timeout)) {
         co_return tx_errc::stale;
     }
+    auto synced_term = _insync_term;
     // catching up with all previous end_tx operations (commit | abort)
     // to avoid writing the same commit | abort marker twice
     if (_mem_state.last_end_tx >= model::offset{0}) {
@@ -538,7 +541,7 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
       pid, model::control_record_type::tx_commit);
     auto reader = model::make_memory_record_batch_reader(std::move(batch));
     auto r = co_await _c->replicate(
-      _insync_term,
+      synced_term,
       std::move(reader),
       raft::replicate_options(raft::consistency_level::quorum_ack));
 
@@ -622,6 +625,7 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
     if (!co_await sync(timeout)) {
         co_return tx_errc::stale;
     }
+    auto synced_term = _insync_term;
     // catching up with all previous end_tx operations (commit | abort)
     // to avoid writing the same commit | abort marker twice
     if (_mem_state.last_end_tx >= model::offset{0}) {
@@ -664,7 +668,7 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
       pid, model::control_record_type::tx_abort);
     auto reader = model::make_memory_record_batch_reader(std::move(batch));
     auto r = co_await _c->replicate(
-      _insync_term,
+      synced_term,
       std::move(reader),
       raft::replicate_options(raft::consistency_level::quorum_ack));
 
@@ -855,6 +859,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     if (!co_await sync(_sync_timeout)) {
         co_return errc::not_leader;
     }
+    auto synced_term = _insync_term;
 
     // fencing
     auto fence_it = _log_state.fence_pid_epoch.find(bid.pid.get_id());
@@ -922,7 +927,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     }
 
     auto r = co_await _c->replicate(
-      _mem_state.term,
+      synced_term,
       std::move(br),
       raft::replicate_options(raft::consistency_level::leader_ack));
     if (!r) {
@@ -961,6 +966,7 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate_seq(
     if (!co_await sync(_sync_timeout)) {
         co_return errc::not_leader;
     }
+    auto synced_term = _insync_term;
 
     auto cached_offset = known_seq(bid);
     if (cached_offset) {
@@ -983,7 +989,7 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate_seq(
     if (!check_seq(bid)) {
         co_return errc::sequence_out_of_order;
     }
-    auto r = co_await _c->replicate(_insync_term, std::move(br), opts);
+    auto r = co_await _c->replicate(synced_term, std::move(br), opts);
     if (r) {
         set_seq(bid, r.value().last_offset);
     }
@@ -1179,6 +1185,7 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
     if (!co_await sync(_sync_timeout)) {
         co_return;
     }
+    auto synced_term = _insync_term;
 
     if (!is_known_session(pid)) {
         co_return;
@@ -1214,7 +1221,7 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                   std::move(batch));
                 co_await _c
                   ->replicate(
-                    _insync_term,
+                    synced_term,
                     std::move(reader),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack))
@@ -1226,7 +1233,7 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                   std::move(batch));
                 co_await _c
                   ->replicate(
-                    _insync_term,
+                    synced_term,
                     std::move(reader),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack))

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -86,8 +86,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(tx3.status, tx_status::preparing);
     BOOST_REQUIRE_EQUAL(tx3.tx_seq, tx2.tx_seq);
     BOOST_REQUIRE_EQUAL(tx3.partitions.size(), 2);
-    auto tx4 = expect_tx(
-      stm.try_change_status(tx_id, tx_status::prepared).get());
+    auto tx4 = expect_tx(stm.mark_tx_prepared(tx_id).get());
     BOOST_REQUIRE_EQUAL(tx4.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx4.pid, pid);
     BOOST_REQUIRE_EQUAL(tx4.status, tx_status::prepared);
@@ -129,9 +128,7 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
     auto tx3 = expect_tx(stm.get_tx(tx_id));
     auto tx4 = expect_tx(stm.mark_tx_preparing(tx_id).get());
-    auto tx5 = expect_tx(
-      stm.try_change_status(tx_id, tx_status::prepared).get());
-
+    auto tx5 = expect_tx(stm.mark_tx_prepared(tx_id).get());
     auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
     BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx6.pid, pid);
@@ -168,8 +165,7 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
     auto tx3 = expect_tx(stm.get_tx(tx_id));
     auto tx4 = expect_tx(stm.mark_tx_preparing(tx_id).get());
-    auto tx5 = expect_tx(
-      stm.try_change_status(tx_id, tx_status::prepared).get());
+    auto tx5 = expect_tx(stm.mark_tx_prepared(tx_id).get());
     auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
 
     auto pid2 = model::producer_identity{.id = 1, .epoch = 1};

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -476,11 +476,11 @@ std::vector<kafka::transactional_id> tm_stm::get_expired_txs() {
 }
 
 ss::future<> tm_stm::expire_tx(kafka::transactional_id tx_id) {
-    auto ptx = _tx_table.find(tx_id);
-    if (ptx == _tx_table.end()) {
+    auto tx_opt = get_tx(tx_id);
+    if (!tx_opt.has_value()) {
         co_return;
     }
-    tm_transaction tx = ptx->second;
+    tm_transaction tx = tx_opt.value();
     tx.etag = _insync_term;
     tx.status = tm_transaction::tx_status::tombstone;
     tx.partitions.clear();

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -464,12 +464,12 @@ bool tm_stm::is_expired(const tm_transaction& tx) {
     return _transactional_id_expiration < now_ts - tx.last_update_ts;
 }
 
-std::vector<kafka::transactional_id> tm_stm::get_expired_txs() {
+absl::btree_set<kafka::transactional_id> tm_stm::get_expired_txs() {
     auto now_ts = clock_type::now();
-    std::vector<kafka::transactional_id> ids;
+    absl::btree_set<kafka::transactional_id> ids;
     for (auto& [id, tx] : _tx_table) {
         if (_transactional_id_expiration < now_ts - tx.last_update_ts) {
-            ids.push_back(id);
+            ids.insert(id);
         }
     }
     return ids;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -138,6 +138,21 @@ tm_stm::try_change_status(
 }
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
+tm_stm::mark_tx_preparing(kafka::transactional_id tx_id) {
+    auto ptx = _tx_table.find(tx_id);
+    if (ptx == _tx_table.end()) {
+        co_return tm_stm::op_status::not_found;
+    }
+    auto tx = ptx->second;
+    if (tx.status != tm_transaction::tx_status::ongoing) {
+        co_return tm_stm::op_status::conflict;
+    }
+    tx.status = cluster::tm_transaction::tx_status::preparing;
+    tx.last_update_ts = clock_type::now();
+    co_return co_await update_tx(tx, tx.etag);
+}
+
+ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::get_actual_tx(kafka::transactional_id tx_id) {
     if (!_c->is_leader()) {
         co_return tm_stm::op_status::not_leader;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -157,12 +157,12 @@ tm_stm::get_actual_tx(kafka::transactional_id tx_id) {
 }
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
-tm_stm::mark_tx_ready(kafka::transactional_id tx_id) {
-    return mark_tx_ready(tx_id, _insync_term);
+tm_stm::reset_tx_ready(kafka::transactional_id tx_id) {
+    return reset_tx_ready(tx_id, _insync_term);
 }
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
-tm_stm::mark_tx_ready(kafka::transactional_id tx_id, model::term_id term) {
+tm_stm::reset_tx_ready(kafka::transactional_id tx_id, model::term_id term) {
     auto ptx = _tx_table.find(tx_id);
     if (ptx == _tx_table.end()) {
         co_return tm_stm::op_status::not_found;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -153,6 +153,21 @@ tm_stm::mark_tx_preparing(kafka::transactional_id tx_id) {
 }
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
+tm_stm::mark_tx_aborting(kafka::transactional_id tx_id) {
+    auto ptx = _tx_table.find(tx_id);
+    if (ptx == _tx_table.end()) {
+        co_return tm_stm::op_status::not_found;
+    }
+    auto tx = ptx->second;
+    if (tx.status != tm_transaction::tx_status::ongoing) {
+        co_return tm_stm::op_status::conflict;
+    }
+    tx.status = cluster::tm_transaction::tx_status::aborting;
+    tx.last_update_ts = clock_type::now();
+    co_return co_await update_tx(tx, tx.etag);
+}
+
+ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::get_actual_tx(kafka::transactional_id tx_id) {
     if (!_c->is_leader()) {
         co_return tm_stm::op_status::not_leader;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -147,7 +147,7 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_prepared(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
-      try_change_status(kafka::transactional_id, tm_transaction::tx_status);
+      mark_tx_killed(kafka::transactional_id);
     ss::future<tm_stm::op_status> re_register_producer(
       kafka::transactional_id,
       std::chrono::milliseconds,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -179,12 +179,14 @@ protected:
 private:
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
+    ss::future<bool> sync(model::timeout_clock::duration);
 
     ss::basic_rwlock<> _state_lock;
     std::chrono::milliseconds _sync_timeout;
     std::chrono::milliseconds _transactional_id_expiration;
     model::violation_recovery_policy _recovery_policy;
-    absl::flat_hash_map<kafka::transactional_id, tm_transaction> _tx_table;
+    absl::flat_hash_map<kafka::transactional_id, tm_transaction> _log_txes;
+    absl::flat_hash_map<kafka::transactional_id, tm_transaction> _mem_txes;
     absl::flat_hash_map<model::producer_identity, kafka::transactional_id>
       _pid_tx_id;
     absl::flat_hash_map<kafka::transactional_id, ss::lw_shared_ptr<mutex>>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -27,6 +27,7 @@
 #include "utils/expiring_promise.h"
 #include "utils/mutex.h"
 
+#include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
 
 #include <compare>
@@ -170,7 +171,7 @@ public:
         return lock_it->second;
     }
 
-    std::vector<kafka::transactional_id> get_expired_txs();
+    absl::btree_set<kafka::transactional_id> get_expired_txs();
 
 protected:
     ss::future<> handle_eviction() override;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -143,6 +143,8 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_preparing(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
+      mark_tx_aborting(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
     ss::future<tm_stm::op_status> re_register_producer(
       kafka::transactional_id,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -145,6 +145,8 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_aborting(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
+      mark_tx_prepared(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
     ss::future<tm_stm::op_status> re_register_producer(
       kafka::transactional_id,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -110,6 +110,10 @@ public:
     std::optional<tm_transaction> get_tx(kafka::transactional_id);
     checked<tm_transaction, tm_stm::op_status>
       mark_tx_ongoing(kafka::transactional_id);
+    // mark_xxx: updates a transaction if the term matches etag
+    // reset_xxx: updates a transaction and an etag
+    checked<tm_transaction, tm_stm::op_status>
+      reset_tx_ongoing(kafka::transactional_id);
     bool add_partitions(
       kafka::transactional_id, std::vector<tm_transaction::tx_partition>);
     bool add_group(kafka::transactional_id, kafka::group_id, model::term_id);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -141,6 +141,8 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       reset_tx_ready(kafka::transactional_id, model::term_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
+      mark_tx_preparing(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
     ss::future<tm_stm::op_status> re_register_producer(
       kafka::transactional_id,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -124,15 +124,6 @@ public:
         return r;
     }
 
-    std::optional<tm_transaction> get_tx_by_id(kafka::transactional_id id) {
-        auto tx_it = _tx_table.find(id);
-        std::optional<tm_transaction> r;
-        if (tx_it != _tx_table.end()) {
-            r = tx_it->second;
-        }
-        return r;
-    }
-
     ss::future<bool> barrier();
 
     ss::future<ss::basic_rwlock<>::holder> read_lock() {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -137,9 +137,9 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       get_actual_tx(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
-      mark_tx_ready(kafka::transactional_id);
+      reset_tx_ready(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
-      mark_tx_ready(kafka::transactional_id, model::term_id);
+      reset_tx_ready(kafka::transactional_id, model::term_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
     ss::future<tm_stm::op_status> re_register_producer(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1330,8 +1330,7 @@ tx_gateway_frontend::do_commit_tm_tx(
         }
 
         if (tx.status == tm_transaction::tx_status::ongoing) {
-            auto preparing_tx = co_await stm->try_change_status(
-              tx.id, cluster::tm_transaction::tx_status::preparing);
+            auto preparing_tx = co_await stm->mark_tx_preparing(tx.id);
             if (!preparing_tx.has_value()) {
                 if (preparing_tx.error() == tm_stm::op_status::not_leader) {
                     outcome->set_value(tx_errc::not_coordinator);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1564,7 +1564,7 @@ tx_gateway_frontend::get_ongoing_tx(
         }
     }
 
-    auto ongoing_tx = stm->mark_tx_ongoing(tx.id);
+    auto ongoing_tx = stm->reset_tx_ongoing(tx.id);
     if (!ongoing_tx.has_value()) {
         co_return tx_errc::invalid_txn_state;
     }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -356,7 +356,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
                     }
                     auto tx_id = tx_id_opt.value();
 
-                    auto tx_opt = stm->get_tx_by_id(tx_id);
+                    auto tx_opt = stm->get_tx(tx_id);
                     if (!tx_opt) {
                         return ss::make_ready_future<try_abort_reply>(
                           try_abort_reply{

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1377,8 +1377,7 @@ tx_gateway_frontend::do_commit_tm_tx(
     }
     outcome->set_value(tx_errc::none);
 
-    auto changed_tx = co_await stm->try_change_status(
-      tx.id, cluster::tm_transaction::tx_status::prepared);
+    auto changed_tx = co_await stm->mark_tx_prepared(tx.id);
     if (!changed_tx.has_value()) {
         if (changed_tx.error() == tm_stm::op_status::not_leader) {
             co_return tx_errc::not_coordinator;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -439,8 +439,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
         });
         co_return try_abort_reply{.ec = tx_errc::none};
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        auto killed_tx = co_await stm->try_change_status(
-          tx.id, cluster::tm_transaction::tx_status::killed);
+        auto killed_tx = co_await stm->mark_tx_killed(tx.id);
         if (!killed_tx.has_value()) {
             if (killed_tx.error() == tm_stm::op_status::not_leader) {
                 co_return try_abort_reply{.ec = tx_errc::not_coordinator};
@@ -1354,8 +1353,7 @@ tx_gateway_frontend::do_commit_tm_tx(
             rejected = rejected || (r.ec == tx_errc::request_rejected);
         }
         if (rejected) {
-            auto aborting_tx = co_await stm->try_change_status(
-              tx.id, cluster::tm_transaction::tx_status::killed);
+            auto aborting_tx = co_await stm->mark_tx_killed(tx.id);
             if (!aborting_tx.has_value()) {
                 if (aborting_tx.error() == tm_stm::op_status::not_leader) {
                     outcome->set_value(tx_errc::not_coordinator);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1237,8 +1237,32 @@ tx_gateway_frontend::do_end_txn(
         if (tx.status == tm_transaction::tx_status::ongoing) {
             r = co_await do_commit_tm_tx(term, stm, tx, timeout, outcome);
         } else {
-            outcome->set_value(tx_errc::invalid_txn_state);
-            co_return tx_errc::invalid_txn_state;
+            // Lets look when we may observe this situation:
+            //
+            //   1. a client commits a transaction
+            //   2. the transaction is committed
+            //   3. tx coordinator dies just before ack'ing a tx
+            //   4. the client retries the commit
+            //   5. the commit hits server & sees that the transaction may be
+            //   committed
+            //
+            // if we return invalid_txn_state the client interpreters it as a
+            // reject while the tx is committed. it seems that the server should
+            // roll the tx forward since commit is an idempotent op. but there
+            // is a problem with this solution too:
+            //
+            //   1. a client commits a transaction
+            //   2. the transaction is committed
+            //   3. the client initiates next transaction
+            //   4. tx cordinator reboots before the prepare phase
+            //   5. the client retries the commit, tx coordiantor sees prepared
+            //      state of the previous transaction
+            //   6. if we roll it forward the client will think that the current
+            //      transaciton is committed
+            //
+            // so we fail the request with unknow error and let user to recover
+            outcome->set_value(tx_errc::unknown_server_error);
+            co_return tx_errc::unknown_server_error;
         }
     } else {
         try {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -343,11 +343,17 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
           return stm->read_lock().then([&self, stm, pid, tx_seq, timeout](
                                          ss::basic_rwlock<>::holder unit) {
               return stm->barrier()
-                .then([&self, stm, pid, tx_seq, timeout](bool ready) {
-                    if (!ready) {
+                .then([&self, stm, pid, tx_seq, timeout](
+                        checked<model::term_id, tm_stm::op_status> term_opt) {
+                    if (!term_opt.has_value()) {
+                        if (term_opt.error() == tm_stm::op_status::not_leader) {
+                            return ss::make_ready_future<try_abort_reply>(
+                              try_abort_reply{.ec = tx_errc::not_coordinator});
+                        }
                         return ss::make_ready_future<try_abort_reply>(
                           try_abort_reply{.ec = tx_errc::unknown_server_error});
                     }
+                    auto term = term_opt.value();
                     auto tx_id_opt = stm->get_id_by_pid(pid);
                     if (!tx_id_opt) {
                         return ss::make_ready_future<try_abort_reply>(
@@ -356,27 +362,14 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
                     }
                     auto tx_id = tx_id_opt.value();
 
-                    auto tx_opt = stm->get_tx(tx_id);
-                    if (!tx_opt) {
-                        return ss::make_ready_future<try_abort_reply>(
-                          try_abort_reply{
-                            .aborted = true, .ec = tx_errc::none});
-                    }
-                    auto tx = tx_opt.value();
-                    if (tx.pid != pid || tx.tx_seq != tx_seq) {
-                        return ss::make_ready_future<try_abort_reply>(
-                          try_abort_reply{
-                            .aborted = true, .ec = tx_errc::none});
-                    }
-
                     return with(
                              stm,
                              tx_id,
                              "try_abort",
                              timeout,
-                             [&self, stm, tx_id, pid, tx_seq, timeout]() {
+                             [&self, stm, term, tx_id, pid, tx_seq, timeout]() {
                                  return self.do_try_abort(
-                                   stm, tx_id, pid, tx_seq, timeout);
+                                   term, stm, tx_id, pid, tx_seq, timeout);
                              })
                       .handle_exception_type(
                         [](const ss::semaphore_timed_out&) {
@@ -390,29 +383,25 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
 }
 
 ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
+  model::term_id expected_term,
   ss::shared_ptr<tm_stm> stm,
-  kafka::transactional_id transactional_id,
+  kafka::transactional_id tx_id,
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = co_await stm->get_actual_tx(transactional_id);
-    if (!maybe_tx.has_value()) {
-        if (maybe_tx.error() == tm_stm::op_status::not_found) {
-            // missing tx => state was lost => can't be comitted => aborted
-            co_return try_abort_reply{.aborted = true, .ec = tx_errc::none};
-        }
-        if (maybe_tx.error() == tm_stm::op_status::not_leader) {
-            co_return try_abort_reply{.ec = tx_errc::not_coordinator};
-        }
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
         co_return try_abort_reply{.ec = tx_errc::unknown_server_error};
     }
-
-    auto tx = maybe_tx.value();
-
+    if (term_opt.value() != expected_term) {
+        co_return try_abort_reply{.ec = tx_errc::unknown_server_error};
+    }
+    auto tx_opt = stm->get_tx(tx_id);
+    if (!tx_opt) {
+        co_return try_abort_reply{.aborted = true, .ec = tx_errc::none};
+    }
+    auto tx = tx_opt.value();
     if (tx.pid != pid || tx.tx_seq != tx_seq) {
-        // tx coordinator issued prepare_tx and died before writing
-        // preparing status, so it could not be committed => it's
-        // safe to abort
         co_return try_abort_reply{.aborted = true, .ec = tx_errc::none};
     }
 
@@ -439,7 +428,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
         });
         co_return try_abort_reply{.ec = tx_errc::none};
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        auto killed_tx = co_await stm->mark_tx_killed(tx.id);
+        auto killed_tx = co_await stm->mark_tx_killed(expected_term, tx.id);
         if (!killed_tx.has_value()) {
             if (killed_tx.error() == tm_stm::op_status::not_leader) {
                 co_return try_abort_reply{.ec = tx_errc::not_coordinator};
@@ -460,14 +449,19 @@ tx_gateway_frontend::do_commit_tm_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = co_await stm->get_actual_tx(tx_id);
-    if (!maybe_tx.has_value()) {
-        if (maybe_tx.error() == tm_stm::op_status::not_leader) {
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
             co_return tx_errc::not_coordinator;
         }
         co_return tx_errc::invalid_txn_state;
     }
-    auto tx = maybe_tx.value();
+    auto term = term_opt.value();
+    auto tx_opt = stm->get_tx(tx_id);
+    if (!tx_opt.has_value()) {
+        co_return tx_errc::invalid_txn_state;
+    }
+    auto tx = tx_opt.value();
     if (tx.pid != pid) {
         co_return tx_errc::invalid_txn_state;
     }
@@ -478,7 +472,7 @@ tx_gateway_frontend::do_commit_tm_tx(
         co_return tx_errc::invalid_txn_state;
     }
     co_return co_await do_commit_tm_tx(
-      stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
+      term, stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
 }
 
 ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
@@ -682,25 +676,26 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = co_await stm->get_actual_tx(tx_id);
-
-    if (!maybe_tx.has_value()) {
-        if (maybe_tx.error() == tm_stm::op_status::not_leader) {
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
             vlog(
               txlog.warn,
               "this node isn't a leader for tx.id={} coordinator",
               tx_id);
             co_return init_tm_tx_reply{.ec = tx_errc::not_coordinator};
         }
-        if (maybe_tx.error() != tm_stm::op_status::not_found) {
-            vlog(
-              txlog.warn,
-              "got error {} on loading tx.id={}",
-              maybe_tx.error(),
-              tx_id);
-            co_return init_tm_tx_reply{.ec = tx_errc::invalid_txn_state};
-        }
+        vlog(
+          txlog.warn,
+          "got error {} on loading tx.id={}",
+          term_opt.error(),
+          tx_id);
+        co_return init_tm_tx_reply{.ec = tx_errc::invalid_txn_state};
+    }
+    auto term = term_opt.value();
+    auto tx_opt = stm->get_tx(tx_id);
 
+    if (!tx_opt.has_value()) {
         allocate_id_reply pid_reply
           = co_await _id_allocator_frontend.local().allocate_id(timeout);
         if (pid_reply.ec != errc::success) {
@@ -710,7 +705,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
 
         model::producer_identity pid{.id = pid_reply.id, .epoch = 0};
         tm_stm::op_status op_status = co_await stm->register_new_producer(
-          tx_id, transaction_timeout_ms, pid);
+          term, tx_id, transaction_timeout_ms, pid);
         init_tm_tx_reply reply{.pid = pid};
         if (op_status == tm_stm::op_status::success) {
             reply.ec = tx_errc::none;
@@ -739,7 +734,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
         co_return reply;
     }
 
-    auto tx = maybe_tx.value();
+    auto tx = tx_opt.value();
 
     checked<tm_transaction, tx_errc> r(tx);
 
@@ -747,10 +742,14 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
         // already in a good state, we don't need to do nothing. even if
         // tx's etag is old it will be bumped by re_register_producer
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        r = co_await do_abort_tm_tx(stm, tx, timeout);
+        r = co_await do_abort_tm_tx(term, stm, tx, timeout);
     } else if (tx.status == tm_transaction::tx_status::preparing) {
         r = co_await do_commit_tm_tx(
-          stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
+          term,
+          stm,
+          tx,
+          timeout,
+          ss::make_lw_shared<available_promise<tx_errc>>());
     } else {
         tx_errc ec;
         if (tx.status == tm_transaction::tx_status::prepared) {
@@ -790,7 +789,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
     }
 
     auto op_status = co_await stm->re_register_producer(
-      tx.id, transaction_timeout_ms, reply.pid);
+      term, tx.id, transaction_timeout_ms, reply.pid);
     if (op_status == tm_stm::op_status::success) {
         reply.ec = tx_errc::none;
     } else if (op_status == tm_stm::op_status::conflict) {
@@ -874,14 +873,30 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
 
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
+            co_return make_add_partitions_error_response(
+              request, tx_errc::not_coordinator);
+        }
+        co_return make_add_partitions_error_response(
+          request, tx_errc::invalid_txn_state);
+    }
+    auto term = term_opt.value();
+
     auto r = co_await get_ongoing_tx(
-      stm, pid, request.transactional_id, timeout);
+      term, stm, pid, request.transactional_id, timeout);
 
     if (!r.has_value()) {
         co_return make_add_partitions_error_response(request, r.error());
     }
-
     auto tx = r.value();
+
+    if (tx.etag != term) {
+        co_return make_add_partitions_error_response(
+          request, tx_errc::invalid_txn_state);
+    }
+
     co_return co_await do_add_partition_to_tx(
       std::move(tx), stm, request, timeout);
 }
@@ -1044,12 +1059,28 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::do_add_offsets_to_tx(
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
 
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
+            co_return add_offsets_tx_reply{
+              .error_code = tx_errc::not_coordinator};
+        }
+        co_return add_offsets_tx_reply{
+          .error_code = tx_errc::invalid_txn_state};
+    }
+    auto term = term_opt.value();
+
     auto r = co_await get_ongoing_tx(
-      stm, pid, request.transactional_id, timeout);
+      term, stm, pid, request.transactional_id, timeout);
     if (!r.has_value()) {
         co_return add_offsets_tx_reply{.error_code = r.error()};
     }
     auto tx = r.value();
+
+    if (tx.etag != term) {
+        co_return add_offsets_tx_reply{
+          .error_code = tx_errc::invalid_txn_state};
+    }
 
     auto group_info = co_await _rm_group_proxy->begin_group_tx(
       request.group_id, pid, tx.tx_seq, timeout);
@@ -1164,30 +1195,33 @@ tx_gateway_frontend::do_end_txn(
   ss::shared_ptr<cluster::tm_stm> stm,
   model::timeout_clock::duration timeout,
   ss::lw_shared_ptr<available_promise<tx_errc>> outcome) {
-    checked<tm_transaction, tm_stm::op_status> maybe_tx
+    checked<model::term_id, tm_stm::op_status> term_opt
       = tm_stm::op_status::unknown;
     try {
-        maybe_tx = co_await stm->get_actual_tx(request.transactional_id);
+        term_opt = co_await stm->sync();
     } catch (...) {
         outcome->set_value(tx_errc::invalid_txn_state);
         throw;
     }
-    if (!maybe_tx.has_value()) {
-        if (maybe_tx.error() == tm_stm::op_status::not_found) {
-            outcome->set_value(tx_errc::invalid_producer_id_mapping);
-            co_return tx_errc::invalid_producer_id_mapping;
-        }
-        if (maybe_tx.error() == tm_stm::op_status::not_leader) {
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
             outcome->set_value(tx_errc::not_coordinator);
             co_return tx_errc::not_coordinator;
         }
         outcome->set_value(tx_errc::invalid_txn_state);
         co_return tx_errc::invalid_txn_state;
     }
+    auto term = term_opt.value();
+    auto tx_opt = stm->get_tx(request.transactional_id);
+
+    if (!tx_opt.has_value()) {
+        outcome->set_value(tx_errc::invalid_producer_id_mapping);
+        co_return tx_errc::invalid_producer_id_mapping;
+    }
 
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
-    auto tx = maybe_tx.value();
+    auto tx = tx_opt.value();
     if (tx.pid != pid) {
         if (tx.pid.id == pid.id && tx.pid.epoch > pid.epoch) {
             outcome->set_value(tx_errc::fenced);
@@ -1201,14 +1235,14 @@ tx_gateway_frontend::do_end_txn(
     checked<cluster::tm_transaction, tx_errc> r(tx_errc::unknown_server_error);
     if (request.committed) {
         if (tx.status == tm_transaction::tx_status::ongoing) {
-            r = co_await do_commit_tm_tx(stm, tx, timeout, outcome);
+            r = co_await do_commit_tm_tx(term, stm, tx, timeout, outcome);
         } else {
             outcome->set_value(tx_errc::invalid_txn_state);
             co_return tx_errc::invalid_txn_state;
         }
     } else {
         try {
-            r = co_await do_abort_tm_tx(stm, tx, timeout);
+            r = co_await do_abort_tm_tx(term, stm, tx, timeout);
         } catch (...) {
             outcome->set_value(tx_errc::unknown_server_error);
             throw;
@@ -1236,9 +1270,14 @@ tx_gateway_frontend::do_end_txn(
 
 ss::future<checked<cluster::tm_transaction, tx_errc>>
 tx_gateway_frontend::do_abort_tm_tx(
+  model::term_id expected_term,
   ss::shared_ptr<cluster::tm_stm> stm,
   cluster::tm_transaction tx,
   model::timeout_clock::duration timeout) {
+    if (!stm->is_actual_term(expected_term)) {
+        co_return tx_errc::not_coordinator;
+    }
+
     if (tx.status == tm_transaction::tx_status::ready) {
         if (stm->is_actual_term(tx.etag)) {
             // client should start a transaction before attempting to
@@ -1249,19 +1288,25 @@ tx_gateway_frontend::do_abort_tm_tx(
 
         // writing ready status to overwrite an ongoing transaction if
         // it exists on an older leader
-        auto ready_tx = co_await stm->reset_tx_ready(tx.id);
+        auto ready_tx = co_await stm->reset_tx_ready(expected_term, tx.id);
         if (!ready_tx.has_value()) {
             co_return tx_errc::invalid_txn_state;
         }
         co_return ready_tx.value();
-    } else if (
+    }
+
+    if (
       tx.status != tm_transaction::tx_status::ongoing
       && tx.status != tm_transaction::tx_status::killed) {
         co_return tx_errc::invalid_txn_state;
     }
 
     if (tx.status == tm_transaction::tx_status::ongoing) {
-        auto changed_tx = co_await stm->mark_tx_aborting(tx.id);
+        if (expected_term != tx.etag) {
+            // making sure we're canceling a tx started within current term
+            co_return tx_errc::invalid_txn_state;
+        }
+        auto changed_tx = co_await stm->mark_tx_aborting(expected_term, tx.id);
         if (!changed_tx.has_value()) {
             if (changed_tx.error() == tm_stm::op_status::not_leader) {
                 co_return tx_errc::not_coordinator;
@@ -1298,16 +1343,29 @@ tx_gateway_frontend::do_abort_tm_tx(
 
 ss::future<checked<cluster::tm_transaction, tx_errc>>
 tx_gateway_frontend::do_commit_tm_tx(
+  model::term_id expected_term,
   ss::shared_ptr<cluster::tm_stm> stm,
   cluster::tm_transaction tx,
   model::timeout_clock::duration timeout,
   ss::lw_shared_ptr<available_promise<tx_errc>> outcome) {
+    if (!stm->is_actual_term(expected_term)) {
+        outcome->set_value(tx_errc::not_coordinator);
+        co_return tx_errc::not_coordinator;
+    }
+
     try {
         if (
           tx.status != tm_transaction::tx_status::ongoing
           && tx.status != tm_transaction::tx_status::preparing) {
             outcome->set_value(tx_errc::invalid_txn_state);
             co_return tx_errc::invalid_txn_state;
+        }
+
+        if (tx.status == tm_transaction::tx_status::ongoing) {
+            if (tx.etag != expected_term) {
+                outcome->set_value(tx_errc::invalid_txn_state);
+                co_return tx_errc::invalid_txn_state;
+            }
         }
 
         std::vector<ss::future<prepare_tx_reply>> pfs;
@@ -1328,7 +1386,8 @@ tx_gateway_frontend::do_commit_tm_tx(
         }
 
         if (tx.status == tm_transaction::tx_status::ongoing) {
-            auto preparing_tx = co_await stm->mark_tx_preparing(tx.id);
+            auto preparing_tx = co_await stm->mark_tx_preparing(
+              expected_term, tx.id);
             if (!preparing_tx.has_value()) {
                 if (preparing_tx.error() == tm_stm::op_status::not_leader) {
                     outcome->set_value(tx_errc::not_coordinator);
@@ -1353,7 +1412,8 @@ tx_gateway_frontend::do_commit_tm_tx(
             rejected = rejected || (r.ec == tx_errc::request_rejected);
         }
         if (rejected) {
-            auto aborting_tx = co_await stm->mark_tx_killed(tx.id);
+            auto aborting_tx = co_await stm->mark_tx_killed(
+              expected_term, tx.id);
             if (!aborting_tx.has_value()) {
                 if (aborting_tx.error() == tm_stm::op_status::not_leader) {
                     outcome->set_value(tx_errc::not_coordinator);
@@ -1375,7 +1435,7 @@ tx_gateway_frontend::do_commit_tm_tx(
     }
     outcome->set_value(tx_errc::none);
 
-    auto changed_tx = co_await stm->mark_tx_prepared(tx.id);
+    auto changed_tx = co_await stm->mark_tx_prepared(expected_term, tx.id);
     if (!changed_tx.has_value()) {
         if (changed_tx.error() == tm_stm::op_status::not_leader) {
             co_return tx_errc::not_coordinator;
@@ -1432,7 +1492,7 @@ ss::future<tx_errc> tx_gateway_frontend::recommit_tm_tx(
         ok = ok && (r.ec == tx_errc::none);
     }
     if (!ok) {
-        co_return tx_errc::invalid_txn_state;
+        co_return tx_errc::unknown_server_error;
     }
     co_return tx_errc::none;
 }
@@ -1467,22 +1527,16 @@ ss::future<tx_errc> tx_gateway_frontend::reabort_tm_tx(
 // get_tx must be called under stm->get_tx_lock
 ss::future<checked<tm_transaction, tx_errc>>
 tx_gateway_frontend::get_ongoing_tx(
+  model::term_id expected_term,
   ss::shared_ptr<tm_stm> stm,
   model::producer_identity pid,
-  kafka::transactional_id transactional_id,
+  kafka::transactional_id tx_id,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = co_await stm->get_actual_tx(transactional_id);
-    if (!maybe_tx.has_value()) {
-        if (maybe_tx.error() == tm_stm::op_status::not_found) {
-            co_return tx_errc::invalid_producer_id_mapping;
-        }
-        if (maybe_tx.error() == tm_stm::op_status::not_leader) {
-            co_return tx_errc::not_coordinator;
-        }
-        co_return tx_errc::invalid_txn_state;
+    auto tx_opt = stm->get_tx(tx_id);
+    if (!tx_opt.has_value()) {
+        co_return tx_errc::invalid_producer_id_mapping;
     }
-
-    auto tx = maybe_tx.value();
+    auto tx = tx_opt.value();
 
     if (tx.pid != pid) {
         if (tx.pid.id == pid.id && tx.pid.epoch > pid.epoch) {
@@ -1493,7 +1547,7 @@ tx_gateway_frontend::get_ongoing_tx(
     }
 
     if (tx.status == tm_transaction::tx_status::ready) {
-        if (!stm->is_actual_term(tx.etag)) {
+        if (expected_term != tx.etag) {
             // There is a possibility that a transaction was already started on
             // a previous leader. Failing this request since it has a chance of
             // being a part of that transaction. We expect client to abort on
@@ -1501,16 +1555,10 @@ tx_gateway_frontend::get_ongoing_tx(
             co_return tx_errc::invalid_txn_state;
         }
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        if (!stm->is_actual_term(tx.etag)) {
-            // Intentnally empty body. Leaving it just to comment what's going
-            // on.
-            //
-            // We don't save ongoing state to the log so the only case when it's
-            // possible to observe old ongoing transaction is when the tx was
-            // started on this node. Then an another node became leader, a
-            // client didn't issue any new requests to that node, the current
-            // node became leader again and the client woke up. It's safe to
-            // continue it.
+        if (expected_term != tx.etag) {
+            // Impossible situation: sync() should wipe all ongoing txes
+            // existed in prev term
+            co_return tx_errc::invalid_txn_state;
         }
         co_return tx;
     } else if (tx.status == tm_transaction::tx_status::preparing) {
@@ -1544,7 +1592,7 @@ tx_gateway_frontend::get_ongoing_tx(
             co_return ec;
         }
 
-        if (!stm->is_actual_term(tx.etag)) {
+        if (expected_term != tx.etag) {
             // The tx has started on the previous term. Even though we rolled it
             // forward there is a possibility that a previous leader did the
             // same and already started the current transaction.
@@ -1554,12 +1602,13 @@ tx_gateway_frontend::get_ongoing_tx(
             // So marking it as ready. We use previous term because aborting a
             // tx in current ready state with current term means we abort a tx
             // which wasn't started and it leads to an error.
-            std::ignore = co_await stm->reset_tx_ready(tx.id, tx.etag);
+            std::ignore = co_await stm->reset_tx_ready(
+              expected_term, tx.id, tx.etag);
             co_return tx_errc::invalid_txn_state;
         }
     }
 
-    auto ongoing_tx = stm->reset_tx_ongoing(tx.id);
+    auto ongoing_tx = stm->reset_tx_ongoing(tx.id, expected_term);
     if (!ongoing_tx.has_value()) {
         co_return tx_errc::invalid_txn_state;
     }
@@ -1664,7 +1713,12 @@ ss::future<> tx_gateway_frontend::do_expire_old_tx(
   ss::shared_ptr<tm_stm> stm,
   kafka::transactional_id tx_id,
   model::timeout_clock::duration timeout) {
-    auto tx_opt = co_await stm->get_actual_tx(tx_id);
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        co_return;
+    }
+    auto term = term_opt.value();
+    auto tx_opt = stm->get_tx(tx_id);
     if (!tx_opt) {
         // either timeout or already expired
         co_return;
@@ -1680,10 +1734,14 @@ ss::future<> tx_gateway_frontend::do_expire_old_tx(
     if (tx.status == tm_transaction::tx_status::ready) {
         // already in a good state, we don't need to do anything
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        r = co_await do_abort_tm_tx(stm, tx, timeout);
+        r = co_await do_abort_tm_tx(term, stm, tx, timeout);
     } else if (tx.status == tm_transaction::tx_status::preparing) {
         r = co_await do_commit_tm_tx(
-          stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
+          term,
+          stm,
+          tx,
+          timeout,
+          ss::make_lw_shared<available_promise<tx_errc>>());
     } else {
         tx_errc ec;
         if (tx.status == tm_transaction::tx_status::prepared) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1250,7 +1250,7 @@ tx_gateway_frontend::do_abort_tm_tx(
 
         // writing ready status to overwrite an ongoing transaction if
         // it exists on an older leader
-        auto ready_tx = co_await stm->mark_tx_ready(tx.id);
+        auto ready_tx = co_await stm->reset_tx_ready(tx.id);
         if (!ready_tx.has_value()) {
             co_return tx_errc::invalid_txn_state;
         }
@@ -1559,7 +1559,7 @@ tx_gateway_frontend::get_ongoing_tx(
             // So marking it as ready. We use previous term because aborting a
             // tx in current ready state with current term means we abort a tx
             // which wasn't started and it leads to an error.
-            std::ignore = co_await stm->mark_tx_ready(tx.id, tx.etag);
+            std::ignore = co_await stm->reset_tx_ready(tx.id, tx.etag);
             co_return tx_errc::invalid_txn_state;
         }
     }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -748,8 +748,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
         // already in a good state, we don't need to do nothing. even if
         // tx's etag is old it will be bumped by re_register_producer
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        r = co_await do_abort_tm_tx(
-          stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
+        r = co_await do_abort_tm_tx(stm, tx, timeout);
     } else if (tx.status == tm_transaction::tx_status::preparing) {
         r = co_await do_commit_tm_tx(
           stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
@@ -1209,10 +1208,21 @@ tx_gateway_frontend::do_end_txn(
             co_return tx_errc::invalid_txn_state;
         }
     } else {
-        r = co_await do_abort_tm_tx(stm, tx, timeout, outcome);
+        try {
+            r = co_await do_abort_tm_tx(stm, tx, timeout);
+        } catch (...) {
+            outcome->set_value(tx_errc::unknown_server_error);
+            throw;
+        }
+        if (r.has_value()) {
+            outcome->set_value(tx_errc::none);
+        } else {
+            auto ret = r.error();
+            outcome->set_value(std::move(ret));
+        }
     }
     // starting from this point we don't need to set outcome on return because
-    // we shifted this responsibility to do_commit_tm_tx & do_abort_tm_tx
+    // we shifted this responsibility to do_commit_tm_tx
     if (!r.has_value()) {
         co_return r;
     }
@@ -1229,52 +1239,39 @@ ss::future<checked<cluster::tm_transaction, tx_errc>>
 tx_gateway_frontend::do_abort_tm_tx(
   ss::shared_ptr<cluster::tm_stm> stm,
   cluster::tm_transaction tx,
-  model::timeout_clock::duration timeout,
-  ss::lw_shared_ptr<available_promise<tx_errc>> outcome) {
-    try {
-        if (tx.status == tm_transaction::tx_status::ready) {
-            if (stm->is_actual_term(tx.etag)) {
-                // client should start a transaction before attempting to
-                // abort it. since tx has actual term we know for sure it
-                // wasn't start on a different leader
-                outcome->set_value(tx_errc::invalid_txn_state);
-                co_return tx_errc::invalid_txn_state;
-            }
-
-            // writing ready status to overwrite an ongoing transaction if
-            // it exists on an older leader
-            auto ready_tx = co_await stm->mark_tx_ready(tx.id);
-            if (!ready_tx.has_value()) {
-                outcome->set_value(tx_errc::invalid_txn_state);
-                co_return tx_errc::invalid_txn_state;
-            }
-            outcome->set_value(tx_errc::none);
-            co_return ready_tx.value();
-        } else if (
-          tx.status != tm_transaction::tx_status::ongoing
-          && tx.status != tm_transaction::tx_status::killed) {
-            outcome->set_value(tx_errc::invalid_txn_state);
+  model::timeout_clock::duration timeout) {
+    if (tx.status == tm_transaction::tx_status::ready) {
+        if (stm->is_actual_term(tx.etag)) {
+            // client should start a transaction before attempting to
+            // abort it. since tx has actual term we know for sure it
+            // wasn't start on a different leader
             co_return tx_errc::invalid_txn_state;
         }
 
-        if (tx.status == tm_transaction::tx_status::ongoing) {
-            auto changed_tx = co_await stm->try_change_status(
-              tx.id, cluster::tm_transaction::tx_status::aborting);
-            if (!changed_tx.has_value()) {
-                if (changed_tx.error() == tm_stm::op_status::not_leader) {
-                    outcome->set_value(tx_errc::not_coordinator);
-                    co_return tx_errc::not_coordinator;
-                }
-                outcome->set_value(tx_errc::unknown_server_error);
-                co_return tx_errc::unknown_server_error;
-            }
-            tx = changed_tx.value();
+        // writing ready status to overwrite an ongoing transaction if
+        // it exists on an older leader
+        auto ready_tx = co_await stm->mark_tx_ready(tx.id);
+        if (!ready_tx.has_value()) {
+            co_return tx_errc::invalid_txn_state;
         }
-    } catch (...) {
-        outcome->set_value(tx_errc::unknown_server_error);
-        throw;
+        co_return ready_tx.value();
+    } else if (
+      tx.status != tm_transaction::tx_status::ongoing
+      && tx.status != tm_transaction::tx_status::killed) {
+        co_return tx_errc::invalid_txn_state;
     }
-    outcome->set_value(tx_errc::none);
+
+    if (tx.status == tm_transaction::tx_status::ongoing) {
+        auto changed_tx = co_await stm->try_change_status(
+          tx.id, cluster::tm_transaction::tx_status::aborting);
+        if (!changed_tx.has_value()) {
+            if (changed_tx.error() == tm_stm::op_status::not_leader) {
+                co_return tx_errc::not_coordinator;
+            }
+            co_return tx_errc::unknown_server_error;
+        }
+        tx = changed_tx.value();
+    }
 
     std::vector<ss::future<abort_tx_reply>> pfs;
     for (auto rm : tx.partitions) {
@@ -1688,8 +1685,7 @@ ss::future<> tx_gateway_frontend::do_expire_old_tx(
     if (tx.status == tm_transaction::tx_status::ready) {
         // already in a good state, we don't need to do anything
     } else if (tx.status == tm_transaction::tx_status::ongoing) {
-        r = co_await do_abort_tm_tx(
-          stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());
+        r = co_await do_abort_tm_tx(stm, tx, timeout);
     } else if (tx.status == tm_transaction::tx_status::preparing) {
         r = co_await do_commit_tm_tx(
           stm, tx, timeout, ss::make_lw_shared<available_promise<tx_errc>>());

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1262,8 +1262,7 @@ tx_gateway_frontend::do_abort_tm_tx(
     }
 
     if (tx.status == tm_transaction::tx_status::ongoing) {
-        auto changed_tx = co_await stm->try_change_status(
-          tx.id, cluster::tm_transaction::tx_status::aborting);
+        auto changed_tx = co_await stm->mark_tx_aborting(tx.id);
         if (!changed_tx.has_value()) {
             if (changed_tx.error() == tm_stm::op_status::not_leader) {
                 co_return tx_errc::not_coordinator;

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -99,6 +99,7 @@ private:
     ss::future<bool> try_create_tx_topic();
 
     ss::future<checked<tm_transaction, tx_errc>> get_ongoing_tx(
+      model::term_id,
       ss::shared_ptr<tm_stm>,
       model::producer_identity,
       kafka::transactional_id,
@@ -117,6 +118,7 @@ private:
       model::tx_seq,
       model::timeout_clock::duration);
     ss::future<try_abort_reply> do_try_abort(
+      model::term_id,
       ss::shared_ptr<tm_stm>,
       kafka::transactional_id,
       model::producer_identity,
@@ -145,10 +147,12 @@ private:
       model::timeout_clock::duration,
       ss::lw_shared_ptr<available_promise<tx_errc>>);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_abort_tm_tx(
+      model::term_id,
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_commit_tm_tx(
+      model::term_id,
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -147,8 +147,7 @@ private:
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_abort_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
-      model::timeout_clock::duration,
-      ss::lw_shared_ptr<available_promise<tx_errc>>);
+      model::timeout_clock::duration);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_commit_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,


### PR DESCRIPTION
## Cover letter

The PR [fixes](https://github.com/vectorizedio/redpanda/commit/b2f952a714d2db53c5ece362463b20969d1378ea) a situation in which a transaction is reported to client as being rejected while it actually is committed:

 1. a client commits a transaction
 2. the transaction is committed
 3. tx coordinator dies just before it acks a tx
 4. the client retries the commit
 5. the commit hits server and sees that the transaction may be already committed

In this case we used to return `invalid_txn_state` which users were interpreting as a rejection. Redpanda could roll a transaction forward but it would caused another problem. In case when a transaction was genuine aborted the retried transaction might observed previous committed transaction and wrongly "thought" that it was committed. This misunderstanding is possible since txs don't have unique id and use producer's id instead: so it's barley possible to distinguish transactions withing a session.

The rest parts of the PR make transaction subsystem in general more robust:

 - drop volatile state on re-election to prevent acting on dirty state
 - fix lock bypass by using conditional replicate
 - get rid of sophisticated code (early abort)

## Release notes

### Improvements

* make transactional system more robust