### PR TITLE
rpk: admin API client fixes for partially unavailable clusters & transient errors

### DIFF
--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -586,6 +586,8 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sethgrid/pester v1.1.0 h1:IyEAVvwSUPjs2ACFZkBe5N59BBUpSIkQ71Hr6cM5A+w=
+github.com/sethgrid/pester v1.1.0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8
+	github.com/sethgrid/pester v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -296,6 +296,8 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sethgrid/pester v1.1.0 h1:IyEAVvwSUPjs2ACFZkBe5N59BBUpSIkQ71Hr6cM5A+w=
+github.com/sethgrid/pester v1.1.0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -88,12 +88,10 @@ func NewHostClient(
 }
 
 func NewAdminAPI(urls []string, tlsConfig *tls.Config) (*AdminAPI, error) {
-	return newAdminAPI(urls, tlsConfig, true)
+	return newAdminAPI(urls, tlsConfig)
 }
 
-func newAdminAPI(
-	urls []string, tlsConfig *tls.Config, tryToMapBrokerIDstoHosts bool,
-) (*AdminAPI, error) {
+func newAdminAPI(urls []string, tlsConfig *tls.Config) (*AdminAPI, error) {
 	if len(urls) == 0 {
 		return nil, errors.New("at least one url is required for the admin api")
 	}
@@ -153,15 +151,11 @@ func newAdminAPI(
 		a.urls[i] = fmt.Sprintf("%s://%s", scheme, host)
 	}
 
-	if tryToMapBrokerIDstoHosts {
-		a.mapBrokerIDsToURLs()
-	}
-
 	return a, nil
 }
 
 func (a *AdminAPI) newAdminForSingleHost(host string) (*AdminAPI, error) {
-	return newAdminAPI([]string{host}, a.tlsConfig, false)
+	return newAdminAPI([]string{host}, a.tlsConfig)
 }
 
 func (a *AdminAPI) urlsWithPath(path string) []string {

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -46,9 +46,8 @@ func TestAdminAPI(t *testing.T) {
 			nNodes:   1,
 			leaderID: 0,
 			action:   func(t *testing.T, a *AdminAPI) error { return a.DeleteUser("Milo") },
-			all:      []string{"/v1/node_config"},
 			leader:   []string{"/v1/security/users/Milo"},
-			none:     []string{"/v1/partitions/redpanda/controller/0"},
+			none:     []string{"/v1/partitions/redpanda/controller/0", "/v1/node_config"},
 		},
 		{
 			name:     "delete user in 3 node cluster",
@@ -84,7 +83,6 @@ func TestAdminAPI(t *testing.T) {
 				require.Len(t, users, 4)
 				return nil
 			},
-			all:  []string{"/v1/node_config"},
 			any:  []string{"/v1/security/users"},
 			none: []string{"/v1/partitions/redpanda/controller/0"},
 		},

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -25,7 +25,7 @@ type Config map[string]interface{}
 // multiple URLs are configured.
 func (a *AdminAPI) Config() (Config, error) {
 	var rawResp []byte
-	err := a.sendOne(http.MethodGet, "/v1/config", nil, &rawResp)
+	err := a.sendOne(http.MethodGet, "/v1/config", nil, &rawResp, false)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (a *AdminAPI) SetLogLevel(name, level string, expirySeconds int) error {
 	}
 
 	path := fmt.Sprintf("/v1/config/log_level/%s?level=%s&expires=%d", url.PathEscape(name), level, expirySeconds)
-	return a.sendOne(http.MethodPut, path, nil, nil)
+	return a.sendOne(http.MethodPut, path, nil, nil, false)
 }
 
 type ConfigPropertyItems struct {

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -25,7 +25,7 @@ type Config map[string]interface{}
 // multiple URLs are configured.
 func (a *AdminAPI) Config() (Config, error) {
 	var rawResp []byte
-	err := a.sendOne(http.MethodGet, "/v1/config", nil, &rawResp, false)
+	err := a.sendAny(http.MethodGet, "/v1/config", nil, &rawResp)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/api/admin/api_metrics.go
+++ b/src/go/rpk/pkg/api/admin/api_metrics.go
@@ -13,6 +13,6 @@ import "net/http"
 
 func (a *AdminAPI) PrometheusMetrics() ([]byte, error) {
 	var res []byte
-	err := a.sendOne(http.MethodGet, "/metrics", nil, &res)
+	err := a.sendOne(http.MethodGet, "/metrics", nil, &res, false)
 	return res, err
 }

--- a/src/go/rpk/pkg/api/admin/api_node_config.go
+++ b/src/go/rpk/pkg/api/admin/api_node_config.go
@@ -21,5 +21,6 @@ type NodeConfig struct {
 // otherwise the method will return an error.
 func (a *AdminAPI) GetNodeConfig() (NodeConfig, error) {
 	var nodeconfig NodeConfig
-	return nodeconfig, a.sendOne(http.MethodGet, "/v1/node_config", nil, &nodeconfig)
+
+	return nodeconfig, a.sendOne(http.MethodGet, "/v1/node_config", nil, &nodeconfig, false)
 }

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -50,7 +50,7 @@ public:
     }
 
     template<typename T>
-    auto get(const credential_user& name) -> std::optional<T> const {
+    auto get(const credential_user& name) const -> std::optional<T> const {
         if (auto it = _credentials.find(name); it != _credentials.end()) {
             return std::get<T>(it->second);
         }

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -293,6 +293,21 @@ public:
         return bytes(result.begin(), result.end());
     }
 
+    /**
+     * For doing non-SCRAM authentication, such as HTTP basic auth over TLS,
+     * using stored SCRAM credentials.
+     */
+    static bool validate_password(
+      const ss::sstring& password,
+      bytes_view reference_stored_key,
+      bytes_view salt,
+      int iterations) {
+        auto salted_password = salt_password(password, salt, iterations);
+        auto clientkey = client_key(salted_password);
+        auto storedkey = stored_key(clientkey);
+        return storedkey == reference_stored_key;
+    }
+
 private:
     static bytes salt_password(
       const ss::sstring& password, bytes_view salt, int iterations) {

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -310,8 +310,10 @@ class RpkTool:
 
     def _admin_host(self, node=None):
         if node is None:
-            node = self._redpanda.nodes[0]
-        return f"{node.account.hostname}:9644"
+            return ",".join(
+                [f"{n.account.hostname}:9644" for n in self._redpanda.nodes])
+        else:
+            return f"{node.account.hostname}:9644"
 
     def admin_config_print(self, node):
         return self._execute([

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -38,6 +38,9 @@ Partition = collections.namedtuple('Partition',
 MetricSample = collections.namedtuple(
     'MetricSample', ['family', 'sample', 'node', 'value', 'labels'])
 
+SaslCredentials = collections.namedtuple("SaslCredentials",
+                                         ["username", "password", "algorithm"])
+
 DEFAULT_LOG_ALLOW_LIST = [
     # Tests currently don't run on XFS, although in future they should.
     # https://github.com/vectorizedio/redpanda/issues/2376
@@ -192,7 +195,8 @@ class RedpandaService(Service):
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"
 
-    SUPERUSER_CREDENTIALS = ("admin", "admin", "SCRAM-SHA-256")
+    SUPERUSER_CREDENTIALS: SaslCredentials = SaslCredentials(
+        "admin", "admin", "SCRAM-SHA-256")
 
     COV_KEY = "enable_cov"
     DEFAULT_COV_OPT = False

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -210,7 +210,7 @@ class ScramTest(RedpandaTest):
         print(topics)
         assert topic.name in topics
 
-        username = self.redpanda.SUPERUSER_CREDENTIALS[0]
+        username = self.redpanda.SUPERUSER_CREDENTIALS.username
         self.delete_user(username)
 
         try:
@@ -228,7 +228,7 @@ class ScramTest(RedpandaTest):
             pass
 
         # recreate user
-        algorithm = self.redpanda.SUPERUSER_CREDENTIALS[2]
+        algorithm = self.redpanda.SUPERUSER_CREDENTIALS.algorithm
         password = self.create_user(username, algorithm)
 
         # works ok again


### PR DESCRIPTION
## Cover letter

Issue #3615 highlighted that RPK does not retry on 503 -- it turns out that the default golang http client doesn't retry at all.  That's okay when the cluster is in a stable state, but creates avoidable errors from RPK when the cluster is going through changes or when only one node is unavailable.

When looking into this, it turned out there were various other cases that needed handling: not just when an http request needs retrying, but when we need to retry on a different node, or when we need to retry because the leader ID is unknown (normal when leader transfer is taking place or shortly after restarts).

Added tests for RPK CLI operations on degraded clusters, and completely offline clusters.  In the process of doing that with user creation as one of the examples, also noticed that this endpoint is awkward to retry because it isn't idempotent (POSTs don't have to be idempotent, but it's helpful if they are).

Fixes: #3615

## Release notes

### Improvements

* RPK commands that use the Redpanda admin API are more robust when a node is offline or a leadership transfer is in process.
