### PR TITLE
idempotency: support compacted topics

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -218,6 +218,18 @@ rm_stm::rm_stm(
     auto_abort_timer.set_callback([this] { abort_old_txes(); });
 }
 
+bool rm_stm::check_tx_permitted() {
+    if (_c->log_config().is_compacted()) {
+        vlog(
+          clusterlog.error,
+          "Can't process a transactional request to {}. Compacted topic "
+          "doesn't support transactional processing.",
+          _c->ntp());
+        return false;
+    }
+    return true;
+}
+
 ss::future<checked<model::term_id, tx_errc>> rm_stm::begin_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
@@ -237,6 +249,10 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   std::chrono::milliseconds transaction_timeout_ms) {
+    if (!check_tx_permitted()) {
+        co_return tx_errc::request_rejected;
+    }
+
     if (!_c->is_leader()) {
         co_return tx_errc::leader_not_found;
     }
@@ -343,6 +359,10 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    if (!check_tx_permitted()) {
+        co_return tx_errc::request_rejected;
+    }
+
     if (!co_await sync(timeout)) {
         co_return tx_errc::stale;
     }
@@ -452,6 +472,10 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    if (!check_tx_permitted()) {
+        co_return tx_errc::request_rejected;
+    }
+
     // doesn't make sense to fence off a commit because transaction
     // manager has already decided to commit and acked to a client
     if (!co_await sync(timeout)) {
@@ -617,6 +641,10 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
   model::producer_identity pid,
   std::optional<model::tx_seq> tx_seq,
   model::timeout_clock::duration timeout) {
+    if (!check_tx_permitted()) {
+        co_return tx_errc::request_rejected;
+    }
+
     // doesn't make sense to fence off an abort because transaction
     // manager has already decided to abort and acked to a client
     if (!co_await sync(timeout)) {
@@ -852,6 +880,10 @@ void rm_stm::set_seq(model::batch_identity bid, model::offset last_offset) {
 
 ss::future<result<raft::replicate_result>>
 rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
+    if (!check_tx_permitted()) {
+        co_return errc::generic_tx_error;
+    }
+
     if (!co_await sync(_sync_timeout)) {
         co_return errc::not_leader;
     }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -274,6 +274,7 @@ private:
     void compact_snapshot();
 
     ss::future<bool> sync(model::timeout_clock::duration);
+    bool check_tx_permitted();
 
     void track_tx(model::producer_identity, std::chrono::milliseconds);
     void abort_old_txes();

--- a/tests/rptest/tests/idempotency_test.py
+++ b/tests/rptest/tests/idempotency_test.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+from confluent_kafka import (Producer, KafkaException)
+
+
+def on_delivery(err, msg):
+    if err is not None:
+        raise KafkaException(err)
+
+
+class IdempotencyTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(IdempotencyTest, self).__init__(test_context=test_context,
+                                              extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3)
+    def test_idempotency_compacted_topic(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1", config={"cleanup.policy": "compact"})
+
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "retries": 5
+        })
+        producer.produce("topic1",
+                         key="key1".encode('utf-8'),
+                         value="value1".encode('utf-8'),
+                         callback=on_delivery)
+        producer.flush()


### PR DESCRIPTION
## Cover letter

Idempotency already support the compacted topics; it was turned off by default because the support isn't complete and may cause premature session termination but it doesn't lead to a violation so it's ok to turn it on.

Premature session termination?

Idempotency relies on the applied batches, uses the batch's metadata to fill its seq table (a map from producer is to the last send record number). When a batch is overwritten during the compaction we may lose the meta info too and the seq table may be incomplete.

It leads to situation when a producer relays on the local knowledge of what was replicated, tries replicating a record with the next seq number and it is got rejected because the seq table isn't complete (another producer issued a record with the same key and it overwritten the first during compaction).

The complete support requires Raft snapshots that aren't bound to truncation.

## Release notes

* update idempotency to support compacted topics