### PR TITLE
[transaction] Get all transaction request 

### DIFF
--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -141,6 +141,10 @@ public:
      */
     const ntp_table_container& partitions() const { return _ntp_table; }
 
+    ss::sharded<cluster::tx_gateway_frontend>& get_tx_frontend() {
+        return _tx_gateway_frontend;
+    }
+
 private:
     /// Download log if partition_recovery_manager is initialized.
     ///

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -412,6 +412,24 @@ std::vector<kafka::transactional_id> tm_stm::get_expired_txs() {
     return ids;
 }
 
+ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
+    if (!_c->is_leader()) {
+        co_return tm_stm::op_status::not_leader;
+    }
+
+    auto is_ready = co_await sync(_sync_timeout);
+    if (!is_ready) {
+        co_return tm_stm::op_status::unknown;
+    }
+
+    std::vector<tm_transaction> ans;
+    for (const auto& [_, tx] : _tx_table) {
+        ans.push_back(tx);
+    }
+
+    co_return ans;
+}
+
 ss::future<> tm_stm::expire_tx(kafka::transactional_id tx_id) {
     auto ptx = _tx_table.find(tx_id);
     if (ptx == _tx_table.end()) {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -171,6 +171,10 @@ public:
 
     std::vector<kafka::transactional_id> get_expired_txs();
 
+    using get_txs_result
+      = checked<std::vector<tm_transaction>, tm_stm::op_status>;
+    ss::future<get_txs_result> get_all_transactions();
+
 protected:
     ss::future<> handle_eviction() override;
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -79,6 +79,33 @@ struct tm_transaction {
     std::vector<tx_group> groups;
 
     friend std::ostream& operator<<(std::ostream&, const tm_transaction&);
+
+    std::string_view get_status() const {
+        switch (status) {
+        case tx_status::ongoing:
+            return "ongoing";
+        case tx_status::preparing:
+            return "preparing";
+        case tx_status::prepared:
+            return "prepared";
+        case tx_status::aborting:
+            return "aborting";
+        case tx_status::killed:
+            return "killed";
+        case tx_status::ready:
+            return "ready";
+        case tx_status::tombstone:
+            return "tombstone";
+        }
+    }
+
+    std::chrono::milliseconds get_staleness() const {
+        auto now = ss::lowres_system_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          now - last_update_ts);
+    }
+
+    std::chrono::milliseconds get_timeout() const { return timeout_ms; }
 };
 
 struct tm_snapshot {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -25,6 +25,7 @@
 #include "config/configuration.h"
 #include "errc.h"
 #include "types.h"
+#include "utils/gate_guard.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -1157,6 +1158,55 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
 
           return decided.then(
             [](tx_errc ec) { return end_tx_reply{.error_code = ec}; });
+      });
+}
+
+ss::future<tx_gateway_frontend::return_all_txs_res>
+tx_gateway_frontend::get_all_transactions() {
+    auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
+
+    if (!shard.has_value()) {
+        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
+        co_return tx_errc::shard_not_found;
+    }
+
+    co_return co_await container().invoke_on(
+      *shard,
+      _ssg,
+      [](tx_gateway_frontend& self)
+        -> ss::future<tx_gateway_frontend::return_all_txs_res> {
+          auto partition = self._partition_manager.local().get(
+            model::tx_manager_ntp);
+          if (!partition) {
+              vlog(
+                txlog.warn,
+                "can't get partition by {} ntp",
+                model::tx_manager_ntp);
+              co_return tx_errc::partition_not_found;
+          }
+
+          auto stm = partition->tm_stm();
+
+          if (!stm) {
+              vlog(
+                txlog.error,
+                "can't get tm stm of the {}' partition",
+                model::tx_manager_ntp);
+              co_return tx_errc::unknown_server_error;
+          }
+
+          auto gate_lock = gate_guard(self._gate);
+          auto read_lock = co_await stm->read_lock();
+
+          auto res = co_await stm->get_all_transactions();
+          if (!res.has_value()) {
+              if (res.error() == tm_stm::op_status::not_leader) {
+                  co_return tx_errc::not_coordinator;
+              }
+              co_return tx_errc::unknown_server_error;
+          }
+
+          co_return res.value();
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -62,6 +62,9 @@ public:
     ss::future<end_tx_reply>
       end_txn(end_tx_request, model::timeout_clock::duration);
 
+    using return_all_txs_res = result<std::vector<tm_transaction>, tx_errc>;
+    ss::future<return_all_txs_res> get_all_transactions();
+
     ss::future<> stop();
 
 private:

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -55,6 +55,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/hbadger.json.h
 )
 
+seastar_generate_swagger(
+  TARGET transaction_swagger
+  VAR transaction_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/transaction.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/transaction.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS 
@@ -77,7 +84,8 @@ add_executable(redpanda
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger cluster_config_swagger raft_swagger
-    security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger)
+    security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger
+    transaction_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -1,0 +1,129 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/transactions",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/transactions",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get a list of transactions",
+                    "type": "array",
+                    "items": {
+                        "type": "transaction_summary"
+                    },
+                    "nickname": "get_all_transactions",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        }
+    ],
+    "models": {
+        "producer_identity": {
+            "id": "producer_identity",
+            "description": "Producer identity",
+            "properties": {
+                "id": {
+                    "type": "long",
+                    "description": "Producer id"
+                },
+                "epoch": {
+                    "type": "long",
+                    "description": "Producer epoch"
+                }
+            }
+        },
+        "partition": {
+            "id": "partition",
+            "description": "Partition info",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "topic"
+                },
+                "partition_id": {
+                    "type": "long",
+                    "description": "partition"
+                },
+                "etag": {
+                    "type": "long",
+                    "description": "Raft term"
+                }
+            }
+        },
+        "group": {
+            "id": "group",
+            "description": "Group info",
+            "properties": {
+                "group_id": {
+                    "type": "string",
+                    "description": "Group id"
+                },
+                "etag": {
+                    "type": "long",
+                    "description": "Raft term"
+                }
+            }
+        },
+        "transaction_summary": {
+            "id": "transaction_summary",
+            "description": "Transaction summary",
+            "properties": {
+                "transactional_id": {
+                    "type": "string",
+                    "description": "Id of an application executing a transaction"
+                },
+                "pid": {
+                    "type": "producer_identity",
+                    "description": "pid"
+                },
+                "tx_seq": {
+                    "type": "long",
+                    "description": "tx_seq identifues a transactions within a session"
+                },
+                "etag": {
+                    "type": "long",
+                    "description": "Term of a transaction coordinated started a transaction"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Current status for transaction"
+                },
+                "timeout_ms": {
+                    "type": "long",
+                    "description": "Transaction timeout"
+                },
+                "staleness_ms": {
+                    "type": "long",
+                    "description": "How long transaction does not make progress"
+                },
+                "partitions": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition"
+                    },
+                    "description": "Partitions for transaction"
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "group"
+                    },
+                    "description": "Consumer groups for transaction"
+                }
+            }
+        }
+    }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -22,6 +22,7 @@
 #include "cluster/security_frontend.h"
 #include "cluster/shard_table.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
@@ -39,6 +40,7 @@
 #include "redpanda/admin/api-doc/raft.json.h"
 #include "redpanda/admin/api-doc/security.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
+#include "redpanda/admin/api-doc/transaction.json.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "vlog.h"
@@ -128,6 +130,8 @@ void admin_server::configure_admin_routes() {
     rb->register_api_file(_server._routes, "hbadger");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "broker");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "transaction");
 
     register_config_routes();
     register_cluster_config_routes();
@@ -138,6 +142,7 @@ void admin_server::configure_admin_routes() {
     register_broker_routes();
     register_partition_routes();
     register_hbadger_routes();
+    register_transaction_routes();
 }
 
 struct json_validator {
@@ -1746,5 +1751,86 @@ void admin_server::register_hbadger_routes() {
                    [m, p] { finjector::shard_local_badger().unset(m, p); })
             .then(
               [] { return ss::json::json_return_type(ss::json::json_void()); });
+      });
+}
+
+void admin_server::register_transaction_routes() {
+    ss::httpd::transaction_json::get_all_transactions.set(
+      _server._routes,
+      [this](std::unique_ptr<ss::httpd::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          if (!config::shard_local_cfg().enable_transactions) {
+              throw ss::httpd::bad_request_exception(
+                "Transaction are disabled");
+          }
+
+          if (need_redirect_to_leader(model::tx_manager_ntp, _metadata_cache)) {
+              throw co_await redirect_to_leader(*req, model::tx_manager_ntp);
+          }
+
+          auto& tx_frontend = _partition_manager.local().get_tx_frontend();
+          if (!tx_frontend.local_is_initialized()) {
+              throw ss::httpd::bad_request_exception("Can not get tx_frontend");
+          }
+
+          auto res = co_await tx_frontend.local().get_all_transactions();
+          if (!res.has_value()) {
+              co_await throw_on_error(*req, res.error(), model::tx_manager_ntp);
+          }
+
+          using tx_info = ss::httpd::transaction_json::transaction_summary;
+          std::vector<tx_info> ans;
+          ans.reserve(res.value().size());
+
+          for (auto& tx : res.value()) {
+              if (tx.status == cluster::tm_transaction::tx_status::tombstone) {
+                  continue;
+              }
+
+              tx_info new_tx;
+
+              new_tx.transactional_id = tx.id;
+
+              ss::httpd::transaction_json::producer_identity pid;
+              pid.id = tx.pid.id;
+              pid.epoch = tx.pid.epoch;
+              new_tx.pid = pid;
+
+              new_tx.tx_seq = tx.tx_seq;
+              new_tx.etag = tx.etag;
+
+              // The motivation behind mapping killed to aborting is to make
+              // user not to think about the subtle differences between both
+              // statuses
+              if (tx.status == cluster::tm_transaction::tx_status::killed) {
+                  tx.status = cluster::tm_transaction::tx_status::aborting;
+              }
+              new_tx.status = ss::sstring(tx.get_status());
+
+              new_tx.timeout_ms = tx.get_timeout().count();
+              new_tx.staleness_ms = tx.get_staleness().count();
+
+              for (auto& partition : tx.partitions) {
+                  ss::httpd::transaction_json::partition partition_info;
+                  partition_info.ns = partition.ntp.ns;
+                  partition_info.topic = partition.ntp.tp.topic;
+                  partition_info.partition_id = partition.ntp.tp.partition;
+                  partition_info.etag = partition.etag;
+
+                  new_tx.partitions.push(partition_info);
+              }
+
+              for (auto& group : tx.groups) {
+                  ss::httpd::transaction_json::group group_info;
+                  group_info.group_id = group.group_id;
+                  group_info.etag = group.etag;
+
+                  new_tx.groups.push(group_info);
+              }
+
+              ans.push_back(std::move(new_tx));
+          }
+
+          co_return ss::json::json_return_type(ans);
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -83,6 +83,7 @@ private:
     void register_broker_routes();
     void register_partition_routes();
     void register_hbadger_routes();
+    void register_transaction_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -204,6 +204,13 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transactions"
         return self._request('get', path, node=node).json()
 
+    def get_all_transactions(self, node=None):
+        """
+        Get all transactions
+        """
+        path = f"transactions"
+        return self._request('get', path, node=node).json()
+
     def mark_transaction_expired(self,
                                  topic,
                                  partition,

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -16,12 +16,8 @@ from rptest.tests.redpanda_test import RedpandaTest
 
 
 class TxAdminTest(RedpandaTest):
-    topics = (TopicSpec(name="tx_test1",
-                        partition_count=3,
-                        replication_factor=3),
-              TopicSpec(name="tx_test2",
-                        partition_count=3,
-                        replication_factor=3))
+    topics = (TopicSpec(partition_count=3, replication_factor=3),
+              TopicSpec(partition_count=3, replication_factor=3))
 
     def __init__(self, test_context):
         super(TxAdminTest,
@@ -209,3 +205,41 @@ class TxAdminTest(RedpandaTest):
                     assert (self.extract_pid(tx) in expected_pids)
                     assert (tx['status'] == 'ongoing')
                     assert (tx['timeout_ms'] == 60000)
+
+    @cluster(num_nodes=3)
+    def test_all_transactions(self):
+        tx_id = "0"
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': tx_id,
+        })
+        producer.init_transactions()
+        producer.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer.produce(topic.name, '0', '0', partition)
+
+        producer.flush()
+
+        txs_info = self.admin.get_all_transactions()
+        assert len(txs_info) == 1
+
+        expected_partitions = dict()
+        tx = txs_info[0]
+
+        assert tx["transactional_id"] == tx_id
+        assert tx["timeout_ms"] == 60000
+
+        for partition in tx["partitions"]:
+            assert partition["ns"] == "kafka"
+            if partition["topic"] not in expected_partitions:
+                expected_partitions[partition["topic"]] = set()
+            expected_partitions[partition["topic"]].add(
+                partition["partition_id"])
+
+        for topic in self.topics:
+            assert len(
+                expected_partitions[topic.name]) == topic.partition_count
+            for partition in range(topic.partition_count):
+                assert partition in expected_partitions[topic.name]

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -16,9 +16,12 @@ from rptest.tests.redpanda_test import RedpandaTest
 
 
 class TxAdminTest(RedpandaTest):
-    topics = (TopicSpec(name="tx_test",
+    topics = (TopicSpec(name="tx_test1",
                         partition_count=3,
-                        replication_factor=3), )
+                        replication_factor=3),
+              TopicSpec(name="tx_test2",
+                        partition_count=3,
+                        replication_factor=3))
 
     def __init__(self, test_context):
         super(TxAdminTest,
@@ -118,17 +121,16 @@ class TxAdminTest(RedpandaTest):
         for topic in self.topics:
             for partition in range(topic.partition_count):
                 old_leader = self.admin.get_partition_leader(
-                    namespace="kafka", topic=self.topic, partition=partition)
+                    namespace="kafka", topic=topic, partition=partition)
 
                 self.admin.transfer_leadership_to(namespace="kafka",
-                                                  topic=self.topic,
+                                                  topic=topic,
                                                   partition=partition,
                                                   target=None)
 
                 def leader_is_changed():
                     return self.admin.get_partition_leader(
-                        namespace="kafka",
-                        topic=self.topic,
+                        namespace="kafka", topic=topic,
                         partition=partition) != old_leader
 
                 wait_until(leader_is_changed,


### PR DESCRIPTION
## Cover letter

Implement `get_all` request for admin api. It returns information about all transactions
Each transaction contains:
- transactional_id - id of an application executing a transaction
- pid - producer_identity
- tx_seq - tx_seq identifues a transactions within a session
- etag" - Term of a transaction coordinated started a transaction
- status - Current status for transaction
- timeout_ms - Transaction timeout
- staleness_ms - How long transaction does not make progress
- partitions - info about partitions in tx
- Partitions for transaction"
- groups - Consumer groups for transaction

If replica get http request it will resend it to leader for partition.

---
Part of fix #3544

## Release notes
### Features

* Implement `get_transaction` request for admin api. It returns information about all transactions
