### PR TITLE
[transaction] Delete partition from transaction request

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -65,6 +65,9 @@ public:
     using return_all_txs_res = result<std::vector<tm_transaction>, tx_errc>;
     ss::future<return_all_txs_res> get_all_transactions();
 
+    ss::future<tx_errc> delete_partition_from_tx(
+      kafka::transactional_id, tm_transaction::tx_partition);
+
     ss::future<> stop();
 
 private:
@@ -184,6 +187,11 @@ private:
       ss::shared_ptr<tm_stm>,
       add_offsets_tx_request,
       model::timeout_clock::duration);
+
+    ss::future<tx_errc> do_delete_partition_from_tx(
+      ss::shared_ptr<tm_stm>,
+      kafka::transactional_id,
+      tm_transaction::tx_partition);
 
     void expire_old_txs();
     ss::future<> do_expire_old_txs();

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -24,6 +24,52 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/transaction/{transactional_id}/delete_partition",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Delete partition from transaction",
+                    "type": "void",
+                    "nickname": "delete_partition",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "transactional_id",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "namespace",
+                            "in": "query",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "query",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition_id",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "etag",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -268,6 +268,27 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/mark_transaction_expired?id={pid['id']}&epoch={pid['epoch']}"
         return self._request("post", path, node=node)
 
+    def delete_partition_from_transaction(self,
+                                          tid,
+                                          namespace,
+                                          topic,
+                                          partition_id,
+                                          etag,
+                                          node=None):
+        """
+        Delete partition from transaction
+        """
+        partition_info = {
+            "namespace": namespace,
+            "topic": topic,
+            "partition_id": partition_id,
+            "etag": etag
+        }
+
+        params = "&".join([f"{k}={v}" for k, v in partition_info.items()])
+        path = f"transaction/{tid}/delete_partition/?{params}"
+        return self._request('post', path, node=node)
+
     def set_partition_replicas(self,
                                topic,
                                partition,


### PR DESCRIPTION
## Cover letter

This pr implements new admin_api requeest `/v1/transaction/{transactional_id}/delete_partition` to delete partition from in-flight transaction.

To identify transaction user should pass `{partition_id, etag}` to query param.

Fixes: #3544
Fixes: #3699

## Release notes
* Add delete partition from transaction request
