### PR TITLE
Unified replication path for all consistency levels

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -658,7 +658,9 @@ replicate_stages consensus::do_replicate(
         _probe.replicate_requests_ack_all();
 
         return wrap_stages_with_gate(
-          _bg, _batcher.replicate(expected_term, std::move(rdr)));
+          _bg,
+          _batcher.replicate(
+            expected_term, std::move(rdr), consistency_level::quorum_ack));
     }
 
     if (opts.consistency == consistency_level::leader_ack) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -361,9 +361,6 @@ consensus::success_reply consensus::update_follower_index(
         return success_reply::no;
     }
     return success_reply::no;
-    // TODO(agallego) - add target_replication_factor,
-    // current_replication_factor to group_configuration so we can promote
-    // learners to nodes and perform data movement to added replicas
 }
 
 void consensus::maybe_promote_to_voter(vnode id) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -26,6 +26,7 @@
 #include "raft/types.h"
 #include "raft/vote_stm.h"
 #include "reflection/adl.h"
+#include "ssx/future-util.h"
 #include "storage/api.h"
 #include "vlog.h"
 
@@ -2040,23 +2041,31 @@ ss::future<result<replicate_result>> consensus::dispatch_replicate(
     auto stm = ss::make_lw_shared<replicate_entries_stm>(
       this, std::move(req), std::move(seqs));
 
-    return stm->apply(std::move(u)).finally([this, stm] {
-        auto f = stm->wait().finally([stm] {});
-        // if gate is closed wait for all futures
-        if (_bg.is_closed()) {
-            _ctxlog.info("gate-closed, waiting to finish background requests");
-            return f;
-        }
-        // background
-        ssx::spawn_with_gate(_bg, [this, stm, f = std::move(f)]() mutable {
-            return std::move(f).handle_exception(
-              [this](const std::exception_ptr& e) {
-                  _ctxlog.error(
+    return stm->apply(std::move(u))
+      .then([stm](result<replicate_result> res) {
+          if (!res) {
+              return ss::make_ready_future<result<replicate_result>>(res);
+          }
+          return stm->wait_for_majority();
+      })
+      .finally([this, stm] {
+          auto f = stm->wait_for_shutdown().finally([stm] {});
+          // if gate is closed wait for all futures
+          if (_bg.is_closed()) {
+              _ctxlog.info(
+                "gate-closed, waiting to finish background requests");
+              return f;
+          }
+          // background
+          ssx::background
+            = ssx::spawn_with_gate_then(_bg, [f = std::move(f)]() mutable {
+                  return std::move(f);
+              }).handle_exception([this, stm](const std::exception_ptr& e) {
+                  _ctxlog.debug(
                     "Error waiting for background acks to finish - {}", e);
               });
-        });
-        return ss::now();
-    });
+          return ss::now();
+      });
 }
 
 append_entries_reply consensus::make_append_entries_reply(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -368,11 +368,6 @@ private:
       std::optional<model::term_id>,
       model::record_batch_reader&&,
       replicate_options);
-    ss::future<result<replicate_result>> do_append_replicate_relaxed(
-      std::optional<model::term_id>,
-      model::record_batch_reader,
-      consistency_level,
-      ss::semaphore_units<>);
 
     ss::future<storage::append_result>
     disk_append(model::record_batch_reader&&, update_last_quorum_index);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -447,8 +447,6 @@ private:
     void maybe_update_last_visible_index(model::offset);
     void maybe_update_majority_replicated_index();
 
-    void start_dispatching_disk_append_events();
-
     voter_priority next_target_priority();
     voter_priority get_node_priority(vnode) const;
 
@@ -582,7 +580,6 @@ private:
     model::offset _last_quorum_replicated_index;
     consistency_level _last_write_consistency_level;
     offset_monitor _consumable_offset_monitor;
-    ss::condition_variable _disk_append;
     ss::condition_variable _follower_reply;
     append_entries_buffer _append_requests_buffer;
     friend std::ostream& operator<<(std::ostream&, const consensus&);

--- a/src/v/raft/log_eviction_stm.cc
+++ b/src/v/raft/log_eviction_stm.cc
@@ -42,6 +42,13 @@ void log_eviction_stm::monitor_log_eviction() {
                 .then([this](model::offset last_evicted) {
                     return handle_deletion_notification(last_evicted);
                 })
+                .handle_exception_type(
+                  [](const ss::abort_requested_exception&) {
+                      // ignore abort requested exception, shutting down
+                  })
+                .handle_exception_type([](const ss::gate_closed_exception&) {
+                    // ignore gate closed exception, shutting down
+                })
                 .handle_exception([this](std::exception_ptr e) {
                     vlog(_logger.trace, "Error handling log eviction - {}", e);
                 });

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -38,15 +38,23 @@ ss::future<append_entries_request> replicate_entries_stm::share_request() {
               // keep a copy around until the end
               _req->batches = std::move(readers.back());
               readers.pop_back();
-              return append_entries_request{
-                _req->node_id, _req->meta, std::move(readers.back())};
+              return append_entries_request(
+                _req->node_id,
+                _req->meta,
+                std::move(readers.back()),
+                _req->flush);
           });
     });
 }
 
 ss::future<result<append_entries_reply>> replicate_entries_stm::flush_log() {
     using ret_t = result<append_entries_reply>;
-    auto f = _ptr->flush_log()
+    auto flush_f = ss::now();
+    if (_req->flush) {
+        flush_f = _ptr->flush_log();
+    }
+
+    auto f = flush_f
                .then([this]() {
                    /**
                     * Replicate STM _dirty_offset is set to the dirty offset of
@@ -228,83 +236,92 @@ ss::future<result<replicate_result>> replicate_entries_stm::apply(units_t u) {
         }
     });
     _units = ss::make_lw_shared<units_t>(std::move(u));
-    return append_to_self()
-      .then([this, cfg = std::move(cfg)](
-              result<storage::append_result> append_result) mutable {
-          if (!append_result) {
-              return ss::make_ready_future<result<storage::append_result>>(
-                append_result);
-          }
-          _dirty_offset = append_result.value().last_offset;
-          // store committed offset to check if it advanced
-          _initial_committed_offset = _ptr->committed_offset();
-          // dispatch requests to followers & leader flush
-          uint16_t requests_count = 0;
-          cfg.for_each_broker_id([this, &requests_count](const vnode& rni) {
-              // We are not dispatching request to followers that are
-              // recovering
-              if (should_skip_follower_request(rni)) {
-                  vlog(
-                    _ctxlog.trace,
-                    "Skipping sending append request to {}",
-                    rni);
-                  _ptr->update_suppress_heartbeats(
-                    rni, _followers_seq[rni], heartbeats_suppressed::no);
-                  return;
-              }
-              ++requests_count;
-              (void)dispatch_one(rni); // background
-          });
-          // Wait until all RPCs will be dispatched
-          return _dispatch_sem.wait(requests_count)
-            .then([this, append_result]() mutable {
-                _req.reset();
-                _units.release();
-                return append_result;
-            });
-      })
-      .then([this](result<storage::append_result> append_result) {
-          if (!append_result) {
-              return ss::make_ready_future<result<replicate_result>>(
-                append_result.error());
-          }
-          // this is happening outside of _opsem
-          // store offset and term of an appended entry
-          auto appended_offset = append_result.value().last_offset;
-          auto appended_term = append_result.value().last_term;
-          /**
-           * we have to finish replication when committed offset is greater or
-           * equal to the appended offset or when term have changed after
-           * commit_index update, if that happend it means that entry might
-           * have been either commited or truncated
-           */
-          auto stop_cond = [this, appended_offset, appended_term] {
-              const auto current_committed_offset = _ptr->committed_offset();
-              const auto committed = current_committed_offset
-                                     >= appended_offset;
-              const auto truncated = _ptr->term() > appended_term
-                                     && current_committed_offset
-                                          > _initial_committed_offset
-                                     && _ptr->_log.get_term(appended_offset)
-                                          != appended_term;
+    _append_result = co_await append_to_self();
 
-              return committed || truncated;
-          };
-          return _ptr->_commit_index_updated.wait(stop_cond)
-            .then([this, appended_offset, appended_term] {
-                return process_result(appended_offset, appended_term);
-            })
-            .handle_exception_type(
-              [this](const ss::broken_condition_variable&) {
-                  vlog(
-                    _ctxlog.debug,
-                    "Replication of entries with last offset: {} aborted - "
-                    "shutting down",
-                    _dirty_offset);
-                  return result<replicate_result>(
-                    make_error_code(errc::shutting_down));
-              });
-      });
+    if (!_append_result) {
+        co_return build_replicate_result();
+    }
+    _dirty_offset = _append_result->value().last_offset;
+    // store committed offset to check if it advanced
+    _initial_committed_offset = _ptr->committed_offset();
+    // dispatch requests to followers & leader flush
+    cfg.for_each_broker_id([this](const vnode& rni) {
+        // We are not dispatching request to followers that are
+        // recovering
+        if (should_skip_follower_request(rni)) {
+            _ptr->update_suppress_heartbeats(
+              rni, _followers_seq[rni], heartbeats_suppressed::no);
+            return;
+        }
+        ++_requests_count;
+        (void)dispatch_one(rni); // background
+    });
+
+    // wait for the requests to be dispatched in background and then release
+    // units
+    (void)ss::with_gate(_req_bg, [this]() -> ss::future<> {
+        // Wait until all RPCs will be dispatched
+        co_await _dispatch_sem.wait(_requests_count);
+        // release memory reservations, and destroy data
+        _req.reset();
+        _units.release();
+    });
+
+    co_return build_replicate_result();
+}
+
+result<replicate_result> replicate_entries_stm::build_replicate_result() const {
+    vassert(
+      _append_result,
+      "Leader append result must be present before returning any result to "
+      "caller");
+
+    if (_append_result->has_error()) {
+        return _append_result->error();
+    }
+
+    return replicate_result{.last_offset = _append_result->value().last_offset};
+}
+
+ss::future<result<replicate_result>>
+replicate_entries_stm::wait_for_majority() {
+    if (!_append_result) {
+        co_return build_replicate_result();
+    }
+    // this is happening outside of _opsem
+    // store offset and term of an appended entry
+    auto appended_offset = _append_result->value().last_offset;
+    auto appended_term = _append_result->value().last_term;
+    /**
+     * we have to finish replication when committed offset is greater or
+     * equal to the appended offset or when term have changed after
+     * commit_index update, if that happend it means that entry might
+     * have been either commited or truncated
+     */
+    auto stop_cond = [this, appended_offset, appended_term] {
+        const auto current_committed_offset = _ptr->committed_offset();
+        const auto committed = current_committed_offset >= appended_offset;
+        const auto truncated = _ptr->term() > appended_term
+                               && current_committed_offset
+                                    > _initial_committed_offset
+                               && _ptr->_log.get_term(appended_offset)
+                                    != appended_term;
+
+        return committed || truncated;
+    };
+    try {
+        co_await _ptr->_commit_index_updated.wait(stop_cond);
+        co_return process_result(appended_offset, appended_term);
+
+    } catch (const ss::broken_condition_variable&) {
+        vlog(
+          _ctxlog.debug,
+          "Replication of entries with last offset: {} aborted - "
+          "shutting down",
+          _dirty_offset);
+        co_return result<replicate_result>(
+          make_error_code(errc::shutting_down));
+    }
 }
 
 result<replicate_result> replicate_entries_stm::process_result(
@@ -352,11 +369,12 @@ result<replicate_result> replicate_entries_stm::process_result(
       "Replication success, last offset: {}, term: {}",
       appended_offset,
       appended_term);
-    return ret_t(
-      replicate_result{.last_offset = model::offset(appended_offset)});
+    return build_replicate_result();
 }
 
-ss::future<> replicate_entries_stm::wait() { return _req_bg.close(); }
+ss::future<> replicate_entries_stm::wait_for_shutdown() {
+    return _req_bg.close();
+}
 
 replicate_entries_stm::replicate_entries_stm(
   consensus* p,

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -141,13 +141,10 @@ struct follower_index_metadata {
     ss::condition_variable recovery_finished;
     /**
      * When recovering, the recovery state machine will wait on this condition
-     * variable to wait for any changes that may require triggering recovery.
-     *
-     * This is:
-     * - follower log indices moved backward
-     * - disk append happened on the leader
-     * - follower is going to be removed
-     * - started leadership transfer to this follower
+     * variable to wait for changes that may alter recovery state when all
+     * necessary requests were already dispatched to the follower. This
+     * condition variable is used not to make the recovery loop tight when
+     * checking if recovery may be finished
      */
     ss::condition_variable follower_state_change;
     /**

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -78,6 +78,7 @@ struct follower_index_metadata {
     }
     // next index to send to this follower
     model::offset next_index;
+    model::offset last_sent_offset;
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_sent_append_entries_req_timesptamp;
     clock_type::time_point last_received_append_entries_reply_timestamp;

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -16,6 +16,7 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.default import DefaultClient
 
 
 class FullNodeRecoveryTest(EndToEndTest):
@@ -30,7 +31,6 @@ class FullNodeRecoveryTest(EndToEndTest):
         super(FullNodeRecoveryTest, self).__init__(test_context=test_context,
                                                    extra_rp_conf=extra_rp_conf)
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/3476
     @cluster(num_nodes=6)
     def test_node_recovery(self):
         self.start_redpanda(num_nodes=3)
@@ -41,7 +41,7 @@ class FullNodeRecoveryTest(EndToEndTest):
         for _ in range(0, 6):
             topics.append(TopicSpec(partition_count=random.randint(1, 10)))
         # chose one topic to run the main workload
-        self.redpanda.create_topic(topics)
+        DefaultClient(self.redpanda).create_topic(topics)
         self.topic = random.choice(topics).name
 
         self.start_producer(1)

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -17,6 +17,7 @@ from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.default import DefaultClient
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
 
 
 class FullNodeRecoveryTest(EndToEndTest):
@@ -31,7 +32,7 @@ class FullNodeRecoveryTest(EndToEndTest):
         super(FullNodeRecoveryTest, self).__init__(test_context=test_context,
                                                    extra_rp_conf=extra_rp_conf)
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_node_recovery(self):
         self.start_redpanda(num_nodes=3)
         kafka_tools = KafkaCliTools(self.redpanda)


### PR DESCRIPTION
## Cover letter

Unified code path for all Raft consistency levels. Simplified coordination of `recovery_stm`.

All the details can be found in #3542 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

Related: #3542

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.


-->
### Improvements

* `under_replicated_partitions` metric now reflects the number of follower which are actually behind the leader