### PR TITLE
Backport v21.11.x pandaproxy schema registry

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -393,6 +393,10 @@ pandaproxy:
       name: external
       port: 8083
 
+  # How long to wait for an idle consumer before removing it.
+  # Default: 60000
+  consumer_instance_timeout_ms: 60000
+
 # The REST API client
 pandaproxy_client:
   # List of address and port of the brokers

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -533,9 +533,11 @@ ss::future<> partition_downloader::download_segment_file(
         co_await ss::remove_file(localpath.string());
     }
 
-    auto stream = [this, part, remote_path, localpath, otl](
+    auto stream = [this, part, remote_path, _localpath{localpath}, _otl{otl}](
                     uint64_t len,
                     ss::input_stream<char> in) -> ss::future<uint64_t> {
+        auto localpath{_localpath};
+        auto otl{_otl};
         vlog(
           _ctxlog.info,
           "Copying s3 path {} to local location {}",

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -50,8 +50,9 @@ recursive_directory_walker::walk(ss::sstring start_dir) {
         try {
             ss::file target_dir = co_await open_directory(target);
             auto sub = target_dir.list_directory(
-              [&files, &current_cache_size, &dirlist, target](
+              [&files, &current_cache_size, &dirlist, _target{target}](
                 ss::directory_entry entry) -> ss::future<> {
+                  auto target{_target};
                   vlog(cst_log.debug, "Looking at directory {}", target);
 
                   auto entry_path = std::filesystem::path(target)

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -308,7 +308,8 @@ write_materialized(output_write_inputs replies, output_write_args args) {
     grouping_t grs = group_replies(std::move(replies));
     bool err{false};
     co_await ss::parallel_for_each(
-      grs, [args, &err](grouping_t::value_type& vt) -> ss::future<> {
+      grs, [_args{args}, &err](grouping_t::value_type& vt) -> ss::future<> {
+          auto args{_args};
           try {
               co_await process_reply_group(
                 vt.first, std::move(vt.second), args);

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -35,7 +35,8 @@ ss::future<> fiber_mock_fixture::init_test(test_parameters params) {
         auto shard = app.shard_table.local().shard_for(ntp);
         vassert(shard, "topic not up yet");
         co_await _state.invoke_on(
-          *shard, [this, ntp, params](state& s) -> ss::future<> {
+          *shard, [this, _ntp{ntp}, params](state& s) -> ss::future<> {
+              auto ntp{_ntp};
               auto src = co_await make_source(ntp, s, params);
               auto [_, success] = s.routes.emplace(ntp, src);
               vassert(success, "no double insert attempt should occur");

--- a/src/v/coproc/tests/pacemaker_tests.cc
+++ b/src/v/coproc/tests/pacemaker_tests.cc
@@ -86,8 +86,9 @@ FIXTURE_TEST(test_coproc_router_off_by_one, coproc_test_fixture) {
           .topics = {std::make_pair<>(
             src_topic, coproc::topic_ingestion_policy::stored)}}}})
       .get();
-    auto fn =
-      [this, input_ntp, output_ntp](model::offset start) -> ss::future<size_t> {
+    auto fn = [this, input_ntp, _output_ntp{output_ntp}](
+                model::offset start) -> ss::future<size_t> {
+        auto output_ntp{_output_ntp};
         co_await produce(input_ntp, make_random_batch(1));
         auto r = co_await consume(output_ntp, 1, start);
         co_return num_records(r);

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -63,7 +63,7 @@ public:
           .with([this, r{std::move(r)}]() mutable {
               vlog(kclog.debug, "Dispatch: {} req: {}", api_t::name, r);
               return _client.dispatch(std::move(r)).then([](Ret res) {
-                  vlog(kclog.debug, "Dispatch: {} res: ", api_t::name, res);
+                  vlog(kclog.debug, "Dispatch: {} res: {}", api_t::name, res);
                   return std::move(res);
               });
           })

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
+#include "kafka/client/logger.h"
 #include "kafka/client/transport.h"
 #include "model/metadata.h"
 #include "utils/mutex.h"
@@ -57,9 +58,14 @@ public:
     template<typename T, typename Ret = typename T::api_type::response_type>
     CONCEPT(requires(KafkaApi<typename T::api_type>))
     ss::future<Ret> dispatch(T r) {
+        using api_t = typename T::api_type;
         return _gated_mutex
           .with([this, r{std::move(r)}]() mutable {
-              return _client.dispatch(std::move(r));
+              vlog(kclog.debug, "Dispatch: {} req: {}", api_t::name, r);
+              return _client.dispatch(std::move(r)).then([](Ret res) {
+                  vlog(kclog.debug, "Dispatch: {} res: ", api_t::name, res);
+                  return std::move(res);
+              });
           })
           .handle_exception_type([this](const std::bad_optional_access&) {
               // Short read

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -121,13 +121,16 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
           .then([this](shared_broker_t broker) {
               return broker->dispatch(metadata_request{.list_all_topics = true})
                 .then([this](metadata_response res) {
-                    // Create new seeds from the returned set of brokers
-                    std::vector<unresolved_address> seeds;
-                    seeds.reserve(res.data.brokers.size());
-                    for (const auto& b : res.data.brokers) {
-                        seeds.emplace_back(b.host, b.port);
+                    // Create new seeds from the returned set of brokers if
+                    // they're not empty
+                    if (!res.data.brokers.empty()) {
+                        std::vector<unresolved_address> seeds;
+                        seeds.reserve(res.data.brokers.size());
+                        for (const auto& b : res.data.brokers) {
+                            seeds.emplace_back(b.host, b.port);
+                        }
+                        std::swap(_seeds, seeds);
                     }
-                    std::swap(_seeds, seeds);
 
                     return apply(std::move(res));
                 })

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -102,8 +102,9 @@ ss::future<> client::stop() noexcept {
     co_await _gate.close();
     co_await catch_and_log([this]() { return _producer.stop(); });
     for (auto& [id, group] : _consumers) {
-        for (auto& consumer : group) {
-            co_await catch_and_log([consumer]() { return consumer->leave(); });
+        while (!group.empty()) {
+            auto c = *group.begin();
+            co_await catch_and_log([c]() { return c->leave(); });
         }
     }
     co_await catch_and_log([this]() { return _brokers.stop(); });

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -308,7 +308,6 @@ ss::future<fetch_response> client::fetch_partition(
       std::move(build_request),
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
-          vlog(kclog.debug, "fetching: {}", tp);
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
                      return _topic_cache.leader(tp)
                        .then([this](model::node_id leader) {
@@ -450,6 +449,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
     const auto end = model::timeout_clock::now()
                      + std::min(config_timout, timeout.value_or(config_timout));
     return gated_retry_with_mitigation([this, g_id, name, end, max_bytes]() {
+        vlog(kclog.debug, "consumer_fetch: group_id: {}, name: {}", g_id, name);
         return get_consumer(g_id, name)
           .then([end, max_bytes](shared_consumer_t c) {
               auto timeout = std::max(

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -176,8 +176,16 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
             return _wait_or_start_update_metadata();
         }
         default:
-            // TODO(Ben): Maybe vassert
-            vlog(kclog.warn, "partition_error: ", ex);
+            vlog(kclog.warn, "partition_error: {}", ex);
+            return ss::make_exception_future(ex);
+        }
+    } catch (const topic_error& ex) {
+        switch (ex.error) {
+        case error_code::unknown_topic_or_partition:
+            vlog(kclog.debug, "topic_error: {}", ex);
+            return _wait_or_start_update_metadata();
+        default:
+            vlog(kclog.warn, "topic_error: {}", ex);
             return ss::make_exception_future(ex);
         }
     } catch (const ss::gate_closed_exception&) {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -121,6 +121,9 @@ public:
     ss::future<member_id>
     create_consumer(const group_id& g_id, member_id name = kafka::no_member);
 
+    ss::future<shared_consumer_t>
+    get_consumer(const group_id& g_id, const member_id& m_id);
+
     ss::future<> remove_consumer(const group_id& g_id, const member_id& m_id);
 
     ss::future<> subscribe_consumer(
@@ -173,9 +176,6 @@ private:
     /// \brief Handle errors by performing an action that may fix the cause of
     /// the error
     ss::future<> mitigate_error(std::exception_ptr ex);
-
-    ss::future<shared_consumer_t>
-    get_consumer(const group_id& g_id, const member_id& m_id);
 
     /// \brief Apply metadata update
     ss::future<> apply(metadata_response res);

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -85,15 +85,19 @@ reduce_fetch_response(fetch_response result, fetch_response val) {
 } // namespace detail
 
 void consumer::start() {
-    kclog.info("Consumer: {}: start", *this);
+    vlog(kclog.info, "Consumer: {}: start", *this);
     _timer.set_callback([me{shared_from_this()}]() {
-        kclog.trace("Consumer: {}: timer cb", *me);
+        vlog(kclog.trace, "Consumer: {}: timer cb", *me);
         (void)me->heartbeat()
           .handle_exception_type([me](const consumer_error& e) {
-              kclog.error("Consumer: {}: heartbeat failed: {}", *me, e.error);
+              vlog(
+                kclog.error,
+                "Consumer: {}: heartbeat failed: {}",
+                *me,
+                e.error);
           })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
-              kclog.trace("Consumer: {}: heartbeat failed: {}", *me, e);
+              vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
           });
     });
     _timer.rearm_periodic(std::chrono::duration_cast<ss::timer<>::duration>(
@@ -192,7 +196,8 @@ void consumer::on_leader_join(const join_group_response& res) {
       std::unique(_subscribed_topics.begin(), _subscribed_topics.end()),
       _subscribed_topics.end());
 
-    kclog.info(
+    vlog(
+      kclog.info,
       "Consumer: {}: join: members: {}, topics: {}",
       *this,
       _members,
@@ -359,9 +364,9 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
 ss::future<fetch_response>
 consumer::dispatch_fetch(broker_reqs_t::value_type br) {
     auto& [broker, req] = br;
-    kclog.trace("Consumer: {}, fetch_req: {}", *this, req);
+    vlog(kclog.trace, "Consumer: {}, fetch_req: {}", *this, req);
     auto res = co_await broker->dispatch(std::move(req));
-    kclog.trace("Consumer: {}, fetch_res: {}", *this, res);
+    vlog(kclog.trace, "Consumer: {}, fetch_res: {}", *this, res);
 
     if (res.data.error_code != error_code::none) {
         throw broker_error(broker->id(), res.data.error_code);

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -127,6 +127,8 @@ ss::future<> consumer::stop() {
       .finally([me{shared_from_this()}] {});
 }
 
+ss::future<> consumer::initialize() { return join(); }
+
 ss::future<> consumer::join() {
     _timer.cancel();
     auto req_builder = [me{shared_from_this()}]() {
@@ -458,7 +460,7 @@ ss::future<shared_consumer_t> make_consumer(
       std::move(coordinator),
       std::move(group_id),
       std::move(name));
-    return c->join().then([c]() mutable { return std::move(c); });
+    return c->initialize().then([c]() mutable { return std::move(c); });
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -84,6 +84,21 @@ reduce_fetch_response(fetch_response result, fetch_response val) {
 
 } // namespace detail
 
+consumer::consumer(
+  const configuration& config,
+  topic_cache& topic_cache,
+  brokers& brokers,
+  shared_broker_t coordinator,
+  kafka::group_id group_id,
+  kafka::member_id name)
+  : _config(config)
+  , _topic_cache(topic_cache)
+  , _brokers(brokers)
+  , _coordinator(std::move(coordinator))
+  , _group_id(std::move(group_id))
+  , _name(std::move(name))
+  , _topics() {}
+
 void consumer::start() {
     vlog(kclog.info, "Consumer: {}: start", *this);
     _timer.set_callback([me{shared_from_this()}]() {

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -118,7 +118,7 @@ private:
     shared_broker_t _coordinator;
     ss::abort_source _as;
     ss::gate _gate{};
-    ss::timer<> _timer;
+    ss::timer<> _heartbeat_timer;
 
     kafka::group_id _group_id;
     generation_id _generation_id{no_generation};

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -39,20 +39,20 @@ class consumer final : public ss::enable_lw_shared_from_this<consumer> {
     using broker_reqs_t = absl::node_hash_map<shared_broker_t, fetch_request>;
 
 public:
+    /// \brief Construct a consumer
+    ///
+    /// \param coordinator - The coordinator broker for this group. There should
+    /// be no other owners, as it is used for the long-poll fetch.
+    ///
+    /// \param name - If this is unknowm_member_id, then the name is generated
+    /// by the broker.
     consumer(
       const configuration& config,
       topic_cache& topic_cache,
       brokers& brokers,
       shared_broker_t coordinator,
       group_id group_id,
-      member_id name)
-      : _config(config)
-      , _topic_cache(topic_cache)
-      , _brokers(brokers)
-      , _coordinator(std::move(coordinator))
-      , _group_id(std::move(group_id))
-      , _name(std::move(name))
-      , _topics() {}
+      member_id name);
 
     const kafka::group_id& group_id() const { return _group_id; }
     const kafka::member_id& member_id() const { return _member_id; }

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -62,7 +62,7 @@ public:
     const std::vector<model::topic>& topics() const { return _topics; }
     const assignment_t& assignment() const { return _assignment; }
 
-    ss::future<> join();
+    ss::future<> initialize();
     ss::future<leave_group_response> leave();
     ss::future<> subscribe(std::vector<model::topic> topics);
     ss::future<offset_fetch_response>
@@ -82,6 +82,7 @@ private:
 
     void on_leader_join(const join_group_response& res);
 
+    ss::future<> join();
     ss::future<> sync();
 
     ss::future<std::vector<metadata_response::topic>>

--- a/src/v/pandaproxy/api/api-doc/header.json
+++ b/src/v/pandaproxy/api/api-doc/header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy API",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/api/api-doc/rest.json
+++ b/src/v/pandaproxy/api/api-doc/rest.json
@@ -2,6 +2,7 @@
         "get": {
           "summary": "Get a list of brokers.",
           "operationId": "get_brokers",
+          "produces": ["application/vnd.kafka.v2+json"],
           "responses": {
             "200": {
               "description": "Array of topic names",
@@ -265,7 +266,6 @@
         "get": {
           "summary": "Fetch data for the consumer assignments",
           "operationId": "consumer_fetch",
-          "consumes": ["application/vnd.kafka.v2+json"],
           "parameters": [
             {
               "name": "group_name",
@@ -366,6 +366,7 @@
             }
           }
         ],
+        "produces": ["application/vnd.kafka.v2+json"],
         "responses": {
           "204": {
             "description": ""
@@ -383,6 +384,7 @@
       "get": {
         "summary": "Get a list of Kafka topics.",
         "operationId": "get_topics_names",
+        "produces": ["application/vnd.kafka.v2+json"],
         "responses": {
           "200": {
             "description": "Array of topic names",
@@ -469,7 +471,6 @@
       "get": {
         "summary": "Get records from a topic.",
         "operationId": "get_topics_records",
-        "consumes": ["application/vnd.kafka.v2+json"],
         "parameters": [
           {
             "name": "topic_name",

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -52,6 +52,9 @@ struct reply_error_category final : std::error_category {
             return "subject_version_soft_deleted";
         case reply_error_code::subject_version_not_deleted:
             return "subject_version_not_deleted";
+        case reply_error_code::consumer_already_exists:
+            return "Consumer with specified consumer ID already exists in the "
+                   "specified consumer group.";
         case reply_error_code::schema_empty:
             return "Empty schema";
         case reply_error_code::schema_version_invalid:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -40,6 +40,7 @@ enum class reply_error_code : uint16_t {
     subject_not_deleted = 40405,
     subject_version_soft_deleted = 40406,
     subject_version_not_deleted = 40407,
+    consumer_already_exists = 40902,
     schema_empty = 42201,
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -9,10 +9,13 @@
 
 #include "configuration.h"
 
+#include "config/base_property.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "model/metadata.h"
 #include "units.h"
+
+#include <chrono>
 
 namespace pandaproxy::rest {
 using namespace std::chrono_literals;
@@ -47,6 +50,12 @@ configuration::configuration()
       "api_doc_dir",
       "API doc directory",
       config::required::no,
-      "/usr/share/redpanda/proxy-api-doc") {}
+      "/usr/share/redpanda/proxy-api-doc")
+  , consumer_instance_timeout(
+      *this,
+      "consumer_instance_timeout_ms",
+      "How long to wait for an idle consumer before removing it",
+      config::required::no,
+      std::chrono::minutes{5}) {}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -32,6 +32,7 @@ struct configuration final : public config::config_store {
     config::one_or_many_property<model::broker_endpoint>
       advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
+    config::property<std::chrono::milliseconds> consumer_instance_timeout;
 
     configuration();
     explicit configuration(const YAML::Node& cfg);

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -21,6 +21,7 @@
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/requests/brokers.h"
 #include "pandaproxy/json/requests/create_consumer.h"
+#include "pandaproxy/json/requests/error_reply.h"
 #include "pandaproxy/json/requests/fetch.h"
 #include "pandaproxy/json/requests/offset_commit.h"
 #include "pandaproxy/json/requests/offset_fetch.h"
@@ -49,6 +50,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <system_error>
 
 namespace ppj = pandaproxy::json;
 
@@ -279,6 +281,15 @@ create_consumer(server::request_t rq, server::reply_t rp) {
           req_data.auto_offset_reset,
           req_data.auto_commit_enable);
 
+        try {
+            co_await client.get_consumer(group_id, req_data.name);
+            auto ec = make_error_condition(
+              reply_error_code::consumer_already_exists);
+            rp.rep = errored_body(ec, ec.message());
+            co_return std::move(rp);
+        } catch (const kafka::client::consumer_error& e) {
+            // Ignore - consumer doesn't exist
+        }
         auto name = co_await client.create_consumer(group_id, req_data.name);
         json::create_consumer_response res{
           .instance_id = name,

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -69,9 +69,6 @@ ss::shard_id consumer_shard(const kafka::group_id& g_id) {
 
 ss::future<server::reply_t>
 get_brokers(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
@@ -108,9 +105,6 @@ get_brokers(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_names(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
@@ -146,9 +140,6 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_records(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::binary_v2,
@@ -387,9 +378,6 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 consumer_fetch(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::binary_v2,

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -254,13 +254,20 @@ create_consumer(server::request_t rq, server::reply_t rp) {
           parse::error_code::invalid_param, "auto.commit must be false");
     }
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       res_fmt,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
+
         vlog(
           plog.debug,
           "create_consumer: group_id: {}, name: {}, min_bytes: {}, timeout: "
@@ -283,7 +290,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -298,9 +305,17 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
     auto member_id = parse::request_param<kafka::member_id>(
       *rq.req, "instance");
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id, member_id, rq{std::move(rq)}, rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "remove_consumer: group_id: {}, member_id: {}",
@@ -313,7 +328,7 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -331,14 +346,21 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::subscribe_consumer_request_handler());
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       res_fmt,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "subscribe_consumer: group_id: {}, member_id: {}, topics: {}",
@@ -354,7 +376,7 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -374,15 +396,23 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
     auto max_bytes{
       parse::query_param<std::optional<int32_t>>(*rq.req, "max_bytes")};
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       name,
-       timeout,
-       max_bytes,
-       res_fmt,
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _name{std::move(name)},
+       _timeout{timeout},
+       _max_bytes{max_bytes},
+       _res_fmt{res_fmt},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto name{std::move(_name)};
+        auto timeout{_timeout};
+        auto max_bytes{_max_bytes};
+        auto res_fmt{_res_fmt};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "consumer_fetch: group_id: {}, name: {}, timeout: {}, max_bytes: {}",
@@ -406,7 +436,7 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -422,14 +452,21 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::partitions_request_to_offset_request(ppj::rjson_parse(
       rq.req->content.data(), ppj::partitions_request_handler()));
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       req_data{std::move(req_data)},
-       res_fmt,
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "get_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -449,7 +486,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -470,13 +507,19 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
                           rq.req->content.data(),
                           ppj::partition_offsets_request_handler()));
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "post_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -491,7 +534,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -187,7 +187,7 @@ ss::future<const pb::FileDescriptor*> build_file_with_refs(
 ss::future<const pb::FileDescriptor*> import_schema(
   pb::DescriptorPool& dp, sharded_store& store, canonical_schema schema) {
     try {
-        co_return co_await build_file_with_refs(dp, store, std::move(schema));
+        co_return co_await build_file_with_refs(dp, store, schema);
     } catch (const exception& e) {
         vlog(plog.warn, "Failed to decode schema: {}", e.what());
         throw as_exception(invalid_schema(schema));

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -35,9 +35,10 @@ using server = ctx_server<service>;
 
 template<typename Handler>
 auto wrap(ss::gate& g, one_shot& os, Handler h) {
-    return [&g, &os, h{std::move(h)}](
+    return [&g, &os, _h{std::move(h)}](
              server::request_t rq,
              server::reply_t rp) -> ss::future<server::reply_t> {
+        auto h{_h};
         auto units = co_await os();
         auto guard = gate_guard(g);
         co_return co_await h(std::move(rq), std::move(rp));

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -179,8 +179,7 @@ ss::future<bool> sharded_store::upsert(
       deleted);
 }
 
-ss::future<subject_schema>
-sharded_store::has_schema(const canonical_schema& schema) {
+ss::future<subject_schema> sharded_store::has_schema(canonical_schema schema) {
     auto versions = co_await get_versions(schema.sub(), include_deleted::no);
 
     try {
@@ -214,7 +213,7 @@ sharded_store::has_schema(const canonical_schema& schema) {
 }
 
 ss::future<canonical_schema_definition>
-sharded_store::get_schema_definition(const schema_id& id) {
+sharded_store::get_schema_definition(schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
@@ -234,9 +233,7 @@ sharded_store::get_schema_subject_versions(schema_id id) {
 }
 
 ss::future<subject_schema> sharded_store::get_subject_schema(
-  const subject& sub,
-  std::optional<schema_version> version,
-  include_deleted inc_del) {
+  subject sub, std::optional<schema_version> version, include_deleted inc_del) {
     auto v_id = co_await _store.invoke_on(
       shard_for(sub), _smp_opts, [sub, version, inc_del](store& s) {
           return s.get_subject_version_id(sub, version, inc_del).value();
@@ -268,21 +265,22 @@ sharded_store::get_subjects(include_deleted inc_del) {
 }
 
 ss::future<std::vector<schema_version>>
-sharded_store::get_versions(const subject& sub, include_deleted inc_del) {
+sharded_store::get_versions(subject sub, include_deleted inc_del) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, inc_del](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, inc_del](store& s) {
           return s.get_versions(sub, inc_del).value();
       });
 }
 
-ss::future<bool>
-sharded_store::is_referenced(const subject& sub, schema_version ver) {
-    auto map = [&sub, ver](store& s) { return s.is_referenced(sub, ver); };
+ss::future<bool> sharded_store::is_referenced(subject sub, schema_version ver) {
+    auto map = [sub{std::move(sub)}, ver](store& s) {
+        return s.is_referenced(sub, ver);
+    };
     co_return co_await _store.map_reduce0(map, false, std::logical_or<>{});
 }
 
 ss::future<std::vector<schema_id>> sharded_store::referenced_by(
-  const subject& sub, std::optional<schema_version> opt_ver) {
+  subject sub, std::optional<schema_version> opt_ver) {
     schema_version ver;
     if (opt_ver.has_value()) {
         ver = *opt_ver;
@@ -293,7 +291,9 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
         ver = versions.back();
     }
 
-    auto map = [&sub, ver](store& s) { return s.referenced_by(sub, ver); };
+    auto map = [sub{std::move(sub)}, ver](store& s) {
+        return s.referenced_by(sub, ver);
+    };
     auto reduce = [](std::vector<schema_id> acc, std::vector<schema_id> refs) {
         acc.insert(acc.end(), refs.begin(), refs.end());
         return acc;
@@ -305,49 +305,50 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
 }
 
 ss::future<std::vector<schema_version>> sharded_store::delete_subject(
-  seq_marker marker, const subject& sub, permanent_delete permanent) {
+  seq_marker marker, subject sub, permanent_delete permanent) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [marker, sub, permanent](store& s) {
+      shard_for(sub),
+      _smp_opts,
+      [marker, sub{std::move(sub)}, permanent](store& s) {
           return s.delete_subject(marker, sub, permanent).value();
       });
 }
 
-ss::future<is_deleted> sharded_store::is_subject_deleted(const subject& sub) {
+ss::future<is_deleted> sharded_store::is_subject_deleted(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.is_subject_deleted(sub).value();
       });
 }
 
-ss::future<is_deleted> sharded_store::is_subject_version_deleted(
-  const subject& sub, const schema_version ver) {
+ss::future<is_deleted>
+sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.is_subject_version_deleted(sub, ver).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
-sharded_store::get_subject_written_at(const subject& sub) {
+sharded_store::get_subject_written_at(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.store::get_subject_written_at(sub).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
-sharded_store::get_subject_version_written_at(
-  const subject& sub, schema_version ver) {
+sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.get_subject_version_written_at(sub, ver).value();
       });
 }
 
 ss::future<bool>
-sharded_store::delete_subject_version(const subject& sub, schema_version ver) {
+sharded_store::delete_subject_version(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.delete_subject_version(sub, ver).value();
       });
 }
@@ -356,10 +357,10 @@ ss::future<compatibility_level> sharded_store::get_compatibility() {
     co_return _store.local().get_compatibility().value();
 }
 
-ss::future<compatibility_level> sharded_store::get_compatibility(
-  const subject& sub, default_to_global fallback) {
+ss::future<compatibility_level>
+sharded_store::get_compatibility(subject sub, default_to_global fallback) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), [sub, fallback](store& s) {
+      shard_for(sub), [sub{std::move(sub)}, fallback](store& s) {
           return s.get_compatibility(sub, fallback).value();
       });
 }
@@ -374,16 +375,18 @@ sharded_store::set_compatibility(compatibility_level compatibility) {
 }
 
 ss::future<bool> sharded_store::set_compatibility(
-  seq_marker marker, const subject& sub, compatibility_level compatibility) {
+  seq_marker marker, subject sub, compatibility_level compatibility) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [marker, sub, compatibility](store& s) {
+      shard_for(sub),
+      _smp_opts,
+      [marker, sub{std::move(sub)}, compatibility](store& s) {
           return s.set_compatibility(marker, sub, compatibility).value();
       });
 }
 
-ss::future<bool> sharded_store::clear_compatibility(const subject& sub) {
+ss::future<bool> sharded_store::clear_compatibility(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.clear_compatibility(sub).value();
       });
 }
@@ -402,7 +405,7 @@ ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
     auto [version, inserted] = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      [sub, refs{std::move(refs)}, id](store& s) mutable {
+      [sub{std::move(sub)}, refs{std::move(refs)}, id](store& s) mutable {
           return s.insert_subject(sub, std::move(refs), id);
       });
     co_return insert_subject_result{version, inserted};
@@ -456,7 +459,7 @@ ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
 }
 
 ss::future<bool> sharded_store::is_compatible(
-  schema_version version, const canonical_schema& new_schema) {
+  schema_version version, canonical_schema new_schema) {
     // Lookup the version_ids
     const auto& sub = new_schema.sub();
     const auto versions = co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -98,12 +98,13 @@ ss::future<> sharded_store::validate_schema(canonical_schema schema) {
 
 ss::future<valid_schema>
 sharded_store::make_valid_schema(canonical_schema schema) {
+    // This method seems to confuse clang 12.0.1
+    // See #3596 for details, especially if modifying it.
     switch (schema.type()) {
     case schema_type::avro:
         co_return make_avro_schema_definition(schema.def().raw()()).value();
     case schema_type::protobuf:
-        co_return co_await make_protobuf_schema_definition(
-          *this, std::move(schema));
+        co_return co_await make_protobuf_schema_definition(*this, schema);
     case schema_type::json:
         throw as_exception(invalid_schema_type(schema.type()));
     }

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -50,11 +50,10 @@ public:
       schema_version version,
       is_deleted deleted);
 
-    ss::future<subject_schema> has_schema(const canonical_schema& schema);
+    ss::future<subject_schema> has_schema(canonical_schema schema);
 
     ///\brief Return a schema definition by id.
-    ss::future<canonical_schema_definition>
-    get_schema_definition(const schema_id& id);
+    ss::future<canonical_schema_definition> get_schema_definition(schema_id id);
 
     ///\brief Return a list of subject-versions for the shema id.
     ss::future<std::vector<subject_version>>
@@ -62,7 +61,7 @@ public:
 
     ///\brief Return a schema by subject and version (or latest).
     ss::future<subject_schema> get_subject_schema(
-      const subject& sub,
+      subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec);
 
@@ -71,52 +70,51 @@ public:
 
     ///\brief Return a list of versions and associated schema_id.
     ss::future<std::vector<schema_version>>
-    get_versions(const subject& sub, include_deleted inc_del);
+    get_versions(subject sub, include_deleted inc_del);
 
     ///\brief Return whether there are any references to a subject version.
-    ss::future<bool> is_referenced(const subject& sub, schema_version ver);
+    ss::future<bool> is_referenced(subject sub, schema_version ver);
 
     ///\brief Return the schema_ids that reference a subject version.
     ss::future<std::vector<schema_id>>
-    referenced_by(const subject& sub, std::optional<schema_version> ver);
+    referenced_by(subject sub, std::optional<schema_version> ver);
 
     ///\brief Delete a subject.
-    ss::future<std::vector<schema_version>> delete_subject(
-      seq_marker marker, const subject& sub, permanent_delete permanent);
+    ss::future<std::vector<schema_version>>
+    delete_subject(seq_marker marker, subject sub, permanent_delete permanent);
 
-    ss::future<is_deleted> is_subject_deleted(const subject& sub);
+    ss::future<is_deleted> is_subject_deleted(subject sub);
 
-    ss::future<is_deleted> is_subject_version_deleted(
-      const subject& sub, const schema_version version);
+    ss::future<is_deleted>
+    is_subject_version_deleted(subject sub, schema_version version);
+
+    ///\brief Get sequence number history (errors out if not soft-deleted)
+    ss::future<std::vector<seq_marker>> get_subject_written_at(subject sub);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
     ss::future<std::vector<seq_marker>>
-    get_subject_written_at(const subject& sub);
-
-    ///\brief Get sequence number history (errors out if not soft-deleted)
-    ss::future<std::vector<seq_marker>>
-    get_subject_version_written_at(const subject& sub, schema_version version);
+    get_subject_version_written_at(subject sub, schema_version version);
 
     ///\brief Delete a subject version
     ss::future<bool>
-    delete_subject_version(const subject& sub, schema_version version);
+    delete_subject_version(subject sub, schema_version version);
 
     ///\brief Get the global compatibility level.
     ss::future<compatibility_level> get_compatibility();
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
     ss::future<compatibility_level>
-    get_compatibility(const subject& sub, default_to_global fallback);
+    get_compatibility(subject sub, default_to_global fallback);
 
     ///\brief Set the global compatibility level.
     ss::future<bool> set_compatibility(compatibility_level compatibility);
 
     ///\brief Set the compatibility level for a subject.
     ss::future<bool> set_compatibility(
-      seq_marker marker, const subject& sub, compatibility_level compatibility);
+      seq_marker marker, subject sub, compatibility_level compatibility);
 
     ///\brief Clear the compatibility level for a subject.
-    ss::future<bool> clear_compatibility(const subject& sub);
+    ss::future<bool> clear_compatibility(subject sub);
 
     ///\brief Check if the provided schema is compatible with the subject and
     /// version, according the the current compatibility.
@@ -124,7 +122,7 @@ public:
     /// If the compatibility level is transitive, then all versions are checked,
     /// otherwise checks are against the version provided and newer.
     ss::future<bool>
-    is_compatible(schema_version version, const canonical_schema& new_schema);
+    is_compatible(schema_version version, canonical_schema new_schema);
 
 private:
     ss::future<bool>

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -142,6 +142,27 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
       = pps::make_protobuf_schema_definition(store.store, schema3).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{
+      pps::subject{"empty.proto"},
+      pps::canonical_schema_definition{
+        R"(syntax =  "proto3";)", pps::schema_type::protobuf}};
+    auto schema2 = pps::canonical_schema{
+      pps::subject{"google/protobuf/timestamp.proto"},
+      pps::canonical_schema_definition{
+        R"(syntax =  "proto3"; package google.protobuf; message Timestamp { int64 seconds = 1;  int32 nanos = 2; })",
+        pps::schema_type::protobuf}};
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    auto sch2 = store.insert(schema2, pps::schema_version{1});
+
+    auto valid_empty
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    auto valid_timestamp
+      = pps::make_protobuf_schema_definition(store.store, schema2).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_empty) {
     BOOST_REQUIRE(check_compatible(
       pps::compatibility_level::full,

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -120,3 +120,25 @@ FIXTURE_TEST(
           R"({"error_code":422,"message":")"));
     }
 }
+
+FIXTURE_TEST(
+  schema_registry_post_subjects_subject_version_many_proto,
+  pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    for (auto i = 0; i < 10; ++i) {
+        info("Post a schema as key (expect schema_id=1)");
+        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+{
+  "schema": "syntax = \"proto3\"; message Simple { string i = 1; }",
+  "schemaType": "PROTOBUF"
+})");
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
+        BOOST_REQUIRE_EQUAL(
+          res.headers.at(boost::beast::http::field::content_type),
+          to_header_value(ppj::serialization_format::schema_registry_v1_json));
+    }
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -360,6 +360,10 @@ void application::hydrate_config(const po::variables_map& cfg) {
         } else {
             set_local_kafka_client_config(_proxy_client_config, config::node());
         }
+        // override pandaparoxy_client.consumer_session_timeout_ms with
+        // pandaproxy.consumer_instance_timeout_ms
+        _proxy_client_config->consumer_session_timeout.set_value(
+          _proxy_config->consumer_instance_timeout.value());
         _proxy_config->for_each(config_printer("pandaproxy"));
         _proxy_client_config->for_each(config_printer("pandaproxy_client"));
     }

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -408,8 +408,9 @@ void test_client_pool(s3::client_pool_overdraft_policy policy) {
     std::vector<ss::future<>> fut;
     for (size_t i = 0; i < 20; i++) {
         auto f = pool->acquire().then(
-          [server = server](
+          [_server = server](
             s3::client_pool::client_lease lease) -> ss::future<> {
+              auto server = _server;
               auto& [client, _] = lease;
               iobuf payload;
               auto payload_stream = make_iobuf_ref_output_stream(payload);
@@ -450,8 +451,9 @@ SEASTAR_TEST_CASE(test_client_pool_reconnect) {
         std::vector<ss::future<bool>> fut;
         for (size_t i = 0; i < 20; i++) {
             auto f = pool->acquire().then(
-              [server = server](
+              [_server = server](
                 s3::client_pool::client_lease lease) -> ss::future<bool> {
+                  auto server = _server;
                   co_await ss::sleep(100ms);
                   auto& [client, _] = lease;
                   iobuf payload;

--- a/tests/rptest/clients/python_librdkafka_serde_client.py
+++ b/tests/rptest/clients/python_librdkafka_serde_client.py
@@ -1,0 +1,231 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import argparse
+import logging
+from collections import OrderedDict
+from enum import Enum
+from uuid import uuid4
+
+from confluent_kafka import DeserializingConsumer, SerializingProducer
+from confluent_kafka.serialization import StringDeserializer, StringSerializer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
+from confluent_kafka.schema_registry.protobuf import ProtobufDeserializer, ProtobufSerializer
+
+from google.protobuf.descriptor_pb2 import FieldDescriptorProto
+from google.protobuf import proto_builder
+
+
+class AvroPayload(OrderedDict):
+    def __init__(self, val: int):
+        OrderedDict.__init__(OrderedDict([('val', int)]))
+        self['val'] = val
+
+    @property
+    def val(self):
+        return self['val']
+
+
+AVRO_SCHEMA = '''{
+"type": "record",
+"name": "payload",
+  "fields": [
+    {"name": "val", "type": "int"}
+  ]
+}
+'''
+
+ProtobufPayloadClass = proto_builder.MakeSimpleProtoClass(
+    OrderedDict([('val', FieldDescriptorProto.TYPE_INT64)]),
+    full_name="example.Payload")
+
+
+def make_protobuf_payload(val: int):
+    p = ProtobufPayloadClass()
+    p.val = val
+    return p
+
+
+class SchemaType(Enum):
+    AVRO = 1
+    PROTOBUF = 2
+
+
+class SerdeClient:
+    """
+    SerdeClient produces and consumes payloads in avro or protobuf formats
+
+    The expected offset is stored in the payload and checked.
+    """
+    def __init__(self,
+                 brokers,
+                 schema_registry_url,
+                 schema_type: SchemaType,
+                 *,
+                 topic=str(uuid4()),
+                 group=str(uuid4()),
+                 logger=logging.getLogger("SerdeClient")):
+        self.logger = logger
+        self.brokers = brokers
+        self.sr_client = SchemaRegistryClient({'url': schema_registry_url})
+        self.schema_type = schema_type
+        self.topic = topic
+        self.group = group
+
+        self.produced = 0
+        self.acked = 0
+        self.consumed = 0
+
+    def _make_serializer(self):
+        return {
+            SchemaType.AVRO:
+            AvroSerializer(self.sr_client, AVRO_SCHEMA),
+            SchemaType.PROTOBUF:
+            ProtobufSerializer(ProtobufPayloadClass, self.sr_client)
+        }[self.schema_type]
+
+    def _make_deserializer(self):
+        return {
+            SchemaType.AVRO:
+            AvroDeserializer(self.sr_client,
+                             AVRO_SCHEMA,
+                             from_dict=lambda d, _: AvroPayload(d['val'])),
+            SchemaType.PROTOBUF:
+            ProtobufDeserializer(ProtobufPayloadClass)
+        }[self.schema_type]
+
+    def _make_payload(self, val: int):
+        return {
+            SchemaType.AVRO: AvroPayload(val),
+            SchemaType.PROTOBUF: make_protobuf_payload(val)
+        }[self.schema_type]
+
+    def produce(self, count: int):
+        def increment(err, msg):
+            assert err is None
+            assert msg is not None
+            assert msg.offset() == self.acked
+            self.logger.debug("Acked offset %d", msg.offset())
+            self.acked += 1
+
+        producer = SerializingProducer({
+            'bootstrap.servers':
+            self.brokers,
+            'key.serializer':
+            StringSerializer('utf_8'),
+            'value.serializer':
+            self._make_serializer()
+        })
+
+        self.logger.info("Producing %d %s records to topic %s", count,
+                         self.schema_type.name, self.topic)
+        for i in range(count):
+            # Prevent overflow of buffer
+            while len(producer) > 50000:
+                # Serve on_delivery callbacks from previous calls to produce()
+                producer.poll(0.1)
+
+            producer.produce(topic=self.topic,
+                             key=str(uuid4()),
+                             value=self._make_payload(i),
+                             on_delivery=increment)
+            self.produced += 1
+
+        self.logger.info("Flushing records...")
+        producer.flush()
+        self.logger.info("Records flushed: %d", self.produced)
+        while self.acked < count:
+            producer.poll(0.01)
+        self.logger.info("Records acked: %d", self.acked)
+
+    def consume(self, count: int):
+        consumer = DeserializingConsumer({
+            'bootstrap.servers':
+            self.brokers,
+            'key.deserializer':
+            StringDeserializer('utf_8'),
+            'value.deserializer':
+            self._make_deserializer(),
+            'group.id':
+            self.group,
+            'auto.offset.reset':
+            "earliest"
+        })
+        consumer.subscribe([self.topic])
+
+        self.logger.info("Consuming %d %s records from topic %s with group %s",
+                         count, self.schema_type.name, self.topic, self.group)
+        while self.consumed < count:
+            msg = consumer.poll(1)
+            if msg is None:
+                continue
+            payload = msg.value()
+            self.logger.debug("Consumed %d at %d", payload.val, msg.offset())
+            assert payload.val == self.consumed
+            self.consumed += 1
+
+        consumer.close()
+
+    def run(self, count: int):
+        self.produce(count)
+        assert self.produced == count
+        assert self.acked == count
+        self.consume(count)
+        assert self.consumed == count
+
+
+def main(args):
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    handler.setLevel(logging.DEBUG)
+    logger = logging.getLogger("SerdeClient")
+    logger.addHandler(handler)
+
+    p = SerdeClient(args.bootstrap_servers,
+                    args.schema_registry,
+                    SchemaType[args.protocol],
+                    topic=args.topic,
+                    group=args.group,
+                    logger=logger)
+    p.run(args.count)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="SerdeClient")
+    parser.add_argument('-b',
+                        dest="bootstrap_servers",
+                        required=True,
+                        help="Bootstrap broker(s) (host[:port])")
+    parser.add_argument('-s',
+                        dest="schema_registry",
+                        required=True,
+                        help="Schema Registry (http(s)://host[:port]")
+    parser.add_argument('-p',
+                        dest="protocol",
+                        default=SchemaType.AVRO.name,
+                        choices=SchemaType._member_names_,
+                        help="Topic name")
+    parser.add_argument('-t',
+                        dest="topic",
+                        default=str(uuid4()),
+                        help="Topic name")
+    parser.add_argument('-g',
+                        dest="group",
+                        default=str(uuid4()),
+                        help="Topic name")
+    parser.add_argument('-c',
+                        dest="count",
+                        default=1,
+                        type=int,
+                        help="Number of messages to send")
+
+    main(parser.parse_args())

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -225,7 +225,6 @@ class PandaProxyTest(RedpandaTest):
         """
         Acceptable headers:
         * Accept: "", "*.*", "application/vnd.kafka.v2+json"
-        * Content-Type: "", "*.*", "application/vnd.kafka.v2+json"
 
         """
         self.logger.debug(f"List topics with no accept header")
@@ -259,11 +258,6 @@ class PandaProxyTest(RedpandaTest):
         self.logger.debug(f"List topics with invalid accept header")
         result_raw = self._get_topics({"Accept": "application/json"})
         assert result_raw.status_code == requests.codes.not_acceptable
-        assert result_raw.headers["Content-Type"] == "application/json"
-
-        self.logger.debug(f"List topics with invalid content-type header")
-        result_raw = self._get_topics({"Content-Type": "application/json"})
-        assert result_raw.status_code == requests.codes.unsupported_media_type
         assert result_raw.headers["Content-Type"] == "application/json"
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -191,6 +191,22 @@ class PandaProxyTest(RedpandaTest):
                             headers=headers)
         return res
 
+    def _create_named_consumer(self,
+                               group_id,
+                               name,
+                               headers=HTTP_CREATE_CONSUMER_HEADERS):
+        res = requests.post(f"{self._base_uri()}/consumers/{group_id}",
+                            json.dumps({
+                                "format": "binary",
+                                "name": name,
+                                "auto.offset.reset": "earliest",
+                                "auto.commit.enable": "false",
+                                "fetch.min.bytes": "1",
+                                "consumer.request.timeout.ms": "10000"
+                            }),
+                            headers=headers)
+        return res
+
     @cluster(num_nodes=3)
     def test_get_brokers(self):
         """
@@ -531,6 +547,15 @@ class PandaProxyTest(RedpandaTest):
         # It's not possible to return an error body in this case due to the way
         # ss::httpd::path_description and routing works - path can't be matched
         assert cc_res.status_code == requests.codes.not_found
+
+        self.logger.info("Create a named consumer")
+        cc_res = self._create_named_consumer(group_id, "my_consumer")
+        assert cc_res.status_code == requests.codes.ok
+
+        self.logger.info("Create a consumer with duplicate name")
+        cc_res = self._create_named_consumer(group_id, "my_consumer")
+        assert cc_res.status_code == requests.codes.conflict
+        assert cc_res.json()["error_code"] == 40902
 
     @cluster(num_nodes=3)
     def test_subscribe_consumer_validation(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -21,6 +21,7 @@ from ducktape.services.background_thread import BackgroundThreadService
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.python_librdkafka_serde_client import SerdeClient, SchemaType
 from rptest.tests.redpanda_test import RedpandaTest
 
 
@@ -1013,3 +1014,30 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json() == [2]
+
+    @cluster(num_nodes=3)
+    def test_serde_client(self):
+        """
+        Verify basic serialization client
+        """
+        protocols = [SchemaType.AVRO, SchemaType.PROTOBUF]
+        topics = [f"serde-topic-{x.name}" for x in protocols]
+        self._create_topics(topics)
+        schema_reg = self.redpanda.schema_reg().split(',', 1)[0]
+        for i in range(len(protocols)):
+            self.logger.info(
+                f"Connecting to redpanda: {self.redpanda.brokers()} schema_reg: {schema_reg}"
+            )
+            client = SerdeClient(self.redpanda.brokers(),
+                                 schema_reg,
+                                 protocols[i],
+                                 topic=topics[i],
+                                 logger=self.logger)
+            client.run(2)
+            schema = self._get_subjects_subject_versions_version(
+                f"{topics[i]}-value", "latest")
+            self.logger.info(schema.json())
+            if protocols[i] == SchemaType.AVRO:
+                assert schema.json().get("schemaType") is None
+            else:
+                assert schema.json()["schemaType"] == protocols[i].name

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -472,6 +472,24 @@ class SchemaRegistryTest(RedpandaTest):
         # assert result["schema"] == json.dumps(schema_def)
 
     @cluster(num_nodes=3)
+    def test_post_subjects_subject_versions_version_many(self):
+        """
+        Verify posting a schema many times
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_data = json.dumps({"schema": schema1_def})
+
+        # Post the same schema many times.
+        for _ in range(20):
+            result_raw = self._post_subjects_subject_versions(
+                subject=subject, data=schema_1_data)
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == 1
+
+    @cluster(num_nodes=3)
     def test_post_subjects_subject(self):
         """
         Verify posting a schema

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,7 +16,7 @@ setup(
         'ducktape@git+https://github.com/vectorizedio/ducktape.git@master',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
-        'xxhash==2.0.2'
+        'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9'
     ],
     scripts=[],
 )


### PR DESCRIPTION
## Cover letter

Backports

Fix #3649 
Fix #3650 

* https://github.com/vectorizedio/redpanda/pull/3256
* https://github.com/vectorizedio/redpanda/pull/3600
* https://github.com/vectorizedio/redpanda/pull/3584
* https://github.com/vectorizedio/redpanda/pull/3628
* https://github.com/vectorizedio/redpanda/pull/3257
* https://github.com/vectorizedio/redpanda/pull/3339
* https://github.com/vectorizedio/redpanda/pull/3664
* https://github.com/vectorizedio/redpanda/pull/3663
* https://github.com/vectorizedio/redpanda/pull/3596

## Release notes

### Improvements

* Pandaproxy
  * Creating a consumer with an existing name now fails with `{"error_code": 40902}`
  * An inactive consumer is now timed out after `pandaproxy.consumer_instance_timeout_ms`
  * Improve header validation and Swagger API
* Schema Registry
  * Fix a crash when publishing multiple protobuf schema
  * Support protobuf encoded protobuf schema for compatibility with Protobuf Serializers.
