### PR TITLE
Backport of #3558 #3617 #3671

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -240,7 +240,7 @@ std::vector<topic_table::delta> calculate_bootstrap_deltas(
         // partition with correct offset
         if (auto next = std::next(it); next != deltas.rend()) {
             if (
-              next->type == op_t::update_finished
+              (next->type == op_t::update_finished || next->type == op_t::add)
               && !has_local_replicas(self, next->new_assignment.replicas)) {
                 break;
             }

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -107,6 +107,7 @@ ss::future<> metadata_dissemination_service::start() {
     if (ss::this_shard_id() != 0) {
         return ss::make_ready_future<>();
     }
+    _dispatch_timer.arm(_dissemination_interval);
     // poll either seed servers or configuration
     auto all_brokers = _members_table.local().all_brokers();
     // use hash set to deduplicate ids
@@ -139,7 +140,6 @@ ss::future<> metadata_dissemination_service::start() {
           return update_metadata_with_retries(std::move(addresses));
       });
 
-    _dispatch_timer.arm(_dissemination_interval);
     return ss::make_ready_future<>();
 }
 


### PR DESCRIPTION
## Cover letter

- https://github.com/vectorizedio/redpanda/pull/3558

When replica is moved x-cores cluster::controller_backend has to
establish its initial revision on given node to use exactly the same
data folder as the replica was using previously.

When bootstrapping controller backend we look for the first operation
that created a partition replica on given node to establish the
revision_id. Fixed error that caused bootstrap process to never finish.

The addition operation preceding update containing x-core update should
terminate lookup. Previously the addition operation was added to
bootstrap deltas on target core preventing the rest of bootstrap logic
from finding replica initial revision.


- https://github.com/vectorizedio/redpanda/pull/3617

In redpanda we store auxiliary metadata batches in the same log as the data.
The metadata baches may contain important information about raft
configuration transaction state or archival machinery. We can not
guarantee that those batches can be safely deleted during compaction.

This patch prevents compaction of non data batches.

Problem that is fixed with this batch was discovered in chaos testing.
Removal of raft configuration batches during compaction caused the
offset translator state to diverge on the nodes which were added to
partition replica set (offset translator rebuilt its state but
configuration batches were missing).

- https://github.com/vectorizedio/redpanda/pull/3671

Recent changes in metadata_dissemination service introduced an issue
that lead to situation in which leadership metadata were not
disseminated from the node that started with empty broker set. The issue
was caused by the fact that the timer was armed only when start()
method dispatched metadata update request. If the start method
returned early timer wasn't armed.

## Release Notes
### Improvements
- Fixed error preventing redpanda from starting if the only partition movement operation involved x-core move
- Fixed metadata dissemination in newly created clusters