### PR TITLE
tests: expand use of default kafka client

### DIFF
--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 import typing
+from collections.abc import Sequence
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kcl import KCL
@@ -46,6 +47,11 @@ class DefaultClient:
         client = KafkaCliTools(self._redpanda)
         for spec in specs:
             client.create_topic(spec)
+
+    def create_topic_with_assignment(self, name: str,
+                                     assignments: Sequence[Sequence[int]]):
+        client = KafkaCliTools(self._redpanda)
+        client.create_topic_with_assignment(name, assignments)
 
     def delete_topic(self, name):
         client = KafkaCliTools(self._redpanda)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -9,6 +9,7 @@
 import typing
 from collections.abc import Sequence
 from rptest.clients.types import TopicSpec
+from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kcl import KCL
 from rptest.clients.rpk import RpkTool
@@ -37,6 +38,12 @@ class TopicConfigValue(typing.NamedTuple):
         return self.value == other
 
 
+class BrokerDescription(typing.NamedTuple):
+    id: int
+    host: str
+    port: int
+
+
 class DefaultClient:
     def __init__(self, redpanda):
         self._redpanda = redpanda
@@ -52,6 +59,19 @@ class DefaultClient:
                                      assignments: Sequence[Sequence[int]]):
         client = KafkaCliTools(self._redpanda)
         client.create_topic_with_assignment(name, assignments)
+
+    def brokers(self):
+        """
+        Note for implementers: this method is expected to return the set of
+        brokers reported by the cluster, rather than the nodes allocated for use
+        in the self._redpanda service.
+        """
+        client = PythonLibrdkafka(self._redpanda)
+        brokers = client.brokers()
+        return {
+            b.id: BrokerDescription(id=b.id, host=b.host, port=b.port)
+            for b in brokers.values()
+        }
 
     def delete_topic(self, name):
         client = KafkaCliTools(self._redpanda)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -110,10 +110,14 @@ class DefaultClient:
         rpk = RpkTool(self._redpanda)
         rpk.delete_topic_config(topic, key)
 
-    def alter_broker_config(self, values, incremental, broker=None):
+    def alter_broker_config(self,
+                            values: dict[str, typing.Any],
+                            incremental: bool,
+                            *,
+                            broker: typing.Optional[int] = None):
         kcl = KCL(self._redpanda)
         return kcl.alter_broker_config(values, incremental, broker)
 
-    def delete_broker_config(self, keys, incremental):
+    def delete_broker_config(self, keys: list[str], incremental: bool):
         kcl = KCL(self._redpanda)
         return kcl.delete_broker_config(keys, incremental)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -113,3 +113,7 @@ class DefaultClient:
     def alter_broker_config(self, values, incremental, broker=None):
         kcl = KCL(self._redpanda)
         return kcl.alter_broker_config(values, incremental, broker)
+
+    def delete_broker_config(self, keys, incremental):
+        kcl = KCL(self._redpanda)
+        return kcl.delete_broker_config(keys, incremental)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -9,6 +9,7 @@
 import typing
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kcl import KCL
 from rptest.clients.rpk import RpkTool
 from kafka import KafkaAdminClient
 
@@ -108,3 +109,7 @@ class DefaultClient:
     def delete_topic_config(self, topic: str, key: str):
         rpk = RpkTool(self._redpanda)
         rpk.delete_topic_config(topic, key)
+
+    def alter_broker_config(self, values, incremental, broker=None):
+        kcl = KCL(self._redpanda)
+        return kcl.alter_broker_config(values, incremental, broker)

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -115,7 +115,8 @@ class KCL:
             cmd.extend(["-k", f"s:{k}={v}" if incremental else f"{k}={v}"])
 
         if broker:
-            cmd.append(broker)
+            # cmd needs to be string, so handle things like broker=1
+            cmd.append(str(broker))
 
         return self._cmd(cmd, attempts=1)
 

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -142,6 +142,7 @@ class KCL:
         brokers = self._redpanda.brokers()
         cmd = ["kcl", "-X", f"seed_brokers={brokers}", "--no-config-file"
                ] + cmd
+        assert attempts > 0
         for retry in reversed(range(attempts)):
             try:
                 res = subprocess.check_output(cmd,
@@ -157,3 +158,6 @@ class KCL:
                     "kcl retrying after exit code {}: {}".format(
                         e.returncode, e.output))
                 time.sleep(1)
+        # it looks impossible to reach this case, but pyright static analyzer
+        # can't see that and deduces Optional[str] as return type.
+        raise RuntimeError(f"Command failed after retries: {cmd}")

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -172,7 +172,7 @@ class RpkTool:
         cmd = ['describe', topic, '-p']
         output = self._run_topic(cmd)
         if "not found" in output:
-            return None
+            raise Exception(f"Topic not found: {topic}")
         lines = output.splitlines()
 
         def partition_line(line):
@@ -189,7 +189,7 @@ class RpkTool:
                                 hw=int(m.group('hw')),
                                 start_offset=int(m.group("logstart")))
 
-        return filter(lambda p: p != None, map(partition_line, lines))
+        return filter(None, map(partition_line, lines))
 
     def describe_topic_configs(self, topic):
         cmd = ['describe', topic, '-c']

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -881,7 +881,7 @@ class ClusterConfigTest(RedpandaTest):
         out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "CreateTime"},
             incremental,
-            broker="1")
+            broker=1)
         assert 'INVALID_CONFIG' in out
         assert "Setting broker properties on named brokers is unsupported" in out
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -506,7 +506,7 @@ class ClusterConfigTest(RedpandaTest):
         text = self._export(all)
 
         # Validate that RPK gives us valid yaml
-        _ = yaml.load(text)
+        _ = yaml.full_load(text)
 
         self.logger.debug(f"Exported config before modification: {text}")
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -19,7 +19,6 @@ from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.rpk_remote import RpkRemoteTool
-from rptest.clients.kcl import KCL
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.mark import parametrize
@@ -836,8 +835,6 @@ class ClusterConfigTest(RedpandaTest):
         :param incremental: whether to use incremental kafka config API or
                             legacy config API.
         """
-        kcl = KCL(self.redpanda)
-
         # Redpanda only support incremental config changes: the legacy
         # AlterConfig API is a bad user experience
         incremental = True
@@ -853,8 +850,8 @@ class ClusterConfigTest(RedpandaTest):
             {"log_message_timestamp_type": "LogAppendTime"}, incremental)
         assert 'OK' in out
         if incremental:
-            kcl.delete_broker_config(["log_message_timestamp_type"],
-                                     incremental)
+            self.client().delete_broker_config(["log_message_timestamp_type"],
+                                               incremental)
             assert 'OK' in out
 
         # Set a property by its Kafka-interop names and values

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -843,13 +843,13 @@ class ClusterConfigTest(RedpandaTest):
         incremental = True
 
         # Set a property by its redpanda name
-        out = kcl.alter_broker_config(
+        out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "CreateTime"}, incremental)
         # kcl does not set an error exist status when config set fails, so must
         # read its output text to validate that calls are successful
         assert 'OK' in out
 
-        out = kcl.alter_broker_config(
+        out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "LogAppendTime"}, incremental)
         assert 'OK' in out
         if incremental:
@@ -865,22 +865,23 @@ class ClusterConfigTest(RedpandaTest):
         }
         for property, value_list in kafka_props.items():
             for value in value_list:
-                out = kcl.alter_broker_config({property: value}, incremental)
+                out = self.client().alter_broker_config({property: value},
+                                                        incremental)
                 assert 'OK' in out
 
         # Set a nonexistent property
-        out = kcl.alter_broker_config({"does_not_exist": "avalue"},
-                                      incremental)
+        out = self.client().alter_broker_config({"does_not_exist": "avalue"},
+                                                incremental)
         assert 'INVALID_CONFIG' in out
 
         # Set a malformed property
-        out = kcl.alter_broker_config(
+        out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "BadValue"}, incremental)
         assert 'INVALID_CONFIG' in out
 
         # Set a property on a named broker: should fail because this
         # interface is only for cluster-wide properties
-        out = kcl.alter_broker_config(
+        out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "CreateTime"},
             incremental,
             broker="1")
@@ -894,8 +895,7 @@ class ClusterConfigTest(RedpandaTest):
         are correctly handled with an 'unsupported' response.
         """
 
-        kcl = KCL(self.redpanda)
-        out = kcl.alter_broker_config(
+        out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "CreateTime"}, incremental=False)
         self.logger.info("AlterConfigs output: {out}")
         assert 'INVALID_CONFIG' in out

--- a/tests/rptest/tests/configuration_update_test.py
+++ b/tests/rptest/tests/configuration_update_test.py
@@ -9,7 +9,6 @@
 
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
-from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services.redpanda import RedpandaService
 
 from rptest.tests.redpanda_test import RedpandaTest
@@ -105,8 +104,7 @@ class ConfigurationUpdateTest(RedpandaTest):
         self.redpanda.start_node(node_3, override_cfg_params=altered_cfg_3)
 
         def metadata_updated():
-            client = PythonLibrdkafka(self.redpanda)
-            brokers = client.brokers()
+            brokers = self.client().brokers()
             self.redpanda.logger.debug(f"brokers metadata: {brokers}")
             ports = [b.port for _, b in brokers.items()]
             ports.sort()
@@ -139,8 +137,7 @@ class ConfigurationUpdateTest(RedpandaTest):
         self.redpanda.start_node(node, altered_port_cfg_1)
 
         def broker_configuration_updated():
-            client = PythonLibrdkafka(self.redpanda)
-            brokers = client.brokers()
+            brokers = self.client().brokers()
             self.logger.debug(f"brokers metadata: {brokers}")
 
             try:

--- a/tests/rptest/tests/custom_topic_assignment_test.py
+++ b/tests/rptest/tests/custom_topic_assignment_test.py
@@ -26,10 +26,9 @@ class CustomTopicAssignmentTest(RedpandaTest):
     def create_and_validate(self, name, custom_assignment):
         self.redpanda.logger.info(
             f"creating topic {name} with {custom_assignment}")
-        cli = KafkaCliTools(self.redpanda)
         rpk = RpkTool(self.redpanda)
 
-        cli.create_topic_with_assignment(name, custom_assignment)
+        self.client().create_topic_with_assignment(name, custom_assignment)
 
         def replica_matches():
             replicas_per_partition = {}

--- a/tests/rptest/tests/custom_topic_assignment_test.py
+++ b/tests/rptest/tests/custom_topic_assignment_test.py
@@ -53,8 +53,6 @@ class CustomTopicAssignmentTest(RedpandaTest):
 
     @cluster(num_nodes=5)
     def test_create_topic_with_custom_partition_assignment(self):
-        cli = KafkaCliTools(self.redpanda)
-        rpk = RpkTool(self.redpanda)
         # 3 partitions with single replica
         self.create_and_validate("topic-1", [[1], [3], [5]])
         # 3 partitions with replication factor of 2

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -73,8 +73,8 @@ rpk:
 schema_registry: {}
 '''
 
-                expected_config = yaml.load(expected_out)
-                actual_config = yaml.load(f.read())
+                expected_config = yaml.full_load(expected_out)
+                actual_config = yaml.full_load(f.read())
 
                 assert actual_config['node_uuid'] is not None
 
@@ -105,7 +105,7 @@ schema_registry: {}
             node.account.copy_from(RedpandaService.CONFIG_FILE, d)
 
             with open(os.path.join(d, config_file)) as f:
-                actual_config = yaml.load(f.read())
+                actual_config = yaml.full_load(f.read())
                 assert f"{actual_config['redpanda']['admin']['port']}" == value
 
     @cluster(num_nodes=3)
@@ -135,8 +135,8 @@ schema_registry: {}
             node.account.copy_from(RedpandaService.CONFIG_FILE, d)
 
             with open(os.path.join(d, 'redpanda.yaml')) as f:
-                expected_config = yaml.load(value)
-                actual_config = yaml.load(f.read())
+                expected_config = yaml.full_load(value)
+                actual_config = yaml.full_load(f.read())
                 assert actual_config['redpanda'][
                     'seed_servers'] == expected_config
 
@@ -150,7 +150,7 @@ schema_registry: {}
 
         rpk.config_set(key, value, format='json')
 
-        expected_config = yaml.load('''
+        expected_config = yaml.full_load('''
 coredump_dir: /var/lib/redpanda/coredump
 enable_memory_locking: false
 enable_usage_stats: false
@@ -170,7 +170,7 @@ tune_swappiness: false
             node.account.copy_from(RedpandaService.CONFIG_FILE, d)
 
             with open(os.path.join(d, 'redpanda.yaml')) as f:
-                actual_config = yaml.load(f.read())
+                actual_config = yaml.full_load(f.read())
 
                 assert actual_config['rpk'] == expected_config
 

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -38,15 +38,11 @@ class WasmCreateTopicsTest(WasmIdentityTest):
 
         # Verify sound input, and grab the input topics config
         test_cfg = self._rpk_tool.describe_topic(self.topic)
-        if test_cfg == None:
-            raise Exception("Input topic missing {}" % self.topic)
         test_cfg = sorted(test_cfg, key=rpk_partition_sort)
 
         # Ensure all materialized topics created and configs match inputs
         for topic in self.wasm_test_output():
             output = self._rpk_tool.describe_topic(topic)
-            if output == None:
-                raise Exception("Materialized topic missing {}" % topic)
             output = sorted(output, key=rpk_partition_sort)
             if output != test_cfg:
                 raise Exception("Bad config, expected: %s observed: %s" %


### PR DESCRIPTION
## Cover letter

* Expands use of default kafka client
* Fixes some type checker issues

The overall strategy for the default kafka client is to first update tests to use the default client which will result in the default client making internal use of a variety of clients, and once that is complete, minimize the set of clients implementing the default client. Perhaps targeting a fully rpk based implementation.

## Release notes

* None