### PR TITLE
Prepare for simplified low storage space metric

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -271,7 +271,11 @@ ss::future<> controller::start() {
             std::ref(_connections),
             std::ref(_partition_manager),
             std::ref(_raft_manager),
-            std::ref(_as));
+            std::ref(_as),
+            config::shard_local_cfg()
+              .storage_space_alert_free_threshold_bytes.bind(),
+            config::shard_local_cfg()
+              .storage_space_alert_free_threshold_percent.bind());
       })
       .then([this] { return _hm_frontend.start(std::ref(_hm_backend)); })
       .then([this] {

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -47,7 +47,9 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_manager>&,
       ss::sharded<raft::group_manager>&,
-      ss::sharded<ss::abort_source>&);
+      ss::sharded<ss::abort_source>&,
+      config::binding<size_t> storage_min_bytes_threshold,
+      config::binding<unsigned> storage_min_percent_threshold);
 
     ss::future<> stop();
 

--- a/src/v/cluster/node/constants.h
+++ b/src/v/cluster/node/constants.h
@@ -14,6 +14,9 @@
 
 namespace cluster::node {
 
+// If you want a smaller threshold, use bytes field.
+// We don't want alert to be disabled, as setting 0% would.
+static constexpr unsigned int min_percent_free_threshold = 1;
 static constexpr unsigned int max_percent_free_threshold = 50;
 static constexpr size_t min_bytes_free_threshold = 1_GiB;
 

--- a/src/v/cluster/node/constants.h
+++ b/src/v/cluster/node/constants.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "units.h"
+
+namespace cluster::node {
+
+static constexpr unsigned int max_percent_free_threshold = 50;
+static constexpr size_t min_bytes_free_threshold = 1_GiB;
+
+} // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -63,7 +63,7 @@ void local_monitor::set_statvfs_for_test(
 }
 
 std::tuple<size_t, size_t>
-local_monitor::minimum_free_by_bytes_and_percent(size_t bytes_available) {
+local_monitor::minimum_free_by_bytes_and_percent(size_t bytes_available) const {
     long double percent_factor = last_free_space_percent_threshold / 100.0;
     return std::make_tuple(
       last_free_space_bytes_threshold, percent_factor * bytes_available);

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -42,9 +42,16 @@ ss::future<> local_monitor::update_state() {
 
 const local_state& local_monitor::get_state_cached() const { return _state; }
 
+void local_monitor::set_path_for_test(const ss::sstring& path) {
+    _path_for_test = path;
+}
+
 ss::future<std::vector<disk>> local_monitor::get_disks() {
-    auto svfs = co_await ss::engine().statvfs(
-      config::node().data_directory().as_sstring());
+    auto path = _path_for_test.empty()
+                  ? config::node().data_directory().as_sstring()
+                  : _path_for_test;
+
+    auto svfs = co_await ss::engine().statvfs(path);
 
     co_return std::vector<disk>{disk{
       .path = config::node().data_directory().as_sstring(),

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -33,6 +33,11 @@
 
 namespace cluster::node {
 
+local_monitor::local_monitor(
+  config::binding<size_t> min_bytes, config::binding<unsigned> min_percent)
+  : _free_bytes_alert_threshold(min_bytes)
+  , _free_percent_alert_threshold(min_percent) {}
+
 ss::future<> local_monitor::update_state() {
     refresh_configuration();
 

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -140,25 +140,6 @@ void local_monitor::update_alert_state() {
 void local_monitor::refresh_configuration() {
     auto percent_threshold = get_config_alert_threshold_percent();
     auto bytes_threshold = get_config_alert_threshold_bytes();
-    // TODO replace with bounded config feature
-    if (percent_threshold > max_percent_free_threshold) {
-        clusterlog.warn(
-          "Configuration value {} for "
-          "storage_space_alert_free_threshold_percent exceeds "
-          "maximum, using {}.",
-          percent_threshold,
-          max_percent_free_threshold);
-        percent_threshold = max_percent_free_threshold;
-    }
-    if (bytes_threshold > max_bytes_free_threshold) {
-        clusterlog.warn(
-          "Configuration value {} for "
-          "storage_space_alert_free_threshold_bytes exceeds "
-          "maximum, using {}.",
-          bytes_threshold,
-          max_bytes_free_threshold);
-        bytes_threshold = max_bytes_free_threshold;
-    }
     if (last_free_space_percent_threshold != percent_threshold) {
         clusterlog.info(
           "Updated free space percent alert threshold {} -> {}",

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -79,7 +79,7 @@ ss::future<struct statvfs> local_monitor::get_statvfs(const ss::sstring& path) {
 }
 
 void local_monitor::update_alert_state() {
-    _state.storage_space_alert = 0;
+    _state.storage_space_alert = disk_space_alert::ok;
     for (const auto& d : _state.disks) {
         vassert(d.total != 0.0, "Total disk space cannot be zero.");
         double min_space = double(d.total) * alert_min_free_space_percent;
@@ -93,7 +93,7 @@ void local_monitor::update_alert_state() {
           double(d.free) <= min_space);
 
         if (double(d.free) <= min_space) {
-            _state.storage_space_alert = 1;
+            _state.storage_space_alert = disk_space_alert::low_space;
         }
     }
 }

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -32,20 +32,29 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
-    // Visible for test...
-    static constexpr double alert_min_free_space_percent = 0.05;
-    static constexpr double alert_min_free_space_bytes = 1_GiB;
+    // Visible for test
+    static constexpr int max_percent_free_threshold = 50;
+    static constexpr size_t max_bytes_free_threshold = 1_TiB;
 
     void set_path_for_test(const ss::sstring& path);
     void
       set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
+    std::tuple<size_t, size_t>
+    minimum_free_by_bytes_and_percent(size_t bytes_available);
 
 private:
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     void update_alert_state();
 
+    // configuration
+    void refresh_configuration();
+    std::size_t get_config_alert_threshold_bytes();
+    unsigned get_config_alert_threshold_percent();
+
     local_state _state;
+    unsigned last_free_space_percent_threshold = 0;
+    size_t last_free_space_bytes_threshold = 0;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -59,8 +59,6 @@ private:
 
     // state
     local_state _state;
-    unsigned last_free_space_percent_threshold = 0;
-    size_t last_free_space_bytes_threshold = 0;
     ss::logger::rate_limit despam_interval = ss::logger::rate_limit(
       std::chrono::hours(1));
     config::binding<size_t> _free_bytes_alert_threshold;

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "cluster/node/types.h"
+#include "config/property.h"
 #include "units.h"
 
 #include <seastar/core/sstring.hh>
@@ -24,12 +25,13 @@ namespace cluster::node {
 
 class local_monitor {
 public:
-    local_monitor() = default;
-    local_monitor(local_monitor&) = delete;
+    local_monitor(
+      config::binding<size_t> min_bytes, config::binding<unsigned> min_percent);
+    local_monitor(local_monitor&) = default;
     local_monitor(local_monitor&&) = default;
     ~local_monitor() = default;
     local_monitor& operator=(local_monitor const&) = delete;
-    local_monitor& operator=(local_monitor&&) = default;
+    local_monitor& operator=(local_monitor&&) = delete;
 
     ss::future<> update_state();
     const local_state& get_state_cached() const;
@@ -61,6 +63,8 @@ private:
     size_t last_free_space_bytes_threshold = 0;
     ss::logger::rate_limit despam_interval = ss::logger::rate_limit(
       std::chrono::hours(1));
+    config::binding<size_t> _free_bytes_alert_threshold;
+    config::binding<unsigned> _free_percent_alert_threshold;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -13,6 +13,8 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <sys/statvfs.h>
+
 // Local node state monitoring is kept separate in case we want to access it
 // pre-quorum formation in the future, etc.
 namespace cluster::node {
@@ -30,13 +32,18 @@ public:
     const local_state& get_state_cached() const;
 
     void set_path_for_test(const ss::sstring& path);
+    void
+      set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
 
 private:
     ss::future<std::vector<disk>> get_disks();
+    ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     local_state _state;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;
+    std::optional<std::function<struct statvfs(const ss::sstring&)>>
+      _statvfs_for_test;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -11,6 +11,8 @@
 #pragma once
 #include "cluster/node/types.h"
 
+#include <seastar/core/sstring.hh>
+
 // Local node state monitoring is kept separate in case we want to access it
 // pre-quorum formation in the future, etc.
 namespace cluster::node {
@@ -27,9 +29,14 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
+    void set_path_for_test(const ss::sstring& path);
+
 private:
-    static ss::future<std::vector<disk>> get_disks();
+    ss::future<std::vector<disk>> get_disks();
     local_state _state;
+
+    // Injection points for unit tests
+    ss::sstring _path_for_test;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "cluster/node/types.h"
+#include "units.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -31,6 +32,10 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
+    // Visible for test...
+    static constexpr double alert_min_free_space_percent = 0.05;
+    static constexpr double alert_min_free_space_bytes = 1_GiB;
+
     void set_path_for_test(const ss::sstring& path);
     void
       set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
@@ -38,6 +43,8 @@ public:
 private:
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
+    void update_alert_state();
+
     local_state _state;
 
     // Injection points for unit tests

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -43,11 +43,11 @@ public:
     void set_path_for_test(const ss::sstring& path);
     void
       set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
-    std::tuple<size_t, size_t>
-    minimum_free_by_bytes_and_percent(size_t bytes_available);
 
 private:
     // helpers
+    std::tuple<size_t, size_t>
+    minimum_free_by_bytes_and_percent(size_t bytes_available) const;
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     void update_alert_state();

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -34,9 +34,6 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
-    // Visible for test
-    static constexpr int max_percent_free_threshold = 50;
-    static constexpr size_t max_bytes_free_threshold = 1_TiB;
     static constexpr std::string_view stable_alert_string
       = "storage space alert"; // for those who grep the logs..
 

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -16,6 +16,8 @@
 
 #include <sys/statvfs.h>
 
+#include <chrono>
+
 // Local node state monitoring is kept separate in case we want to access it
 // pre-quorum formation in the future, etc.
 namespace cluster::node {
@@ -35,6 +37,8 @@ public:
     // Visible for test
     static constexpr int max_percent_free_threshold = 50;
     static constexpr size_t max_bytes_free_threshold = 1_TiB;
+    static constexpr std::string_view stable_alert_string
+      = "storage space alert"; // for those who grep the logs..
 
     void set_path_for_test(const ss::sstring& path);
     void
@@ -43,18 +47,23 @@ public:
     minimum_free_by_bytes_and_percent(size_t bytes_available);
 
 private:
+    // helpers
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     void update_alert_state();
+    void maybe_log_space_error(const disk&);
 
     // configuration
     void refresh_configuration();
     std::size_t get_config_alert_threshold_bytes();
     unsigned get_config_alert_threshold_percent();
 
+    // state
     local_state _state;
     unsigned last_free_space_percent_threshold = 0;
     size_t last_free_space_bytes_threshold = 0;
+    ss::logger::rate_limit despam_interval = ss::logger::rate_limit(
+      std::chrono::hours(1));
 
     // Injection points for unit tests
     ss::sstring _path_for_test;

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -30,6 +30,21 @@ std::ostream& operator<<(std::ostream& o, const disk& d) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -49,6 +49,8 @@ struct local_state {
     std::chrono::milliseconds uptime;
     // Eventually support multiple volumes.
     std::vector<disk> disks;
+    // TODO distinct type instead of int
+    unsigned storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -41,6 +41,8 @@ struct disk {
     friend bool operator==(const disk&, const disk&) = default;
 };
 
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
@@ -49,13 +51,14 @@ struct local_state {
     std::chrono::milliseconds uptime;
     // Eventually support multiple volumes.
     std::vector<disk> disks;
-    // TODO distinct type instead of int
-    unsigned storage_space_alert;
+
+    disk_space_alert storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 
 std::ostream& operator<<(std::ostream& o, const disk& d);
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d);
 std::ostream& operator<<(std::ostream& o, const local_state& s);
 } // namespace cluster::node
 

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -40,7 +40,9 @@ set(srcs
     id_allocator_stm_test.cc
     data_policy_controller_test.cc
     health_monitor_test.cc
-    topic_configuration_compat_test.cc)
+    topic_configuration_compat_test.cc
+    local_monitor_test.cc)
+
 
 rp_test(
   UNIT_TEST

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -19,11 +19,7 @@
 struct local_monitor_fixture {
     local_monitor_fixture();
     local_monitor_fixture(const local_monitor_fixture&) = delete;
-    local_monitor_fixture(local_monitor_fixture&&) = default;
-    local_monitor_fixture& operator=(const local_monitor_fixture&) = delete;
-    local_monitor_fixture& operator=(local_monitor_fixture&&) = default;
     ~local_monitor_fixture();
-
     static constexpr unsigned default_percent_threshold = 5;
     static constexpr size_t default_bytes_threshold = 1_GiB;
 

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -24,10 +24,14 @@ struct local_monitor_fixture {
     local_monitor_fixture& operator=(local_monitor_fixture&&) = default;
     ~local_monitor_fixture();
 
+    static constexpr unsigned default_percent_threshold = 5;
+    static constexpr size_t default_bytes_threshold = 1_GiB;
+
     std::filesystem::path _test_path;
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();
     static struct statvfs make_statvfs(
       unsigned long blk_free, unsigned long blk_total, unsigned long blk_size);
+    void set_config_alert_thresholds(unsigned percent, size_t bytes);
 };

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -28,4 +28,6 @@ struct local_monitor_fixture {
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();
+    static struct statvfs make_statvfs(
+      unsigned long blk_free, unsigned long blk_total, unsigned long blk_size);
 };

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/node/local_monitor.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <string_view>
+
+struct local_monitor_fixture {
+    local_monitor_fixture();
+    local_monitor_fixture(const local_monitor_fixture&) = delete;
+    local_monitor_fixture(local_monitor_fixture&&) = default;
+    local_monitor_fixture& operator=(const local_monitor_fixture&) = delete;
+    local_monitor_fixture& operator=(local_monitor_fixture&&) = default;
+    ~local_monitor_fixture();
+
+    std::filesystem::path _test_path;
+    cluster::node::local_monitor _local_monitor;
+
+    cluster::node::local_state update_state();
+};

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -126,8 +126,7 @@ FIXTURE_TEST(local_monitor_alert_on_space_percent, local_monitor_fixture) {
 FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
     // Minimum by %: 30 GiB total * 0.05 => 1.5 GiB
     // Minimum by bytes:                    1   GiB
-    static constexpr auto total = 30 * 1024 * 1024 * 1024UL,
-                          block_size = 1024UL;
+    static constexpr auto total = 30 * 1024 * 1024UL, block_size = 1024UL;
     static constexpr auto min_bytes_in_blocks = default_bytes_threshold
                                                 / block_size;
     clusterlog.debug(

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -106,7 +106,8 @@ FIXTURE_TEST(local_monitor_alert_on_space_percent, local_monitor_fixture) {
     // Minimum by %: 200 * 4k block = 800KiB total * 0.05 -> 40 KiB
     // Minimum by bytes:                                      1 GiB
     static constexpr auto total = 200UL, free = 0UL, block_size = 4096UL;
-    size_t min_free_percent_blocks = total * (default_percent_threshold / 100.0);
+    size_t min_free_percent_blocks = total
+                                     * (default_percent_threshold / 100.0);
     struct statvfs stats = make_statvfs(free, total, block_size);
     auto lamb = [&](const ss::sstring&) { return stats; };
     _local_monitor.set_statvfs_for_test(lamb);

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -99,12 +99,14 @@ FIXTURE_TEST(local_monitor_alert_on_space_percent, local_monitor_fixture) {
     // One block over the threshold should not alert
     stats.f_bfree = min_free_percent_blocks + 1;
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert == cluster::node::disk_space_alert::ok);
 
     // One block under the free threshold should alert
     stats.f_bfree = min_free_percent_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert != cluster::node::disk_space_alert::ok);
 }
 
 FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
@@ -124,10 +126,12 @@ FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
     _local_monitor.set_statvfs_for_test(lamb);
 
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert == cluster::node::disk_space_alert::ok);
 
     // Min bytes threshold minus a blocks -> Alert
     stats.f_bfree = min_bytes_in_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert != cluster::node::disk_space_alert::ok);
 }

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -10,6 +10,7 @@
  */
 
 #include "cluster/logger.h"
+#include "config/configuration.h"
 #include "local_monitor_fixture.h"
 #include "redpanda/tests/fixture.h"
 #include "seastarx.h"
@@ -28,7 +29,11 @@
 
 using namespace cluster;
 
-local_monitor_fixture::local_monitor_fixture() {
+local_monitor_fixture::local_monitor_fixture()
+  : _local_monitor(
+    config::shard_local_cfg().storage_space_alert_free_threshold_bytes.bind(),
+    config::shard_local_cfg()
+      .storage_space_alert_free_threshold_percent.bind()) {
     clusterlog.info("{}: create", __func__);
     auto test_dir = "local_monitor_test."
                     + random_generators::gen_alphanum_string(4);

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "local_monitor_fixture.h"
+#include "redpanda/tests/fixture.h"
+#include "seastarx.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/interface.hpp>
+#include <fmt/format.h>
+
+#include <filesystem>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+inline ss::logger logger(__FILE__); // NOLINT static may throw
+
+local_monitor_fixture::local_monitor_fixture() {
+    logger.info("{}: create", __func__);
+    auto test_dir = "local_monitor_test."
+                    + random_generators::gen_alphanum_string(4);
+
+    _test_path = std::filesystem::absolute(test_dir.c_str());
+
+    std::error_code errc;
+    std::filesystem::create_directory(_test_path, errc);
+    if (errc) {
+        logger.warn(
+          "{}: failed to create test dir {}: {}", __func__, _test_path, errc);
+    } else {
+        logger.info("{}: created test dir {}", __func__, _test_path);
+    }
+    _local_monitor.set_path_for_test(_test_path.string());
+    BOOST_ASSERT(ss::engine_is_ready());
+}
+
+local_monitor_fixture::~local_monitor_fixture() {
+    logger.info("{}: destroy", __func__);
+    std::error_code err;
+    std::filesystem::remove_all(std::filesystem::path(_test_path), err);
+    if (err) {
+        logger.warn("Cleanup got error {} removing test dir.", err);
+    }
+}
+
+cluster::node::local_state local_monitor_fixture::update_state() {
+    _local_monitor.update_state()
+      .then([&]() { logger.info("Updated local state."); })
+      .get();
+    return _local_monitor.get_state_cached();
+}
+
+FIXTURE_TEST(local_state_has_single_disk, local_monitor_fixture) {
+    auto ls = update_state();
+    BOOST_TEST_REQUIRE(ls.disks.size() == 1);
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1040,14 +1040,16 @@ configuration::configuration()
       "Threshold of minimim percent free space before setting storage space "
       "alert",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5)
+      5,
+      {.min = 0, .max = 50})
   , storage_space_alert_free_threshold_bytes(
       *this,
       "storage_space_alert_free_threshold_bytes",
       "Threshold of minimim bytes free space before setting storage space "
       "alert",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1_GiB)
+      1_GiB,
+      {.min = 1_MiB})
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 
+#include "cluster/node/constants.h"
 #include "config/base_property.h"
 #include "config/node_config.h"
 #include "model/metadata.h"
@@ -1041,7 +1042,7 @@ configuration::configuration()
       "alert",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5,
-      {.min = 0, .max = 50})
+      {.min = 0, .max = cluster::node::max_percent_free_threshold})
   , storage_space_alert_free_threshold_bytes(
       *this,
       "storage_space_alert_free_threshold_bytes",
@@ -1049,7 +1050,7 @@ configuration::configuration()
       "alert",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB,
-      {.min = 1_MiB})
+      {.min = cluster::node::min_bytes_free_threshold})
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1034,6 +1034,20 @@ configuration::configuration()
       "Max age of metadata cached in the health monitor of non controller node",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , storage_space_alert_free_threshold_percent(
+      *this,
+      "storage_space_alert_free_threshold_percent",
+      "Threshold of minimim percent free space before setting storage space "
+      "alert",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5)
+  , storage_space_alert_free_threshold_bytes(
+      *this,
+      "storage_space_alert_free_threshold_bytes",
+      "Threshold of minimim bytes free space before setting storage space "
+      "alert",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_GiB)
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1042,7 +1042,8 @@ configuration::configuration()
       "alert",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5,
-      {.min = 0, .max = cluster::node::max_percent_free_threshold})
+      {.min = cluster::node::min_percent_free_threshold,
+       .max = cluster::node::max_percent_free_threshold})
   , storage_space_alert_free_threshold_bytes(
       *this,
       "storage_space_alert_free_threshold_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -233,8 +233,8 @@ struct configuration final : public config_store {
     // health monitor
     property<std::chrono::milliseconds> health_monitor_tick_interval;
     property<std::chrono::milliseconds> health_monitor_max_metadata_age;
-    property<unsigned> storage_space_alert_free_threshold_percent;
-    property<size_t> storage_space_alert_free_threshold_bytes;
+    bounded_property<unsigned> storage_space_alert_free_threshold_percent;
+    bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     // metrics reporter
     property<bool> enable_metrics_reporter;
     property<std::chrono::milliseconds> metrics_reporter_tick_interval;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -233,6 +233,8 @@ struct configuration final : public config_store {
     // health monitor
     property<std::chrono::milliseconds> health_monitor_tick_interval;
     property<std::chrono::milliseconds> health_monitor_max_metadata_age;
+    property<unsigned> storage_space_alert_free_threshold_percent;
+    property<size_t> storage_space_alert_free_threshold_bytes;
     // metrics reporter
     property<bool> enable_metrics_reporter;
     property<std::chrono::milliseconds> metrics_reporter_tick_interval;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -51,9 +51,9 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int>> rpc_server_tcp_send_buf;
     // Coproc
     property<bool> enable_coproc;
-    property<std::size_t> coproc_max_inflight_bytes;
-    property<std::size_t> coproc_max_ingest_bytes;
-    property<std::size_t> coproc_max_batch_size;
+    property<size_t> coproc_max_inflight_bytes;
+    property<size_t> coproc_max_ingest_bytes;
+    property<size_t> coproc_max_batch_size;
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
     // Controller

--- a/src/v/units.h
+++ b/src/v/units.h
@@ -18,7 +18,9 @@
 constexpr size_t KiB = 1024;
 constexpr size_t MiB = 1024 * KiB;
 constexpr size_t GiB = 1024 * MiB;
+constexpr size_t TiB = 1024 * GiB;
 
 constexpr size_t operator"" _KiB(unsigned long long val) { return val * KiB; }
 constexpr size_t operator"" _MiB(unsigned long long val) { return val * MiB; }
 constexpr size_t operator"" _GiB(unsigned long long val) { return val * GiB; }
+constexpr size_t operator"" _TiB(unsigned long long val) { return val * TiB; }


### PR DESCRIPTION
In preparation for a new, simplified storage space /metrics field, this PR will log periodic error messages, depending on configured thresholds, when storage space gets dangerously low.

### Features

* Error messages will be logged hourly while the low space condition holds.
* By default, the threshold for activating is when free space drops below the smaller of 5% of available space, or 1 GiB.
* New configuration parameters allow changing these thresholds: The % free and minimum bytes free values can be overridden with the `storage_space_alert_free_threshold_percent` and `storage_space_alert_free_threshold_bytes` configuration parameters, respectively.

### Improvements

* Logging low storage space condition, to help alert users to adjust retention policies, even if they don't have other external monitoring systems set up.