### PR TITLE
kafka/cluster: fix ordering of listener startups vs. joining cluster

### DIFF
--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -83,6 +83,8 @@ public:
      */
     ss::future<std::vector<node_update>> get_node_updates();
 
+    ss::future<> join_cluster();
+
 private:
     using seed_iterator = std::vector<config::seed_server>::const_iterator;
     // Cluster join

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -73,6 +73,8 @@ void members_table::update_brokers(
         } else {
             _brokers.emplace(br.id(), ss::make_lw_shared<model::broker>(br));
         }
+
+        _waiters.notify(br.id());
     }
 
     for (auto& [id, br] : _brokers) {

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -14,10 +14,72 @@
 #include "cluster/commands.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
+#include "seastar/core/abort_source.hh"
+#include "seastar/core/weak_ptr.hh"
 
 #include <absl/container/flat_hash_map.h>
 
 namespace cluster {
+
+/**
+ * Generic 'list of waiters' helper, where a waiter is waiting for a particular
+ * item of type `T`, and the owner of the queue is responsible for calling
+ * `notify` with a value of type `T` to wake up all the fibers waiting for
+ * that value.
+ *
+ * Waiters are woken in the same order they called `await`.
+ *
+ * If the abort source passed into `await` fires, then an exceptional
+ * future is returned to the caller with `abort_requested_exception`: callers
+ * should handle that gracefully (this is already done if the caller is inside
+ * a ssx::spawn_with_gate or similar helper).
+ */
+template<typename T>
+class waiter_queue {
+    struct wait_item : ss::weakly_referencable<wait_item> {
+        wait_item(T data_)
+          : data(std::move(data_)) {}
+
+        T data;
+        ss::promise<> p;
+        ss::abort_source::subscription abort_sub;
+    };
+
+    std::vector<std::unique_ptr<wait_item>> _items;
+
+public:
+    ss::future<> await(T value, ss::abort_source& as) {
+        auto item = std::make_unique<wait_item>(value);
+        auto fut = item->p.get_future();
+
+        auto sub_opt = as.subscribe(
+          [item_ptr = item->weak_from_this()]() noexcept {
+              if (item_ptr) {
+                  item_ptr->p.set_exception(ss::abort_requested_exception());
+              }
+          });
+
+        if (!sub_opt) {
+            // Abort source already fired!
+            return ss::make_exception_future<>(ss::abort_requested_exception());
+        } else {
+            item->abort_sub = std::move(*sub_opt);
+        }
+
+        _items.emplace_back(std::move(item));
+        return fut;
+    }
+    void notify(const T& value) {
+        auto items = std::exchange(_items, {});
+        for (auto& wi : items) {
+            if (wi->data == value) {
+                wi->p.set_value();
+            } else {
+                _items.push_back(std::move(wi));
+            }
+        }
+    };
+};
 
 /// Class containing information about cluster members. The members class is
 /// instantiated on each core. Cluster members updates are comming directly from
@@ -44,9 +106,19 @@ public:
 
     model::revision_id version() const { return _version; }
 
+    ss::future<> await_membership(model::node_id id, ss::abort_source& as) {
+        if (!contains(id)) {
+            return _waiters.await(id, as);
+        } else {
+            return ss::now();
+        }
+    }
+
 private:
     using broker_cache_t = absl::flat_hash_map<model::node_id, broker_ptr>;
     broker_cache_t _brokers;
     model::revision_id _version;
+
+    waiter_queue<model::node_id> _waiters;
 };
 } // namespace cluster

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -29,7 +29,8 @@ public:
         app.check_environment();
         app.configure_admin_server();
         app.wire_up_services();
-        app.start();
+        ::stop_signal app_signal;
+        app.start(app_signal);
     }
 
     kc::client make_client() { return kc::client{proxy_client_config()}; }

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -131,7 +131,8 @@ public:
         app.check_environment();
         app.configure_admin_server();
         app.wire_up_services();
-        app.start();
+        ::stop_signal app_signal;
+        app.start(app_signal);
     }
 };
 

--- a/src/v/platform/stop_signal.h
+++ b/src/v/platform/stop_signal.h
@@ -13,6 +13,7 @@
 
 #include "seastarx.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/reactor.hh>
@@ -33,12 +34,16 @@ public:
 
     bool stopping() const { return _caught; }
 
+    ss::abort_source& abort_source() { return _as; };
+
 private:
     void signaled() {
         _caught = true;
+        _as.request_abort();
         _cond.broadcast();
     }
 
     bool _caught = false;
     ss::condition_variable _cond;
+    ss::abort_source _as;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1170,6 +1170,14 @@ void application::start_redpanda() {
       "Started RPC server listening at {}",
       config::node().rpc_server());
 
+    // After we have started internal RPC listener, we may join
+    // the cluster (if we aren't already a member)
+    controller->get_members_manager()
+      .invoke_on(
+        cluster::members_manager::shard,
+        &cluster::members_manager::join_cluster)
+      .get();
+
     if (archival_storage_enabled()) {
         syschecks::systemd_message("Starting archival storage").get();
         archival_scheduler

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -24,6 +24,7 @@
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/fwd.h"
+#include "platform/stop_signal.h"
 #include "raft/fwd.h"
 #include "redpanda/admin_server.h"
 #include "resource_mgmt/cpu_scheduling.h"
@@ -55,8 +56,9 @@ public:
     void configure_admin_server();
     void wire_up_services();
     void wire_up_redpanda_services();
-    void start();
+    void start(::stop_signal&);
     void start_redpanda();
+    void start_kafka(::stop_signal&);
 
     explicit application(ss::sstring = "redpanda::main");
     ~application();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -82,7 +82,8 @@ public:
         app.check_environment();
         app.configure_admin_server();
         app.wire_up_services();
-        app.start();
+        ::stop_signal app_signal;
+        app.start(app_signal);
 
         // used by request context builder
         proto = std::make_unique<kafka::protocol>(


### PR DESCRIPTION
## Cover letter

We had two issues in our startup order affecting nodes joining the cluster:
- Nodes would send join requests to controller leader before starting their internal RPC listener.  This could result in the leader being unable to send an append_entries and backing off before retry, creating an intervening period where the leader thinks the new node is added, but the new node hasn't seen its own addition.
- Kafka listeners would start before the node joined the cluster.  In this state, kafka metadata requests would get incorrect responses because the new node has not yet seen the controller log.

Fixes: https://github.com/vectorizedio/redpanda/issues/3030

## Release notes

### Improvements

* When adding new nodes to the cluster, the added nodes will no longer attempt to serve Kafka requests before they are up to date with the cluster metadata.  This avoids a case where clients might experience transient timeouts if accessing the cluster during node joins.