### PR TITLE
schema_registry/store: Don't depend on argument evaluation order

### DIFF
--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -153,10 +153,9 @@ sharded_store::project_ids(canonical_schema schema) {
         vlog(plog.debug, "project_ids: existing ID {}", s_id.value());
     }
 
+    auto sub_shard{shard_for(schema.sub())};
     auto v_id = co_await _store.invoke_on(
-      shard_for(schema.sub()),
-      _smp_opts,
-      [sub{schema.sub()}, id{s_id.value()}](store& s) {
+      sub_shard, _smp_opts, [sub{schema.sub()}, id{s_id.value()}](store& s) {
           return s.project_version(sub, id);
       });
 
@@ -235,8 +234,9 @@ sharded_store::get_schema_subject_versions(schema_id id) {
 
 ss::future<subject_schema> sharded_store::get_subject_schema(
   subject sub, std::optional<schema_version> version, include_deleted inc_del) {
+    auto sub_shard{shard_for(sub)};
     auto v_id = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, version, inc_del](store& s) {
+      sub_shard, _smp_opts, [sub, version, inc_del](store& s) {
           return s.get_subject_version_id(sub, version, inc_del).value();
       });
 
@@ -267,8 +267,9 @@ sharded_store::get_subjects(include_deleted inc_del) {
 
 ss::future<std::vector<schema_version>>
 sharded_store::get_versions(subject sub, include_deleted inc_del) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}, inc_del](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}, inc_del](store& s) {
           return s.get_versions(sub, inc_del).value();
       });
 }
@@ -307,49 +308,53 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
 
 ss::future<std::vector<schema_version>> sharded_store::delete_subject(
   seq_marker marker, subject sub, permanent_delete permanent) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      [marker, sub{std::move(sub)}, permanent](store& s) {
+      sub_shard, _smp_opts, [marker, sub{std::move(sub)}, permanent](store& s) {
           return s.delete_subject(marker, sub, permanent).value();
       });
 }
 
 ss::future<is_deleted> sharded_store::is_subject_deleted(subject sub) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.is_subject_deleted(sub).value();
       });
 }
 
 ss::future<is_deleted>
 sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.is_subject_version_deleted(sub, ver).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
 sharded_store::get_subject_written_at(subject sub) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.store::get_subject_written_at(sub).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
 sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.get_subject_version_written_at(sub, ver).value();
       });
 }
 
 ss::future<bool>
 sharded_store::delete_subject_version(subject sub, schema_version ver) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.delete_subject_version(sub, ver).value();
       });
 }
@@ -360,8 +365,9 @@ ss::future<compatibility_level> sharded_store::get_compatibility() {
 
 ss::future<compatibility_level>
 sharded_store::get_compatibility(subject sub, default_to_global fallback) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), [sub{std::move(sub)}, fallback](store& s) {
+      sub_shard, [sub{std::move(sub)}, fallback](store& s) {
           return s.get_compatibility(sub, fallback).value();
       });
 }
@@ -377,8 +383,9 @@ sharded_store::set_compatibility(compatibility_level compatibility) {
 
 ss::future<bool> sharded_store::set_compatibility(
   seq_marker marker, subject sub, compatibility_level compatibility) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub),
+      sub_shard,
       _smp_opts,
       [marker, sub{std::move(sub)}, compatibility](store& s) {
           return s.set_compatibility(marker, sub, compatibility).value();
@@ -386,8 +393,9 @@ ss::future<bool> sharded_store::set_compatibility(
 }
 
 ss::future<bool> sharded_store::clear_compatibility(subject sub) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
+      sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.clear_compatibility(sub).value();
       });
 }
@@ -403,8 +411,9 @@ sharded_store::upsert_schema(schema_id id, canonical_schema_definition def) {
 
 ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
   subject sub, canonical_schema::references refs, schema_id id) {
+    auto sub_shard{shard_for(sub)};
     auto [version, inserted] = co_await _store.invoke_on(
-      shard_for(sub),
+      sub_shard,
       _smp_opts,
       [sub{std::move(sub)}, refs{std::move(refs)}, id](store& s) mutable {
           return s.insert_subject(sub, std::move(refs), id);
@@ -419,8 +428,9 @@ ss::future<bool> sharded_store::upsert_subject(
   schema_version version,
   schema_id id,
   is_deleted deleted) {
+    auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
-      shard_for(sub),
+      sub_shard,
       _smp_opts,
       [marker,
        sub{std::move(sub)},


### PR DESCRIPTION
## Cover letter

Clang tends to evaluate arguments left-to-right, but g++ tends to do it right-to-left.

[example on godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCBmAKykAA6oCoRODB7evnrJqY4CQSHhLFEx8baY9vkMQgRMxASZPn5cFVXptfUEhWGR0bEJCnUNTdmtQ109xaUDAJS2qF7EyOwc5gDMwcjeWADUJutuTkPEmKwH2CYaAIJeqUa7zGwKiUwru0PoB1Y3wQS7qn26wAIrsNN8rtc/rt%2BKgILN9jcTAB2H7XXYY3ZoLz/A5uPH7MxmWHmMxA/GHXauWgQm6Y3anAhLBgA6xs9ZolHAyHQiL1eGQlFo%2BnY3GHAmkvnEUnkgnU2nozGM5msyzsznI7k3ABuqDw6F2BEwQwA%2BoQINCmKRdrzZoLUZCRYsxRS3ISzEwgaCZXiCZ7fZT5XT6ZiA27JV73bLKRFo275RzBUjNTzBLsWExgha0/VgMhrWgGEMsQh6rsAFS57UmOJWOLAu3J4WYo2m82w%2BGkKXwu0cxGKjHK4gs8GJ5Na64cea0ThxXh%2BDhaUioTj4tWWD6LZaYQnrHikAiaKfzADWIHW6wAdBeb7e7wA2fScSTzo/Lzi8BQgDQHo/zOCwEgaAsIkdDROQlDAaB9AxMAXBcGYfB0EaxBfhAERvhEwT1AAnm%2BwFsIIADyDC0Hhi68FgGZGOIFGkPgpwOHg2rGm%2BmCqJgyA4qsS5/JUb60HgETELhHhYG%2BBDEHgLCcDw8xUAYwAKAAangmAAO5EYkjCybw/CCCIYjsFIMiCIoKjqHRuitAYRgoGylj6EJX6QPMqCJNUX4cAAtJ8BzAqY64WGYGgYt5RFmJ%2BlScdULgMO4njNP48VTH0MStLkaQCKMLRJCkWUMKlJT9OM0VMQInQjIlYxtDFHTDN0wS9MV6W2A1OV6BMDRFTMXDzAoW4rHokmYKsclPhwc6kAuS4rhwqgABz3t596SLsebILs8GXmSEBrlYjm7LghAkLurS7B4IFgcQZ2zLwh4UbMp7nled5vTej4zhwL7TW%2Bc2ft%2Bv6PaQAGICAzqJDiEEQFB13%2BPgRCtfpwiiOIJnI%2BZahvupImJLp06zq%2BdFzUROKQ/8qBUACS0rWtG1bVwO27HtqBXTBt33X%2Bz0Xte71vRNP0zbw/22IDD1aE9E2Rb9xMfkDEvzCxqHpCAkhAA)

Avoid a use-after-move on g++.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

* none