### PR TITLE
schema_registry/store: Attempt to avoid miscompilation on clang 12.0.1

### DIFF
--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -101,14 +101,16 @@ sharded_store::make_valid_schema(canonical_schema schema) {
     // This method seems to confuse clang 12.0.1
     // See #3596 for details, especially if modifying it.
     switch (schema.type()) {
-    case schema_type::avro:
+    case schema_type::avro: {
         co_return make_avro_schema_definition(schema.def().raw()()).value();
-    case schema_type::protobuf:
-        co_return co_await make_protobuf_schema_definition(*this, schema);
-    case schema_type::json:
-        throw as_exception(invalid_schema_type(schema.type()));
     }
-    __builtin_unreachable();
+    case schema_type::protobuf: {
+        co_return co_await make_protobuf_schema_definition(*this, schema);
+    }
+    case schema_type::json:
+        break;
+    }
+    throw as_exception(invalid_schema_type(schema.type()));
 }
 
 ss::future<sharded_store::insert_result>


### PR DESCRIPTION
## Cover letter

Using a belt-and-braces approach to convince clang 12.0.1 not to miscompile this function.

* Introduce an artificial scope for co_await blocks
* Avoid `__builtin_unreachable()`

The failure is in `pandaproxy_test_fixture::schema_registry_post_subjects_subject_version_many_proto`

The backtrace on arm is:
```
void std::__1::__libcpp_operator_delete<void*>(void*) at /vectorized/llvm/bin/../include/c++/v1/new:245
 (inlined by) void std::__1::__do_deallocate_handle_size<>(void*, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/new:269
 (inlined by) std::__1::__libcpp_deallocate(void*, unsigned long, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/new:285
 (inlined by) std::__1::allocator<char>::deallocate(char*, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/memory:874
 (inlined by) std::__1::allocator_traits<std::__1::allocator<char> >::deallocate(std::__1::allocator<char>&, char*, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/__memory/allocator_traits.h:280
 (inlined by) ~basic_string at /vectorized/llvm/bin/../include/c++/v1/string:2237
 (inlined by) ~error_info at /var/lib/buildkite-agent/builds/buildkite-arm64-builders-i-058d4ead6b38020f3-1/vectorized/redpanda/vbuild/release/clang/../../../src/v/pandaproxy/schema_registry/errors.h:25
 (inlined by) ~basic_result_storage at /vectorized/include/boost/outcome/detail/basic_result_storage.hpp:113
 (inlined by) pandaproxy::schema_registry::sharded_store::make_valid_schema(pandaproxy::schema_registry::typed_schema<pandaproxy::schema_registry::canonical_schema_defnition_tag>) at /var/lib/buildkite-agent/builds/buildkite-arm64-builders-i-058d4ead6b38020f3-1/vectorized/redpanda/vbuild/release/clang/../../../src/v/pandaproxy/schema_registry/sharded_store.cc:110
```

Which implies it's destructing the frame for the avro coroutine, not the protobuf one.

See #3596 for details

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

* none