### PR TITLE
Fix partial truncation

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1739,10 +1739,6 @@ ss::future<> consensus::hydrate_snapshot() {
 }
 
 ss::future<> consensus::truncate_to_latest_snapshot() {
-    auto lstats = _log.offsets();
-    if (lstats.start_offset > _last_snapshot_index) {
-        return ss::now();
-    }
     // we have to prefix truncate config manage at exactly last offset included
     // in snapshot as this is the offset of configuration included in snapshot
     // metadata.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -973,9 +973,7 @@ ss::future<> disk_log_impl::do_truncate_prefix(truncate_prefix_config cfg) {
     /*
      * Persist the desired starting offset
      */
-    if (!co_await update_start_offset(cfg.start_offset)) {
-        co_return;
-    }
+    co_await update_start_offset(cfg.start_offset);
 
     /*
      * Then delete all segments (potentially including the active segment)


### PR DESCRIPTION
## Cover letter

When redpanda crashes during prefix truncation it may happen that the
start offset is updated but log segments were not yet removed. In this
case Raft will retry prefix truncation and this way log state will be
cleaned up.

Changed check in update start offset to allow prefix truncate log with
the same offset allowing re triggering segments deletion.
