### PR TITLE
tools: added simple tool to map group id to underlying partition

### DIFF
--- a/tools/group_id_mapper/mapper.py
+++ b/tools/group_id_mapper/mapper.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+import jump
+import xxhash
+
+
+def main():
+    import argparse
+
+    def generate_options():
+        parser = argparse.ArgumentParser(
+            description='Redpanda Consumer Group Mapper')
+        parser.add_argument('group_id',
+                            type=str,
+                            help='Id of the group to map')
+        parser.add_argument('--partition_count',
+                            type=int,
+                            help='Number of consumer group topic partitions',
+                            required=True)
+
+        return parser
+
+    parser = generate_options()
+    options, _ = parser.parse_known_args()
+    xx = xxhash.xxh64(seed=0)
+
+    xx.update(options.group_id)
+
+    partition_id = jump.hash(xx.intdigest(), options.partition_count)
+    print(f"kafka_internal/group/{partition_id}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/group_id_mapper/requirements.txt
+++ b/tools/group_id_mapper/requirements.txt
@@ -1,0 +1,2 @@
+jump-consistent-hash==3.2.0
+xxhash==2.0.2


### PR DESCRIPTION
Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Cover letter

Implemented simple python tool that allow us to map group id string to `kafka_internal` topic partition underlying the group state.

## Release notes
* none