### PR TITLE
Fix consumer group recovery

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -366,7 +366,7 @@ ss::future<> group_manager::recover_partition(
             auto group = get_group(group_id);
             if (!group) {
                 group = ss::make_lw_shared<kafka::group>(
-                  group_id, group_state::empty, _conf, p->partition);
+                  group_id, group_stm.get_metadata(), _conf, p->partition);
                 group->reset_tx_state(term);
                 _groups.emplace(group_id, group);
                 group->reschedule_all_member_heartbeats();

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -153,6 +153,8 @@ public:
         return _fence_pid_epoch;
     }
 
+    group_log_group_metadata& get_metadata() { return _metadata; }
+
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
     absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;


### PR DESCRIPTION
## Cover letter

Using persisted group metadata to recover group state when group coordinator changes.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
