### PR TITLE
rpk/cli: show help for incorrect number or invalid arguments

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -38,11 +38,10 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		helpOperations bool
 	)
 	command := &cobra.Command{
-		Use:          "acl",
-		Short:        "Manage ACLs and SASL users.",
-		Long:         helpACLs,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(0),
+		Use:   "acl",
+		Short: "Manage ACLs and SASL users.",
+		Long:  helpACLs,
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			if helpOperations {
 				fmt.Println(helpACLOperations)

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -255,7 +255,6 @@ The following are the data sources that are bundled in the compressed file:
  - dmidecode: The DMI table contents. Only included if this command is run
    as root.
 `,
-		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/check.go
@@ -32,9 +32,8 @@ func NewCheckCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		timeout    time.Duration
 	)
 	command := &cobra.Command{
-		Use:          "check",
-		Short:        "Check if system meets redpanda requirements.",
-		SilenceUsage: true,
+		Use:   "check",
+		Short: "Check if system meets redpanda requirements.",
 		RunE: func(ccmd *cobra.Command, args []string) error {
 			return executeCheck(fs, mgr, configFile, timeout)
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
@@ -38,7 +38,6 @@ func NewStopCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 first sends SIGINT, and waits for the specified timeout. Then, if redpanda
 hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
 running.`,
-		SilenceUsage: true,
 		RunE: func(ccmd *cobra.Command, args []string) error {
 			return executeStop(fs, mgr, configFile, timeout)
 		},

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -59,7 +59,6 @@ func Execute() {
 		Short: "rpk is the Redpanda CLI & toolbox.",
 		Long:  "",
 	}
-	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&verbose, config.FlagVerbose,
 		"v", false, "Enable verbose logging (default: false).")
 

--- a/src/go/rpk/pkg/cli/cmd/version.go
+++ b/src/go/rpk/pkg/cli/cmd/version.go
@@ -18,10 +18,9 @@ import (
 
 func NewVersionCommand() *cobra.Command {
 	command := &cobra.Command{
-		Use:          "version",
-		Short:        "Check the current version.",
-		Long:         "",
-		SilenceUsage: true,
+		Use:   "version",
+		Short: "Check the current version.",
+		Long:  "",
 		Run: func(_ *cobra.Command, _ []string) {
 			log.SetFormatter(cli.NewNoopFormatter())
 			log.Infof("%s\n", version.Pretty())

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -31,10 +31,9 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 		skipVersion bool
 	)
 	cmd := &cobra.Command{
-		Use:          "generate [PROJECT DIRECTORY]",
-		Short:        "Create an npm template project for inline WASM engine.",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Use:   "generate [PROJECT DIRECTORY]",
+		Short: "Create an npm template project for inline WASM engine.",
+		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			path, err := filepath.Abs(args[0])
 			out.MaybeDie(err, "unable to get absolute path for %q: %v", args[0], err)


### PR DESCRIPTION
## Cover letter

This is a proposal to fix half of #300 by adding a wrapper to the validation of positional arguments using the [MatchAll](https://github.com/spf13/cobra/blob/e04ec725508c760e70263b031e5697c232d5c3fa/args.go#L112) used in cobra latest release and adding the `usage` after the validation error.

Im doing it this way to avoid using the `silenceUsage=false` at root level and have control on the desired behavior for each error.
 
This will require to modify all commands so I'm requesting your feedback before proceeding with the rest of the commands.

before:
```
rpk api topic create
Error: requires at least 1 arg(s), only received 0
```

after 
```
rpk api topic create
Error: requires at least 1 arg(s), only received 0


Usage:
  rpk topic create [TOPICS...] [flags]

Flags:
  -d, --dry                        dry run: validate the topic creation request; do not create topics
  -h, --help                       help for create
  -p, --partitions int32           Number of partitions to create per topic (default 1)
  -r, --replicas int16             Replication factor; if -1, this will be the broker's default.replication.factor (default -1)
  -c, --topic-config stringArray   key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)

Global Flags:
      --brokers strings         Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' ). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
      --config string           Redpanda config file, if not set the file will be searched for in the default locations
      --password string         SASL password to be used for authentication.
      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
      --tls-cert string         The certificate to be used for TLS authentication with the broker.
      --tls-enabled             Enable TLS for the Kafka API (not necessary if specifying custom certs).
      --tls-key string          The certificate key to be used for TLS authentication with the broker.
      --tls-truststore string   The truststore to be used for TLS communication with the broker.
      --user string             SASL user to be used for authentication.
  -v, --verbose                 Enable verbose logging (default: false).
```

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
