### PR TITLE
rename vectorizedio to redpanda-data for top-level md files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ If a community member engages in unacceptable behavior, the community organizers
 
 ## 7. Reporting Guidelines
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. community@vectorized.io.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. community@redpanda.com.
 
 
 
@@ -65,9 +65,9 @@ Additionally, community organizers are available to help community members engag
 
 ## 8. Addressing Grievances
 
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify vectorizedio with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Redpanda with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.
 
-community@vectorized.io
+community@redpanda.com
 
 ## 9. Scope
 
@@ -77,7 +77,7 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ## 10. Contact info
 
-community@vectorized.io
+community@redpanda.com
 
 ## 11. License and attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,15 @@ make this a welcoming community for all, and we're excited that you are here!
 
 The basics:
 
-* Use the [Issue Tracker](https://github.com/vectorizedio/redpanda/issues/) to
+* Use the [Issue Tracker](https://github.com/redpanda-data/redpanda/issues/) to
   report bugs, crashes, performance issues, etc... Please include as much detail
   as possible.
   
-* [Discussions](https://github.com/vectorizedio/redpanda/discussions) is a great
+* [Discussions](https://github.com/redpanda-data/redpanda/discussions) is a great
   venue to ask questions, start a design discussion, or post an RFC.
   
 * We ask that developers sign our [contributor license
-  agreement](https://github.com/vectorizedio/redpanda/tree/dev/licenses). The
+  agreement](https://github.com/redpanda-data/redpanda/tree/dev/licenses). The
   process of signing the CLA is automated, and you'll be prompted instructions
   the first time you submit a pull request to the project.
 
@@ -45,7 +45,7 @@ feedback.
 
 Located in the root of the Redpanda project are style property files for various
 languages used in the project (e.g.
-[clang-format](https://github.com/vectorizedio/redpanda/blob/dev/.clang-format)
+[clang-format](https://github.com/redpanda-data/redpanda/blob/dev/.clang-format)
 for C/C++).  Our continuous integration checks enforce these styles by verifying
 changes made in each pull request.  All mainstream editors and IDEs should
 provide support (either natively or through a plugin) for integrating with code

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # Redpanda
-[![Documentation](https://img.shields.io/badge/documentation-black)](https://vectorized.io/documentation)
-[![Slack](https://img.shields.io/badge/slack-purple)](https://vectorized.io/slack)
-[![Twitter](https://img.shields.io/twitter/follow/vectorizedio.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=vectorizedio)
-![Go](https://github.com/vectorizedio/redpanda/workflows/Go/badge.svg)
-![C++](https://github.com/vectorizedio/redpanda/workflows/build-test/badge.svg)
+[![Documentation](https://img.shields.io/badge/documentation-black)](https://redpanda.com/documentation)
+[![Slack](https://img.shields.io/badge/slack-purple)](https://redpanda.com/slack)
+[![Twitter](https://img.shields.io/twitter/follow/redpandadata.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=redpandadata)
+![Go](https://github.com/redpanda-data/redpanda/workflows/Go/badge.svg)
+![C++](https://github.com/redpanda-data/redpanda/workflows/build-test/badge.svg)
 
-[<p align="center"><img src="docs/PANDA_sitting.jpg" alt="redpanda sitting" width="400"/></p>](https://vectorized.io/redpanda)
+[<p align="center"><img src="docs/PANDA_sitting.jpg" alt="redpanda sitting" width="400"/></p>](https://redpanda.com/redpanda)
 <img src="https://static.scarf.sh/a.png?x-pxid=3c187215-e862-4b67-8057-45aa9a779055" />
 
 Redpanda is a streaming platform for mission critical workloads. Kafka® compatible, 
@@ -20,11 +20,11 @@ you from the smallest projects to petabytes of data distributed across the globe
 
 # Community
 
-[Slack](https://vectorized.io/slack) is the main way the community interacts with one another in real time :) 
+[Slack](https://redpanda.com/slack) is the main way the community interacts with one another in real time :) 
 
-[Github Discussion](https://github.com/vectorizedio/redpanda/discussions) is preferred for longer, async, thoughtful discussions
+[Github Discussion](https://github.com/redpanda-data/redpanda/discussions) is preferred for longer, async, thoughtful discussions
 
-[GitHub Issues](https://github.com/vectorizedio/redpanda/issues) is reserved only for actual issues. Please use the mailing list for discussions.
+[GitHub Issues](https://github.com/redpanda-data/redpanda/issues) is reserved only for actual issues. Please use the mailing list for discussions.
 
 [Code of conduct](./CODE_OF_CONDUCT.md) code of conduct for the community
 
@@ -38,10 +38,10 @@ We recommend using our free & prebuilt stable releases below.
 
 ### On MacOS
 
-Simply download our `rpk` [binary here](https://github.com/vectorizedio/redpanda/releases). We require Docker on MacOS
+Simply download our `rpk` [binary here](https://github.com/redpanda-data/redpanda/releases). We require Docker on MacOS
 
 ```
-brew install vectorizedio/tap/redpanda && rpk container start
+brew install redpanda-data/tap/redpanda && rpk container start
 ```
 
 ### On Debian/Ubuntu

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,9 +1,9 @@
 # Redpanda
 [![Documentation](https://img.shields.io/badge/documentation-black)](https://vectorized.io/documentation)
 [![Slack](https://img.shields.io/badge/slack-purple)](https://vectorized.io/slack)
-[![Twitter](https://img.shields.io/twitter/follow/vectorizedio.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=vectorizedio)
-![Go](https://github.com/vectorizedio/redpanda/workflows/Go/badge.svg)
-![C++](https://github.com/vectorizedio/redpanda/workflows/build-test/badge.svg)
+[![Twitter](https://img.shields.io/twitter/follow/redpandadata.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=redpandadata)
+![Go](https://github.com/redpanda-data/redpanda/workflows/Go/badge.svg)
+![C++](https://github.com/redpanda-data/redpanda/workflows/build-test/badge.svg)
 
 [<p align="center"><img src="docs/PANDA_sitting.jpg" alt="redpanda sitting" width="400"/></p>](https://vectorized.io/redpanda)
 <img src="https://static.scarf.sh/a.png?x-pxid=3c187215-e862-4b67-8057-45aa9a779055" />
@@ -19,9 +19,9 @@ Redpanda 是一个用于关键任务型工作负载的流计算平台。兼容 K
 
 [Slack](https://vectorized.io/slack) 是社区实时互动的主要方式 :)
 
-[Github 讨论](https://github.com/vectorizedio/redpanda/discussions) 是更长时间、异步、深思熟虑的讨论的首选
+[Github 讨论](https://github.com/redpanda-data/redpanda/discussions) 是更长时间、异步、深思熟虑的讨论的首选
 
-[GitHub 问题](https://github.com/vectorizedio/redpanda/issues) 仅用于实际 issues。请使用邮件列表进行讨论。
+[GitHub 问题](https://github.com/redpanda-data/redpanda/issues) 仅用于实际 issues。请使用邮件列表进行讨论。
 
 [行为准则](./CODE_OF_CONDUCT.md) 社区行为准则
 
@@ -35,10 +35,10 @@ Redpanda 是一个用于关键任务型工作负载的流计算平台。兼容 K
 
 ### MacOS
 
-下载我们的 `rpk` [二进制文件](https://github.com/vectorizedio/redpanda/releases)。我们需要在 MacOS 上使用 Docker
+下载我们的 `rpk` [二进制文件](https://github.com/redpanda-data/redpanda/releases)。我们需要在 MacOS 上使用 Docker
 
 ```shell
-brew install vectorizedio/tap/redpanda && rpk container start
+brew install redpanda-data/tap/redpanda && rpk container start
 ```
 
 ### Debian/Ubuntu

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,4 +12,4 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-Please send email to security@vectorized.io
+Please send email to security@redpanda.com


### PR DESCRIPTION
## Cover letter

There are more docs that need to be changed as a result of the rename to `redpanda-data`, but this PR is a quick one just to get the top-level markdown files updated with what we have changed over to the new name thus far.

## Release notes
* none