### PR TITLE
kafka/server: quiet high-frequency log message

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -322,7 +322,7 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         total_size += r.data_size_bytes();
     }
     vlog(
-      klog.debug,
+      klog.trace,
       "fetch_ntps_in_parallel: for {} partitions returning {} total bytes",
       results.size(),
       total_size);


### PR DESCRIPTION
As reported by community, this particular message is high-frequency, even for DEBUG level. Quiet it to TRACE.

Fixes #3730 

## Release notes
* none
