### PR TITLE
Retention archival fix

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2252,12 +2252,14 @@ consensus::next_followers_request_seq() {
 
 ss::future<> consensus::refresh_commit_index() {
     return _op_lock.get_units().then([this](ss::semaphore_units<> u) mutable {
-        if (!is_leader()) {
-            return ss::now();
-        }
         auto f = ss::now();
+
         if (_has_pending_flushes) {
             f = flush_log();
+        }
+
+        if (!is_leader()) {
+            return f;
         }
         return f.then([this, u = std::move(u)]() mutable {
             return do_maybe_update_leader_commit_idx(std::move(u));

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -138,16 +138,7 @@ public:
     ss::future<result<model::offset>> linearizable_barrier();
 
     vnode self() const { return _self; }
-    protocol_metadata meta() const {
-        auto lstats = _log.offsets();
-        return protocol_metadata{
-          .group = _group,
-          .commit_index = _commit_index,
-          .term = _term,
-          .prev_log_index = lstats.dirty_offset,
-          .prev_log_term = lstats.dirty_offset_term,
-          .last_visible_index = last_visible_index()};
-    }
+    protocol_metadata meta() const;
     raft::group_id group() const { return _group; }
     model::term_id term() const { return _term; }
     group_configuration config() const;

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -28,6 +28,8 @@ class RetentionPolicyTest(RedpandaTest):
         extra_rp_conf = dict(
             log_compaction_interval_ms=5000,
             log_segment_size=1048576,
+            enable_transactions=True,
+            enable_idempotence=True,
         )
 
         super(RetentionPolicyTest, self).__init__(test_context=test_context,


### PR DESCRIPTION
## Cover letter

Redpanda raft implementation never explicitly flush underlying log when
replicating with relaxed consistency. Record batches visibility is
controlled by high watermark offset which is updated even if log isn't
flushed on majority of nodes. Raft committed index semantics is more
strict. Committed index may only be updated if majority of nodes flushed
given offset to the disk.

State machines which underlies transactions and cloud storage require
snapshots to be persisted before allowing log segments to be evicted and
removed by cleanup policy. Snapshots are only taken when all batches up
to the snapshot offsets were applied to the state machine. State machine
batches are applied up to raft committed offset. When committed index is
not updated no state is applied to state machine.

When any of the persisted state machine snapshot creation is pending it
prevents log segments from being evicted.

All together not updating committed index in relaxed consistency mode
and waiting for snapshots to be taken prevents redpanda from cleaning
old data.

The mechanism we introduced previously to prevent described behavior is
based on the eviction_stm notifying raft about a need of commit index
advancement via `refresh_commit_index` method.

Problem that the implementation of that method had was the fact that it
was forcing log to flush only on the leader node, not the followers.
This is not enough since commit index is update when majority of nodes
reached the same flushed offset. Changed the implementation to flush
log on the followers allowing leader to update committed offset of raft
group.


## Release notes

### Improvements

* Fixed cleanup policy application when using cloud storage or transactions 

