### PR TITLE
Mark WasmDeleteTopicsTest.verify_materialized_topics_test as ignored

### DIFF
--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.mark import ignore
 from rptest.services.cluster import cluster
 from rptest.tests.wasm_identity_test import WasmIdentityTest
 from rptest.wasm.wasm_script import WasmScript
@@ -65,6 +66,7 @@ class WasmDeleteTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/3745
     @cluster(num_nodes=3)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()


### PR DESCRIPTION
More information here #3745 

I suspect the bug may have to do with core design choices with wasm, mainly the decision that output topics are dynamically created by coprocessors. More investigation is needed to confirm how the suspected issue is causing the observed behavior so marking this test as @ignore for now and placing its fix within other ongoing work to fix all ducktape tests for wasm.