### PR TITLE
tests/create_partitions_test: disable leader balancer

### DIFF
--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -16,6 +16,12 @@ from rptest.clients.types import TopicSpec
 
 
 class CreatePartitionsTest(RedpandaTest):
+    def __init__(self, test_context):
+        super().__init__(test_context=test_context,
+                         extra_rp_conf={
+                             "enable_leader_balancer": False,
+                         })
+
     def _partition_count(self, topic):
         meta = self.client().describe_topic(topic)
         return len(meta.partitions)
@@ -58,5 +64,3 @@ class CreatePartitionsTest(RedpandaTest):
                               replication_factor=random.choice((1, 3)))
             self._create_add_verify(topic, new_partition_count)
             self.client().delete_topic(topic.name)
-
-            # todo delete the topic to avoid running out of file handles


### PR DESCRIPTION
## Cover letter

If the leader balancer transfers leadership while
a partition is being deleted, it generates log errors
that cause a test failure, like:

recovery_stm.cc:432 - recovery append entries error: raft group does not exist on target broker

Rather than ignore all such errors, disable the
leader balancer to have the test run in a more
predictable way.

## Release notes


* none
