### PR TITLE
Backport of #3743, #3732

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -358,7 +358,7 @@ ss::future<> group_manager::recover_partition(
             auto group = get_group(group_id);
             if (!group) {
                 group = ss::make_lw_shared<kafka::group>(
-                  group_id, group_state::empty, _conf, p->partition);
+                  group_id, group_stm.get_metadata(), _conf, p->partition);
                 group->reset_tx_state(term);
                 _groups.emplace(group_id, group);
                 group->reschedule_all_member_heartbeats();

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -151,6 +151,8 @@ public:
         return _fence_pid_epoch;
     }
 
+    group_log_group_metadata& get_metadata() { return _metadata; }
+
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
     absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2192,12 +2192,33 @@ model::term_id consensus::get_term(model::offset o) {
     if (unlikely(o < model::offset(0))) {
         return model::term_id{};
     }
+    auto lstat = _log.offsets();
+
+    // if log is empty, return term from snapshot
+    if (o == lstat.dirty_offset && lstat.start_offset > lstat.dirty_offset) {
+        return _last_snapshot_term;
+    }
+
     return _log.get_term(o).value_or(model::term_id{});
 }
 
 clock_type::time_point
 consensus::last_sent_append_entries_req_timesptamp(vnode id) {
     return _fstats.get(id).last_sent_append_entries_req_timesptamp;
+}
+
+protocol_metadata consensus::meta() const {
+    auto lstats = _log.offsets();
+    const auto prev_log_term = lstats.dirty_offset >= lstats.start_offset
+                                 ? lstats.dirty_offset_term
+                                 : _last_snapshot_term;
+    return protocol_metadata{
+      .group = _group,
+      .commit_index = _commit_index,
+      .term = _term,
+      .prev_log_index = lstats.dirty_offset,
+      .prev_log_term = prev_log_term,
+      .last_visible_index = last_visible_index()};
 }
 
 void consensus::update_node_append_timestamp(vnode id) {
@@ -2360,9 +2381,7 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
      */
     majority_match = std::min(majority_match, _flushed_offset);
 
-    if (
-      majority_match > _commit_index
-      && _log.get_term(majority_match) == _term) {
+    if (majority_match > _commit_index && get_term(majority_match) == _term) {
         vlog(_ctxlog.trace, "Leader commit index updated {}", majority_match);
         auto old_commit_idx = _commit_index;
         _commit_index = majority_match;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -138,16 +138,7 @@ public:
     ss::future<result<model::offset>> linearizable_barrier();
 
     vnode self() const { return _self; }
-    protocol_metadata meta() const {
-        auto lstats = _log.offsets();
-        return protocol_metadata{
-          .group = _group,
-          .commit_index = _commit_index,
-          .term = _term,
-          .prev_log_index = lstats.dirty_offset,
-          .prev_log_term = lstats.dirty_offset_term,
-          .last_visible_index = last_visible_index()};
-    }
+    protocol_metadata meta() const;
     raft::group_id group() const { return _group; }
     model::term_id term() const { return _term; }
     group_configuration config() const;

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -28,6 +28,8 @@ class RetentionPolicyTest(RedpandaTest):
         extra_rp_conf = dict(
             log_compaction_interval_ms=5000,
             log_segment_size=1048576,
+            enable_transactions=True,
+            enable_idempotence=True,
         )
 
         super(RetentionPolicyTest, self).__init__(test_context=test_context,


### PR DESCRIPTION
- https://github.com/redpanda-data/redpanda/pull/3732

Using persisted state to recover log state

- https://github.com/redpanda-data/redpanda/pull/3743

Redpanda raft implementation never explicitly flush underlying log when
replicating with relaxed consistency. Record batches visibility is
controlled by high watermark offset which is updated even if log isn't
flushed on majority of nodes. Raft committed index semantics is more
strict. Committed index may only be updated if majority of nodes flushed
given offset to the disk.

State machines which underlies transactions and cloud storage require
snapshots to be persisted before allowing log segments to be evicted and
removed by cleanup policy. Snapshots are only taken when all batches up
to the snapshot offsets were applied to the state machine. State machine
batches are applied up to raft committed offset. When committed index is
not updated no state is applied to state machine.

When any of the persisted state machine snapshot creation is pending it
prevents log segments from being evicted.

All together not updating committed index in relaxed consistency mode
and waiting for snapshots to be taken prevents redpanda from cleaning
old data.

The mechanism we introduced previously to prevent described behavior is
based on the eviction_stm notifying raft about a need of commit index
advancement via `refresh_commit_index` method.

Problem that the implementation of that method had was the fact that it
was forcing log to flush only on the leader node, not the followers.
This is not enough since commit index is update when majority of nodes
reached the same flushed offset. Changed the implementation to flush
log on the followers allowing leader to update committed offset of raft
group.


## Release notes

### Improvements

* Fixed cleanup policy application when using cloud storage or transactions 
* Not forcing consumers to rejoin group when transferring group partition leadership

