### PR TITLE
config: enable central config by default

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -40,8 +40,6 @@ redpanda:
     address: "0.0.0.0"
     port: 9644
 
-  auto_create_topics_enabled: true
-
   # Skips most of the checks performed at startup (i.e. memory, xfs)
   # not recomended for production use
   developer_mode: true

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -62,5 +62,8 @@ private:
 
     // Serialize writes to generate version numbers.
     mutex _write_lock;
+
+    // Set once at construction to enable unit testing
+    model::node_id _self;
 };
 } // namespace cluster

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -112,19 +112,9 @@ void config_manager::start_bootstrap() {
                               co_await _feature_table.local().await_feature(
                                 feature::central_config, _as.local());
                           }
-                          if (config::node().enable_central_config()) {
-                              co_await do_bootstrap();
-                              vlog(
-                                clusterlog.info,
-                                "Completed bootstrap as leader");
-                          } else {
-                              // This is a node property, so fixed for
-                              // process lifetime.  Block until the abort
-                              // source is signalled.
-                              vlog(clusterlog.trace, "Central config disabled");
-                              co_await ss::sleep_abortable(
-                                bootstrap_retry, _as.local());
-                          }
+                          co_await do_bootstrap();
+                          vlog(
+                            clusterlog.info, "Completed bootstrap as leader");
                       } else {
                           // Someone else got leadership.  Maybe they
                           // successfully bootstrap config, maybe they don't.

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -18,6 +18,10 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 
+namespace YAML {
+class Node;
+}
+
 namespace cluster {
 
 /// This state machine receives updates to the global cluster config,
@@ -48,7 +52,7 @@ public:
       ss::sharded<feature_table>&,
       ss::sharded<ss::abort_source>&);
 
-    static ss::future<preload_result> preload();
+    static ss::future<preload_result> preload(YAML::Node const&);
     ss::future<> start();
     ss::future<> stop();
 
@@ -83,8 +87,13 @@ private:
     void start_bootstrap();
     ss::future<> do_bootstrap();
 
+    static ss::future<preload_result> load_cache();
+    static ss::future<bool> load_bootstrap();
+    static ss::future<> load_legacy(YAML::Node const&);
+
     ss::future<std::error_code> apply_status(cluster_config_status_cmd&& cmd);
 
+    static std::filesystem::path bootstrap_path();
     static std::filesystem::path cache_path();
 
     config_status my_latest_status;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -46,22 +46,15 @@ uint32_t default_raft_non_local_requests() {
 }
 
 configuration::configuration()
-  : developer_mode(
+  : log_segment_size(
     *this,
-    "developer_mode",
-    "Skips most of the checks performed at startup, not recomended for "
-    "production use",
-    {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-    false)
-  , log_segment_size(
-      *this,
-      "log_segment_size",
-      "How large in bytes should each log segment be (default 1G)",
-      {.needs_restart = needs_restart::no,
-       .example = "2147483648",
-       .visibility = visibility::tunable},
-      1_GiB,
-      {.min = 1_MiB})
+    "log_segment_size",
+    "How large in bytes should each log segment be (default 1G)",
+    {.needs_restart = needs_restart::no,
+     .example = "2147483648",
+     .visibility = visibility::tunable},
+    1_GiB,
+    {.min = 1_MiB})
   , compacted_log_segment_size(
       *this,
       "compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -41,7 +41,6 @@ namespace config {
 
 struct configuration final : public config_store {
     // WAL
-    property<bool> developer_mode;
     bounded_property<uint64_t> log_segment_size;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -14,11 +14,18 @@
 namespace config {
 
 node_config::node_config() noexcept
-  : data_directory(
+  : developer_mode(
     *this,
-    "data_directory",
-    "Place where redpanda will keep the data",
-    {.required = required::yes, .visibility = visibility::user})
+    "developer_mode",
+    "Skips most of the checks performed at startup, not recomended for "
+    "production use",
+    {.visibility = visibility::tunable},
+    false)
+  , data_directory(
+      *this,
+      "data_directory",
+      "Place where redpanda will keep the data",
+      {.required = required::yes, .visibility = visibility::user})
   , node_id(
       *this,
       "node_id",

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -102,12 +102,7 @@ node_config::node_config() noexcept
       "`cloud_storage_enabled` is present",
       {.visibility = visibility::user},
       std::nullopt)
-  , enable_central_config(
-      *this,
-      "enable_central_config",
-      "Enable central storage + sync of cluster configuration",
-      {.visibility = visibility::user},
-      false)
+  , enable_central_config(*this, "enable_central_config")
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -47,8 +47,7 @@ public:
     // Shadow indexing/S3 cache location
     property<std::optional<ss::sstring>> cloud_storage_cache_directory;
 
-    // Feature flag for central config
-    property<bool> enable_central_config;
+    deprecated_property enable_central_config;
 
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -72,10 +72,20 @@ public:
 
     node_config() noexcept;
     error_map_t load(const YAML::Node& root_node);
+    error_map_t load(
+      std::filesystem::path const& loaded_from, const YAML::Node& root_node) {
+        _cfg_file_path = loaded_from;
+        return load(root_node);
+    }
+
+    std::filesystem::path const& get_cfg_file_path() const {
+        return _cfg_file_path;
+    }
 
 private:
     property<std::optional<net::unresolved_address>> _advertised_rpc_api;
     one_or_many_property<model::broker_endpoint> _advertised_kafka_api;
+    std::filesystem::path _cfg_file_path;
 };
 
 node_config& node();

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -20,6 +20,7 @@ namespace config {
 
 struct node_config final : public config_store {
 public:
+    property<bool> developer_mode;
     property<data_directory_path> data_directory;
     property<model::node_id> node_id;
     property<std::optional<ss::sstring>> rack;

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -318,9 +318,8 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
     responses.reserve(resources.size());
 
     // If central config is disabled, we cannot set broker properties
-    if (!(config::node().enable_central_config()
-          && ctx.feature_table().local().is_active(
-            cluster::feature::central_config))) {
+    if (!ctx.feature_table().local().is_active(
+          cluster::feature::central_config)) {
         co_return co_await unsupported_broker_configuration<
           req_resource_t,
           resp_resource_t>(

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -851,12 +851,10 @@ void admin_server::register_cluster_config_routes() {
         std::unique_ptr<ss::httpd::request> req,
         request_auth_result const& auth_state)
         -> ss::future<ss::json::json_return_type> {
-          if (
-            !config::node().enable_central_config()
-            || !_controller->get_feature_table().local().is_active(
-              cluster::feature::central_config)) {
+          if (!_controller->get_feature_table().local().is_active(
+                cluster::feature::central_config)) {
               throw ss::httpd::bad_request_exception(
-                "Requires enable_central_config=True in node configuration");
+                "Central config feature not active (upgrade in progress?)");
           }
 
           auto doc = parse_json_body(*req);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -324,8 +324,8 @@ void application::hydrate_config(const po::variables_map& cfg) {
     };
     _redpanda_enabled = config["redpanda"];
     if (_redpanda_enabled) {
-        ss::smp::invoke_on_all([&config] {
-            config::node().load(config);
+        ss::smp::invoke_on_all([&config, cfg_path] {
+            config::node().load(cfg_path, config);
         }).get0();
 
         auto node_config_errors = config::node().load(config);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -383,7 +383,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
 void application::check_environment() {
     syschecks::systemd_message("checking environment (CPU, Mem)").get();
     syschecks::cpu();
-    syschecks::memory(config::shard_local_cfg().developer_mode());
+    syschecks::memory(config::node().developer_mode());
     if (_redpanda_enabled) {
         storage::directories::initialize(
           config::node().data_directory().as_sstring())

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -314,12 +314,7 @@ ss::app_template::config application::setup_app_config() {
 
 void application::hydrate_config(const po::variables_map& cfg) {
     std::filesystem::path cfg_path(cfg["redpanda-cfg"].as<std::string>());
-    auto buf = read_fully(cfg_path).get0();
-    // see https://github.com/jbeder/yaml-cpp/issues/765
-    auto workaround = ss::uninitialized_string(buf.size_bytes());
-    auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
-    in.consume_to(buf.size_bytes(), workaround.begin());
-    const YAML::Node config = YAML::Load(workaround);
+    const YAML::Node config = YAML::Load(read_fully_to_string(cfg_path).get0());
     auto config_printer = [this](std::string_view service) {
         return [this, service](const config::base_property& item) {
             std::stringstream val;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -371,11 +371,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
         }
 
         vlog(_log.info, "Cluster configuration properties:");
-        if (config::node().enable_central_config) {
-            vlog(_log.info, "(use `rpk cluster config edit` to change)");
-        } else {
-            vlog(_log.info, "(use `rpk config set <cfg> <value>` to change)");
-        }
+        vlog(_log.info, "(use `rpk cluster config edit` to change)");
         config::shard_local_cfg().for_each(config_printer("redpanda"));
 
         vlog(_log.info, "Node configuration properties:");

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "config/node_config.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
@@ -110,8 +111,8 @@ private:
     void hydrate_config(const po::variables_map&);
 
     bool coproc_enabled() {
-        const auto& cfg = config::shard_local_cfg();
-        return cfg.developer_mode() && cfg.enable_coproc();
+        return config::node().developer_mode()
+               && config::shard_local_cfg().enable_coproc();
     }
 
     bool archival_storage_enabled();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -162,7 +162,6 @@ public:
             auto& config = config::shard_local_cfg();
 
             config.get("enable_pid_file").set_value(false);
-            config.get("developer_mode").set_value(true);
             config.get("join_retry_timeout_ms").set_value(100ms);
             config.get("members_backend_retry_ms").set_value(1000ms);
             config.get("disable_metrics").set_value(true);
@@ -170,6 +169,7 @@ public:
             auto& node_config = config::node();
             node_config.get("admin").set_value(
               std::vector<model::broker_endpoint>());
+            node_config.get("developer_mode").set_value(true);
             node_config.get("node_id").set_value(node_id);
             node_config.get("rack").set_value(
               std::optional<ss::sstring>(rack_name));

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -37,6 +37,19 @@ ss::future<iobuf> read_fully(const std::filesystem::path& name) {
     });
 }
 
+/**
+ * This helper is useful for YAML loading, because yaml-cpp expects
+ * a string.
+ *
+ * Background on why: https://github.com/jbeder/yaml-cpp/issues/765
+ */
+ss::future<ss::sstring>
+read_fully_to_string(const std::filesystem::path& name) {
+    return read_fully_tmpbuf(name).then([](ss::temporary_buffer<char> buf) {
+        return ss::to_sstring(std::move(buf));
+    });
+}
+
 ss::future<> write_fully(const std::filesystem::path& p, iobuf buf) {
     static constexpr const size_t buf_size = 4096;
     auto flags = ss::open_flags::wo | ss::open_flags::create

--- a/src/v/utils/file_io.h
+++ b/src/v/utils/file_io.h
@@ -26,5 +26,8 @@ read_fully_tmpbuf(const std::filesystem::path&);
 /// \brief Read an entire file into an iobuf
 ss::future<iobuf> read_fully(const std::filesystem::path&);
 
+/// \brief Read an entire file into a ss:sstring
+ss::future<ss::sstring> read_fully_to_string(const std::filesystem::path&);
+
 /// \brief Write an entire buffer into the file at location 'path'
 ss::future<> write_fully(const std::filesystem::path&, iobuf buf);

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -8,14 +8,12 @@
 # by the Apache License, Version 2.0
 
 organization: "vectorized"
-cluster_id: "{{cluster}}"
 
 {% if enable_rp %}
 redpanda:
   developer_mode: true
   data_directory: "{{data_dir}}"
   node_id: {{node_id}}
-  join_retry_timeout_ms: 200
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145
@@ -35,16 +33,6 @@ redpanda:
       address: "{{node_ip}}"
       port: {{admin_alternate_port}}
 
-  # for librdkafka
-  auto_create_topics_enabled: true
-  default_topic_partitions: 4
-  # disable metrics reporter
-  enable_metrics_reporter: false
-
-  superusers:
-    - {{superuser[0]}}
-
-  enable_auto_rebalance_on_node_add: true
 
 {% if node_id > 1 %}
   seed_servers:

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -17,14 +17,12 @@ class AccessControlListTest(RedpandaTest):
     algorithm = "SCRAM-SHA-256"
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(
-            developer_mode=True,
-            enable_sasl=True,
-        )
+        extra_rp_conf = dict(enable_sasl=True, )
         super(AccessControlListTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf)
+                             extra_rp_conf=extra_rp_conf,
+                             extra_node_conf={'developer_mode': True})
 
     def get_client(self, user):
         return KafkaCliTools(self.redpanda, user=user, passwd=self.password)

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -73,9 +73,7 @@ class AdminApiAuthTest(RedpandaTest):
     enabled.
     """
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,
-                         extra_rp_conf={'enable_central_config': True},
-                         **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.rpk = RpkTool(self.redpanda)
 
@@ -153,9 +151,7 @@ class AdminApiAuthEnablementTest(RedpandaTest):
     Test redpanda's rules for when admin API auth may be switched on
     """
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,
-                         extra_rp_conf={'enable_central_config': True},
-                         **kwargs)
+        super().__init__(*args, **kwargs)
 
     @cluster(num_nodes=3)
     def test_no_superusers(self):

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -109,6 +109,8 @@ class ClusterConfigTest(RedpandaTest):
         set_again = {'enable_idempotence': False}
         assert BOOTSTRAP_CONFIG['enable_idempotence'] != set_again[
             'enable_idempotence']
+        self.redpanda.set_extra_rp_conf(set_again)
+        self.redpanda.write_bootstrap_cluster_config()
 
         self.redpanda.restart_nodes(self.redpanda.nodes, set_again)
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -34,15 +34,12 @@ class ClusterConfigTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         rp_conf = BOOTSTRAP_CONFIG.copy()
 
-        # Enable our feature flag
-        rp_conf['enable_central_config'] = True
+        # Force verbose logging for the secret redaction test
+        kwargs['log_level'] = 'trace'
 
-        super(ClusterConfigTest, self).__init__(
-            *args,
-            extra_rp_conf=rp_conf,
-            # Force verbose logging for the secret redaction test
-            log_level='trace',
-            **kwargs)
+        super(ClusterConfigTest, self).__init__(*args,
+                                                extra_rp_conf=rp_conf,
+                                                **kwargs)
 
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -390,6 +390,9 @@ class ClusterConfigTest(RedpandaTest):
         # using the cluster
         exclude_settings = {'enable_sasl'}
 
+        # Don't enable coproc: it generates log errors if its companion service isn't running
+        exclude_settings.add('enable_coproc')
+
         initial_config = self.admin.get_cluster_config()
 
         for name, p in schema_properties.items():

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -147,8 +147,9 @@ class FeaturesSingleNodeTest(FeaturesTestBase):
         initial_version = self.admin.get_features()['cluster_version']
 
         new_version = initial_version + 1
-        self.logger.info("Simulating upgrade from version {} to version {}",
-                         initial_version, new_version)
+        self.logger.info(
+            f"Simulating upgrade from version {initial_version} to version {new_version}"
+        )
 
         # Modified environment variables apply to processes restarted from this point onwards
         self.redpanda.set_environment(

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -69,7 +69,9 @@ class CompactionRecoveryTest(RedpandaTest):
                              compaction_ctrl_max_shares=1000)
 
         for p in partitions:
-            self.redpanda.start_node(p.node, extra_rp_conf)
+            self.redpanda.start_node(p.node)
+
+        self.redpanda.set_cluster_config(extra_rp_conf, True)
 
         wait_until(lambda: all(map(lambda p: p.recovered(), partitions)),
                    timeout_sec=90,

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -50,12 +50,15 @@ class EndToEndTest(Test):
       - Perform some action (e.g. partition movement)
       - Run validation
     """
-    def __init__(self, test_context, extra_rp_conf=None):
+    def __init__(self, test_context, extra_rp_conf=None, extra_node_conf=None):
         super(EndToEndTest, self).__init__(test_context=test_context)
         if extra_rp_conf is None:
             self._extra_rp_conf = {}
         else:
             self._extra_rp_conf = extra_rp_conf
+
+        self._extra_node_conf = extra_node_conf
+
         self.records_consumed = []
         self.last_consumed_offsets = {}
         self.redpanda = None
@@ -68,9 +71,11 @@ class EndToEndTest(Test):
             # paramter takes the precedence
             self._extra_rp_conf = {**self._extra_rp_conf, **extra_rp_conf}
         assert self.redpanda is None
+
         self.redpanda = RedpandaService(self.test_context,
                                         num_nodes,
-                                        extra_rp_conf=self._extra_rp_conf)
+                                        extra_rp_conf=self._extra_rp_conf,
+                                        extra_node_conf=self._extra_node_conf)
         self.redpanda.start()
         self._client = DefaultClient(self.redpanda)
 

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -99,10 +99,10 @@ schema_registry: {}
         key = 'redpanda.admin.port'
         value = '9641'  # The default is 9644, so we will change it
 
-        rpk.config_set(key, value, path=RedpandaService.CONFIG_FILE)
+        rpk.config_set(key, value, path=RedpandaService.NODE_CONFIG_FILE)
 
         with tempfile.TemporaryDirectory() as d:
-            node.account.copy_from(RedpandaService.CONFIG_FILE, d)
+            node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
 
             with open(os.path.join(d, config_file)) as f:
                 actual_config = yaml.full_load(f.read())
@@ -132,7 +132,7 @@ schema_registry: {}
         rpk.config_set(key, value, format='yaml')
 
         with tempfile.TemporaryDirectory() as d:
-            node.account.copy_from(RedpandaService.CONFIG_FILE, d)
+            node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
 
             with open(os.path.join(d, 'redpanda.yaml')) as f:
                 expected_config = yaml.full_load(value)
@@ -167,7 +167,7 @@ tune_swappiness: false
 ''')
 
         with tempfile.TemporaryDirectory() as d:
-            node.account.copy_from(RedpandaService.CONFIG_FILE, d)
+            node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
 
             with open(os.path.join(d, 'redpanda.yaml')) as f:
                 actual_config = yaml.full_load(f.read())

--- a/tests/rptest/tests/scram_pythonlib_test.py
+++ b/tests/rptest/tests/scram_pythonlib_test.py
@@ -17,13 +17,12 @@ from kafka.admin import NewTopic
 
 class ScramPythonLibTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(
-            developer_mode=True,
-            enable_sasl=True,
-        )
-        super(ScramPythonLibTest, self).__init__(test_context,
-                                                 num_brokers=3,
-                                                 extra_rp_conf=extra_rp_conf)
+        extra_rp_conf = dict(enable_sasl=True, )
+        super(ScramPythonLibTest,
+              self).__init__(test_context,
+                             num_brokers=3,
+                             extra_rp_conf=extra_rp_conf,
+                             extra_node_conf={'developer_mode': True})
 
     def make_superuser_client(self, password_override=None):
         username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -23,13 +23,12 @@ from rptest.services.admin import Admin
 
 class ScramTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(
-            developer_mode=True,
-            enable_sasl=True,
-        )
-        super(ScramTest, self).__init__(test_context,
-                                        num_brokers=3,
-                                        extra_rp_conf=extra_rp_conf)
+        extra_rp_conf = dict(enable_sasl=True, )
+        super(ScramTest,
+              self).__init__(test_context,
+                             num_brokers=3,
+                             extra_rp_conf=extra_rp_conf,
+                             extra_node_conf={'developer_mode': True})
 
     def update_user(self, username):
         def gen(length):

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -265,10 +265,7 @@ class ScramTest(RedpandaTest):
 
 class ScramLiveUpdateTest(RedpandaTest):
     def __init__(self, test_context):
-        super(ScramLiveUpdateTest,
-              self).__init__(test_context,
-                             num_brokers=1,
-                             extra_rp_conf={'enable_central_config': True})
+        super(ScramLiveUpdateTest, self).__init__(test_context, num_brokers=1)
 
     @cluster(num_nodes=1)
     def test_enable_sasl_live(self):

--- a/tests/rptest/tests/topic_autocreate_test.py
+++ b/tests/rptest/tests/topic_autocreate_test.py
@@ -44,8 +44,7 @@ class TopicAutocreateTest(RedpandaTest):
             assert False, "Producing to a nonexistent topic should fail"
 
         # Enable autocreation
-        self.redpanda.restart_nodes(self.redpanda.nodes,
-                                    {'auto_create_topics_enabled': True})
+        self.redpanda.set_cluster_config({'auto_create_topics_enabled': True})
 
         # Auto create topic
         assert auto_topic not in self.kafka_tools.list_topics()

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -41,9 +41,9 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                 # partition movement and the balancer would interfere
                 'enable_leader_balancer': False,
                 'enable_coproc': True,
-                'developer_mode': True,
                 'auto_create_topics_enabled': False
             },
+            extra_node_conf={'developer_mode': True},
             **kvargs)
         self._ctx = ctx
         self._rpk_tool = None

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -37,14 +37,16 @@ class WasmTest(RedpandaTest):
 
     def __init__(self, test_context, extra_rp_conf=dict(), record_size=1024):
         def enable_wasm_options():
-            return dict(developer_mode=True,
-                        enable_coproc=True,
+            return dict(enable_coproc=True,
                         enable_idempotence=True,
                         auto_create_topics_enabled=False)
 
         wasm_opts = enable_wasm_options()
         wasm_opts.update(extra_rp_conf)
-        super(WasmTest, self).__init__(test_context, extra_rp_conf=wasm_opts)
+        super(WasmTest,
+              self).__init__(test_context,
+                             extra_rp_conf=wasm_opts,
+                             extra_node_conf={'developer_mode': True})
         self._rpk_tool = RpkTool(self.redpanda)
         self._test_context = test_context
         self._build_tool = WasmBuildTool(self._rpk_tool)


### PR DESCRIPTION
## Cover letter

This PR follows on from https://github.com/redpanda-data/redpanda/pull/2938

Now that the feature manager mechanism exists to safely enable a new feature that writes new-format messages to the controller log, we can switch on central config by default.

Additional changes to enable this:
- deprecate the configuration property (`enable_central_config`) that existed for switching it on/off.  In the field, having an option to disable central config could produce a chaotic mix of systems which appear to be new enough for central config, but aren't actually using it, and tools would have a hard time knowing whether updates to config via the config file or API were authoritative.
- implement the planned 'bootstrap.yaml' mechanism for cleanly injecting central config properties on first startup.
- changes to ducktape to use the new-style config mechanisms throughout.  This is not very invasive, because most tests only set config one time at startup anyway.  The RedpandaService class now uses the `extra_rp_conf` setting for cluster settings, and any per-node customization happens via arguments to start/restart_node (as was already mostly the case).

## Release notes
### Features
* Redpanda now has an internal store for configuration properties, and many properties can be set without restarting redpanda.  When you upgrade Redpanda, your existing configuration will be imported automatically.  Please consult the documentation for more detail on this feature.
* New `rpk` subcommands for handling cluster configuration: `rpk cluster config [edit|import|export|set|get|status|force-reset|lint]
