### PR TITLE
kafka: expire pending group members

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -221,9 +221,7 @@ public:
     }
 
     /// Add a member to the group in a pending state.
-    void add_pending_member(const kafka::member_id& member_id) {
-        _pending_members.emplace(member_id);
-    }
+    void add_pending_member(const kafka::member_id&, duration_type);
 
     /// Check if the group contains a pending member.
     bool contains_pending_member(const kafka::member_id& member) const {
@@ -237,7 +235,7 @@ public:
         }
     }
 
-    void remove_pending_member(const kafka::member_id& member_id);
+    void remove_pending_member(kafka::member_id member_id);
 
     /// Check if a member id refers to the group leader.
     bool is_leader(const kafka::member_id& member_id) const {
@@ -599,7 +597,8 @@ private:
     protocol_support _supported_protocols;
     member_map _members;
     int _num_members_joining;
-    absl::node_hash_set<kafka::member_id> _pending_members;
+    absl::node_hash_map<kafka::member_id, ss::timer<clock_type>>
+      _pending_members;
     std::optional<kafka::protocol_type> _protocol_type;
     std::optional<kafka::protocol_name> _protocol;
     std::optional<kafka::member_id> _leader;

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -134,9 +134,18 @@ SEASTAR_THREAD_TEST_CASE(has_members) {
 SEASTAR_THREAD_TEST_CASE(pending_members) {
     auto g = get();
     BOOST_TEST(!g.contains_pending_member(kafka::member_id("m")));
-    g.add_pending_member(kafka::member_id("m"));
+    g.add_pending_member(kafka::member_id("m"), 5s);
     BOOST_TEST(g.contains_pending_member(kafka::member_id("m")));
     g.remove_pending_member(kafka::member_id("m"));
+    BOOST_TEST(!g.contains_pending_member(kafka::member_id("m")));
+}
+
+SEASTAR_THREAD_TEST_CASE(pending_members_expire) {
+    auto g = get();
+    BOOST_TEST(!g.contains_pending_member(kafka::member_id("m")));
+    g.add_pending_member(kafka::member_id("m"), 1s);
+    BOOST_TEST(g.contains_pending_member(kafka::member_id("m")));
+    ss::sleep(2s).get();
     BOOST_TEST(!g.contains_pending_member(kafka::member_id("m")));
 }
 
@@ -254,7 +263,7 @@ SEASTAR_THREAD_TEST_CASE(all_members_joined) {
     auto m = get_group_member();
     (void)g.add_member(m);
     BOOST_TEST(g.all_members_joined());
-    g.add_pending_member(kafka::member_id("x"));
+    g.add_pending_member(kafka::member_id("x"), 5s);
     BOOST_TEST(!g.all_members_joined());
 }
 


### PR DESCRIPTION
## Cover letter

Prior to this change a pending member that never rejoins might leave a
pending member indefinitely. Now we kick em out.

When pending members stick around it may cause issues when trying to
determine of all members have joined. The function all members joined
will return false if any pending member exists, which would occur if a
pending member were left lingering in the group and this in turn may
prevent the group from properly transitioning through the state machine.
For example, the inline join completion that occurs in handle_join_group
as well as in the complete_join callback all have scenarios gated on
this condition which would prevent the group from moving into the sync
phase.

## Release notes

* Fixes a potential bug in consumer groups in which a pending member is stuck in a group because redpanda did not set an expiration time for pending members.
