### PR TITLE
storage: make segment/compaction properties live-adjustable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -57,7 +57,9 @@ configuration::configuration()
       *this,
       "log_segment_size",
       "How large in bytes should each log segment be (default 1G)",
-      {.example = "2147483648", .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .example = "2147483648",
+       .visibility = visibility::tunable},
       1_GiB,
       {.min = 1_MiB})
   , compacted_log_segment_size(
@@ -65,7 +67,9 @@ configuration::configuration()
       "compacted_log_segment_size",
       "How large in bytes should each compacted log segment be (default "
       "256MiB)",
-      {.example = "268435456", .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .example = "268435456",
+       .visibility = visibility::tunable},
       256_MiB,
       {.min = 1_MiB})
   , readers_cache_eviction_timeout_ms(
@@ -382,19 +386,19 @@ configuration::configuration()
       *this,
       "delete_retention_ms",
       "delete segments older than this - default 1 week",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10080min)
   , log_compaction_interval_ms(
       *this,
       "log_compaction_interval_ms",
       "How often do we trigger background compaction",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10s)
   , retention_bytes(
       *this,
       "retention_bytes",
       "Default max bytes per partition on disk before triggering a compaction",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
   , group_topic_partitions(
       *this,
@@ -665,7 +669,9 @@ configuration::configuration()
       *this,
       "max_compacted_log_segment_size",
       "Max compacted segment size after consolidation",
-      {.example = "10737418240", .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .example = "10737418240",
+       .visibility = visibility::tunable},
       5_GiB)
   , id_allocator_log_capacity(
       *this,

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -268,6 +268,16 @@ public:
         }
     }
 
+    binding& operator=(const binding& rhs) {
+        _value = rhs._value;
+        _parent = rhs._parent;
+        _on_change = rhs._on_change;
+        if (_parent && this != &rhs) {
+            _parent->_bindings.push_back(*this);
+        }
+        return *this;
+    }
+
     /**
      * This needs to be noexcept for objects with bindings to
      * be usable in seastar futures.  This is not strictly

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -102,11 +102,13 @@ public:
                 directory,
                 storage::debug_sanitize_files::yes);
           },
-          storage::log_config(
-            storage::log_config::storage_type::disk,
-            std::move(directory),
-            1_GiB,
-            storage::debug_sanitize_files::yes))
+          [directory]() {
+              return storage::log_config(
+                storage::log_config::storage_type::disk,
+                std::move(directory),
+                1_GiB,
+                storage::debug_sanitize_files::yes);
+          })
       , _hbeats(
           raft_heartbeat_interval,
           _consensus_client_protocol,

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -41,13 +41,15 @@ struct bootstrap_fixture : raft::simple_record_fixture {
               "test.dir",
               storage::debug_sanitize_files::yes);
         },
-        storage::log_config(
-          storage::log_config::storage_type::disk,
-          "test.dir",
-          1_GiB,
-          storage::debug_sanitize_files::yes,
-          ss::default_priority_class(),
-          storage::with_cache::no)) {
+        []() {
+            return storage::log_config(
+              storage::log_config::storage_type::disk,
+              "test.dir",
+              1_GiB,
+              storage::debug_sanitize_files::yes,
+              ss::default_priority_class(),
+              storage::with_cache::no);
+        }) {
         _storage.start().get();
         // ignore the get_log()
         (void)_storage.log_mgr()

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -43,11 +43,13 @@ struct config_manager_fixture {
               base_dir,
               storage::debug_sanitize_files::yes);
         }),
-        std::move(storage::log_config(
-          storage::log_config::storage_type::disk,
-          base_dir,
-          100_MiB,
-          storage::debug_sanitize_files::yes))))
+        [this]() {
+            return storage::log_config(
+              storage::log_config::storage_type::disk,
+              base_dir,
+              100_MiB,
+              storage::debug_sanitize_files::yes);
+        }))
       , _logger(
           raft::group_id(1),
           model::ntp(model::ns("t"), model::topic("t"), model::partition_id(0)))

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -53,11 +53,13 @@ struct foreign_entry_fixture {
               test_dir,
               storage::debug_sanitize_files::yes);
         },
-        storage::log_config(
-          storage::log_config::storage_type::disk,
-          test_dir,
-          1_GiB,
-          storage::debug_sanitize_files::yes)) {
+        [this]() {
+            return storage::log_config(
+              storage::log_config::storage_type::disk,
+              test_dir,
+              1_GiB,
+              storage::debug_sanitize_files::yes);
+        }) {
         _storage.start().get();
         (void)_storage.log_mgr()
           .manage(storage::ntp_config(_ntp, "test.dir"))

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -45,7 +45,10 @@ struct mux_state_machine_fixture {
           _data_dir,
           storage::debug_sanitize_files::yes);
 
-        _storage.start([kv_conf]() { return kv_conf; }, default_log_cfg())
+        _storage
+          .start(
+            [kv_conf]() { return kv_conf; },
+            [this]() { return default_log_cfg(); })
           .get0();
         _storage.invoke_on_all(&storage::api::start).get0();
         _connections.start().get0();

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -38,7 +38,11 @@ struct base_fixture {
     base_fixture()
       : _test_dir(
         fmt::format("test_{}", random_generators::gen_alphanum_string(6))) {
-        _api.start([this]() { return make_kv_cfg(); }, make_log_cfg()).get();
+        _api
+          .start(
+            [this]() { return make_kv_cfg(); },
+            [this]() { return make_log_cfg(); })
+          .get();
         _api.invoke_on_all(&storage::api::start).get();
     }
 

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -108,11 +108,13 @@ struct raft_node {
                   storage_dir,
                   storage::debug_sanitize_files::yes);
             },
-            storage::log_config(
-              storage_type,
-              storage_dir,
-              segment_size,
-              storage::debug_sanitize_files::yes))
+            [storage_type, storage_dir, segment_size]() {
+                return storage::log_config(
+                  storage_type,
+                  storage_dir,
+                  segment_size,
+                  storage::debug_sanitize_files::yes);
+            })
           .get();
         storage.invoke_on_all(&storage::api::start).get();
 

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -94,11 +94,13 @@ public:
                 directory,
                 storage::debug_sanitize_files::yes);
           },
-          storage::log_config(
-            storage::log_config::storage_type::disk,
-            std::move(directory),
-            1_GiB,
-            storage::debug_sanitize_files::yes))
+          [directory]() {
+              return storage::log_config(
+                storage::log_config::storage_type::disk,
+                std::move(directory),
+                1_GiB,
+                storage::debug_sanitize_files::yes);
+          })
       , _hbeats(
           raft_heartbeat_interval,
           _consensus_client_protocol,

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -20,14 +20,15 @@ namespace storage {
 class api {
 public:
     explicit api(
-      std::function<kvstore_config()> kv_conf_cb, log_config log_conf) noexcept
+      std::function<kvstore_config()> kv_conf_cb,
+      std::function<log_config()> log_conf_cb) noexcept
       : _kv_conf_cb(std::move(kv_conf_cb))
-      , _log_conf(std::move(log_conf)) {}
+      , _log_conf_cb(std::move(log_conf_cb)) {}
 
     ss::future<> start() {
         _kvstore = std::make_unique<kvstore>(_kv_conf_cb());
         return _kvstore->start().then([this] {
-            _log_mgr = std::make_unique<log_manager>(_log_conf, kvs());
+            _log_mgr = std::make_unique<log_manager>(_log_conf_cb(), kvs());
         });
     }
 
@@ -47,7 +48,7 @@ public:
 
 private:
     std::function<kvstore_config()> _kv_conf_cb;
-    log_config _log_conf;
+    std::function<log_config()> _log_conf_cb;
 
     std::unique_ptr<kvstore> _kvstore;
     std::unique_ptr<log_manager> _log_mgr;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -379,7 +379,7 @@ disk_log_impl::find_compaction_range() {
         // found a good range if all the tests pass
         if (
           same_term
-          && total_size < _manager.config().max_compacted_segment_size) {
+          && total_size < _manager.config().max_compacted_segment_size()) {
             break;
         }
 
@@ -745,8 +745,8 @@ size_t disk_log_impl::max_segment_size() const {
         return *config().get_overrides().segment_size;
     }
     // no overrides use defaults
-    return config().is_compacted() ? _manager.config().compacted_segment_size
-                                   : _manager.config().max_segment_size;
+    return config().is_compacted() ? _manager.config().compacted_segment_size()
+                                   : _manager.config().max_segment_size();
 }
 
 size_t disk_log_impl::bytes_left_before_roll() const {

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -68,7 +68,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
             conf.base_dir,
             storage::debug_sanitize_files::yes);
       },
-      conf);
+      [conf]() { return conf; });
     store.start().get();
     auto stop_kvstore = ss::defer([&store] { store.stop().get(); });
     auto& m = store.log_mgr();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -102,7 +102,7 @@ FIXTURE_TEST(append_twice_to_same_segment, storage_test_fixture) {
 
 FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_segment_size = 1_KiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(1_KiB);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -124,7 +124,7 @@ FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
 
 FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_segment_size = 10;
+    cfg.max_segment_size = config::mock_binding<size_t>(10);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -151,7 +151,7 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
 
 FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_segment_size = 10 * 1024;
+    cfg.max_segment_size = config::mock_binding<size_t>(10 * 1024);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -519,7 +519,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
 
 FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_segment_size = 10;
+    cfg.max_segment_size = config::mock_binding<size_t>(10);
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -565,7 +565,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
 FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
     ss::promise<model::offset> last_evicted_offset;
     auto cfg = default_log_config(test_dir);
-    cfg.max_segment_size = 10;
+    cfg.max_segment_size = config::mock_binding<size_t>(10);
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -656,7 +656,7 @@ ss::future<storage::append_result> append_exactly(
 FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     // make sure segments are small
-    cfg.max_segment_size = 1000;
+    cfg.max_segment_size = config::mock_binding<size_t>(1000);
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -1115,7 +1115,7 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
 
     // defaults
-    cfg.max_segment_size = 1_GiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(10_GiB);
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -1140,8 +1140,8 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
 FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     // make sure segments are small
-    cfg.max_segment_size = 10_KiB;
-    cfg.compacted_segment_size = 10_KiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(10_KiB);
+    cfg.compacted_segment_size = config::mock_binding<size_t>(10_KiB);
     cfg.stype = storage::log_config::storage_type::disk;
     // we want force reading most recent compacted batches, disable the cache
     cfg.cache = storage::with_cache::no;
@@ -1198,7 +1198,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
 
     // defaults
-    cfg.max_segment_size = 100_KiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(100_KiB);
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -1344,7 +1344,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
 
 FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_compacted_segment_size = 6_MiB;
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(6_MiB);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
@@ -1487,7 +1487,7 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
-    cfg.max_segment_size = 10_MiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
     storage::ntp_config::default_overrides overrides;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -1547,7 +1547,7 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
 
 FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_compacted_segment_size = 100_MiB;
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
@@ -1625,7 +1625,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
 
 FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.max_compacted_segment_size = 100_MiB;
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
@@ -1692,7 +1692,7 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
-    cfg.max_segment_size = 100_MiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(100_MiB);
     storage::ntp_config::default_overrides overrides;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -1758,7 +1758,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
-    cfg.max_segment_size = 500_MiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(500_MiB);
     cfg.sanitize_fileops = storage::debug_sanitize_files::no;
     storage::ntp_config::default_overrides overrides;
     ss::abort_source as;
@@ -1829,7 +1829,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
 FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     // issue: https://github.com/vectorizedio/redpanda/issues/2214
     auto cfg = default_log_config(test_dir);
-    cfg.max_compacted_segment_size = 100_MiB;
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     storage::ntp_config::default_overrides overrides;
@@ -1941,7 +1941,7 @@ FIXTURE_TEST(reader_prevents_log_shutdown, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
-    cfg.max_segment_size = 10_MiB;
+    cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
     storage::ntp_config::default_overrides overrides;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -31,7 +31,7 @@ disk_log_builder::disk_log_builder(storage::log_config config)
             _log_config.base_dir,
             debug_sanitize_files::yes);
       },
-      _log_config) {}
+      [this]() { return _log_config; }) {}
 
 // Batch generation
 ss::future<> disk_log_builder::add_random_batch(

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -38,11 +38,13 @@ static inline ss::future<> persist_log_file(
                 base_dir,
                 storage::debug_sanitize_files::yes);
           },
-          storage::log_config(
-            storage::log_config::storage_type::disk,
-            base_dir,
-            1_GiB,
-            storage::debug_sanitize_files::yes));
+          [base_dir]() {
+              return storage::log_config(
+                storage::log_config::storage_type::disk,
+                base_dir,
+                1_GiB,
+                storage::debug_sanitize_files::yes);
+          });
         storage.start().get();
         auto& mgr = storage.log_mgr();
         try {
@@ -97,11 +99,13 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
                 base_dir,
                 storage::debug_sanitize_files::yes);
           },
-          storage::log_config(
-            storage::log_config::storage_type::disk,
-            base_dir,
-            1_GiB,
-            storage::debug_sanitize_files::yes));
+          [base_dir]() {
+              return storage::log_config(
+                storage::log_config::storage_type::disk,
+                base_dir,
+                1_GiB,
+                storage::debug_sanitize_files::yes);
+          });
         storage.start().get();
         auto& mgr = storage.log_mgr();
         try {


### PR DESCRIPTION

## Cover letter

This doesn't cover all properties, but enough to hopefully
be useful in the field if a system needs its basic segment
sizes tweaked without a restart.

Did this opportunistically while looking at a test that updated
these settings and thinking "how hard would it be..."

## Release notes

* none
