### PR TITLE
ducktape: Increase RedpandaService.READY_TIMEOUT_SEC to 15s

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -187,7 +187,7 @@ class RedpandaService(Service):
                                             "redpanda.profraw")
 
     CLUSTER_NAME = "my_cluster"
-    READY_TIMEOUT_SEC = 10
+    READY_TIMEOUT_SEC = 15
 
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"


### PR DESCRIPTION
## Cover letter

Fix #3763

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

* none