### PR TITLE
security: make `superusers` config live updatable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -907,7 +907,7 @@ configuration::configuration()
       *this,
       "superusers",
       "List of superuser usernames",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {})
   , kafka_qdc_latency_alpha(
       *this,

--- a/src/v/config/mock_property.h
+++ b/src/v/config/mock_property.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "config_store.h"
+#include "property.h"
+
+namespace config {
+
+/**
+ * Test helper.  A property-like object that does not require
+ * a parent config_store.  Useful if you need bindings that can
+ * be updated via property changes.
+ */
+template<typename T>
+class mock_property {
+public:
+    mock_property(T value)
+      : _mock_store()
+      , _property(
+          _mock_store,
+          "anonymous",
+          "",
+          base_property::metadata{.needs_restart = needs_restart::no}) {}
+
+    void update(T&& value) { _property.update_value(std::move(value)); }
+
+    binding<T> bind() { return _property.bind(); }
+
+private:
+    config_store _mock_store;
+    property<T> _property;
+};
+
+} // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -28,6 +28,9 @@ namespace config {
 template<class T>
 class binding;
 
+template<typename T>
+class mock_property;
+
 template<class T>
 class property : public base_property {
 public:
@@ -212,6 +215,7 @@ private:
     };
 
     friend class binding<T>;
+    friend class mock_property<T>;
     intrusive_list<binding<T>, &binding<T>::_hook> _bindings;
 };
 
@@ -323,6 +327,7 @@ public:
     }
 
     friend class property<T>;
+    friend class mock_property<T>;
     template<typename U>
     friend inline binding<U> mock_binding(U&&);
 };

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -267,6 +267,10 @@ public:
       , _parent(rhs._parent)
       , _on_change(rhs._on_change) {
         if (_parent) {
+            // May not copy between shards, parent is
+            // on the rhs instance's shard.
+            oncore_debug_verify(rhs._verify_shard);
+
             // Both self and rhs now in property's binding list
             _parent->_bindings.push_back(*this);
         }
@@ -284,6 +288,12 @@ public:
         _value = std::move(rhs._value);
         _on_change = std::move(rhs._on_change);
         _parent = rhs._parent;
+
+        if (_parent) {
+            // May not move between shards, parent is
+            // on the rhs instance's shard.
+            oncore_debug_verify(rhs._verify_shard);
+        }
 
         // Steal moved-from binding's place in the property's binding list
         _hook.swap_nodes(rhs._hook);


### PR DESCRIPTION
## Cover letter
    
    This involves an interface change to authorizer to
    have it self-sync with a config binding rather
    than receive add_superuser calls.
    
    The authorizer constructor must take a callback
    to generate a binding rather than the binding, because
    bindings need to be constructed on the same shard as
    the instance will live on.

## Release notes

* none
