### PR TITLE
Backport #3769 prevent deadlock on archival shutdown

### DIFF
--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -199,22 +199,26 @@ retry_permit retry_chain_node::retry(retry_strategy st) {
       .delay = required_delay};
 }
 
-ss::lowres_clock::duration retry_chain_node::get_backoff() {
+ss::lowres_clock::duration retry_chain_node::get_backoff() const {
     auto backoff = ss::lowres_clock::duration(_backoff * (1UL << _retry));
     auto jitter = ss::lowres_clock::duration(
       fast_prng_source() % backoff.count());
     return backoff + jitter;
 }
 
-ss::lowres_clock::duration retry_chain_node::get_poll_interval() {
+ss::lowres_clock::duration retry_chain_node::get_poll_interval() const {
     auto jitter = fast_prng_source() % _backoff;
     return ss::lowres_clock::duration(
       static_cast<ss::lowres_clock::duration::rep>(_backoff) + jitter);
 }
 
-ss::lowres_clock::duration retry_chain_node::get_timeout() {
+ss::lowres_clock::duration retry_chain_node::get_timeout() const {
     auto now = ss::lowres_clock::now();
     return now < _deadline ? _deadline - now : 0ms;
+}
+
+ss::lowres_clock::time_point retry_chain_node::get_deadline() const {
+    return _deadline;
 }
 
 uint16_t retry_chain_node::get_len() const {

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -288,13 +288,16 @@ public:
     void check_abort() const;
 
     /// Return backoff duration that should be used before the next retry
-    ss::lowres_clock::duration get_backoff();
+    ss::lowres_clock::duration get_backoff() const;
 
     /// Return polling interval
-    ss::lowres_clock::duration get_poll_interval();
+    ss::lowres_clock::duration get_poll_interval() const;
 
     /// Return timeout value (time interval before the deadline)
-    ss::lowres_clock::duration get_timeout();
+    ss::lowres_clock::duration get_timeout() const;
+
+    /// Return deadline time
+    ss::lowres_clock::time_point get_deadline() const;
 
 private:
     void format(fmt::memory_buffer& str) const;


### PR DESCRIPTION
## Cover letter

The following situation triggers a deadlock during shutdown.
- The node is being stopped and scheduler_serivce::stop is invoked.
- The method calls ntp_archiver::stop for every archiver that it has.
- If the archiver operation hangs the shutdown can't proceed and because
  the scheduler_service is stopped before most other services the node
  stays online.

The ntp_archiver::stop can hang if after the manifest update we're
trying to update the archival_meta_stm but all other replica nodes of
the same ntp are already down. This can happen during cluster shutdown
or during normral operation (if some nodes are not available for
whatever reasons).

The code inside the ntp_arichiver sets the timeout via the
retry_chain_node that it passes to archival_meta_stm. But the problem is
that the call to _raft->replicate inside the archival_meta_stm doesn't
allow to set a timeout. So when all replicas are not responsive it will
just wait for the quorum. When this happens during node shutdown we can
expect that the raft group will be stopped and the 'replicate' call will
throw an exception or return an error. But it doesn't happen because the
archival subsytem is being shut down in the begining. And when it hangs
it prevents the partition_manager and other components to be stopped. So
the raft_group never gets stopped.

This commit fixes that by using a ss::with_timeout wrapper. In case of
timeout the exception will be thrown inside the upload loop and the
whole operation will be retried some time later. The ntp_archiver itself
won't be used before that moment.


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3360


## Release notes

* Fix the deadlock that can be triggered by uploading the manifest right before a shutdown
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
