### PR TITLE
tests: fix port-waiting at end of FranzGoVerifiableTest

### DIFF
--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -129,7 +129,7 @@ class FranzGoVerifiableWithSiTest(RedpandaTest):
         # The verifier opens huge numbers of connections, which can interfere
         # with subsequent tests' use of the node.  Clear them down first.
         wait_until(
-            lambda: self.redpanda.sockets_clear(self._node_for_franz_go[1]),
+            lambda: self.redpanda.sockets_clear(self._node_for_franz_go[0]),
             timeout_sec=120,
             backoff_sec=10)
 


### PR DESCRIPTION
## Cover letter

Follow up to https://github.com/redpanda-data/redpanda/pull/3754

I think I must have been tired when I did the final variant of the test changes in that PR -- there were two errors:
- A 1 that should have been a 0 when picking out the node to wait for ports on
- The port-waiting code was only being called for the SI variant of the test, not the other one.''

Fixes https://github.com/redpanda-data/redpanda/issues/3763

## Release notes

* none
