### PR TITLE
model: change `operator<<` compaction_strategy to match `operator>>`

### DIFF
--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -236,13 +236,13 @@ std::ostream& operator<<(std::ostream& o, const broker_shard& bs) {
 std::ostream& operator<<(std::ostream& o, compaction_strategy c) {
     switch (c) {
     case compaction_strategy::offset:
-        return o << "{compaction_strategy::offset}";
+        return o << "offset";
     case compaction_strategy::timestamp:
-        return o << "{compaction_strategy::timestamp}";
+        return o << "timestamp";
     case compaction_strategy::header:
-        return o << "{compaction_strategy::header}";
+        return o << "header";
     }
-    return o << "{unknown model::compaction_strategy}";
+    __builtin_unreachable();
 }
 
 std::istream& operator>>(std::istream& i, compaction_strategy& cs) {


### PR DESCRIPTION
This needs for `topic_manifest`, we should be able to recreate topic
manifest from a serialized json, so `operator<<` and `operator>>` should
match

This PR is needed for https://github.com/redpanda-data/redpanda/pull/3785 to pass