### PR TITLE
cloud_storage: topic manifest test

### DIFF
--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ rp_test(
   SOURCES
     directory_walker_test.cc
     partition_manifest_test.cc
+    topic_manifest_test.cc
     s3_imposter.cc
     remote_test.cc
     cache_test.cc

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -70,6 +70,11 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
     return make_iobuf_input_stream(std::move(i));
 }
 
+SEASTAR_THREAD_TEST_CASE(test_manifest_type) {
+    partition_manifest m;
+    BOOST_REQUIRE(m.get_manifest_type() == manifest_type::partition);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_segment_path) {
     auto path = generate_remote_segment_path(
       manifest_ntp,

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "cloud_storage/topic_manifest.h"
+#include "cloud_storage/types.h"
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace cloud_storage;
+
+// update manifest, serialize, compare jsons
+
+static const cluster::topic_configuration cfg(
+  model::ns("cfg-test-namespace"),
+  model::topic("cfg-test-topic"),
+  /* partition_count = */ 32,
+  /* replication_factor = */ 3);
+
+static constexpr std::string_view min_topic_manifest_json = R"json({
+    "version": 1,
+    "namespace": "test-namespace",
+    "topic": "test-topic",
+    "partition_count": 32,
+    "replication_factor": 3,
+    "revision_id": 0,
+    "compression": null,
+    "cleanup_policy_bitflags": null,
+    "compaction_strategy": null,
+    "timestamp_type": null,
+    "segment_size": null
+})json";
+
+static constexpr std::string_view full_topic_manifest_json = R"json({
+    "version": 1,
+    "namespace": "full-test-namespace",
+    "topic": "full-test-topic",
+    "partition_count": 64,
+    "replication_factor": 6,
+    "revision_id": 1,
+    "compression": "snappy",
+    "cleanup_policy_bitflags": "compact,delete",
+    "compaction_strategy": "offset",
+    "timestamp_type": "LogAppendTime",
+    "segment_size": 1234,
+    "retention_bytes": 42342,
+    "retention_duration": 360000000
+})json";
+
+inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+SEASTAR_THREAD_TEST_CASE(create_topic_manifest_correct_path) {
+    topic_manifest m(cfg, model::initial_revision_id(0));
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path,
+      "50000000/meta/cfg-test-namespace/cfg-test-topic/topic_manifest.json");
+}
+
+SEASTAR_THREAD_TEST_CASE(update_topic_manifest_correct_path) {
+    topic_manifest m;
+    m.update(make_manifest_stream(min_topic_manifest_json)).get();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "70000000/meta/test-namespace/test-topic/topic_manifest.json");
+}
+
+SEASTAR_THREAD_TEST_CASE(construct_serialize_update_same_object) {
+    topic_manifest m(cfg, model::initial_revision_id(0));
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    topic_manifest restored;
+    restored.update(std::move(rstr)).get();
+
+    BOOST_REQUIRE(m == restored);
+}
+
+SEASTAR_THREAD_TEST_CASE(update_serialize_update_same_object) {
+    topic_manifest m;
+    m.update(make_manifest_stream(min_topic_manifest_json)).get();
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    topic_manifest restored;
+    restored.update(std::move(rstr)).get();
+
+    BOOST_REQUIRE(m == restored);
+}
+
+SEASTAR_THREAD_TEST_CASE(full_update_serialize_update_same_object) {
+    topic_manifest m;
+    m.update(make_manifest_stream(full_topic_manifest_json)).get();
+
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    topic_manifest restored;
+    restored.update(std::move(rstr)).get();
+
+    BOOST_REQUIRE(m == restored);
+}
+
+SEASTAR_THREAD_TEST_CASE(update_non_empty_manifest) {
+    topic_manifest m(cfg, model::initial_revision_id(0));
+    m.update(make_manifest_stream(full_topic_manifest_json)).get();
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    topic_manifest restored;
+    restored.update(std::move(rstr)).get();
+
+    BOOST_REQUIRE(m == restored);
+}

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -68,6 +68,11 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
     return make_iobuf_input_stream(std::move(i));
 }
 
+SEASTAR_THREAD_TEST_CASE(manifest_type_topic) {
+    topic_manifest m;
+    BOOST_REQUIRE(m.get_manifest_type() == manifest_type::topic);
+}
+
 SEASTAR_THREAD_TEST_CASE(create_topic_manifest_correct_path) {
     topic_manifest m(cfg, model::initial_revision_id(0));
     auto path = m.get_manifest_path();

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -12,7 +12,6 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
-#include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"
 #include "json/writer.h"
@@ -212,21 +211,5 @@ remote_manifest_path topic_manifest::get_manifest_path() const {
     vassert(_topic_config, "Topic config is not set");
     return get_topic_manifest_path(
       _topic_config->tp_ns.ns, _topic_config->tp_ns.tp);
-}
-
-std::vector<remote_manifest_path>
-topic_manifest::get_partition_manifests() const {
-    std::vector<remote_manifest_path> result;
-    const int32_t npart = _topic_config->partition_count;
-    result.reserve(npart);
-    for (int32_t i = 0; i < npart; i++) {
-        model::ntp ntp(
-          _topic_config->tp_ns.ns(),
-          _topic_config->tp_ns.tp(),
-          model::partition_id(i));
-        auto path = generate_partition_manifest_path(ntp, _rev);
-        result.emplace_back(std::move(path));
-    }
-    return result;
 }
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -47,7 +47,7 @@ public:
     std::vector<remote_manifest_path> get_partition_manifests() const;
 
     manifest_type get_manifest_type() const override {
-        return manifest_type::partition;
+        return manifest_type::topic;
     };
 
     model::initial_revision_id get_revision() const noexcept { return _rev; }

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -43,9 +43,6 @@ public:
     /// \param out output stream that should be used to output the json
     void serialize(std::ostream& out) const;
 
-    /// Return all possible manifest locations
-    std::vector<remote_manifest_path> get_partition_manifests() const;
-
     manifest_type get_manifest_type() const override {
         return manifest_type::topic;
     };


### PR DESCRIPTION
## Cover letter

Add unit test for `topic_manifest`. Currently the test doesn't pass because compaction strategy `operator<<` and `operator>>` are not compatible (this operators are used by `boost::lexical_cast`).

I will update this PR after https://github.com/redpanda-data/redpanda/pull/3784 is merged, but feel free to review already since https://github.com/redpanda-data/redpanda/pull/3784 is super small

Fixes: #3734