### PR TITLE
Added support for leader epoch

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -49,6 +49,17 @@ get_kafka_base_offset(const partition_manifest::segment_meta& m) {
                                                         : m.delta_offset;
     return m.base_offset - delta;
 }
+/// This function returns segment max offset as kafka offset
+static model::offset
+get_kafka_max_offset(const partition_manifest::segment_meta& m) {
+    // Manifests created with the old version of redpanda won't have the
+    // delta_offset field. In this case the value will be initialized to
+    // model::offset::min(). In this case offset translation couldn't be
+    // performed.
+    auto delta = m.delta_offset == model::offset::min() ? model::offset(0)
+                                                        : m.delta_offset;
+    return m.committed_offset - delta;
+}
 
 class partition_record_batch_reader_impl final
   : public model::record_batch_reader::impl {
@@ -456,6 +467,29 @@ const model::ntp& remote_partition::get_ntp() const {
 
 bool remote_partition::is_data_available() const {
     return _manifest.size() > 0;
+}
+
+// returns term last kafka offset
+std::optional<model::offset>
+remote_partition::get_term_last_offset(model::term_id term) const {
+    vassert(
+      _manifest.size() > 0,
+      "The manifest for {} is not expected to be empty",
+      _manifest.get_ntp());
+
+    // look for first segment in next term, segments are sorted by base_offset
+    // and term
+    for (auto const& p : _manifest) {
+        if (p.first.term > term) {
+            return get_kafka_base_offset(p.second) - model::offset(1);
+        }
+    }
+    // if last segment term is equal to the one we look for return it
+    if (_manifest.rbegin()->first.term == term) {
+        return get_kafka_max_offset(_manifest.rbegin()->second);
+    }
+
+    return std::nullopt;
 }
 
 ss::future<> remote_partition::stop() {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "s3/client.h"
 #include "storage/ntp_config.h"
@@ -183,6 +184,9 @@ public:
 
     /// Returns true if at least one segment is uploaded to the bucket
     bool is_data_available() const;
+
+    // returns term last kafka offset
+    std::optional<model::offset> get_term_last_offset(model::term_id) const;
 
 private:
     /// Create new remote_segment instances for all new

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -62,13 +62,15 @@ metadata_cache::get_source_topic(model::topic_namespace_view tp) const {
     return mt->second.get_source_topic();
 }
 
-std::optional<model::topic_metadata>
-metadata_cache::get_topic_metadata(model::topic_namespace_view tp) const {
+std::optional<model::topic_metadata> metadata_cache::get_topic_metadata(
+  model::topic_namespace_view tp, metadata_cache::with_leaders leaders) const {
     auto md = _topics_state.local().get_topic_metadata(tp);
     if (!md) {
         return md;
     }
-    fill_partition_leaders(_leaders.local(), *md);
+    if (leaders) {
+        fill_partition_leaders(_leaders.local(), *md);
+    }
 
     return md;
 }
@@ -82,10 +84,13 @@ metadata_cache::get_topic_timestamp_type(model::topic_namespace_view tp) const {
     return _topics_state.local().get_topic_timestamp_type(tp);
 }
 
-std::vector<model::topic_metadata> metadata_cache::all_topics_metadata() const {
+std::vector<model::topic_metadata> metadata_cache::all_topics_metadata(
+  metadata_cache::with_leaders leaders) const {
     auto all_md = _topics_state.local().all_topics_metadata();
-    for (auto& md : all_md) {
-        fill_partition_leaders(_leaders.local(), md);
+    if (leaders) {
+        for (auto& md : all_md) {
+            fill_partition_leaders(_leaders.local(), md);
+        }
     }
     return all_md;
 }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -160,10 +160,14 @@ metadata_cache::get_leader_id(const model::ntp& ntp) const {
     return _leaders.local().get_leader(ntp);
 }
 
-std::optional<model::node_id>
-metadata_cache::get_previous_leader_id(const model::ntp& ntp) const {
-    return _leaders.local().get_previous_leader(
-      model::topic_namespace_view(ntp), ntp.tp.partition);
+std::optional<model::node_id> metadata_cache::get_leader_id(
+  model::topic_namespace_view tp_ns, model::partition_id p_id) const {
+    return _leaders.local().get_leader(tp_ns, p_id);
+}
+
+std::optional<model::node_id> metadata_cache::get_previous_leader_id(
+  model::topic_namespace_view tp_ns, model::partition_id p_id) const {
+    return _leaders.local().get_previous_leader(tp_ns, p_id);
 }
 
 /// If present returns a leader of raft0 group

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -159,6 +159,10 @@ std::optional<model::node_id>
 metadata_cache::get_leader_id(const model::ntp& ntp) const {
     return _leaders.local().get_leader(ntp);
 }
+std::optional<cluster::leader_term> metadata_cache::get_leader_term(
+  model::topic_namespace_view tp_ns, model::partition_id pid) const {
+    return _leaders.local().get_leader_term(tp_ns, pid);
+}
 
 std::optional<model::node_id> metadata_cache::get_leader_id(
   model::topic_namespace_view tp_ns, model::partition_id p_id) const {

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -52,6 +52,7 @@ namespace cluster {
 /// +---------+   +----------+    +------------+
 class metadata_cache {
 public:
+    using with_leaders = ss::bool_class<struct with_leaders_tag>;
     metadata_cache(
       ss::sharded<topic_table>&,
       ss::sharded<members_table>&,
@@ -70,8 +71,8 @@ public:
     ///\brief Returns metadata of single topic.
     ///
     /// If topic does not exists it returns an empty optional
-    std::optional<model::topic_metadata>
-      get_topic_metadata(model::topic_namespace_view) const;
+    std::optional<model::topic_metadata> get_topic_metadata(
+      model::topic_namespace_view, with_leaders = with_leaders::yes) const;
 
     ///\brief Returns configuration of single topic.
     ///
@@ -86,7 +87,8 @@ public:
       get_topic_timestamp_type(model::topic_namespace_view) const;
 
     /// Returns metadata of all topics.
-    std::vector<model::topic_metadata> all_topics_metadata() const;
+    std::vector<model::topic_metadata>
+      all_topics_metadata(with_leaders = with_leaders::yes) const;
 
     /// Returns all brokers, returns copy as the content of broker can change
     std::vector<broker_ptr> all_brokers() const;

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -110,6 +110,8 @@ public:
     }
 
     std::optional<model::node_id> get_leader_id(const model::ntp&) const;
+    std::optional<cluster::leader_term>
+      get_leader_term(model::topic_namespace_view, model::partition_id) const;
 
     std::optional<model::node_id>
       get_leader_id(model::topic_namespace_view, model::partition_id) const;

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -112,7 +112,10 @@ public:
     std::optional<model::node_id> get_leader_id(const model::ntp&) const;
 
     std::optional<model::node_id>
-    get_previous_leader_id(const model::ntp&) const;
+      get_leader_id(model::topic_namespace_view, model::partition_id) const;
+
+    std::optional<model::node_id> get_previous_leader_id(
+      model::topic_namespace_view, model::partition_id) const;
     /// Returns metadata of all topics in cache internal format
     // const cache_t& all_metadata() const { return _cache; }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -326,6 +326,27 @@ ss::future<> partition::update_configuration(topic_properties properties) {
       properties.get_ntp_cfg_overrides());
 }
 
+std::optional<model::offset>
+partition::get_term_last_offset(model::term_id term) const {
+    auto o = _raft->log().get_term_last_offset(term);
+    if (!o) {
+        return std::nullopt;
+    }
+    // Kafka defines leader epoch last offset as a first offset of next leader
+    // epoch
+    return raft::details::next_offset(*o);
+}
+
+std::optional<model::offset>
+partition::get_cloud_term_last_offset(model::term_id term) const {
+    auto o = _cloud_storage_partition->get_term_last_offset(term);
+    if (!o) {
+        return std::nullopt;
+    }
+    // Kafka defines leader epoch last offset as a first offset of next leader
+    // epoch
+    return raft::details::next_offset(*o);
+}
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -175,10 +175,6 @@ public:
         return _id_allocator_stm;
     }
 
-    const raft::configuration_manager& get_cfg_manager() const {
-        return _raft->get_configuration_manager();
-    }
-
     ss::lw_shared_ptr<const storage::offset_translator_state>
     get_offset_translator_state() const {
         return _raft->get_offset_translator_state();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -255,6 +255,15 @@ public:
         }
     }
 
+    std::optional<model::offset> get_term_last_offset(model::term_id) const;
+
+    model::term_id get_term(model::offset o) const {
+        return _raft->get_term(o);
+    }
+
+    std::optional<model::offset>
+    get_cloud_term_last_offset(model::term_id term) const;
+
 private:
     friend partition_manager;
     friend replicated_partition_probe;

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "utils/concepts-enabled.h"
@@ -41,6 +42,11 @@ public:
 
     std::optional<model::node_id>
       get_leader(model::topic_namespace_view, model::partition_id) const;
+
+    std::optional<leader_term> get_leader_term(const model::ntp&) const;
+
+    std::optional<leader_term>
+      get_leader_term(model::topic_namespace_view, model::partition_id) const;
 
     /**
      * Returns previous reader of partition if available. This is required by
@@ -154,6 +160,12 @@ private:
         // previous leader id, this is empty if and only if there were no leader
         // elected for the topic before
         std::optional<model::node_id> previous_leader;
+        /**
+         * We keep a term id of last stable leader, term may be increasing even
+         * if leader election was unsuccessful, here we store a term of last
+         * successfully elected leader
+         */
+        model::term_id last_stable_leader_term;
         model::term_id update_term;
         model::revision_id partition_revision;
     };

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -355,6 +355,11 @@ operator<<(std::ostream& o, const custom_partition_assignment& cas) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const leader_term& lt) {
+    fmt::print(o, "{{leader: {}, term: {}}}", lt.leader, lt.term);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -16,6 +16,7 @@
 #include "kafka/types.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
@@ -846,6 +847,16 @@ struct config_update_request final {
 struct config_update_reply {
     errc error;
     cluster::config_version latest_version{config_version_unset};
+};
+
+struct leader_term {
+    leader_term(std::optional<model::node_id> leader, model::term_id term)
+      : leader(leader)
+      , term(term) {}
+
+    std::optional<model::node_id> leader;
+    model::term_id term;
+    friend std::ostream& operator<<(std::ostream&, const leader_term&);
 };
 
 } // namespace cluster

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -32,8 +32,14 @@ public:
     const model::ntp& ntp() const { return _log.config().ntp(); }
     const storage::ntp_config& config() const { return _log.config(); }
     bool is_leader() const { return _source->is_leader(); }
+    model::term_id term() const { return _source->term(); }
     model::revision_id get_revision_id() const {
         return _log.config().get_revision();
+    }
+
+    std::optional<model::offset>
+    get_term_last_offset(model::term_id term) const {
+        return _source->get_term_last_offset(term);
     }
 
     /// \brief Returns a reader that enters the \ref _gate when it performs

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -33,6 +33,7 @@ set(handlers_srcs
   server/handlers/create_acls.cc
   server/handlers/delete_acls.cc
   server/handlers/create_partitions.cc
+  server/handlers/offset_for_leader_epoch.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/protocol/list_offsets.h
+++ b/src/v/kafka/protocol/list_offsets.h
@@ -76,26 +76,34 @@ struct list_offsets_response final {
       model::partition_id id,
       error_code error,
       model::timestamp timestamp,
-      model::offset offset) {
+      model::offset offset,
+      leader_epoch leader_epoch) {
         return list_offset_partition_response{
           .partition_index = id,
           .error_code = error,
           .timestamp = timestamp,
           .offset = offset,
+          .leader_epoch = leader_epoch,
         };
     }
 
     static list_offset_partition_response make_partition(
       model::partition_id id,
       model::timestamp timestamp,
-      model::offset offset) {
-        return make_partition(id, error_code::none, timestamp, offset);
+      model::offset offset,
+      kafka::leader_epoch leader_epoch) {
+        return make_partition(
+          id, error_code::none, timestamp, offset, leader_epoch);
     }
 
     static list_offset_partition_response
     make_partition(model::partition_id id, error_code error) {
         return make_partition(
-          id, error, model::timestamp(-1), model::offset(-1));
+          id,
+          error,
+          model::timestamp(-1),
+          model::offset(-1),
+          invalid_leader_epoch);
     }
 
     void encode(response_writer& writer, api_version version) {

--- a/src/v/kafka/protocol/offset_for_leader_epoch.h
+++ b/src/v/kafka/protocol/offset_for_leader_epoch.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "bytes/iobuf.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/offset_for_leader_epoch_request.h"
+#include "kafka/protocol/schemata/offset_for_leader_epoch_response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+
+namespace kafka {
+
+class offset_for_leader_epoch_api final {
+public:
+    static constexpr const char* name = "offset_for_leader_epoch";
+    static constexpr api_key key = api_key(23);
+};
+
+struct offset_for_leader_epoch_request final {
+    using api_type = offset_for_leader_epoch_api;
+
+    offset_for_leader_epoch_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const offset_for_leader_epoch_request& r) {
+    return os << r.data;
+}
+
+struct offset_for_leader_epoch_response final {
+    using api_type = offset_for_leader_epoch_api;
+
+    offset_for_leader_epoch_response_data data;
+
+    static epoch_end_offset make_epoch_end_offset(
+      model::partition_id p_id,
+      kafka::error_code ec,
+      model::offset end_offset,
+      kafka::leader_epoch l_epoch) {
+        return epoch_end_offset{
+          .error_code = ec,
+          .partition = p_id,
+          .leader_epoch = l_epoch,
+          .end_offset = end_offset,
+        };
+    }
+
+    static epoch_end_offset make_epoch_end_offset(
+      model::partition_id p_id,
+      model::offset end_offset,
+      kafka::leader_epoch l_epoch) {
+        return make_epoch_end_offset(
+          p_id, error_code::none, end_offset, l_epoch);
+    }
+
+    static epoch_end_offset
+    make_epoch_end_offset(model::partition_id p_id, kafka::error_code ec) {
+        return make_epoch_end_offset(
+          p_id, ec, model::offset(-1), invalid_leader_epoch);
+    }
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const offset_for_leader_epoch_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -64,7 +64,9 @@ set(schemata
   create_partitions_request.json
   create_partitions_response.json
   add_offsets_to_txn_request.json
-  add_offsets_to_txn_response.json)
+  add_offsets_to_txn_response.json
+  offset_for_leader_epoch_request.json
+  offset_for_leader_epoch_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -258,6 +258,24 @@ path_type_map = {
     "CreatePartitionsRequestData": {
         "TimeoutMs": ("std::chrono::milliseconds", "int32")
     },
+    "OffsetForLeaderEpochRequestData": {
+        "Topics": {
+            "Partitions": {
+                "Partition": ("model::partition_id", "int32"),
+                "CurrentLeaderEpoch": ("kafka::leader_epoch", "int32"),
+                "LeaderEpoch": ("kafka::leader_epoch", "int32"),
+            }
+        }
+    },
+    "OffsetForLeaderEpochResponseData": {
+        "Topics": {
+            "Partitions": {
+                "Partition": ("model::partition_id", "int32"),
+                "LeaderEpoch": ("kafka::leader_epoch", "int32"),
+                "EndOffset": ("model::offset", "int64"),
+            }
+        }
+    }
 }
 
 # a few kafka field types specify an entity type
@@ -393,6 +411,10 @@ STRUCT_TYPES = [
     "CreatePartitionsTopic",
     "CreatePartitionsTopicResult",
     "CreatePartitionsAssignment",
+    "OffsetForLeaderTopic",
+    "OffsetForLeaderPartition",
+    "OffsetForLeaderTopicResult",
+    "EpochEndOffset",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/protocol/schemata/offset_for_leader_epoch_request.json
+++ b/src/v/kafka/protocol/schemata/offset_for_leader_epoch_request.json
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 23,
+  "type": "request",
+  "name": "OffsetForLeaderEpochRequest",
+  // Version 1 is the same as version 0.
+  //
+  // Version 2 adds the current leader epoch to support fencing.
+  //
+  // Version 3 adds ReplicaId (the default is -2 which conventionally represents a
+  //    "debug" consumer which is allowed to see offsets beyond the high watermark).
+  //    Followers will use this replicaId when using an older version of the protocol.
+  //
+  // Version 4 enables flexible versions.
+  "validVersions": "0-4",
+  "flexibleVersions": "4+",
+  "fields": [
+    { "name": "ReplicaId", "type": "int32", "versions": "3+", "default": -2, "ignorable": true, "entityType": "brokerId",
+      "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
+    { "name": "Topics", "type": "[]OffsetForLeaderTopic", "versions": "0+",
+      "about": "Each topic to get offsets for.", "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
+        "mapKey": true, "about": "The topic name." },
+      { "name": "Partitions", "type": "[]OffsetForLeaderPartition", "versions": "0+",
+        "about": "Each partition to get offsets for.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true,
+          "about": "An epoch used to fence consumers/replicas with old metadata. If the epoch provided by the client is larger than the current epoch known to the broker, then the UNKNOWN_LEADER_EPOCH error code will be returned. If the provided epoch is smaller, then the FENCED_LEADER_EPOCH error code will be returned." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+          "about": "The epoch to look up an offset for." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/offset_for_leader_epoch_response.json
+++ b/src/v/kafka/protocol/schemata/offset_for_leader_epoch_response.json
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 23,
+  "type": "response",
+  "name": "OffsetForLeaderEpochResponse",
+  // Version 1 added the leader epoch to the response.
+  //
+  // Version 2 added the throttle time.
+  //
+  // Version 3 is the same as version 2.
+  //
+  // Version 4 enables flexible versions.
+  "validVersions": "0-4",
+  "flexibleVersions": "4+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "2+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Topics", "type": "[]OffsetForLeaderTopicResult", "versions": "0+",
+      "about": "Each topic we fetched offsets for.", "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
+        "mapKey": true, "about": "The topic name." },
+      { "name": "Partitions", "type": "[]EpochEndOffset", "versions": "0+",
+        "about": "Each partition in the topic we fetched offsets for.", "fields": [
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code 0, or if there was no error." },
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "1+", "default": "-1", "ignorable": true,
+          "about": "The leader epoch of the partition." },
+        { "name": "EndOffset", "type": "int64", "versions": "0+", "default": "-1",
+          "about": "The end offset of the epoch." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -29,6 +29,7 @@ struct fetch_session_partition {
     model::offset fetch_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
+    kafka::leader_epoch current_leader_epoch = invalid_leader_epoch;
 };
 /**
  * Map of partitions that is kept by fetch session. This map is using intrusive

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -21,6 +21,7 @@ static fetch_session_partition make_fetch_partition(
       .fetch_offset = p.fetch_offset,
       .high_watermark = model::offset(-1),
       .last_stable_offset = model::offset(-1),
+      .current_leader_epoch = p.current_leader_epoch,
     };
 }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -137,8 +137,7 @@ public:
         model::offset log_offset;
         model::offset offset;
         ss::sstring metadata;
-        // BUG: support leader_epoch (KIP-320)
-        // https://github.com/vectorizedio/redpanda/issues/1181
+        kafka::leader_epoch committed_leader_epoch;
     };
 
     struct offset_metadata_with_probe {
@@ -651,7 +650,7 @@ private:
 
     struct volatile_offset {
         model::offset offset;
-        int32_t leader_epoch;
+        kafka::leader_epoch leader_epoch;
         std::optional<ss::sstring> metadata;
     };
 

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -1,6 +1,7 @@
 #include "kafka/server/group_stm.h"
 
 #include "cluster/logger.h"
+#include "kafka/types.h"
 
 namespace kafka {
 
@@ -49,9 +50,8 @@ void group_stm::update_prepared(
           .log_offset = offset,
           .offset = tx_offset.offset,
           .metadata = tx_offset.metadata.value_or(""),
+          .committed_leader_epoch = kafka::leader_epoch(tx_offset.leader_epoch),
         };
-        // BUG: support leader_epoch (KIP-320)
-        // https://github.com/vectorizedio/redpanda/issues/1181
         prepared_it->second.offsets[tx_offset.tp] = md;
     }
 }

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -54,7 +54,8 @@ using request_types = make_request_types<
   txn_offset_commit_handler,
   add_offsets_to_txn_handler,
   end_txn_handler,
-  create_partitions_handler>;
+  create_partitions_handler,
+  offset_for_leader_epoch_handler>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/server/handlers/details/leader_epoch.h
+++ b/src/v/kafka/server/handlers/details/leader_epoch.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "kafka/protocol/errors.h"
+#include "kafka/server/partition_proxy.h"
+#include "kafka/types.h"
+
+#include <compare>
+
+namespace kafka::details {
+
+inline kafka::error_code check_leader_epoch(
+  kafka::leader_epoch request_epoch, const kafka::partition_proxy& p) {
+    /**
+     * no leader epoch provided, skip validation
+     */
+    if (request_epoch < 0) {
+        return error_code::none;
+    }
+    auto const partition_epoch = p.leader_epoch();
+
+    if (request_epoch > partition_epoch) {
+        return error_code::unknown_leader_epoch;
+    } else if (request_epoch < partition_epoch) {
+        return error_code::fenced_leader_epoch;
+    } else {
+        return error_code::none;
+    }
+}
+
+} // namespace kafka::details

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/handler.h"
+#include "kafka/types.h"
 
 namespace kafka {
 
@@ -146,16 +147,18 @@ struct fetch_config {
     model::timeout_clock::time_point timeout;
     bool strict_max_bytes{false};
     bool skip_read{false};
+    kafka::leader_epoch current_leader_epoch;
 
     friend std::ostream& operator<<(std::ostream& o, const fetch_config& cfg) {
         fmt::print(
           o,
-          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}}})",
+          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "current_leader_epoch:" {}}})",
           cfg.start_offset,
           cfg.max_offset,
           cfg.isolation_level,
           cfg.max_bytes,
-          cfg.strict_max_bytes);
+          cfg.strict_max_bytes,
+          cfg.current_leader_epoch);
         return o;
     }
 };

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -37,6 +37,7 @@
 #include "kafka/server/handlers/metadata.h"
 #include "kafka/server/handlers/offset_commit.h"
 #include "kafka/server/handlers/offset_fetch.h"
+#include "kafka/server/handlers/offset_for_leader_epoch.h"
 #include "kafka/server/handlers/produce.h"
 #include "kafka/server/handlers/sasl_authenticate.h"
 #include "kafka/server/handlers/sasl_handshake.h"

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -13,6 +13,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/materialized_partition.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/server/replicated_partition.h"
@@ -64,6 +65,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   model::timestamp timestamp,
   model::ntp ntp,
   model::isolation_level isolation_lvl,
+  kafka::leader_epoch current_leader_epoch,
   cluster::partition_manager& mgr) {
     auto kafka_partition = make_partition_proxy(
       ntp, mgr, octx.rctx.coproc_partition_manager().local());
@@ -81,6 +83,15 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           ntp.tp.partition, error_code::not_leader_for_partition);
     }
 
+    /**
+     * validate leader epoch. for more details see KIP-320
+     */
+    auto leader_epoch_err = details::check_leader_epoch(
+      current_leader_epoch, *kafka_partition);
+    if (leader_epoch_err != error_code::none) {
+        co_return list_offsets_response::make_partition(
+          ntp.tp.partition, leader_epoch_err);
+    }
     /*
      * the responses for earliest/latest timestamp queries do not require
      * that the actual timestamp be returned. only the offset is required.
@@ -144,10 +155,16 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
        &octx,
        ntp = std::move(ntp),
        isolation_lvl = model::isolation_level(
-         octx.request.data.isolation_level)](
+         octx.request.data.isolation_level),
+       current_leader_epoch = part.current_leader_epoch](
         cluster::partition_manager& mgr) mutable {
           return list_offsets_partition(
-            octx, timestamp, std::move(ntp), isolation_lvl, mgr);
+            octx,
+            timestamp,
+            std::move(ntp),
+            isolation_lvl,
+            current_leader_epoch,
+            mgr);
       });
 }
 

--- a/src/v/kafka/server/handlers/list_offsets.h
+++ b/src/v/kafka/server/handlers/list_offsets.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_offsets_handler = handler<list_offsets_api, 0, 3>;
+using list_offsets_handler = handler<list_offsets_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -15,8 +15,10 @@
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "kafka/server/errors.h"
+#include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/types.h"
 #include "likely.h"
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
@@ -26,6 +28,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/thread.hh>
 
+#include <boost/numeric/conversion/cast.hpp>
 #include <fmt/ostream.h>
 
 namespace kafka {
@@ -63,23 +66,26 @@ static constexpr model::node_id no_leader(-1);
  * With those heuristics we will always force the client to communicate with the
  * nodes that may not be partitioned.
  */
-model::node_id get_leader(
+std::optional<cluster::leader_term> get_leader_term(
   model::topic_namespace_view tp_ns,
   model::partition_id p_id,
   const cluster::metadata_cache& md_cache,
   const std::vector<model::node_id>& replicas) {
-    const auto current = md_cache.get_leader_id(tp_ns, p_id);
-    if (current) {
-        return *current;
+    auto leader_term = md_cache.get_leader_term(tp_ns, p_id);
+    if (!leader_term) {
+        return std::nullopt;
+    }
+    if (!leader_term->leader.has_value()) {
+        const auto previous = md_cache.get_previous_leader_id(tp_ns, p_id);
+        leader_term->leader = previous;
+
+        if (previous == config::node().node_id()) {
+            auto idx = fast_prng_source() % replicas.size();
+            leader_term->leader = replicas[idx];
+        }
     }
 
-    const auto previous = md_cache.get_previous_leader_id(tp_ns, p_id);
-    if (previous == config::node().node_id()) {
-        auto idx = fast_prng_source() % replicas.size();
-        return replicas[idx];
-    }
-
-    return previous.value_or(no_leader);
+    return leader_term;
 }
 
 metadata_response::topic make_topic_response_from_topic_metadata(
@@ -104,7 +110,12 @@ metadata_response::topic make_topic_response_from_topic_metadata(
           metadata_response::partition p;
           p.error_code = error_code::none;
           p.partition_index = p_md.id;
-          p.leader_id = get_leader(tp_ns, p_md.id, md_cache, replicas);
+          p.leader_id = no_leader;
+          auto lt = get_leader_term(tp_ns, p_md.id, md_cache, replicas);
+          if (lt) {
+              p.leader_id = lt->leader.value_or(no_leader);
+              p.leader_epoch = leader_epoch_from_term(lt->term);
+          }
           p.replica_nodes = std::move(replicas);
           p.isr_nodes = p.replica_nodes;
           p.offline_replicas = {};
@@ -191,7 +202,8 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
 
     // request can be served from whatever happens to be in the cache
     if (request.list_all_topics) {
-        auto topics = ctx.metadata_cache().all_topics_metadata();
+        auto topics = ctx.metadata_cache().all_topics_metadata(
+          cluster::metadata_cache::with_leaders::no);
         // only serve topics from the kafka namespace
         std::erase_if(topics, [](model::topic_metadata& t_md) {
             return t_md.tp_ns.ns != model::kafka_namespace;
@@ -234,7 +246,8 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
             continue;
         }
         if (auto md = ctx.metadata_cache().get_topic_metadata(
-              model::topic_namespace_view(model::kafka_namespace, topic.name));
+              model::topic_namespace_view(model::kafka_namespace, topic.name),
+              cluster::metadata_cache::with_leaders::no);
             md) {
             auto src_topic_response = make_topic_response(
               ctx, request, std::move(*md));

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -1,0 +1,232 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/offset_for_leader_epoch.h"
+
+#include "cluster/shard_table.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/offset_for_leader_epoch_response.h"
+#include "kafka/server/handlers/details/leader_epoch.h"
+#include "kafka/server/partition_proxy.h"
+#include "kafka/server/request_context.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "security/acl.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/smp.hh>
+
+#include <absl/container/flat_hash_set.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <vector>
+
+namespace kafka {
+
+using response_t = offset_for_leader_epoch_response;
+
+struct ntp_last_offset_request {
+    model::ntp ntp;
+    kafka::leader_epoch requested_epoch;
+    kafka::leader_epoch current_epoch;
+};
+
+struct shard_op_ctx {
+    std::vector<ntp_last_offset_request> requests;
+    std::vector<std::reference_wrapper<epoch_end_offset>> responses;
+};
+/**
+ * Epoch end offset is an offset passed the last record in when current epoch is
+ * requested, or first offset of leader epoch next to the one requested
+ */
+
+model::offset
+get_epoch_end_offset(kafka::leader_epoch epoch, const partition_proxy& p) {
+    return p.get_leader_epoch_last_offset(epoch).value_or(model::offset{-1});
+}
+
+static ss::future<std::vector<epoch_end_offset>> fetch_offsets_from_shard(
+  request_context& ctx,
+  ss::shard_id shard,
+  std::vector<ntp_last_offset_request> requests) {
+    return ss::smp::submit_to(shard, [&ctx, requests = std::move(requests)] {
+        std::vector<epoch_end_offset> ret;
+        ret.reserve(requests.size());
+        for (auto& r : requests) {
+            auto p = make_partition_proxy(
+              r.ntp,
+              ctx.partition_manager().local(),
+              ctx.coproc_partition_manager().local());
+
+            if (!p) {
+                ret.push_back(response_t::make_epoch_end_offset(
+                  r.ntp.tp.partition, error_code::not_leader_for_partition));
+                continue;
+            }
+
+            auto l_epoch_error = details::check_leader_epoch(
+              r.current_epoch, *p);
+            if (l_epoch_error != error_code::none) {
+                ret.push_back(response_t::make_epoch_end_offset(
+                  r.ntp.tp.partition, l_epoch_error));
+                continue;
+            }
+
+            ret.push_back(response_t::make_epoch_end_offset(
+              r.ntp.tp.partition,
+              get_epoch_end_offset(r.requested_epoch, *p),
+              p->leader_epoch()));
+        }
+        return ret;
+    });
+}
+
+static ss::future<> fetch_offsets_from_shards(
+  request_context& ctx,
+  absl::flat_hash_map<ss::shard_id, shard_op_ctx> requests_per_shard) {
+    using value_t = absl::flat_hash_map<ss::shard_id, shard_op_ctx>::value_type;
+    return ss::parallel_for_each(
+      std::move(requests_per_shard), [&ctx](value_t& p) {
+          return fetch_offsets_from_shard(
+                   ctx, p.first, std::move(p.second.requests))
+            .then([responses = std::move(p.second.responses)](
+                    std::vector<epoch_end_offset> results) mutable {
+                auto it = responses.begin();
+                vassert(
+                  results.size() == responses.size(),
+                  "expected to have end epoch result for each requested "
+                  "partition. Requested partitions: {}, results: {}",
+                  results.size(),
+                  responses.size());
+                for (auto& r : results) {
+                    it->get() = r;
+                    ++it;
+                }
+            });
+      });
+}
+
+static ss::future<std::vector<offset_for_leader_topic_result>>
+get_offsets_for_leader_epochs(
+  request_context& ctx, std::vector<offset_for_leader_topic> topics) {
+    std::vector<offset_for_leader_topic_result> result;
+    result.reserve(topics.size());
+
+    absl::flat_hash_map<ss::shard_id, shard_op_ctx> requests_per_shard;
+
+    for (auto& request_topic : topics) {
+        result.push_back(
+          offset_for_leader_topic_result{.topic = request_topic.topic});
+        result.back().partitions.reserve(request_topic.partitions.size());
+
+        for (auto& request_partition : request_topic.partitions) {
+            // add reponse placeholder
+            result.back().partitions.push_back(epoch_end_offset{});
+            // we are reserving both topics and partitions, reference to
+            // response is stable and we can capture it
+            auto& partition_response = result.back().partitions.back();
+
+            auto ntp = model::ntp(
+              model::kafka_namespace,
+              request_topic.topic,
+              request_partition.partition);
+
+            if (!ctx.metadata_cache().contains(ntp)) {
+                partition_response = response_t::make_epoch_end_offset(
+                  request_partition.partition,
+                  error_code::unknown_topic_or_partition);
+                continue;
+            }
+
+            auto shard = ctx.shards().shard_for(ntp);
+            // no shard found, we may be in the middle of partiton move, return
+            // not leader for partition error
+            if (!shard) {
+                partition_response = response_t::make_epoch_end_offset(
+                  request_partition.partition,
+                  error_code::unknown_topic_or_partition);
+                continue;
+            }
+
+            ntp_last_offset_request req{
+              .ntp = std::move(ntp),
+              .requested_epoch = request_partition.leader_epoch,
+              .current_epoch = request_partition.current_leader_epoch,
+            };
+            auto& per_shard = requests_per_shard[*shard];
+            per_shard.requests.push_back(std::move(req));
+            per_shard.responses.push_back(std::ref(partition_response));
+        }
+    }
+    co_await fetch_offsets_from_shards(ctx, std::move(requests_per_shard));
+    co_return result;
+}
+
+template<>
+ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
+  request_context ctx, ss::smp_service_group ssg) {
+    offset_for_leader_epoch_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    vlog(klog.trace, "Handling request {}", request);
+
+    std::vector<offset_for_leader_topic_result> unauthorized;
+
+    // authorize
+    if (!ctx.authorized(
+          security::acl_operation::cluster_action,
+          security::default_cluster_name)) {
+        auto it = std::stable_partition(
+          request.data.topics.begin(),
+          request.data.topics.end(),
+          [&ctx](const offset_for_leader_topic& topic) {
+              return ctx.authorized(
+                security::acl_operation::describe, topic.topic);
+          });
+
+        unauthorized.reserve(std::distance(it, request.data.topics.end()));
+        std::transform(
+          it,
+          request.data.topics.end(),
+          std::back_inserter(unauthorized),
+          [](offset_for_leader_topic& topic) {
+              offset_for_leader_topic_result res;
+              res.partitions.reserve(topic.partitions.size());
+              for (auto& p : topic.partitions) {
+                  res.partitions.push_back(response_t::make_epoch_end_offset(
+                    p.partition, error_code::topic_authorization_failed));
+              }
+              return res;
+          });
+        // remove unauthorized topics
+        request.data.topics.erase(it, request.data.topics.end());
+    }
+
+    // fetch offsets
+    auto results = co_await get_offsets_for_leader_epochs(
+      ctx, std::move(request.data.topics));
+
+    offset_for_leader_epoch_response response;
+    response.data.topics = std::move(results);
+    response.data.throttle_time_ms = std::chrono::milliseconds(
+      ctx.throttle_delay_ms());
+
+    // merge with unauthorized topics
+    std::move(
+      unauthorized.begin(),
+      unauthorized.end(),
+      std::back_inserter(response.data.topics));
+
+    co_return co_await ctx.respond(std::move(response));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.h
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/offset_for_leader_epoch.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using offset_for_leader_epoch_handler
+  = handler<offset_for_leader_epoch_api, 0, 3>;
+}

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -12,6 +12,8 @@
 #include "cluster/partition_probe.h"
 #include "coproc/partition.h"
 #include "kafka/server/partition_proxy.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
 #include "raft/errc.h"
 #include "storage/log.h"
 
@@ -40,6 +42,15 @@ public:
     }
 
     bool is_leader() const final { return _partition->is_leader(); }
+
+    kafka::leader_epoch leader_epoch() const final {
+        return leader_epoch_from_term(_partition->term());
+    }
+
+    std::optional<model::offset>
+    get_leader_epoch_last_offset(kafka::leader_epoch epoch) const final {
+        return _partition->get_term_last_offset(model::term_id(epoch()));
+    }
 
     ss::future<std::error_code> linearizable_barrier() final {
         return _partition->source_partition()->linearizable_barrier().then(

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -13,6 +13,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "coproc/fwd.h"
+#include "kafka/types.h"
 #include "model/fundamental.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
@@ -33,6 +34,9 @@ public:
         virtual model::offset start_offset() const = 0;
         virtual model::offset high_watermark() const = 0;
         virtual model::offset last_stable_offset() const = 0;
+        virtual kafka::leader_epoch leader_epoch() const = 0;
+        virtual std::optional<model::offset>
+          get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
         virtual bool is_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<storage::translating_reader> make_reader(
@@ -91,6 +95,13 @@ public:
     }
 
     cluster::partition_probe& probe() { return _impl->probe(); }
+
+    kafka::leader_epoch leader_epoch() const { return _impl->leader_epoch(); }
+
+    std::optional<model::offset>
+    get_leader_epoch_last_offset(kafka::leader_epoch epoch) const {
+        return _impl->get_leader_epoch_last_offset(epoch);
+    }
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -11,6 +11,7 @@
 #include "kafka/server/replicated_partition.h"
 
 #include "kafka/protocol/errors.h"
+#include "kafka/types.h"
 #include "model/fundamental.h"
 #include "raft/types.h"
 #include "storage/types.h"
@@ -184,5 +185,26 @@ raft::replicate_stages replicated_partition::replicate(
             _translator->from_log_offset(r.value().last_offset)});
       });
     return res;
+}
+
+std::optional<model::offset> replicated_partition::get_leader_epoch_last_offset(
+  kafka::leader_epoch epoch) const {
+    const model::term_id term(epoch);
+    const auto first_local_term = _partition->get_term(
+      _partition->start_offset());
+    // found in local state
+    if (term >= first_local_term) {
+        auto last_offset = _partition->get_term_last_offset(term);
+        if (last_offset) {
+            return _translator->from_log_offset(*last_offset);
+        }
+    }
+
+    if (
+      _partition->is_remote_fetch_enabled()
+      && _partition->cloud_data_available()) {
+        return _partition->get_cloud_term_last_offset(term);
+    }
+    return std::nullopt;
 }
 } // namespace kafka

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -13,12 +13,15 @@
 #include "cluster/partition.h"
 #include "cluster/partition_probe.h"
 #include "kafka/server/partition_proxy.h"
+#include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "raft/errc.h"
 #include "raft/types.h"
 
 #include <seastar/core/coroutine.hh>
+
+#include <boost/numeric/conversion/cast.hpp>
 
 #include <memory>
 #include <system_error>
@@ -85,6 +88,13 @@ public:
       ss::lw_shared_ptr<const storage::offset_translator_state>) final;
 
     cluster::partition_probe& probe() final { return _partition->probe(); }
+
+    std::optional<model::offset>
+      get_leader_epoch_last_offset(kafka::leader_epoch) const final;
+
+    kafka::leader_epoch leader_epoch() const final {
+        return leader_epoch_from_term(_partition->term());
+    }
 
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -316,6 +316,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<end_txn_handler>(std::move(ctx), g);
     case create_partitions_handler::api::key:
         return do_process<create_partitions_handler>(std::move(ctx), g);
+    case offset_for_leader_epoch_handler::api::key:
+        return do_process<offset_for_leader_epoch_handler>(std::move(ctx), g);
     };
     throw std::runtime_error(
       fmt::format("Unsupported API {}", ctx.header().key));

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "bytes/bytes.h"
+#include "model/fundamental.h"
 #include "reflection/adl.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
@@ -155,6 +156,14 @@ std::ostream& operator<<(std::ostream&, const member_protocol&);
 
 using assignments_type = std::unordered_map<member_id, bytes>;
 
+inline kafka::leader_epoch leader_epoch_from_term(model::term_id term) {
+    try {
+        return kafka::leader_epoch(
+          boost::numeric_cast<kafka::leader_epoch::type>(term()));
+    } catch (boost::bad_numeric_cast&) {
+        return kafka::invalid_leader_epoch;
+    }
+}
 } // namespace kafka
 
 /*

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2119,7 +2119,7 @@ ss::future<storage::append_result> consensus::disk_append(
       });
 }
 
-model::term_id consensus::get_term(model::offset o) {
+model::term_id consensus::get_term(model::offset o) const {
     if (unlikely(o < model::offset(0))) {
         return model::term_id{};
     }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -313,10 +313,6 @@ public:
     std::vector<follower_metrics> get_follower_metrics() const;
     result<follower_metrics> get_follower_metrics(model::node_id) const;
 
-    const configuration_manager& get_configuration_manager() const {
-        return _configuration_manager;
-    }
-
     offset_monitor& visible_offset_monitor() {
         return _consumable_offset_monitor;
     }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -319,6 +319,8 @@ public:
 
     ss::future<> refresh_commit_index();
 
+    model::term_id get_term(model::offset) const;
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;
@@ -384,7 +386,6 @@ private:
     void maybe_update_leader_commit_idx();
     ss::future<> do_maybe_update_leader_commit_idx(ss::semaphore_units<>);
 
-    model::term_id get_term(model::offset);
     clock_type::time_point majority_heartbeat() const;
     /*
      * Start an election. When leadership transfer is requested, the election is

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -80,6 +80,8 @@ public:
     size_t segment_count() const final { return _segs.size(); }
     offset_stats offsets() const final;
     std::optional<model::term_id> get_term(model::offset) const final;
+    std::optional<model::offset>
+    get_term_last_offset(model::term_id term) const final;
     std::ostream& print(std::ostream&) const final;
 
     ss::future<> maybe_roll(

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -72,6 +72,8 @@ public:
         virtual storage::offset_stats offsets() const = 0;
         virtual std::ostream& print(std::ostream& o) const = 0;
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
+        virtual std::optional<model::offset>
+          get_term_last_offset(model::term_id) const = 0;
 
         virtual ss::future<model::offset>
         monitor_eviction(ss::abort_source&) = 0;
@@ -150,6 +152,12 @@ public:
     std::optional<model::term_id> get_term(model::offset o) const {
         return _impl->get_term(o);
     }
+
+    std::optional<model::offset>
+    get_term_last_offset(model::term_id term) const {
+        return _impl->get_term_last_offset(term);
+    }
+
     ss::future<std::optional<timequery_result>>
     timequery(timequery_config cfg) {
         return _impl->timequery(cfg);

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -372,6 +372,16 @@ struct mem_log_impl final : log::impl {
         return std::nullopt;
     }
 
+    std::optional<model::offset>
+    get_term_last_offset(model::term_id term) const final {
+        for (auto it = _data.rbegin(); it != _data.rend(); ++it) {
+            if (it->term() == term) {
+                return it->last_offset();
+            }
+        }
+        return std::nullopt;
+    }
+
     size_t segment_count() const final { return 1; }
 
     storage::offset_stats offsets() const final {

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -38,6 +38,13 @@ struct segment_ordering {
     bool operator()(const type& seg, model::timestamp value) const {
         return seg->index().max_timestamp() < value;
     }
+
+    bool operator()(const type& seg, model::term_id value) const {
+        return seg->offsets().term < value;
+    }
+    bool operator()(model::term_id value, const type& seg) const {
+        return value < seg->offsets().term;
+    }
 };
 
 segment_set::segment_set(segment_set::underlying_t segs)
@@ -140,6 +147,17 @@ segment_set::const_iterator
 segment_set::lower_bound(model::timestamp needle) const {
     return segments_lower_bound(
       std::cbegin(_handles), std::cend(_handles), needle);
+}
+
+segment_set::iterator segment_set::upper_bound(model::term_id term) {
+    return std::upper_bound(
+      _handles.begin(), _handles.end(), term, segment_ordering{});
+}
+
+segment_set::const_iterator
+segment_set::upper_bound(model::term_id term) const {
+    return std::upper_bound(
+      _handles.cbegin(), _handles.cend(), term, segment_ordering{});
 }
 
 std::ostream& operator<<(std::ostream& o, const segment_set& s) {

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -73,6 +73,8 @@ public:
     const_iterator lower_bound(model::offset o) const;
     iterator lower_bound(model::timestamp o);
     const_iterator lower_bound(model::timestamp o) const;
+    iterator upper_bound(model::term_id o);
+    const_iterator upper_bound(model::term_id o) const;
 
     const_iterator cbegin() const { return _handles.cbegin(); }
     const_iterator cend() const { return _handles.cend(); }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -29,22 +29,24 @@ class RpkException(Exception):
 
 
 class RpkPartition:
-    def __init__(self, id, leader, replicas, hw, start_offset):
+    def __init__(self, id, leader, leader_epoch, replicas, hw, start_offset):
         self.id = id
         self.leader = leader
+        self.leader_epoch = leader_epoch
         self.replicas = replicas
         self.high_watermark = hw
         self.start_offset = start_offset
 
     def __str__(self):
-        return "id: {}, leader: {}, replicas: {}, hw: {}, start_offset: {}".format(
-            self.id, self.leader, self.replicas, self.high_watermark,
-            self.start_offset)
+        return "id: {}, leader: {}, leader_epoch: {} replicas: {}, hw: {}, start_offset: {}".format(
+            self.id, self.leader, self.leader_epoch, self.replicas,
+            self.high_watermark, self.start_offset)
 
     def __eq__(self, other):
         if other is None:
             return False
         return self.id == other.id and self.leader == other.leader \
+            and self.leader_epoch == other.leader_epoch \
             and self.replicas == other.replicas \
             and self.high_watermark == other.high_watermark \
             and self.start_offset == other.start_offset
@@ -175,13 +177,14 @@ class RpkTool:
 
         def partition_line(line):
             m = re.match(
-                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>\d+?) +(?P<hw>\d+) *",
+                r" *(?P<id>\d+) +(?P<leader>\d+) +(?P<epoch>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>\d+?) +(?P<hw>\d+) *",
                 line)
             if m == None:
                 return None
             replicas = list(map(lambda r: int(r), m.group('replicas').split()))
             return RpkPartition(id=int(m.group('id')),
                                 leader=int(m.group('leader')),
+                                leader_epoch=int(m.group('epoch')),
                                 replicas=replicas,
                                 hw=int(m.group('hw')),
                                 start_offset=int(m.group("logstart")))

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -1,0 +1,95 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kcl import KCL
+from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.util import (
+    produce_until_segments,
+    wait_for_segments_removal,
+)
+
+
+class OffsetForLeaderEpochArchivalTest(RedpandaTest):
+    """
+    Check offset for leader epoch handling
+    """
+    segment_size = 1 * (2 << 20)
+
+    def _produce(self, topic, msg_cnt):
+        rpk = RpkTool(self.redpanda)
+        for i in range(0, msg_cnt):
+            rpk.produce(topic, f"k-{i}", f"v-{i}")
+
+    def __init__(self, test_context):
+        super(OffsetForLeaderEpochArchivalTest, self).__init__(
+            test_context=test_context,
+            extra_rp_conf={
+                'enable_leader_balancer': False,
+                "log_compaction_interval_ms": 1000
+            },
+            si_settings=SISettings(
+                log_segment_size=OffsetForLeaderEpochArchivalTest.segment_size,
+                cloud_storage_cache_size=5 *
+                OffsetForLeaderEpochArchivalTest.segment_size))
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_querying_remote_partitions(self):
+        topic = TopicSpec(redpanda_remote_read=True,
+                          redpanda_remote_write=True)
+        epoch_offsets = {}
+        rpk = RpkTool(self.redpanda)
+        self.client().create_topic(topic)
+        rpk.alter_topic_config(topic.name, "redpanda.remote.read", 'true')
+        rpk.alter_topic_config(topic.name, "redpanda.remote.write", 'true')
+
+        def wait_for_topic():
+            wait_until(lambda: len(list(rpk.describe_topic(topic.name))) > 0,
+                       30,
+                       backoff_sec=2)
+
+        # restart whole cluster 6 times to trigger term rolls
+        for i in range(0, 6):
+            wait_for_topic()
+            produce_until_segments(
+                redpanda=self.redpanda,
+                topic=topic.name,
+                partition_idx=0,
+                count=2 * i,
+            )
+            res = list(rpk.describe_topic(topic.name))
+            epoch_offsets[res[0].leader_epoch] = res[0].high_watermark
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        self.logger.info(f"ledear epoch high watermarks: {epoch_offsets}")
+
+        wait_for_topic()
+
+        rpk.alter_topic_config(topic.name, TopicSpec.PROPERTY_RETENTION_BYTES,
+                               OffsetForLeaderEpochArchivalTest.segment_size)
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=topic.name,
+                                  partition_idx=0,
+                                  count=7)
+        kcl = KCL(self.redpanda)
+
+        for epoch, offset in epoch_offsets.items():
+            self.logger.info(f"querying partition epoch {epoch} end offsets")
+            epoch_end_offset = kcl.offset_for_leader_epoch(
+                topics=topic.name, leader_epoch=epoch)[0].epoch_end_offset
+            self.logger.info(
+                f"epoch {epoch} end_offset: {epoch_end_offset}, expected offset: {offset}"
+            )
+            assert epoch_end_offset == offset

--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -1,0 +1,112 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kcl import KCL
+from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+
+
+class OffsetForLeaderEpochTest(RedpandaTest):
+    """
+    Check offset for leader epoch handling
+    """
+    def _produce(self, topic, msg_cnt):
+        rpk = RpkTool(self.redpanda)
+        for i in range(0, msg_cnt):
+            rpk.produce(topic, f"k-{i}", f"v-{i}")
+
+    def __init__(self, test_context):
+        super(OffsetForLeaderEpochTest,
+              self).__init__(num_brokers=5,
+                             test_context=test_context,
+                             extra_rp_conf={
+                                 'enable_leader_balancer': False,
+                                 "log_compaction_interval_ms": 1000
+                             })
+
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_offset_for_leader_epoch(self):
+        replication_factors = [1, 3, 5]
+        cleanup_policies = [
+            TopicSpec.CLEANUP_COMPACT, TopicSpec.CLEANUP_DELETE
+        ]
+        topics = []
+
+        for i in range(0, 10):
+            topics.append(
+                TopicSpec(
+                    partition_count=random.randint(1, 50),
+                    replication_factor=random.choice(replication_factors),
+                    cleanup_policy=random.choice(cleanup_policies)))
+
+        topic_names = [t.name for t in topics]
+        # create test topics
+        self.client().create_topic(topics)
+        kcl = KCL(self.redpanda)
+        for t in topics:
+            self._produce(t.name, 20)
+
+        def list_offsets_map():
+            offsets_map = {}
+            offsets = kcl.list_offsets(topic_names)
+            self.logger.info(f"offsets_list: {offsets}")
+            for p in offsets:
+                offsets_map[(p.topic, p.partition)] = int(p.end_offset)
+            self.logger.info(f"offsets_map: {offsets_map}")
+            return offsets_map
+
+        initial_offsets = list_offsets_map()
+
+        leader_epoch_offsets = kcl.offset_for_leader_epoch(topics=topic_names,
+                                                           leader_epoch=1)
+
+        for o in leader_epoch_offsets:
+            assert initial_offsets[(o.topic,
+                                    o.partition)] == o.epoch_end_offset
+
+        # restart all the nodes to force leader election
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        # produce more data
+        for t in topics:
+            self._produce(t.name, 20)
+
+        # check epoch end offsets for term 1
+        leader_epoch_offsets = kcl.offset_for_leader_epoch(topics=topic_names,
+                                                           leader_epoch=1)
+
+        for o in leader_epoch_offsets:
+            assert initial_offsets[(o.topic,
+                                    o.partition)] == o.epoch_end_offset
+
+        last_offsets = list_offsets_map()
+        rpk = RpkTool(self.redpanda)
+        for t in topics:
+            tp_desc = rpk.describe_topic(t.name)
+            for p in tp_desc:
+                for o in kcl.offset_for_leader_epoch(
+                        topics=f"{t.name}:{p.id}",
+                        leader_epoch=p.leader_epoch,
+                        current_leader_epoch=p.leader_epoch):
+                    assert last_offsets[(o.topic,
+                                         o.partition)] == o.epoch_end_offset
+
+        # test returning unknown leader epoch error, we use large leader epoch value
+
+        leader_epoch_offsets = kcl.offset_for_leader_epoch(
+            topics=topic_names, leader_epoch=1, current_leader_epoch=1000)
+
+        for o in leader_epoch_offsets:
+            assert o.error is not None and "UNKNOWN_LEADER_EPOCH" in o.error


### PR DESCRIPTION
## Cover letter

In Kafka, some of the client requests are fenced with the leader epoch. 
The leader epoch is a 32-bit integer that is increased every time the partition 
leadership changes. The leader epoch is used to detect stale metadata, 
fence produce and fetch requests, and recognize truncations.

The leader epoch is used by Kafka clients to detect truncations and stale metadata. 
In Redpanda we are missing that mechanism. This may lead to some issues that 
can occur when one of the nodes is isolated and does not receive metadata updates. 
Returning the leader epoch will allow the client to identify this situation 
and update metadata against a different broker. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3689  

## Release notes

### Features

* Added full support for leader epoch in Redpanda

