### PR TITLE
cloud_manifest: use SAX parsing for topic_manifest

### DIFF
--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -15,6 +15,7 @@
 
 namespace cloud_storage {
 
+struct topic_manifest_handler;
 class topic_manifest final : public base_manifest {
 public:
     /// Create manifest for specific ntp
@@ -55,7 +56,7 @@ public:
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
-    void update(const json::Document& m);
+    void update(const topic_manifest_handler& handler);
 
     std::optional<cluster::topic_configuration> _topic_config;
     model::initial_revision_id _rev;

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -11,7 +11,10 @@
 #pragma once
 
 #include "cloud_storage/base_manifest.h"
+#include "cluster/types.h"
 #include "json/document.h"
+
+#include <optional>
 
 namespace cloud_storage {
 
@@ -52,6 +55,11 @@ public:
 
     /// Change topic-manifest revision
     void set_revision(model::initial_revision_id id) noexcept { _rev = id; }
+
+    std::optional<cluster::topic_configuration> const&
+    get_topic_config() const noexcept {
+        return _topic_config;
+    }
 
 private:
     /// Update manifest content from json document that supposed to be generated

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -59,9 +59,7 @@ enum class manifest_version : int32_t {
     v1 = 1,
 };
 
-enum class topic_manifest_version : int32_t {
-    v1 = 1,
-};
+static constexpr int32_t topic_manifest_version = 1;
 
 std::ostream& operator<<(std::ostream& o, const download_result& r);
 


### PR DESCRIPTION
## Cover letter

Previously we created a `rapidjson::Document` from topic manifest json and then created a `topic_manifest` from that `rapidjson::Document`. That was an unnecessary usage of memory. This PR changes this to use SAX parsing.

~There's a chain of PR that needs to be merged before this one: https://github.com/redpanda-data/redpanda/pull/3784, https://github.com/redpanda-data/redpanda/pull/3785 (they are almost approved already)~

## Release notes
- none