### PR TITLE
rpc/tls: Fix lint error

### DIFF
--- a/src/v/rpc/tls.h
+++ b/src/v/rpc/tls.h
@@ -30,4 +30,4 @@ namespace rpc {
 /// the one that exists. This path is then passed to GnuTLS.
 ss::future<std::optional<ss::sstring>> find_ca_file();
 
-} // namespace net
+} // namespace rpc


### PR DESCRIPTION
## Cover letter

rpc/tls: Fix lint error

Came in from a #3727, but tls is in a different namespace

## Release notes

* none