### PR TITLE
Backport of #3676

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -319,14 +319,25 @@ void metadata_dissemination_service::cleanup_finished_updates() {
 
 ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
     /**
-     * Use currently available health report snapshot to update leadership
-     * information. If snapshot would contain stale data they will be ignored by
+     * Use currently available health report to update leadership
+     * information. If report would contain stale data they will be ignored by
      * term check in partition leaders table
      */
     return _health_monitor.local()
-      .get_current_cluster_health_snapshot(cluster_report_filter{})
-      .then([this](cluster_health_report report) {
-          return update_leaders_with_health_report(std::move(report));
+      .get_cluster_health(
+        cluster_report_filter{},
+        force_refresh::no,
+        _dissemination_interval + model::timeout_clock::now())
+      .then([this](result<cluster_health_report> report) {
+          if (report.has_error()) {
+              vlog(
+                clusterlog.info,
+                "unable to retrieve cluster health report - {}",
+                report.error().message());
+              return ss::now();
+          }
+
+          return update_leaders_with_health_report(std::move(report.value()));
       })
       .then([this] {
           collect_pending_updates();


### PR DESCRIPTION
Previously metadata dissemination service used cluster health snapshot
to update partition leaders metadata. This might lead to situation in
which cluster health report in never requested and eventually metadata
information is not updated. This may lead to situation in which
different subsystems querying `cluster::partitions_leaders_table`
directly would receive stale leadership information. (if dissemination
request was lost)
Changed the metadata dissemination to request cluster health report
refresh. This way leadership information will always be updated and not
older than health monitor max metadata age.
