### PR TITLE
tests/many_partitions_test: bump raft_election_timeout_ms

### DIFF
--- a/tests/rptest/tests/many_partitions_test.py
+++ b/tests/rptest/tests/many_partitions_test.py
@@ -75,6 +75,7 @@ class ManyPartitionsTest(RedpandaTest):
                 # on weaker test nodes.
                 'raft_heartbeat_interval_ms': 450,
                 'raft_heartbeat_timeout_ms': 9000,
+                'election_timeout_ms': 4500,
                 'replicate_append_timeout_ms': 9000,
                 'recovery_append_timeout_ms': 15000,
             },


### PR DESCRIPTION
This test already increased timeouts to reduce leadership
flaps on oversubscribed test nodes, but missed this
particular property.

On ARM nodes in particular, we have seen CPU stalls
long enough to trip the default 1500ms timeout and
cause nodes to drop leadership.

Fixes https://github.com/redpanda-data/redpanda/issues/3797

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
