### PR TITLE
tests: update log allow list for partition_movement_test

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -30,7 +30,9 @@ PARTITION_MOVEMENT_LOG_ERRORS = [
     # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
     "raft - .*raft group does not exist on target broker",
     # e.g.  raft - [group_id:3, {kafka/topic/2}] consensus.cc:2317 - unable to replicate updated configuration: raft::errc::replicated_entry_truncated
-    "raft - .*unable to replicate updated configuration: .*"
+    "raft - .*unable to replicate updated configuration: .*",
+    # e.g. recovery_stm.cc:432 - recovery append entries error: rpc::errc::client_request_timeout"
+    "raft - .*recovery append entries error.*client_request_timeout"
 ]
 
 


### PR DESCRIPTION
## Cover letter

Quick fix for a failure seen here:
https://buildkite.com/redpanda/redpanda/builds/7283#2de1c01f-73dc-41f1-af52-d3d5f9275e25

As with other updates to log allow lists, this is potentially a candidate for revisiting with a change to the underlying logging later -- our log allow lists become to-do lists for cleaning the logging up.

## Release notes

* none
