### PR TITLE
Make id_allocator less likely to stuck

### DIFF
--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -166,17 +166,27 @@ ss::future<> id_allocator_stm::apply(model::record_batch b) {
 
         _processed++;
         if (_processed > _log_capacity) {
-            return _c
-              ->write_snapshot(
-                raft::write_snapshot_cfg(_next_snapshot, iobuf()))
-              .then([this] {
-                  _next_snapshot = _insync_offset;
-                  _processed = 0;
-              });
+            ssx::spawn_with_gate(_gate, [this] { return write_snapshot(); });
         }
     }
 
     return ss::now();
+}
+
+ss::future<> id_allocator_stm::write_snapshot() {
+    if (_is_writing_snapshot) {
+        return ss::now();
+    }
+    if (_processed <= _log_capacity) {
+        return ss::now();
+    }
+    _is_writing_snapshot = true;
+    return _c->write_snapshot(raft::write_snapshot_cfg(_next_snapshot, iobuf()))
+      .then([this] {
+          _next_snapshot = _insync_offset;
+          _processed = 0;
+      })
+      .finally([this] { _is_writing_snapshot = false; });
 }
 
 ss::future<> id_allocator_stm::apply_snapshot(stm_snapshot_header, iobuf&&) {

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -97,6 +97,7 @@ private:
 
     ss::future<> apply(model::record_batch) override;
 
+    ss::future<> write_snapshot();
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
     ss::future<> handle_eviction() override;
@@ -125,6 +126,8 @@ private:
     int64_t _curr_id{0};
     int64_t _curr_batch{0};
     int64_t _state{0};
+
+    bool _is_writing_snapshot{false};
 };
 
 } // namespace cluster

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -178,6 +178,7 @@ ss::future<bool> persisted_stm::do_sync(
   model::term_id term) {
     const auto committed = _c->committed_offset();
     const auto ntp = _c->ntp();
+    _c->events().notify_commit_index();
 
     if (offset > committed) {
         try {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2397,7 +2397,7 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
           range_start,
           _commit_index);
         _commit_index_updated.broadcast();
-        _event_manager.notify_commit_index(_commit_index);
+        _event_manager.notify_commit_index();
         // if we successfully acknowledged all quorum writes we can make pending
         // relaxed consistency requests visible
         if (_commit_index >= _last_quorum_replicated_index) {
@@ -2425,7 +2425,7 @@ consensus::maybe_update_follower_commit_idx(model::offset request_commit_idx) {
             vlog(
               _ctxlog.trace, "Follower commit index updated {}", _commit_index);
             _commit_index_updated.broadcast();
-            _event_manager.notify_commit_index(_commit_index);
+            _event_manager.notify_commit_index();
         }
     }
     return ss::make_ready_future<>();

--- a/src/v/raft/event_manager.cc
+++ b/src/v/raft/event_manager.cc
@@ -42,6 +42,6 @@ ss::future<> event_manager::wait(
     return _commit_index.wait(offset, timeout, as);
 }
 
-void event_manager::notify_commit_index(model::offset) { _cond.signal(); }
+void event_manager::notify_commit_index() { _cond.signal(); }
 
 } // namespace raft

--- a/src/v/raft/event_manager.h
+++ b/src/v/raft/event_manager.h
@@ -51,7 +51,7 @@ public:
     ss::future<>
     wait(model::offset, model::timeout_clock::time_point, ss::abort_source&);
 
-    void notify_commit_index(model::offset);
+    void notify_commit_index();
 
 private:
     consensus* _consensus;


### PR DESCRIPTION
## Cover letter

Decouple snapshots and apply to avoid `write_snapshot` blocking apply and `state_machine::wait` as a result

`notify_commit_index` before sync to unblock apply in case it missed an update from consensus.

## Release notes

* none