### PR TITLE
persisted_stm: fix directory not empty error

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -190,7 +190,7 @@ ss::future<allocate_id_reply> id_allocator_frontend::do_allocate_id(
               return ss::make_ready_future<allocate_id_reply>(
                 allocate_id_reply{0, errc::topic_not_exists});
           }
-          auto& stm = partition->id_allocator_stm();
+          auto stm = partition->id_allocator_stm();
           if (!stm) {
               vlog(
                 clusterlog.warn,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -41,7 +41,7 @@ partition::partition(
     auto stm_manager = _raft->log().stm_manager();
 
     if (is_id_allocator_topic(_raft->ntp())) {
-        _id_allocator_stm = ss::make_lw_shared<cluster::id_allocator_stm>(
+        _id_allocator_stm = ss::make_shared<cluster::id_allocator_stm>(
           clusterlog, _raft.get());
     } else if (is_tx_manager_topic(_raft->ntp())) {
         if (_raft->log_config().is_collectable()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -171,7 +171,7 @@ public:
         return _raft->get_latest_configuration_offset();
     }
 
-    ss::lw_shared_ptr<cluster::id_allocator_stm>& id_allocator_stm() {
+    ss::shared_ptr<cluster::id_allocator_stm> id_allocator_stm() {
         return _id_allocator_stm;
     }
 
@@ -244,6 +244,21 @@ public:
         return _cloud_storage_partition->make_reader(config, deadline);
     }
 
+    ss::future<> remove_persistent_state() {
+        if (_rm_stm) {
+            co_await _rm_stm->remove_persistent_state();
+        }
+        if (_tm_stm) {
+            co_await _tm_stm->remove_persistent_state();
+        }
+        if (_archival_meta_stm) {
+            co_await _archival_meta_stm->remove_persistent_state();
+        }
+        if (_id_allocator_stm) {
+            co_await _id_allocator_stm->remove_persistent_state();
+        }
+    }
+
 private:
     friend partition_manager;
     friend replicated_partition_probe;
@@ -253,7 +268,7 @@ private:
 private:
     consensus_ptr _raft;
     ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;
-    ss::lw_shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
+    ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -154,6 +154,7 @@ ss::future<> partition_manager::remove(const model::ntp& ntp) {
       .remove(partition->raft())
       .then([this, ntp] { _unmanage_watchers.notify(ntp, ntp.tp.partition); })
       .then([partition] { return partition->stop(); })
+      .then([partition] { return partition->remove_persistent_state(); })
       .then([this, ntp] { return _storage.log_mgr().remove(ntp); })
       .finally([partition] {}); // in the end remove partition
 }

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -31,6 +31,11 @@ persisted_stm::persisted_stm(
       ss::default_priority_class())
   , _log(logger) {}
 
+ss::future<> persisted_stm::remove_persistent_state() {
+    co_await _snapshot_mgr.remove_snapshot();
+    co_await _snapshot_mgr.remove_partial_snapshots();
+}
+
 ss::future<std::optional<stm_snapshot>> persisted_stm::load_snapshot() {
     auto maybe_reader = co_await _snapshot_mgr.open_snapshot();
     if (!maybe_reader) {

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -89,6 +89,7 @@ public:
     void make_snapshot_in_background() final;
     ss::future<> ensure_snapshot_exists(model::offset) final;
     model::offset max_collectible_offset() override;
+    ss::future<> remove_persistent_state();
 
     ss::future<> make_snapshot();
     /*


### PR DESCRIPTION
## Cover letter

When users delete a partition with idempotency or transactions enabled they observe directory not empty error. This PR fixes it.

Fixes #3287

## Release notes

* none