### PR TITLE
Fixed updating leadership metadata after topic is recreated

### DIFF
--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -18,6 +18,7 @@
 #include "utils/expiring_promise.h"
 
 #include <seastar/core/sharded.hh>
+#include <seastar/util/bool_class.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
@@ -33,6 +34,7 @@ namespace cluster {
 /// received by cluster::metadata_dissemination_service.
 class partition_leaders_table {
 public:
+    using force_leader_update = ss::bool_class<struct force_leader_update_tag>;
     explicit partition_leaders_table(ss::sharded<topic_table>&);
 
     ss::future<> stop();
@@ -78,7 +80,10 @@ public:
     }
 
     void update_partition_leader(
-      const model::ntp&, model::term_id, std::optional<model::node_id>);
+      const model::ntp&,
+      model::term_id,
+      std::optional<model::node_id>,
+      force_leader_update force_update = force_leader_update::no);
 
 private:
     // optimized to reduce number of ntp copies

--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -1,0 +1,97 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from ducktape.mark import parametrize
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RecreateTopicMetadataTest(RedpandaTest):
+    def __init__(self, test_context):
+
+        super(RecreateTopicMetadataTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=5,
+                             extra_rp_conf={})
+
+    @cluster(num_nodes=5)
+    @parametrize(replication_factor=3)
+    @parametrize(replication_factor=5)
+    def test_recreated_topic_metadata_are_valid(self, replication_factor):
+        """
+        Test recreated topic metadata are valid across all the nodes
+        """
+
+        topic = 'tp-test'
+        partition_count = 5
+        rpk = RpkTool(self.redpanda)
+        kcat = KafkaCat(self.redpanda)
+        admin = Admin(self.redpanda)
+        # create topic with replication factor of 3
+        rpk.create_topic(topic='tp-test',
+                         partitions=partition_count,
+                         replicas=replication_factor)
+
+        # produce some data to the topic
+
+        def wait_for_leader(partition, expected_leader):
+            leader, _ = kcat.get_partition_leader(topic, partition)
+            return leader == expected_leader
+
+        def transfer_all_leaders():
+            partitions = rpk.describe_topic(topic)
+            for p in partitions:
+                replicas = set(p.replicas)
+                replicas.remove(p.leader)
+                target = random.choice(list(replicas))
+                admin.partition_transfer_leadership("kafka", topic, p.id,
+                                                    target)
+                wait_until(lambda: wait_for_leader(p.id, target),
+                           timeout_sec=30,
+                           backoff_sec=1)
+
+        for i in range(0, 100):
+            rpk.produce(topic=topic, key=str(i), msg=f"payload-{i}")
+
+        # transfer leadership to grow the term
+        for i in range(0, 10):
+            transfer_all_leaders()
+
+        # recreate the topic
+        rpk.delete_topic(topic)
+        rpk.create_topic(topic='tp-test',
+                         partitions=partition_count,
+                         replicas=3)
+
+        def metadata_consistent():
+            # validate leadership information on each node
+            for p in range(0, partition_count):
+                leaders = set()
+                for n in self.redpanda.nodes:
+                    admin_partition = admin.get_partitions(topic=topic,
+                                                           partition=p,
+                                                           namespace="kafka",
+                                                           node=n)
+                    self.logger.info(
+                        f"node: {n.account.hostname} partition: {admin_partition}"
+                    )
+                    leaders.add(admin_partition['leader_id'])
+
+                self.logger.info(f"{topic}/{p} leaders: {leaders}")
+                if len(leaders) != 1:
+                    return False
+            return True
+
+        wait_until(metadata_consistent, 30, backoff_sec=2)


### PR DESCRIPTION
## Cover letter

When partition is deleted and then created again its NTP does not change
but all underlying structures are reset. Raft `term` value is
initialized to 0.

In partitions leaders table we use `term` to fence stale metadata
updates. Currently `partitions_leader_table` is not aware of partition
revision. When term is reset after partition is deleted and then created
again all the updates coming from the new partition instance are ignored
since their `term` value is smaller from the one that is currently
stored in `partitions_leaders_table`.

When deleting topic `partitions_leader_table` entries related with its
partition are deleted, however this action is not coordinated on all of
the nodes and this may lead to situation in which metadata dissemination
update will be lost and/or leadership update coming from the partition
that was deleted is applied after the entry was deleted from leaders
table.

Implemented a heuristic that checks if majority of current replicas
agree on the leader value and forcing an update in leader table. This
way even when topic was recreated we eventually force update its
leadership information.

This solution is temporary. We need to add revision id to all RPC
requests related with leadership updates, this way we will know exactly
the partition instance that the update is related with.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
