### PR TITLE
admin: add HTTP basic authentication

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -512,7 +512,7 @@ func (r *ClusterReconciler) setInitialSuperUserPassword(
 		urls = append(urls, fmt.Sprintf("%s-%d.%s:%d", redpandaCluster.Name, i, fqdn, adminInternalPort))
 	}
 
-	adminAPI, err := admin.NewAdminAPI(urls, nil)
+	adminAPI, err := admin.NewAdminAPI(urls, admin.BasicCredentials{}, nil)
 	if err != nil {
 		return fmt.Errorf("creating admin api: %w", err)
 	}

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -101,7 +101,7 @@ func TestAdminAPI(t *testing.T) {
 				urls = append(urls, ts.URL)
 			}
 
-			adminClient, err := NewAdminAPI(urls, nil)
+			adminClient, err := NewAdminAPI(urls, BasicCredentials{}, nil)
 			require.NoError(t, err)
 			err = tt.action(t, adminClient)
 			require.NoError(t, err)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -147,6 +147,13 @@ configuration::configuration()
         .max = 1000 // A system with 1M ulimit should be allowed to create at
                     // least 1000 partitions
       })
+  , admin_api_require_auth(
+      *this,
+      "admin_api_require_auth",
+      "Whether admin API clients must provide HTTP Basic authentication "
+      "headers",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , seed_server_meta_topic_partitions(
       *this, "seed_server_meta_topic_partitions")
   , raft_heartbeat_interval_ms(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -175,12 +175,7 @@ configuration::configuration()
   , max_version(*this, "max_version")
 
   , use_scheduling_groups(*this, "use_scheduling_groups")
-  , enable_admin_api(
-      *this,
-      "enable_admin_api",
-      "Enable the admin API",
-      base_property::metadata{},
-      true)
+  , enable_admin_api(*this, "enable_admin_api")
   , default_num_windows(
       *this,
       "default_num_windows",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -69,7 +69,7 @@ struct configuration final : public config_store {
     deprecated_property max_version;
     // Kafka
     deprecated_property use_scheduling_groups;
-    property<bool> enable_admin_api;
+    deprecated_property enable_admin_api;
     bounded_property<int16_t> default_num_windows;
     bounded_property<std::chrono::milliseconds> default_window_sec;
     property<std::chrono::milliseconds> quota_manager_gc_sec;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -60,6 +60,9 @@ struct configuration final : public config_store {
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;
     bounded_property<std::optional<int32_t>> topic_fds_per_partition;
 
+    // Admin API
+    property<bool> admin_api_require_auth;
+
     // Raft
     deprecated_property seed_server_meta_topic_partitions;
     bounded_property<std::chrono::milliseconds> raft_heartbeat_interval_ms;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -73,6 +73,7 @@ v_cc_library(
   NAME application
   SRCS 
     admin_server.cc
+    request_auth.cc
     application.cc
   DEPS
     Seastar::seastar

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -540,35 +540,26 @@ ss::future<> admin_server::throw_on_error(
 }
 
 void admin_server::register_config_routes() {
-    auto get_config_handler_f = new ss::httpd::function_handler{
-      [this](ss::const_req req, ss::reply& reply) {
-          _auth.authenticate(req).require_superuser();
+    register_route_raw<superuser>(
+      ss::httpd::config_json::get_config, [](ss::const_req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
           config::shard_local_cfg().to_json(writer);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
-      },
-      "json"};
+      });
 
-    ss::httpd::config_json::get_config.set(
-      _server._routes, get_config_handler_f);
-
-    auto get_node_config_handler_f = new ss::httpd::function_handler{
-      [this](ss::const_req req, ss::reply& reply) {
-          _auth.authenticate(req).require_superuser();
+    register_route_raw<superuser>(
+      ss::httpd::config_json::get_node_config,
+      [](ss::const_req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
           config::node().to_json(writer);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
-      },
-      "json"};
-
-    ss::httpd::config_json::get_node_config.set(
-      _server._routes, get_node_config_handler_f);
+      });
 
     register_route<superuser>(
       ss::httpd::config_json::set_log_level,

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -44,6 +44,7 @@
 #include "redpanda/admin/api-doc/security.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
 #include "redpanda/admin/api-doc/transaction.json.h"
+#include "redpanda/request_auth.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "vlog.h"
@@ -90,7 +91,9 @@ admin_server::admin_server(
   , _cp_partition_manager(cpm)
   , _controller(controller)
   , _shard_table(st)
-  , _metadata_cache(metadata_cache) {}
+  , _metadata_cache(metadata_cache)
+  , _auth(
+      config::shard_local_cfg().admin_api_require_auth.bind(), _controller) {}
 
 ss::future<> admin_server::start() {
     configure_metrics_route();

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -14,6 +14,7 @@
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
 #include "model/metadata.h"
+#include "request_auth.h"
 #include "seastarx.h"
 
 #include <seastar/core/scheduling.hh>
@@ -117,5 +118,8 @@ private:
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
+
+    request_authenticator _auth;
+
     bool _ready{false};
 };

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -30,7 +30,6 @@ struct admin_server_cfg {
     std::vector<config::endpoint_tls_config> endpoints_tls;
     std::optional<ss::sstring> dashboard_dir;
     ss::sstring admin_api_docs_dir;
-    bool enable_admin_api;
     ss::scheduling_group sg;
 };
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -428,16 +428,15 @@ admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
       .endpoints_tls = config::node().admin_api_tls(),
       .dashboard_dir = config::node().dashboard_dir(),
       .admin_api_docs_dir = config::node().admin_api_doc_dir(),
-      .enable_admin_api = config::shard_local_cfg().enable_admin_api(),
       .sg = sgs.admin_sg(),
     };
 }
 
 void application::configure_admin_server() {
-    auto& conf = config::shard_local_cfg();
-    if (!conf.enable_admin_api()) {
+    if (config::node().admin().empty()) {
         return;
     }
+
     syschecks::systemd_message("constructing http server").get();
     construct_service(
       _admin,
@@ -1189,7 +1188,7 @@ void application::start_redpanda() {
 
     quota_mgr.invoke_on_all(&kafka::quota_manager::start).get();
 
-    if (config::shard_local_cfg().enable_admin_api()) {
+    if (!config::node().admin().empty()) {
         _admin.invoke_on_all(&admin_server::start).get0();
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -428,8 +428,7 @@ admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
       .endpoints_tls = config::node().admin_api_tls(),
       .dashboard_dir = config::node().dashboard_dir(),
       .admin_api_docs_dir = config::node().admin_api_doc_dir(),
-      .sg = sgs.admin_sg(),
-    };
+      .sg = sgs.admin_sg()};
 }
 
 void application::configure_admin_server() {

--- a/src/v/redpanda/request_auth.cc
+++ b/src/v/redpanda/request_auth.cc
@@ -109,8 +109,11 @@ request_auth_result request_authenticator::do_authenticate(
               "Unauthorized", ss::httpd::reply::status_type::unauthorized);
         } else {
             const auto& cred = cred_opt.value();
-            bool is_valid = security::scram_sha256::validate_password(
-              password, cred.stored_key(), cred.salt(), cred.iterations());
+            bool is_valid = (
+              security::scram_sha256::validate_password(
+                password, cred.stored_key(), cred.salt(), cred.iterations())
+              || security::scram_sha512::validate_password(
+                password, cred.stored_key(), cred.salt(), cred.iterations()));
             if (!is_valid) {
                 // User found, password doesn't match
                 vlog(

--- a/src/v/redpanda/request_auth.cc
+++ b/src/v/redpanda/request_auth.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "request_auth.h"
+
+#include "cluster/controller.h"
+#include "config/configuration.h"
+#include "seastar/http/exception.hh"
+#include "security/scram_algorithm.h"
+#include "vlog.h"
+
+static ss::logger logger{"request_auth"};
+
+request_authenticator::request_authenticator(
+  config::binding<bool> require_auth, cluster::controller* controller)
+  : _controller(controller)
+  , _require_auth(std::move(require_auth)) {}
+
+/**
+ * Attempt to authenticate the request.
+ *
+ * The returned object **must be used** via one of its authorization
+ * helpers (e.g. require_superuser) or it will throw an exception
+ * on destruction.
+ *
+ * @param req
+ * @return
+ */
+request_auth_result
+request_authenticator::authenticate(const ss::httpd::request& req) {
+    if (_controller == nullptr) {
+        // We are running outside of an environment with credentials, e.g.
+        // a unit test or a standalone pandaproxy/schema_registry
+        return request_auth_result(
+          request_auth_result::authenticated::yes,
+          request_auth_result::superuser::yes);
+    }
+
+    const auto& cred_store = _controller->get_credential_store().local();
+    try {
+        return do_authenticate(req, cred_store, _require_auth());
+    } catch (ss::httpd::base_exception const& e) {
+        if (e.status() == ss::httpd::reply::status_type::unauthorized) {
+            if (_require_auth()) {
+                throw;
+            } else {
+                // Auth is disabled: give this user full access, but
+                // treat them as anonymous.
+                return request_auth_result(
+                  request_auth_result::authenticated::yes,
+                  request_auth_result::superuser::yes);
+            }
+        } else {
+            throw;
+        }
+    }
+}
+
+request_auth_result request_authenticator::do_authenticate(
+  ss::httpd::request const& req,
+  security::credential_store const& cred_store,
+  bool require_auth) {
+    security::credential_user username;
+
+    auto auth_hdr = req.get_header("authorization");
+    if (auth_hdr.substr(0, 5) == "Basic") {
+        // Minimal length: Basic, a space, 1 or more bytes
+        if (auth_hdr.size() < 7) {
+            throw ss::httpd::bad_request_exception(
+              "Malformed Authorization header");
+        }
+
+        auto base64 = auth_hdr.substr(6);
+        ss::sstring decoded_bytes;
+        try {
+            decoded_bytes = base64_to_string(base64);
+        } catch (base64_decoder_exception const&) {
+            vlog(logger.info, "Client auth failure: bad BASE64 encoding");
+            throw ss::httpd::bad_request_exception(
+              "Malformed Authorization header");
+        }
+
+        auto colon = decoded_bytes.find(":");
+        if (colon == std::string::npos || colon == decoded_bytes.size() - 1) {
+            vlog(logger.info, "Client auth failure: malformed 'user:password'");
+            throw ss::httpd::bad_request_exception(
+              "Malformed Authorization header");
+        }
+        username = security::credential_user{decoded_bytes.substr(0, colon)};
+        auto password = ss::sstring(decoded_bytes.substr(colon + 1));
+
+        const auto cred_opt = cred_store.get<security::scram_credential>(
+          username);
+        if (!cred_opt.has_value()) {
+            // User not found
+            vlog(
+              logger.info,
+              "Client auth failure: user '{}' not found",
+              username);
+            throw ss::httpd::base_exception(
+              "Unauthorized", ss::httpd::reply::status_type::unauthorized);
+        } else {
+            const auto& cred = cred_opt.value();
+            bool is_valid = security::scram_sha256::validate_password(
+              password, cred.stored_key(), cred.salt(), cred.iterations());
+            if (!is_valid) {
+                // User found, password doesn't match
+                vlog(
+                  logger.info,
+                  "Client auth failure: user '{}' wrong password",
+                  username);
+                throw ss::httpd::base_exception(
+                  "Unauthorized", ss::httpd::reply::status_type::unauthorized);
+            } else {
+                vlog(logger.trace, "Authenticated user {}", username);
+                const auto& superusers = config::shard_local_cfg().superusers();
+                auto found = std::find(
+                  superusers.begin(), superusers.end(), username);
+                bool superuser = (found != superusers.end()) || (!require_auth);
+                return request_auth_result(
+                  username, request_auth_result::superuser(superuser));
+            }
+        }
+    } else if (!auth_hdr.empty()) {
+        throw ss::httpd::bad_request_exception(
+          "Unsupported Authorization method");
+    } else {
+        // No Authorization header: user is anonymous
+        if (require_auth) {
+            return request_auth_result(
+              request_auth_result::authenticated::no,
+              request_auth_result::superuser::no);
+        } else {
+            return request_auth_result(
+              request_auth_result::authenticated::yes,
+              request_auth_result::superuser::yes);
+        }
+    }
+}
+
+void request_auth_result::require_superuser() {
+    _checked = true;
+    if (!_superuser) {
+        vlog(
+          logger.info,
+          "Client authorization failure: {} is not a superuser",
+          _username);
+        throw ss::httpd::base_exception(
+          "Forbidden (superuser role required)",
+          ss::httpd::reply::status_type::forbidden);
+    }
+}
+
+void request_auth_result::require_authenticated() {
+    _checked = true;
+    if (!_authenticated) {
+        vlog(
+          logger.info,
+          "Client authorization failure: user must be authenticated");
+        throw ss::httpd::base_exception(
+          "Forbidden (authentication is required)",
+          ss::httpd::reply::status_type::unauthorized);
+    }
+}
+
+void request_auth_result::pass() { _checked = true; }
+
+/**
+ * It is important to protect against someone calling authenticate()
+ * but then not calling any of the authorization helpers: this indicates
+ * a request handler that might be unintentionally allowing unchecked
+ * access.
+ *
+ * This is a rare case of a throwing destructor.  It is made safe by
+ * checking if there is already an exception in flight first, and by
+ * knowing that all our member objects have nothrow destructors.
+ */
+request_auth_result::~request_auth_result() noexcept(false) {
+    if (!_checked && !std::current_exception()) {
+        vlog(
+          logger.error, "request_auth_result destroyed without being checked!");
+
+        // In this case, it is essential that we do not send any data
+        // in a response: they get a 500 instead.  Since this is security
+        // code, we do not tell them why.
+        throw ss::httpd::server_error_exception("Internal Error");
+    }
+}

--- a/src/v/redpanda/request_auth.h
+++ b/src/v/redpanda/request_auth.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "config/property.h"
+
+#include <seastar/http/request.hh>
+
+#include <security/credential_store.h>
+
+/**
+ * Helper for HTTP request handlers that would like to enforce
+ * authentication and authorization rules.
+ *
+ * Authentication is done on construction: either basic auth or mtls is
+ * accepted.  If neither succeeds, an http response exception will be thrown.
+ *
+ * Authorization is done using one of the require_* methods: e.g.
+ * require_superuser.
+ */
+class [[nodiscard]] request_auth_result {
+public:
+    using authenticated = ss::bool_class<struct authenticated_tag>;
+    using superuser = ss::bool_class<struct superuser_tag>;
+
+    /**
+     * Authenticated user.  They have passed authentication so we know
+     * their identity, and whether that identity is a superuser.
+     *
+     * @param username
+     * @param is_superuser
+     */
+    request_auth_result(
+      security::credential_user username, superuser is_superuser)
+      : _username(username)
+      , _authenticated(true)
+      , _superuser(is_superuser){};
+
+    /**
+     * Anonymous user.  They may still be considered authenticated/superuser
+     * if the global require_auth property is set to false (i.e. anonymous
+     * users have all powers)
+     */
+    request_auth_result(authenticated is_authenticated, superuser is_superuser)
+      : _authenticated(is_authenticated)
+      , _superuser(is_superuser){};
+
+    ~request_auth_result() noexcept(false);
+
+    /**
+     * Raise 403 if not a superuser
+     */
+    void require_superuser();
+
+    /**
+     * Raise 403 if not authenticated
+     */
+    void require_authenticated();
+
+    /**
+     * Do nothing.  Hook for logging access on un-authenticated API endpoints.
+     */
+    void pass();
+
+    ss::sstring const& get_username() const { return _username; }
+
+private:
+    security::credential_user _username;
+    bool _authenticated{false};
+    bool _superuser{false};
+    bool _checked{false};
+};
+
+class request_authenticator {
+public:
+    request_authenticator(
+      config::binding<bool> require_auth, cluster::controller*);
+
+    request_auth_result authenticate(const ss::httpd::request& req);
+
+private:
+    request_auth_result do_authenticate(
+      ss::httpd::request const& req,
+      security::credential_store const& cred_store,
+      bool require_auth);
+
+    cluster::controller* _controller{nullptr};
+    config::binding<bool> _require_auth;
+};

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -163,12 +163,13 @@ public:
 
             config.get("enable_pid_file").set_value(false);
             config.get("developer_mode").set_value(true);
-            config.get("enable_admin_api").set_value(false);
             config.get("join_retry_timeout_ms").set_value(100ms);
             config.get("members_backend_retry_ms").set_value(1000ms);
             config.get("disable_metrics").set_value(true);
 
             auto& node_config = config::node();
+            node_config.get("admin").set_value(
+              std::vector<model::broker_endpoint>());
             node_config.get("node_id").set_value(node_id);
             node_config.get("rack").set_value(
               std::optional<ss::sstring>(rack_name));

--- a/src/v/security/tests/scram_algorithm_test.cc
+++ b/src/v/security/tests/scram_algorithm_test.cc
@@ -289,4 +289,19 @@ BOOST_AUTO_TEST_CASE(server_final_message_ctor) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(validate_password) {
+    ss::sstring password = "letmein";
+    ss::sstring garbage = "letmeout";
+    int iterations = 3;
+
+    auto creds = scram_sha256::make_credentials(password, iterations);
+
+    bool check_password = scram_sha256::validate_password(
+      password, creds.stored_key(), creds.salt(), creds.iterations());
+    bool check_garbage = scram_sha256::validate_password(
+      garbage, creds.stored_key(), creds.salt(), creds.iterations());
+    BOOST_REQUIRE_EQUAL(check_password, true);
+    BOOST_REQUIRE_EQUAL(check_garbage, false);
+}
+
 } // namespace security

--- a/src/v/utils/base64.cc
+++ b/src/v/utils/base64.cc
@@ -21,8 +21,10 @@ static inline size_t encode_capacity(size_t input_size) {
     return (((4 * input_size) / 3) + 3) & ~0x3U;
 }
 
-bytes base64_to_bytes(std::string_view input) {
-    bytes output(bytes::initialized_later{}, input.size());
+template<typename S>
+S base64_to_string_impl(std::string_view input) {
+    using initialized_later = typename S::initialized_later;
+    S output(initialized_later{}, input.size());
     size_t output_len; // NOLINT
     int ret = base64_decode(
       input.data(),
@@ -40,6 +42,14 @@ bytes base64_to_bytes(std::string_view input) {
       input.size());
     output.resize(output_len);
     return output;
+}
+
+bytes base64_to_bytes(std::string_view input) {
+    return base64_to_string_impl<bytes>(input);
+}
+
+ss::sstring base64_to_string(std::string_view input) {
+    return base64_to_string_impl<ss::sstring>(input);
 }
 
 ss::sstring bytes_to_base64(bytes_view input) {

--- a/src/v/utils/base64.h
+++ b/src/v/utils/base64.h
@@ -26,5 +26,8 @@ public:
 bytes base64_to_bytes(std::string_view);
 ss::sstring bytes_to_base64(bytes_view);
 
+// base64 -> string
+ss::sstring base64_to_string(std::string_view);
+
 // base64 <-> iobuf
 ss::sstring iobuf_to_base64(const iobuf&);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -25,10 +25,16 @@ class Admin:
     value is a decoded dict of the JSON payload, for other requests
     the successful HTTP response object is returned.
     """
-    def __init__(self, redpanda, default_node=None, retry_codes=None):
+    def __init__(self,
+                 redpanda,
+                 default_node=None,
+                 retry_codes=None,
+                 auth=None):
         self.redpanda = redpanda
 
         self._session = requests.Session()
+        if auth is not None:
+            self._session.auth = auth
 
         self._default_node = default_node
 
@@ -118,6 +124,9 @@ class Admin:
 
         r.raise_for_status()
         return r
+
+    def get_status_ready(self, node=None):
+        return self._request("GET", "status/ready", node=node).json()
 
     def get_cluster_config(self, node=None):
         return self._request("GET", "config", node=node).json()
@@ -259,6 +268,9 @@ class Admin:
         path = f"security/users/{username}"
 
         self._request("delete", path)
+
+    def list_users(self, node=None):
+        return self._request("get", "security/users", node=node).json()
 
     def partition_transfer_leadership(self, namespace, topic, partition,
                                       target_id):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -309,6 +309,9 @@ class RedpandaService(Service):
             self._log_level = log_level
 
         self._admin = Admin(self)
+        self._admin = Admin(self,
+                            auth=(self.SUPERUSER_CREDENTIALS.username,
+                                  self.SUPERUSER_CREDENTIALS.password))
         self._started = []
         self._security_config = dict()
 

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -1,0 +1,186 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from contextlib import contextmanager
+from requests.exceptions import HTTPError
+
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SaslCredentials
+
+from ducktape.utils.util import wait_until
+
+
+@contextmanager
+def expect_exception(exception_klass, validator):
+    """
+    :param exception_klass: the expected exception type
+    :param validator: a callable that is expected to return true when passed the exception
+    :return: None.  Raises on unexpected exception or no exception.
+    """
+    try:
+        yield
+    except exception_klass as e:
+        if not validator(e):
+            raise
+    else:
+        raise RuntimeError("Expected an exception!")
+
+
+def expect_http_error(status_code: int):
+    """
+    Context manager for HTTP calls expected to result in an HTTP exception
+    carrying a particular status code.
+
+    :param status_code: expected HTTP status code
+    :return: None.  Raises on unexpected exception, no exception, or unexpected status code.
+    """
+    return expect_exception(HTTPError,
+                            lambda e: e.response.status_code == status_code)
+
+
+def create_user_and_wait(redpanda, admin: Admin, creds: SaslCredentials):
+    admin.create_user(*creds)
+
+    def user_exists_everywhere():
+        for node in redpanda.nodes:
+            users = redpanda._admin.list_users(node=node)
+            if creds.username not in users:
+                redpanda.logger.info(f"{creds.username} not in {users}")
+                return False
+
+        return True
+
+    # It should only take milliseconds for raft0 write to propagate
+    wait_until(user_exists_everywhere, timeout_sec=5, backoff_sec=0.5)
+
+
+# A user account who is not the default superuser
+ALICE = SaslCredentials("alice", "itsMeH0nest", "SCRAM-SHA-256")
+
+
+class AdminApiAuthTest(RedpandaTest):
+    """
+    Test the behaviour of a redpanda cluster with admin API authentication
+    enabled.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={'enable_central_config': True},
+                         **kwargs)
+
+        self.rpk = RpkTool(self.redpanda)
+
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.superuser_admin = Admin(self.redpanda,
+                                     auth=(self.superuser.username,
+                                           self.superuser.password))
+        self.regular_user_admin = Admin(self.redpanda,
+                                        auth=(ALICE.username, ALICE.password))
+        self.anonymous_admin = Admin(self.redpanda)
+
+    def setUp(self):
+        super().setUp()
+        create_user_and_wait(self.redpanda, self.anonymous_admin, ALICE)
+
+        self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+
+    @cluster(num_nodes=3)
+    def test_superuser_access(self):
+        # A superuser may access the config API
+        self.superuser_admin.get_cluster_config()
+
+    @cluster(num_nodes=3)
+    def test_regular_user_access(self):
+        # A non-superuser may not access the config API
+        with expect_http_error(403):
+            self.regular_user_admin.get_cluster_config()
+
+    @cluster(num_nodes=3)
+    def test_anonymous_access(self):
+        # An anonymous user may not access the config API
+        with expect_http_error(403):
+            self.anonymous_admin.get_cluster_config()
+
+        # An anonymous user may access unauthenticated endpoints
+        self.anonymous_admin.get_status_ready()
+        self.redpanda.metrics(self.redpanda.nodes[0])
+
+
+class AdminApiAuthEnablementTest(RedpandaTest):
+    """
+    Test redpanda's rules for when admin API auth may be switched on
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={'enable_central_config': True},
+                         **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_no_superusers(self):
+        anonymous_admin = Admin(self.redpanda)
+
+        # Nobody may enable auth if there are no superusers
+        self.redpanda.set_cluster_config({'superusers': []})
+        with expect_http_error(400):
+            self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+        with expect_http_error(400):
+            anonymous_admin.patch_cluster_config(
+                {'admin_api_require_auth': True})
+
+        # Once we are a superuser, we can enable auth
+        self.redpanda.set_cluster_config(
+            {'superusers': [self.redpanda.SUPERUSER_CREDENTIALS.username]})
+        self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+
+        # Once auth is enabled, we cannot clear the superusers list
+        with expect_http_error(400):
+            self.redpanda.set_cluster_config({'superusers': []})
+
+    @cluster(num_nodes=3)
+    def test_not_a_superuser(self):
+        anonymous_admin = Admin(self.redpanda)
+
+        # Nobody may enable auth unless they are themselves in the superusers list
+        self.redpanda.set_cluster_config({'superusers': ['bob']})
+        with expect_http_error(400):
+            self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+        with expect_http_error(400):
+            anonymous_admin.patch_cluster_config(
+                {'admin_api_require_auth': True})
+
+        # A superuser may enable auth
+        self.redpanda.set_cluster_config({
+            'superusers':
+            ['bob', self.redpanda.SUPERUSER_CREDENTIALS.username]
+        })
+        self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+
+    @cluster(num_nodes=3)
+    def test_combined_request(self):
+        """
+        Check that the API accepts a config update that simultaneously updates superusers
+        and enables auth.
+        """
+        regular_user_admin = Admin(self.redpanda,
+                                   auth=(ALICE.username, ALICE.password))
+
+        # We can use our regular user for admin API access right away, because
+        # we didn't enable authentication yet.
+        create_user_and_wait(self.redpanda, regular_user_admin, ALICE)
+
+        regular_user_admin.patch_cluster_config({
+            'admin_api_require_auth':
+            True,
+            "superusers":
+            [self.redpanda.SUPERUSER_CREDENTIALS.username, ALICE.username]
+        })

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -354,7 +354,7 @@ class ClusterConfigTest(RedpandaTest):
 
         # Don't change these settings, they prevent the test from subsequently
         # using the cluster
-        exclude_settings = {'enable_sasl', 'enable_admin_api'}
+        exclude_settings = {'enable_sasl'}
 
         initial_config = self.admin.get_cluster_config()
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -390,6 +390,10 @@ class ClusterConfigTest(RedpandaTest):
                 # Don't try enabling coproc, it has external dependencies
                 continue
 
+            if name == 'admin_api_require_auth':
+                # Don't lock ourselves out of the admin API!
+                continue
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,


### PR DESCRIPTION
## Cover letter

RFC: https://github.com/redpanda-data/redpanda/pull/3751

This adds HTTP Basic authentication to the admin service, motivated primarily by enabling use of the new central config features.

The core authentication piece is made up of several layers:
- scram_algorithm::validate_password to check a plaintext password against stored sasl/scram credentials -- this ended up being merged in an earlier PR for making user creation idempotent, but this PR includes a proper test for it and builds upon it.
- the `request_authenticator` and `request_auth_result`, which implement HTTP basic auth and some simple authorization checks (for whether the user is a superuser, a regular user, or not authenticated at all)
- the new `admin_server::register_route` function, which is a central place to invoke `request_authenticator::authenticate` on incoming requests.  This should be much less error prone than relying on each handler to remember to call auth functions.
- the `config_multi_property_validation` helper in admin_server.cc, which prevents users from locking themselves out by enabling authentication.  This could be extended to a more generic multi-property validation system in future, but for the moment it's most robust to just define it as part of the API handler for changing config properties.

## Release notes

### Features

* The Redpanda Admin REST API now includes optional username/password authentication.  This is in addition to the existing mTLS option, which remains available.  To ensure backward compatibility for existing systems, username/password authentication is disabled by default, and may be enabled using the `admin_api_require_auth` cluster configuration property.
* The `enable_admin_api` configuration property is deprecated and will be ignored.  The Admin API is now necessary for making subsequent Redpanda configuration changes, and security conscious users have the option to enable TLS&password authentication.
