### PR TITLE
Make idempotency compatible with sarama

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1409,8 +1409,8 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
         } else {
             seq_it->second.update(bid.last_seq, last_offset);
         }
-        seq_it->second.last_write_timestamp = bid.max_timestamp.value();
-        _oldest_session = std::min(_oldest_session, bid.max_timestamp);
+        seq_it->second.last_write_timestamp = bid.first_timestamp.value();
+        _oldest_session = std::min(_oldest_session, bid.first_timestamp);
     }
 
     if (bid.is_transactional) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -199,6 +199,7 @@ rm_stm::rm_stm(
                          .abort_timed_out_transactions_interval_ms.value())
   , _abort_index_segment_size(
       config::shard_local_cfg().abort_index_segment_size.value())
+  , _seq_table_min_size(config::shard_local_cfg().seq_table_min_size.value())
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _transactional_id_expiration(
@@ -1099,10 +1100,37 @@ void rm_stm::compact_snapshot() {
     if (cutoff_timestamp <= _oldest_session.value()) {
         return;
     }
+
+    if (_log_state.seq_table.size() <= _seq_table_min_size) {
+        return;
+    }
+
+    if (_log_state.seq_table.size() == 0) {
+        return;
+    }
+
+    std::vector<model::timestamp::type> lw_tss;
+    lw_tss.reserve(_log_state.seq_table.size());
+    for (auto it = _log_state.seq_table.cbegin();
+         it != _log_state.seq_table.cend();
+         it++) {
+        lw_tss.push_back(it->second.last_write_timestamp);
+    }
+    std::sort(lw_tss.begin(), lw_tss.end());
+    auto pivot = lw_tss[lw_tss.size() - 1 - _seq_table_min_size];
+
+    if (pivot < cutoff_timestamp) {
+        cutoff_timestamp = pivot;
+    }
+
     auto next_oldest_session = model::timestamp::now();
+    auto size = _log_state.seq_table.size();
     for (auto it = _log_state.seq_table.cbegin();
          it != _log_state.seq_table.cend();) {
-        if (it->second.last_write_timestamp < cutoff_timestamp) {
+        if (
+          size > _seq_table_min_size
+          && it->second.last_write_timestamp <= cutoff_timestamp) {
+            size--;
             _log_state.seq_table.erase(it++);
         } else {
             next_oldest_session = std::min(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -403,6 +403,7 @@ private:
     std::chrono::milliseconds _tx_timeout_delay;
     std::chrono::milliseconds _abort_interval_ms;
     uint32_t _abort_index_segment_size;
+    uint32_t _seq_table_min_size;
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_autoabort_enabled{true};

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -288,6 +288,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       {.visibility = visibility::user},
       10s)
+  , seq_table_min_size(
+      *this,
+      "seq_table_min_size",
+      "Minimum size of the seq table non affected by compaction",
+      {.visibility = visibility::user},
+      1000)
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -86,6 +86,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
     property<model::violation_recovery_policy> tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
+    property<uint32_t> seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     property<model::violation_recovery_policy> rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -456,7 +456,7 @@ struct batch_identity {
           .last_seq = increment_sequence(
             hdr.base_sequence, hdr.last_offset_delta),
           .record_count = hdr.record_count,
-          .max_timestamp = hdr.max_timestamp,
+          .first_timestamp = hdr.first_timestamp,
           .is_transactional = hdr.attrs.is_transactional()};
     }
 
@@ -464,7 +464,7 @@ struct batch_identity {
     int32_t first_seq{0};
     int32_t last_seq{0};
     int32_t record_count;
-    timestamp max_timestamp;
+    timestamp first_timestamp;
     bool is_transactional{false};
 
     bool has_idempotent() { return pid.id >= 0; }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -106,6 +106,10 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     cd /opt/sarama/examples/consumergroup && go mod tidy && go build && \
     cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
 
+# Install our in-tree go tests
+COPY --chown=0:0 tests/go /tmp/go
+RUN cd /tmp/go/sarama/produce_test && go mod tidy && go build
+
 # Install franz-go
 RUN git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go && \
     cd /opt/franz-go/examples/bench && go mod tidy && go build

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -3,3 +3,4 @@
 !tests/docker/ssh
 !tests/setup.py
 !tests/python
+!tests/go

--- a/tests/go/sarama/produce_test/go.mod
+++ b/tests/go/sarama/produce_test/go.mod
@@ -1,0 +1,5 @@
+module produce_test
+
+go 1.16
+
+require github.com/Shopify/sarama v1.31.1

--- a/tests/go/sarama/produce_test/main.go
+++ b/tests/go/sarama/produce_test/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+var (
+	brokers = flag.String("brokers", "127.0.0.1:9092", "Th Redpanda brokers to connect to, as a comma separated list")
+	count   = flag.Int64("count", 100, "Optional count to run")
+)
+
+func main() {
+	flag.Parse()
+
+	brokerList := strings.Split(*brokers, ",")
+	fmt.Printf("Redpanda brokers: %s\n", strings.Join(brokerList, ", "))
+
+	topics := []string{
+		"topic1",
+	}
+
+	producer, err := newProducer(brokerList)
+	if err != nil {
+		fmt.Printf("Error creating producer, %v", err)
+		os.Exit(1)
+	}
+
+	err = runTest(producer, topics, *count)
+	if err != nil {
+		fmt.Printf("Error running test: %v", err)
+		os.Exit(1)
+	}
+}
+
+func newProducer(brokers []string) (sarama.SyncProducer, error) {
+	config := sarama.NewConfig()
+
+	config.Metadata.Full = false
+	config.Producer.Compression = sarama.CompressionZSTD
+	config.Producer.Idempotent = true // hard
+	config.Producer.Partitioner = sarama.NewReferenceHashPartitioner
+	config.Producer.RequiredAcks = sarama.WaitForAll // hard
+	config.Producer.Retry.Max = 10                   //hard
+	config.Producer.Return.Successes = true
+	config.Net.MaxOpenRequests = 1
+	config.Version = sarama.V2_1_0_0
+
+	producer, err := sarama.NewSyncProducer(brokers, config)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return producer, nil
+}
+
+func prepareMessage(
+	producer sarama.SyncProducer, topic string, message string,
+) *sarama.ProducerMessage {
+	producerMessage := &sarama.ProducerMessage{
+		Topic:     topic,
+		Partition: -1,
+		Value:     sarama.ByteEncoder(message),
+		Timestamp: time.Now(),
+	}
+
+	return producerMessage
+}
+
+func runTest(producer sarama.SyncProducer, topics []string, count int64) error {
+	fmt.Printf("Starting Sarama test\n")
+	message := "some message"
+
+	msg := prepareMessage(producer, topics[0], message)
+	_, _, err := producer.SendMessage(msg)
+
+	if err != nil {
+		return fmt.Errorf("SendMessage error: %w", err)
+	}
+
+	for i := 0; i < int(count); i++ {
+		msg := prepareMessage(producer, topics[0], message+strconv.Itoa(i))
+		_, _, err := producer.SendMessage(msg)
+		if err != nil {
+			return fmt.Errorf("SendMessage error: %w", err)
+		}
+	}
+
+	fmt.Printf("%d messages was written\n", count)
+	return nil
+}

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from ducktape.errors import DucktapeError
+from time import sleep
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+import subprocess
+
+# Expected log errors in tests that test misbehaving
+# idempotency clients.
+TX_ERROR_LOGS = []
+
+NOT_LEADER_FOR_PARTITION = "Tried to send a message to a replica that is not the leader for some partition"
+
+
+class SaramaProduceTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(SaramaProduceTest, self).__init__(test_context=test_context,
+                                                extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
+    def test_produce(self):
+        verifier_bin = "/tmp/go/sarama/produce_test/produce_test"
+
+        self.redpanda.logger.info("creating topics")
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1")
+
+        self.redpanda.logger.info("testing sarama produce")
+        retries = 5
+        for i in range(0, retries):
+            try:
+                cmd = "{verifier_bin} --brokers {brokers}".format(
+                    verifier_bin=verifier_bin, brokers=self.redpanda.brokers())
+                subprocess.check_output(["/bin/sh", "-c", cmd],
+                                        stderr=subprocess.STDOUT)
+                self.redpanda.logger.info("sarama produce test passed")
+                break
+            except subprocess.CalledProcessError as e:
+                error = str(e.output)
+                self.redpanda.logger.info("sarama produce failed with " +
+                                          error)
+                if i + 1 != retries and NOT_LEADER_FOR_PARTITION in error:
+                    sleep(5)
+                    continue
+                raise DucktapeError("sarama produce failed with " + error)


### PR DESCRIPTION
## Cover letter

By default Redpanda is configured to use `message.timestamp.type=CreateTime` but Sarama doesn't set timestamp correctly and it defaults to `-1`. Redpanda immediately performs garbage collection (-1 is always past `transactional_id_expiration`) and removes sequential numbers before the next requests reach the broker.

As a result Redpanda returns an "out of order sequence" error.

Adding `seq_table_min_size` configuration to prevent gc before the size of the sequential numbers (sessions) reaches the threshold.

## Release notes

* make idempotency compatible with Sarama