### PR TITLE
cluster: Use mem and log state of tm_stm for get_txs

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -518,8 +518,15 @@ ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
     }
 
     std::vector<tm_transaction> ans;
-    for (const auto& [_, tx] : _tx_table) {
+    for (const auto& [_, tx] : _mem_txes) {
         ans.push_back(tx);
+    }
+
+    for (const auto& [id, tx] : _log_txes) {
+        auto it = _mem_txes.find(id);
+        if (it == _mem_txes.end()) {
+            ans.push_back(tx);
+        }
     }
 
     co_return ans;


### PR DESCRIPTION
## Cover letter

Use mem and log state of tm_stm to get all transactions