### PR TITLE
cloud_storage: Remote segment compressed index

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     types.cc
     remote_segment.cc
     remote_partition.cc
+    remote_segment_index.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_storage/remote_segment.h"
 
+#include "bytes/iobuf.h"
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/remote_segment_index.h"
@@ -249,12 +250,14 @@ ss::future<> remote_segment::do_hydrate() {
         });
         auto [rparse, rput] = co_await ss::when_all(
           std::move(fparse), std::move(fput));
+        bool index_prepared = true;
         if (rparse.failed()) {
             vlog(
               _ctxlog.warn,
               "Failed to build a remote_segment index, error: {}",
               rparse.get_exception());
             rparse.ignore_ready_future();
+            index_prepared = false;
         }
         if (rput.failed()) {
             vlog(
@@ -263,7 +266,11 @@ ss::future<> remote_segment::do_hydrate() {
               rput.get_exception());
             rput.get();
         }
-        _index = std::move(tmpidx);
+        if (index_prepared) {
+            auto index_stream = make_iobuf_input_stream(tmpidx.to_iobuf());
+            co_await _cache.put(_path().native() + ".index", index_stream);
+            _index = std::move(tmpidx);
+        }
         co_return size_bytes;
     };
 
@@ -281,6 +288,48 @@ ss::future<> remote_segment::do_hydrate() {
           _path,
           _wait_list.size());
         throw download_exception(res, _path);
+    }
+}
+
+ss::future<> remote_segment::maybe_materialize_index() {
+    ss::gate::holder guard(_gate);
+    auto path = _path().native() + ".index";
+    offset_index ix(_base_rp_offset, _base_rp_offset - _base_offset_delta, 0);
+    if (auto cache_item = co_await _cache.get(path); cache_item.has_value()) {
+        // The cache item is expected to be present if the segment is present
+        // so it's very unlikely that we will call this method if there is no
+        // segment. This can only happen due to race condition between the
+        // remote_segment materialization and cache eviction.
+        vlog(_ctxlog.info, "Trying to materialize index '{}'", path);
+        try {
+            ss::file_input_stream_options options{};
+            options.buffer_size
+              = config::shard_local_cfg().storage_read_buffer_size;
+            options.read_ahead
+              = config::shard_local_cfg().storage_read_readahead_count;
+            options.io_priority_class
+              = priority_manager::local().shadow_indexing_priority();
+            auto inp_stream = ss::make_file_input_stream(
+              cache_item->body, options);
+            iobuf state;
+            auto out_stream = make_iobuf_ref_output_stream(state);
+            co_await ss::copy(inp_stream, out_stream).finally([&inp_stream] {
+                return inp_stream.close();
+            });
+            ix.from_iobuf(std::move(state));
+            _index = std::move(ix);
+        } catch (...) {
+            // In case of any failure during index materialization just continue
+            // without the index.
+            vlog(
+              _ctxlog.warn,
+              "Failed to materialize index '{}'. Error: {}",
+              path,
+              std::current_exception());
+        }
+        co_await cache_item->body.close();
+    } else {
+        vlog(_ctxlog.info, "Index '{}' is not available", path);
     }
 }
 
@@ -351,6 +400,10 @@ ss::future<> remote_segment::run_hydrate_bg() {
                         continue;
                     }
                     _data_file = maybe_file->body;
+                    if (!_index) {
+                        // materialize index state
+                        co_await maybe_materialize_index();
+                    }
                 }
             }
             // Invariant: here we should have a data file or error to be set.

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/partition_probe.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/remote_segment_index.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -106,8 +107,16 @@ public:
     bool download_in_progress() const noexcept { return !_wait_list.empty(); }
 
 private:
-    /// Hydrates segment in the background if there is any consumer
+    /// Run hydration loop. The method is supposed to be constantly running
+    /// in the background. The background loop is triggered by the condition
+    /// variable '_bg_cvar' and the promise list '_wait_list'. When the promise
+    /// is waitning in the list and the cond-variable is triggered the loop
+    /// wakes up and hydrates the segment if needed.
     ss::future<> run_hydrate_bg();
+
+    /// Actually hydrate the segment. The method downloads the segment file
+    /// to the cache dir and updates the segment index.
+    ss::future<> do_hydrate();
 
     ss::gate _gate;
     remote& _api;
@@ -132,6 +141,7 @@ private:
     ss::expiring_fifo<ss::promise<ss::file>, expiry_handler> _wait_list;
 
     ss::file _data_file;
+    std::optional<offset_index> _index;
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -133,6 +133,9 @@ private:
     /// to the cache dir and updates the segment index.
     ss::future<> do_hydrate();
 
+    /// Load segment index from file (if available)
+    ss::future<> maybe_materialize_index();
+
     ss::gate _gate;
     remote& _api;
     cache& _cache;

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/remote_segment_index.h"
+
+namespace cloud_storage {
+
+offset_index::offset_index(
+  model::offset initial_rp, model::offset initial_kaf, int64_t initial_file_pos)
+  : _rp_offsets{}
+  , _kaf_offsets{}
+  , _file_offsets{}
+  , _pos{}
+  , _initial_rp(initial_rp)
+  , _initial_kaf(initial_kaf)
+  , _initial_file_pos(initial_file_pos)
+  , _rp_encoder(initial_rp)
+  , _kaf_encoder(initial_kaf)
+  , _file_encoder(initial_file_pos) {}
+
+void offset_index::add(
+  model::offset rp_offset, model::offset kaf_offset, int64_t file_offset) {
+    auto ix = index_mask & _pos++;
+    _rp_offsets.at(ix) = rp_offset();
+    _kaf_offsets.at(ix) = kaf_offset();
+    _file_offsets.at(ix) = file_offset;
+    try {
+        if ((_pos & index_mask) == 0) {
+            _rp_encoder.add(_rp_offsets);
+            _kaf_encoder.add(_kaf_offsets);
+            _file_encoder.add(_file_offsets);
+        }
+    } catch (...) {
+        // Get rid of the corrupted state in the encoders.
+        // If the exception is thrown out of 'add' method
+        // the invariant of the index is broken.
+        _pos = 0;
+        _rp_offsets = {};
+        _kaf_offsets = {};
+        _file_offsets = {};
+        _rp_encoder = deltafor_encoder<int64_t>(_initial_rp);
+        _kaf_encoder = deltafor_encoder<int64_t>(_initial_kaf);
+        _file_encoder = deltafor_encoder<int64_t>(_initial_file_pos);
+        throw;
+    }
+}
+
+std::
+  variant<std::monostate, offset_index::index_value, offset_index::find_result>
+  offset_index::maybe_find_offset(
+    model::offset upper_bound,
+    deltafor_encoder<int64_t>& encoder,
+    const std::array<int64_t, buffer_depth>& write_buffer) {
+    deltafor_decoder<int64_t> decoder(
+      encoder.get_initial_value(), encoder.get_row_count(), encoder.share());
+    auto max_index = encoder.get_row_count() * details::FOR_buffer_depth - 1;
+    auto maybe_ix = _find_under(std::move(decoder), upper_bound());
+    if (!maybe_ix || maybe_ix->ix == max_index) {
+        auto ixend = _pos & index_mask;
+        std::optional<find_result> candidate;
+        for (size_t i = 0; i < ixend; i++) {
+            if (write_buffer.at(i) < upper_bound) {
+                candidate = find_result{
+                  .rp_offset = model::offset(_rp_offsets.at(i)),
+                  .kaf_offset = model::offset(_kaf_offsets.at(i)),
+                  .file_pos = _file_offsets.at(i),
+                };
+            } else {
+                break;
+            }
+        }
+        // maybe_ix can point to the last element of the compressed
+        // chunk if all elements inside it are less than the offset that
+        // we're looking for. In this case we should use it even if
+        // we can't find anything inside the buffer.
+        // maybe_ix will be null if the compressed chunk is empty.
+        if (candidate) {
+            return *candidate;
+        }
+        if (!maybe_ix) {
+            return std::monostate();
+        }
+    }
+    // Invariant: maybe_ix here can't be nullopt
+    return *maybe_ix;
+}
+
+std::optional<offset_index::find_result>
+offset_index::find_rp_offset(model::offset upper_bound) {
+    size_t ix = 0;
+    find_result res{};
+
+    auto search_result = maybe_find_offset(
+      upper_bound, _rp_encoder, _rp_offsets);
+
+    if (std::holds_alternative<std::monostate>(search_result)) {
+        return std::nullopt;
+    } else if (std::holds_alternative<find_result>(search_result)) {
+        return std::get<find_result>(search_result);
+    }
+    auto maybe_ix = std::get<index_value>(search_result);
+
+    // Invariant: maybe_ix here can't be nullopt
+    ix = maybe_ix.ix;
+    res.rp_offset = model::offset(maybe_ix.value);
+
+    deltafor_decoder<int64_t> kaf_dec(
+      _kaf_encoder.get_initial_value(),
+      _kaf_encoder.get_row_count(),
+      _kaf_encoder.copy());
+    auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
+    vassert(kaf_offset.has_value(), "Inconsistent index state");
+    res.kaf_offset = model::offset(*kaf_offset);
+    deltafor_decoder<int64_t> file_dec(
+      _file_encoder.get_initial_value(),
+      _file_encoder.get_row_count(),
+      _file_encoder.copy());
+    auto file_pos = _fetch_ix(std::move(file_dec), ix);
+    res.file_pos = *file_pos;
+    return res;
+}
+
+std::optional<offset_index::find_result>
+offset_index::find_kaf_offset(model::offset upper_bound) {
+    size_t ix = 0;
+    find_result res{};
+
+    auto search_result = maybe_find_offset(
+      upper_bound, _kaf_encoder, _kaf_offsets);
+
+    if (std::holds_alternative<std::monostate>(search_result)) {
+        return std::nullopt;
+    } else if (std::holds_alternative<find_result>(search_result)) {
+        return std::get<find_result>(search_result);
+    }
+    auto maybe_ix = std::get<index_value>(search_result);
+
+    // Invariant: maybe_ix here can't be nullopt
+    ix = maybe_ix.ix;
+    res.kaf_offset = model::offset(maybe_ix.value);
+
+    deltafor_decoder<int64_t> rp_dec(
+      _rp_encoder.get_initial_value(),
+      _rp_encoder.get_row_count(),
+      _rp_encoder.copy());
+    auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
+    vassert(rp_offset.has_value(), "Inconsistent index state");
+    res.rp_offset = model::offset(*rp_offset);
+    deltafor_decoder<int64_t> file_dec(
+      _file_encoder.get_initial_value(),
+      _file_encoder.get_row_count(),
+      _file_encoder.copy());
+    auto file_pos = _fetch_ix(std::move(file_dec), ix);
+    res.file_pos = *file_pos;
+    return res;
+}
+
+std::optional<offset_index::index_value>
+offset_index::_find_under(deltafor_decoder<int64_t> decoder, int64_t offset) {
+    size_t ix = 0;
+    std::array<int64_t, buffer_depth> rp_buf{};
+    std::optional<index_value> candidate;
+    while (decoder.read(rp_buf)) {
+        for (auto o : rp_buf) {
+            if (o >= offset) {
+                return candidate;
+            }
+            candidate = {.ix = size_t(ix), .value = o};
+            ix++;
+        }
+        rp_buf = {};
+    }
+    return candidate;
+}
+
+std::optional<int64_t>
+offset_index::_fetch_ix(deltafor_decoder<int64_t> decoder, size_t target_ix) {
+    size_t ix = 0;
+    std::array<int64_t, buffer_depth> buffer{};
+    while (decoder.read(buffer)) {
+        for (auto o : buffer) {
+            if (ix == target_ix) {
+                return o;
+            }
+            ix++;
+        }
+        buffer = {};
+    }
+    return std::nullopt;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "model/fundamental.h"
+#include "seastarx.h"
+#include "storage/parser.h"
+#include "utils/delta_for.h"
+
+#include <seastar/util/log.hh>
+
+#include <variant>
+
+namespace cloud_storage {
+
+/// Offset index for remote_segment
+///
+/// The object indexes tuples that contain three elements:
+/// - redpanda offset
+/// - kafka offset
+/// - file offset
+///
+/// The search is linear. The underlying data structure is a
+/// fragmented buffer (iobuf). It is possible to search by redpanda
+/// and kafka offsets, but not by file offset.
+///
+/// The invariant of the offset_index is that all three encoders
+/// have the same number of elements. All three buffers should also
+/// have the same number of elements.
+class offset_index {
+    static constexpr uint32_t buffer_depth = details::FOR_buffer_depth;
+    static constexpr uint32_t index_mask = buffer_depth - 1;
+    static_assert(
+      (buffer_depth & index_mask) == 0,
+      "buffer_depth have to be a power of two");
+
+public:
+    offset_index(
+      model::offset initial_rp,
+      model::offset initial_kaf,
+      int64_t initial_file_pos);
+
+    /// Add new tuple to the index.
+    void
+    add(model::offset rp_offset, model::offset kaf_offset, int64_t file_offset);
+
+    struct find_result {
+        model::offset rp_offset;
+        model::offset kaf_offset;
+        int64_t file_pos;
+    };
+
+    /// Find index entry which is strictly lower than the redpanda offset
+    ///
+    /// The returned value has rp_offset less than upper_bound.
+    /// If all elements are larger than 'upper_bound' nullopt is returned.
+    /// If all elements are smaller than 'upper_bound' the last value is
+    /// returned.
+    std::optional<find_result> find_rp_offset(model::offset upper_bound);
+
+    /// Find index entry which is strictly lower than the kafka offset
+    ///
+    /// The returned value has kaf_offset less than upper_bound.
+    /// If all elements are larger than 'upper_bound' nullopt is returned.
+    /// If all elements are smaller than 'upper_bound' the last value is
+    /// returned.
+    std::optional<find_result> find_kaf_offset(model::offset upper_bound);
+
+private:
+    struct index_value {
+        size_t ix;
+        int64_t value;
+    };
+
+    /// Find index entry which is strictly lower than the provided value
+    ///
+    /// The encoder and the write buffer have to be provided via parameters.
+    /// The returned value is a variant which contains a monostate if no value
+    /// can be found; index_value if the value is found in the encoder;
+    /// find_result if the value is found in the write buffer (in this case no
+    /// further search is needed).
+    std::variant<std::monostate, index_value, find_result> maybe_find_offset(
+      model::offset upper_bound,
+      deltafor_encoder<int64_t>& encoder,
+      const std::array<int64_t, buffer_depth>& write_buffer);
+
+    /// Find element inside the offset range stored in the decoder which is
+    /// less than offset. Return last element if no such element can be found.
+    /// Return nullopt if all emlements are larger or equal than offset.
+    static std::optional<index_value>
+    _find_under(deltafor_decoder<int64_t> decoder, int64_t offset);
+
+    /// Return element by index.
+    static std::optional<int64_t>
+    _fetch_ix(deltafor_decoder<int64_t> decoder, size_t target_ix);
+
+private:
+    std::array<int64_t, buffer_depth> _rp_offsets;
+    std::array<int64_t, buffer_depth> _kaf_offsets;
+    std::array<int64_t, buffer_depth> _file_offsets;
+    uint64_t _pos;
+    model::offset _initial_rp;
+    model::offset _initial_kaf;
+    int64_t _initial_file_pos;
+    deltafor_encoder<int64_t> _rp_encoder;
+    deltafor_encoder<int64_t> _kaf_encoder;
+    deltafor_encoder<int64_t> _file_encoder;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -77,6 +77,12 @@ public:
     /// returned.
     std::optional<find_result> find_kaf_offset(model::offset upper_bound);
 
+    /// Serialize offset_index
+    iobuf to_iobuf();
+
+    /// Deserialize offset_index
+    void from_iobuf(iobuf in);
+
 private:
     struct index_value {
         size_t ix;
@@ -114,9 +120,11 @@ private:
     model::offset _initial_rp;
     model::offset _initial_kaf;
     int64_t _initial_file_pos;
-    deltafor_encoder<int64_t> _rp_encoder;
-    deltafor_encoder<int64_t> _kaf_encoder;
-    deltafor_encoder<int64_t> _file_encoder;
+    using encoder_t = deltafor_encoder<int64_t>;
+    using decoder_t = deltafor_decoder<int64_t>;
+    encoder_t _rp_index;
+    encoder_t _kaf_index;
+    encoder_t _file_index;
 };
 
 class remote_segment_index_builder : public storage::batch_consumer {

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     offset_translation_layer_test.cc
     remote_segment_test.cc
     remote_partition_test.cc
+    remote_segment_index_test.cc 
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -522,6 +522,12 @@ FIXTURE_TEST(test_remote_partition_scan_second_half, cloud_storage_fixture) {
     print_segments(segments);
 
     auto headers_read = scan_remote_partition(*this, base, max);
+    vlog(test_log.debug, "scan results: \n\n");
+    int hdr_ix = 0;
+    for (const auto& hdr : headers_read) {
+        vlog(test_log.debug, "header at pos {}: {}", hdr_ix, hdr);
+        hdr_ix++;
+    }
 
     BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches / 2);
     auto coverage = get_coverage(headers_read, segments, batches_per_segment);

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/remote_segment_index.h"
+#include "random/generators.h"
+#include "vlog.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+
+using namespace cloud_storage;
+
+BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
+    // This value is a power of two - 1 on purpose. This way we
+    // will read from the compressed part and from the buffer of
+    // recent values. This is because the row widht is 16 and the
+    // buffer has 16 elements. 1024 is 64 rows and 1023 is 63
+    // rows + almost full buffer.
+    size_t segment_num_batches = 1023;
+    model::offset segment_base_rp_offset{1234};
+    model::offset segment_base_kaf_offset{1210};
+
+    std::vector<model::offset> rp_offsets;
+    std::vector<model::offset> kaf_offsets;
+    std::vector<size_t> file_offsets;
+    int64_t rp = segment_base_rp_offset();
+    int64_t kaf = segment_base_kaf_offset();
+    size_t fpos = 0;
+    bool is_config = false;
+    for (size_t i = 0; i < segment_num_batches; i++) {
+        if (!is_config) {
+            rp_offsets.push_back(model::offset(rp));
+            kaf_offsets.push_back(model::offset(kaf));
+            file_offsets.push_back(fpos);
+        }
+        // The test queries every element using the key that matches the element
+        // exactly and then it queries the element using the key which is
+        // smaller than the element. In order to do this we need a way to
+        // guarantee that the distance between to elements in the sequence is at
+        // least 2, so we can decrement the key safely.
+        auto batch_size = random_generators::get_int(2, 100);
+        is_config = random_generators::get_int(20) == 0;
+        rp += batch_size;
+        kaf += is_config ? batch_size - 1 : batch_size;
+        fpos += random_generators::get_int(1, 1000);
+    }
+
+    offset_index index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
+    model::offset last;
+    model::offset klast;
+    size_t flast;
+    for (size_t i = 0; i < rp_offsets.size(); i++) {
+        index.add(rp_offsets.at(i), kaf_offsets.at(i), file_offsets.at(i));
+        last = rp_offsets.at(i);
+        klast = kaf_offsets.at(i);
+        flast = file_offsets.at(i);
+    }
+
+    // Query element before the first one
+    auto opt_first = index.find_rp_offset(
+      segment_base_rp_offset - model::offset(1));
+    BOOST_REQUIRE(!opt_first.has_value());
+
+    auto kopt_first = index.find_kaf_offset(
+      segment_base_kaf_offset - model::offset(1));
+    BOOST_REQUIRE(!kopt_first.has_value());
+
+    for (unsigned ix = 0; ix < rp_offsets.size(); ix++) {
+        auto opt = index.find_rp_offset(rp_offsets[ix] + model::offset(1));
+        auto [rp, kaf, fpos] = *opt;
+        BOOST_REQUIRE_EQUAL(rp, rp_offsets[ix]);
+        BOOST_REQUIRE_EQUAL(kaf, kaf_offsets[ix]);
+        BOOST_REQUIRE_EQUAL(fpos, file_offsets[ix]);
+
+        auto kopt = index.find_kaf_offset(kaf_offsets[ix] + model::offset(1));
+        BOOST_REQUIRE_EQUAL(kopt->rp_offset, rp_offsets[ix]);
+        BOOST_REQUIRE_EQUAL(kopt->kaf_offset, kaf_offsets[ix]);
+        BOOST_REQUIRE_EQUAL(kopt->file_pos, file_offsets[ix]);
+    }
+
+    // Query after the last element
+    auto opt_last = index.find_rp_offset(last + model::offset(1));
+    auto [rp_last, kaf_last, file_last] = *opt_last;
+    BOOST_REQUIRE_EQUAL(rp_last, last);
+    BOOST_REQUIRE_EQUAL(kaf_last, klast);
+    BOOST_REQUIRE_EQUAL(file_last, flast);
+
+    auto kopt_last = index.find_kaf_offset(klast + model::offset(1));
+    BOOST_REQUIRE_EQUAL(kopt_last->rp_offset, last);
+    BOOST_REQUIRE_EQUAL(kopt_last->kaf_offset, klast);
+    BOOST_REQUIRE_EQUAL(kopt_last->file_pos, flast);
+}

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -60,16 +60,20 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
         fpos += random_generators::get_int(1, 1000);
     }
 
-    offset_index index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
+    offset_index tmp_index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
     model::offset last;
     model::offset klast;
     size_t flast;
     for (size_t i = 0; i < rp_offsets.size(); i++) {
-        index.add(rp_offsets.at(i), kaf_offsets.at(i), file_offsets.at(i));
+        tmp_index.add(rp_offsets.at(i), kaf_offsets.at(i), file_offsets.at(i));
         last = rp_offsets.at(i);
         klast = kaf_offsets.at(i);
         flast = file_offsets.at(i);
     }
+
+    offset_index index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
+    auto buf = tmp_index.to_iobuf();
+    index.from_iobuf(std::move(buf));
 
     // Query element before the first one
     auto opt_first = index.find_rp_offset(

--- a/src/v/test_utils/tmp_dir.h
+++ b/src/v/test_utils/tmp_dir.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+#include <seastar/util/tmp_file.hh>
+
+#include <exception>
+
+namespace details {
+inline ss::logger tmpdir_logger("tmpdir-log");
+}
+
+class temporary_dir {
+public:
+    explicit temporary_dir(const char* test_name)
+      : temporary_dir(std::filesystem::path("."), test_name) {}
+    temporary_dir(const std::filesystem::path& root, const char* test_name) {
+        auto path = root / fmt::format("{}-XXXX", test_name);
+        try {
+            vlog(
+              details::tmpdir_logger.info,
+              "Creating temporary directory {}",
+              path.native());
+            _dir = ss::make_tmp_dir(path.native()).get();
+        } catch (...) {
+            vlog(
+              details::tmpdir_logger.error,
+              "Can't create temporary directory at {}, Error: {}",
+              path,
+              std::current_exception());
+            throw;
+        }
+    }
+    temporary_dir(const temporary_dir&) = delete;
+    temporary_dir& operator=(const temporary_dir&) = delete;
+    temporary_dir(temporary_dir&&) = delete;
+    temporary_dir& operator=(temporary_dir&&) = delete;
+    ~temporary_dir() noexcept {
+        try {
+            vlog(details::tmpdir_logger.info, "About to call remove");
+            if (_dir.has_path()) {
+                _dir.remove().get0();
+            }
+        } catch (...) {
+            vlog(
+              details::tmpdir_logger.error,
+              "Can't remove temporary directory. Error: {}",
+              std::current_exception());
+        }
+    }
+    std::filesystem::path get_path() const { return _dir.get_path(); }
+    ss::future<> remove() { return _dir.remove(); }
+
+private:
+    ss::tmp_dir _dir;
+};

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -1,0 +1,1080 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "model/fundamental.h"
+#include "seastarx.h"
+#include "storage/parser.h"
+
+#include <seastar/util/log.hh>
+
+#include <variant>
+
+namespace details {
+static constexpr uint32_t FOR_buffer_depth = 16;
+}
+
+/** \brief Delta-FOR encoder
+ *
+ * The algorithm uses differential encoding followed by the
+ * frame of reference (FoR) encoding step. The differential step
+ * is implemented using XOR to simplify dealing with negative deltas.
+ * The encoder is supposed to deal with monotonically increasing
+ * sequences (offsets in a segment) but it's not limited to that
+ * and will work with any integer sequence with 64-bit values.
+ * The compression ratio depends on data and for redpanda offsets
+ * it's expected to be around 10% to 15%.
+ *
+ * The encoder works with 16-element rows. This is needed to
+ * enable easy loop unrolling (e.g. 4-bit values can be packed into
+ * single uint64_t variable, 3-bit values can be packed into uint32_t
+ * + uint16_t, etc). It also simplifies the loop unrolling for the
+ * compiler since the loops that process the single row can be
+ * easily unrolled or vectorized since the number of iterations is
+ * known at compile time. Most bit-packing required by FoR can be
+ * done as a series of simple operations (shifts/loads/stores) in a
+ * loop that doesn't require any branching.
+ *
+ * Also, because bit-packing routines work with rows of 16 elements
+ * they always start and stop on a byte boundary. This simplifies the
+ * code quite a lot.
+ *
+ * The FoR encoding memory layout is not conventional. It's not
+ * placing values one after another. It uses the following schema
+ * instead. Consider the following size classes: 64, 32, 16, and
+ * 8-bits. Each 64-bit value can be represented as a series of those + some
+ * reminder. For instance, 18-bit value can be represented as 16-bit
+ * value + 2-bit reminder, 47-bit value can be represented as 32-bit
+ * value + 8-bit value + 7-bit reminder, etc.
+ *
+ * The bit-packing algorithm works in the following way. First, it
+ * calculates minimal number of bits that can be used to store any
+ * value in a row. Then the number of bits is factored into one or
+ * several size classes + reminder. After that the algorithm writes
+ * the number of bits that corresponds to the largest size class, then
+ * the next one, etc. After that it writes the reminder of every element.
+ * This means that the data from all 16 values is interliving. The number
+ * of bits used to represent the row is stored using 8 bits.
+ *
+ * Example: let's say that we have a row that requires us to use 59
+ * bits per element. Bit-packing will go like this:
+ * - write first 32-bits from every value in a row (64 bytes total);
+ * - write next 16-bits from every value in a row (32 bytes total);
+ * - write next 8-bits from every value in a row (16 bytes total);
+ * - write the remaining 3-bits from every value (6 bytes total);
+ * The result is represented using 118 bytes.
+ *
+ * One advantage of this approach is that it requires less code to
+ * implement. It needs bit-packing functions that can pack 1-7 bits
+ * and also 8, 16, 32, and 64 bits. All possible bit-packing arrangements
+ * from 0 to 64 bits can be produced using this functions.
+ * The alternative to this is to implement 63 bit-packing functions that
+ * can pack all possible values. The approach used here requires only
+ * 7 custom bit-packing functions + 4 bit-packing functions for different
+ * size classes (8, 16, 32, 64) which is much easier to impelment and
+ * test.
+ *
+ * It's also beneficial for further compression using general purpose
+ * compression algorithms (e.g. zstd or lz4). If the values have some
+ * common substructure (e.g. the lowest bits are zeroed) this common bits
+ * will be stored together and the compression alg. could take advantage
+ * of that.
+ *
+ * The compressed data is stored internally using an iobuf. This iobuf
+ * can be copied and pushed to the decoder to decompress the values.
+ */
+template<class TVal>
+class deltafor_encoder {
+    static constexpr uint32_t row_width = details::FOR_buffer_depth;
+
+public:
+    explicit deltafor_encoder(TVal initial_value)
+      : _initial(initial_value)
+      , _last(initial_value)
+      , _cnt{0} {}
+
+    deltafor_encoder(
+      TVal initial_value, uint32_t cnt, TVal last_value, iobuf data)
+      : _initial(initial_value)
+      , _last(last_value)
+      , _data(std::move(data))
+      , _cnt(cnt) {}
+
+    using row_t = std::array<TVal, row_width>;
+
+    /// Encode single row
+    void add(const row_t& row) {
+        row_t buf;
+        auto p = _last;
+        uint64_t agg = 0;
+        for (uint32_t i = 0; i < row_width; ++i) {
+            buf[i] = row[i] ^ p;
+            agg |= buf[i];
+            p = row[i];
+        }
+        _last = row.back();
+        uint8_t nbits = 64 - (agg == 0 ? 64 : (uint8_t)__builtin_clzll(agg));
+        _data.append(&nbits, 1);
+        pack(buf, nbits);
+        _cnt++;
+    }
+
+    /// Copy the underlying iobuf
+    iobuf copy() const { return _data.copy(); }
+
+    /// Share the underlying iobuf
+    iobuf share() { return _data.share(0, _data.size_bytes()); }
+
+    /// Return number of rows stored in the underlying iobuf instance
+    uint32_t get_row_count() const noexcept { return _cnt; }
+
+    /// Get initial value used to crate the encoder
+    TVal get_initial_value() const noexcept { return _initial; }
+
+    /// Get last value used to crate the encoder
+    TVal get_last_value() const noexcept { return _last; }
+
+private:
+    template<typename T>
+    void _pack_as(const row_t& input) {
+        static_assert(
+          std::is_unsigned<T>::value,
+          "Only unsigned integer can be used as a type parameter");
+        for (unsigned i = 0; i < row_width; i++) {
+            T bits = static_cast<T>(input[i]);
+            uint8_t buf[sizeof(bits)];
+            std::memcpy(&buf, &bits, sizeof(bits));
+            _data.append(buf, sizeof(bits));
+        }
+    }
+
+    template<typename T>
+    void _shift_as(row_t& input) {
+        for (uint32_t i = 0; i < row_width; i++) {
+            input[i] >>= 8 * sizeof(T);
+        }
+    }
+
+    template<typename T>
+    void _pack_shift(row_t& input) {
+        _pack_as<T>(input);
+        _shift_as<T>(input);
+    }
+
+    template<typename... Ts>
+    void _pack_shift_all(row_t& input) {
+        (_pack_shift<Ts>(input), ...);
+    }
+
+    void _pack1(const row_t& input) {
+        uint16_t bits = 0;
+        for (uint32_t i = 0; i < row_width; i++) {
+            bits |= static_cast<uint16_t>((input[i] & 1) << i);
+        }
+        _data.append(reinterpret_cast<uint8_t*>(&bits), sizeof(bits));
+    }
+
+    void _pack2(const row_t& input) {
+        uint32_t bits = 0;
+        for (uint32_t i = 0; i < row_width; i++) {
+            bits |= static_cast<uint32_t>((input[i] & 3) << (2 * i));
+        }
+        _data.append(reinterpret_cast<uint8_t*>(&bits), sizeof(bits));
+    }
+
+    void _pack3(const row_t& input) {
+        uint32_t bits0 = 0;
+        uint16_t bits1 = 0;
+        bits0 |= static_cast<uint32_t>((input[0] & 7));
+        bits0 |= static_cast<uint32_t>((input[1] & 7) << 3);
+        bits0 |= static_cast<uint32_t>((input[2] & 7) << 6);
+        bits0 |= static_cast<uint32_t>((input[3] & 7) << 9);
+        bits0 |= static_cast<uint32_t>((input[4] & 7) << 12);
+        bits0 |= static_cast<uint32_t>((input[5] & 7) << 15);
+        bits0 |= static_cast<uint32_t>((input[6] & 7) << 18);
+        bits0 |= static_cast<uint32_t>((input[7] & 7) << 21);
+        bits0 |= static_cast<uint32_t>((input[8] & 7) << 24);
+        bits0 |= static_cast<uint32_t>((input[9] & 7) << 27);
+        bits0 |= static_cast<uint32_t>((input[10] & 3) << 30);
+        bits1 |= static_cast<uint32_t>((input[10] & 4) >> 2);
+        bits1 |= static_cast<uint32_t>((input[11] & 7) << 1);
+        bits1 |= static_cast<uint32_t>((input[12] & 7) << 4);
+        bits1 |= static_cast<uint32_t>((input[13] & 7) << 7);
+        bits1 |= static_cast<uint32_t>((input[14] & 7) << 10);
+        bits1 |= static_cast<uint32_t>((input[15] & 7) << 13);
+        _data.append(reinterpret_cast<uint8_t*>(&bits0), sizeof(bits0));
+        _data.append(reinterpret_cast<uint8_t*>(&bits1), sizeof(bits1));
+    }
+
+    void _pack4(const row_t& input) {
+        uint64_t bits0 = 0;
+        bits0 |= static_cast<uint64_t>((input[0] & 0xF));
+        bits0 |= static_cast<uint64_t>((input[1] & 0xF) << 4);
+        bits0 |= static_cast<uint64_t>((input[2] & 0xF) << 8);
+        bits0 |= static_cast<uint64_t>((input[3] & 0xF) << 12);
+        bits0 |= static_cast<uint64_t>((input[4] & 0xF) << 16);
+        bits0 |= static_cast<uint64_t>((input[5] & 0xF) << 20);
+        bits0 |= static_cast<uint64_t>((input[6] & 0xF) << 24);
+        bits0 |= static_cast<uint64_t>((input[7] & 0xF) << 28);
+        bits0 |= static_cast<uint64_t>((input[8] & 0xF) << 32);
+        bits0 |= static_cast<uint64_t>((input[9] & 0xF) << 36);
+        bits0 |= static_cast<uint64_t>((input[10] & 0xF) << 40);
+        bits0 |= static_cast<uint64_t>((input[11] & 0xF) << 44);
+        bits0 |= static_cast<uint64_t>((input[12] & 0xF) << 48);
+        bits0 |= static_cast<uint64_t>((input[13] & 0xF) << 52);
+        bits0 |= static_cast<uint64_t>((input[14] & 0xF) << 56);
+        bits0 |= static_cast<uint64_t>((input[15] & 0xF) << 60);
+        _data.append(reinterpret_cast<uint8_t*>(&bits0), sizeof(bits0));
+    }
+
+    void _pack5(const row_t& input) {
+        uint64_t bits0 = 0;
+        uint16_t bits1 = 0;
+        bits0 |= static_cast<uint64_t>((input[0] & 0x1F));
+        bits0 |= static_cast<uint64_t>((input[1] & 0x1F) << 5);
+        bits0 |= static_cast<uint64_t>((input[2] & 0x1F) << 10);
+        bits0 |= static_cast<uint64_t>((input[3] & 0x1F) << 15);
+        bits0 |= static_cast<uint64_t>((input[4] & 0x1F) << 20);
+        bits0 |= static_cast<uint64_t>((input[5] & 0x1F) << 25);
+        bits0 |= static_cast<uint64_t>((input[6] & 0x1F) << 30);
+        bits0 |= static_cast<uint64_t>((input[7] & 0x1F) << 35);
+        bits0 |= static_cast<uint64_t>((input[8] & 0x1F) << 40);
+        bits0 |= static_cast<uint64_t>((input[9] & 0x1F) << 45);
+        bits0 |= static_cast<uint64_t>((input[10] & 0x1F) << 50);
+        bits0 |= static_cast<uint64_t>((input[11] & 0x1F) << 55);
+        bits0 |= static_cast<uint64_t>((input[12] & 0x0F) << 60);
+        bits1 |= static_cast<uint32_t>((input[12] & 0x10) >> 4);
+        bits1 |= static_cast<uint32_t>((input[13] & 0x1F) << 1);
+        bits1 |= static_cast<uint32_t>((input[14] & 0x1F) << 6);
+        bits1 |= static_cast<uint32_t>((input[15] & 0x1F) << 11);
+        _data.append(reinterpret_cast<uint8_t*>(&bits0), sizeof(bits0));
+        _data.append(reinterpret_cast<uint8_t*>(&bits1), sizeof(bits1));
+    }
+
+    void _pack6(const row_t& input) {
+        uint64_t bits0 = 0;
+        uint32_t bits1 = 0;
+        bits0 |= static_cast<uint64_t>((input[0] & 0x3F));
+        bits0 |= static_cast<uint64_t>((input[1] & 0x3F) << 6);
+        bits0 |= static_cast<uint64_t>((input[2] & 0x3F) << 12);
+        bits0 |= static_cast<uint64_t>((input[3] & 0x3F) << 18);
+        bits0 |= static_cast<uint64_t>((input[4] & 0x3F) << 24);
+        bits0 |= static_cast<uint64_t>((input[5] & 0x3F) << 30);
+        bits0 |= static_cast<uint64_t>((input[6] & 0x3F) << 36);
+        bits0 |= static_cast<uint64_t>((input[7] & 0x3F) << 42);
+        bits0 |= static_cast<uint64_t>((input[8] & 0x3F) << 48);
+        bits0 |= static_cast<uint64_t>((input[9] & 0x3F) << 54);
+        bits0 |= static_cast<uint64_t>((input[10] & 0x0F) << 60);
+        bits1 |= static_cast<uint32_t>((input[10] & 0x30) >> 4);
+        bits1 |= static_cast<uint32_t>((input[11] & 0x3F) << 2);
+        bits1 |= static_cast<uint32_t>((input[12] & 0x3F) << 8);
+        bits1 |= static_cast<uint32_t>((input[13] & 0x3F) << 14);
+        bits1 |= static_cast<uint32_t>((input[14] & 0x3F) << 20);
+        bits1 |= static_cast<uint32_t>((input[15] & 0x3F) << 26);
+        _data.append(reinterpret_cast<uint8_t*>(&bits0), sizeof(bits0));
+        _data.append(reinterpret_cast<uint8_t*>(&bits1), sizeof(bits1));
+    }
+
+    void _pack7(const row_t& input) {
+        uint64_t bits0 = 0;
+        uint32_t bits1 = 0;
+        uint16_t bits2 = 0;
+        bits0 |= static_cast<uint64_t>((input[0] & 0x7F));
+        bits0 |= static_cast<uint64_t>((input[1] & 0x7F) << 7);
+        bits0 |= static_cast<uint64_t>((input[2] & 0x7F) << 14);
+        bits0 |= static_cast<uint64_t>((input[3] & 0x7F) << 21);
+        bits0 |= static_cast<uint64_t>((input[4] & 0x7F) << 28);
+        bits0 |= static_cast<uint64_t>((input[5] & 0x7F) << 35);
+        bits0 |= static_cast<uint64_t>((input[6] & 0x7F) << 42);
+        bits0 |= static_cast<uint64_t>((input[7] & 0x7F) << 49);
+        bits0 |= static_cast<uint64_t>((input[8] & 0x7F) << 56);
+        bits0 |= static_cast<uint64_t>((input[9] & 0x01) << 63);
+        bits1 |= static_cast<uint32_t>((input[9] & 0x7E) >> 1);
+        bits1 |= static_cast<uint32_t>((input[10] & 0x7F) << 6);
+        bits1 |= static_cast<uint32_t>((input[11] & 0x7F) << 13);
+        bits1 |= static_cast<uint32_t>((input[12] & 0x7F) << 20);
+        bits1 |= static_cast<uint32_t>((input[13] & 0x1F) << 27);
+        bits2 |= static_cast<uint16_t>((input[13] & 0x60) >> 5);
+        bits2 |= static_cast<uint16_t>((input[14] & 0x7F) << 2);
+        bits2 |= static_cast<uint16_t>((input[15] & 0x7F) << 9);
+        _data.append(reinterpret_cast<uint8_t*>(&bits0), sizeof(bits0));
+        _data.append(reinterpret_cast<uint8_t*>(&bits1), sizeof(bits1));
+        _data.append(reinterpret_cast<uint8_t*>(&bits2), sizeof(bits2));
+    }
+
+    void pack(row_t& input, int n) {
+        switch (n) {
+        case 0:
+            break;
+        case 1:
+            _pack1(input);
+            break;
+        case 2:
+            _pack2(input);
+            break;
+        case 3:
+            _pack3(input);
+            break;
+        case 4:
+            _pack4(input);
+            break;
+        case 5:
+            _pack5(input);
+            break;
+        case 6:
+            _pack6(input);
+            break;
+        case 7:
+            _pack7(input);
+            break;
+        case 8:
+            _pack_as<uint8_t>(input);
+            break;
+        case 9:
+            _pack_shift<uint8_t>(input);
+            _pack1(input);
+            break;
+        case 10:
+            _pack_shift<uint8_t>(input);
+            _pack2(input);
+            break;
+        case 11:
+            _pack_shift<uint8_t>(input);
+            _pack3(input);
+            break;
+        case 12:
+            _pack_shift<uint8_t>(input);
+            _pack4(input);
+            break;
+        case 13:
+            _pack_shift<uint8_t>(input);
+            _pack5(input);
+            break;
+        case 14:
+            _pack_shift<uint8_t>(input);
+            _pack6(input);
+            break;
+        case 15:
+            _pack_shift<uint8_t>(input);
+            _pack7(input);
+            break;
+        case 16:
+            _pack_as<uint16_t>(input);
+            break;
+        case 17:
+            _pack_shift<uint16_t>(input);
+            _pack1(input);
+            break;
+        case 18:
+            _pack_shift<uint16_t>(input);
+            _pack2(input);
+            break;
+        case 19:
+            _pack_shift<uint16_t>(input);
+            _pack3(input);
+            break;
+        case 20:
+            _pack_shift<uint16_t>(input);
+            _pack4(input);
+            break;
+        case 21:
+            _pack_shift<uint16_t>(input);
+            _pack5(input);
+            break;
+        case 22:
+            _pack_shift<uint16_t>(input);
+            _pack6(input);
+            break;
+        case 23:
+            _pack_shift<uint16_t>(input);
+            _pack7(input);
+            break;
+        case 24:
+            _pack_shift<uint16_t>(input);
+            _pack_as<uint8_t>(input);
+            break;
+        case 25:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack1(input);
+            break;
+        case 26:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack2(input);
+            break;
+        case 27:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack3(input);
+            break;
+        case 28:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack4(input);
+            break;
+        case 29:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack5(input);
+            break;
+        case 30:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack6(input);
+            break;
+        case 31:
+            _pack_shift_all<uint16_t, uint8_t>(input);
+            _pack7(input);
+            break;
+        case 32:
+            _pack_as<uint32_t>(input);
+            break;
+        case 33:
+            _pack_shift<uint32_t>(input);
+            _pack1(input);
+            break;
+        case 34:
+            _pack_shift<uint32_t>(input);
+            _pack2(input);
+            break;
+        case 35:
+            _pack_shift<uint32_t>(input);
+            _pack3(input);
+            break;
+        case 36:
+            _pack_shift<uint32_t>(input);
+            _pack4(input);
+            break;
+        case 37:
+            _pack_shift<uint32_t>(input);
+            _pack5(input);
+            break;
+        case 38:
+            _pack_shift<uint32_t>(input);
+            _pack6(input);
+            break;
+        case 39:
+            _pack_shift<uint32_t>(input);
+            _pack7(input);
+            break;
+        case 40:
+            _pack_shift<uint32_t>(input);
+            _pack_as<uint8_t>(input);
+            break;
+        case 41:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack1(input);
+            break;
+        case 42:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack2(input);
+            break;
+        case 43:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack3(input);
+            break;
+        case 44:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack4(input);
+            break;
+        case 45:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack5(input);
+            break;
+        case 46:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack6(input);
+            break;
+        case 47:
+            _pack_shift_all<uint32_t, uint8_t>(input);
+            _pack7(input);
+            break;
+        case 48:
+            _pack_shift<uint32_t>(input);
+            _pack_as<uint16_t>(input);
+            break;
+        case 49:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack1(input);
+            break;
+        case 50:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack2(input);
+            break;
+        case 51:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack3(input);
+            break;
+        case 52:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack4(input);
+            break;
+        case 53:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack5(input);
+            break;
+        case 54:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack6(input);
+            break;
+        case 55:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack7(input);
+            break;
+        case 56:
+            _pack_shift_all<uint32_t, uint16_t>(input);
+            _pack_as<uint8_t>(input);
+            break;
+        case 57:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack1(input);
+            break;
+        case 58:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack2(input);
+            break;
+        case 59:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack3(input);
+            break;
+        case 60:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack4(input);
+            break;
+        case 61:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack5(input);
+            break;
+        case 62:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack6(input);
+            break;
+        case 63:
+            _pack_shift_all<uint32_t, uint16_t, uint8_t>(input);
+            _pack7(input);
+            break;
+        case 64:
+            return _pack_as<uint64_t>(input);
+        }
+    }
+
+    TVal _initial;
+    TVal _last;
+    iobuf _data;
+    uint32_t _cnt;
+};
+
+/** \brief Delta-FOR decoder
+ *
+ * The object can be used to decode the iobuf copied from the encoder.
+ * It can only read the whole sequence once. Once it's done reading
+ * it can't be reset to read the seqnece again.
+ *
+ * The initial_value and number of rows should match the corresponding
+ * encoder wich was used to compress the data.
+ */
+template<class TVal>
+class deltafor_decoder {
+    static constexpr uint32_t row_width = details::FOR_buffer_depth;
+
+public:
+    explicit deltafor_decoder(TVal initial_value, uint32_t cnt, iobuf data)
+      : _initial(initial_value)
+      , _total{cnt}
+      , _pos{0}
+      , _data(std::move(data)) {}
+
+    using row_t = std::array<TVal, row_width>;
+
+    /// Decode single row
+    bool read(row_t& row) {
+        if (_pos == _total) {
+            return false;
+        }
+        auto bytes = _data.read_bytes(1);
+        uint8_t nbits = *bytes.data();
+        unpack(row, nbits);
+        auto p = _initial;
+        for (unsigned i = 0; i < row_width; i++) {
+            row[i] = row[i] ^ p;
+            p = row[i];
+        }
+        _initial = p;
+        _pos++;
+        return true;
+    }
+
+private:
+    template<typename T>
+    void _unpack_as(row_t& input, unsigned shift) {
+        static_assert(
+          std::is_unsigned<T>::value,
+          "Only unsigned integer can be used as a type parameter");
+        for (uint32_t i = 0; i < row_width; i++) {
+            static_assert(sizeof(T) <= sizeof(uint64_t));
+            T val{};
+            auto bytes = _data.read_bytes(sizeof(T));
+            std::memcpy(&val, bytes.data(), bytes.size());
+            input[i] |= static_cast<uint64_t>(val) << shift;
+        }
+    }
+
+    void _unpack1(row_t& output, unsigned shift) {
+        uint16_t bits{};
+        auto bytes = _data.read_bytes(sizeof(bits));
+        std::memcpy(&bits, bytes.data(), bytes.size());
+        for (uint32_t i = 0; i < row_width; i++) {
+            output[i] |= static_cast<uint64_t>((bits & (1U << i)) >> i)
+                         << shift;
+        }
+    }
+
+    void _unpack2(row_t& output, unsigned shift) {
+        uint32_t bits{};
+        auto bytes = _data.read_bytes(sizeof(bits));
+        std::memcpy(&bits, bytes.data(), bytes.size());
+        for (uint32_t i = 0; i < row_width; i++) {
+            output[i] |= static_cast<uint64_t>((bits & (3U << 2 * i)) >> 2 * i)
+                         << shift;
+        }
+    }
+
+    void _unpack3(row_t& output, unsigned shift) {
+        uint32_t tmp32{};
+        auto bytes = _data.read_bytes(sizeof(tmp32));
+        std::memcpy(&tmp32, bytes.data(), bytes.size());
+        uint64_t bits0 = tmp32;
+        uint16_t tmp16{};
+        bytes = _data.read_bytes(sizeof(tmp16));
+        std::memcpy(&tmp16, bytes.data(), bytes.size());
+        uint64_t bits1 = tmp16;
+        output[0] |= ((bits0 & 7U)) << shift;
+        output[1] |= ((bits0 & (7U << 3U)) >> 3U) << shift;
+        output[2] |= ((bits0 & (7U << 6U)) >> 6U) << shift;
+        output[3] |= ((bits0 & (7U << 9U)) >> 9U) << shift;
+        output[4] |= ((bits0 & (7U << 12U)) >> 12U) << shift;
+        output[5] |= ((bits0 & (7U << 15U)) >> 15U) << shift;
+        output[6] |= ((bits0 & (7U << 18U)) >> 18U) << shift;
+        output[7] |= ((bits0 & (7U << 21U)) >> 21U) << shift;
+        output[8] |= ((bits0 & (7U << 24U)) >> 24U) << shift;
+        output[9] |= ((bits0 & (7U << 27U)) >> 27U) << shift;
+        output[10] |= (((bits0 & (3U << 30U)) >> 30U) | ((bits1 & 1U) << 2U))
+                      << shift;
+        output[11] |= ((bits1 & (7U << 1U)) >> 1U) << shift;
+        output[12] |= ((bits1 & (7U << 4U)) >> 4U) << shift;
+        output[13] |= ((bits1 & (7U << 7U)) >> 7U) << shift;
+        output[14] |= ((bits1 & (7U << 10U)) >> 10U) << shift;
+        output[15] |= ((bits1 & (7U << 13U)) >> 13U) << shift;
+    }
+
+    void _unpack4(row_t& output, unsigned shift) {
+        uint64_t bits0{};
+        auto bytes = _data.read_bytes(sizeof(bits0));
+        std::memcpy(&bits0, bytes.data(), bytes.size());
+        output[0] |= ((bits0 & 15U)) << shift;
+        output[1] |= ((bits0 & (15ULL << 4U)) >> 4U) << shift;
+        output[2] |= ((bits0 & (15ULL << 8U)) >> 8U) << shift;
+        output[3] |= ((bits0 & (15ULL << 12U)) >> 12U) << shift;
+        output[4] |= ((bits0 & (15ULL << 16U)) >> 16U) << shift;
+        output[5] |= ((bits0 & (15ULL << 20U)) >> 20U) << shift;
+        output[6] |= ((bits0 & (15ULL << 24U)) >> 24U) << shift;
+        output[7] |= ((bits0 & (15ULL << 28U)) >> 28U) << shift;
+        output[8] |= ((bits0 & (15ULL << 32U)) >> 32U) << shift;
+        output[9] |= ((bits0 & (15ULL << 36U)) >> 36U) << shift;
+        output[10] |= ((bits0 & (15ULL << 40U)) >> 40U) << shift;
+        output[11] |= ((bits0 & (15ULL << 44U)) >> 44U) << shift;
+        output[12] |= ((bits0 & (15ULL << 48U)) >> 48U) << shift;
+        output[13] |= ((bits0 & (15ULL << 52U)) >> 52U) << shift;
+        output[14] |= ((bits0 & (15ULL << 56U)) >> 56U) << shift;
+        output[15] |= ((bits0 & (15ULL << 60U)) >> 60U) << shift;
+    }
+
+    void _unpack5(row_t& output, unsigned shift) {
+        uint64_t bits0{};
+        auto bytes = _data.read_bytes(sizeof(bits0));
+        std::memcpy(&bits0, bytes.data(), bytes.size());
+        uint16_t tmp16{};
+        bytes = _data.read_bytes(sizeof(tmp16));
+        std::memcpy(&tmp16, bytes.data(), bytes.size());
+        uint64_t bits1 = tmp16;
+        output[0] |= ((bits0 & 0x1FU)) << shift;
+        output[1] |= ((bits0 & (0x1FULL << 5U)) >> 5U) << shift;
+        output[2] |= ((bits0 & (0x1FULL << 10U)) >> 10U) << shift;
+        output[3] |= ((bits0 & (0x1FULL << 15U)) >> 15U) << shift;
+        output[4] |= ((bits0 & (0x1FULL << 20U)) >> 20U) << shift;
+        output[5] |= ((bits0 & (0x1FULL << 25U)) >> 25U) << shift;
+        output[6] |= ((bits0 & (0x1FULL << 30U)) >> 30U) << shift;
+        output[7] |= ((bits0 & (0x1FULL << 35U)) >> 35U) << shift;
+        output[8] |= ((bits0 & (0x1FULL << 40U)) >> 40U) << shift;
+        output[9] |= ((bits0 & (0x1FULL << 45U)) >> 45U) << shift;
+        output[10] |= ((bits0 & (0x1FULL << 50U)) >> 50U) << shift;
+        output[11] |= ((bits0 & (0x1FULL << 55U)) >> 55U) << shift;
+        output[12]
+          |= (((bits0 & (0x0FULL << 60U)) >> 60U) | ((bits1 & 1U) << 4U))
+             << shift;
+        output[13] |= ((bits1 & (0x1FULL << 1U)) >> 1U) << shift;
+        output[14] |= ((bits1 & (0x1FULL << 6U)) >> 6U) << shift;
+        output[15] |= ((bits1 & (0x1FULL << 11U)) >> 11U) << shift;
+    }
+
+    void _unpack6(row_t& output, unsigned shift) {
+        uint64_t bits0{};
+        auto bytes = _data.read_bytes(sizeof(bits0));
+        std::memcpy(&bits0, bytes.data(), bytes.size());
+        uint32_t tmp32{};
+        bytes = _data.read_bytes(sizeof(tmp32));
+        std::memcpy(&tmp32, bytes.data(), bytes.size());
+        uint64_t bits1 = tmp32;
+        output[0] |= ((bits0 & 0x3FU)) << shift;
+        output[1] |= ((bits0 & (0x3FULL << 6U)) >> 6U) << shift;
+        output[2] |= ((bits0 & (0x3FULL << 12U)) >> 12U) << shift;
+        output[3] |= ((bits0 & (0x3FULL << 18U)) >> 18U) << shift;
+        output[4] |= ((bits0 & (0x3FULL << 24U)) >> 24U) << shift;
+        output[5] |= ((bits0 & (0x3FULL << 30U)) >> 30U) << shift;
+        output[6] |= ((bits0 & (0x3FULL << 36U)) >> 36U) << shift;
+        output[7] |= ((bits0 & (0x3FULL << 42U)) >> 42U) << shift;
+        output[8] |= ((bits0 & (0x3FULL << 48U)) >> 48U) << shift;
+        output[9] |= ((bits0 & (0x3FULL << 54U)) >> 54U) << shift;
+        output[10]
+          |= (((bits0 & (0xFULL << 60U)) >> 60U) | (bits1 & 0x3U) << 4U)
+             << shift;
+        output[11] |= ((bits1 & (0x3FULL << 2U)) >> 2U) << shift;
+        output[12] |= ((bits1 & (0x3FULL << 8U)) >> 8U) << shift;
+        output[13] |= ((bits1 & (0x3FULL << 14U)) >> 14U) << shift;
+        output[14] |= ((bits1 & (0x3FULL << 20U)) >> 20U) << shift;
+        output[15] |= ((bits1 & (0x3FULL << 26U)) >> 26U) << shift;
+    }
+
+    void _unpack7(row_t& output, unsigned shift) {
+        uint64_t bits0{};
+        auto bytes = _data.read_bytes(sizeof(bits0));
+        std::memcpy(&bits0, bytes.data(), bytes.size());
+        uint32_t tmp32{};
+        bytes = _data.read_bytes(sizeof(tmp32));
+        std::memcpy(&tmp32, bytes.data(), bytes.size());
+        uint64_t bits1 = tmp32;
+        uint16_t tmp16{};
+        bytes = _data.read_bytes(sizeof(tmp16));
+        std::memcpy(&tmp16, bytes.data(), bytes.size());
+        uint64_t bits2 = tmp16;
+        output[0] |= ((bits0 & 0x7FU)) << shift;
+        output[1] |= ((bits0 & (0x7FULL << 7U)) >> 7U) << shift;
+        output[2] |= ((bits0 & (0x7FULL << 14U)) >> 14U) << shift;
+        output[3] |= ((bits0 & (0x7FULL << 21U)) >> 21U) << shift;
+        output[4] |= ((bits0 & (0x7FULL << 28U)) >> 28U) << shift;
+        output[5] |= ((bits0 & (0x7FULL << 35U)) >> 35U) << shift;
+        output[6] |= ((bits0 & (0x7FULL << 42U)) >> 42U) << shift;
+        output[7] |= ((bits0 & (0x7FULL << 49U)) >> 49U) << shift;
+        output[8] |= ((bits0 & (0x7FULL << 56U)) >> 56U) << shift;
+        output[9]
+          |= (((bits0 & (0x01ULL << 63U)) >> 63U) | ((bits1 & 0x3FU) << 1U))
+             << shift;
+        output[10] |= ((bits1 & (0x7FULL << 6U)) >> 6U) << shift;
+        output[11] |= ((bits1 & (0x7FULL << 13U)) >> 13U) << shift;
+        output[12] |= ((bits1 & (0x7FULL << 20U)) >> 20U) << shift;
+        output[13]
+          |= (((bits1 & (0x1FULL << 27U)) >> 27U) | ((bits2 & 0x03U) << 5U))
+             << shift;
+        output[14] |= ((bits2 & (0x7FULL << 2U)) >> 2U) << shift;
+        output[15] |= ((bits2 & (0x7FULL << 9U)) >> 9U) << shift;
+    }
+
+    void unpack(row_t& output, int n) {
+        switch (n) {
+        case 0:
+            break;
+        case 1:
+            _unpack1(output, 0);
+            break;
+        case 2:
+            _unpack2(output, 0);
+            break;
+        case 3:
+            _unpack3(output, 0);
+            break;
+        case 4:
+            _unpack4(output, 0);
+            break;
+        case 5:
+            _unpack5(output, 0);
+            break;
+        case 6:
+            _unpack6(output, 0);
+            break;
+        case 7:
+            _unpack7(output, 0);
+            break;
+        case 8:
+            _unpack_as<uint8_t>(output, 0);
+            break;
+        case 9:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack1(output, 8);
+            break;
+        case 10:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack2(output, 8);
+            break;
+        case 11:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack3(output, 8);
+            break;
+        case 12:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack4(output, 8);
+            break;
+        case 13:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack5(output, 8);
+            break;
+        case 14:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack6(output, 8);
+            break;
+        case 15:
+            _unpack_as<uint8_t>(output, 0);
+            _unpack7(output, 8);
+            break;
+        case 16:
+            _unpack_as<uint16_t>(output, 0);
+            break;
+        case 17:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack1(output, 16);
+            break;
+        case 18:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack2(output, 16);
+            break;
+        case 19:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack3(output, 16);
+            break;
+        case 20:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack4(output, 16);
+            break;
+        case 21:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack5(output, 16);
+            break;
+        case 22:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack6(output, 16);
+            break;
+        case 23:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack7(output, 16);
+            break;
+        case 24:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            break;
+        case 25:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack1(output, 24);
+            break;
+        case 26:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack2(output, 24);
+            break;
+        case 27:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack3(output, 24);
+            break;
+        case 28:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack4(output, 24);
+            break;
+        case 29:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack5(output, 24);
+            break;
+        case 30:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack6(output, 24);
+            break;
+        case 31:
+            _unpack_as<uint16_t>(output, 0);
+            _unpack_as<uint8_t>(output, 16);
+            _unpack7(output, 24);
+            break;
+        case 32:
+            _unpack_as<uint32_t>(output, 0);
+            break;
+        case 33:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack1(output, 32);
+            break;
+        case 34:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack2(output, 32);
+            break;
+        case 35:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack3(output, 32);
+            break;
+        case 36:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack4(output, 32);
+            break;
+        case 37:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack5(output, 32);
+            break;
+        case 38:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack6(output, 32);
+            break;
+        case 39:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack7(output, 32);
+            break;
+        case 40:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            break;
+        case 41:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack1(output, 40);
+            break;
+        case 42:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack2(output, 40);
+            break;
+        case 43:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack3(output, 40);
+            break;
+        case 44:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack4(output, 40);
+            break;
+        case 45:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack5(output, 40);
+            break;
+        case 46:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack6(output, 40);
+            break;
+        case 47:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint8_t>(output, 32);
+            _unpack7(output, 40);
+            break;
+        case 48:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            break;
+        case 49:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack1(output, 48);
+            break;
+        case 50:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack2(output, 48);
+            break;
+        case 51:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack3(output, 48);
+            break;
+        case 52:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack4(output, 48);
+            break;
+        case 53:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack5(output, 48);
+            break;
+        case 54:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack6(output, 48);
+            break;
+        case 55:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack7(output, 48);
+            break;
+        case 56:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            break;
+        case 57:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack1(output, 56);
+            break;
+        case 58:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack2(output, 56);
+            break;
+        case 59:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack3(output, 56);
+            break;
+        case 60:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack4(output, 56);
+            break;
+        case 61:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack5(output, 56);
+            break;
+        case 62:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack6(output, 56);
+            break;
+        case 63:
+            _unpack_as<uint32_t>(output, 0);
+            _unpack_as<uint16_t>(output, 32);
+            _unpack_as<uint8_t>(output, 48);
+            _unpack7(output, 56);
+            break;
+        case 64:
+            _unpack_as<uint64_t>(output, 0);
+            break;
+        }
+    }
+
+    TVal _initial;
+    uint32_t _total;
+    uint32_t _pos;
+    iobuf_parser _data;
+};

--- a/src/v/utils/stream_utils.h
+++ b/src/v/utils/stream_utils.h
@@ -204,8 +204,8 @@ struct fanout_data_source final : ss::data_source_impl {
     ss::future<ss::temporary_buffer<char>> get() final {
         co_return co_await _isf->get(_id);
     }
-    size_t _id;
     ss::lw_shared_ptr<input_stream_fanout<Ch>> _isf;
+    size_t _id;
 };
 
 template<typename Ch, size_t... ix>

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ rp_test(
     retry_chain_node_test.cc
     input_stream_fanout_test.cc
     waiter_queue_test.cc
+    delta_for_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes
   ARGS "-- -c 1"
   LABELS utils

--- a/src/v/utils/tests/delta_for_test.cc
+++ b/src/v/utils/tests/delta_for_test.cc
@@ -1,0 +1,198 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "random/generators.h"
+#include "utils/delta_for.h"
+#include "vlog.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+
+template<class TVal>
+std::vector<TVal> populate_encoder(
+  deltafor_encoder<TVal>& c,
+  uint64_t initial_value,
+  const std::vector<TVal>& deltas) {
+    std::vector<TVal> result;
+    auto p = initial_value;
+    for (TVal delta : deltas) {
+        std::array<TVal, details::FOR_buffer_depth> buf = {};
+        for (int x = 0; x < details::FOR_buffer_depth; x++) {
+            result.push_back(p);
+            buf.at(x) = p;
+            p += random_generators::get_int(delta);
+            if (p < buf.at(x)) {
+                throw std::out_of_range("delta can't be represented");
+            }
+        }
+        c.add(buf);
+    }
+    return result;
+}
+
+BOOST_AUTO_TEST_CASE(roundtrip_test_2) {
+    static constexpr int64_t initial_value = 0;
+    deltafor_encoder<int64_t> enc(initial_value);
+    std::vector<int64_t> deltas = {
+      0LL,
+      10LL,
+      100LL,
+      1000LL,
+      10000LL,
+      100000LL,
+      1000000LL,
+      10000000LL,
+      100000000LL,
+      1000000000LL,
+      10000000000LL,
+      100000000000LL,
+      1000000000000LL,
+      10000000000000LL,
+      100000000000000LL,
+      1000000000000000LL,
+      10000000000000000LL,
+      100000000000000000LL,
+      1000000000000000000LL,
+    };
+    auto expected = populate_encoder(enc, initial_value, deltas);
+
+    deltafor_decoder<int64_t> dec(
+      initial_value, enc.get_row_count(), enc.copy());
+
+    std::vector<int64_t> actual;
+    std::array<int64_t, details::FOR_buffer_depth> buf{};
+    int cnt = 0;
+    while (dec.read(buf)) {
+        cnt++;
+        std::copy(buf.begin(), buf.end(), std::back_inserter(actual));
+        buf = {};
+    }
+    BOOST_REQUIRE_EQUAL(cnt, deltas.size());
+    BOOST_REQUIRE(expected == actual);
+}
+
+BOOST_AUTO_TEST_CASE(roundtrip_test_1) {
+    static constexpr uint64_t initial_value = 0;
+    deltafor_encoder<uint64_t> enc(initial_value);
+    std::vector<uint64_t> deltas = {
+      0ULL,
+      10ULL,
+      100ULL,
+      1000ULL,
+      10000ULL,
+      100000ULL,
+      1000000ULL,
+      10000000ULL,
+      100000000ULL,
+      1000000000ULL,
+      10000000000ULL,
+      100000000000ULL,
+      1000000000000ULL,
+      10000000000000ULL,
+      100000000000000ULL,
+      1000000000000000ULL,
+      10000000000000000ULL,
+      100000000000000000ULL,
+      1000000000000000000ULL,
+    };
+    auto expected = populate_encoder(enc, initial_value, deltas);
+
+    deltafor_decoder<uint64_t> dec(
+      initial_value, enc.get_row_count(), enc.copy());
+
+    std::vector<uint64_t> actual;
+    std::array<uint64_t, details::FOR_buffer_depth> buf{};
+    int cnt = 0;
+    while (dec.read(buf)) {
+        cnt++;
+        std::copy(buf.begin(), buf.end(), std::back_inserter(actual));
+        buf = {};
+    }
+    BOOST_REQUIRE_EQUAL(cnt, deltas.size());
+    BOOST_REQUIRE(expected == actual);
+}
+
+template<class TVal>
+void test_random_walk_roundtrip(int test_size, int max_delta) {
+    static constexpr TVal initial_value = 0;
+    deltafor_encoder<TVal> enc(initial_value);
+    std::vector<TVal> deltas;
+    deltas.reserve(test_size);
+    for (int i = 0; i < test_size; i++) {
+        deltas.push_back(random_generators::get_int(max_delta));
+    }
+    auto expected = populate_encoder(enc, initial_value, deltas);
+
+    deltafor_decoder<TVal> dec(initial_value, enc.get_row_count(), enc.copy());
+
+    std::vector<TVal> actual;
+    std::array<TVal, details::FOR_buffer_depth> buf{};
+    int cnt = 0;
+    while (dec.read(buf)) {
+        cnt++;
+        std::copy(buf.begin(), buf.end(), std::back_inserter(actual));
+        buf = {};
+    }
+    BOOST_REQUIRE_EQUAL(cnt, deltas.size());
+    BOOST_REQUIRE(expected == actual);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_1) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 100;
+    test_random_walk_roundtrip<uint64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_2) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 1000;
+    test_random_walk_roundtrip<uint64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_3) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 10000;
+    test_random_walk_roundtrip<uint64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_4) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 100000;
+    test_random_walk_roundtrip<uint64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_5) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 100;
+    test_random_walk_roundtrip<int64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_6) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 1000;
+    test_random_walk_roundtrip<int64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_7) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 10000;
+    test_random_walk_roundtrip<int64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(random_walk_test_8) {
+    static constexpr int test_size = 100000;
+    static constexpr int max_delta = 100000;
+    test_random_walk_roundtrip<int64_t>(test_size, max_delta);
+}


### PR DESCRIPTION
## Cover letter

Add compressed index to the `remote_segment` instance. The index is used to optimise segment access. When the point query targets the record batch in the middle of the segment `remote_segment_batch_reader` have to scan from the beginning. This may cause significant problems when the fetch requests access segment in random order or if the subsequent fetch requests are misaligned.

The delta-FOR algorithm is used to compress the index. It's a for of differential coding. First the delta values are computed for all elements and then these values are encoded using FOR (Frame-of-Reference) coding.

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/b95026f9ae543bfe9650938a077235d2b0677552..c0b5e4c12c2e4f543536b300370b89d36f06bfbd)
- fix code review issues
- implement offset index caching

## Release notes

* Add compressed in-memory index for segments accessed via Shadow Indexing
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
