### PR TITLE
config: clean up old-style property constructor

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -351,7 +351,7 @@ configuration::configuration()
       "metadata_status_wait_timeout_ms",
       "Maximum time to wait in metadata request for cluster health to be "
       "refreshed",
-      required::no,
+      {.visibility = visibility::tunable},
       2s)
   , transactional_id_expiration_ms(
       *this,
@@ -865,31 +865,31 @@ configuration::configuration()
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",
       "",
-      required::no,
+      {.visibility = visibility::tunable},
       60s)
   , cloud_storage_upload_ctrl_p_coeff(
       *this,
       "cloud_storage_upload_ctrl_p_coeff",
       "proportional coefficient for upload PID controller",
-      required::no,
+      {.visibility = visibility::tunable},
       -2.0)
   , cloud_storage_upload_ctrl_d_coeff(
       *this,
       "cloud_storage_upload_ctrl_d_coeff",
       "derivative coefficient for upload PID controller.",
-      required::no,
+      {.visibility = visibility::tunable},
       0.0)
   , cloud_storage_upload_ctrl_min_shares(
       *this,
       "cloud_storage_upload_ctrl_min_shares",
       "minimum number of IO and CPU shares that archival upload can use",
-      required::no,
+      {.visibility = visibility::tunable},
       100)
   , cloud_storage_upload_ctrl_max_shares(
       *this,
       "cloud_storage_upload_ctrl_max_shares",
       "maximum number of IO and CPU shares that archival upload can use",
-      required::no,
+      {.visibility = visibility::tunable},
       1000)
   , cloud_storage_cache_size(
       *this,

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -18,102 +18,107 @@ node_config::node_config() noexcept
     *this,
     "data_directory",
     "Place where redpanda will keep the data",
-    required::yes)
+    {.required = required::yes, .visibility = visibility::user})
   , node_id(
       *this,
       "node_id",
       "Unique id identifying a node in the cluster",
-      required::yes)
-  , rack(*this, "rack", "Rack identifier", required::no, std::nullopt)
+      {.required = required::yes, .visibility = visibility::user})
+  , rack(
+      *this,
+      "rack",
+      "Rack identifier",
+      {.visibility = visibility::user},
+      std::nullopt)
   , seed_servers(
       *this,
       "seed_servers",
       "List of the seed servers used to join current cluster. If the "
       "seed_server list is empty the node will be a cluster root and it will "
       "form a new cluster",
-      required::no,
+      {.visibility = visibility::user},
       {})
   , rpc_server(
       *this,
       "rpc_server",
       "IpAddress and port for RPC server",
-      required::no,
+      {.visibility = visibility::user},
       net::unresolved_address("127.0.0.1", 33145))
   , rpc_server_tls(
       *this,
       "rpc_server_tls",
       "TLS configuration for RPC server",
-      required::no,
+      {.visibility = visibility::user},
       tls_config(),
       tls_config::validate)
   , kafka_api(
       *this,
       "kafka_api",
       "Address and port of an interface to listen for Kafka API requests",
-      required::no,
+      {.visibility = visibility::user},
       {model::broker_endpoint(net::unresolved_address("127.0.0.1", 9092))})
   , kafka_api_tls(
       *this,
       "kafka_api_tls",
       "TLS configuration for Kafka API endpoint",
-      required::no,
+      {.visibility = visibility::user},
       {},
       endpoint_tls_config::validate_many)
   , admin(
       *this,
       "admin",
       "Address and port of admin server",
-      required::no,
+      {.visibility = visibility::user},
       {model::broker_endpoint(net::unresolved_address("127.0.0.1", 9644))})
   , admin_api_tls(
       *this,
       "admin_api_tls",
       "TLS configuration for admin HTTP server",
-      required::no,
+      {.visibility = visibility::user},
       {},
       endpoint_tls_config::validate_many)
   , coproc_supervisor_server(
       *this,
       "coproc_supervisor_server",
       "IpAddress and port for supervisor service",
-      required::no,
+      {.visibility = visibility::user},
       net::unresolved_address("127.0.0.1", 43189))
   , admin_api_doc_dir(
       *this,
       "admin_api_doc_dir",
       "Admin API doc directory",
-      required::no,
+      {.visibility = visibility::user},
       "/usr/share/redpanda/admin-api-doc")
   , dashboard_dir(
       *this,
       "dashboard_dir",
       "serve http dashboard on / url",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_cache_directory(
       *this,
       "cloud_storage_cache_directory",
       "Directory for archival cache. Should be present when "
       "`cloud_storage_enabled` is present",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , enable_central_config(
       *this,
       "enable_central_config",
       "Enable central storage + sync of cluster configuration",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",
       "Address of RPC endpoint published to other cluster members",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",
       "Address of Kafka API published to the clients",
-      required::no,
+      {.visibility = visibility::user},
       {}) {}
 
 node_config::error_map_t node_config::load(const YAML::Node& root_node) {

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -46,18 +46,6 @@ public:
       , _default(std::move(def))
       , _validator(std::move(validator)) {}
 
-    property(
-      config_store& conf,
-      std::string_view name,
-      std::string_view desc,
-      required req = {},
-      T def = T{},
-      property::validator validator = property::noop_validator)
-      : base_property(conf, name, desc, {.required = req})
-      , _value(def)
-      , _default(std::move(def))
-      , _validator(std::move(validator)) {}
-
     /**
      * Properties aren't moved in normal used on the per-shard
      * cluster configuration objects.  This method exists for

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -50,13 +50,12 @@ struct test_config : public config::config_store {
           "Required string value",
           {.needs_restart = config::needs_restart::no,
            .visibility = config::visibility::user})
-      , an_int64_t(
-          *this, "an_int64_t", "Some other int type", config::required::no, 200)
+      , an_int64_t(*this, "an_int64_t", "Some other int type", {}, 200)
       , an_aggregate(
           *this,
           "an_aggregate",
           "Aggregate type",
-          config::required::no,
+          {},
           custom_aggregate{"str", 10})
       , strings(
           *this,
@@ -67,13 +66,13 @@ struct test_config : public config::config_store {
           *this,
           "nullable_int",
           "A nullable (std::optional) int value",
-          config::required::no,
+          {},
           std::nullopt)
       , nullable_string(
           *this,
           "optional_string",
           "An optional string value",
-          config::required::no,
+          {},
           std::nullopt)
       , boolean(
           *this,
@@ -82,19 +81,9 @@ struct test_config : public config::config_store {
           config::base_property::metadata{
             .needs_restart = config::needs_restart::no},
           false)
-      , seconds(*this, "seconds", "Plain seconds", config::required::no, {})
-      , optional_seconds(
-          *this,
-          "optional_seconds",
-          "Optional seconds",
-          config::required::no,
-          {})
-      , milliseconds(
-          *this,
-          "milliseconds",
-          "Plain milliseconds",
-          config::required::no,
-          {}) {}
+      , seconds(*this, "seconds", "Plain seconds")
+      , optional_seconds(*this, "optional_seconds", "Optional seconds")
+      , milliseconds(*this, "milliseconds", "Plain milliseconds") {}
 };
 
 YAML::Node minimal_valid_configuration() {

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -28,86 +28,82 @@ configuration::configuration()
     *this,
     "brokers",
     "List of address and port of the brokers",
-    config::required::yes,
+    {.required = config::required::yes},
     std::vector<net::unresolved_address>({{"127.0.0.1", 9092}}))
   , broker_tls(
       *this,
       "broker_tls",
       "TLS configuration for the brokers",
-      config::required::no,
+      {},
       config::tls_config(),
       config::tls_config::validate)
   , retries(
-      *this,
-      "retries",
-      "Number of times to retry a request to a broker",
-      config::required::no,
-      5)
+      *this, "retries", "Number of times to retry a request to a broker", {}, 5)
   , retry_base_backoff(
       *this,
       "retry_base_backoff_ms",
       "Delay (in milliseconds) for initial retry backoff",
-      config::required::no,
+      {},
       100ms)
   , produce_batch_record_count(
       *this,
       "produce_batch_record_count",
       "Number of records to batch before sending to broker",
-      config::required::no,
+      {},
       1000)
   , produce_batch_size_bytes(
       *this,
       "produce_batch_size_bytes",
       "Number of bytes to batch before sending to broker",
-      config::required::no,
+      {},
       1048576)
   , produce_batch_delay(
       *this,
       "produce_batch_delay_ms",
       "Delay (in milliseconds) to wait before sending batch",
-      config::required::no,
+      {},
       100ms)
   , consumer_request_timeout(
       *this,
       "consumer_request_timeout_ms",
       "Interval (in milliseconds) for consumer request timeout",
-      config::required::no,
+      {},
       100ms)
   , consumer_request_max_bytes(
       *this,
       "consumer_request_max_bytes",
       "Max bytes to fetch per request",
-      config::required::no,
+      {},
       1_MiB)
   , consumer_session_timeout(
       *this,
       "consumer_session_timeout_ms",
       "Timeout (in milliseconds) for consumer session",
-      config::required::no,
+      {},
       10s)
   , consumer_rebalance_timeout(
       *this,
       "consumer_rebalance_timeout_ms",
       "Timeout (in milliseconds) for consumer rebalance",
-      config::required::no,
+      {},
       2s)
   , consumer_heartbeat_interval(
       *this,
       "consumer_heartbeat_interval_ms",
       "Interval (in milliseconds) for consumer heartbeats",
-      config::required::no,
+      {},
       500ms)
   , sasl_mechanism(
       *this,
       "sasl_mechanism",
       "The SASL mechanism to use when connecting",
-      config::required::no,
+      {},
       "")
   , scram_username(
       *this,
       "scram_username",
       "Username to use for SCRAM authentication mechanisms",
-      config::required::no,
+      {},
       "")
   , scram_password(
       *this,

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -30,32 +30,30 @@ configuration::configuration()
     *this,
     "pandaproxy_api",
     "Rest API listen address and port",
-    config::required::no,
+    {},
     {model::broker_endpoint(net::unresolved_address("0.0.0.0", 8082))})
   , pandaproxy_api_tls(
       *this,
       "pandaproxy_api_tls",
       "TLS configuration for Pandaproxy api",
-      config::required::no,
+      {},
       {},
       config::endpoint_tls_config::validate_many)
   , advertised_pandaproxy_api(
       *this,
       "advertised_pandaproxy_api",
-      "Rest API address and port to publish to client",
-      config::required::no,
-      {})
+      "Rest API address and port to publish to client")
   , api_doc_dir(
       *this,
       "api_doc_dir",
       "API doc directory",
-      config::required::no,
+      {},
       "/usr/share/redpanda/proxy-api-doc")
   , consumer_instance_timeout(
       *this,
       "consumer_instance_timeout_ms",
       "How long to wait for an idle consumer before removing it",
-      config::required::no,
+      {},
       std::chrono::minutes{5}) {}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -21,13 +21,13 @@ configuration::configuration()
     *this,
     "schema_registry_api",
     "Schema Registry API listen address and port",
-    config::required::no,
+    {},
     {model::broker_endpoint(net::unresolved_address("0.0.0.0", 8081))})
   , schema_registry_api_tls(
       *this,
       "schema_registry_api_tls",
       "TLS configuration for Schema Registry API",
-      config::required::no,
+      {},
       {},
       config::endpoint_tls_config::validate_many)
   , schema_registry_replication_factor(
@@ -35,13 +35,13 @@ configuration::configuration()
       "schema_registry_replication_factor",
       "Replication factor for internal _schemas topic.  If unset, defaults to "
       "`default_topic_replication`",
-      config::required::no,
+      {},
       std::nullopt)
   , api_doc_dir(
       *this,
       "api_doc_dir",
       "API doc directory",
-      config::required::no,
+      {},
       "/usr/share/redpanda/proxy-api-doc") {}
 
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
Properties didn't used to have a metadata object:
they just took a `required` flag.  When the metadata
was introduced, the old-style constructor was kept
around to reduce the up-front churn.

These days new properties should all have metadata,
so to avoid confusion, remove the old constructor
and convert remaining uses to the new-style constructor.

For the node config properties, that just means empty
metadata, because at the moment they aren't touched
by an API that would make use of it.

## Cover letter

* none
