### PR TITLE
Using partition revision_id to clear out partition leadership metadata

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1108,10 +1108,10 @@ controller_backend::delete_partition(model::ntp ntp, model::revision_id rev) {
       .invoke_on_all([ntp, group_id, rev](shard_table& st) mutable {
           st.erase(ntp, group_id, rev);
       })
-      .then([this, ntp] {
+      .then([this, ntp, rev] {
           return _partition_leaders_table.invoke_on_all(
-            [ntp](partition_leaders_table& leaders) {
-                leaders.remove_leader(ntp);
+            [ntp, rev](partition_leaders_table& leaders) {
+                leaders.remove_leader(ntp, rev);
             });
       })
       .then([this, ntp = std::move(ntp)] {

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -528,7 +528,7 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
 
     co_return ret;
 }
-
+namespace {
 struct ntp_leader {
     model::ntp ntp;
     model::term_id term;
@@ -587,7 +587,7 @@ reduce_leaders_map(leaders_acc_t acc, std::vector<ntp_leader> current_leaders) {
     }
     return acc;
 }
-
+} // namespace
 ss::future<std::vector<topic_status>>
 health_monitor_backend::collect_topic_status(partitions_filter filters) {
     auto leaders_map = co_await _partition_manager.map_reduce0(

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -533,6 +533,7 @@ struct ntp_leader {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
+    model::revision_id revision_id;
 };
 
 partition_status to_partition_leader(const ntp_leader& ntpl) {
@@ -540,6 +541,7 @@ partition_status to_partition_leader(const ntp_leader& ntpl) {
       .id = ntpl.ntp.tp.partition,
       .term = ntpl.term,
       .leader_id = ntpl.leader_id,
+      .revision_id = ntpl.revision_id,
     };
 }
 
@@ -558,6 +560,7 @@ std::vector<ntp_leader> collect_shard_local_leaders(
                 .ntp = p.first,
                 .term = p.second->term(),
                 .leader_id = p.second->get_leader_id(),
+                .revision_id = p.second->get_revision_id(),
               };
           });
     } else {
@@ -567,6 +570,7 @@ std::vector<ntp_leader> collect_shard_local_leaders(
                   .ntp = ntp,
                   .term = partition->term(),
                   .leader_id = partition->get_leader_id(),
+                  .revision_id = partition->get_revision_id(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -80,9 +80,14 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {
     return o;
 }
 
-std::ostream& operator<<(std::ostream& o, const partition_status& pl) {
+std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
     fmt::print(
-      o, "{{id: {}, term: {}, leader_id: {}}}", pl.id, pl.term, pl.leader_id);
+      o,
+      "{{id: {}, term: {}, leader_id: {}, revision_id: {}}}",
+      ps.id,
+      ps.term,
+      ps.leader_id,
+      ps.revision_id);
     return o;
 }
 
@@ -376,13 +381,13 @@ void adl<cluster::get_node_health_request>::to(
 
 cluster::get_node_health_request
 adl<cluster::get_node_health_request>::from(iobuf_parser& p) {
-    read_and_assert_version<cluster::get_node_health_request>(
-      "cluster::get_node_health_request", p);
+    auto version = adl<int8_t>{}.from(p);
 
     auto filter = adl<cluster::node_report_filter>{}.from(p);
 
     return cluster::get_node_health_request{
       .filter = std::move(filter),
+      .decoded_version = version,
     };
 }
 
@@ -411,8 +416,7 @@ void adl<cluster::get_cluster_health_request>::to(
 
 cluster::get_cluster_health_request
 adl<cluster::get_cluster_health_request>::from(iobuf_parser& p) {
-    read_and_assert_version<cluster::get_cluster_health_request>(
-      "cluster::get_cluster_health_request", p);
+    auto version = adl<int8_t>{}.from(p);
 
     auto filter = adl<cluster::cluster_report_filter>{}.from(p);
     auto refresh = adl<cluster::force_refresh>{}.from(p);
@@ -420,6 +424,7 @@ adl<cluster::get_cluster_health_request>::from(iobuf_parser& p) {
     return cluster::get_cluster_health_request{
       .filter = std::move(filter),
       .refresh = refresh,
+      .decoded_version = version,
     };
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -146,9 +146,12 @@ using force_refresh = ss::bool_class<struct hm_force_refresh_tag>;
  */
 
 struct get_node_health_request {
-    static constexpr int8_t current_version = 0;
+    // version -1: included revision id in partition status
+    static constexpr int8_t current_version = -1;
 
     node_report_filter filter;
+    // this field is not serialized
+    int8_t decoded_version = current_version;
 };
 
 struct get_node_health_reply {
@@ -159,11 +162,13 @@ struct get_node_health_reply {
 };
 
 struct get_cluster_health_request {
-    static constexpr int8_t current_version = 0;
-
+    // version -1: included revision id in partition status
+    static constexpr int8_t current_version = -1;
     cluster_report_filter filter;
     // if set to true will force node health metadata refresh
     force_refresh refresh = force_refresh::no;
+    // this field is not serialized
+    int8_t decoded_version = current_version;
 };
 
 struct get_cluster_health_reply {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -44,11 +44,19 @@ struct node_state {
 };
 
 struct partition_status {
-    static constexpr int8_t current_version = 0;
+    /**
+     * We increase a version here 'backward' since incorrect assertion would
+     * cause older redpanda versions to crash.
+     *
+     * Version: -1: added revision_id field
+     */
+    static constexpr int8_t current_version = -1;
 
     model::partition_id id;
     model::term_id term;
     std::optional<model::node_id> leader_id;
+    model::revision_id revision_id;
+
     friend std::ostream& operator<<(std::ostream&, const partition_status&);
     friend bool operator==(const partition_status&, const partition_status&)
       = default;

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -371,6 +371,7 @@ ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
                       if (p.leader_id.has_value()) {
                           leaders.update_partition_leader(
                             model::ntp(tp.tp_ns.ns, tp.tp_ns.tp, p.id),
+                            p.revision_id,
                             p.term,
                             p.leader_id);
                       }

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -348,6 +348,16 @@ ss::future<get_cluster_health_reply> service::get_cluster_health_report(
       });
 }
 
+namespace {
+void clear_partition_revisions(node_health_report& report) {
+    for (auto& t : report.topics) {
+        for (auto& p : t.partitions) {
+            p.revision_id = model::revision_id{};
+        }
+    }
+}
+} // namespace
+
 ss::future<get_node_health_reply>
 service::do_collect_node_health_report(get_node_health_request req) {
     auto res = co_await _hm_frontend.local().collect_node_health(
@@ -356,9 +366,14 @@ service::do_collect_node_health_report(get_node_health_request req) {
         co_return get_node_health_reply{
           .error = map_health_monitor_error_code(res.error())};
     }
+    auto report = std::move(res.value());
+    // clear all revision ids to prevent sending them to old redpanda nodes
+    if (req.decoded_version == 0) {
+        clear_partition_revisions(report);
+    }
     co_return get_node_health_reply{
       .error = errc::success,
-      .report = res.value(),
+      .report = std::move(report),
     };
 }
 
@@ -368,13 +383,21 @@ service::do_get_cluster_health_report(get_cluster_health_request req) {
                 + model::timeout_clock::now();
     auto res = co_await _hm_frontend.local().get_cluster_health(
       req.filter, req.refresh, tout);
+
     if (res.has_error()) {
         co_return get_cluster_health_reply{
           .error = map_health_monitor_error_code(res.error())};
     }
+    auto report = std::move(res.value());
+    // clear all revision ids to prevent sending them to old redpanda nodes
+    if (req.decoded_version == 0) {
+        for (auto& r : report.node_reports) {
+            clear_partition_revisions(r);
+        }
+    }
     co_return get_cluster_health_reply{
       .error = errc::success,
-      .report = res.value(),
+      .report = std::move(report),
     };
 }
 

--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -1,0 +1,97 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from ducktape.mark import parametrize
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RecreateTopicMetadataTest(RedpandaTest):
+    def __init__(self, test_context):
+
+        super(RecreateTopicMetadataTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=5,
+                             extra_rp_conf={})
+
+    @cluster(num_nodes=5)
+    @parametrize(replication_factor=3)
+    @parametrize(replication_factor=5)
+    def test_recreated_topic_metadata_are_valid(self, replication_factor):
+        """
+        Test recreated topic metadata are valid across all the nodes
+        """
+
+        topic = 'tp-test'
+        partition_count = 5
+        rpk = RpkTool(self.redpanda)
+        kcat = KafkaCat(self.redpanda)
+        admin = Admin(self.redpanda)
+        # create topic with replication factor of 3
+        rpk.create_topic(topic='tp-test',
+                         partitions=partition_count,
+                         replicas=replication_factor)
+
+        # produce some data to the topic
+
+        def wait_for_leader(partition, expected_leader):
+            leader, _ = kcat.get_partition_leader(topic, partition)
+            return leader == expected_leader
+
+        def transfer_all_leaders():
+            partitions = rpk.describe_topic(topic)
+            for p in partitions:
+                replicas = set(p.replicas)
+                replicas.remove(p.leader)
+                target = random.choice(list(replicas))
+                admin.partition_transfer_leadership("kafka", topic, p.id,
+                                                    target)
+                wait_until(lambda: wait_for_leader(p.id, target),
+                           timeout_sec=30,
+                           backoff_sec=1)
+
+        for i in range(0, 100):
+            rpk.produce(topic=topic, key=str(i), msg=f"payload-{i}")
+
+        # transfer leadership to grow the term
+        for i in range(0, 10):
+            transfer_all_leaders()
+
+        # recreate the topic
+        rpk.delete_topic(topic)
+        rpk.create_topic(topic='tp-test',
+                         partitions=partition_count,
+                         replicas=3)
+
+        def metadata_consistent():
+            # validate leadership information on each node
+            for p in range(0, partition_count):
+                leaders = set()
+                for n in self.redpanda.nodes:
+                    admin_partition = admin.get_partitions(topic=topic,
+                                                           partition=p,
+                                                           namespace="kafka",
+                                                           node=n)
+                    self.logger.info(
+                        f"node: {n.account.hostname} partition: {admin_partition}"
+                    )
+                    leaders.add(admin_partition['leader_id'])
+
+                self.logger.info(f"{topic}/{p} leaders: {leaders}")
+                if len(leaders) != 1:
+                    return False
+            return True
+
+        wait_until(metadata_consistent, 45, backoff_sec=2)


### PR DESCRIPTION
## Cover letter

When partition is deleted and then created again its NTP does not change but all underlying structures are reset. Raft term value is initialized to 0.

In partitions leaders table we use term to fence stale metadata updates. Currently partitions_leader_table is not aware of partition revision. When term is reset after partition is deleted and then created again all the updates coming from the new partition instance are ignored since their term value is smaller from the one that is currently stored in partitions_leaders_table.

When deleting topic partitions_leader_table entries related with its partition are deleted, however this action is not coordinated on all of the nodes and this may lead to situation in which metadata dissemination update will be lost and/or leadership update coming from the partition that was deleted is applied after the entry was deleted from leaders table.

Added revision_id to `partition_status` field sent in `node_health_report`. 
This make it possible for the `partition_leaders_table` to recognize that the partition was removed and created again and set leadership metadata ignoring the `term` check.

Solution contained in this PR touches only part of metadata delivery path. The health monitor reports are used to periodically poll metadata information. A follow up PR will contain changes in push (notification based delivery path). The push based path is handled by `metadata_dissemination_service` and would require breaking changes in the RPC requests/responses. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
