### PR TITLE
Backport #3813: cloud_storage: fix race between remote_partition::stop and readers

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -60,7 +60,8 @@ public:
       , _partition(std::move(part))
       , _ot_state(std::move(ot_state))
       , _it(_partition->begin())
-      , _end(_partition->end()) {
+      , _end(_partition->end())
+      , _gate_guard(_partition->_gate) {
         if (config.abort_source) {
             vlog(_ctxlog.debug, "abort_source is set");
             auto sub = config.abort_source->get().subscribe([this]() noexcept {
@@ -315,6 +316,8 @@ private:
     std::unique_ptr<remote_segment_batch_reader> _reader;
     /// Cancelation subscription
     ss::abort_source::subscription _as_sub;
+    /// Guard for the partition gate
+    gate_guard _gate_guard;
 };
 
 remote_partition::remote_partition(
@@ -355,9 +358,6 @@ ss::future<> remote_partition::run_eviction_loop() {
             }
         }
     } catch (const ss::broken_condition_variable&) {
-    }
-    for (auto& rs : _eviction_list) {
-        co_await std::visit([](auto&& rs) { return rs->stop(); }, rs);
     }
     vlog(_ctxlog.debug, "remote partition eviction loop stopped");
 }
@@ -469,6 +469,12 @@ ss::future<> remote_partition::stop() {
 
     co_await _gate.close();
 
+    // Do the last pass over the eviction list to stop remaining items returned
+    // from readers after the eviction loop stopped.
+    for (auto& rs : _eviction_list) {
+        co_await std::visit([](auto&& rs) { return rs->stop(); }, rs);
+    }
+
     for (auto& [offset, seg] : _segments) {
         vlog(_ctxlog.debug, "remote partition stop {}", offset);
         co_await std::visit([](auto&& st) { return st->stop(); }, seg);
@@ -564,7 +570,6 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
   storage::log_reader_config config,
   std::optional<model::timeout_clock::time_point> deadline) {
     std::ignore = deadline;
-    gate_guard g(_gate);
     vlog(
       _ctxlog.debug,
       "remote partition make_reader invoked, config: {}, num segments {}",

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -296,7 +296,6 @@ private:
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     ss::gate _gate;
-    ss::abort_source _as;
     remote& _api;
     cache& _cache;
     const manifest& _manifest;

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -585,39 +585,6 @@ FIXTURE_TEST(test_remote_partition_scan_off, cloud_storage_fixture) {
     auto headers_read = scan_remote_partition(*this, base, max);
     BOOST_REQUIRE_EQUAL(headers_read.size(), 0);
 }
-/// This test scans batches in the middle
-FIXTURE_TEST(test_remote_partition_lifetime_issue, cloud_storage_fixture) {
-    constexpr int batches_per_segment = 10;
-    constexpr int num_segments = 3;
-    constexpr int total_batches = batches_per_segment * num_segments;
-
-    auto segments = setup_s3_imposter(*this, 3, 10);
-    auto base = segments[0].headers[batches_per_segment / 2].last_offset();
-    auto max = segments[2].headers[batches_per_segment / 2 - 1].last_offset();
-
-    vlog(test_log.debug, "offset range: {}-{}", base, max);
-    print_segments(segments);
-
-    auto conf = get_configuration();
-    static auto bucket = s3::bucket_name("bucket");
-    remote api(s3_connection_limit(10), conf);
-    auto action = ss::defer([&api] { api.stop().get(); });
-
-    auto manifest = hydrate_manifest(api, bucket);
-
-    auto partition = ss::make_lw_shared<remote_partition>(
-      manifest, api, *cache, bucket);
-
-    storage::log_reader_config reader_config(
-      base, max, ss::default_priority_class());
-    auto reader = partition->make_reader(reader_config).get().reader;
-
-    partition->stop().get();
-    partition = {};
-
-    auto res = reader.consume(test_consumer(), model::no_timeout).get();
-    BOOST_REQUIRE_EQUAL(res.size(), 0);
-}
 
 /// This test scans the entire range of offsets
 FIXTURE_TEST(


### PR DESCRIPTION
Backport #3813 

## Cover letter

Fixes #3507. Previously remote_partition readers could return segment readers to the partition object after stop() was called, leading to an assertion failure in the remote_partition destructor. To fix that we make readers hold a guard for the partition gate and do a last pass over the eviction list after the gate was closed (and thus all readers had finished).

## Release notes

### Bug fixes
* Fix a rare crash that could happen when doing a shadow indexing fetch concurrently with topic deletion.
