### PR TITLE
Ignored unstable `RpkClusterTest.test_node_down` test

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -12,6 +12,7 @@ import re
 import zipfile
 import json
 
+from ducktape.mark import ignore
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.utils.util import wait_until
@@ -118,6 +119,7 @@ class RpkClusterTest(RedpandaTest):
         assert 'enable_transactions' in parsed
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/3847
     def test_node_down(self):
         """
         Test RPK's handling of a degraded cluster.  For requests using the


### PR DESCRIPTION
Revert this commit after following issue is fixed:

https://github.com/redpanda-data/redpanda/issues/3847

Signed-off-by: Michal Maslanka <michal@vectorized.io>

