### PR TITLE
Fix flaky test_leader_transfers_recover

### DIFF
--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -250,7 +250,7 @@ class RaftAvailabilityTest(RedpandaTest):
                     continue
                 else:
                     raise e
-            break
+            break  # no exception -> success, we can return now
 
         self.logger.info(f"Completed transfer to {target_node_id}")
 

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -221,9 +221,20 @@ class RaftAvailabilityTest(RedpandaTest):
         self.logger.info(f"Starting transfer to {target_node_id}")
         admin.partition_transfer_leadership("kafka", topic, 0, target_node_id)
 
-        self._wait_for_leader(
-            lambda l : l and l == target_node_id,
-            timeout=ELECTION_TIMEOUT * 2)
+        last_log_msg = ""      # avoid spamming log
+        def leader_predicate(l: Optional[int]) -> bool:
+            nonlocal last_log_msg, target_node_id
+            if not l:
+                return False
+            if l != target_node_id:
+                log_msg = f'Still waiting for leader {target_node_id}, got {l}'
+                if log_msg != last_log_msg:  # type: ignore # "unbound"
+                    self.logger.info(log_msg)
+                    last_log_msg = log_msg
+                return False
+            return True
+
+        self._wait_for_leader(leader_predicate, timeout=ELECTION_TIMEOUT * 2)
         self.logger.info(f"Completed transfer to {target_node_id}")
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -220,12 +220,13 @@ class RaftAvailabilityTest(RedpandaTest):
     def _transfer_leadership(self, admin: Admin, namespace: str, topic: str,
                              target_node_id: int) -> None:
 
-        last_log_msg = ""      # avoid spamming log
+        last_log_msg = ""  # avoid spamming log
+
         def leader_predicate(l: Optional[int]) -> bool:
             nonlocal last_log_msg, target_node_id
             if not l:
                 return False
-            if l != target_node_id: # type: ignore
+            if l != target_node_id:  # type: ignore
                 log_msg = f'Still waiting for leader {target_node_id}, got {l}'
                 if log_msg != last_log_msg:  # type: ignore # "unbound"
                     self.logger.info(log_msg)
@@ -472,7 +473,8 @@ class RaftAvailabilityTest(RedpandaTest):
             target_idx = (initial_leader_id + n) % len(self.redpanda.nodes)
             target_node_id = target_idx + 1
 
-            self._transfer_leadership(admin, "kafka", self.topic, target_node_id)
+            self._transfer_leadership(admin, "kafka", self.topic,
+                                      target_node_id)
 
         self.logger.info(f"Completed {transfer_count} transfers successfully")
 


### PR DESCRIPTION
Similar to chaos tests, wrap topic leader transfer request in a retry.

Long term, we should isolate raft protocol to allow for deterministic testing. For now, adding retries allows us to validate that recovery happens, without dealing with flaky tests based on live infrastructure timings.

Fixes #3453

## Release notes
* none
