### PR TITLE
[transaction] Fix test_expired_transaction

### DIFF
--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -81,7 +81,6 @@ class TxAdminTest(RedpandaTest):
                     assert (tx['timeout_ms'] == 60000)
 
     @cluster(num_nodes=3)
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3849
     def test_expired_transaction(self):
         '''
         Problem: rm_stm contains timer to run try_abort_old_txs.
@@ -104,7 +103,7 @@ class TxAdminTest(RedpandaTest):
         producer1 = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': '30000'
+            'transaction.timeout.ms': '900000'
         })
         producer1.init_transactions()
         producer1.begin_transaction()


### PR DESCRIPTION
## Cover letter

Looks like time for leadership transfer was increased and 30 seconds too small for transaction timeout, because `rm_stm` has time to expire transaction before leadership transfer

Fix for test also include #3851

Fixes #3849


### More info
`test_expired_transaction` create transaction for each partition, do transfer leadership for each partition, and check that for all partition transaction is expired.

We got problem after merge #3834 
I did not check that transfer leadership was finished, and got for `new_leader` -1, so it means that transfer is in progress.
After adding wait for finish transfer leadership I got new error:
`rm_stm` for last partition in test has time to expire transaction before leader for partition was changed. So I start to use 15 min for transaction timeout. It should be enough.

## Release notes

* none