### PR TITLE
Sync topic directory before deletion

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -292,13 +292,15 @@ ss::future<> log_manager::dispatch_topic_dir_deletion(ss::sstring dir) {
                 if (!exists) {
                     return ss::now();
                 }
-                return directory_walker::empty(std::filesystem::path(dir))
-                  .then([dir](bool empty) {
-                      if (!empty) {
-                          return ss::now();
-                      }
-                      return ss::remove_file(dir);
-                  });
+                return ss::sync_directory(dir).then([dir] {
+                    return directory_walker::empty(std::filesystem::path(dir))
+                      .then([dir](bool empty) {
+                          if (!empty) {
+                              return ss::now();
+                          }
+                          return ss::remove_file(dir);
+                      });
+                });
             });
         });
     });

--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -13,7 +13,6 @@ from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 
 from rptest.tests.redpanda_test import RedpandaTest
@@ -27,7 +26,6 @@ class RecreateTopicMetadataTest(RedpandaTest):
                              num_brokers=5,
                              extra_rp_conf={})
 
-    @ignore  # issue #3859
     @cluster(num_nodes=5)
     @parametrize(replication_factor=3)
     @parametrize(replication_factor=5)


### PR DESCRIPTION
## Cover letter

Before removing topic directory we have to sync its metadata to make sure that all partitions were already removed.

Fixes: #3859

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
