### PR TITLE
fix: use a unique secret name for webhook cert

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/_helpers.tpl
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{- define "redpanda-operator.webhook-cert" -}}
-{{- printf "webhook-server-cert" }}
+{{- printf .Values.webhookSecretName }}
 {{- end }}
 
 {{/*

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -96,3 +96,5 @@ labels:
 # monitoring -- Add service monitor to the deployment
 monitoring:
   enabled: false
+
+webhookSecretName: webhook-server-cert


### PR DESCRIPTION
## Cover letter

Currently, the Redpanda Operator can't be deployed via Helm Chart when another `kubebuilder` operator is deployed to the same namespace ... because the generated helm charts all use the same secret name.

This is a problem :)

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
