### PR TITLE
test/node_operations_fuzzy: disable flaky CI test

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -113,7 +113,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
     """
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @parametrize(enable_failures=True)
+    # @ignore see issue #3866: @parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster


### PR DESCRIPTION
Temporarily disable test while we stabilize CI.
Related: #3866


## Release notes
* none
