### PR TITLE
tests/node_op_test: use longer timeout for starting redpanda

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -117,7 +117,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
     """
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    # @ignore see issue #3866: @parametrize(enable_failures=True)
+    @parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster


### PR DESCRIPTION
Recent changes in redpanda start sequence changed the behavior,
currently redpanda does not serve any requests before it is member of a
cluster. This makes the whole joining process longer, especially in face
of failures. Using longer timeout in `node_operations_fuzzy` test to
wait for node start.

Fixes: #3866
