### PR TITLE
tests: update CHAOS_LOG_ALLOW_LIST

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -94,6 +94,9 @@ CHAOS_LOG_ALLOW_LIST = [
 
     # rpc - Service handler threw an exception: std::exception (std::exception)
     re.compile("rpc - Service handler threw an exception: std"),
+
+    # rpc - Service handler threw an exception: seastar::broken_promise (broken promise)"
+    re.compile("rpc - Service handler threw an exception: seastar"),
 ]
 
 


### PR DESCRIPTION
## Cover letter

One additional type of exception that could occur during request processing.

It's not obvious how this is happening in the context of the test (it isn't during shutdown), but there's no indication this should be a test failure.

Seen here:
https://buildkite.com/redpanda/redpanda/builds/7549#1aa7d5c8-9c7e-43c8-83dd-4f290fe78662

## Release notes

* none