### PR TITLE
cluster: pass through revision IDs for local leadership updates

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -102,7 +102,10 @@ ss::future<> metadata_dissemination_service::start() {
             }
             auto ntp = c->ntp();
             handle_leadership_notification(
-              std::move(ntp), c->config().revision_id(), term, std::move(leader_id));
+              std::move(ntp),
+              c->config().revision_id(),
+              term,
+              std::move(leader_id));
         });
 
     if (ss::this_shard_id() != 0) {
@@ -145,24 +148,31 @@ ss::future<> metadata_dissemination_service::start() {
 }
 
 void metadata_dissemination_service::handle_leadership_notification(
-  model::ntp ntp, model::revision_id revision, model::term_id term, std::optional<model::node_id> lid) {
+  model::ntp ntp,
+  model::revision_id revision,
+  model::term_id term,
+  std::optional<model::node_id> lid) {
     ssx::spawn_with_gate(
       _bg, [this, ntp = std::move(ntp), lid, revision, term]() mutable {
           // the lock sequences the updates from raft
-          return _lock.with([this, ntp = std::move(ntp), lid, revision, term]() mutable {
-              return container().invoke_on(
-                0,
-                [ntp = std::move(ntp), lid, revision, term](
-                  metadata_dissemination_service& s) mutable {
-                    return s.apply_leadership_notification(
-                      std::move(ntp), revision, term, lid);
-                });
-          });
+          return _lock.with(
+            [this, ntp = std::move(ntp), lid, revision, term]() mutable {
+                return container().invoke_on(
+                  0,
+                  [ntp = std::move(ntp), lid, revision, term](
+                    metadata_dissemination_service& s) mutable {
+                      return s.apply_leadership_notification(
+                        std::move(ntp), revision, term, lid);
+                  });
+            });
       });
 }
 
 ss::future<> metadata_dissemination_service::apply_leadership_notification(
-  model::ntp ntp, model::revision_id revision, model::term_id term, std::optional<model::node_id> lid) {
+  model::ntp ntp,
+  model::revision_id revision,
+  model::term_id term,
+  std::optional<model::node_id> lid) {
     // the gate also needs to be taken on the destination core.
     return ss::with_gate(
       _bg, [this, ntp = std::move(ntp), lid, revision, term]() mutable {

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -112,9 +112,15 @@ private:
       = absl::flat_hash_map<model::node_id, update_retry_meta>;
 
     void handle_leadership_notification(
-      model::ntp, model::revision_id, model::term_id, std::optional<model::node_id>);
+      model::ntp,
+      model::revision_id,
+      model::term_id,
+      std::optional<model::node_id>);
     ss::future<> apply_leadership_notification(
-      model::ntp, model::revision_id, model::term_id, std::optional<model::node_id>);
+      model::ntp,
+      model::revision_id,
+      model::term_id,
+      std::optional<model::node_id>);
 
     void collect_pending_updates();
     void cleanup_finished_updates();

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -112,9 +112,9 @@ private:
       = absl::flat_hash_map<model::node_id, update_retry_meta>;
 
     void handle_leadership_notification(
-      model::ntp, model::term_id, std::optional<model::node_id>);
+      model::ntp, model::revision_id, model::term_id, std::optional<model::node_id>);
     ss::future<> apply_leadership_notification(
-      model::ntp, model::term_id, std::optional<model::node_id>);
+      model::ntp, model::revision_id, model::term_id, std::optional<model::node_id>);
 
     void collect_pending_updates();
     void cleanup_finished_updates();

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -12,7 +12,6 @@ import re
 import zipfile
 import json
 
-from ducktape.mark import ignore
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.utils.util import wait_until
@@ -119,7 +118,6 @@ class RpkClusterTest(RedpandaTest):
         assert 'enable_transactions' in parsed
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3847
     def test_node_down(self):
         """
         Test RPK's handling of a degraded cluster.  For requests using the


### PR DESCRIPTION
## Cover letter

In https://github.com/redpanda-data/redpanda/pull/3834, the partition leadership updates were changed so that any update with a valid revision ID took precedence over an update without one.  Health monitor updates had such an ID, regular metadata dissemination updates do not.

There is a pending followup to that PR to implement revision IDs in metadata dissemination messages generally, but for now we can help with the unstable RPK test by fixing this just for 3 node clusters, by propagating revision ID in the handle_leadership_update path of metadata dissemination service.

No release notes because this is mitigating a change from just before, the end state as at 22.1.1 will be unchanged compared with user's experience of earlier releases without the issue.

Fixes https://github.com/redpanda-data/redpanda/issues/3847

## Release notes

* none