### PR TITLE
Added revision to metadata dissemination service

### DIFF
--- a/src/v/cluster/metadata_dissemination_handler.h
+++ b/src/v/cluster/metadata_dissemination_handler.h
@@ -45,9 +45,12 @@ public:
     ss::future<get_leadership_reply>
     get_leadership(get_leadership_request&&, rpc::streaming_context&) final;
 
+    ss::future<update_leadership_reply> update_leadership_v2(
+      update_leadership_request_v2&&, rpc::streaming_context&) final;
+
 private:
     ss::future<update_leadership_reply>
-    do_update_leadership(update_leadership_request&&);
+      do_update_leadership(std::vector<ntp_leader_revision>);
 
     ss::sharded<partition_leaders_table>& _leaders;
 }; // namespace cluster

--- a/src/v/cluster/metadata_dissemination_rpc.json
+++ b/src/v/cluster/metadata_dissemination_rpc.json
@@ -14,6 +14,11 @@
             "name": "get_leadership",
             "input_type": "get_leadership_request",
             "output_type": "get_leadership_reply"
+        },
+        {
+            "name": "update_leadership_v2",
+            "input_type": "update_leadership_request_v2",
+            "output_type": "update_leadership_reply"
         }
     ]
 }

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -82,7 +82,10 @@ public:
       ss::sharded<health_monitor_frontend>&);
 
     void disseminate_leadership(
-      model::ntp, model::term_id, std::optional<model::node_id>);
+      model::ntp,
+      model::revision_id,
+      model::term_id,
+      std::optional<model::node_id>);
 
     void initialize_leadership_metadata();
 
@@ -94,7 +97,7 @@ private:
     // When update was delivered successfully the finished flag is set to true
     // and object is removed from pending updates map
     struct update_retry_meta {
-        ntp_leaders updates;
+        std::vector<ntp_leader_revision> updates;
         bool finished = false;
     };
     // Used to track the process of requesting update when redpanda starts
@@ -147,7 +150,7 @@ private:
     model::broker _self;
     std::chrono::milliseconds _dissemination_interval;
     config::tls_config _rpc_tls_config;
-    std::vector<ntp_leader> _requests;
+    std::vector<ntp_leader_revision> _requests;
     std::vector<net::unresolved_address> _seed_servers;
     broker_updates_t _pending_updates;
     mutex _lock;


### PR DESCRIPTION
## Cover letter

Recently we added `revision_id` field to recognize `ntp` instances in `partition_leaders_table`. The metadata dissemination  component of redpanda was ignoring revision id field which might lead to situation in which leadership metadata update was slower (with the rate of health monitor updates). 

Added new method to metadata dissemination service to add revision id field to leadership information disseminated on leadership change. 

Note: we do not need to change the `get_leadership_update` API since that is the request issued only once when leadership table is still empty and not populated with metadata.


## Release notes
 - none
