### PR TITLE
New storage disk metrics

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -54,6 +54,7 @@ controller::controller(
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
+  ss::sharded<storage::node_api>& storage_node,
   ss::sharded<raft::group_manager>& raft_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table)
   : _config_preload(std::move(config_preload))
@@ -61,6 +62,7 @@ controller::controller(
   , _partition_manager(pm)
   , _shard_table(st)
   , _storage(storage)
+  , _storage_node(storage_node)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state, _partition_leaders)
   , _security_manager(_credentials, _authorizer)
   , _data_policy_manager(data_policy_table)
@@ -283,6 +285,7 @@ ss::future<> controller::start() {
             std::ref(_partition_manager),
             std::ref(_raft_manager),
             std::ref(_as),
+            std::ref(_storage_node),
             config::shard_local_cfg()
               .storage_space_alert_free_threshold_bytes.bind(),
             config::shard_local_cfg()

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -23,6 +23,7 @@
 #include "rpc/connection_cache.h"
 #include "security/authorizer.h"
 #include "security/credential_store.h"
+#include "storage/api.h"
 #include "storage/fwd.h"
 
 #include <seastar/core/abort_source.hh>
@@ -39,6 +40,7 @@ public:
       ss::sharded<partition_manager>& pm,
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
+      ss::sharded<storage::node_api>& storage_node,
       ss::sharded<raft::group_manager>&,
       ss::sharded<v8_engine::data_policy_table>&);
 
@@ -118,6 +120,7 @@ private:
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<storage::api>& _storage;
+    ss::sharded<storage::node_api>& _storage_node; // single instance
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
     security_manager _security_manager;

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -46,6 +46,7 @@ health_monitor_backend::health_monitor_backend(
   ss::sharded<partition_manager>& partition_manager,
   ss::sharded<raft::group_manager>& raft_manager,
   ss::sharded<ss::abort_source>& as,
+  ss::sharded<storage::node_api>& storage_api,
   config::binding<size_t> storage_min_bytes_threshold,
   config::binding<unsigned> storage_min_percent_threshold)
   : _raft0(std::move(raft0))
@@ -56,7 +57,8 @@ health_monitor_backend::health_monitor_backend(
   , _as(as)
   , _local_monitor(
       std::move(storage_min_bytes_threshold),
-      std::move(storage_min_percent_threshold)) {
+      std::move(storage_min_percent_threshold),
+      storage_api) {
     _tick_timer.set_callback([this] { tick(); });
     _tick_timer.arm(tick_interval());
     _leadership_notification_handle

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -53,6 +53,7 @@ public:
       ss::sharded<partition_manager>&,
       ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
+      ss::sharded<storage::node_api>&,
       config::binding<size_t> storage_min_bytes_threshold,
       config::binding<unsigned> storage_min_percent_threshold);
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -247,7 +247,7 @@ adl<cluster::node_health_report>::from(iobuf_parser& p) {
     auto id = adl<model::node_id>{}.from(p);
     auto redpanda_version = adl<cluster::node::application_version>{}.from(p);
     auto uptime = adl<std::chrono::milliseconds>{}.from(p);
-    auto disks = adl<std::vector<cluster::node::disk>>{}.from(p);
+    auto disks = adl<std::vector<storage::disk>>{}.from(p);
     auto topics = adl<std::vector<cluster::topic_status>>{}.from(p);
     cluster::cluster_version logical_version{cluster::invalid_version};
     if (version >= 1) {

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -200,7 +200,7 @@ metrics_reporter::build_metrics_snapshot() {
           report.local_state.disks.begin(),
           report.local_state.disks.end(),
           std::back_inserter(metrics.disks),
-          [](const cluster::node::disk& nds) {
+          [](const storage::disk& nds) {
               return node_disk_space{.free = nds.free, .total = nds.total};
           });
 

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -72,14 +72,14 @@ local_monitor::minimum_free_by_bytes_and_percent(size_t bytes_available) const {
       _free_bytes_alert_threshold(), percent_factor * bytes_available);
 }
 
-ss::future<std::vector<disk>> local_monitor::get_disks() {
+ss::future<std::vector<storage::disk>> local_monitor::get_disks() {
     auto path = _path_for_test.empty()
                   ? config::node().data_directory().as_sstring()
                   : _path_for_test;
 
     auto svfs = co_await get_statvfs(path);
 
-    co_return std::vector<disk>{disk{
+    co_return std::vector<storage::disk>{storage::disk{
       .path = config::node().data_directory().as_sstring(),
       // f_bsize is a historical linux-ism, use f_frsize
       .free = svfs.f_bfree * svfs.f_frsize,
@@ -95,12 +95,12 @@ ss::future<struct statvfs> local_monitor::get_statvfs(const ss::sstring& path) {
     }
 }
 
-float percent_free(const disk& disk) {
+float percent_free(const storage::disk& disk) {
     long double free = disk.free, total = disk.total;
     return float((free / total) * 100.0);
 }
 
-void local_monitor::maybe_log_space_error(const disk& disk) {
+void local_monitor::maybe_log_space_error(const storage::disk& disk) {
     auto [min_by_bytes, min_by_percent] = minimum_free_by_bytes_and_percent(
       disk.total);
     auto min_space = std::min(min_by_percent, min_by_bytes);

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -120,7 +120,7 @@ void local_monitor::maybe_log_space_error(const disk& disk) {
 }
 
 void local_monitor::update_alert_state() {
-    _state.storage_space_alert = disk_space_alert::ok;
+    _state.storage_space_alert = storage::disk_space_alert::ok;
     for (const auto& d : _state.disks) {
         vassert(d.total != 0.0, "Total disk space cannot be zero.");
         auto [min_by_bytes, min_by_percent] = minimum_free_by_bytes_and_percent(
@@ -134,7 +134,7 @@ void local_monitor::update_alert_state() {
           d.free <= min_space);
 
         if (unlikely(d.free <= min_space)) {
-            _state.storage_space_alert = disk_space_alert::low_space;
+            _state.storage_space_alert = storage::disk_space_alert::low_space;
             maybe_log_space_error(d);
         }
     }

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -47,10 +47,10 @@ private:
     // helpers
     std::tuple<size_t, size_t>
     minimum_free_by_bytes_and_percent(size_t bytes_available) const;
-    ss::future<std::vector<disk>> get_disks();
+    ss::future<std::vector<storage::disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     void update_alert_state();
-    void maybe_log_space_error(const disk&);
+    void maybe_log_space_error(const storage::disk&);
 
     // configuration
     void refresh_configuration();

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -20,16 +20,6 @@
 
 namespace cluster::node {
 
-std::ostream& operator<<(std::ostream& o, const disk& d) {
-    fmt::print(
-      o,
-      "{{path: {}, free: {}, total: {}}}",
-      d.path,
-      human::bytes(d.free),
-      human::bytes(d.total));
-    return o;
-}
-
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,
@@ -54,18 +44,18 @@ void read_and_assert_version(std::string_view type, iobuf_parser& parser) {
       T::current_version);
 }
 
-void adl<cluster::node::disk>::to(iobuf& out, cluster::node::disk&& s) {
+void adl<storage::disk>::to(iobuf& out, storage::disk&& s) {
     serialize(out, s.current_version, s.path, s.free, s.total);
 }
 
-cluster::node::disk adl<cluster::node::disk>::from(iobuf_parser& p) {
-    read_and_assert_version<cluster::node::disk>("cluster::node::disk", p);
+storage::disk adl<storage::disk>::from(iobuf_parser& p) {
+    read_and_assert_version<storage::disk>("storage::disk", p);
 
     auto path = adl<ss::sstring>{}.from(p);
     auto free = adl<uint64_t>{}.from(p);
     auto total = adl<uint64_t>{}.from(p);
 
-    return cluster::node::disk{
+    return storage::disk{
       .path = path,
       .free = free,
       .total = total,

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -30,21 +30,6 @@ std::ostream& operator<<(std::ostream& o, const disk& d) {
     return o;
 }
 
-std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
-    switch (d) {
-    case disk_space_alert::ok:
-        o << "ok";
-        break;
-    case disk_space_alert::low_space:
-        o << "low_space";
-        break;
-    case disk_space_alert::degraded:
-        o << "degraded";
-        break;
-    }
-    return o;
-}
-
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -13,6 +13,7 @@
 #include "cluster/types.h"
 #include "model/metadata.h"
 #include "reflection/adl.h"
+#include "storage/types.h"
 #include "types.h"
 #include "utils/human.h"
 #include "utils/named_type.h"
@@ -31,6 +32,7 @@ namespace cluster::node {
 
 using application_version = named_type<ss::sstring, struct version_number_tag>;
 
+// TODO move to ::storage namespace
 struct disk {
     static constexpr int8_t current_version = 0;
 
@@ -42,8 +44,6 @@ struct disk {
     friend bool operator==(const disk&, const disk&) = default;
 };
 
-enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
-
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
@@ -54,13 +54,12 @@ struct local_state {
     // Eventually support multiple volumes.
     std::vector<disk> disks;
 
-    disk_space_alert storage_space_alert;
+    storage::disk_space_alert storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 
 std::ostream& operator<<(std::ostream& o, const disk& d);
-std::ostream& operator<<(std::ostream& o, const disk_space_alert d);
 std::ostream& operator<<(std::ostream& o, const local_state& s);
 } // namespace cluster::node
 

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -32,18 +32,6 @@ namespace cluster::node {
 
 using application_version = named_type<ss::sstring, struct version_number_tag>;
 
-// TODO move to ::storage namespace
-struct disk {
-    static constexpr int8_t current_version = 0;
-
-    ss::sstring path;
-    uint64_t free;
-    uint64_t total;
-
-    friend std::ostream& operator<<(std::ostream&, const disk&);
-    friend bool operator==(const disk&, const disk&) = default;
-};
-
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
@@ -52,21 +40,20 @@ struct local_state {
     cluster_version logical_version{invalid_version};
     std::chrono::milliseconds uptime;
     // Eventually support multiple volumes.
-    std::vector<disk> disks;
+    std::vector<storage::disk> disks;
 
     storage::disk_space_alert storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 
-std::ostream& operator<<(std::ostream& o, const disk& d);
 std::ostream& operator<<(std::ostream& o, const local_state& s);
 } // namespace cluster::node
 
 namespace reflection {
 template<>
-struct adl<cluster::node::disk> {
-    void to(iobuf&, cluster::node::disk&&);
-    cluster::node::disk from(iobuf_parser&);
+struct adl<storage::disk> {
+    void to(iobuf&, storage::disk&&);
+    storage::disk from(iobuf_parser&);
 };
 } // namespace reflection

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/node/local_monitor.h"
+#include "storage/api.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -24,6 +25,7 @@ struct local_monitor_fixture {
     static constexpr size_t default_bytes_threshold = 1_GiB;
 
     std::filesystem::path _test_path;
+    ss::sharded<storage::node_api> _storage_api;
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -32,8 +32,10 @@ using namespace cluster;
 local_monitor_fixture::local_monitor_fixture()
   : _local_monitor(
     config::shard_local_cfg().storage_space_alert_free_threshold_bytes.bind(),
-    config::shard_local_cfg()
-      .storage_space_alert_free_threshold_percent.bind()) {
+    config::shard_local_cfg().storage_space_alert_free_threshold_percent.bind(),
+    _storage_api) {
+    _storage_api.start_single().get0();
+
     clusterlog.info("{}: create", __func__);
     auto test_dir = "local_monitor_test."
                     + random_generators::gen_alphanum_string(4);
@@ -62,6 +64,7 @@ local_monitor_fixture::~local_monitor_fixture() {
     if (err) {
         clusterlog.warn("Cleanup got error {} removing test dir.", err);
     }
+    _storage_api.stop().get0();
 }
 
 node::local_state local_monitor_fixture::update_state() {

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -120,12 +120,12 @@ FIXTURE_TEST(local_monitor_alert_on_space_percent, local_monitor_fixture) {
     // One block over the threshold should not alert
     stats.f_bfree = min_free_percent_blocks + 1;
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == node::disk_space_alert::ok);
+    BOOST_TEST_REQUIRE(ls.storage_space_alert == storage::disk_space_alert::ok);
 
     // One block under the free threshold should alert
     stats.f_bfree = min_free_percent_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != node::disk_space_alert::ok);
+    BOOST_TEST_REQUIRE(ls.storage_space_alert != storage::disk_space_alert::ok);
 }
 
 FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
@@ -144,10 +144,10 @@ FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
     _local_monitor.set_statvfs_for_test(lamb);
 
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == node::disk_space_alert::ok);
+    BOOST_TEST_REQUIRE(ls.storage_space_alert == storage::disk_space_alert::ok);
 
     // Min bytes threshold minus a blocks -> Alert
     stats.f_bfree = min_bytes_in_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != node::disk_space_alert::ok);
+    BOOST_TEST_REQUIRE(ls.storage_space_alert != storage::disk_space_alert::ok);
 }

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -77,6 +77,7 @@ public:
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<cluster::shard_table> shard_table;
     ss::sharded<storage::api> storage;
+    ss::sharded<storage::node_api> storage_node;
     std::unique_ptr<coproc::api> coprocessing;
     ss::sharded<coproc::partition_manager> cp_partition_manager;
     ss::sharded<cluster::partition_manager> partition_manager;
@@ -129,6 +130,15 @@ private:
         s = std::make_unique<Service>(std::forward<Args>(args)...);
         _deferred.emplace_back([&s] { s->stop().get(); });
     }
+
+    template<typename Service, typename... Args>
+    ss::future<>
+    construct_single_service_sharded(ss::sharded<Service>& s, Args&&... args) {
+        auto f = s.start_single(std::forward<Args>(args)...);
+        _deferred.emplace_back([&s] { s.stop().get(); });
+        return f;
+    }
+
     void setup_metrics();
     std::unique_ptr<ss::app_template> _app;
     bool _redpanda_enabled{true};

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -14,9 +14,30 @@
 #include "seastarx.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
+#include "storage/probe.h"
 
 namespace storage {
 
+// Per-node API. For non-sharded state.
+class node_api {
+public:
+    ss::future<> start() {
+        _probe.setup_node_metrics();
+        return ss::now();
+    }
+
+    ss::future<> stop() { return ss::now(); }
+
+    void set_disk_metrics(
+      uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert) {
+        _probe.set_disk_metrics(total_bytes, free_bytes, alert);
+    }
+
+private:
+    storage::node_probe _probe;
+};
+
+// Top-level sharded storage API.
 class api {
 public:
     explicit api(

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -14,6 +14,7 @@
 namespace storage {
 
 class api;
+class node_api;
 class kvstore;
 class log_manager;
 class ntp_config;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "storage/fwd.h"
 #include "storage/logger.h"
+#include "storage/types.h"
 
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -20,6 +21,25 @@
 #include <cstdint>
 
 namespace storage {
+struct disk_metrics {
+    uint64_t total_bytes = 0;
+    uint64_t free_bytes = 0;
+    disk_space_alert space_alert = disk_space_alert::ok;
+};
+
+// Per-node storage probe (metrics).
+class node_probe {
+public:
+    void setup_node_metrics();
+    void set_disk_metrics(
+      uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
+
+private:
+    disk_metrics _disk;
+    ss::metrics::metric_groups _metrics;
+};
+
+// Per-NTP probe.
 class probe {
 public:
     void add_bytes_written(uint64_t written) {

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -32,6 +32,17 @@ std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
     }
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const disk& d) {
+    fmt::print(
+      o,
+      "{{path: {}, free: {}, total: {}}}",
+      d.path,
+      human::bytes(d.free),
+      human::bytes(d.total));
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const log_reader_config& cfg) {
     o << "{start_offset:" << cfg.start_offset
       << ", max_offset:" << cfg.max_offset << ", min_bytes:" << cfg.min_bytes

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -17,6 +17,21 @@
 #include <fmt/ostream.h>
 
 namespace storage {
+
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
 std::ostream& operator<<(std::ostream& o, const log_reader_config& cfg) {
     o << "{start_offset:" << cfg.start_offset
       << ", max_offset:" << cfg.max_offset << ", min_bytes:" << cfg.min_bytes

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -31,6 +31,10 @@ namespace storage {
 using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 
+enum class disk_space_alert : uint32_t { ok = 0, low_space = 1, degraded = 2 };
+
+std::ostream& operator<<(std::ostream& o, const storage::disk_space_alert d);
+
 class snapshotable_stm {
 public:
     // create a snapshot at given offset unless a snapshot with given or newer

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -32,6 +32,16 @@ using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 
 enum class disk_space_alert : uint32_t { ok = 0, low_space = 1, degraded = 2 };
+struct disk {
+    static constexpr int8_t current_version = 0;
+
+    ss::sstring path;
+    uint64_t free;
+    uint64_t total;
+
+    friend std::ostream& operator<<(std::ostream&, const disk&);
+    friend bool operator==(const disk&, const disk&) = default;
+};
 
 std::ostream& operator<<(std::ostream& o, const storage::disk_space_alert d);
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -31,7 +31,7 @@ namespace storage {
 using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 
-enum class disk_space_alert : uint32_t { ok = 0, low_space = 1, degraded = 2 };
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
 struct disk {
     static constexpr int8_t current_version = 0;
 


### PR DESCRIPTION
For easier monitoring of disk space, this PR adds new free space metrics.

Related: #2166

## Release notes
Three new metrics have been added:

- vectorized_storage_disk_total_bytes
- vectorized_storage_disk_free_bytes
- vectorized_storage_disk_free_space_alert

### Features

* More direct monitoring of Redpanda's disk usage and free space.
* A simple alert metric field 'vectorized_storage_free_space_alert` which is
  non-zero when space is running low.

### Improvements

* Continuing improvements around full disk handling.
