### PR TITLE
Backport PR 3871 - fix: use a unique secret name for webhook cert

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/_helpers.tpl
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{- define "redpanda-operator.webhook-cert" -}}
-{{- printf "webhook-server-cert" }}
+{{- printf .Values.webhookSecretName }}
 {{- end }}
 
 {{/*

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -96,3 +96,5 @@ labels:
 # monitoring -- Add service monitor to the deployment
 monitoring:
   enabled: false
+
+webhookSecretName: webhook-server-cert


### PR DESCRIPTION
## Cover letter

Back port #3871 

## Release notes
* give a way to parameterize secret name for a webhook
