### PR TITLE
k8s: Turn off idempotence and transactions by default

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -286,8 +286,8 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.Other = make(map[string]interface{})
 	}
 	cr.Other["auto_create_topics_enabled"] = r.pandaCluster.Spec.Configuration.AutoCreateTopics
-	cr.Other["enable_idempotence"] = true
-	cr.Other["enable_transactions"] = true
+	cr.Other["enable_idempotence"] = false
+	cr.Other["enable_transactions"] = false
 	if featuregates.ShadowIndex(r.pandaCluster.Spec.Version) {
 		cr.Other["cloud_storage_segment_max_upload_interval_sec"] = 60 * 30 // 60s * 30 = 30 minutes
 	}

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -80,7 +80,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedString:          "transactional_id_expiration_ms: 25920000000",
-			expectedHash:            "18d411a2fb4b60021ce9b749e083ca39",
+			expectedHash:            "c9d9847a020aea975358a691539e06fc",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -90,13 +90,13 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`,
-			expectedHash: "6ada3aa3ed70ae1013f0ca95003d4a45",
+			expectedHash: "a254899246080e7729f831fa5b9bd75c",
 		},
 		{
 			name: "shadow index cache directory",
 			expectedString: `cloud_storage_cache_directory: /var/lib/shadow-index-cache
     cloud_storage_cache_size: "10737418240"`,
-			expectedHash: "8ecc6ffc3ff19a93b99ac14c36f78c7e",
+			expectedHash: "eb6af32178a9f5afd1983505eb4fa3ec",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -148,10 +148,10 @@ func TestEnsure_ConfigMap(t *testing.T) {
 	if !strings.Contains(data, "auto_create_topics_enabled: false") {
 		t.Fatalf("expecting configmap containing 'auto_create_topics_enabled: false' but got %v", data)
 	}
-	if !strings.Contains(data, "enable_idempotence: true") {
+	if !strings.Contains(data, "enable_idempotence: false") {
 		t.Fatalf("expecting configmap containing 'enable_idempotence: true' but got %v", data)
 	}
-	if !strings.Contains(data, "enable_transactions: true") {
+	if !strings.Contains(data, "enable_transactions: false") {
 		t.Fatalf("expecting configmap containing 'enable_transactions: true' but got %v", data)
 	}
 

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
@@ -41,8 +41,8 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   default_topic_partitions: 3
   developer_mode: true
-  enable_idempotence: true
-  enable_transactions: true
+  enable_idempotence: false
+  enable_transactions: false
   kafka_api:
   - address: 0.0.0.0
     name: kafka


### PR DESCRIPTION
## Cover letter

Disable by default idempotence and transactions as this features are not GA.

## Release notes

* By default idempotence and transactions will be disabled