### PR TITLE
Backport v21.11 pr3831: k8s/operator: Reserve 10% of memory for the OS

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -32,11 +32,31 @@ type RedpandaResourceRequirements struct {
 
 // RedpandaCPU returns a copy of the rounded value for Redpanda CPU
 //
-// If it's not explicitly set, the Request.Cpu is used.
+// If it's not explicitly set, the Request.Cpu is used. This allows
+// overprovisioning the CPU, which is not recommended, but --smp can't be
+// reduced on an update.
+//
+// The value returned is:
+// * Is rounded up to an integer.
+// * Is limited by 2Gi per core if requests.memory is set.
+//
+// Example:
+//    in: minimum requirement per core, 2GB
+//    in: Requests.Memory, 16GB
+//    => maxAllowedCores = 8
+//    if requestedCores == 8, set smp = 8 (with 2GB per core)
+//    if requestedCores == 4, set smp = 4 (with 4GB per core)
 func (r *RedpandaResourceRequirements) RedpandaCPU() *resource.Quantity {
 	q := r.Redpanda.Cpu()
 	if q == nil || q.IsZero() {
-		q = r.Requests.Cpu()
+		requestedMemory := r.Requests.Memory().Value()
+		requestedCores := r.Requests.Cpu().Value()
+		maxAllowedCores := requestedMemory / MinimumMemoryPerCore
+		smp := maxAllowedCores
+		if smp == 0 || requestedCores < smp {
+			smp = requestedCores
+		}
+		q = resource.NewQuantity(smp, resource.BinarySI)
 	}
 	qd := q.DeepCopy()
 	qd.RoundUp(0)

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -69,7 +69,9 @@ func (r *RedpandaResourceRequirements) RedpandaCPU() *resource.Quantity {
 func (r *RedpandaResourceRequirements) RedpandaMemory() *resource.Quantity {
 	q := r.Redpanda.Memory()
 	if q == nil || q.IsZero() {
-		q = r.Requests.Memory()
+		requestedMemory := r.Requests.Memory().Value()
+		requestedMemory = int64(float64(requestedMemory) * RedpandaMemoryAllocationRatio)
+		q = resource.NewQuantity(requestedMemory, resource.BinarySI)
 	}
 	qd := q.DeepCopy()
 	return &qd
@@ -510,6 +512,8 @@ type SocketAddress struct {
 const (
 	// MinimumMemoryPerCore the minimum amount of memory needed per core
 	MinimumMemoryPerCore = 2 * gb
+	// RedpandaMemoryAllocationRatio reserves 10% for the OS
+	RedpandaMemoryAllocationRatio = 0.9
 )
 
 func init() {

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestRedpandaResourceRequirements(t *testing.T) {
+	type test struct {
+		name                string
+		setRequestsCPU      resource.Quantity
+		setRequestsMem      resource.Quantity
+		setRedpandaCPU      resource.Quantity
+		setRedpandaMem      resource.Quantity
+		expectedRedpandaCPU resource.Quantity
+		expectedRedpandaMem resource.Quantity
+	}
+	makeResources := func(t test) v1alpha1.RedpandaResourceRequirements {
+		return v1alpha1.RedpandaResourceRequirements{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: t.setRequestsMem,
+					corev1.ResourceCPU:    t.setRequestsCPU,
+				}},
+			Redpanda: corev1.ResourceList{
+				corev1.ResourceMemory: t.setRedpandaMem,
+				corev1.ResourceCPU:    t.setRedpandaCPU,
+			},
+		}
+	}
+
+	t.Run("Memory", func(t *testing.T) {
+		tests := []test{
+			{
+				name:                "RedpandaMemory is set from requests.memory",
+				setRequestsMem:      resource.MustParse("3000Mi"),
+				expectedRedpandaMem: resource.MustParse("3000Mi"),
+			},
+			{
+				name:                "RedpandaMemory is set from lower redpanda.memory",
+				setRequestsMem:      resource.MustParse("4000Mi"),
+				setRedpandaMem:      resource.MustParse("3000Mi"),
+				expectedRedpandaMem: resource.MustParse("3000Mi"),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rrr := makeResources(tt)
+				assert.Equal(t, tt.expectedRedpandaMem.Value(), rrr.RedpandaMemory().Value())
+			})
+		}
+	})
+
+	t.Run("Cpu", func(t *testing.T) {
+		tests := []test{
+			{
+				name:                "RedpandaCPU is set from integer requests.cpu",
+				setRequestsCPU:      resource.MustParse("1"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				expectedRedpandaCPU: resource.MustParse("1"),
+			},
+			{
+				name:                "RedpandaCPU is set from milli requests.cpu",
+				setRequestsCPU:      resource.MustParse("1000m"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				expectedRedpandaCPU: resource.MustParse("1"),
+			},
+			{
+				name:                "RedpandaCPU is rounded up from milli requests.cpu",
+				setRequestsCPU:      resource.MustParse("1001m"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				expectedRedpandaCPU: resource.MustParse("2"),
+			},
+			{
+				name:                "RedpandaCPU is set from lower redpanda.cpu",
+				setRequestsCPU:      resource.MustParse("2"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				setRedpandaCPU:      resource.MustParse("1"),
+				expectedRedpandaCPU: resource.MustParse("1"),
+			},
+			{
+				name:                "RedpandaCPU is set from higher redpanda.cpu",
+				setRequestsCPU:      resource.MustParse("1"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				setRedpandaCPU:      resource.MustParse("2"),
+				expectedRedpandaCPU: resource.MustParse("2"),
+			},
+			{
+				name:                "RedpandaCPU is rounded up from milli redpanda.cpu",
+				setRequestsCPU:      resource.MustParse("1"),
+				setRequestsMem:      resource.MustParse("20Gi"),
+				setRedpandaCPU:      resource.MustParse("1001m"),
+				expectedRedpandaCPU: resource.MustParse("2"),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rrr := makeResources(tt)
+				assert.Equal(t, tt.expectedRedpandaCPU.Value(), rrr.RedpandaCPU().Value())
+			})
+		}
+	})
+}

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// nolint:funlen // this is ok for a test
 func TestRedpandaResourceRequirements(t *testing.T) {
 	type test struct {
 		name                string
@@ -104,6 +105,22 @@ func TestRedpandaResourceRequirements(t *testing.T) {
 				setRequestsMem:      resource.MustParse("20Gi"),
 				setRedpandaCPU:      resource.MustParse("1001m"),
 				expectedRedpandaCPU: resource.MustParse("2"),
+			},
+			{
+				name:                "RedpandaCPU is limited by 2GiB/core",
+				setRequestsCPU:      resource.MustParse("10"),
+				setRequestsMem:      resource.MustParse("4Gi"),
+				expectedRedpandaCPU: resource.MustParse("2"),
+			},
+			{
+				name:                "RedpandaCPU has a minimum if requests >0",
+				setRequestsCPU:      resource.MustParse("100m"),
+				setRequestsMem:      resource.MustParse("100Mi"),
+				expectedRedpandaCPU: resource.MustParse("1"),
+			},
+			{
+				name:                "RedpandaCPU not set if no request",
+				expectedRedpandaCPU: resource.MustParse("0"),
 			},
 		}
 		for _, tt := range tests {

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
@@ -48,7 +48,7 @@ func TestRedpandaResourceRequirements(t *testing.T) {
 			{
 				name:                "RedpandaMemory is set from requests.memory",
 				setRequestsMem:      resource.MustParse("3000Mi"),
-				expectedRedpandaMem: resource.MustParse("3000Mi"),
+				expectedRedpandaMem: resource.MustParse("2700Mi"),
 			},
 			{
 				name:                "RedpandaMemory is set from lower redpanda.memory",

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -11,6 +11,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -492,7 +493,8 @@ func (r *Cluster) validateRedpandaMemory() field.ErrorList {
 	}
 
 	redpandaCores := r.Spec.Resources.RedpandaCPU().Value()
-	if !r.Spec.Resources.RedpandaMemory().IsZero() && r.Spec.Resources.RedpandaMemory().Value() < redpandaCores*MinimumMemoryPerCore {
+	minimumMemoryPerCore := int64(math.Floor(MinimumMemoryPerCore * RedpandaMemoryAllocationRatio))
+	if !r.Spec.Resources.RedpandaMemory().IsZero() && r.Spec.Resources.RedpandaMemory().Value() < redpandaCores*minimumMemoryPerCore {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec").Child("resources").Child("redpanda").Child("memory"),

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -437,7 +437,7 @@ func (r *Cluster) validateResources(rf resourceField) field.ErrorList {
 			field.Invalid(
 				rf.path.Child("requests").Child("memory"),
 				rf.resources.Requests.Memory(),
-				"Memory limit cannot be lower than the request, either increase the limit or remove it"))
+				"limits.memory < requests.memory; either increase the limit or remove it"))
 	}
 
 	// CPU limit (if set) cannot be lower than the requested
@@ -447,7 +447,7 @@ func (r *Cluster) validateResources(rf resourceField) field.ErrorList {
 			field.Invalid(
 				rf.path.Child("requests").Child("cpu"),
 				rf.resources.Requests.Cpu(),
-				"CPU limit cannot be lower than the request, either increase the limit or remove it"))
+				"limits.cpu < requests.cpu; either increase the limit or remove it"))
 	}
 
 	return allErrs
@@ -458,22 +458,13 @@ func (r *Cluster) validateRedpandaResources(
 ) field.ErrorList {
 	allErrs := r.validateResources(resourceField{&rf.resources.ResourceRequirements, rf.path})
 
-	// Memory redpanda (if set) must be less than or equal to limit (if set)
-	if !rf.resources.Limits.Memory().IsZero() && !rf.resources.RedpandaMemory().IsZero() && rf.resources.Limits.Memory().Cmp(*rf.resources.RedpandaMemory()) == -1 {
-		allErrs = append(allErrs,
-			field.Invalid(
-				rf.path.Child("redpanda").Child("memory"),
-				rf.resources.Requests.Memory(),
-				"Memory limit cannot be lower than the redanda memory, either increase the limit, decrease redpanda, or remove either"))
-	}
-
 	// Memory redpanda (if set) must be less than or equal to request (if set)
 	if !rf.resources.Requests.Memory().IsZero() && !rf.resources.RedpandaMemory().IsZero() && rf.resources.Requests.Memory().Cmp(*rf.resources.RedpandaMemory()) == -1 {
 		allErrs = append(allErrs,
 			field.Invalid(
 				rf.path.Child("redpanda").Child("memory"),
 				rf.resources.Requests.Memory(),
-				"Memory request cannot be lower than the redanda memory, either increase the request, decrease redpanda, or remove either"))
+				"requests.memory < redpanda.memory; decrease or remove redpanda.memory"))
 	}
 
 	return allErrs
@@ -497,7 +488,7 @@ func (r *Cluster) validateRedpandaMemory() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec").Child("resources").Child("requests").Child("memory"),
 				r.Spec.Resources.Requests.Memory(),
-				"need 2GB of memory per core; need to decrease the requested CPU or increase the memory request"))
+				"requests.memory < 2Gi per core; either decrease requests.cpu or increase requests.memory"))
 	}
 
 	redpandaCores := r.Spec.Resources.RedpandaCPU().Value()
@@ -506,7 +497,7 @@ func (r *Cluster) validateRedpandaMemory() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec").Child("resources").Child("redpanda").Child("memory"),
 				r.Spec.Resources.Requests.Memory(),
-				"need 2GB of memory per core; need to decrease the redpanda CPU or increase the redpanda memory"))
+				"redpanda.memory < 2Gi per core; either decrease redpanda.cpu or increase redpanda.memory"))
 	}
 
 	return allErrs
@@ -528,12 +519,12 @@ func (r *Cluster) validateRedpandaCoreChanges(old *Cluster) field.ErrorList {
 		newCores := newCPURequest.Value()
 
 		if newCores < oldCores {
-			minAllowedCPU := fmt.Sprintf("%dm", (oldCores-1)*1000+1)
+			minAllowedCPU := (oldCores-1)*1000 + 1
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec").Child("resources").Child("requests").Child("cpu"),
 					r.Spec.Resources.Requests.Cpu(),
-					fmt.Sprintf("CPU request may decrease the number of cores used in the existing cluster; increase the CPU request to at least %s", minAllowedCPU)))
+					fmt.Sprintf("CPU request must not be decreased; increase requests.cpu or redpanda.cpu to at least %dm", minAllowedCPU)))
 		}
 	}
 

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -587,22 +587,7 @@ func prepareAdditionalArguments(
 		"--reserve-memory=0M",
 	}
 
-	/*
-	 * Example:
-	 *    in: minimum requirement per core, 2GB
-	 *    in: requestedMemory, 16GB
-	 *    => maxAllowedCores = 8
-	 *    if requestedCores == 8, set smp = 8 (with 2GB per core)
-	 *    if requestedCores == 4, set smp = 4 (with 4GB per core)
-	 */
-
-	// The webhook ensures that the requested memory is >= the per-core requirement
-	maxAllowedCores := requestedMemory / redpandav1alpha1.MinimumMemoryPerCore
-	var smp int64 = maxAllowedCores
-	if requestedCores != 0 && requestedCores < smp {
-		smp = requestedCores
-	}
-	args = append(args, "--smp="+strconv.FormatInt(smp, 10),
+	args = append(args, "--smp="+strconv.FormatInt(requestedCores, 10),
 		"--memory="+strconv.FormatInt(requestedMemory, 10))
 
 	return args

--- a/src/go/k8s/tests/e2e/resources-redpanda/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/00-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster-resources
+  labels:
+    app.kubernetes.io/name: "redpanda"
+    app.kubernetes.io/instance: "update-cluster-resources"
+    app.kubernetes.io/managed-by: redpanda-operator
+    app.kubernetes.io/part-of: redpanda
+status:
+  readyReplicas: 1
+  observedGeneration: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod 
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/resources-redpanda/00-dev-cluster.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/00-dev-cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster-resources
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/resources-redpanda/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster-resources
+status:
+  readyReplicas: 1
+  observedGeneration: 2
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/resources-redpanda/01-make-production.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/01-make-production.yaml
@@ -1,0 +1,13 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster-resources
+spec:
+  resources:
+    requests:
+      cpu: 2
+      memory: 4Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+    developerMode: false

--- a/src/go/k8s/tests/e2e/resources-redpanda/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/02-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster-resources
+status:
+  readyReplicas: 1
+  observedGeneration: 3
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/resources-redpanda/02-scale-back-with-redpanda-cpu.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/02-scale-back-with-redpanda-cpu.yaml
@@ -1,0 +1,16 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster-resources
+spec:
+  resources:
+    redpanda:
+      cpu: 2
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  configuration:
+    developerMode: true

--- a/src/go/k8s/tests/e2e/resources-redpanda/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/03-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster-resources
+status:
+  readyReplicas: 1
+  observedGeneration: 4
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/resources-redpanda/03-scale-up-with-redpanda-memory.yaml
+++ b/src/go/k8s/tests/e2e/resources-redpanda/03-scale-up-with-redpanda-memory.yaml
@@ -1,0 +1,17 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster-resources
+spec:
+  resources:
+    redpanda:
+      cpu: 2
+      memory: 4Gi
+    requests:
+      cpu: 2
+      memory: 5Gi
+    limits:
+      cpu: 2
+      memory: 5Gi
+  configuration:
+    developerMode: false


### PR DESCRIPTION
## Cover letter

Backport v21.11 #3831

If Redpanda runs inside a cgroup with a memory limit, then it should not be allowed to consume all of the memory by default. There are memory allocations and book-keeping done outside of Redpanda.

Setting `Resources.Requests.Memory` now reduces `Resources.RedpandaMemory()` by 10% to allow for memory allocations outside of Redpanda. This should avoid an OOMKill for default installations.

If `Resources.Redpanda.Memory` is set, it will be honoured.

Redpanda is allowed to drop to 1.8Gi/core for backwards compatibility.

This is an extension of #3773 

## Release notes

### Improvements

* k8s/operator: Reserve 10% of memory for the OS by default, to avoid `OOMKill`
