### PR TITLE
net: add `conn_quota` for connection count limits

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -792,6 +792,19 @@ configuration::configuration()
       "Time between members backend reconciliation loop retries ",
       {.visibility = visibility::tunable},
       5s)
+  , kafka_connections_max(
+      *this,
+      "kafka_connections_max",
+      "Maximum number of Kafka client connections per broker",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt)
+  , kafka_connections_max_per_ip(
+      *this,
+      "kafka_connections_max_per_ip",
+      "Maximum number of Kafka client connections from each IP addreess, per "
+      "broker",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt)
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -175,6 +175,8 @@ struct configuration final : public config_store {
     property<int16_t> compaction_ctrl_max_shares;
     property<std::optional<size_t>> compaction_ctrl_backlog_size;
     property<std::chrono::milliseconds> members_backend_retry_ms;
+    property<std::optional<uint32_t>> kafka_connections_max;
+    property<std::optional<uint32_t>> kafka_connections_max_per_ip;
 
     // Archival storage
     property<bool> cloud_storage_enabled;

--- a/src/v/config/mock_property.h
+++ b/src/v/config/mock_property.h
@@ -29,7 +29,9 @@ public:
           _mock_store,
           "anonymous",
           "",
-          base_property::metadata{.needs_restart = needs_restart::no}) {}
+          base_property::metadata{.needs_restart = needs_restart::no}) {
+        _property.set_value(value);
+    }
 
     void update(T&& value) { _property.update_value(std::move(value)); }
 

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     dns.cc
     transport.cc
     connection.cc
+    conn_quota.cc
     server.cc
     probes.cc
     tls.cc
@@ -13,6 +14,7 @@ v_cc_library(
     Seastar::seastar
     absl::node_hash_map
     v::config
+    v::rphashing
   )
 
 add_subdirectory(tests)

--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -1,0 +1,436 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "conn_quota.h"
+
+#include "config/configuration.h"
+#include "hashing/xx.h"
+#include "rpc/logger.h"
+#include "seastar/core/coroutine.hh"
+#include "ssx/future-util.h"
+#include "vassert.h"
+#include "vlog.h"
+
+namespace net {
+
+conn_quota::units::~units() {
+    if (_quotas) {
+        (*_quotas).get().put(_addr);
+    }
+}
+
+conn_quota::conn_quota(conn_quota::config_fn cfg_f) noexcept
+  : _cfg(cfg_f()) {
+    if (ss::this_shard_id() == total_shard) {
+        if (_cfg.max_connections()) {
+            // Initialize state for enforcement of global connection count
+            total_home.max = _cfg.max_connections().value();
+            total_home.available = total_home.max;
+        }
+    }
+
+    _cfg.max_connections.watch([this]() {
+        if (ss::this_shard_id() == total_shard) {
+            if (_cfg.max_connections()) {
+                vlog(
+                  rpc::rpclog.info,
+                  "Connection count limit updated to {}",
+                  _cfg.max_connections().value());
+                update_limit({}, total_home, _cfg.max_connections().value());
+            } else {
+                total_home = home_allowance{};
+                vlog(rpc::rpclog.info, "Connection count limit disabled");
+            }
+        } else {
+            if (!_cfg.max_connections()) {
+                // Reset, in anticipation of limit being re-enabled later
+                // (do not want to keep borrowed units around)
+                total_remote = remote_allowance{};
+            }
+        }
+    });
+
+    _cfg.max_connections_per_ip.watch([this]() {
+        if (!_cfg.max_connections_per_ip()) {
+            if (ss::this_shard_id() == 0) {
+                vlog(
+                  rpc::rpclog.info, "Connection count per-IP limit disabled");
+            }
+            ip_home.clear();
+            ip_remote.clear();
+        } else {
+            auto new_limit = _cfg.max_connections_per_ip().value();
+            if (ss::this_shard_id() == 0) {
+                vlog(
+                  rpc::rpclog.info,
+                  "Connection count per-IP limit updated to {}",
+                  new_limit);
+            }
+
+            for (auto& i : ip_home) {
+                update_limit(i.first, i.second, new_limit);
+            }
+        }
+    });
+}
+
+ss::future<> conn_quota::stop() { return _gate.close(); }
+
+/**
+ * Release a token, on close of a connection from client IP `addr`
+ *
+ * Always completes without yielding.  Usually shard local, but
+ * may spawn a background invoke_on future if the limits are close
+ * to being reached.
+ */
+void conn_quota::put(ss::net::inet_address addr) {
+    vlog(rpc::rpclog.trace, "put({})", addr);
+
+    // If enforcement was disabled since the token
+    // was issued, drop it on the floor.
+    if (_cfg.max_connections()) {
+        do_put({});
+    }
+
+    if (_cfg.max_connections_per_ip()) {
+        do_put(addr);
+    }
+}
+
+/**
+ * Attempt to acquire a token for an incoming connection from a particular
+ * client IP.  If none is available, an inert units object is returned.
+ *
+ * Very fast if limits are disabled.  If limits are enabled this is usually
+ * a shard-local operation but can be cross-shard if we are close to reaching
+ * limits.
+ */
+ss::future<conn_quota::units> conn_quota::get(ss::net::inet_address addr) {
+    vlog(rpc::rpclog.trace, "get({})", addr);
+
+    if (_cfg.max_connections()) {
+        if (!co_await do_get({})) {
+            co_return units();
+        };
+    } else {
+        vlog(rpc::rpclog.trace, "Global conn limit disabled");
+    }
+
+    if (_cfg.max_connections_per_ip()) {
+        if (!co_await do_get(addr)) {
+            // Release the unit we already took for total connection count
+            if (_cfg.max_connections()) {
+                do_put({});
+            }
+            co_return units();
+        };
+    }
+
+    co_return units(*this, addr);
+}
+
+/**
+ * @addr either a real address, or {} for total allowance
+ */
+ss::future<bool> conn_quota::do_get(ss::net::inet_address addr) {
+    // Apply global connection count limit
+    auto home_shard = addr_to_shard(addr);
+    if (home_shard == ss::this_shard_id()) {
+        // Fast path: we are the home shard for this address, can
+        // probably get a token locally (unless exhausted)
+        return home_get_units(addr);
+    } else {
+        auto& allowance = get_remote_allowance(addr);
+        if (allowance.borrowed > 0) {
+            // Fast path: we have a borrowed token on this shard
+            vlog(rpc::rpclog.trace, "got local borrowed token");
+            allowance.borrowed -= 1;
+            return ss::make_ready_future<bool>(true);
+        } else {
+            // Slow path: call to the home core to request a token
+            return container().invoke_on(home_shard, [addr](conn_quota& cq) {
+                return cq.home_get_units(addr);
+            });
+        }
+    }
+}
+
+ss::shard_id conn_quota::addr_to_shard(ss::net::inet_address addr) const {
+    if (addr == ss::net::inet_address()) {
+        return total_shard;
+    } else {
+        uint32_t hash = xxhash_32((char*)(addr.data()), addr.size());
+        return hash % ss::smp::count;
+    }
+}
+
+void conn_quota::update_limit(
+  ss::net::inet_address addr,
+  conn_quota::home_allowance& allowance,
+  uint32_t new_limit) {
+    auto in_use = allowance.max - allowance.available;
+    bool was_dirty_decrease = in_use != 0 && allowance.max > new_limit;
+
+    allowance.max = new_limit;
+    if (in_use >= allowance.max) {
+        vlog(
+          rpc::rpclog.trace,
+          "Connection count limit {} decreased below current ({}) for {}",
+          allowance.max,
+          in_use,
+          addr);
+        allowance.available = 0;
+    } else {
+        allowance.available = allowance.max - in_use;
+    }
+
+    // If the allowance might have had borrowed units on other
+    // nodes, then we must reclaim them in case of a decrease
+    // to the limit.
+    if (was_dirty_decrease) {
+        ssx::spawn_with_gate(_gate, [this, addr]() {
+            auto& allowance = get_home_allowance(addr);
+            return reclaim_to(allowance, addr, true);
+        });
+    }
+}
+
+conn_quota::home_allowance&
+conn_quota::get_home_allowance(ss::net::inet_address addr) {
+    assert_on_home(addr);
+
+    if (addr == ss::net::inet_address{}) {
+        return total_home;
+    } else {
+        auto found = ip_home.find(addr);
+        if (found != ip_home.end()) {
+            return found->second;
+        } else {
+            auto [iter, created] = ip_home.insert(std::make_pair(
+              addr,
+              home_allowance{
+                .max = _cfg.max_connections_per_ip().value(),
+                .available = _cfg.max_connections_per_ip().value()}));
+            return iter->second;
+        }
+    }
+}
+
+conn_quota::remote_allowance&
+conn_quota::get_remote_allowance(ss::net::inet_address addr) {
+    if (addr == ss::net::inet_address{}) {
+        return total_remote;
+    } else {
+        auto found = ip_remote.find(addr);
+        if (found != ip_remote.end()) {
+            return found->second;
+        } else {
+            auto [iter, created] = ip_remote.insert(
+              std::make_pair(addr, remote_allowance{}));
+            return iter->second;
+        }
+    }
+}
+
+/**
+ * Called on the home shard for `addr`.  Dispatch reclaim requests
+ * to all other shards, hopefully they had some borrowed tokens
+ * that we can claw back.
+ */
+ss::future<> conn_quota::reclaim_to(
+  conn_quota::home_allowance& allowance,
+  ss::net::inet_address addr,
+  bool one_time) {
+    auto locked = allowance.reclaim_lock.get_units();
+    if (allowance.reclaim) {
+        // We are already in reclaim mode: remote allowances will
+        // not be holding any units belong to us, so don't waste
+        // time looking.
+        co_return;
+    }
+
+    allowance.reclaim = true;
+    uint32_t total_released = co_await container().map_reduce0(
+      [addr, one_time, home = ss::this_shard_id()](conn_quota& cq) -> uint32_t {
+          if (home == ss::this_shard_id()) {
+              return 0;
+          } else {
+              return cq.reclaim_from(addr, one_time);
+          }
+      },
+      0,
+      std::plus<uint32_t>());
+
+    allowance.available = std::min(
+      allowance.max, allowance.available + total_released);
+}
+
+/**
+ * Called on the non-home shards for `addr` during a reclaim of
+ * borrowed tokens.  Returns the number of borrowed tokens, and
+ * sets the reclaim flag to true so that subsequently freed tokens
+ * will be dispatched back to the home shard.
+ *
+ * @param one_time if true, do not leave the shard in reclaim mode,
+ *                 just grab any borrowed units they have currently.
+ */
+uint32_t conn_quota::reclaim_from(ss::net::inet_address addr, bool one_time) {
+    vlog(rpc::rpclog.trace, "reclaim_from({})", addr);
+    if (addr == ss::net::inet_address()) {
+        total_remote.reclaim = !one_time;
+        return std::exchange(total_remote.borrowed, 0);
+    } else {
+        ip_remote[addr].reclaim = !one_time;
+        return std::exchange(ip_remote[addr].borrowed, 0);
+    }
+}
+
+/**
+ * Called on non-home shards for `addr` after a previous call
+ * to `reclaim_from`, to unset the reclaim flag and permit this
+ * non-home shard to store borrowed tokens again.
+ *
+ * This is invoked from the home shard when it deems that there
+ * is no longer pressure for tokens.
+ */
+void conn_quota::cancel_reclaim_from(ss::net::inet_address addr) {
+    vlog(rpc::rpclog.trace, "cancel_reclaim_from({})", addr);
+    if (addr == ss::net::inet_address()) {
+        total_remote.reclaim = false;
+    } else {
+        auto found = ip_remote.find(addr);
+        if (found != ip_remote.end()) {
+            found->second.reclaim = false;
+        }
+    }
+}
+
+/**
+ * I am the home shard for this address.  Acquire tokens, reclaiming
+ * if necessary.
+ */
+ss::future<bool> conn_quota::home_get_units(ss::net::inet_address addr) {
+    assert_on_home(addr);
+
+    auto& allowance = get_home_allowance(addr);
+    vlog(rpc::rpclog.trace, "home_get_units({}) allowance={}", addr, allowance);
+
+    bool result = try_get_units(allowance);
+    if (result || allowance.reclaim) {
+        // If we got a token, or we didn't and are already in
+        // reclaim mode, this is the final answer
+        vlog(rpc::rpclog.trace, "home_get_units: fast path got={}", result);
+        co_return result;
+    }
+
+    // We didn't get any units, but there might be some on other cores
+    co_await reclaim_to(allowance, addr, false);
+
+    // This can still fail if there were no reclaimable units, but
+    // we did our best.
+    result = try_get_units(allowance);
+    vlog(
+      rpc::rpclog.trace, "home_get_units: slow (reclaim) path got={}", result);
+    co_return result;
+}
+
+bool conn_quota::try_get_units(home_allowance& allowance) {
+    if (allowance.available) {
+        allowance.available -= 1;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * Given the home state of an allowance, decide whether it should
+ * leave reclaim (i.e. permit other shards to borrow tokens again)
+ */
+bool conn_quota::should_leave_reclaim(home_allowance& allowance) {
+    return allowance.reclaim
+           // Must be enough tokens for it to be worth borrowing any
+           && allowance.max > ss::smp::count
+           // Must have at least half its tokens free
+           && allowance.available > allowance.max / 2
+           // Must not be in the middle of starting a reclaim
+           && allowance.reclaim_lock.ready();
+}
+
+/**
+ * Broadcast (in the background) to all other shards that they
+ * may clear the reclaim flag.
+ */
+void conn_quota::cancel_reclaim_to(ss::net::inet_address addr) {
+    assert_on_home(addr);
+
+    vlog(rpc::rpclog.trace, "cancel_reclaim_to({})", addr);
+
+    // Guaranteed to have units because of precheck in
+    // should_leave_reclaim
+    auto& allowance = get_home_allowance(addr);
+    auto units = allowance.reclaim_lock.try_get_units().value();
+    allowance.reclaim = false;
+
+    ssx::spawn_with_gate(_gate, [this, addr, units = std::move(units)] {
+        return container().invoke_on_others(
+          [addr](conn_quota& cq) -> ss::future<> {
+              cq.cancel_reclaim_from(addr);
+              return ss::now();
+          });
+    });
+}
+
+void conn_quota::do_put(ss::net::inet_address addr) {
+    vlog(rpc::rpclog.trace, "do_put({})", addr);
+
+    auto home_shard = addr_to_shard(addr);
+    if (home_shard == ss::this_shard_id()) {
+        vlog(rpc::rpclog.trace, "do_put: release directly to home");
+        auto& allowance = get_home_allowance(addr);
+        allowance.put();
+        if (should_leave_reclaim(allowance)) {
+            cancel_reclaim_to(addr);
+        }
+    } else {
+        auto& allowance = get_remote_allowance(addr);
+        if (!allowance.reclaim) {
+            vlog(rpc::rpclog.trace, "do_put: release to local borrowed");
+            allowance.put();
+        } else {
+            vlog(rpc::rpclog.trace, "do_put: reclaim, dispatch to home");
+
+            ssx::spawn_with_gate(_gate, [this, addr, home_shard]() {
+                return container().invoke_on(
+                  home_shard, [addr](conn_quota& cq) { cq.do_put(addr); });
+            });
+        }
+    }
+}
+
+bool conn_quota::test_only_is_in_reclaim(ss::net::inet_address addr) const {
+    auto home_shard = addr_to_shard(addr);
+    if (home_shard == ss::this_shard_id()) {
+        if (addr == ss::net::inet_address{} || ip_home.contains(addr)) {
+            auto& allowance = get_home_allowance(addr);
+            return allowance.reclaim;
+        } else {
+            return false;
+        }
+    } else {
+        if (addr == ss::net::inet_address{} || ip_remote.contains(addr)) {
+            auto& allowance = get_remote_allowance(addr);
+            return allowance.reclaim;
+        } else {
+            return false;
+        }
+    }
+}
+
+} // namespace net

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -1,0 +1,215 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "config/property.h"
+#include "seastar/core/gate.hh"
+#include "seastar/core/sharded.hh"
+#include "seastar/net/inet_address.hh"
+#include "seastarx.h"
+#include "utils/mutex.h"
+#include "vassert.h"
+
+#include <absl/container/node_hash_map.h>
+#include <absl/hash/hash.h>
+
+#include <stdint.h>
+
+namespace net {
+
+class conn_quota;
+
+struct conn_quota_config {
+    config::binding<std::optional<uint32_t>> max_connections;
+    config::binding<std::optional<uint32_t>> max_connections_per_ip;
+};
+
+/**
+ * A sharded service responsible for storing connection counts by
+ * IP and node-wide, to enable network servers to apply limits on
+ * concurrent connections.
+ *
+ * There are global quotas and per-IP quotas.  Many functions take
+ * an inet_address argument, and if it is a default-initialized
+ * object, that means we are acting on the global quota.
+ */
+class conn_quota : public ss::peering_sharded_service<conn_quota> {
+public:
+    /**
+     * RAII helper for reliably releasing connection count quota.
+     *
+     * For convenience of call sites where quotas may be optional,
+     * there is a default constructor that provides a guard that
+     * does nothing.
+     */
+    class [[nodiscard]] units {
+    public:
+        units() {}
+
+        units(conn_quota& quotas, ss::net::inet_address const& addr)
+          : _quotas(std::ref(quotas))
+          , _addr(addr) {}
+
+        units(units const&) = delete;
+        units(units&& rhs) noexcept
+          : _addr(std::move(rhs._addr)) {
+            _quotas = std::exchange(rhs._quotas, std::nullopt);
+        }
+        units& operator=(units&& rhs) {
+            _quotas = std::exchange(rhs._quotas, std::nullopt);
+            _addr = std::move(rhs._addr);
+            return *this;
+        }
+
+        ~units();
+
+        /**
+         * A default-constructed `units` is not live, i.e.
+         * does not release anything on destruction.  Once
+         * it is constructed with a reference to a `conn_quota`
+         * it becomes live.
+         */
+        bool live() { return _quotas.has_value(); }
+
+    private:
+        std::optional<std::reference_wrapper<conn_quota>> _quotas;
+        ss::net::inet_address _addr;
+    };
+
+    using config_fn = std::function<conn_quota_config()>;
+    conn_quota(config_fn) noexcept;
+
+    ss::future<units> get(ss::net::inet_address);
+    void put(ss::net::inet_address);
+
+    ss::future<> stop();
+
+    /**
+     * Hook for unit tests to validate the reclaim logic.
+     */
+    bool test_only_is_in_reclaim(ss::net::inet_address addr) const;
+
+private:
+    /**
+     * State on a home core for an address: this records the authoritative
+     * maximum tokens allowed, plus how many are available on this core.  The
+     * available count does not include tokens which are currently borrowed
+     * by another core (i.e. in a remote_allowance::borrowed)
+     */
+    struct home_allowance {
+        uint32_t max{0};
+        uint32_t available{0};
+
+        void put() { available = std::min(max, available + 1); }
+
+        // When reclaim is true and available=0, it is not necessary
+        // to do cross-core communication: we can be sure there are
+        // not any borrowed tokens elsewhere.
+        bool reclaim{false};
+
+        // Lock to prevent multiple fibers trying to concurrently
+        // do reclaims (would happen if multiple incoming connections
+        // on the same shard when available==0)
+        mutex reclaim_lock;
+    };
+
+    friend std::ostream& operator<<(std::ostream& o, const home_allowance& ha) {
+        fmt::print(
+          o, "{{ {}/{} reclaim={}}}", ha.available, ha.max, ha.reclaim);
+        return o;
+    }
+
+    /**
+     * State on a non-home core for an address: records how many tokens
+     * we have borrowed from the home core, and whether we are in reclaim
+     * mode (release tokens to home core) or not (release tokens to our
+     * own borrowed pool).
+     */
+    struct remote_allowance {
+        uint32_t borrowed{0};
+
+        void put() { borrowed += 1; }
+
+        // When reclaim is true, released tokens are dispatched to
+        // the home core rather than back into `borrowed`.
+        bool reclaim{false};
+    };
+
+    /**
+     * Wrapper for inet_address implementing operators needed for use in a map
+     */
+    class inet_address_key : public ss::net::inet_address {
+    public:
+        inet_address_key(ss::net::inet_address addr)
+          : ss::net::inet_address(addr) {}
+
+        template<typename H>
+        friend H AbslHashValue(H h, const inet_address_key& k) {
+            return H::combine(
+              std::move(h), std::hash<ss::net::inet_address>{}(k));
+        }
+    };
+
+    // Which shard holds home_allowance for this address?
+    ss::shard_id addr_to_shard(ss::net::inet_address) const;
+
+    void assert_on_home([[maybe_unused]] ss::net::inet_address const& addr) {
+#ifndef NDEBUG
+        vassert(
+          conn_quota::addr_to_shard(addr) == ss::this_shard_id(),
+          "Wrong shard");
+#endif
+    }
+
+    // Which shard holds the allowances for the total connection count?
+    static constexpr ss::shard_id total_shard = 0;
+
+    // impl details of put/get
+    ss::future<bool> do_get(ss::net::inet_address);
+    void do_put(ss::net::inet_address);
+    ss::future<bool> home_get_units(ss::net::inet_address);
+    bool try_get_units(home_allowance& allowance);
+
+    // Reclaim logic
+    ss::future<>
+    reclaim_to(home_allowance& allowance, ss::net::inet_address, bool one_time);
+    uint32_t reclaim_from(ss::net::inet_address, bool one_time);
+    void cancel_reclaim_to(ss::net::inet_address);
+    void cancel_reclaim_from(ss::net::inet_address);
+    bool should_leave_reclaim(home_allowance& allowance);
+
+    home_allowance& get_home_allowance(ss::net::inet_address);
+    const home_allowance& get_home_allowance(ss::net::inet_address addr) const {
+        return const_cast<conn_quota&>(*this).get_home_allowance(addr);
+    };
+    remote_allowance& get_remote_allowance(ss::net::inet_address);
+    const remote_allowance&
+    get_remote_allowance(ss::net::inet_address addr) const {
+        return const_cast<conn_quota&>(*this).get_remote_allowance(addr);
+    };
+
+    // Allowance state for total connection count
+    home_allowance total_home;     // Valid on shard 0
+    remote_allowance total_remote; // Valid on shard !=0
+
+    // Allowance state for each client IP.
+    absl::node_hash_map<inet_address_key, home_allowance> ip_home;
+    absl::node_hash_map<inet_address_key, remote_allowance> ip_remote;
+
+    // Apply a configuration change
+    void
+    update_limit(ss::net::inet_address, conn_quota::home_allowance&, uint32_t);
+
+    conn_quota_config _cfg;
+
+    ss::gate _gate;
+};
+
+} // namespace net

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -40,6 +40,12 @@ void server_probe::setup_metrics(
           sm::description(ssx::sformat(
             "{}: Number of errors when shutting down the connection", proto))),
         sm::make_derive(
+          "connections_rejected",
+          [this] { return _connections_rejected; },
+          sm::description(ssx::sformat(
+            "{}: Number of connections rejected for hitting connection limits",
+            proto))),
+        sm::make_derive(
           "requests_completed",
           [this] { return _requests_completed; },
           sm::description(

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -155,6 +155,7 @@ ss::future<> server::accept(listener& s) {
                     ar.remote_address.addr());
                   if (!cq_units.live()) {
                       // Connection limit hit, drop this connection.
+                      _probe.connection_rejected();
                       vlog(
                         rpc::rpclog.info,
                         "Connection limit reached, rejecting {}",

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/property.h"
+#include "net/conn_quota.h"
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
@@ -82,6 +83,8 @@ struct server_configuration {
     // we use the same default as seastar for load balancing algorithm
     ss::server_socket::load_balancing_algorithm load_balancing_algo
       = ss::server_socket::load_balancing_algorithm::connection_distribution;
+
+    std::optional<std::reference_wrapper<ss::sharded<conn_quota>>> conn_quotas;
 
     explicit server_configuration(ss::sstring n)
       : name(std::move(n)) {}

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -30,6 +30,8 @@ public:
 
     void connection_close_error() { ++_connection_close_error; }
 
+    void connection_rejected() { ++_connections_rejected; }
+
     void add_bytes_sent(size_t sent) { _out_bytes += sent; }
 
     void add_bytes_received(size_t recv) { _in_bytes += recv; }
@@ -59,6 +61,7 @@ private:
     uint64_t _service_errors = 0;
     uint32_t _connections = 0;
     uint32_t _connection_close_error = 0;
+    uint64_t _connections_rejected = 0;
     uint32_t _corrupted_headers = 0;
     uint32_t _method_not_found_errors = 0;
     uint32_t _requests_blocked_memory = 0;

--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -1,10 +1,20 @@
+
 rp_test(
-  UNIT_TEST
-  BINARY_NAME net_connection_rate
-  SOURCES
-    connection_rate_test.cc
-  DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
-  ARGS "-- -c 1"
-  LABELS net
+        UNIT_TEST
+        BINARY_NAME net_connection_rate
+        SOURCES
+        connection_rate_test.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+        ARGS "-- -c 1"
+        LABELS net
+)
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME test_conn_quota
+        SOURCES conn_quota_test.cc
+        LIBRARIES v::seastar_testing_main v::net v::config absl::hash absl::node_hash_map
+        ARGS "-- -c 8"
+        LABELS net
 )

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -1,0 +1,434 @@
+
+#include "config/mock_property.h"
+#include "net/conn_quota.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/preempt.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
+
+static ss::logger logger("test");
+
+using namespace net;
+using namespace tests;
+using namespace std::chrono_literals;
+
+conn_quota::config_fn get_config_fn(
+  std::optional<uint32_t> max_con, std::optional<uint32_t> max_con_per_ip) {
+    return [max_con, max_con_per_ip]() mutable {
+        return conn_quota_config{
+          .max_connections = config::mock_binding<std::optional<uint32_t>>(
+            std::move(max_con)),
+          .max_connections_per_ip
+          = config::mock_binding<std::optional<uint32_t>>(
+            std::move(max_con_per_ip))};
+    };
+}
+
+// Some made up addresses to make tests terser
+static ss::net::inet_address addr1("10.0.0.1");
+static ss::net::inet_address addr2("10.0.0.2");
+static ss::net::inet_address addr3("10.0.0.3");
+
+struct conn_quota_fixture {
+    conn_quota_fixture() {}
+
+    ~conn_quota_fixture() {
+        drop_shard_units();
+        scq.stop().get();
+        max_con_per_ip.stop().get();
+        max_con.stop().get();
+    }
+
+    void start(
+      std::optional<uint32_t> max_con_,
+      std::optional<uint32_t> max_con_per_ip_) {
+        max_con.start(max_con_).get();
+        max_con_per_ip.start(max_con_per_ip_).get();
+        scq
+          .start([this]() {
+              return conn_quota_config{
+                .max_connections = max_con.local().bind(),
+                .max_connections_per_ip = max_con_per_ip.local().bind()};
+          })
+          .get();
+    }
+
+    std::vector<conn_quota::units>
+    take_units(ss::net::inet_address addr, size_t n) {
+        std::vector<conn_quota::units> units;
+        for (size_t i = 0; i < n; ++i) {
+            auto u = scq.local().get(addr).get();
+            BOOST_TEST_REQUIRE(u.live());
+            units.push_back(std::move(u));
+        }
+        return units;
+    }
+
+    ss::future<> expect_no_units(ss::net::inet_address addr) {
+        auto dead_unit = co_await scq.local().get(addr);
+        BOOST_TEST_REQUIRE(!dead_unit.live());
+    }
+
+    void drop_shard_units() {
+        for (ss::shard_id i = 0; i < ss::smp::count; ++i) {
+            scq
+              .invoke_on(i, [i, this](conn_quota& cq) { shard_units.erase(i); })
+              .get();
+        }
+    }
+
+    void set_limit(
+      ss::sharded<config::mock_property<std::optional<uint32_t>>>& limit,
+      std::optional<uint32_t> new_value) {
+        limit
+          .invoke_on_all(
+            [new_value](config::mock_property<std::optional<uint32_t>>& p) {
+                p.update(std::optional<uint32_t>(new_value));
+            })
+          .get();
+    }
+
+    void take_on_shard(
+      ss::shard_id shard, ss::net::inet_address addr, uint32_t take_units) {
+        scq
+          .invoke_on(
+            shard,
+            [shard, this, take_units, addr](conn_quota& cq) -> ss::future<> {
+                for (unsigned int j = 0; j < take_units; ++j) {
+                    auto u = co_await cq.get(addr);
+                    BOOST_TEST_REQUIRE(u.live());
+                    shard_units[shard].push_back(std::move(u));
+                }
+            })
+          .get();
+    }
+
+    void drop_on_shard(
+      ss::shard_id shard, ss::net::inet_address addr, uint32_t take_units) {
+        assert(shard_units[shard].size() >= take_units);
+
+        scq
+          .invoke_on(
+            shard,
+            [shard, this, take_units, addr](conn_quota& cq) {
+                for (size_t i = 0; i < take_units; ++i) {
+                    shard_units[shard].pop_back();
+                }
+            })
+          .get();
+    }
+
+    /**
+     * Helper for acquiring units on all the shards at once.
+     */
+    void take_on_all(uint32_t take_units, ss::net::inet_address addr = addr1) {
+        for (ss::shard_id i = 0; i < ss::smp::count; ++i) {
+            take_on_shard(i, addr, take_units);
+        }
+    }
+
+    void test_borrows(
+      unsigned int,
+      unsigned int,
+      std::optional<uint32_t>,
+      std::optional<uint32_t>);
+
+    ss::sharded<conn_quota> scq;
+    ss::sharded<config::mock_property<std::optional<uint32_t>>> max_con;
+    ss::sharded<config::mock_property<std::optional<uint32_t>>> max_con_per_ip;
+
+    // Stash your foreign shard units here, so that the fixture can
+    // clean them up for you on destruction (e.g. when handling exception)
+    std::map<ss::shard_id, std::vector<conn_quota::units>> shard_units;
+};
+
+FIXTURE_TEST(test_total_limit, conn_quota_fixture) {
+    start(10, std::nullopt);
+
+    std::vector<conn_quota::units> units;
+    for (size_t i = 0; i < 10; ++i) {
+        auto u = scq.local().get(addr1).get();
+        BOOST_TEST_REQUIRE(u.live());
+        units.push_back(std::move(u));
+    }
+
+    auto dead_unit = scq.local().get(addr1).get();
+    BOOST_TEST_REQUIRE(!dead_unit.live());
+
+    // Other addresses should also be limited by hitting the total limit
+    dead_unit = scq.local().get(addr2).get();
+    BOOST_TEST_REQUIRE(!dead_unit.live());
+    dead_unit = scq.local().get(addr3).get();
+    BOOST_TEST_REQUIRE(!dead_unit.live());
+
+    // Releasing one unit should enable another address to get a unit
+    units.pop_back();
+
+    auto live_unit = scq.local().get(addr3).get();
+    BOOST_TEST_REQUIRE(live_unit.live());
+}
+
+FIXTURE_TEST(test_addr_limits, conn_quota_fixture) {
+    start(4, 2);
+
+    vlog(logger.debug, "Taking 2 from addr1");
+    auto addr1_units = take_units(addr1, 2);
+    vlog(logger.debug, "Checking exhausted on addr1");
+    expect_no_units(addr1).get();
+    vlog(logger.debug, "Taking 2 from addr2");
+    auto addr2_units = take_units(addr2, 2);
+    vlog(logger.debug, "Checking exhausted on addr2");
+    expect_no_units(addr2).get();
+
+    // We have hit total limit.  Even though addr3 still has allowance, it
+    // is refused.
+    vlog(logger.debug, "Checking exhausted on addr3");
+    expect_no_units(addr3).get();
+
+    addr1_units.clear();
+    auto addr3_units = take_units(addr3, 2);
+}
+
+/**
+ * For testing token borrowing across shards.  May either exercise
+ * per-IP or total limit, depending on args.
+ *
+ * @param core_count pretend there are this many shards, i.e. only take
+ *                   units on these shards.
+ * @param take_each  how many units to take on each shard
+ * @param max_con    as for start()
+ * @param max_con_per_ip  as for start()
+ */
+void conn_quota_fixture::test_borrows(
+  unsigned int core_count,
+  unsigned int take_each,
+  std::optional<uint32_t> max_con,
+  std::optional<uint32_t> max_con_per_ip) {
+    start(max_con, max_con_per_ip);
+
+    // Take one unit on each shard
+    vlog(logger.debug, "Take units");
+    for (ss::shard_id i = 0; i < core_count; ++i) {
+        scq
+          .invoke_on(
+            i,
+            [i, take_each, this](conn_quota& cq) -> ss::future<> {
+                for (unsigned int j = 0; j < take_each; ++j) {
+                    auto u = co_await cq.get(addr1);
+                    BOOST_TEST_REQUIRE(u.live());
+                    shard_units[i].push_back(std::move(u));
+                }
+            })
+          .get();
+    }
+
+    // All shards should now see no units available
+    vlog(logger.debug, "Check allowances used up");
+    for (ss::shard_id i = 0; i < core_count; ++i) {
+        scq
+          .invoke_on(
+            i, [this](conn_quota& cq) { return expect_no_units(addr1); })
+          .get();
+    }
+
+    // Release a unit, then try taking it on a different shard.  This triggers
+    // a reclaim.
+    vlog(logger.debug, "Trigger a reclaim");
+    scq.invoke_on(1, [this](conn_quota& cq) { shard_units.erase(1); }).get();
+    scq
+      .invoke_on(
+        2,
+        [this, i = 2](conn_quota& cq) -> ss::future<> {
+            auto u = co_await cq.get(addr1);
+            BOOST_TEST_REQUIRE(u.live());
+            shard_units[i].push_back(std::move(u));
+        })
+      .get();
+
+    // Clean up units on their respective cores
+    vlog(logger.debug, "Dropping all units");
+    drop_shard_units();
+
+    // Now that all units are released, we should find that reclaim
+    // flag is switched off everywhere.
+    vlog(logger.debug, "Checking reclaim status");
+    ss::thread::yield(); // give the backgrounded part of reclaim_to a chance
+    cooperative_spin_wait_with_timeout(5s, [core_count, this]() {
+        bool any_in_reclaim = false;
+
+        for (ss::shard_id i = 0; i < core_count; ++i) {
+            scq
+              .invoke_on(
+                i,
+                [&any_in_reclaim](conn_quota& cq) {
+                    any_in_reclaim |= cq.test_only_is_in_reclaim({});
+                    any_in_reclaim = cq.test_only_is_in_reclaim(addr1);
+                })
+              .get();
+        }
+
+        return !any_in_reclaim;
+    }).get();
+}
+
+FIXTURE_TEST(test_total_borrows, conn_quota_fixture) {
+    auto core_count = ss::smp::count;
+
+    // This test needs at least a few cores.  If you run it with -c 1 it
+    // won't work.  We're testing sharded logic so we really do need multiple
+    // shards for it to be a valid test.
+    BOOST_REQUIRE(core_count >= 4);
+
+    test_borrows(core_count, 2, core_count * 2, std::nullopt);
+}
+
+/**
+ * Variant of test_total_borrows that stresses the per-IP limit instead
+ */
+FIXTURE_TEST(test_per_ip_borrows, conn_quota_fixture) {
+    auto core_count = ss::smp::count;
+    BOOST_REQUIRE(core_count >= 4);
+    test_borrows(core_count, 2, std::nullopt, core_count * 2);
+}
+
+FIXTURE_TEST(test_change_limits, conn_quota_fixture) {
+    auto core_count = ss::smp::count;
+    uint32_t initial_limit = core_count * 3;
+    start(initial_limit, std::nullopt);
+
+    // Take units on each shard
+    for (ss::shard_id i = 0; i < core_count; ++i) {
+        scq
+          .invoke_on(
+            i,
+            [i, this](conn_quota& cq) -> ss::future<> {
+                for (unsigned int j = 0; j < 3; ++j) {
+                    auto u = co_await cq.get(addr1);
+                    BOOST_TEST_REQUIRE(u.live());
+                    shard_units[i].push_back(std::move(u));
+                }
+            })
+          .get();
+    }
+
+    // We took all the units, should not be able to get any.
+    expect_no_units(addr1).get();
+
+    // Non-null value
+    vlog(logger.debug, "Updating total non-null");
+    set_limit(max_con, initial_limit + 1);
+
+    // We increased the limit by 1, we should be able to get one more token
+    // and no more.
+    {
+        auto u = take_units(addr1, 1);
+        expect_no_units(addr1).get();
+    }
+
+    // Null value
+    vlog(logger.debug, "Updating total null");
+    max_con
+      .invoke_on_all([](config::mock_property<std::optional<uint32_t>>& p) {
+          p.update(std::nullopt);
+      })
+      .get();
+
+    // We cleared the limit, should be able to get as many tokens as we like
+    { auto u = take_units(addr1, initial_limit * 2); }
+
+    // Releasing a bunch of units after disabling the limit should
+    // work (they should be dropped)
+    drop_shard_units();
+}
+
+FIXTURE_TEST(test_decrease_limit, conn_quota_fixture) {
+    auto core_count = ss::smp::count;
+    uint32_t initial_limit = core_count * 3;
+    start(initial_limit, std::nullopt);
+
+    // Take units on each shard
+    vlog(logger.debug, "Taking units");
+    take_on_all(3);
+
+    // We took all the units, should not be able to get any.
+    expect_no_units(addr1).get();
+
+    // Try decreasing the limit (we still hold initial_limit tokens)
+    vlog(logger.debug, "Decreasing limit");
+    set_limit(max_con, 1);
+    // We should still be in an exhausted state
+    expect_no_units(addr1).get();
+
+    // If we drop our existing units, it should be possible to take a unit
+    // from our new limit
+    vlog(logger.debug, "Dropping units");
+    drop_shard_units();
+
+    // Drain futures for background cross-core releases
+    for (uint32_t i = 0; i < initial_limit; ++i) {
+        ss::thread::yield();
+    }
+
+    vlog(logger.debug, "Taking 1st unit");
+    auto u = take_units(addr1, 1);
+    // We set the limit to 1 so it should not be possible to take >1
+    vlog(logger.debug, "Taking 2nd unit");
+    expect_no_units(addr1).get();
+}
+
+FIXTURE_TEST(test_change_limits_per_ip, conn_quota_fixture) {
+    auto core_count = ss::smp::count;
+    uint32_t initial_limit = core_count * 3;
+    start(std::nullopt, initial_limit);
+
+    // Populate some state
+    take_on_all(3);
+
+    // Non-null value per IP
+    uint32_t new_limit = initial_limit + 1;
+    vlog(logger.debug, "Updating per-IP non-null");
+    max_con_per_ip
+      .invoke_on_all(
+        [new_limit](config::mock_property<std::optional<uint32_t>>& p) {
+            p.update(new_limit);
+        })
+      .get();
+
+    // Having added one to the limit, we should be able to take exactly one
+    // more connection
+    auto took_1 = take_units(addr1, 1);
+    expect_no_units(addr1).get();
+
+    // Null value per IP
+    vlog(logger.debug, "Updating per-IP null");
+    max_con_per_ip
+      .invoke_on_all([](config::mock_property<std::optional<uint32_t>>& p) {
+          p.update(std::nullopt);
+      })
+      .get();
+
+    // Having cleared the limit, we should be able to take as many
+    // as we want.
+    auto took_2 = take_units(addr1, initial_limit * 10);
+}
+
+FIXTURE_TEST(test_overlaps, conn_quota_fixture) {
+    start(10, 10);
+
+    // First take all the tokens on shard 1 and drop them
+    // again, this puts all the borrowed tokens here
+    take_on_shard(1, addr1, 10);
+    drop_on_shard(1, addr1, 10);
+
+    // Now take tokens from each shard
+    for (int i = 0; i < 5; ++i) {
+        take_on_shard(1, addr1, 1);
+        take_on_shard(2, addr1, 1);
+    }
+
+    expect_no_units(addr1).get();
+}

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -20,6 +20,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
+#include "net/conn_quota.h"
 #include "net/fwd.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/fwd.h"
@@ -155,6 +156,7 @@ private:
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<net::server> _rpc;
     ss::sharded<admin_server> _admin;
+    ss::sharded<net::conn_quota> _kafka_conn_quotas;
     ss::sharded<net::server> _kafka_server;
     ss::sharded<kafka::client::client> _proxy_client;
     ss::sharded<pandaproxy::rest::proxy> _proxy;

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -58,6 +58,8 @@ public:
 
     auto get_units() noexcept { return ss::get_units(_sem, 1); }
 
+    auto try_get_units() noexcept { return ss::try_get_units(_sem, 1); }
+
     void broken() noexcept { _sem.broken(); }
 
     bool ready() { return _sem.waiters() == 0 && _sem.available_units() == 1; }

--- a/tests/rptest/services/metrics_check.py
+++ b/tests/rptest/services/metrics_check.py
@@ -1,0 +1,97 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+
+
+class MetricCheckFailed(Exception):
+    def __init__(self, metric, old_value, new_value):
+        self.metric = metric
+        self.old_value = old_value
+        self.new_value = new_value
+
+    def __str__(self):
+        return f"MetricCheckFailed<{self.metric} old={self.old_value} new={self.new_value}>"
+
+
+class MetricCheck(object):
+    def __init__(self, logger, redpanda, node, metrics, labels):
+        """
+        :param redpanda: a RedpandaService
+        :param logger: a Logger
+        :param node: a ducktape Node
+        :param metrics: a list of metric names, or a single compiled regex (use re.compile())
+        :param labels: dict, to filter metrics as we capture and check.
+        """
+        self.redpanda = redpanda
+        self.node = node
+        self.labels = labels
+        self.logger = logger
+
+        self._initial_samples = self._capture(metrics)
+
+    def _capture(self, check_metrics):
+        metrics = self.redpanda.metrics(self.node)
+
+        samples = {}
+        for family in metrics:
+            for sample in family.samples:
+                if isinstance(check_metrics, re.Pattern):
+                    include = bool(check_metrics.match(sample.name))
+                else:
+                    include = sample.name in check_metrics
+
+                if not include:
+                    continue
+
+                label_mismatch = False
+                for k, v in self.labels.items():
+                    if sample.labels.get(k, None) != v:
+                        label_mismatch = True
+                        continue
+
+                if label_mismatch:
+                    continue
+
+                if sample.name in samples:
+                    raise RuntimeError(
+                        f"Labels {self.labels} on {sample.name} not specific enough"
+                    )
+
+                self.logger.info(
+                    f"  Captured {sample.name}={sample.value} {sample.labels}")
+                samples[sample.name] = sample.value
+
+        return samples
+
+    def expect(self, expectations):
+        # Gather current values for all the metrics we are going to
+        # apply expectations to (this may be a subset of the metrics
+        # we originally gathered at construction time).
+        samples = self._capture([e[0] for e in expectations])
+
+        error = None
+        for (metric, comparator) in expectations:
+            try:
+                old_value = self._initial_samples[metric]
+            except KeyError:
+                self.logger.error(
+                    f"Missing metrics {metric} on {self.node.account.hostname}.  Have metrics: {list(self._initial_samples.keys())}"
+                )
+                raise
+
+            new_value = samples[metric]
+            ok = comparator(old_value, new_value)
+            if not ok:
+                error = MetricCheckFailed(metric, old_value, new_value)
+                # Log each bad metric, raise the last one as our actual exception below
+                self.logger.error(str(error))
+
+        if error:
+            raise error

--- a/tests/rptest/tests/connection_limits_test.py
+++ b/tests/rptest/tests/connection_limits_test.py
@@ -1,0 +1,100 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.rpk_producer import RpkProducer
+from rptest.services.rpk_consumer import RpkConsumer
+from rptest.clients.types import TopicSpec
+from rptest.services.metrics_check import MetricCheck
+
+REJECTED_METRIC = "vectorized_kafka_rpc_connections_rejected_total"
+
+
+class ConnectionLimitsTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=1), )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=1, **kwargs)
+
+    @cluster(num_nodes=4)
+    def test_exceed_broker_limit(self):
+        self.redpanda.set_cluster_config({"kafka_connections_max": 6})
+
+        metrics = [
+            MetricCheck(self.logger, self.redpanda, n, REJECTED_METRIC, {},
+                        sum) for n in self.redpanda.nodes
+        ]
+
+        # I happen to know that an `rpk topic consume` occupies three
+        # connections.  So after opening two consumers, I should find
+        # that a producer cannot get in.
+        consumers = [
+            RpkConsumer(self.test_context, self.redpanda, self.topic),
+            RpkConsumer(self.test_context, self.redpanda, self.topic),
+        ]
+
+        for c in consumers:
+            c.start()
+
+        producer = RpkProducer(self.test_context,
+                               self.redpanda,
+                               self.topic,
+                               msg_size=16384,
+                               msg_count=1,
+                               produce_timeout=5)
+        producer.start()
+        try:
+            producer.wait()
+        except Exception:
+            # This is a non-specific exception because ducktape re-raises in wait()
+            # as a bare Exception
+            pass
+        else:
+            raise RuntimeError("Producer should have failed")
+
+        for c in consumers:
+            c.stop()
+            c.wait()
+
+        assert any([
+            m.evaluate([(REJECTED_METRIC, lambda a, b: b > a)])
+            for m in metrics
+        ])
+
+    @cluster(num_nodes=2)
+    def test_null(self):
+        """
+        The null case where we are never exceeding the limit, but
+        are repeatedly creating+destroying connections.
+        """
+        self.redpanda.set_cluster_config({"kafka_connections_max": 6})
+
+        metrics = [
+            MetricCheck(self.logger, self.redpanda, n, REJECTED_METRIC, {},
+                        sum) for n in self.redpanda.nodes
+        ]
+
+        producer = RpkProducer(self.test_context,
+                               self.redpanda,
+                               self.topic,
+                               msg_size=16384,
+                               msg_count=1,
+                               quiet=True,
+                               produce_timeout=5)
+        for n in range(0, 100):
+            producer.start()
+            producer.wait()
+
+        assert all([
+            m.evaluate([(REJECTED_METRIC, lambda a, b: b == a)])
+            for m in metrics
+        ])

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -27,6 +27,7 @@ from rptest.services.kaf_producer import KafProducer
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.metrics_check import MetricCheck
 
 ELECTION_TIMEOUT = 10
 
@@ -35,93 +36,6 @@ ISOLATION_LOG_ALLOW_LIST = [
     # rpc - server.cc:91 - vectorized internal rpc protocol - Error[shutting down] remote address: 10.89.0.16:60960 - std::__1::system_error (error system:32, sendmsg: Broken pipe)
     "rpc - .*Broken pipe",
 ]
-
-
-class MetricCheckFailed(Exception):
-    def __init__(self, metric, old_value, new_value):
-        self.metric = metric
-        self.old_value = old_value
-        self.new_value = new_value
-
-    def __str__(self):
-        return f"MetricCheckFailed<{self.metric} old={self.old_value} new={self.new_value}>"
-
-
-class MetricCheck(object):
-    def __init__(self, logger, redpanda, node, metrics, labels):
-        """
-        :param redpanda: a RedpandaService
-        :param logger: a Logger
-        :param node: a ducktape Node
-        :param metrics: a list of metric names, or a single compiled regex (use re.compile())
-        :param labels: dict, to filter metrics as we capture and check.
-        """
-        self.redpanda = redpanda
-        self.node = node
-        self.labels = labels
-        self.logger = logger
-
-        self._initial_samples = self._capture(metrics)
-
-    def _capture(self, check_metrics):
-        metrics = self.redpanda.metrics(self.node)
-
-        samples = {}
-        for family in metrics:
-            for sample in family.samples:
-                if isinstance(check_metrics, re.Pattern):
-                    include = bool(check_metrics.match(sample.name))
-                else:
-                    include = sample.name in check_metrics
-
-                if not include:
-                    continue
-
-                label_mismatch = False
-                for k, v in self.labels.items():
-                    if sample.labels.get(k, None) != v:
-                        label_mismatch = True
-                        continue
-
-                if label_mismatch:
-                    continue
-
-                if sample.name in samples:
-                    raise RuntimeError(
-                        f"Labels {self.labels} on {sample.name} not specific enough"
-                    )
-
-                self.logger.info(
-                    f"  Captured {sample.name}={sample.value} {sample.labels}")
-                samples[sample.name] = sample.value
-
-        return samples
-
-    def expect(self, expectations):
-        # Gather current values for all the metrics we are going to
-        # apply expectations to (this may be a subset of the metrics
-        # we originally gathered at construction time).
-        samples = self._capture([e[0] for e in expectations])
-
-        error = None
-        for (metric, comparator) in expectations:
-            try:
-                old_value = self._initial_samples[metric]
-            except KeyError:
-                self.logger.error(
-                    f"Missing metrics {metric} on {self.node.account.hostname}.  Have metrics: {list(self._initial_samples.keys())}"
-                )
-                raise
-
-            new_value = samples[metric]
-            ok = comparator(old_value, new_value)
-            if not ok:
-                error = MetricCheckFailed(metric, old_value, new_value)
-                # Log each bad metric, raise the last one as our actual exception below
-                self.logger.error(str(error))
-
-        if error:
-            raise error
 
 
 class RaftAvailabilityTest(RedpandaTest):


### PR DESCRIPTION
## Cover letter

RFC: https://github.com/redpanda-data/redpanda/pull/3744

The main complexity here is the cross-shard coordination of limits that apply at a per-node level.  Each client IP has a "home" shard where their `home_allowance` lives, and other shards can "borrow" some tokens in their `remote_allowance`.  To avoid starvation when many tokens have been borrowed, there is a "reclaim" mechanism whereby the home shard reclaims all borrowed tokens, and sets a flag on the remote shards to dispatch any freed tokens back to the home shard.

In normal operation where the limit is comfortably high enough for the workload, all shards that are handling connections will end up with a few tokens in their borrowed pool, and service incoming requests without having to do cross-shard communication.  Cross-shard communication only kicks in when there is some pressure for the tokens.

This PR does not add the "overrides" variant of the config for setting limits on individual addresses, that is future work.

These settings are similar to Kafka's `max.connections.per.ip` and `max.connections` settings.

Connection limits are only applied to the Kafka protocol server, not the internal RPC server.

Fixes https://github.com/redpanda-data/redpanda/issues/3698

## Release notes

### Features

* It is now possible to impose limits on the number of client connections.  Cluster configuration properties `kafka_connections_max` and `kafka_connections_max_per_ip` are added to control this behavior. By default both properties are switched off (i.e. the connection count is unlimited).  These limits apply on  a per-node basis.  Note that the number of connections is not exactly equal to the number of clients: clients typically open 2-3 connections each.
