### PR TITLE
adding schemaRegistry to example tls.yaml

### DIFF
--- a/src/go/k8s/config/samples/tls.yaml
+++ b/src/go/k8s/config/samples/tls.yaml
@@ -24,6 +24,10 @@ spec:
      - port: 8082
        tls:
          enabled: true
+    schemaRegistry:
+       port: 8081
+       tls:
+         enabled: true
     adminApi:
     - port: 9644
     developerMode: true


### PR DESCRIPTION
enabling schema registry for tls was not in the tls.yaml example file. 