### PR TITLE
admin: add `include_defaults` flag to /v1/cluster_config endpoint

### DIFF
--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -108,13 +108,26 @@ public:
         }
     }
 
-    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const {
+    /**
+     *
+     * @param filter optional callback for filtering out config properties.
+     *               callback should return false to exclude a property.
+     */
+    void to_json(
+      rapidjson::Writer<rapidjson::StringBuffer>& w,
+      std::optional<std::function<bool(base_property&)>> filter
+      = std::nullopt) const {
         w.StartObject();
 
         for (const auto& [name, property] : _properties) {
             if (property->get_visibility() == visibility::deprecated) {
                 continue;
             }
+
+            if (filter && !filter.value()(*property)) {
+                continue;
+            }
+
             w.Key(name.data(), name.size());
             property->to_json(w);
         }

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -35,6 +35,32 @@
               }
             }
           }
+        },
+        {"method": "GET",
+          "summary": "Read cluster configuration",
+          "type": "void",
+          "nickname": "get_cluster_config",
+          "produces": ["application/json"],
+          "parameters": [
+            {
+              "in": "query",
+              "name": "include_defaults",
+              "schema": {"type": "boolean"},
+              "required": false,
+              "description": "If false, only properties which have been changed from the default are included."
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK"
+            },
+            "400": {
+              "description": "Invalid properties.  Response is a map of property name to error string",
+              "schema":{
+                "type": "object"
+              }
+            }
+          }
         }
       ]
     },

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -43,10 +43,11 @@
           "produces": ["application/json"],
           "parameters": [
             {
-              "in": "query",
               "name": "include_defaults",
+              "in": "query",
               "schema": {"type": "boolean"},
               "required": false,
+              "allowMultiple": false,
               "description": "If false, only properties which have been changed from the default are included."
             }
           ],

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -551,6 +551,17 @@ void admin_server::register_config_routes() {
       });
 
     register_route_raw<superuser>(
+      ss::httpd::cluster_config_json::get_cluster_config,
+      [](ss::const_req, ss::reply& reply) {
+          rapidjson::StringBuffer buf;
+          rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+          config::shard_local_cfg().to_json(writer);
+
+          reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
+          return "";
+      });
+
+    register_route_raw<superuser>(
       ss::httpd::config_json::get_node_config,
       [](ss::const_req, ss::reply& reply) {
           rapidjson::StringBuffer buf;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -142,7 +142,7 @@ class Admin:
         return self._request("GET", "status/ready", node=node).json()
 
     def get_cluster_config(self, node=None):
-        return self._request("GET", "config", node=node).json()
+        return self._request("GET", "cluster_config", node=node).json()
 
     def get_cluster_config_schema(self, node=None):
         return self._request("GET", "cluster_config/schema", node=node).json()

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -141,8 +141,14 @@ class Admin:
     def get_status_ready(self, node=None):
         return self._request("GET", "status/ready", node=node).json()
 
-    def get_cluster_config(self, node=None):
-        return self._request("GET", "cluster_config", node=node).json()
+    def get_cluster_config(self, node=None, include_defaults=None):
+        if include_defaults is not None:
+            kwargs = {"params": {"include_defaults": include_defaults}}
+        else:
+            kwargs = {}
+
+        return self._request("GET", "cluster_config", node=node,
+                             **kwargs).json()
 
     def get_cluster_config_schema(self, node=None):
         return self._request("GET", "cluster_config/schema", node=node).json()

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -49,12 +49,19 @@ class ClusterConfigTest(RedpandaTest):
         self.rpk = RpkTool(self.redpanda)
 
     @cluster(num_nodes=3)
-    def test_get_config(self):
+    @parametrize(legacy=False)
+    @parametrize(legacy=True)
+    def test_get_config(self, legacy):
         """
         Verify that the config GET endpoint serves valid json with some options in it.
+
+        :param legacy: whether to use the legacy /config endpoint
         """
         admin = Admin(self.redpanda)
-        config = admin.get_cluster_config()
+        if legacy:
+            config = admin._request("GET", "config").json()
+        else:
+            config = admin.get_cluster_config()
 
         # Pick an arbitrary config property to verify that the result
         # contained some properties

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -72,6 +72,32 @@ class ClusterConfigTest(RedpandaTest):
         # Some arbitrary property to check syntax of result
         assert 'kafka_api' in node_config
 
+    @cluster(num_nodes=1)
+    def test_get_config_nodefaults(self):
+        admin = Admin(self.redpanda)
+        initial_short_config = admin.get_cluster_config(include_defaults=False)
+        long_config = admin.get_cluster_config(include_defaults=True)
+
+        assert len(long_config) > len(initial_short_config)
+
+        assert 'kafka_qdc_enable' not in initial_short_config
+
+        # After setting something to non-default is should appear
+        patch_result = self.admin.patch_cluster_config(
+            upsert={'kafka_qdc_enable': True})
+        self._wait_for_version_sync(patch_result['config_version'])
+        short_config = admin.get_cluster_config(include_defaults=False)
+        assert 'kafka_qdc_enable' in short_config
+        assert len(short_config) == len(initial_short_config) + 1
+
+        # After resetting to default it should disappear
+        patch_result = self.admin.patch_cluster_config(
+            remove=['kafka_qdc_enable'])
+        self._wait_for_version_sync(patch_result['config_version'])
+        short_config = admin.get_cluster_config(include_defaults=False)
+        assert 'kafka_qdc_enable' not in short_config
+        assert len(short_config) == len(initial_short_config)
+
     @cluster(num_nodes=3)
     def test_bootstrap(self):
         """


### PR DESCRIPTION
## Cover letter

This is useful if the caller wants to know which settings are different from defaults, to implement a synchronization step (e.g. from the k8s operator) that first reads all non-default config, then reconciles it with an externally stored config dict.

Add this to a new `/v1/cluster/config` endpoint.  Previously cluster_config was served through `/v1/config` as a partial backward compatibility to callers using that pre-existing endpoint, but for new functionality let's have a new endpoint with a more consistent name.

This was called for in the original design but not added with the main centralized config changes.

## Release notes

* none
