### PR TITLE
adding tls enabled to admin api

### DIFF
--- a/src/go/k8s/config/samples/tls.yaml
+++ b/src/go/k8s/config/samples/tls.yaml
@@ -29,5 +29,7 @@ spec:
        tls:
          enabled: true
     adminApi:
-    - port: 9644
+     - port: 9644
+       tls:
+         enabled: true
     developerMode: true


### PR DESCRIPTION
admin api didn't have tls enabled in the tls.yaml example. I'm documenting this and it makes more sense for it to be enabled in the example file. 