### PR TITLE
v21.11.x/backport: #3413

### DIFF
--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -32,6 +32,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::topic_already_exists:
         return error_code::topic_already_exists;
     case cluster::errc::topic_not_exists:
+        return error_code::unknown_topic_or_partition;
     case cluster::errc::source_topic_still_in_use:
         return error_code::cluster_authorization_failed;
     case cluster::errc::timeout:


### PR DESCRIPTION
## Cover letter

backport: https://github.com/redpanda-data/redpanda/pull/3413

Controller topic delete error code incorrectly mapped to an
authorization failure instead of the kafka error corresponding to a
unknown topic or partition.

Fixes: #3079
Fixes: #3382 

## Release notes

* Fixes return error code when deleting a topic that doesn't exist.
