### PR TITLE
tests: fix running test_secret_redaction locally

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -38,9 +38,12 @@ class ClusterConfigTest(RedpandaTest):
         # Enable our feature flag
         rp_conf['enable_central_config'] = True
 
-        super(ClusterConfigTest, self).__init__(*args,
-                                                extra_rp_conf=rp_conf,
-                                                **kwargs)
+        super(ClusterConfigTest, self).__init__(
+            *args,
+            extra_rp_conf=rp_conf,
+            # Force verbose logging for the secret redaction test
+            log_level='trace',
+            **kwargs)
 
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)


### PR DESCRIPTION
## Cover letter

This test relied on debug/trace level logs to work,
because part of it's job is to test we aren't leaking
secrets to those logs.

That always worked in CI and on my local setup where
I set redpanda log level to trace, but if someone
runs ducktape without any REDPANDA_LOG_LEVEL argument,
it will fail.

Fix by explicitly setting the redpanda log level for this
test.

## Release notes

* none