### PR TITLE
tools: Handle FileNotFoundError for Snapshot

### DIFF
--- a/tools/metadata_viewer/viewer.py
+++ b/tools/metadata_viewer/viewer.py
@@ -17,6 +17,7 @@ logger = logging.getLogger('viewer')
 def print_kv_store(store):
     for ntp in store.ntps:
         if ntp.nspace == "redpanda" and ntp.topic == "kvstore":
+            logger.info(f"inspecting {ntp}")
             kv = KvStore(ntp)
             kv.decode()
             items = kv.items()


### PR DESCRIPTION
## Cover letter

kvstore.py fails to parse the `kvstore` directory in a case when it doesn't have the `snapshot` file. 

```
$ python3 ~/Redpanda/src/redpanda/tools/metadata_viewer/viewer.py --path ~/Redpanda/playground/localcluster/redpanda1/data --type kvstore 
INFO:viewer:starting metadata viewer with options: Namespace(path='/home/daisuke/Redpanda/playground/localcluster/redpanda1/data', type='kvstore', topic=None, verbose=False)
INFO:kvstore:building kvstore on path: /home/daisuke/Redpanda/playground/localcluster/redpanda1/data/redpanda/kvstore/0_0
INFO:kvstore:reading snapshot from /home/daisuke/Redpanda/playground/localcluster/redpanda1/data/redpanda/kvstore/0_0/snapshot
Traceback (most recent call last):
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/viewer.py", line 87, in <module>
    main()
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/viewer.py", line 79, in main
    print_kv_store(store)
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/viewer.py", line 20, in print_kv_store
    kv.decode()
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/kvstore.py", line 290, in decode
    snap = KvSnapshot(f"{self.ntp.path}/snapshot")
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/kvstore.py", line 155, in __init__
    self.snap.read()
  File "/home/daisuke/Redpanda/src/redpanda/tools/metadata_viewer/kvstore.py", line 141, in read
    with open(self.path, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/daisuke/Redpanda/playground/localcluster/redpanda1/data/redpanda/kvstore/0_0/snapshot'
```

Because of this, the entire viewer.py has also failed. To be able to analyze the existing files, I have just added a logic to skip reading the snapshot when it doesn't exist.


