### PR TITLE
kafka: ability to Limit Connection Creation Rate on Brokers

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -5,9 +5,11 @@ v_cc_library(
     node_config.cc
     base_property.cc
     rjson_serialization.cc
+    validators.cc
   DEPS
     v::json
     v::model
    boost_filesystem
+   absl::node_hash_set
 )
 add_subdirectory(tests)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -12,6 +12,7 @@
 #include "cluster/node/constants.h"
 #include "config/base_property.h"
 #include "config/node_config.h"
+#include "config/validators.h"
 #include "model/metadata.h"
 #include "storage/chunk_cache.h"
 #include "storage/segment_appender.h"
@@ -374,6 +375,23 @@ configuration::configuration()
       "refreshed",
       {.visibility = visibility::tunable},
       2s)
+  , kafka_connection_rate_limit(
+      *this,
+      "kafka_connection_rate_limit",
+      "Maximum connections per second for one core",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      {.min = 1})
+  , kafka_connection_rate_limit_overrides(
+      *this,
+      "kafka_connection_rate_limit_overrides",
+      "Overrides for specific ips for maximum connections per second for one "
+      "core",
+      {.needs_restart = needs_restart::no,
+       .example = R"(['127.0.0.1:90', '50.20.1.1:40'])",
+       .visibility = visibility::user},
+      {},
+      validate_connection_rate)
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -100,6 +100,8 @@ struct configuration final : public config_store {
     property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
     property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
+    bounded_property<std::optional<int64_t>> kafka_connection_rate_limit;
+    property<std::vector<ss::sstring>> kafka_connection_rate_limit_overrides;
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     property<bool> enable_idempotence;

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config/validators.h"
+
+#include "net/inet_address_wrapper.h"
+
+#include <absl/container/node_hash_set.h>
+#include <fmt/format.h>
+
+#include <optional>
+
+namespace config {
+
+std::optional<std::pair<ss::sstring, int64_t>>
+parse_connection_rate_override(const ss::sstring& raw_option) {
+    auto del_pos = raw_option.find(":");
+    if (del_pos == std::string::npos || del_pos == raw_option.size() - 1) {
+        return std::nullopt;
+    }
+
+    auto ip = raw_option.substr(0, del_pos);
+    auto rate_str = raw_option.substr(del_pos + 1);
+
+    std::pair<ss::sstring, int64_t> ans;
+    ans.first = ip;
+    try {
+        ans.second = std::stoi(rate_str);
+    } catch (...) {
+        return std::nullopt;
+    }
+    return ans;
+}
+
+std::optional<ss::sstring>
+validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit) {
+    absl::node_hash_set<net::inet_address_wrapper> ip_set;
+    for (const auto& ip_and_limit : ips_with_limit) {
+        auto parsing_setting = parse_connection_rate_override(ip_and_limit);
+        if (!parsing_setting) {
+            return fmt::format(
+              "Can not parse connection_rate override {}", ip_and_limit);
+        }
+
+        ss::net::inet_address addr;
+        try {
+            addr = ss::net::inet_address(parsing_setting->first);
+        } catch (...) {
+            return fmt::format(
+              "Looks like {} is not ip", parsing_setting->first);
+        }
+
+        if (!ip_set.insert(addr).second) {
+            return fmt::format(
+              "Duplicate setting for ip: {}", parsing_setting->first);
+        }
+    }
+
+    return std::nullopt;
+}
+
+}; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <optional>
+
+namespace config {
+
+std::optional<std::pair<ss::sstring, int64_t>>
+parse_connection_rate_override(const ss::sstring& raw_option);
+
+std::optional<ss::sstring>
+validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit);
+
+}; // namespace config

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     absl::node_hash_map
+    v::config
   )
 
 add_subdirectory(tests)

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -11,4 +11,7 @@ v_cc_library(
     tls.cc
   DEPS
     Seastar::seastar
+    absl::node_hash_map
   )
+
+add_subdirectory(tests)

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
   NAME net
   SRCS
     batched_output_stream.cc
+    connection_rate.cc
     dns.cc
     transport.cc
     connection.cc

--- a/src/v/net/connection_rate.cc
+++ b/src/v/net/connection_rate.cc
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "net/connection_rate.h"
+
+#include "config/validators.h"
+#include "seastar/core/coroutine.hh"
+#include "ssx/future-util.h"
+#include "vassert.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/net/inet_address.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <algorithm>
+#include <chrono>
+#include <optional>
+
+namespace net {
+
+connection_rate::connection_rate(
+  const connection_rate_info& rate_info, ss::gate& connection_gate) noexcept
+  : _connection_gate(connection_gate) {
+    if (rate_info.max_connection_rate) {
+        _general_rate = ss::make_lw_shared<connection_rate_counter>(
+          rate_info.max_connection_rate.value());
+    }
+
+    fill_overrides(rate_info.overrides);
+}
+
+void connection_rate::update_general_rate(std::optional<int64_t> new_value) {
+    if (_general_rate) {
+        update_connection_rate(_general_rate, new_value);
+    } else {
+        if (!new_value) {
+            return;
+        }
+
+        _general_rate = ss::make_lw_shared<connection_rate_counter>(
+          new_value.value());
+    }
+}
+
+void connection_rate::update_overrides_rate(
+  const std::vector<ss::sstring>& new_value) {
+    if (_overrides.size() != 0) {
+        if (new_value.size() != 0) {
+            absl::node_hash_map<inet_address_wrapper, int64_t> new_overrides;
+            for (const auto& new_connection_rate_str : new_value) {
+                auto parsed_override = config::parse_connection_rate_override(
+                  new_connection_rate_str);
+                vassert(
+                  parsed_override.has_value(),
+                  "Validation for redpanda config should signal about invalid "
+                  "overrides");
+
+                ss::net::inet_address addr;
+                try {
+                    addr = ss::net::inet_address(parsed_override->first);
+                } catch (...) {
+                    vassert(
+                      false,
+                      "Validation for redpanda config should signal about "
+                      "invalid ip: {}",
+                      parsed_override->first);
+                }
+
+                auto [_, res] = new_overrides.emplace(
+                  addr, parsed_override->second);
+                vassert(
+                  res,
+                  "Validation for redpanda config should signal about invalid "
+                  "overrides");
+            }
+
+            auto current_overrides_it = _overrides.begin();
+            while (current_overrides_it != _overrides.end()) {
+                auto new_overrides_it = new_overrides.find(
+                  current_overrides_it->first);
+                if (new_overrides_it != new_overrides.end()) {
+                    current_overrides_it->second->update_max_rate(
+                      new_overrides_it->second);
+                    current_overrides_it++;
+                } else {
+                    update_connection_rate(
+                      current_overrides_it->second, std::nullopt);
+                    _overrides.erase(current_overrides_it++);
+                }
+            }
+
+        } else {
+            for (auto& [_, sem] : _overrides) {
+                update_connection_rate(sem, std::nullopt);
+            }
+            _overrides.clear();
+        }
+    } else {
+        if (new_value.size() == 0) {
+            return;
+        }
+
+        fill_overrides(new_value);
+    }
+}
+
+ss::future<> connection_rate::maybe_wait(const ss::net::inet_address& addr) {
+    inet_address_wrapper addr_wrapper(addr);
+    auto sem = find_sem(addr_wrapper);
+    if (sem.get() == nullptr) {
+        co_return;
+    }
+
+    allow_new_connections(sem);
+    co_await sem->bucket.wait(_max_wait_time, 1);
+    spawn_updating_fiber_if_needed(sem);
+}
+
+connection_rate::connection_rate_t
+connection_rate::find_sem(const inet_address_wrapper& addr) {
+    auto overrides_it = _overrides.find(addr);
+    if (overrides_it != _overrides.end()) {
+        return overrides_it->second;
+    }
+
+    return _general_rate;
+}
+
+void connection_rate::stop() {
+    if (_general_rate) {
+        _general_rate->break_semaphore();
+    }
+    for (auto& [_, sem] : _overrides) {
+        sem->break_semaphore();
+    }
+}
+
+void connection_rate::allow_new_connections(connection_rate_t rate_counter) {
+    int64_t max_tokens_for_update = std::max(
+      0l, rate_counter->max_tokens - rate_counter->avaiable_new_connections());
+
+    if (max_tokens_for_update == 0) {
+        return;
+    }
+
+    auto now = ss::lowres_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now - rate_counter->last_update_time);
+
+    int64_t tokens_for_update = duration.count()
+                                / rate_counter->one_token_time.count();
+
+    if (tokens_for_update == 0) {
+        return;
+    }
+
+    int64_t new_tokens_count = std::min(
+      tokens_for_update, max_tokens_for_update);
+
+    rate_counter->update_rate(new_tokens_count, now);
+}
+
+void connection_rate::spawn_updating_fiber_if_needed(
+  connection_rate_t rate_counter) {
+    if (rate_counter->avaiable_new_connections() == 0) {
+        // Should spawn fiber to update tokens on next second
+        ssx::spawn_with_gate(
+          _connection_gate,
+          [this,
+           rate_counter,
+           sleep_time = rate_counter->one_token_time]() mutable {
+              return ss::sleep(ss::lowres_clock::duration(sleep_time))
+                .then([this, rate_counter] {
+                    if (rate_counter.get() != nullptr) {
+                        allow_one_new_connection(rate_counter);
+                    }
+                });
+          });
+    }
+}
+
+void connection_rate::allow_one_new_connection(connection_rate_t rate_counter) {
+    auto now = ss::lowres_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now - rate_counter->last_update_time);
+
+    // If somebody update tokens in updating interval we should skip
+    // updating phase
+    if (
+      duration.count() < rate_counter->one_token_time.count()
+      || rate_counter->avaiable_new_connections() > 0) {
+        return;
+    }
+
+    rate_counter->update_rate(1, now);
+}
+
+void connection_rate::update_connection_rate(
+  connection_rate_t rate_counter, std::optional<int64_t> new_value) {
+    if (new_value) {
+        auto should_spawn_fiber = rate_counter->update_max_rate(
+          new_value.value());
+        if (should_spawn_fiber == should_spawn_fiber_on_update::yes) {
+            spawn_updating_fiber_if_needed(rate_counter);
+        }
+    } else {
+        rate_counter->break_semaphore();
+        rate_counter = nullptr;
+    }
+}
+
+void connection_rate::fill_overrides(
+  const std::vector<ss::sstring>& new_overrides) {
+    for (const auto& setting_for_ip : new_overrides) {
+        auto parsed_override = config::parse_connection_rate_override(
+          setting_for_ip);
+
+        vassert(
+          parsed_override.has_value(),
+          "Validation for redpanda config should signal about invalid "
+          "overrides");
+
+        auto [_, res] = _overrides.emplace(
+          parsed_override.value().first,
+          ss::make_lw_shared<connection_rate_counter>(
+            parsed_override.value().second));
+
+        vassert(
+          res,
+          "Validation for redpanda config should signal about invalid "
+          "overrides");
+    }
+}
+
+} // namespace net

--- a/src/v/net/connection_rate.h
+++ b/src/v/net/connection_rate.h
@@ -11,13 +11,16 @@
 
 #pragma once
 
+#include "net/inet_address_wrapper.h"
 #include "seastarx.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/net.hh>
+#include <seastar/util/bool_class.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
@@ -29,8 +32,107 @@ using namespace std::chrono_literals;
 namespace net {
 
 struct connection_rate_info {
-    int64_t max_connection_rate;
+    std::optional<int64_t> max_connection_rate;
     std::vector<ss::sstring> overrides;
+};
+
+using should_spawn_fiber_on_update
+  = ss::bool_class<struct should_spawn_fiber_on_update_tag>;
+
+struct connection_rate_counter {
+    explicit connection_rate_counter(int64_t max_rate) noexcept
+      : max_tokens(max_rate)
+      , one_token_time(std::max(1000 / max_tokens, 1l))
+      , bucket(max_rate)
+      , last_update_time(ss::lowres_clock::now()) {}
+
+    void break_semaphore() { bucket.broken(); }
+
+    should_spawn_fiber_on_update update_max_rate(int64_t new_max_rate) {
+        auto diff = new_max_rate - max_tokens;
+        if (diff == 0) {
+            return should_spawn_fiber_on_update::no;
+        }
+
+        max_tokens = new_max_rate;
+        one_token_time = std::chrono::milliseconds(
+          std::max(1000 / max_tokens, 1l));
+
+        if (diff > 0) {
+            auto need_add = max_tokens - bucket.current();
+            bucket.signal(need_add);
+        } else {
+            auto need_move = static_cast<int64_t>(bucket.current())
+                             - max_tokens;
+            if (need_move > 0) {
+                bucket.consume(need_move);
+            }
+            return should_spawn_fiber_on_update::yes;
+        }
+
+        return should_spawn_fiber_on_update::no;
+    }
+
+    void
+    update_rate(int64_t spawned_tokens, ss::lowres_clock::time_point time) {
+        bucket.signal(spawned_tokens);
+        last_update_time = time;
+    }
+
+    int64_t avaiable_new_connections() {
+        return static_cast<int64_t>(bucket.current());
+    }
+
+    int64_t max_tokens;
+    std::chrono::milliseconds one_token_time;
+    ss::semaphore bucket;
+    ss::lowres_clock::time_point last_update_time;
+};
+
+// This class implement logic to count connections for current seconds. It uses
+// token bucket algorithm inside. If we can not accept new connections they will
+// wait new tokens. We use handlers to on-line updates for redpanda config.
+class connection_rate {
+    static constexpr ss::lowres_clock::duration _max_wait_time
+      = ss::lowres_clock::duration(100ms);
+
+public:
+    connection_rate(
+      const connection_rate_info& rate_info,
+      ss::gate& connection_gate) noexcept;
+
+    // Handlers for on-line update config calue for connection_rate
+    void update_general_rate(std::optional<int64_t> new_value);
+    void update_overrides_rate(const std::vector<ss::sstring>& new_value);
+
+    // New connection will wait when redpanda have free tokens for new
+    // connection
+    ss::future<> maybe_wait(const ss::net::inet_address& addr);
+
+    void stop();
+
+private:
+    void fill_overrides(const std::vector<ss::sstring>& new_overrides);
+
+    using connection_rate_t = ss::lw_shared_ptr<connection_rate_counter>;
+
+    connection_rate_t find_sem(const inet_address_wrapper& addr);
+
+    // Increae rate_counter to max connections for current second
+    void allow_new_connections(connection_rate_t rate_counter);
+
+    void spawn_updating_fiber_if_needed(connection_rate_t rate_counter);
+
+    void allow_one_new_connection(connection_rate_t rate_counter);
+
+    void update_connection_rate(
+      connection_rate_t rate_counter, std::optional<int64_t> new_value);
+
+    connection_rate_t _general_rate;
+    // absl::node_hash_map<ss::sstring, connection_rate_t> _overrides;
+    absl::node_hash_map<inet_address_wrapper, connection_rate_t> _overrides;
+
+    ss::gate& _connection_gate;
 };
 
 } // namespace net

--- a/src/v/net/connection_rate.h
+++ b/src/v/net/connection_rate.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/net/net.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace net {
+
+struct connection_rate_info {
+    int64_t max_connection_rate;
+    std::vector<ss::sstring> overrides;
+};
+
+} // namespace net

--- a/src/v/net/inet_address_wrapper.h
+++ b/src/v/net/inet_address_wrapper.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/net/inet_address.hh>
+
+namespace net {
+
+class inet_address_wrapper : public ss::net::inet_address {
+public:
+    inet_address_wrapper(ss::net::inet_address addr)
+      : ss::net::inet_address(addr) {}
+
+    template<typename H>
+    friend H AbslHashValue(H h, const inet_address_wrapper& k) {
+        return H::combine(std::move(h), std::hash<ss::net::inet_address>{}(k));
+    }
+};
+
+} // namespace net

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include "config/property.h"
 #include "net/connection.h"
+#include "net/connection_rate.h"
 #include "net/types.h"
 #include "utils/hdr_hist.h"
 
@@ -25,6 +27,7 @@
 #include <boost/intrusive/list.hpp>
 
 #include <list>
+#include <optional>
 #include <type_traits>
 #include <vector>
 
@@ -62,6 +65,11 @@ struct server_endpoint {
 
 std::ostream& operator<<(std::ostream&, const server_endpoint&);
 
+struct config_connection_rate_bindings {
+    config::binding<std::optional<int64_t>> config_general_rate;
+    config::binding<std::vector<ss::sstring>> config_overrides_rate;
+};
+
 struct server_configuration {
     std::vector<server_endpoint> addrs;
     int64_t max_service_memory_per_core;
@@ -70,6 +78,7 @@ struct server_configuration {
     std::optional<int> tcp_send_buf;
     net::metrics_disabled disable_metrics = net::metrics_disabled::no;
     ss::sstring name;
+    std::optional<config_connection_rate_bindings> connection_rate_bindings;
     // we use the same default as seastar for load balancing algorithm
     ss::server_socket::load_balancing_algorithm load_balancing_algo
       = ss::server_socket::load_balancing_algorithm::connection_distribution;
@@ -171,6 +180,9 @@ private:
     hdr_hist _hist;
     server_probe _probe;
     ss::metrics::metric_groups _metrics;
+
+    std::optional<config_connection_rate_bindings> connection_rate_bindings;
+    std::optional<connection_rate> _connection_rates;
 };
 
 } // namespace net

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -46,6 +46,8 @@ public:
 
     void waiting_for_available_memory() { ++_requests_blocked_memory; }
 
+    void timeout_waiting_rate_limit() { ++_declined_new_connections; }
+
     void setup_metrics(ss::metrics::metric_groups& mgs, const char* name);
 
 private:
@@ -60,6 +62,7 @@ private:
     uint32_t _corrupted_headers = 0;
     uint32_t _method_not_found_errors = 0;
     uint32_t _requests_blocked_memory = 0;
+    uint32_t _declined_new_connections = 0;
     friend std::ostream& operator<<(std::ostream& o, const server_probe& p);
 };
 

--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME net_connection_rate
+  SOURCES
+    connection_rate_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+  ARGS "-- -c 1"
+  LABELS net
+)

--- a/src/v/net/tests/connection_rate_test.cc
+++ b/src/v/net/tests/connection_rate_test.cc
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "net/connection_rate.h"
+#include "seastarx.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+#include <unordered_map>
+
+namespace {
+
+// In test we can get situation when one fiber succesfull go in
+// semaphore.wait(), but increase counter for next_second
+void check_rate(int64_t rate, int64_t prev_diff, int64_t max_rate) {
+    BOOST_CHECK(rate <= max_rate + prev_diff);
+}
+
+} // namespace
+
+// TODO: for unit tests, it's ideal to avoid sleeps/wallclock time as much as
+// possible. seastar has a manual_clock class for this. Maybe connection_rate
+// could be templated on the clock type, and instantiate it with a manual clock
+// for tests.
+
+SEASTAR_THREAD_TEST_CASE(rate_test) {
+    ss::gate gate;
+
+    const int64_t max_rate = 5;
+    const int64_t max_wait_time_sec = 20;
+
+    net::connection_rate_info info{.max_connection_rate = max_rate};
+    net::connection_rate connection_rate(info, gate);
+
+    std::vector<ss::future<>> futures;
+    std::unordered_map<int64_t, int64_t> rate_counter;
+
+    auto start = ss::lowres_clock::now();
+    while (true) {
+        auto current_time = ss::lowres_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::seconds>(
+          current_time - start);
+
+        if (duration.count() > max_wait_time_sec) {
+            break;
+        }
+
+        ss::net::inet_address addr("127.0.0.1");
+        auto f = connection_rate.maybe_wait(addr)
+                   .then([&rate_counter, start] {
+                       auto current_time = ss::lowres_clock::now();
+                       auto duration
+                         = std::chrono::duration_cast<std::chrono::seconds>(
+                           current_time - start);
+                       rate_counter[duration.count()]++;
+                   })
+                   .handle_exception([](std::exception_ptr const&) {});
+
+        futures.push_back(std::move(f));
+
+        // We should move execution to seastar.
+        if (futures.size() % 30 == 0) {
+            ss::sleep(1ms).get();
+        }
+    }
+
+    connection_rate.stop();
+    gate.close().get();
+
+    ss::when_all(futures.begin(), futures.end()).get();
+
+    auto diff = 0;
+    for (const auto& [second, rate] : rate_counter) {
+        // For zero second we have max_rate tokens, and will add new each
+        // 1000ms/max_rate, so for seconds with max_rate tokens we can expect
+        // max_rate * 2 connections
+        if (second == 0) {
+            check_rate(rate, diff, 2 * max_rate);
+            diff = 2 * max_rate - rate;
+        } else {
+            check_rate(rate, diff, max_rate);
+            diff = max_rate - rate;
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(update_rate_test) {
+    ss::gate gate;
+    net::connection_rate_info info{.max_connection_rate = 1};
+    net::connection_rate connection_rate(info, gate);
+    int64_t max_wait_time_sec = 10;
+
+    std::vector<int64_t> rate_counter(40, 0);
+
+    struct rate_test_t {
+        int64_t max_rate;
+        std::vector<ss::future<>> futures;
+        ss::lowres_clock::time_point updating_rate_time;
+    };
+
+    std::vector<rate_test_t> rates(3);
+    rates[0].max_rate = 10;
+    rates[1].max_rate = 20;
+    rates[2].max_rate = 5;
+
+    auto start = ss::lowres_clock::now();
+
+    for (auto& rate : rates) {
+        connection_rate.update_general_rate(rate.max_rate);
+
+        rate.updating_rate_time = ss::lowres_clock::now();
+        while (true) {
+            auto current_time = ss::lowres_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::seconds>(
+              current_time - rate.updating_rate_time);
+
+            if (duration.count() >= max_wait_time_sec) {
+                break;
+            }
+
+            ss::net::inet_address addr("127.0.0.1");
+            auto f = connection_rate.maybe_wait(addr)
+                       .then([&rate_counter, start] {
+                           auto current_time = ss::lowres_clock::now();
+                           auto duration
+                             = std::chrono::duration_cast<std::chrono::seconds>(
+                               current_time - start);
+                           rate_counter[duration.count()]++;
+                       })
+                       .handle_exception([](std::exception_ptr const&) {});
+
+            rate.futures.push_back(std::move(f));
+
+            // We should move execution to seastar.
+            if (rate.futures.size() % 30 == 0) {
+                ss::sleep(1ms).get();
+            }
+        }
+    }
+
+    connection_rate.stop();
+    gate.close().get();
+
+    for (auto& rate_info : rates) {
+        ss::when_all(rate_info.futures.begin(), rate_info.futures.end()).get();
+    }
+
+    size_t current_index = 0;
+    auto max_rate = rates[0].max_rate;
+    auto change_rate_time = rates[0].updating_rate_time;
+    int64_t diff = 0;
+    for (auto second = 0; second < rate_counter.size(); ++second) {
+        auto rate = rate_counter[second];
+        auto duration = std::chrono::duration_cast<std::chrono::seconds>(
+          rates[current_index].updating_rate_time - start);
+        if (second >= duration.count() + max_wait_time_sec) {
+            current_index = std::min(++current_index, rates.size() - 1);
+            max_rate = rates[current_index].max_rate;
+            change_rate_time = rates[current_index].updating_rate_time;
+        }
+        if (
+          std::chrono::duration_cast<std::chrono::seconds>(
+            change_rate_time - start)
+            .count()
+          == second) {
+            check_rate(rate, diff, max_rate * 2);
+            diff = max_rate * 2 - rate;
+        } else {
+            check_rate(rate, diff, max_rate);
+            diff = max_rate - rate;
+        }
+    }
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -993,6 +993,16 @@ void application::wire_up_redpanda_services() {
 
               c.disable_metrics = net::metrics_disabled(
                 config::shard_local_cfg().disable_metrics());
+
+              net::config_connection_rate_bindings bindings{
+                .config_general_rate
+                = config::shard_local_cfg().kafka_connection_rate_limit.bind(),
+                .config_overrides_rate
+                = config::shard_local_cfg()
+                    .kafka_connection_rate_limit_overrides.bind(),
+              };
+
+              c.connection_rate_bindings.emplace(std::move(bindings));
           });
       })
       .get();

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -432,6 +432,8 @@ class ClusterConfigTest(RedpandaTest):
             initial_value = initial_config[name]
             if 'example' in p:
                 valid_value = p['example']
+                if p['type'] == "array":
+                    valid_value = yaml.load(valid_value)
             elif p['type'] == 'integer':
                 if initial_value:
                     valid_value = initial_value * 2

--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -1,0 +1,109 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster_spec import ClusterSpec
+
+import os
+import time
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings
+from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer
+from rptest.services.kaf_consumer import KafConsumer
+
+
+class ConnectionRateLimitTest(RedpandaTest):
+    MSG_SIZE = 1000000
+    PRODUCE_COUNT = 2100
+    READ_COUNT = 2000
+    RANDOM_READ_PARALLEL = 2
+
+    topics = (TopicSpec(partition_count=1, replication_factor=1), )
+
+    def __init__(self, test_context):
+        resource_setting = ResourceSettings(num_cpus=1)
+        super(ConnectionRateLimitTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=1,
+                             extra_rp_conf={"kafka_connection_rate_limit": 6},
+                             resource_settings=resource_setting)
+
+        self._node_for_franz_go = test_context.cluster.alloc(
+            ClusterSpec.simple_linux(1))
+        self.logger.debug(
+            f"Allocated verifier node {self._node_for_franz_go[0].name}")
+
+        self._producer = FranzGoVerifiableProducer(test_context, self.redpanda,
+                                                   self.topics[0],
+                                                   self.MSG_SIZE,
+                                                   self.PRODUCE_COUNT,
+                                                   self._node_for_franz_go)
+
+    def free_nodes(self):
+        # Free the normally allocated nodes (e.g. RedpandaService)
+        super().free_nodes()
+
+        assert len(self._node_for_franz_go) == 1
+
+        # The verifier opens huge numbers of connections, which can interfere
+        # with subsequent tests' use of the node.  Clear them down first.
+        wait_until(
+            lambda: self.redpanda.sockets_clear(self._node_for_franz_go[0]),
+            timeout_sec=120,
+            backoff_sec=10)
+
+        # Free the hand-allocated node that we share between the various
+        # verifier services
+        self.logger.debug(
+            f"Freeing verifier node {self._node_for_franz_go[0].name}")
+        self.test_context.cluster.free_single(self._node_for_franz_go[0])
+
+    def read_data(self, consumers_count):
+        consumers = []
+        for i in range(consumers_count):
+            new_consumer = KafConsumer(self.test_context, self.redpanda,
+                                       self.topics[0], self.READ_COUNT,
+                                       "oldest")
+            consumers.append(new_consumer)
+
+        for consumer in consumers:
+            consumer.start()
+
+        def consumed():
+            need_finish = True
+            for consumer in consumers:
+                self.logger.debug(consumer.offset)
+                if (consumer.offset.get(0) is
+                        None) or consumer.offset[0] < self.READ_COUNT:
+                    need_finish = False
+            return need_finish
+
+        wait_until(consumed, timeout_sec=180, backoff_sec=3)
+
+    @cluster(num_nodes=8)
+    def connection_rate_test(self):
+        self._producer.start(clean=False)
+        self._producer.wait()
+
+        start1 = time.time()
+        self.read_data(self.RANDOM_READ_PARALLEL)
+        finish1 = time.time()
+
+        start2 = time.time()
+        self.read_data(self.RANDOM_READ_PARALLEL * 2)
+        finish2 = time.time()
+
+        time1 = finish1 - start1
+        time2 = finish2 - start2
+
+        assert time2 >= time1 * 1.7


### PR DESCRIPTION
## Cover letter
KIP: #3778

This pr implements new redpanda options:
* `rpc_server_connection_rate_limit` - Maximum connections per second for one core
* `rpc_server_connection_rate_limit_overrides` - Overrides for specific ips for maximum connections per second for one core. (It should be array of strings like `['127.0.0.1:90', '50.20.1.1:40']`)

It contains logic to count external connections to redpanda for current seconds and uses token bucket algorithm inside.

When a connection is accepted which exceeds one of the configured
bounds, it is blocking before reading or writing anything to the socket.

This options support on-line updating without restart redpanda.

TODO:
- [ ] Add ducktape tests for overrides

Fixes: #3688 

## Release notes

Added new redpanda options:
* `rpc_server_connection_rate_limit` - Maximum connections per second for one core
* `rpc_server_connection_rate_limit_overrides` - Overrides for specific ips for maximum connections per second for one core. (It should be array of strings like `['127.0.0.1:90', '50.20.1.1:40']`)