### PR TITLE
Run multiple repetitions of redpanda build steps

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This file should be kept in sync with vtools's pre-command file.
+# https://github.com/redpanda-data/vtools/.buildkite/hooks/pre-command
+
+set -uo pipefail
+set +e
+
+PARALLEL_STEPS=1
+
+repo=$(echo $BUILDKITE_REPO | awk -F/ '{print $NF}' | awk -F. '{print $1}')
+
+if [[ ${BUILDKITE_PULL_REQUEST} != false ]]; then
+  labels=$(curl \
+    --retry 3 --retry-connrefused --fail \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${GITHUB_API_TOKEN}" \
+    "https://api.github.com/repos/redpanda-data/${repo}/issues/${BUILDKITE_PULL_REQUEST}/labels")
+
+  if [[ $? == "0" ]]; then
+    set -e
+    parallel=$(echo "${labels}" | jq -r '.[].name|select(startswith("ci-repeat-"))|ltrimstr("ci-repeat-")' | head -1)
+    curl \
+      -X "DELETE" \
+      --retry 3 --retry-connrefused --silent \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: token ${GITHUB_API_TOKEN}" \
+      "https://api.github.com/repos/redpanda-data/${repo}/issues/${BUILDKITE_PULL_REQUEST}/labels/ci-repeat-$parallel"
+
+    if ((parallel > 1 && parallel < 20)); then
+      PARALLEL_STEPS=$parallel
+    else
+      echo >&2 "Provided parallel number is out of range(2-19). Changing to 1."
+      PARALLEL_STEPS=1
+    fi
+  fi
+fi
+
+export PARALLEL_STEPS

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.out
 *.app
 /*build*
+!.buildkite
 /dbuild
 bin
 _e2e_artifacts/


### PR DESCRIPTION
## Cover letter

### feature

Run in parallel the below bk steps:

* `release-clang-arm64`
* `release-clang-amd64`
* `debug-clang-amd64`

This can be done by adding a label in the PR that has the structure `ci-repeat-<TIMES-TO-REPEAT>` (TIMES-TO-REPEAT should be 2-19) eg `ci-repeat-2` and then committing to the PR or hitting `Rebuild` on the PR's Buildkite build. The `vbotbuildovich` will then remove the label.

[buildkite hooks](https://buildkite.com/docs/agent/v3/hooks)

example build in parallel: https://buildkite.com/redpanda/redpanda/builds/7774

Fixes https://github.com/redpanda-data/vtools/issues/492

