### PR TITLE
Support node maintenance mode

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -91,6 +91,7 @@ v_cc_library(
     feature_manager.cc
     feature_barrier.cc
     feature_table.cc
+    drain_manager.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -76,6 +76,7 @@ static constexpr int8_t delete_data_policy_cmd_type = 1;
 static constexpr int8_t decommission_node_cmd_type = 0;
 static constexpr int8_t recommission_node_cmd_type = 1;
 static constexpr int8_t finish_reallocations_cmd_type = 2;
+static constexpr int8_t maintenance_mode_cmd_type = 3;
 
 // cluster config commands
 static constexpr int8_t cluster_config_delta_cmd_type = 0;
@@ -182,6 +183,12 @@ using finish_reallocations_cmd = controller_command<
   model::node_id,
   int8_t, // unused
   finish_reallocations_cmd_type,
+  model::record_batch_type::node_management_cmd>;
+
+using maintenance_mode_cmd = controller_command<
+  model::node_id,
+  bool, // enabled or disabled
+  maintenance_mode_cmd_type,
   model::record_batch_type::node_management_cmd>;
 
 // Cluster configuration deltas

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -152,6 +152,7 @@ ss::future<> controller::start() {
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),
+            std::ref(_feature_table),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -14,6 +14,7 @@
 #include "cluster/config_frontend.h"
 #include "cluster/config_manager.h"
 #include "cluster/controller_stm.h"
+#include "cluster/drain_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/health_manager.h"
 #include "cluster/health_monitor_frontend.h"
@@ -93,6 +94,8 @@ public:
     }
     ss::sharded<feature_table>& get_feature_table() { return _feature_table; }
 
+    ss::sharded<drain_manager>& get_drain_manager() { return _drain_manager; }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -109,6 +112,7 @@ private:
     ss::sharded<members_table> _members_table;             // instance per core
     ss::sharded<partition_leaders_table>
       _partition_leaders;                            // instance per core
+    ss::sharded<drain_manager> _drain_manager;       // instance per core
     ss::sharded<members_manager> _members_manager;   // single instance
     ss::sharded<topics_frontend> _tp_frontend;       // instance per core
     ss::sharded<controller_backend> _backend;        // instance per core

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -72,6 +72,11 @@
             "output_type": "finish_reallocation_reply"
         },
         {
+            "name": "set_maintenance_mode",
+            "input_type": "set_maintenance_mode_request",
+            "output_type": "set_maintenance_mode_reply"
+        },
+        {
             "name": "config_status",
             "input_type": "config_status_request",
             "output_type": "config_status_reply"

--- a/src/v/cluster/drain_manager.cc
+++ b/src/v/cluster/drain_manager.cc
@@ -1,0 +1,273 @@
+#include "cluster/drain_manager.h"
+
+#include "cluster/logger.h"
+#include "cluster/partition_manager.h"
+#include "random/generators.h"
+#include "vlog.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/when_all.hh>
+
+namespace cluster {
+
+drain_manager::drain_manager(
+  ss::sharded<cluster::partition_manager>& partition_manager)
+  : _partition_manager(partition_manager) {}
+
+ss::future<> drain_manager::start() {
+    vassert(!_drain.has_value(), "service cannot be restarted");
+    vlog(clusterlog.info, "Drain manager starting");
+    _drain = task();
+    co_return;
+}
+
+ss::future<> drain_manager::stop() {
+    if (!_drain.has_value()) {
+        vlog(clusterlog.info, "Drain manager stopping (was not started)");
+        return ss::now();
+    }
+    vlog(clusterlog.info, "Drain manager stopping");
+    _abort.request_abort();
+    _sem.signal();
+    return _drain.value().handle_exception([](std::exception_ptr e) {
+        vlog(clusterlog.warn, "Draining manager task experience error: {}", e);
+    });
+}
+
+ss::future<> drain_manager::drain() {
+    if (_abort.abort_requested()) {
+        // handle http requests racing with shutdown
+        co_return;
+    }
+
+    if (_draining) {
+        vlog(clusterlog.info, "Node draining is already active");
+        co_return;
+    }
+
+    vlog(clusterlog.info, "Node draining is starting");
+    _draining = true;
+    _status = drain_status{};
+    _sem.signal();
+}
+
+ss::future<> drain_manager::restore() {
+    if (_abort.abort_requested()) {
+        co_return;
+    }
+
+    if (!_draining) {
+        vlog(clusterlog.info, "Node draining is not active");
+        co_return;
+    }
+
+    vlog(clusterlog.info, "Node draining is stopping");
+    _draining = false;
+    _sem.signal();
+}
+
+ss::future<std::optional<drain_manager::drain_status>> drain_manager::status() {
+    if (_abort.abort_requested()) {
+        co_return std::nullopt;
+    }
+
+    co_return co_await container().map_reduce0(
+      [](drain_manager& dm) -> std::optional<drain_status> {
+          if (dm._draining) {
+              return dm._status;
+          }
+          return std::nullopt;
+      },
+      std::optional<drain_status>(std::nullopt),
+      [](std::optional<drain_status> res, std::optional<drain_status> update) {
+          if (!update.has_value()) {
+              return res;
+          }
+          if (!res.has_value()) {
+              res = drain_status{
+                .finished = true,
+                .errors = false,
+              };
+          }
+          res->finished &= update->finished;
+          res->errors |= update->errors;
+          if (update->partitions.has_value()) {
+              res->partitions = res->partitions.value_or(0)
+                                + update->partitions.value();
+          }
+          if (update->eligible.has_value()) {
+              res->eligible = res->eligible.value_or(0)
+                              + update->eligible.value();
+          }
+          if (update->transferring.has_value()) {
+              res->transferring = res->transferring.value_or(0)
+                                  + update->transferring.value();
+          }
+          if (update->failed.has_value()) {
+              res->failed = res->failed.value_or(0) + update->failed.value();
+          }
+          return res;
+      });
+}
+
+ss::future<> drain_manager::task() {
+    while (true) {
+        co_await _sem.wait();
+        _sem.consume(_sem.available_units());
+
+        if (_abort.abort_requested()) {
+            break;
+        }
+
+        const auto draining = _draining;
+        try {
+            if (draining) {
+                co_await do_drain();
+            } else {
+                co_await do_restore();
+            }
+        } catch (...) {
+            vlog(
+              clusterlog.warn,
+              "Draining task {{{}}} experienced error: {}",
+              draining ? "drain" : "restore",
+              std::current_exception());
+            _status.errors = true;
+        }
+        _status.finished = true;
+    }
+}
+
+ss::future<> drain_manager::do_drain() {
+    vlog(clusterlog.info, "Node draining has started");
+
+    /*
+     * Prevent this node from becomming a leader for new and existing raft
+     * groups. This does not immediately reliquish existing leadership. it is
+     * assumed that all raft groups (e.g. controller/raft0 and kafka data) are
+     * represented in the partition manager.
+     */
+    _partition_manager.local().block_new_leadership();
+
+    while (_draining && !_abort.abort_requested()) {
+        /*
+         * build a set of eligible partitions. ignore any raft groups that
+         * will fail when transferring leadership and which shouldn't be
+         * retried. note that above when we block new leadership we don't bother
+         * skipping over groups without followers. this is safe because such a
+         * group won't lose leadership in the first place.
+         */
+        std::vector<ss::lw_shared_ptr<cluster::partition>> eligible;
+        eligible.reserve(_partition_manager.local().partitions().size());
+        for (const auto& p : _partition_manager.local().partitions()) {
+            if (!p.second->is_leader() || !p.second->has_followers()) {
+                continue;
+            }
+            eligible.push_back(p.second);
+        }
+        _status.eligible = eligible.size();
+        _status.partitions = _partition_manager.local().partitions().size();
+
+        if (eligible.empty()) {
+            break;
+        }
+
+        /*
+         * choose a random sample from the set of eligible partitions. this is
+         * useful when we have a draining policy in which we want to drain as
+         * much as possible even if some groups continue to have leadership
+         * transfer errors. an alternative approach would be to fence off groups
+         * experiencing errors, but then we would have to create some type of
+         * retry policy to deal with those partitions.
+         */
+        std::vector<ss::lw_shared_ptr<cluster::partition>> selected;
+        selected.reserve(max_parallel_transfers);
+        std::sample(
+          eligible.begin(),
+          eligible.end(),
+          std::back_inserter(selected),
+          max_parallel_transfers,
+          random_generators::internal::gen);
+        eligible.clear();
+
+        /*
+         * start a group of transfers
+         */
+        std::vector<ss::future<std::error_code>> transfers;
+        transfers.reserve(selected.size());
+        for (auto& p : selected) {
+            transfers.push_back(p->transfer_leadership(std::nullopt));
+        }
+        _status.transferring = transfers.size();
+
+        vlog(
+          clusterlog.info,
+          "Draining leadership from {} groups",
+          transfers.size());
+
+        auto started = ss::lowres_clock::now();
+
+        auto results = co_await ss::when_all(
+          transfers.begin(), transfers.end());
+
+        size_t failed = 0;
+        for (auto& f : results) {
+            try {
+                auto err = f.get();
+                if (err) {
+                    vlog(
+                      clusterlog.debug,
+                      "Draining leadership failed for group: {}",
+                      err);
+                    failed++;
+                }
+            } catch (...) {
+                vlog(
+                  clusterlog.debug,
+                  "Draining leadership failed for group: {}",
+                  std::current_exception());
+                failed++;
+            }
+        }
+        _status.failed = failed;
+
+        vlog(
+          clusterlog.info,
+          "Draining leadership from {} groups {} succeeded",
+          transfers.size(),
+          transfers.size() - failed);
+
+        /*
+         * to avoid spinning, cool off if we failed fast
+         */
+        auto dur = ss::lowres_clock::now() - started;
+        if (failed > 0 && dur < transfer_throttle && _draining) {
+            try {
+                co_await ss::sleep_abortable(transfer_throttle - dur, _abort);
+            } catch (ss::sleep_aborted&) {
+            }
+        }
+    }
+
+    vlog(
+      clusterlog.info,
+      "Node draining has completed on shard {}",
+      ss::this_shard_id());
+}
+
+/*
+ * Unblock this node from new leadership.
+ *
+ * Currently the unblocking process does not attempt to restore leadership back
+ * to the node. This is assumed to be handled at a higher level (e.g. by the
+ * operator by enabling or poking the cluster leadership rebalancer). However,
+ * we could imagine being more aggresive here in the future.
+ */
+ss::future<> drain_manager::do_restore() {
+    vlog(clusterlog.info, "Node drain stopped");
+    _partition_manager.local().unblock_new_leadership();
+    co_return;
+}
+
+} // namespace cluster

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/fwd.h"
+#include "seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/util/log.hh>
+
+#include <chrono>
+
+namespace cluster {
+
+/*
+ * The drain manager is responsible for managing the draining of leadership from
+ * a node. It is a core building block for implementing node maintenance mode.
+ */
+class drain_manager : public ss::peering_sharded_service<drain_manager> {
+    static constexpr size_t max_parallel_transfers = 25;
+    static constexpr std::chrono::duration transfer_throttle
+      = std::chrono::seconds(5);
+
+public:
+    /*
+     * finsihed:     draining has completed
+     * errors:       draining finished with errors
+     * partitions:   total partitions
+     * eligible:     total drain-eligible partitions
+     * transferring: total partitions currently transferring
+     * failed:       total transfers failed in last batch
+     *
+     * the optional fields may not be set if draining has been requested, but
+     * not yet started. in this case the values are not yet known.
+     */
+    struct drain_status {
+        bool finished{false};
+        bool errors{false};
+        std::optional<size_t> partitions;
+        std::optional<size_t> eligible;
+        std::optional<size_t> transferring;
+        std::optional<size_t> failed;
+    };
+
+    explicit drain_manager(ss::sharded<cluster::partition_manager>&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /*
+     * Start draining this broker.
+     *
+     * Invoke this on each core.
+     */
+    ss::future<> drain();
+
+    /*
+     * Restore broker to a non-drain[ing] state.
+     *
+     * Invoke this on each core.
+     */
+    ss::future<> restore();
+
+    /*
+     * Check the status of the draining process.
+     *
+     * This performs a global reduction across cores.
+     */
+    ss::future<std::optional<drain_status>> status();
+
+private:
+    ss::future<> task();
+    ss::future<> do_drain();
+    ss::future<> do_restore();
+
+    ss::sharded<cluster::partition_manager>& _partition_manager;
+    std::optional<ss::future<>> _drain;
+    bool _draining{false};
+    ss::semaphore _sem{0};
+    drain_status _status;
+    ss::abort_source _abort;
+};
+
+} // namespace cluster

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -22,6 +22,8 @@ std::string_view to_string_view(feature f) {
         return "central_config";
     case feature::consumer_offsets:
         return "consumer_offsets";
+    case feature::maintenance_mode:
+        return "maintenance_mode";
     case feature::test_alpha:
         return "test_alpha";
     }
@@ -30,7 +32,7 @@ std::string_view to_string_view(feature f) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
-static constexpr cluster_version latest_version = cluster_version{2};
+static constexpr cluster_version latest_version = cluster_version{3};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -22,6 +22,7 @@ namespace cluster {
 enum class feature : std::uint64_t {
     central_config = 0x1,
     consumer_offsets = 0x2,
+    maintenance_mode = 0x4,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -86,6 +87,12 @@ constexpr static std::array feature_schema{
     feature::consumer_offsets,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::requires_migration},
+  feature_spec{
+    cluster_version{3},
+    "maintenance_mode",
+    feature::maintenance_mode,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{2001},
     "__test_alpha",

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -45,5 +45,6 @@ class metrics_reporter;
 class feature_frontend;
 class feature_manager;
 class feature_table;
+class drain_manager;
 
 } // namespace cluster

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/cluster_utils.h"
 #include "cluster/controller_stm.h"
+#include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
@@ -35,6 +36,7 @@ public:
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
+      ss::sharded<feature_table>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -59,6 +61,7 @@ private:
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<feature_table>& _feature_table;
     ss::sharded<ss::abort_source>& _as;
 };
 } // namespace cluster

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -44,6 +44,9 @@ public:
     ss::future<std::error_code> recommission_node(model::node_id);
     ss::future<std::error_code> finish_node_reallocations(model::node_id);
 
+    ss::future<std::error_code>
+    set_maintenance_mode(model::node_id, bool enabled);
+
 private:
     template<typename T>
     ss::future<std::error_code> do_replicate_node_command(model::node_id id) {

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -43,6 +43,7 @@ members_manager::members_manager(
   ss::sharded<rpc::connection_cache>& connections,
   ss::sharded<partition_allocator>& allocator,
   ss::sharded<storage::api>& storage,
+  ss::sharded<drain_manager>& drain_manager,
   ss::sharded<ss::abort_source>& as)
   : _seed_servers(config::node().seed_servers())
   , _self(make_self_broker(config::node()))
@@ -53,6 +54,7 @@ members_manager::members_manager(
   , _connection_cache(connections)
   , _allocator(allocator)
   , _storage(storage)
+  , _drain_manager(drain_manager)
   , _as(as)
   , _rpc_tls_config(config::node().rpc_server_tls())
   , _update_queue(max_updates_queue_size) {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -38,7 +38,8 @@ public:
     static constexpr auto accepted_commands = make_commands_list<
       decommission_node_cmd,
       recommission_node_cmd,
-      finish_reallocations_cmd>{};
+      finish_reallocations_cmd,
+      maintenance_mode_cmd>{};
     static constexpr ss::shard_id shard = 0;
     static constexpr size_t max_updates_queue_size = 100;
     enum class node_update_type : int8_t {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -61,6 +61,7 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_allocator>&,
       ss::sharded<storage::api>&,
+      ss::sharded<drain_manager>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -127,6 +128,7 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     ss::sharded<partition_allocator>& _allocator;
     ss::sharded<storage::api>& _storage;
+    ss::sharded<drain_manager>& _drain_manager;
     ss::sharded<ss::abort_source>& _as;
     config::tls_config _rpc_tls_config;
     ss::gate _gate;

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -58,18 +58,20 @@ void members_table::update_brokers(
     for (auto& br : new_brokers) {
         /**
          * broker properties may be updated event if it is draining partitions,
-         * we have to preserve its membership_state.
+         * we have to preserve its membership and maintenance states.
          */
         auto it = _brokers.find(br.id());
         if (it != _brokers.end()) {
             // save state from the previous version of the broker
             const auto membership_state = it->second->get_membership_state();
+            const auto maintenance_state = it->second->get_maintenance_state();
             it->second = ss::make_lw_shared<model::broker>(br);
 
+            // preserve state from previous version
             if (membership_state != model::membership_state::removed) {
-                // preserve state from previous version
                 it->second->set_membership_state(membership_state);
             }
+            it->second->set_maintenance_state(maintenance_state);
         } else {
             _brokers.emplace(br.id(), ss::make_lw_shared<model::broker>(br));
         }
@@ -138,6 +140,56 @@ std::vector<model::node_id> members_table::get_decommissioned() const {
         }
     }
     return ret;
+}
+
+std::error_code
+members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
+    _version = model::revision_id(version());
+
+    const auto target = _brokers.find(cmd.key);
+    if (target == _brokers.end()) {
+        return errc::node_does_not_exists;
+    }
+
+    // no rules to enforce when disabling maintenance mode
+    const auto enable = cmd.value;
+    if (!enable) {
+        target->second->set_maintenance_state(
+          model::maintenance_state::inactive);
+        return errc::success;
+    }
+
+    if (
+      target->second->get_maintenance_state()
+      == model::maintenance_state::active) {
+        return errc::success;
+    }
+
+    /*
+     * enforce one-node-at-a-time in maintenance mode rule
+     */
+    const auto other = std::find_if(
+      _brokers.cbegin(), _brokers.cend(), [](const auto& b) {
+          return b.second->get_maintenance_state()
+                 == model::maintenance_state::active;
+      });
+
+    if (other != _brokers.cend()) {
+        vlog(
+          clusterlog.info,
+          "cannot place node {} into maintenance mode. node {} already in "
+          "maintenance mode",
+          target->first,
+          other->first);
+        return errc::invalid_node_operation;
+    }
+
+    vlog(
+      clusterlog.info, "changing node {} to maintenance state", target->first);
+
+    target->second->set_maintenance_state(model::maintenance_state::active);
+
+    return errc::success;
 }
 
 bool members_table::contains(model::node_id id) const {

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -62,12 +62,12 @@ void members_table::update_brokers(
          */
         auto it = _brokers.find(br.id());
         if (it != _brokers.end()) {
-            auto membership_state = it->second->get_membership_state();
-            _brokers.insert_or_assign(
-              br.id(), ss::make_lw_shared<model::broker>(br));
+            // save state from the previous version of the broker
+            const auto membership_state = it->second->get_membership_state();
+            it->second = ss::make_lw_shared<model::broker>(br);
 
             if (membership_state != model::membership_state::removed) {
-                // do not override membership state of brokers
+                // preserve state from previous version
                 it->second->set_membership_state(membership_state);
             }
         } else {

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -42,6 +42,7 @@ public:
 
     std::error_code apply(model::offset, decommission_node_cmd);
     std::error_code apply(model::offset, recommission_node_cmd);
+    std::error_code apply(model::offset, maintenance_mode_cmd);
 
     model::revision_id version() const { return _version; }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -137,6 +137,7 @@ public:
       timequery(model::timestamp, model::offset, ss::io_priority_class);
 
     bool is_leader() const { return _raft->is_leader(); }
+    bool has_followers() const { return _raft->has_followers(); }
 
     void block_new_leadership() const { _raft->block_new_leadership(); }
     void unblock_new_leadership() const { _raft->unblock_new_leadership(); }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -138,6 +138,9 @@ public:
 
     bool is_leader() const { return _raft->is_leader(); }
 
+    void block_new_leadership() const { _raft->block_new_leadership(); }
+    void unblock_new_leadership() const { _raft->unblock_new_leadership(); }
+
     ss::future<result<model::offset>> linearizable_barrier() {
         return _raft->linearizable_barrier();
     }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -88,7 +88,21 @@ ss::future<consensus_ptr> partition_manager::manage(
 
     _ntp_table.emplace(log.config().ntp(), p);
     _raft_table.emplace(group, p);
+
+    /*
+     * part of the node leadership draining infrastructure. when a node is in a
+     * drianing state new groups might be created since the controller will
+     * still be active as a follower. however, if draining is almost complete
+     * then new groups may not be noticed. marking as blocked should be done
+     * atomically with adding the partition to the ntp_table index above for
+     * proper synchronization with the drianing manager.
+     */
+    if (_block_new_leadership) {
+        p->block_new_leadership();
+    }
+
     _manage_watchers.notify(p->ntp(), p);
+
     co_await p->start();
     co_return c;
 }

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -145,6 +145,24 @@ public:
         return _tx_gateway_frontend;
     }
 
+    /*
+     * Block/unblock current node from leadership for new and existing raft
+     * groups.
+     */
+    void block_new_leadership() {
+        _block_new_leadership = true;
+        for (const auto& p : _ntp_table) {
+            p.second->block_new_leadership();
+        }
+    }
+
+    void unblock_new_leadership() {
+        _block_new_leadership = false;
+        for (const auto& p : _ntp_table) {
+            p.second->unblock_new_leadership();
+        }
+    }
+
 private:
     /// Download log if partition_recovery_manager is initialized.
     ///
@@ -172,6 +190,7 @@ private:
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     ss::gate _gate;
+    bool _block_new_leadership{false};
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
 };

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -302,6 +302,26 @@ ss::future<finish_reallocation_reply> service::finish_reallocation(
       [this, req]() mutable { return do_finish_reallocation(req); });
 }
 
+ss::future<set_maintenance_mode_reply> service::set_maintenance_mode(
+  set_maintenance_mode_request&& req, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+      get_scheduling_group(), [this, req]() mutable {
+          return _members_frontend.local()
+            .set_maintenance_mode(req.id, req.enabled)
+            .then([](std::error_code ec) {
+                if (!ec) {
+                    return set_maintenance_mode_reply{.error = errc::success};
+                }
+                if (ec.category() == cluster::error_category()) {
+                    return set_maintenance_mode_reply{
+                      .error = errc(ec.value())};
+                }
+                return set_maintenance_mode_reply{
+                  .error = errc::replication_error};
+            });
+      });
+}
+
 ss::future<config_status_reply>
 service::config_status(config_status_request&& req, rpc::streaming_context&) {
     auto ec = co_await _config_frontend.local().set_status(

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -92,6 +92,9 @@ public:
     ss::future<feature_barrier_response>
     feature_barrier(feature_barrier_request&&, rpc::streaming_context&) final;
 
+    ss::future<set_maintenance_mode_reply> set_maintenance_mode(
+      set_maintenance_mode_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1247,7 +1247,7 @@ adl<cluster::feature_barrier_request>::from(iobuf_parser& parser) {
       version == cluster::feature_barrier_request::current_version,
       "Unexpected version: {} (expected {})",
       version,
-      cluster::feature_update_action::current_version);
+      cluster::feature_barrier_request::current_version);
 
     auto tag = adl<cluster::feature_barrier_tag>{}.from(parser);
     auto peer = adl<model::node_id>{}.from(parser);
@@ -1269,7 +1269,7 @@ adl<cluster::feature_barrier_response>::from(iobuf_parser& parser) {
       version == cluster::feature_barrier_response::current_version,
       "Unexpected version: {} (expected {})",
       version,
-      cluster::feature_update_action::current_version);
+      cluster::feature_barrier_response::current_version);
 
     auto entered = adl<bool>{}.from(parser);
     auto complete = adl<bool>{}.from(parser);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1278,4 +1278,43 @@ adl<cluster::feature_barrier_response>::from(iobuf_parser& parser) {
       .entered = entered, .complete = complete};
 }
 
+void adl<cluster::set_maintenance_mode_request>::to(
+  iobuf& out, cluster::set_maintenance_mode_request&& r) {
+    reflection::serialize(out, r.current_version, r.id, r.enabled);
+}
+
+cluster::set_maintenance_mode_request
+adl<cluster::set_maintenance_mode_request>::from(iobuf_parser& parser) {
+    auto version = adl<uint8_t>{}.from(parser);
+    vassert(
+      version == cluster::set_maintenance_mode_request::current_version,
+      "Unexpected version: {} (expected {})",
+      version,
+      cluster::set_maintenance_mode_request::current_version);
+
+    auto id = adl<model::node_id>{}.from(parser);
+    auto enabled = adl<bool>{}.from(parser);
+
+    return cluster::set_maintenance_mode_request{.id = id, .enabled = enabled};
+}
+
+void adl<cluster::set_maintenance_mode_reply>::to(
+  iobuf& out, cluster::set_maintenance_mode_reply&& r) {
+    reflection::serialize(out, r.current_version, r.error);
+}
+
+cluster::set_maintenance_mode_reply
+adl<cluster::set_maintenance_mode_reply>::from(iobuf_parser& parser) {
+    auto version = adl<uint8_t>{}.from(parser);
+    vassert(
+      version == cluster::set_maintenance_mode_reply::current_version,
+      "Unexpected version: {} (expected {})",
+      version,
+      cluster::set_maintenance_mode_reply::current_version);
+
+    auto error = adl<cluster::errc>{}.from(parser);
+
+    return cluster::set_maintenance_mode_reply{.error = error};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -839,6 +839,17 @@ struct finish_reallocation_reply {
     errc error;
 };
 
+struct set_maintenance_mode_request {
+    static constexpr int8_t current_version = 1;
+    model::node_id id;
+    bool enabled;
+};
+
+struct set_maintenance_mode_reply {
+    static constexpr int8_t current_version = 1;
+    errc error;
+};
+
 struct config_status_request {
     config_status status;
 };
@@ -1093,6 +1104,18 @@ template<>
 struct adl<cluster::feature_barrier_response> {
     void to(iobuf&, cluster::feature_barrier_response&&);
     cluster::feature_barrier_response from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::set_maintenance_mode_request> {
+    void to(iobuf&, cluster::set_maintenance_mode_request&&);
+    cluster::set_maintenance_mode_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::set_maintenance_mode_reply> {
+    void to(iobuf&, cluster::set_maintenance_mode_reply&&);
+    cluster::set_maintenance_mode_reply from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -120,6 +120,11 @@ enum class violation_recovery_policy { crash = 0, best_effort };
  */
 enum class membership_state : int8_t { active, draining, removed };
 
+/*
+ * Broker maintenance mode
+ */
+enum class maintenance_state { active, inactive };
+
 std::ostream& operator<<(std::ostream&, membership_state);
 
 class broker {
@@ -164,6 +169,13 @@ public:
     membership_state get_membership_state() const { return _membership_state; }
     void set_membership_state(membership_state st) { _membership_state = st; }
 
+    maintenance_state get_maintenance_state() const {
+        return _maintenance_state;
+    }
+    void set_maintenance_state(maintenance_state st) {
+        _maintenance_state = st;
+    }
+
     bool operator==(const model::broker& other) const = default;
     bool operator<(const model::broker& other) const { return _id < other._id; }
 
@@ -175,6 +187,7 @@ private:
     broker_properties _properties;
     // in memory state, not serialized
     membership_state _membership_state = membership_state::active;
+    maintenance_state _maintenance_state{maintenance_state::inactive};
 
     friend std::ostream& operator<<(std::ostream&, const broker&);
 };

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2489,6 +2489,21 @@ ss::future<timeout_now_reply> consensus::timeout_now(timeout_now_request&& r) {
         });
     }
 
+    if (_node_priority_override == zero_voter_priority) {
+        vlog(
+          _ctxlog.debug,
+          "Ignoring timeout request in state {} with node voter priority zero "
+          "from node {} at term {}",
+          _vstate,
+          r.node_id,
+          r.term);
+
+        return ss::make_ready_future<timeout_now_reply>(timeout_now_reply{
+          .term = _term,
+          .result = timeout_now_reply::status::failure,
+        });
+    }
+
     // start an election immediately
     dispatch_vote(true);
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2940,6 +2940,10 @@ voter_priority consensus::next_target_priority() {
  * so it should give us fairly even distribution of leaders across the nodes.
  */
 voter_priority consensus::get_node_priority(vnode rni) const {
+    if (_node_priority_override.has_value() && rni == _self) {
+        return _node_priority_override.value();
+    }
+
     auto& latest_cfg = _configuration_manager.get_latest();
     auto& brokers = latest_cfg.brokers();
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -327,6 +327,19 @@ public:
 
     model::term_id get_term(model::offset) const;
 
+    /*
+     * Prevent the current node from becoming a leader for this group. If the
+     * node is the leader then this only takes affect if leadership is lost.
+     */
+    void block_new_leadership() {
+        _node_priority_override = raft::zero_voter_priority;
+    }
+
+    /*
+     * Allow the current node to become a leader for this group.
+     */
+    void unblock_new_leadership() { _node_priority_override.reset(); }
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;
@@ -579,6 +592,8 @@ private:
     model::offset _majority_replicated_index;
     model::offset _visibility_upper_bound_index;
     voter_priority _target_priority = voter_priority::max();
+    std::optional<voter_priority> _node_priority_override;
+
     /**
      * We keep an idex of the most recent entry replicated with quorum
      * consistency level to make sure that all requests replicated with quorum

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -318,6 +318,7 @@ public:
 
     std::vector<follower_metrics> get_follower_metrics() const;
     result<follower_metrics> get_follower_metrics(model::node_id) const;
+    bool has_followers() const { return _fstats.size() > 0; }
 
     offset_monitor& visible_offset_monitor() {
         return _consumable_offset_monitor;

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -105,6 +105,79 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/brokers/{id}/maintenance",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "nickname": "start_broker_maintenance",
+                    "summary": "Request broker enter maintenance mode",
+                    "type": "void",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                },
+                {
+                    "method": "DELETE",
+                    "nickname": "stop_broker_maintenance",
+                    "summary": "Request broker exit maintenance mode",
+                    "type": "void",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/v1/maintenance",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Force start local maintenance",
+                    "type": "void",
+                    "nickname": "start_local_maintenance",
+                    "produces": [
+                        "application/json"
+                    ]
+                },
+                {
+                    "method": "DELETE",
+                    "summary": "Force stop local maintenance",
+                    "type": "void",
+                    "nickname": "stop_local_maintenance",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                },
+                {
+                    "method": "GET",
+                    "summary": "Get local maintenance status",
+                    "type": "maintenance_status",
+                    "nickname": "get_local_maintenance",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {
@@ -171,6 +244,40 @@
                 "total": {
                     "type": "long",
                     "description": "total space bytes"
+                }
+            }
+        },
+        "maintenance_status": {
+            "id": "maintenance_status",
+            "description": "Drain status",
+            "properties": {
+                "draining": {
+                    "type": "boolean",
+                    "description": "in maintenance state"
+                },
+                "finished": {
+                    "type": "boolean",
+                    "description": "drain finished"
+                },
+                "errors": {
+                    "type": "boolean",
+                    "description": "drain errors"
+                },
+                "partitions": {
+                    "type": "long",
+                    "description": "partition count"
+                },
+                "eligible": {
+                    "type": "long",
+                    "description": "eligible partition count"
+                },
+                "transferring": {
+                    "type": "long",
+                    "description": "transferring partition count"
+                },
+                "failed": {
+                    "type": "long",
+                    "description": "failed transfer partition count"
                 }
             }
         }

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -241,6 +241,10 @@
                 "materialized": {
                     "type": "boolean",
                     "description": "materialized"
+                },
+                "leader": {
+                    "type": "long",
+                    "description": "Latest known leader (or -1 if unknown)"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1775,9 +1775,9 @@ void admin_server::register_partition_routes() {
       ss::httpd::partition_json::get_partitions,
       [this](std::unique_ptr<ss::httpd::request>) {
           using summary = ss::httpd::partition_json::partition_summary;
-          auto get_summaries = [](auto& partition_manager, bool materialized) {
+          auto get_summaries = [](auto& partition_manager, bool materialized, auto get_leader) {
               return partition_manager.map_reduce0(
-                [materialized](auto& pm) {
+                [materialized, get_leader](auto& pm) {
                     std::vector<summary> partitions;
                     partitions.reserve(pm.partitions().size());
                     for (const auto& it : pm.partitions()) {
@@ -1787,6 +1787,7 @@ void admin_server::register_partition_routes() {
                         p.partition_id = it.first.tp.partition;
                         p.core = ss::this_shard_id();
                         p.materialized = materialized;
+                        p.leader = get_leader(it.second);
                         partitions.push_back(std::move(p));
                     }
                     return partitions;
@@ -1797,8 +1798,8 @@ void admin_server::register_partition_routes() {
                     return acc;
                 });
           };
-          auto f1 = get_summaries(_partition_manager, false);
-          auto f2 = get_summaries(_cp_partition_manager, true);
+          auto f1 = get_summaries(_partition_manager, false, [](const auto& p) { return p->get_leader_id().value_or(model::node_id(-1))(); });
+          auto f2 = get_summaries(_cp_partition_manager, true, [](const auto&) { return -1; });
           return ss::when_all_succeed(std::move(f1), std::move(f2))
             .then([](auto summaries) {
                 auto& [partitions, s2] = summaries;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -216,8 +216,6 @@ private:
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
-
     request_authenticator _auth;
-
     bool _ready{false};
 };

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -358,3 +358,32 @@ class Admin:
         leader = self.redpanda.get_node(details['leader_id'])
         ret = self._request('post', path=path, node=leader)
         return ret.status_code == 200
+
+    def maintenance_start(self, node):
+        """
+        Start maintenanceing on node.
+        """
+        id = self.redpanda.idx(node)
+        url = f"brokers/{id}/maintenance"
+        self.redpanda.logger.info(
+            f"Starting maintenance on node {node.name}/{id}")
+        return self._request("put", url)
+
+    def maintenance_stop(self, node):
+        """
+        Stop maintenanceing on node.
+        """
+        id = self.redpanda.idx(node)
+        url = f"brokers/{id}/maintenance"
+        self.redpanda.logger.info(
+            f"Stopping maintenance on node {node.name}/{id}")
+        return self._request("delete", url)
+
+    def maintenance_status(self, node):
+        """
+        Get maintenance status of a node.
+        """
+        id = self.redpanda.idx(node)
+        self.redpanda.logger.info(
+            f"Getting maintenance status on node {node.name}/{id}")
+        return self._request("get", "maintenance", node=node).json()

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -40,7 +40,7 @@ class FeaturesTestBase(RedpandaTest):
         # This assertion will break each time we increment the value
         # of `latest_version` in the redpanda source.  Update it when
         # that happens.
-        assert features_response['cluster_version'] == 2
+        assert features_response['cluster_version'] == 3
 
         assert self._get_features_map(
             features_response)['central_config']['state'] == 'active'

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -1,0 +1,147 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from ducktape.utils.util import wait_until
+import requests
+
+
+class MaintenanceTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=10, replication_factor=3),
+              TopicSpec(partition_count=20, replication_factor=3))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.admin = Admin(self.redpanda)
+
+    def _has_leadership_role(self, node):
+        """
+        Returns true if node is leader for some partition, and false otherwise.
+        """
+        id = self.redpanda.idx(node)
+        partitions = self.admin.get_partitions(node=node)
+        return len(list(filter(lambda p: p["leader"] == id, partitions))) > 0
+
+    def _in_maintenance_mode(self, node):
+        status = self.admin.maintenance_status(node)
+        return status["draining"]
+
+    def _in_maintenance_mode_fully(self, node):
+        status = self.admin.maintenance_status(node)
+        return status["finished"] and not status["errors"] and \
+                status["partitions"] > 0
+
+    def _enable_maintenance(self, node):
+        """
+        1. Verifies that node is leader for some partitions
+        2. Verifies node is not already in maintenance mode
+        3. Requests that node enter maintenance mode (persistent interface)
+        4. Verifies node enters maintenance mode
+        5. Verifies that node has no leadership role
+        6. Verifies that maintenance mode completes
+
+        Note that there is a terminology issue that we need to work on. When we
+        say that 'maintenance mode completes' it doesn't mean that the node
+        leaves maintenance mode. What we mean is that it has entered maintenance
+        mode and all of the work associated with that has completed.
+        """
+        self.logger.debug(
+            "Checking that node {node.name} has a leadership role")
+        wait_until(lambda: self._has_leadership_role(node),
+                   timeout_sec=60,
+                   backoff_sec=10)
+
+        self.logger.debug(
+            "Checking that node {node.name} is not in maintenance mode")
+        status = self.admin.maintenance_status(node)
+        assert status[
+            "draining"] == False, f"Node {node.name} in maintenance mode"
+
+        self.admin.maintenance_start(node)
+
+        self.logger.debug(
+            "Waiting for node {node.name} to enter maintenance mode")
+        wait_until(lambda: self._in_maintenance_mode(node),
+                   timeout_sec=30,
+                   backoff_sec=5)
+
+        self.logger.debug("Waiting for node {node.name} leadership to drain")
+        wait_until(lambda: not self._has_leadership_role(node),
+                   timeout_sec=60,
+                   backoff_sec=10)
+
+        self.logger.debug(
+            "Waiting for node {node.name} maintenance mode to complete")
+        wait_until(lambda: self._in_maintenance_mode_fully(node),
+                   timeout_sec=60,
+                   backoff_sec=10)
+
+    def _disable_maintenance(self, node):
+        wait_until(lambda: not self._in_maintenance_mode(node),
+                   timeout_sec=30,
+                   backoff_sec=5)
+
+        wait_until(lambda: self._has_leadership_role(node),
+                   timeout_sec=120,
+                   backoff_sec=10)
+
+    def _verify_cluster(self, target, target_expect):
+        for node in self.redpanda.nodes:
+            expect = False if node != target else target_expect
+            wait_until(
+                lambda: self._in_maintenance_mode(node) == expect,
+                timeout_sec=30,
+                backoff_sec=5,
+                err_msg=f"expected {node.name} maintenance mode: {expect}")
+
+    @cluster(num_nodes=3)
+    def test_maintenance(self):
+        target = random.choice(self.redpanda.nodes)
+        self._enable_maintenance(target)
+        self.admin.maintenance_stop(target)
+        self._disable_maintenance(target)
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_maintenance_sticky(self):
+        nodes = random.sample(self.redpanda.nodes, len(self.redpanda.nodes))
+        for node in nodes:
+            self._enable_maintenance(node)
+            self._verify_cluster(node, True)
+
+            self.redpanda.restart_nodes(node)
+            self._verify_cluster(node, True)
+
+            self.admin.maintenance_stop(node)
+            self._disable_maintenance(node)
+            self._verify_cluster(node, False)
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._verify_cluster(None, False)
+
+    @cluster(num_nodes=3)
+    def test_exclusive_maintenance(self):
+        target, other = random.sample(self.redpanda.nodes, k=2)
+        assert target is not other
+        self._enable_maintenance(target)
+        try:
+            self._enable_maintenance(other)
+        except requests.exceptions.HTTPError as e:
+            if "invalid state transition" in e.response.text and e.response.status_code == 400:
+                return
+            raise
+        except:
+            raise
+        else:
+            raise Exception("Expected maintenance enable to fail")


### PR DESCRIPTION
## Cover letter

Adds three administrative interfaces:

```
   Start maintenance:  PUT    /v1/brokers/ID/maintenance
   Stop maintenance:   DELETE /v1/brokers/ID/maintenance
   Drain status: GET    /v1/brokers/ID/maintenance
```

which allow a node to be placed into a maintenance mode in which the primary action is to relinquished all leadership from a node. if a node is taken out of the maintenance state then leadership is allowed to return. this is a building block for rolling upgrades in which a target node to upgrade is drained to minimize disruption to client traffic.

maintenance mode is persistent and stored in the controller. currently, only one node at a time may be in maintenance mode.

reviewers may notice some obvious failure scenarios. for example, if leadership cannot be transferred off of a node then draining can never complete. this is by design: initially the design assumes that an external process (e.g. k8s operator) will monitor cluster health and draining progress. it may choose to proceed with upgrade despite some leadership failing to transfer, or may take a node out of draining state to deal with the underlying issue.

this feature and the heuristics for dealing with cluster situations is sure to expand. this initial set of functionality should be sufficient to allow k8s operator work to proceed.

Fixes: #3706
Fixes: #3705

## Release notes

* Support for placing node into a draining state in which all leadership is relinquished.