### PR TITLE
raft: Interrupt configuration change

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -938,6 +938,54 @@ ss::future<std::error_code> consensus::replace_configuration(
       });
 }
 
+template<typename Func>
+ss::future<std::error_code>
+consensus::interrupt_configuration_change(model::revision_id revision, Func f) {
+    auto u = co_await _op_lock.get_units();
+    auto latest_cfg = config();
+    // latest configuration is of joint type
+    if (latest_cfg.type() == configuration_type::simple) {
+        vlog(_ctxlog.info, "no configuration changes in progress");
+        co_return errc::invalid_configuration_update;
+    }
+    if (latest_cfg.revision_id() > revision) {
+        co_return errc::invalid_configuration_update;
+    }
+    result<group_configuration> new_cfg = f(std::move(latest_cfg));
+    if (new_cfg.has_error()) {
+        co_return new_cfg.error();
+    }
+
+    co_return co_await replicate_configuration(
+      std::move(u), std::move(new_cfg.value()));
+}
+
+ss::future<std::error_code>
+consensus::revert_configuration_change(model::revision_id revision) {
+    vlog(
+      _ctxlog.info,
+      "requested revert of current configuration change - {}",
+      config());
+    return interrupt_configuration_change(
+      revision, [](raft::group_configuration cfg) {
+          cfg.revert_configuration_change();
+          return cfg;
+      });
+}
+
+ss::future<std::error_code>
+consensus::abort_configuration_change(model::revision_id revision) {
+    vlog(
+      _ctxlog.info,
+      "requested abort of current configuration change - {}",
+      config());
+    return interrupt_configuration_change(
+      revision, [](raft::group_configuration cfg) {
+          cfg.abort_configuration_change();
+          return cfg;
+      });
+}
+
 ss::future<> consensus::start() {
     return ss::try_with_gate(_bg, [this] { return do_start(); });
 }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -122,7 +122,11 @@ public:
     // Replace configuration of raft group with given set of nodes
     ss::future<std::error_code>
       replace_configuration(std::vector<model::broker>, model::revision_id);
-
+    // Abort ongoing configuration change - may cause data loss
+    ss::future<std::error_code> abort_configuration_change(model::revision_id);
+    // Revert current configuration change - this is safe and will never cause
+    // data loss
+    ss::future<std::error_code> revert_configuration_change(model::revision_id);
     bool is_leader() const { return _vstate == vote_state::leader; }
     bool is_candidate() const { return _vstate == vote_state::candidate; }
     std::optional<model::node_id> get_leader_id() const {
@@ -429,6 +433,10 @@ private:
 
     template<typename Func>
     ss::future<std::error_code> change_configuration(Func&&);
+
+    template<typename Func>
+    ss::future<std::error_code>
+      interrupt_configuration_change(model::revision_id, Func);
 
     ss::future<> maybe_commit_configuration(ss::semaphore_units<>);
     void maybe_promote_to_voter(vnode);

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -466,6 +466,16 @@ bool operator==(const group_configuration& a, const group_configuration& b) {
     return a._brokers == b._brokers && a._current == b._current
            && a._old == b._old;
 }
+
+std::ostream& operator<<(std::ostream& o, configuration_type t) {
+    switch (t) {
+    case configuration_type::simple:
+        return o << "simple";
+    case configuration_type::joint:
+        return o << "joint";
+    }
+    __builtin_unreachable();
+}
 } // namespace raft
 
 namespace reflection {

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -13,6 +13,7 @@
 #include "model/metadata.h"
 #include "reflection/adl.h"
 #include "utils/concepts-enabled.h"
+#include "utils/to_string.h"
 
 #include <boost/range/join.hpp>
 
@@ -49,6 +50,8 @@ private:
 };
 
 enum class configuration_type : uint8_t { simple, joint };
+
+std::ostream& operator<<(std::ostream& o, configuration_type t);
 
 struct group_nodes {
     std::vector<vnode> voters;

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -129,6 +129,23 @@ public:
     void discard_old_config();
 
     /**
+     * Forcefully abort changing configuration. If current configuration in in
+     * joint state it drops the new configuration part and allow raft to operate
+     * with old quorum
+     *
+     * NOTE: may lead to data loss in some situations use only for cluster
+     * recovery from critical failures
+     */
+    void abort_configuration_change();
+
+    /**
+     * Reverts configuration change, the configuration is still in joint state
+     * but the direction of change is being changed
+     *
+     */
+    void revert_configuration_change();
+
+    /**
      * demotes all voters if they were removed from current configuration,
      * returns false if no voters were demoted
      */


### PR DESCRIPTION
## Cover letter

Added API that allows caller to abort ongoing configuration change.

Two APIs were added

`revert_configuration_change` - this api is safe and will never cause
the data loss. The API changes the direction of configuration migration
in joint consensus. i.e. desired configuration becomes an old one and
the old one becomes desired. This approach will allow raft to handle all
necessary recoveries even if some of the nodes were already demoted to
learners.

`abort_configuration_change` - this is a method of last resort that may
be required to recover from catastrophic failures. f.e. single replica
was moved between nodes and it is stuck in the middle of move. This
method is not always safe as it may lead to data loss. This should be
used for catastrophic failure recovery.

## Release notes

* none
