### PR TITLE
cluster: extend feature manager with 'preparing' state and API for explicit activation

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -86,6 +86,9 @@ public:
         return _hm_frontend;
     }
 
+    ss::sharded<feature_manager>& get_feature_manager() {
+        return _feature_manager;
+    }
     ss::sharded<feature_table>& get_feature_table() { return _feature_table; }
 
     ss::future<> wire_up();

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -90,6 +90,11 @@
             "name": "get_cluster_health_report",
             "input_type": "get_cluster_health_request",
             "output_type": "get_cluster_health_reply"
+        },
+        {
+            "name": "feature_action",
+            "input_type": "feature_action_request",
+            "output_type": "feature_action_response"
         }
     ]
 }

--- a/src/v/cluster/feature_backend.cc
+++ b/src/v/cluster/feature_backend.cc
@@ -26,6 +26,11 @@ feature_backend::apply_update(model::record_batch b) {
           t.set_active_version(v);
       });
 
+    for (const auto& a : update.key.actions) {
+        co_await _feature_table.invoke_on_all(
+          [a](feature_table& t) mutable { t.apply_action(a); });
+    }
+
     co_return errc::success;
 }
 

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -294,7 +294,10 @@ feature_manager::write_action(cluster::feature_update_action action) {
       action.feature_name);
 
     // This should  have been validated by admin server before calling us
-    vassert(feature_id_opt.has_value(), "Invalid feature name");
+    vassert(
+      feature_id_opt.has_value(),
+      "Invalid feature name '{}'",
+      action.feature_name);
 
     // Validate that teh feature is in a state compatible with the
     // requested transition.

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -290,12 +290,16 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
 
 ss::future<std::error_code>
 feature_manager::write_action(cluster::feature_update_action action) {
-    // TODO: validate earlier that the feature name is known to us
+    auto feature_id_opt = _feature_table.local().resolve_name(
+      action.feature_name);
+
+    // This should  have been validated by admin server before calling us
+    vassert(feature_id_opt.has_value(), "Invalid feature name");
 
     // Validate that teh feature is in a state compatible with the
     // requested transition.
     bool valid = true;
-    auto state = _feature_table.local().get_state(action.feature_name);
+    auto state = _feature_table.local().get_state(feature_id_opt.value());
     switch (action.action) {
     case cluster::feature_update_action::action_t::complete_preparing:
         // Look up feature by name

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -288,4 +288,61 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     vlog(clusterlog.info, "Updated cluster version to {}", max_version);
 }
 
+ss::future<std::error_code>
+feature_manager::write_action(cluster::feature_update_action action) {
+    // TODO: validate earlier that the feature name is known to us
+
+    // Validate that teh feature is in a state compatible with the
+    // requested transition.
+    bool valid = true;
+    auto state = _feature_table.local().get_state(action.feature_name);
+    switch (action.action) {
+    case cluster::feature_update_action::action_t::complete_preparing:
+        // Look up feature by name
+        if (state.get_state() != feature_state::state::preparing) {
+            // Drop this silently, we presume that this is some kind of
+            // race and the thing we thought was preparing is either
+            // now active or administratively deactivated.
+            valid = false;
+        }
+
+        break;
+    case cluster::feature_update_action::action_t::administrative_activate:
+        if (
+          state.get_state() != feature_state::state::available
+          && state.get_state() != feature_state::state::disabled_clean
+          && state.get_state() != feature_state::state::disabled_active
+          && state.get_state() != feature_state::state::disabled_preparing) {
+            valid = false;
+        }
+        break;
+    case cluster::feature_update_action::action_t::administrative_deactivate:
+        if (
+          state.get_state() == feature_state::state::disabled_clean
+          || state.get_state() == feature_state::state::disabled_preparing
+          || state.get_state() == feature_state::state::disabled_active) {
+            valid = false;
+        }
+    }
+
+    if (!valid) {
+        vlog(
+          clusterlog.warn,
+          "Dropping feature action {}, feature not in expected state",
+          action);
+        return ss::make_ready_future<std::error_code>(cluster::errc::success);
+    } else {
+        // Construct and dispatch command to log
+        auto timeout = model::timeout_clock::now() + status_retry;
+        auto data = feature_update_cmd_data{
+          .logical_version = _feature_table.local().get_active_version(),
+          .actions = {action}};
+        auto cmd = feature_update_cmd(
+          std::move(data),
+          0 // unused
+        );
+        return replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+    }
+}
+
 } // namespace cluster

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -31,23 +31,14 @@ using version_map = std::map<model::node_id, cluster_version>;
  *  - The version is useful for protocol changes that don't necessarily
  *    correspond to a feature, but are needed to safely read or write
  *    persistent structures in the controller log.
- *  - Feature flags could be stored independently to the version, but
- *    our linear development process makes it unnecessary: we can simply
- *    hardcode which versions have which features.
- *
- *  At time of writing, features auto enable as soon as all the nodes
- *  support them.  However, this is not ideal for some upgrade
- *  scenarios where a rollback may be needed: once we've written
- *  structures that require a new feature, rollback becomes hard.
- *  So we might move to a model where new features only enable on
- *  an explicit API request, to be issued usually by the k8s operator
- *  once all nodes are up and it has satisfied that health checks
- *  are OK.
  *
  *  The persistence of the cluster version is also useful for marking
  *  in the controller log where the upgrade was finalized: in a disaster
  *  if we need to snip the controller log back to something an old
  *  version can read, that would be the offset at which to snip.
+ *
+ *  For the detail of how individual features are enabled, consult
+ *  the definition of `feature_state`.
  */
 
 /**

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -83,6 +83,8 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    ss::future<std::error_code> write_action(cluster::feature_update_action);
+
 private:
     void update_node_version(model::node_id, cluster_version v);
 

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -63,35 +63,6 @@ cluster_version feature_table::get_latest_logical_version() {
     return latest_version_cache;
 }
 
-feature_list feature_table::get_active_features() const {
-    if (_active_version == invalid_version) {
-        // The active version will be invalid_version when
-        // the first version of redpanda with feature_manager
-        // first runs (all nodes must check in before active_version
-        // gets updated to a valid version for the first time)
-        vlog(
-          clusterlog.debug,
-          "Feature manager not yet initialized, returning no features");
-        return {};
-    }
-
-    if (_active_version < cluster_version{1}) {
-        // 1 was the earliest version number, and invalid_version was
-        // handled above.  This an unexpected situation.
-        vlog(
-          clusterlog.warn,
-          "Invalid logical version {}, returning no features",
-          _active_version);
-        return {};
-    } else {
-        // A single branch for now, this will become a check of _active_version
-        // with different features per version when we add another version
-        return {
-          feature::central_config,
-        };
-    }
-}
-
 void feature_state::transition_active() { _state = state::active; }
 
 void feature_state::transition_preparing() {

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -20,6 +20,8 @@ std::string_view to_string_view(feature f) {
     switch (f) {
     case feature::central_config:
         return "central_config";
+    case feature::consumer_offsets:
+        return "consumer_offsets";
     case feature::test_alpha:
         return "test_alpha";
     }
@@ -28,7 +30,7 @@ std::string_view to_string_view(feature f) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
-static constexpr cluster_version latest_version = cluster_version{1};
+static constexpr cluster_version latest_version = cluster_version{2};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -20,6 +20,8 @@ std::string_view to_string_view(feature f) {
     switch (f) {
     case feature::central_config:
         return "central_config";
+    case feature::test_alpha:
+        return "test_alpha";
     }
     __builtin_unreachable();
 }
@@ -29,8 +31,16 @@ std::string_view to_string_view(feature f) {
 static constexpr cluster_version latest_version = cluster_version{1};
 
 feature_table::feature_table() {
+    // Intentionally undocumented environment variable, only for use
+    // in integration tests.
+    const bool enable_test_features
+      = (std::getenv("__REDPANDA_TEST_FEATURES") != nullptr);
+
     _feature_state.reserve(feature_schema.size());
     for (const auto& spec : feature_schema) {
+        if (spec.name.substr(0, 6) == "__test" && !enable_test_features) {
+            continue;
+        }
         _feature_state.emplace_back(feature_state{spec});
     }
 }

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -136,6 +136,76 @@ void feature_table::set_active_version(cluster_version v) {
     }
 }
 
+void feature_table::apply_action(const feature_update_action& fua) {
+    auto feature_id_opt = resolve_name(fua.feature_name);
+    if (!feature_id_opt.has_value()) {
+        vlog(clusterlog.warn, "Ignoring action {}, unknown feature", fua);
+        return;
+    } else {
+        if (ss::this_shard_id() == 0) {
+            vlog(clusterlog.debug, "apply_action {}", fua);
+        }
+    }
+
+    auto& fstate = get_state(feature_id_opt.value());
+    if (fua.action == feature_update_action::action_t::complete_preparing) {
+        if (fstate.get_state() == feature_state::state::preparing) {
+            fstate.transition_active();
+        } else {
+            vlog(
+              clusterlog.warn,
+              "Ignoring action {}, feature is in state {}",
+              fua,
+              fstate.get_state());
+        }
+    } else if (
+      fua.action == feature_update_action::action_t::administrative_activate) {
+        auto current_state = fstate.get_state();
+        if (current_state == feature_state::state::disabled_clean) {
+            if (_active_version >= fstate.spec.require_version) {
+                fstate.transition_preparing();
+            } else {
+                fstate.transition_unavailable();
+            }
+        } else if (current_state == feature_state::state::disabled_preparing) {
+            fstate.transition_preparing();
+        } else if (current_state == feature_state::state::disabled_active) {
+            fstate.transition_active();
+        } else if (current_state == feature_state::state::available) {
+            fstate.transition_preparing();
+        } else {
+            vlog(
+              clusterlog.warn,
+              "Ignoring action {}, feature is in state {}",
+              fua,
+              current_state);
+        }
+    } else if (
+      fua.action
+      == feature_update_action::action_t::administrative_deactivate) {
+        auto current_state = fstate.get_state();
+        if (
+          current_state == feature_state::state::disabled_preparing
+          || current_state == feature_state::state::disabled_active
+          || current_state == feature_state::state::disabled_clean) {
+            vlog(
+              clusterlog.warn,
+              "Ignoring action {}, feature is in state {}",
+              fua,
+              current_state);
+        } else if (current_state == feature_state::state::active) {
+            fstate.transition_disabled_active();
+        } else if (current_state == feature_state::state::preparing) {
+            fstate.transition_disabled_preparing();
+        } else {
+            fstate.transition_disabled_clean();
+        }
+    } else {
+        vassert(
+          false, "Unknown feature action {}", static_cast<uint8_t>(fua.action));
+    }
+}
+
 /**
  * Wait until this feature becomes available, or the abort
  * source fires.  If the abort source fires, the future

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -151,4 +151,14 @@ ss::future<> feature_table::await_feature(feature f, ss::abort_source& as) {
     }
 }
 
+feature_state& feature_table::get_state(std::string_view feature_name) {
+    for (auto& i : _feature_state) {
+        if (i.spec.name == feature_name) {
+            return i;
+        }
+    }
+
+    throw std::runtime_error(fmt::format("Unknown feature {}", feature_name));
+}
+
 } // namespace cluster

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -174,6 +174,8 @@ public:
     void transition_preparing();
     void transition_active();
 
+    state get_state() { return _state; };
+
 private:
     state _state{state::unavailable};
 };
@@ -213,6 +215,8 @@ public:
     static cluster_version get_latest_logical_version();
 
     feature_table();
+
+    feature_state& get_state(std::string_view feature_name);
 
 private:
     // Only for use by our friends feature backend & manager

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -21,6 +21,7 @@ namespace cluster {
 
 enum class feature : std::uint64_t {
     central_config = 0x1,
+    consumer_offsets = 0x2,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -79,6 +80,12 @@ constexpr static std::array feature_schema{
     feature::central_config,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{2},
+    "consumer_offsets",
+    feature::consumer_offsets,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::requires_migration},
   feature_spec{
     cluster_version{2001},
     "__test_alpha",

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -170,6 +170,12 @@ public:
     void notify_version(cluster_version v);
 
     // State transition hooks
+    void transition_unavailable() { _state = state::unavailable; }
+
+    void transition_disabled_clean() { _state = state::disabled_clean; }
+    void transition_disabled_preparing() { _state = state::disabled_preparing; }
+    void transition_disabled_active() { _state = state::disabled_active; }
+
     void transition_available();
     void transition_preparing();
     void transition_active();
@@ -221,6 +227,7 @@ public:
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster_version);
+    void apply_action(const feature_update_action& fua);
 
     cluster_version _active_version{invalid_version};
 

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -180,7 +180,7 @@ public:
     void transition_preparing();
     void transition_active();
 
-    state get_state() { return _state; };
+    state get_state() const { return _state; };
 
 private:
     state _state{state::unavailable};
@@ -216,18 +216,40 @@ public:
         return (uint64_t(f) & _active_features_mask) != 0;
     }
 
+    /**
+     * Query whether a feature has reached ::preparing state, i.e. it is
+     * ready to go active, but will wait for preparatory work to be done
+     * elsewhere in the system first.
+     *
+     * Once the preparatory work (like a data migration) is complete,
+     * the feature may be advanced to ::active with a `feature_action`
+     * RPC to the controller leader
+     */
+    bool is_preparing(feature f) const noexcept {
+        return get_state(f).get_state() == feature_state::state::preparing;
+    }
+
     ss::future<> await_feature(feature f, ss::abort_source& as);
+
+    ss::future<> await_feature_preparing(feature f, ss::abort_source& as);
 
     static cluster_version get_latest_logical_version();
 
     feature_table();
 
-    feature_state& get_state(std::string_view feature_name);
+    feature_state& get_state(feature f_id);
+    const feature_state& get_state(feature f_id) const {
+        return const_cast<feature_table&>(*this).get_state(f_id);
+    }
 
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster_version);
     void apply_action(const feature_update_action& fua);
+
+    std::optional<feature> resolve_name(std::string_view feature_name) const;
+
+    void on_update();
 
     cluster_version _active_version{invalid_version};
 
@@ -237,8 +259,11 @@ private:
     // just use a bigger one.  Do not serialize this as a bitmask anywhere.
     uint64_t _active_features_mask{0};
 
-    // Waiting for a particular feature to be available
-    waiter_queue<feature> _waiters;
+    // Waiting for a particular feature to be active
+    waiter_queue<feature> _waiters_active;
+
+    // Waiting for a particular feature to be preparing
+    waiter_queue<feature> _waiters_preparing;
 
     // feature_manager is a friend so that they can initialize
     // the active version on single-node first start.

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -19,8 +19,11 @@
 
 namespace cluster {
 
-enum class feature {
+enum class feature : std::uint64_t {
     central_config = 0x1,
+
+    // Dummy features for testing only
+    test_alpha = uint64_t(1) << 63,
 };
 
 /**
@@ -69,12 +72,19 @@ struct feature_spec {
     prepare_policy prepare_rule;
 };
 
-constexpr static std::array feature_schema{feature_spec{
-  cluster_version{1},
-  "central_config",
-  feature::central_config,
-  feature_spec::available_policy::always,
-  feature_spec::prepare_policy::always}};
+constexpr static std::array feature_schema{
+  feature_spec{
+    cluster_version{1},
+    "central_config",
+    feature::central_config,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{2001},
+    "__test_alpha",
+    feature::test_alpha,
+    feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always}};
 
 /**
  * Feature states

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -14,14 +14,168 @@
 #include "cluster/types.h"
 #include "utils/waiter_queue.h"
 
+#include <array>
 #include <string_view>
-
-class cluster_version;
 
 namespace cluster {
 
 enum class feature {
     central_config = 0x1,
+};
+
+/**
+ * The definition of a feature specifies rules for when it should
+ * be activated,
+ */
+struct feature_spec {
+    // Policy defining how the feature behaves when in 'available' state.
+    enum class available_policy {
+        // The feature proceeds to activate as soon as it is available
+        always,
+
+        // The feature only becomes available once all cluster nodes
+        // are recent enough *and* an administrator explicitly enables it.
+        explicit_only,
+    };
+
+    // Policy defining whether the feature passes through 'preparing'
+    // state on the way to 'active' state.
+    enum class prepare_policy {
+        // The feature is activated as soon as it becomes available.
+        always,
+
+        // The feature only becomes active once a migration step has
+        // completed and the feature manager has been notified of this.
+        requires_migration
+    };
+
+    constexpr feature_spec(
+      cluster_version require_version_,
+      std::string_view name_,
+      feature bits_,
+      available_policy apol,
+      prepare_policy ppol)
+      : bits(bits_)
+      , name(name_)
+      , require_version(require_version_)
+      , available_rule(apol)
+      , prepare_rule(ppol) {}
+
+    feature bits{0};
+    std::string_view name;
+    cluster_version require_version;
+
+    available_policy available_rule;
+    prepare_policy prepare_rule;
+};
+
+constexpr static std::array feature_schema{feature_spec{
+  cluster_version{1},
+  "central_config",
+  feature::central_config,
+  feature_spec::available_policy::always,
+  feature_spec::prepare_policy::always}};
+
+/**
+ * Feature states
+ * ==============
+ *
+ * Start as unavailable.  Become available once all nodes
+ * are recent enough.
+ *
+ * Once available, either advance straight to 'preparing'
+ * if available_policy is 'always', else wait for administrator
+ * to activate the feature.
+ *
+ * Once in preparing, either advance straight to 'active'
+ * if prepare_policy is 'always', else wait for notification
+ * that preparation is complete before proceeding.
+ *
+ * Features may be disabled at any time, but from unavailable/available
+ * states they go to disabled_clean, whereas from other states they
+ * go to disabled_dirty.  This tracks whether the feature may have
+ * written persistent structures.
+ *
+    ┌──────────────┐           ┌──────────────────┐
+    │              ├──────────►│                  │
+    │  unavailable │           │  disabled_clean  │
+    │              │◄──────────┤                  │
+    └───────┬──────┘           └───┬──────────────┘
+            │                      │            ▲
+            ▼                      │            │
+    ┌──────────────┐               │            │
+    │              │◄──────────────┘            │
+    │   available  │                            │
+    │              ├────────────────────────────┘
+    └───────┬──────┘
+            │
+            ▼
+    ┌──────────────┐            ┌─────────────────────┐
+    │              ├───────────►│                     │
+    │   preparing  │            │  disabled_preparing │
+    │              │◄───────────┤                     │
+    └───────┬──────┘            └─────────────────────┘
+            │
+            ▼
+    ┌──────────────┐            ┌─────────────────────┐
+    │              ├───────────►│                     │
+    │    active    │            │  disabled_active    │
+    │              │◄───────────┤                     │
+    └──────────────┘            └─────────────────────┘
+ *
+ */
+class feature_state {
+public:
+    enum class state {
+        // Unavailable means not all nodes in the cluster are recent
+        unavailable,
+
+        // Available means the feature is eligible for activation.  If the
+        // feature spec allows it, it may proceed autonomously to preparing
+        // or active.  Otherwise, it may have too wait for an administrator
+        // to permit it to activate.
+        available,
+
+        // Preparing means the feature is in the process of a data migration
+        // or other preparatory step.  It will proceed to active status
+        // autonomously.
+        preparing,
+
+        // Active means the feature is up and running and ready to use.  This
+        // is the normal state of most features through most of their lifetime.
+        active,
+
+        // Administratively disabled, but it was in 'active' or 'preparing'
+        // state at some point in the past.  Indicates that while the feature
+        // is disabled now, there may be data structures written to disk that
+        // depend on this feature to read back.
+        // The distinction between _active and _perparing variants is needed
+        // so that when an administrator re-activates the feature, we know
+        // what state to go back into.
+        disabled_active,
+        disabled_preparing,
+
+        // Administratively disabled, and never progressed past 'available'.
+        // Means that any data structures dependent on this feature were
+        // never written to disk, and no migrations for this feature were done.
+        disabled_clean,
+    };
+
+    const feature_spec& spec;
+
+    feature_state(const feature_spec& spec_)
+      : spec(spec_){};
+
+    // External inputs
+    void notify_version(cluster_version v);
+
+    // State transition hooks
+    void transition_available();
+    void transition_preparing();
+    void transition_active();
+
+private:
+    state _state{state::unavailable};
 };
 
 std::string_view to_string_view(feature);
@@ -58,11 +212,15 @@ public:
 
     static cluster_version get_latest_logical_version();
 
+    feature_table();
+
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster_version);
 
     cluster_version _active_version{invalid_version};
+
+    std::vector<feature_state> _feature_state;
 
     // Bitmask only used at runtime: if we run out of bits for features
     // just use a bigger one.  Do not serialize this as a bitmask anywhere.

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -188,8 +188,6 @@ private:
 
 std::string_view to_string_view(feature);
 
-using feature_list = std::vector<feature>;
-
 /**
  * To enable all shards to efficiently check enablement of features
  * in their hot paths, the cluster logical version and features
@@ -203,7 +201,9 @@ public:
         return _active_version;
     }
 
-    feature_list get_active_features() const;
+    const std::vector<feature_state>& get_feature_state() const {
+        return _feature_state;
+    }
 
     /**
      * Query whether a feature is active, i.e. whether functionality

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -242,12 +242,12 @@ public:
         return const_cast<feature_table&>(*this).get_state(f_id);
     }
 
+    std::optional<feature> resolve_name(std::string_view feature_name) const;
+
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster_version);
     void apply_action(const feature_update_action& fua);
-
-    std::optional<feature> resolve_name(std::string_view feature_name) const;
 
     void on_update();
 

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -32,6 +32,7 @@ public:
       ss::sharded<controller_api>&,
       ss::sharded<members_frontend>&,
       ss::sharded<config_frontend>&,
+      ss::sharded<feature_manager>&,
       ss::sharded<feature_table>&,
       ss::sharded<health_monitor_frontend>&);
 
@@ -85,6 +86,9 @@ public:
     ss::future<get_cluster_health_reply> get_cluster_health_report(
       get_cluster_health_request&&, rpc::streaming_context&) final;
 
+    ss::future<feature_action_response>
+    feature_action(feature_action_request&& req, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -115,6 +119,7 @@ private:
     ss::sharded<controller_api>& _api;
     ss::sharded<members_frontend>& _members_frontend;
     ss::sharded<config_frontend>& _config_frontend;
+    ss::sharded<feature_manager>& _feature_manager;
     ss::sharded<feature_table>& _feature_table;
     ss::sharded<health_monitor_frontend>& _hm_frontend;
 };

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -360,6 +360,24 @@ std::ostream& operator<<(std::ostream& o, const leader_term& lt) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const feature_update_action& fua) {
+    std::string_view action_name;
+    switch (fua.action) {
+    case feature_update_action::action_t::complete_preparing:
+        action_name = "complete_preparing";
+        break;
+    case feature_update_action::action_t::administrative_activate:
+        action_name = "administrative_activate";
+        break;
+    case feature_update_action::action_t::administrative_deactivate:
+        action_name = "administrative_deactivate";
+        break;
+    }
+
+    fmt::print(o, "{{action {} {} }}", fua.feature_name, action_name);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {
@@ -1161,6 +1179,32 @@ adl<cluster::cluster_config_status_cmd_data>::from(iobuf_parser& in) {
     };
 }
 
+void adl<cluster::feature_update_action>::to(
+  iobuf& out, cluster::feature_update_action&& cmd) {
+    return serialize(
+      out,
+      cmd.current_version,
+      std::move(cmd.feature_name),
+      std::move(cmd.action));
+}
+
+cluster::feature_update_action
+adl<cluster::feature_update_action>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::feature_update_action::current_version,
+      "Unexpected version: {} (expected {})",
+      version,
+      cluster::feature_update_action::current_version);
+    auto feature_name = adl<ss::sstring>().from(in);
+    auto action = adl<cluster::feature_update_action::action_t>().from(in);
+
+    return cluster::feature_update_action{
+      .feature_name = std::move(feature_name),
+      .action = std::move(action),
+    };
+}
+
 void adl<cluster::incremental_topic_custom_updates>::to(
   iobuf& out, cluster::incremental_topic_custom_updates&& t) {
     reflection::serialize(out, t.data_policy);
@@ -1177,7 +1221,8 @@ adl<cluster::incremental_topic_custom_updates>::from(iobuf_parser& in) {
 
 void adl<cluster::feature_update_cmd_data>::to(
   iobuf& out, cluster::feature_update_cmd_data&& data) {
-    reflection::serialize(out, data.current_version, data.logical_version);
+    reflection::serialize(
+      out, data.current_version, data.logical_version, data.actions);
 }
 
 cluster::feature_update_cmd_data
@@ -1186,7 +1231,8 @@ adl<cluster::feature_update_cmd_data>::from(iobuf_parser& in) {
     std::ignore = version;
 
     auto logical_version = adl<cluster::cluster_version>{}.from(in);
-    return {.logical_version = logical_version};
+    auto actions = adl<std::vector<cluster::feature_update_action>>{}.from(in);
+    return {.logical_version = logical_version, .actions = std::move(actions)};
 }
 
 } // namespace reflection

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1099,7 +1099,14 @@ configuration::configuration()
       "cluster metrics reporter url",
       {.needs_restart = needs_restart::no,
        .visibility = visibility::deprecated},
-      "https://m.rp.vectorized.io/v2") {}
+      "https://m.rp.vectorized.io/v2")
+  , features_auto_enable(
+      *this,
+      "features_auto_enable",
+      "Whether new feature flags may auto-activate after upgrades (true) or "
+      "must wait for manual activation via the admin API (false)",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -246,6 +246,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metrics_reporter_report_interval;
     property<ss::sstring> metrics_reporter_url;
 
+    property<bool> features_auto_enable;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -21,6 +21,37 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/features/{feature_name}",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Activate or deactivate a feature",
+                    "nickname": "put_feature",
+                    "type": "void",
+                    "produces": ["application/json"],
+                    "parameters": [
+                        {
+                            "name": "feature_name",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "OK"
+                        },
+                        "400": {
+                            "description": "Invalid action, response body contains reason",
+                            "schema":{
+                                "type": "json"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -55,6 +55,23 @@
         }
     ],
     "models": {
+        "feature_state": {
+            "id": "feature_state",
+            "description": "State of one feature (active, available etc)",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["active", "preparing", "available", "unavailable", "disabled"]
+                },
+                "was_active": {
+                    "type": "boolean",
+                    "description": "Whether the feature has ever been active, i.e. data depending on this feature may have been written to disk"
+                }
+            }
+        },
         "features_response": {
             "id": "features_response",
             "description": "Describe available features in this redpanda cluster",
@@ -65,10 +82,8 @@
                 },
                 "features": {
                     "type": "array",
-                    "description": "list of feature names",
-                    "items": {
-                        "type": "string"
-                    }
+                    "description": "list of feature_state for each feature",
+                    "items": {"type": "feature_state"}
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1331,8 +1331,8 @@ void admin_server::register_status_routes() {
 }
 
 void admin_server::register_features_routes() {
-    ss::httpd::features_json::get_features.set(
-      _server._routes,
+    register_route<user>(
+      ss::httpd::features_json::get_features,
       [this](std::unique_ptr<ss::httpd::request>)
         -> ss::future<ss::json::json_return_type> {
           ss::httpd::features_json::features_response res;
@@ -2073,8 +2073,9 @@ void admin_server::register_hbadger_routes() {
     /*
      * Remove all failure injectors at given point
      */
-    ss::httpd::hbadger_json::delete_failure_probe.set(
-      _server._routes, [](std::unique_ptr<ss::httpd::request> req) {
+    register_route<superuser>(
+      ss::httpd::hbadger_json::delete_failure_probe,
+      [](std::unique_ptr<ss::httpd::request> req) {
           auto m = req->param["module"];
           auto p = req->param["point"];
           vlog(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1129,6 +1129,7 @@ void application::start_redpanda() {
             std::ref(controller->get_api()),
             std::ref(controller->get_members_frontend()),
             std::ref(controller->get_config_frontend()),
+            std::ref(controller->get_feature_manager()),
             std::ref(controller->get_feature_table()),
             std::ref(controller->get_health_monitor()));
 

--- a/src/v/utils/waiter_queue.h
+++ b/src/v/utils/waiter_queue.h
@@ -64,6 +64,7 @@ public:
     }
     void notify(const T& value) {
         auto items = std::exchange(_items, {});
+        _items.reserve(items.size());
         for (auto& wi : items) {
             if (wi->data == value) {
                 wi->p.set_value();
@@ -71,5 +72,6 @@ public:
                 _items.push_back(std::move(wi));
             }
         }
+        _items.shrink_to_fit();
     };
 };

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -179,6 +179,9 @@ class Admin:
     def get_features(self):
         return self._request("GET", "features").json()
 
+    def put_feature(self, feature_name, body):
+        return self._request("PUT", f"features/{feature_name}", json=body)
+
     def set_log_level(self, name, level, expires=None):
         """
         Set broker log level

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -35,7 +35,7 @@ class FeaturesTestBase(RedpandaTest):
         # This assertion will break each time we increment the value
         # of `latest_version` in the redpanda source.  Update it when
         # that happens.
-        assert features_response['cluster_version'] == 1
+        assert features_response['cluster_version'] == 2
 
         assert features_response['features'] == ['central_config']
 

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -23,6 +23,11 @@ class FeaturesTestBase(RedpandaTest):
     Test cases defined in this parent class are executed as part
     of subclasses that define node count below.
     """
+    def _get_features_map(self, feature_response=None):
+        if feature_response is None:
+            feature_response = self.admin.get_features()
+        return dict((f['name'], f) for f in feature_response['features'])
+
     def _assert_default_features(self):
         """
         Verify that the config GET endpoint serves valid json with
@@ -37,7 +42,8 @@ class FeaturesTestBase(RedpandaTest):
         # that happens.
         assert features_response['cluster_version'] == 2
 
-        assert features_response['features'] == ['central_config']
+        assert self._get_features_map(
+            features_response)['central_config']['state'] == 'active'
 
         return features_response
 
@@ -121,6 +127,80 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         self.redpanda.restart_nodes([self.redpanda.nodes[1]])
         time.sleep(5)  # Give it a chance to update
         assert initial_version == self.admin.get_features()['cluster_version']
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_explicit_activation(self):
+        """
+        Using a dummy feature, verify its progression through unavailable->available->active
+        """
+
+        # Parameters of the compiled-in test feature
+        feature_alpha_version = 2001
+        feature_alpha_name = "__test_alpha"
+
+        initial_version = self.admin.get_features()['cluster_version']
+        assert (initial_version < feature_alpha_version)
+        # Initially, before setting the magic environment variable, dummy test features
+        # should be hidden
+        assert feature_alpha_name not in self._get_features_map().keys()
+
+        self.redpanda.set_environment({'__REDPANDA_TEST_FEATURES': "ON"})
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        assert self._get_features_map(
+        )[feature_alpha_name]['state'] == 'unavailable'
+
+        # Version is too low, feature should be unavailable
+        assert initial_version == self.admin.get_features()['cluster_version']
+
+        self.redpanda.set_environment({
+            '__REDPANDA_TEST_FEATURES':
+            "ON",
+            '__REDPANDA_LOGICAL_VERSION':
+            f'{feature_alpha_version}'
+        })
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Wait for version to increment: this is a little slow because we wait
+        # for health monitor structures to time out in order to propagate the
+        # updated version
+        wait_until(lambda: feature_alpha_version == self.admin.get_features()[
+            'cluster_version'],
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+        # Feature should become available now that version increased.  It should NOT
+        # become active, because it has an explicit_only policy for activation.
+        assert self._get_features_map(
+        )[feature_alpha_name]['state'] == 'available'
+
+        # Disable the feature, see that it enters the expected state
+        self.admin.put_feature(feature_alpha_name, {"state": "disabled"})
+        wait_until(lambda: self._get_features_map()[feature_alpha_name][
+            'state'] == 'disabled',
+                   timeout_sec=5,
+                   backoff_sec=1)
+        state = self._get_features_map()[feature_alpha_name]
+        assert state['state'] == 'disabled'
+        assert state['was_active'] == False
+
+        # Write to admin API to enable the feature
+        self.admin.put_feature(feature_alpha_name, {"state": "active"})
+
+        # This is an async check because propagation of feature_table is async
+        wait_until(lambda: self._get_features_map()[feature_alpha_name][
+            'state'] == 'active',
+                   timeout_sec=5,
+                   backoff_sec=1)
+
+        # Disable the feature, see that it enters the expected state
+        self.admin.put_feature(feature_alpha_name, {"state": "disabled"})
+        wait_until(lambda: self._get_features_map()[feature_alpha_name][
+            'state'] == 'disabled',
+                   timeout_sec=5,
+                   backoff_sec=1)
+        state = self._get_features_map()[feature_alpha_name]
+        assert state['state'] == 'disabled'
+        assert state['was_active'] == True
 
 
 class FeaturesSingleNodeTest(FeaturesTestBase):


### PR DESCRIPTION
## Cover letter

This partly implements the "phase 2" extensions from the [feature gates design doc](https://docs.google.com/document/d/1QvHcyIK-aQLILLVAlOE0S1qA1s68ufkZxw3PmIJtGYg/edit#heading=h.mvlqwsjv79vf), with the addition of a mechanism for new features to have a data migration phase before going active.

Features now have an explicit state machine from unavailable->available->preparing->active, and can step through it in a few different ways:
- Some features may want to wait in `preparing` until some migration work is  done, like consumer offsets
- Some features may not want to go active at all unless explicitly requested by the administrator (e.g. experimental features), these wait in `available` until a PUT to the admin API activates them.

For the consumer offsets case, the migration code waits for the preparing state before doing anything, and then signals feature_manager via an RPC to advance to `active` once the migration work is done.

```
    ┌──────────────┐           ┌──────────────────┐
    │              ├──────────►│                  │
    │  unavailable │           │  disabled_clean  │
    │              │◄──────────┤                  │
    └───────┬──────┘           └───┬──────────────┘
            │                      │            ▲
            ▼                      │            │
    ┌──────────────┐               │            │
    │              │◄──────────────┘            │
    │   available  │                            │
    │              ├────────────────────────────┘
    └───────┬──────┘
            │
            ▼
    ┌──────────────┐            ┌─────────────────────┐
    │              ├───────────►│                     │
    │   preparing  │            │  disabled_preparing │
    │              │◄───────────┤                     │
    └───────┬──────┘            └─────────────────────┘
            │
            ▼
    ┌──────────────┐            ┌─────────────────────┐
    │              ├───────────►│                     │
    │    active    │            │  disabled_active    │
    │              │◄───────────┤                     │
    └──────────────┘            └─────────────────────
```

## Release notes

### Improvements

* New admin API endpoint `PUT /v1/features/<feature>`, for use on future feature flags which may not be enabled by default.
