### PR TITLE
Backport #3881 to v21.11.x

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -53,11 +53,9 @@ std::ostream& operator<<(std::ostream& s, const upload_candidate& c) {
 
 archival_policy::archival_policy(
   model::ntp ntp,
-  ntp_level_probe& ntp_probe,
   std::optional<segment_time_limit> limit,
   ss::io_priority_class io_priority)
   : _ntp(std::move(ntp))
-  , _ntp_probe(ntp_probe)
   , _upload_limit(limit)
   , _io_priority(io_priority) {}
 
@@ -110,10 +108,7 @@ archival_policy::lookup_result archival_policy::find_segment(
             if (start_offset < sg->offsets().base_offset) {
                 // Move last offset forward
                 it = i;
-                auto offset = sg->offsets().base_offset;
-                auto delta = offset - start_offset;
-                start_offset = offset;
-                _ntp_probe.gap_detected(delta);
+                start_offset = sg->offsets().base_offset;
                 break;
             }
         }

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -53,12 +53,10 @@ std::ostream& operator<<(std::ostream& s, const upload_candidate& c) {
 
 archival_policy::archival_policy(
   model::ntp ntp,
-  service_probe& svc_probe,
   ntp_level_probe& ntp_probe,
   std::optional<segment_time_limit> limit,
   ss::io_priority_class io_priority)
   : _ntp(std::move(ntp))
-  , _svc_probe(svc_probe)
   , _ntp_probe(ntp_probe)
   , _upload_limit(limit)
   , _io_priority(io_priority) {}
@@ -119,7 +117,6 @@ archival_policy::lookup_result archival_policy::find_segment(
                 auto offset = sg->offsets().base_offset;
                 auto delta = offset - start_offset;
                 start_offset = offset;
-                _svc_probe.add_gap();
                 _ntp_probe.gap_detected(delta);
                 break;
             }

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -101,10 +101,6 @@ archival_policy::lookup_result archival_policy::find_segment(
     }
     const auto& set = plog->segments();
 
-    if (start_offset <= adjusted_lso) {
-        _ntp_probe.upload_lag(adjusted_lso - start_offset);
-    }
-
     const auto& ntp_conf = plog->config();
     auto it = set.lower_bound(start_offset);
     if (it == set.end() || (*it)->is_compacted_segment()) {

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -45,7 +45,6 @@ class archival_policy {
 public:
     explicit archival_policy(
       model::ntp ntp,
-      service_probe& svc_probe,
       ntp_level_probe& ntp_probe,
       std::optional<segment_time_limit> limit = std::nullopt,
       ss::io_priority_class io_priority = ss::default_priority_class());
@@ -83,7 +82,6 @@ private:
       const storage::offset_translator_state&);
 
     model::ntp _ntp;
-    service_probe& _svc_probe;
     ntp_level_probe& _ntp_probe;
     std::optional<segment_time_limit> _upload_limit;
     std::optional<ss::lowres_clock::time_point> _upload_deadline;

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -45,7 +45,6 @@ class archival_policy {
 public:
     explicit archival_policy(
       model::ntp ntp,
-      ntp_level_probe& ntp_probe,
       std::optional<segment_time_limit> limit = std::nullopt,
       ss::io_priority_class io_priority = ss::default_priority_class());
 
@@ -82,7 +81,6 @@ private:
       const storage::offset_translator_state&);
 
     model::ntp _ntp;
-    ntp_level_probe& _ntp_probe;
     std::optional<segment_time_limit> _upload_limit;
     std::optional<ss::lowres_clock::time_point> _upload_deadline;
     ss::io_priority_class _io_priority;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -285,6 +285,7 @@ ntp_archiver::schedule_uploads(
       "scheduling uploads, start_upload_offset: {}, last_stable_offset: {}",
       start_upload_offset,
       last_stable_offset);
+    _probe.upload_lag(last_stable_offset - start_upload_offset);
 
     return ss::do_with(
       std::vector<scheduled_upload>(),

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -52,7 +52,7 @@ ntp_archiver::ntp_archiver(
   , _rev(ntp.get_initial_revision())
   , _remote(remote)
   , _partition(std::move(part))
-  , _policy(_ntp, std::ref(_probe), conf.time_limit, conf.upload_io_priority)
+  , _policy(_ntp, conf.time_limit, conf.upload_io_priority)
   , _bucket(conf.bucket_name)
   , _manifest(_ntp, _rev)
   , _gate()
@@ -355,8 +355,21 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
             break;
         }
         const auto& upload = scheduled[ixupload[i]];
+
         _probe.uploaded(*upload.delta);
         _probe.uploaded_bytes(upload.meta->size_bytes);
+        model::offset expected_base_offset;
+        if (_manifest.get_last_offset() < model::offset{0}) {
+            expected_base_offset = model::offset{0};
+        } else {
+            expected_base_offset = _manifest.get_last_offset()
+                                   + model::offset{1};
+        }
+        if (upload.meta->base_offset > expected_base_offset) {
+            _probe.gap_detected(
+              upload.meta->base_offset - expected_base_offset);
+        }
+
         _manifest.add(segment_name(*upload.name), *upload.meta);
     }
     if (total.num_succeded != 0) {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -356,6 +356,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
         }
         const auto& upload = scheduled[ixupload[i]];
         _probe.uploaded(*upload.delta);
+        _probe.uploaded_bytes(upload.meta->size_bytes);
         _manifest.add(segment_name(*upload.name), *upload.meta);
     }
     if (total.num_succeded != 0) {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -46,20 +46,13 @@ ntp_archiver::ntp_archiver(
   const storage::ntp_config& ntp,
   const configuration& conf,
   cloud_storage::remote& remote,
-  ss::lw_shared_ptr<cluster::partition> part,
-  service_probe& svc_probe)
-  : _svc_probe(svc_probe)
-  , _probe(conf.ntp_metrics_disabled, ntp.ntp())
+  ss::lw_shared_ptr<cluster::partition> part)
+  : _probe(conf.ntp_metrics_disabled, ntp.ntp())
   , _ntp(ntp.ntp())
   , _rev(ntp.get_initial_revision())
   , _remote(remote)
   , _partition(std::move(part))
-  , _policy(
-      _ntp,
-      _svc_probe,
-      std::ref(_probe),
-      conf.time_limit,
-      conf.upload_io_priority)
+  , _policy(_ntp, std::ref(_probe), conf.time_limit, conf.upload_io_priority)
   , _bucket(conf.bucket_name)
   , _manifest(_ntp, _rev)
   , _gate()

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -67,8 +67,7 @@ public:
       const storage::ntp_config& ntp,
       const configuration& conf,
       cloud_storage::remote& remote,
-      ss::lw_shared_ptr<cluster::partition> part,
-      service_probe& svc_probe);
+      ss::lw_shared_ptr<cluster::partition> part);
 
     /// Stop archiver.
     ///
@@ -166,7 +165,6 @@ private:
     ss::future<cloud_storage::upload_result>
     upload_segment(upload_candidate candidate, retry_chain_node& fib);
 
-    service_probe& _svc_probe;
     ntp_level_probe _probe;
     model::ntp _ntp;
     model::initial_revision_id _rev;

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -67,10 +67,6 @@ service_probe::service_probe(service_metrics_disabled disabled) {
       prometheus_sanitize::metrics_name("archival_service"),
       {
         sm::make_counter(
-          "num_gaps",
-          [this] { return _cnt_gaps; },
-          sm::description("Number of detected offset gaps")),
-        sm::make_counter(
           "start_archiving_ntp",
           [this] { return _cnt_start_archiving_ntp; },
           sm::description("Start archiving ntp event counter")),

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -18,10 +18,7 @@
 namespace archival {
 
 ntp_level_probe::ntp_level_probe(
-  per_ntp_metrics_disabled disabled, const model::ntp& ntp)
-  : _uploaded()
-  , _missing()
-  , _pending() {
+  per_ntp_metrics_disabled disabled, const model::ntp& ntp) {
     if (disabled) {
         return;
     }
@@ -40,14 +37,19 @@ ntp_level_probe::ntp_level_probe(
       prometheus_sanitize::metrics_name("ntp_archiver"),
       {
         sm::make_counter(
-          "missing",
-          [this] { return _missing; },
-          sm::description("Missing offsets due to gaps"),
-          labels),
-        sm::make_counter(
           "uploaded",
           [this] { return _uploaded; },
           sm::description("Uploaded offsets"),
+          labels),
+        sm::make_total_bytes(
+          "uploaded_bytes",
+          [this] { return _uploaded_bytes; },
+          sm::description("Total number of uploaded bytes"),
+          labels),
+        sm::make_counter(
+          "missing",
+          [this] { return _missing; },
+          sm::description("Missing offsets due to gaps"),
           labels),
         sm::make_gauge(
           "pending",

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -57,11 +57,7 @@ ntp_level_probe::ntp_level_probe(
       });
 }
 
-service_probe::service_probe(service_metrics_disabled disabled)
-  : _cnt_gaps()
-  , _cnt_start_archiving_ntp()
-  , _cnt_stop_archiving_ntp()
-  , _cnt_reconciliations() {
+service_probe::service_probe(service_metrics_disabled disabled) {
     if (disabled) {
         return;
     }
@@ -85,11 +81,7 @@ service_probe::service_probe(service_metrics_disabled disabled)
         sm::make_gauge(
           "num_archived_ntp",
           [this] { return _cnt_start_archiving_ntp - _cnt_stop_archiving_ntp; },
-          sm::description("Total number of ntp that archiver manages")),
-        sm::make_counter(
-          "num_reconciliations",
-          [this] { return _cnt_reconciliations; },
-          sm::description("Number of reconciliation loop iterations")),
+          sm::description("Current number of ntp that archiver manages")),
       });
 }
 

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -67,18 +67,13 @@ public:
     /// of the ntp event
     void stop_archiving_ntp() { _cnt_stop_archiving_ntp++; }
 
-    /// Count reconciliation loop iterations (liveliness probe)
-    void reconciliation() { _cnt_reconciliations++; }
-
 private:
     /// Number of gaps dected
-    uint64_t _cnt_gaps;
+    uint64_t _cnt_gaps = 0;
     /// Start archiving npt event counter
-    uint64_t _cnt_start_archiving_ntp;
+    uint64_t _cnt_start_archiving_ntp = 0;
     /// Stop archiving npt event counter
-    uint64_t _cnt_stop_archiving_ntp;
-    /// Number of reconciliation loop iterations
-    uint64_t _cnt_reconciliations;
+    uint64_t _cnt_stop_archiving_ntp = 0;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -57,9 +57,6 @@ class service_probe {
 public:
     explicit service_probe(service_metrics_disabled disabled);
 
-    /// Increment gap counter (global)
-    void add_gap() { _cnt_gaps++; }
-
     /// Count new ntp archiving event
     void start_archiving_ntp() { _cnt_start_archiving_ntp++; }
 
@@ -68,8 +65,6 @@ public:
     void stop_archiving_ntp() { _cnt_stop_archiving_ntp++; }
 
 private:
-    /// Number of gaps dected
-    uint64_t _cnt_gaps = 0;
     /// Start archiving npt event counter
     uint64_t _cnt_start_archiving_ntp = 0;
     /// Stop archiving npt event counter

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -35,6 +35,8 @@ public:
     /// Register log-segment upload
     void uploaded(model::offset offset_delta) { _uploaded += offset_delta; }
 
+    void uploaded_bytes(uint64_t bytes) { _uploaded_bytes += bytes; }
+
     /// Register gap
     void gap_detected(model::offset offset_delta) { _missing += offset_delta; }
 
@@ -43,11 +45,13 @@ public:
 
 private:
     /// Uploaded offsets
-    int64_t _uploaded;
+    uint64_t _uploaded = 0;
+    /// Total uploaded bytes
+    uint64_t _uploaded_bytes = 0;
     /// Missing offsets due to gaps
-    int64_t _missing;
+    int64_t _missing = 0;
     /// Width of the offset range yet to be uploaded
-    int64_t _pending;
+    int64_t _pending = 0;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -338,7 +338,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
               && (part->get_ntp_config().is_archival_enabled()
                   || config::shard_local_cfg().cloud_storage_enable_remote_read())) {
               auto svc = ss::make_lw_shared<ntp_archiver>(
-                log->config(), _conf, _remote.local(), part, _probe);
+                log->config(), _conf, _remote.local(), part);
               return ss::repeat(
                 [this, svc = std::move(svc)] { return add_ntp_archiver(svc); });
           } else {

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -200,8 +200,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     };
     init_storage_api_local(segments);
     auto& lm = get_local_storage_api().log_mgr();
-    ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    archival::archival_policy policy(manifest_ntp, ntp_probe);
+    archival::archival_policy policy(manifest_ntp);
 
     log_segment_set(lm);
 
@@ -265,9 +264,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
         storage::maybe_compress_batches::no,
         model::record_batch_type::archival_metadata);
 
-    ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    archival::archival_policy policy(
-      manifest_ntp, ntp_probe, segment_time_limit{0s});
+    archival::archival_policy policy(manifest_ntp, segment_time_limit{0s});
 
     auto log = b.get_log();
 
@@ -725,8 +722,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     };
     init_storage_api_local(segments);
     auto& lm = get_local_storage_api().log_mgr();
-    ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    archival::archival_policy policy(manifest_ntp, ntp_probe);
+    archival::archival_policy policy(manifest_ntp);
 
     // Patch segment offsets to create overlaps for the archival_policy.
     // The archival_policy instance only touches the offsets, not the

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -104,7 +104,6 @@ void log_upload_candidate(const archival::upload_candidate& up) {
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     set_expectations_and_listen({});
     auto [arch_conf, remote_conf] = get_configurations();
-    service_probe probe(service_metrics_disabled::yes);
     cloud_storage::remote remote(
       remote_conf.connection_limit, remote_conf.client_config);
 
@@ -128,8 +127,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       part->committed_offset(),
       *part);
 
-    archival::ntp_archiver archiver(
-      get_ntp_conf(), arch_conf, remote, part, probe);
+    archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -203,8 +201,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     init_storage_api_local(segments);
     auto& lm = get_local_storage_api().log_mgr();
     ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    service_probe svc_probe(service_metrics_disabled::yes);
-    archival::archival_policy policy(manifest_ntp, svc_probe, ntp_probe);
+    archival::archival_policy policy(manifest_ntp, ntp_probe);
 
     log_segment_set(lm);
 
@@ -269,9 +266,8 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
         model::record_batch_type::archival_metadata);
 
     ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    service_probe svc_probe(service_metrics_disabled::yes);
     archival::archival_policy policy(
-      manifest_ntp, svc_probe, ntp_probe, segment_time_limit{0s});
+      manifest_ntp, ntp_probe, segment_time_limit{0s});
 
     auto log = b.get_log();
 
@@ -369,11 +365,9 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
 
     set_expectations_and_listen(expectations);
     auto [arch_conf, remote_conf] = get_configurations();
-    service_probe probe(service_metrics_disabled::yes);
     cloud_storage::remote remote(
       remote_conf.connection_limit, remote_conf.client_config);
-    archival::ntp_archiver archiver(
-      get_ntp_conf(), arch_conf, remote, part, probe);
+    archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -587,10 +581,9 @@ static void test_partial_upload_impl(
     test.set_expectations_and_listen(expectations);
 
     auto [aconf, cconf] = get_configurations();
-    service_probe probe(service_metrics_disabled::yes);
     cloud_storage::remote remote(cconf.connection_limit, cconf.client_config);
     aconf.time_limit = segment_time_limit(0s);
-    archival::ntp_archiver archiver(get_ntp_conf(), aconf, remote, part, probe);
+    archival::ntp_archiver archiver(get_ntp_conf(), aconf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -733,8 +726,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     init_storage_api_local(segments);
     auto& lm = get_local_storage_api().log_mgr();
     ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
-    service_probe svc_probe(service_metrics_disabled::yes);
-    archival::archival_policy policy(manifest_ntp, svc_probe, ntp_probe);
+    archival::archival_policy policy(manifest_ntp, ntp_probe);
 
     // Patch segment offsets to create overlaps for the archival_policy.
     // The archival_policy instance only touches the offsets, not the

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   NAME cloud_storage
   SRCS
     cache_service.cc
+    cache_probe.cc
     manifest.cc
     recursive_directory_walker.cc
     remote.cc

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     remote.cc
     offset_translation_layer.cc
     probe.cc
+    partition_probe.cc
     partition_recovery_manager.cc
     types.cc
     remote_segment.cc

--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/cache_probe.h"
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+namespace cloud_storage {
+
+cache_probe::cache_probe() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_storage:cache"),
+      {
+        sm::make_counter(
+          "puts",
+          [this] { return _num_puts; },
+          sm::description("Total number of files put into cache.")),
+        sm::make_counter(
+          "gets",
+          [this] { return _num_gets; },
+          sm::description("Total number of cache get requests.")),
+        sm::make_counter(
+          "cached_gets",
+          [this] { return _num_cached_gets; },
+          sm::description(
+            "Total number of get requests that are already in cache.")),
+
+        sm::make_gauge(
+          "size_bytes",
+          [this] { return _cur_size_bytes; },
+          sm::description("Current cache size in bytes.")),
+        sm::make_gauge(
+          "files",
+          [this] { return _cur_num_files; },
+          sm::description("Current number of files in cache.")),
+        sm::make_gauge(
+          "in_progress_files",
+          [this] { return _cur_in_progress_files; },
+          sm::description(
+            "Current number of files that are being put to cache.")),
+      });
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace cloud_storage {
+
+class cache_probe {
+public:
+    cache_probe();
+
+    void put() { ++_num_puts; }
+    void get() { ++_num_gets; }
+    void cached_get() { ++_num_cached_gets; }
+
+    void set_size(uint64_t size) { _cur_size_bytes = size; }
+    void set_num_files(uint64_t num_files) { _cur_num_files = num_files; }
+    void put_started() { ++_cur_in_progress_files; }
+    void put_ended() { --_cur_in_progress_files; }
+
+private:
+    uint64_t _num_puts = 0;
+    uint64_t _num_gets = 0;
+    uint64_t _num_cached_gets = 0;
+
+    int64_t _cur_size_bytes = 0;
+    int64_t _cur_num_files = 0;
+    int64_t _cur_in_progress_files = 0;
+
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage/cache_probe.h"
 #include "cloud_storage/recursive_directory_walker.h"
 #include "resource_mgmt/io_priority.h"
 #include "seastarx.h"
@@ -106,6 +107,7 @@ private:
     cloud_storage::recursive_directory_walker _walker;
     uint64_t _total_cleaned;
     std::set<std::filesystem::path> _files_in_progress;
+    cache_probe probe;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_probe.cc
+++ b/src/v/cloud_storage/partition_probe.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/partition_probe.h"
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+namespace cloud_storage {
+
+partition_probe::partition_probe(const model::ntp& ntp) {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    const std::vector<sm::label_instance> labels = {
+      sm::label("namespace")(ntp.ns()),
+      sm::label("topic")(ntp.tp.topic()),
+      sm::label("partition")(ntp.tp.partition()),
+    };
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_storage:partition"),
+      {
+        sm::make_total_bytes(
+          "read_bytes",
+          [this] { return _bytes_read; },
+          sm::description("Total bytes read from remote partition"),
+          labels),
+        sm::make_derive(
+          "read_records",
+          [this] { return _records_read; },
+          sm::description("Total number of records read from remote partition"),
+          labels),
+
+        sm::make_gauge(
+          "segments",
+          [this] { return _cur_segments; },
+          sm::description("Current number of remote segments"),
+          labels),
+        sm::make_gauge(
+          "materialized_segments",
+          [this] { return _cur_materialized_segments; },
+          sm::description("Current number of materialized remote segments"),
+          labels),
+
+        sm::make_gauge(
+          "readers",
+          [this] { return _cur_readers; },
+          sm::description("Current number of remote partition readers"),
+          labels),
+        sm::make_gauge(
+          "segment_readers",
+          [this] { return _cur_segment_readers; },
+          sm::description("Current number of remote segment readers"),
+          labels),
+      });
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace cloud_storage {
+
+class partition_probe {
+public:
+    partition_probe(const model::ntp& ntp);
+
+    void add_bytes_read(uint64_t read) { _bytes_read += read; }
+    void add_records_read(uint64_t read) { _records_read += read; }
+
+    void segment_added() { ++_cur_segments; }
+    void segment_materialized() { ++_cur_materialized_segments; }
+    void segment_offloaded() { --_cur_materialized_segments; }
+
+    void reader_created() { ++_cur_readers; }
+    void reader_destroyed() { --_cur_readers; }
+    void segment_reader_created() { ++_cur_segment_readers; }
+    void segment_reader_destroyed() { --_cur_segment_readers; }
+
+private:
+    uint64_t _bytes_read = 0;
+    uint64_t _records_read = 0;
+
+    int32_t _cur_segments = 0;
+    int32_t _cur_materialized_segments = 0;
+
+    int32_t _cur_readers = 0;
+    int32_t _cur_segment_readers = 0;
+
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/offset_translation_layer.h"
+#include "cloud_storage/partition_probe.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
@@ -224,7 +225,9 @@ private:
         /// Borrow reader or make a new one.
         /// In either case return a reader.
         std::unique_ptr<remote_segment_batch_reader> borrow_reader(
-          const storage::log_reader_config& cfg, retry_chain_logger& ctxlog);
+          const storage::log_reader_config& cfg,
+          retry_chain_logger& ctxlog,
+          partition_probe& probe);
 
         ss::future<> stop();
 
@@ -311,6 +314,7 @@ private:
     /// Timer use to periodically evict stale readers
     ss::timer<ss::lowres_clock> _stm_timer;
     simple_time_jitter<ss::lowres_clock> _stm_jitter;
+    partition_probe _probe;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -12,6 +12,7 @@
 
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/partition_probe.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
@@ -157,7 +158,8 @@ class remote_segment_batch_reader final {
 public:
     remote_segment_batch_reader(
       ss::lw_shared_ptr<remote_segment>,
-      const storage::log_reader_config& config) noexcept;
+      const storage::log_reader_config& config,
+      partition_probe& probe) noexcept;
 
     remote_segment_batch_reader(
       remote_segment_batch_reader&&) noexcept = delete;
@@ -196,6 +198,7 @@ private:
 
     ss::lw_shared_ptr<remote_segment> _seg;
     storage::log_reader_config _config;
+    partition_probe& _probe;
     ss::circular_buffer<model::record_batch> _ringbuf;
     std::optional<std::reference_wrapper<storage::offset_translator_state>>
       _cur_ot_state;

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -166,7 +166,8 @@ FIXTURE_TEST(
       model::offset(1), model::offset(1), ss::default_priority_class());
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, *cache, bucket, m, key, fib);
-    remote_segment_batch_reader reader(segment, reader_config);
+    partition_probe probe(manifest_ntp);
+    remote_segment_batch_reader reader(segment, reader_config, probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 
     auto s = reader.read_some(model::no_timeout, ot_state).get();
@@ -257,7 +258,8 @@ void test_remote_segment_batch_reader(
     reader_config.max_bytes = std::numeric_limits<size_t>::max();
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, *fixture.cache, bucket, m, key, fib);
-    remote_segment_batch_reader reader(segment, reader_config);
+    partition_probe probe(manifest_ntp);
+    remote_segment_batch_reader reader(segment, reader_config, probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 
     size_t batch_ix = 0;
@@ -363,12 +365,14 @@ FIXTURE_TEST(
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, *cache, bucket, m, key, fib);
 
+    partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(
       segment,
       storage::log_reader_config(
         headers.at(0).base_offset,
         headers.at(0).last_offset(),
-        ss::default_priority_class()));
+        ss::default_priority_class()),
+      probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 
     auto s = reader.read_some(model::no_timeout, ot_state).get();


### PR DESCRIPTION
Backport #3881 to v21.11.x

## Cover letter

Improve shadow indexing metrics:
* add partition-level shadow read metrics
* add cloud storage cache metrics
* make archival metrics more robust

Fixes: #2818

## Release notes

### Improvements

* Add more detailed shadow indexing metrics.
