### PR TITLE
tests: improve failure reporting to call out redpanda crashes

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -34,6 +34,7 @@ def cluster(log_allow_list=None, **kwargs):
             try:
                 r = f(self, *args, **kwargs)
             except:
+                self.redpanda.raise_on_crash()
                 raise
             else:
                 # Only do log inspections on tests that are otherwise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -752,7 +752,7 @@ class RedpandaService(Service):
                     # are permitted, as they can occur during Seastar shutdown.
                     # See https://github.com/redpanda-data/redpanda/issues/3626
                     for summary_line in node.account.ssh_capture(
-                            f"grep -e \"SUMMARY: AddressSanitizer:\" {RedpandaService.STDOUT_STDERR_CAPTURE} | true"
+                            f"grep -e \"SUMMARY: AddressSanitizer:\" {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
                     ):
                         m = re.match(
                             "SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked in (\d+) allocation\(s\).",


### PR DESCRIPTION
## Cover letter

With this change, redpanda crashes in tests will be reported as such.  Currently, a node crash is reported only via its consequences (e.g. a client IO timeout or a test wait_until timeout).

This will make it much clearer when a test failure is a clear-cut redpanda bug.

## Release notes

* none