### PR TITLE
Fix offset for leader epoch test

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -24,8 +24,19 @@ class OffsetForLeaderEpochTest(RedpandaTest):
     """
     Check offset for leader epoch handling
     """
+    def _all_have_leaders(self, topic):
+        rpk = RpkTool(self.redpanda)
+        partitions = rpk.describe_topic(topic)
+
+        for p in partitions:
+            self.logger.debug(f"rpk partition: {p}")
+            if p.leader == None or p.leader == -1:
+                return False
+        return True
+
     def _produce(self, topic, msg_cnt):
         rpk = RpkTool(self.redpanda)
+        wait_until(lambda: self._all_have_leaders(topic), 20, backoff_sec=2)
         for i in range(0, msg_cnt):
             rpk.produce(topic, f"k-{i}", f"v-{i}")
 

--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import random
-from ducktape.mark import ignore
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
@@ -49,7 +48,6 @@ class OffsetForLeaderEpochTest(RedpandaTest):
                                  "log_compaction_interval_ms": 1000
                              })
 
-    @ignore  # Temporarily disabled see issue #3907
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_offset_for_leader_epoch(self):
         replication_factors = [1, 3, 5]


### PR DESCRIPTION
## Cover letter

Rpk produce expects that the cluster will be stable before actually
executing. Added waiting for the partition leadership to stabilize
before producing to partitions.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3907

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
