### PR TITLE
RFC: simplify service reference sharing

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -30,19 +30,13 @@
 
 namespace cluster {
 
-partition_manager::partition_manager(
-  ss::sharded<storage::api>& storage,
-  ss::sharded<raft::group_manager>& raft,
-  ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
-  ss::sharded<cloud_storage::partition_recovery_manager>& recovery_mgr,
-  ss::sharded<cloud_storage::remote>& cloud_storage_api,
-  ss::sharded<cloud_storage::cache>& cloud_storage_cache)
-  : _storage(storage.local())
-  , _raft_manager(raft)
-  , _tx_gateway_frontend(tx_gateway_frontend)
-  , _partition_recovery_mgr(recovery_mgr)
-  , _cloud_storage_api(cloud_storage_api)
-  , _cloud_storage_cache(cloud_storage_cache) {}
+partition_manager::partition_manager(services& rs)
+  : _storage(rs.storage.local())
+  , _raft_manager(rs.raft_group_manager)
+  , _tx_gateway_frontend(rs.tx_gateway_frontend)
+  , _partition_recovery_mgr(rs.partition_recovery_manager)
+  , _cloud_storage_api(rs.cloud_storage_api)
+  , _cloud_storage_cache(rs.shadow_index_cache) {}
 
 partition_manager::ntp_table_container
 partition_manager::get_topic_partition_table(

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -20,6 +20,7 @@
 #include "raft/consensus_client_protocol.h"
 #include "raft/group_manager.h"
 #include "raft/heartbeat_manager.h"
+#include "redpanda/services.h"
 #include "storage/api.h"
 #include "utils/named_type.h"
 
@@ -31,13 +32,7 @@ public:
     using ntp_table_container
       = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
 
-    partition_manager(
-      ss::sharded<storage::api>&,
-      ss::sharded<raft::group_manager>&,
-      ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<cloud_storage::partition_recovery_manager>&,
-      ss::sharded<cloud_storage::remote>&,
-      ss::sharded<cloud_storage::cache>&);
+    partition_manager(services&);
 
     using manage_cb_t
       = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -676,15 +676,7 @@ void application::wire_up_redpanda_services() {
     }
 
     syschecks::systemd_message("Adding partition manager").get();
-    construct_service(
-      partition_manager,
-      std::ref(rs.storage),
-      std::ref(rs.raft_group_manager),
-      std::ref(rs.tx_gateway_frontend),
-      std::ref(rs.partition_recovery_manager),
-      std::ref(rs.cloud_storage_api),
-      std::ref(rs.shadow_index_cache))
-      .get();
+    construct_service(partition_manager, std::ref(rs)).get();
     vlog(_log.info, "Partition manager started");
 
     construct_service(cp_partition_manager, std::ref(rs.storage)).get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -27,6 +27,7 @@
 #include "platform/stop_signal.h"
 #include "raft/fwd.h"
 #include "redpanda/admin_server.h"
+#include "redpanda/services.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/smp_groups.h"
@@ -72,15 +73,12 @@ public:
     ss::future<> set_proxy_config(ss::sstring name, std::any val);
     ss::future<> set_proxy_client_config(ss::sstring name, std::any val);
 
-    ss::sharded<cluster::metadata_cache> metadata_cache;
-    ss::sharded<kafka::group_router> group_router;
-    ss::sharded<cluster::shard_table> shard_table;
-    ss::sharded<storage::api> storage;
+    services rs;
+
     std::unique_ptr<coproc::api> coprocessing;
     ss::sharded<coproc::partition_manager> cp_partition_manager;
     ss::sharded<cluster::partition_manager> partition_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;
-    ss::sharded<raft::group_manager> raft_group_manager;
     ss::sharded<cluster::metadata_dissemination_service>
       md_dissemination_service;
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
@@ -89,15 +87,10 @@ public:
     smp_groups smp_service_groups;
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
-    ss::sharded<cloud_storage::remote> cloud_storage_api;
-    ss::sharded<cloud_storage::partition_recovery_manager>
-      partition_recovery_manager;
     ss::sharded<archival::scheduler_service> archival_scheduler;
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
     ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
-    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
     ss::sharded<v8_engine::data_policy_table> data_policies;
-    ss::sharded<cloud_storage::cache> shadow_index_cache;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/services.h
+++ b/src/v/redpanda/services.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cloud_storage/fwd.h"
+#include "cluster/fwd.h"
+#include "kafka/server/fwd.h"
+#include "raft/fwd.h"
+#include "seastarx.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/sharded.hh>
+
+struct services {
+    ss::sharded<cluster::metadata_cache> metadata_cache;
+    ss::sharded<kafka::group_router> group_router;
+    ss::sharded<cluster::shard_table> shard_table;
+    ss::sharded<storage::api> storage;
+    ss::sharded<raft::group_manager> raft_group_manager;
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    ss::sharded<cloud_storage::partition_recovery_manager>
+      partition_recovery_manager;
+    ss::sharded<cloud_storage::remote> cloud_storage_api;
+    ss::sharded<cloud_storage::cache> shadow_index_cache;
+};


### PR DESCRIPTION
Factors out `seastar::sharded<T>` services from `application::` and places them into a `services` object:

```c++
struct services {
   seastar::sharded<T> ...;
};
```

and then passes a around `services&` instead of explicitly passing in each service instance.

RFC demonstrates the idea for one service:

```diff
@@ -31,13 +32,7 @@ class partition_manager {
     using ntp_table_container
       = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
 
-    partition_manager(
-      ss::sharded<storage::api>&,
-      ss::sharded<raft::group_manager>&,
-      ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<cloud_storage::partition_recovery_manager>&,
-      ss::sharded<cloud_storage::remote>&,
-      ss::sharded<cloud_storage::cache>&);
+    partition_manager(services&);
```