### PR TITLE
rpk: add missing loggers

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -174,6 +174,7 @@ failure of enabling each logger is individually printed.
 var possibleLoggers = []string{
 	"admin_api_server",
 	"archival",
+	"archival-ctrl",
 	"assert",
 	"cloud_storage",
 	"cluster",
@@ -186,9 +187,12 @@ var possibleLoggers = []string{
 	"http",
 	"httpd",
 	"io",
+	"json",
 	"kafka",
 	// "kafka/client", disabled until redpanda supports slashes in the handler
 	"kvstore",
+	"metrics-reporter",
+	"offset_translator",
 	"pandaproxy",
 	// "r/heartbeat", disabled until redpanda supports slashes in the handler
 	"raft",
@@ -200,5 +204,7 @@ var possibleLoggers = []string{
 	"seastar",
 	"security",
 	"storage",
+	"storage-gc",
 	"syschecks",
+	"tx",
 }


### PR DESCRIPTION
## Cover letter

This is related to the community report, https://github.com/redpanda-data/redpanda/issues/3772; `rpk redpanda admin config log-level set all ...` does not take account of all loggers.

I have checked what have been added and been removed since beginning via:

```
$ git -P log -p  | grep -e "^+.*ss::logger " -e "^-.*ss::logger "
```

, and added

```
archival-ctrl
json
metrics-reporter
offset_translator
storage-gc
tx
```

I've run `rpk redpanda admin config log-level set --host localhost:9644 all -l trace -e 1` and confirmed the following loggers are enabled from the log.

```
INFO  2022-03-05 17:38:38,867 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {admin_api_server}: info -> trace
INFO  2022-03-05 17:38:38,867 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {archival}: info -> trace
INFO  2022-03-05 17:38:38,867 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {archival-ctrl}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {assert}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {cloud_storage}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {cluster}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {compaction_ctrl}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {compression}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {coproc}: info -> trace
INFO  2022-03-05 17:38:38,868 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {dns_resolver}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {exception}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {fault_injector}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {http}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {httpd}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {io}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {json}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {kafka}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {kvstore}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {metrics-reporter}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {offset_translator}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {pandaproxy}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {raft}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {redpanda::main}: info -> trace
INFO  2022-03-05 17:38:38,869 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {rpc}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {s3}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {scheduler}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {scollectd}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {seastar}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {security}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {storage}: info -> trace
INFO  2022-03-05 17:38:38,870 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {storage-gc}: info -> trace
INFO  2022-03-05 17:38:38,871 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {syschecks}: info -> trace
INFO  2022-03-05 17:38:38,871 [shard 0] admin_api_server - admin_server.cc:495 - Set log level for {tx}: info -> trace
```

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
