### PR TITLE
tests: fix a log allow list entry

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -104,7 +104,7 @@ CHAOS_LOG_ALLOW_LIST = [
         "rpc - .*Unable to parse received RPC request payload - std::out_of_range"
     ),
     re.compile(
-        "cluster - .*exception while executing partition operation:.*std::exception (std::exception)"
+        "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
     ),
 ]
 


### PR DESCRIPTION
## Cover letter

This was added in 23b562e1302f871606da8c832de8da850d487082

The parentheses should have been escaped.

## Release notes

* none