### PR TITLE
admin: add a dry_run flag to PUT /cluster_config

### DIFF
--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -22,6 +22,13 @@
               "schema": {"type": "integer"},
               "required": false,
               "description": "If nonzero, skip validation of properties, and permit setting unknown properties"
+            },
+            {
+              "in": "query",
+              "name": "dry_run",
+              "schema": {"type": "integer"},
+              "required": false,
+              "description": "If nonzero, do not apply any changes (but still do validation and return 400 on errors)"
             }
           ],
           "responses": {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -153,15 +153,26 @@ class Admin:
     def get_cluster_config_schema(self, node=None):
         return self._request("GET", "cluster_config/schema", node=node).json()
 
-    def patch_cluster_config(self, upsert=None, remove=None, force=False):
+    def patch_cluster_config(self,
+                             upsert=None,
+                             remove=None,
+                             force=False,
+                             dry_run=False):
         if upsert is None:
             upsert = {}
         if remove is None:
             remove = []
 
         path = "cluster_config"
+        params = {}
         if force:
-            path = path + "?force=true"
+            params['force'] = 'true'
+        if dry_run:
+            params['dry_run'] = 'true'
+
+        if params:
+            joined = "&".join([f"{k}={v}" for k, v in params.items()])
+            path = path + f"?{joined}"
 
         return self._request("PUT",
                              path,


### PR DESCRIPTION
## Cover letter

This enables clients to validate a configuration
change without applying it.  This is useful for a client
that wants to use the admin API for validation, but apply
configuration changes via another means, such as updating
a k8s cluster CRD.

## Release notes

* none