### PR TITLE
tests: fix wasm_partition_movement_test log allow list

### DIFF
--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -175,7 +175,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         num_nodes=6,
         log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS + RESTART_LOG_ALLOW_LIST +
         [
-            "coproc - .*Failed to connect wasm engine" +
+            "coproc - .*Failed to connect wasm engine",
             "coproc - .*Wasm engine failed to reply to heartbeat within the expected interval"
         ])
     def test_dynamic_with_failure(self):


### PR DESCRIPTION
## Cover letter

This was a straight typo, concatenating two strings instead
of putting them in a list.

The mistake was in https://github.com/redpanda-data/redpanda/pull/3942

## Release notes

* none