### PR TITLE
coproc: disable unit test in CI

### DIFF
--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -32,5 +32,5 @@ rp_test(
     kafka_api_materialized_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main ${fixture_deps}
-  LABELS coproc
+  LABELS coproc disable_on_ci
 )


### PR DESCRIPTION
## Cover letter

This test failed 4/148 runs in the last 7 days of CI.

Related: https://github.com/redpanda-data/redpanda/issues/3384

## Release notes

* none