### PR TITLE
test: disable test_node_operations.enable_failures=True

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -117,7 +117,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
     """
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @parametrize(enable_failures=True)
+    # @ignore failures=True mode for https://github.com/redpanda-data/redpanda/issues/3866
+    #@parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster


### PR DESCRIPTION
## Cover letter

Timeouts during decommission: a rare failure mode (hasn't happened on `dev` in last 7 days), but 

Related: https://github.com/redpanda-data/redpanda/issues/3866

## Release notes

* none
