### PR TITLE
v21.11.x/backport: #3964 (kafka: reduce oversized fetch log from info to debug)

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -353,7 +353,7 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
     if (total_max_bytes > max_bytes_per_fetch) {
         auto per_partition = max_bytes_per_fetch / ntp_fetch_configs.size();
         vlog(
-          klog.info,
+          klog.debug,
           "Fetch requested very large response ({}), clamping each partition's "
           "max_bytes to {} bytes",
           total_max_bytes,


### PR DESCRIPTION
## Cover letter

This turns out to be fairly common in the field: clients
are routinely setting their per-partition fetch limit
to something much higher than they really expect to read.

Backport: #3965

Fixes https://github.com/redpanda-data/redpanda/issues/3964

## Release notes

### Improvements

* "Fetch requested very large response" log messages are reduced from INFO to DEBUG severity.
