### PR TITLE
k8s: make deploy to use dev tag instead of latest

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,7 +1,7 @@
 
 # Image URL to use all building/pushing image targets
-OPERATOR_IMG_LATEST ?= "vectorized/redpanda-operator:latest"
-CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:latest"
+OPERATOR_IMG_LATEST ?= "vectorized/redpanda-operator:dev"
+CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:dev"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -2,8 +2,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
-  - vectorized/redpanda-operator:latest
-  - vectorized/configurator:latest
+  - vectorized/redpanda-operator:dev
+  - vectorized/configurator:dev
 testDirs:
   - ./tests/e2e-helm
 kindConfig: ./kind.yaml
@@ -13,7 +13,7 @@ commands:
   - command: "kubectl apply -k ./config/crd"
   - command: "kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml"
   - command: "helm dep up ./helm-chart/charts/redpanda-operator"
-  - command: "helm install --set configurator.tag=latest --set image.tag=latest --namespace helm-test --create-namespace redpanda-operator ./helm-chart/charts/redpanda-operator"
+  - command: "helm install --set configurator.tag=dev --set image.tag=dev --namespace helm-test --create-namespace redpanda-operator ./helm-chart/charts/redpanda-operator"
   - command: "./hack/wait-for-webhook-ready.sh"
   - command: "mkdir -p tests/_helm_e2e_artifacts"
 artifactsDir: tests/_helm_e2e_artifacts

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -2,8 +2,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
-  - vectorized/redpanda-operator:latest
-  - vectorized/configurator:latest
+  - vectorized/redpanda-operator:dev
+  - vectorized/configurator:dev
 testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml


### PR DESCRIPTION
## Cover letter

We don't update latest tag for the last 5 months.

Replace https://github.com/redpanda-data/redpanda/pull/3292