### PR TITLE
cluster: add feature manager barriers

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -89,6 +89,7 @@ v_cc_library(
     node/local_monitor.cc
     feature_backend.cc
     feature_manager.cc
+    feature_barrier.cc
     feature_table.cc
   DEPS
     Seastar::seastar

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -243,6 +243,7 @@ ss::future<> controller::start() {
             std::ref(_hm_frontend),
             std::ref(_hm_backend),
             std::ref(_feature_table),
+            std::ref(_connections),
             _raft0->group());
       })
       .then([this] {

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -95,6 +95,11 @@
             "name": "feature_action",
             "input_type": "feature_action_request",
             "output_type": "feature_action_response"
+        },
+        {
+            "name": "feature_barrier",
+            "input_type": "feature_barrier_request",
+            "output_type": "feature_barrier_response"
         }
     ]
 }

--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "feature_barrier.h"
+
+#include "cluster/feature_manager.h"
+#include "cluster/logger.h"
+#include "cluster/members_table.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <seastar/core/sleep.hh>
+
+namespace cluster {
+
+ss::future<> feature_barrier_tag_state::wait_abortable(ss::abort_source& as) {
+    if (!_exited) {
+        as.check();
+        auto sub_opt = as.subscribe([this]() noexcept { _exit_wait.broken(); });
+        co_await _exit_wait.wait();
+    }
+}
+
+ss::future<> feature_barrier_state::barrier(feature_barrier_tag tag) {
+    vassert(
+      ss::this_shard_id() == feature_manager::backend_shard,
+      "Called barrier on wrong shard");
+
+    vlog(clusterlog.debug, "barrier enter [{}] ({})", _self, tag);
+
+    auto gate_holder = _gate.hold();
+
+    if (!_members.contains(_self)) {
+        vlog(
+          clusterlog.debug,
+          "waiting for cluster membership for barrier ({})",
+          tag);
+        co_await _members.await_membership(_self, _as);
+    }
+
+    if (_members.all_broker_ids().size() < 2) {
+        // We are alone, immediate complete.
+        vlog(clusterlog.debug, "barrier exit {} (single node)", tag);
+        co_return;
+    }
+
+    // Set our entered state, so that any peers sending feature_barrier
+    // requests will see it.
+    update_barrier(tag, _self, true);
+
+    // Announce to peers.  Iterate until we have successfully communicated
+    // with all peers.
+    std::set<model::node_id> sent_to;
+    while (true) {
+        bool all_sent = true;
+        for (const auto& member_id : _members.all_broker_ids()) {
+            if (member_id == _self) {
+                // Don't try and send to self
+                continue;
+            }
+
+            // Check early exit conditions before each RPC
+            _as.check();
+
+            // We only need to send an RPC to each peer once.  If they restart
+            // during this time, they will do an RPC to us and get our readiness
+            // in that way.
+            if (sent_to.contains(member_id)) {
+                vlog(
+                  clusterlog.trace,
+                  "barrier {} skipping peer {}, already communicated",
+                  tag,
+                  member_id);
+                continue;
+            }
+
+            auto rpc_result = co_await _rpc_hook(_self, member_id, tag, true);
+
+            if (rpc_result.has_error()) {
+                // Throw abort_requested if the error occurred during shutdown
+                _as.check();
+
+                // Only at debug level because errors are totally expected
+                // when cluster is in the middle of e.g. a rolling restart.
+                auto& err = rpc_result.error();
+                vlog(
+                  clusterlog.debug,
+                  "barrier exception sending to {}: {}",
+                  member_id,
+                  err);
+
+                // Proceed to next node, and eventual retry of this node
+                all_sent = false;
+                continue;
+            } else {
+                auto result = rpc_result.value().data;
+
+                sent_to.insert(member_id);
+
+                if (result.complete) {
+                    vlog(
+                      clusterlog.debug,
+                      "barrier {} (peer {} told us complete)",
+                      tag,
+                      member_id);
+                    // Why don't we drop out when someone tells us they
+                    // are complete?
+                    // Because we must proceed around the loop until I have
+                    // successfully communicated with all peers: this is
+                    // necessary to ensure that they all know I am ready.
+                }
+
+                // Only apply this peer's `entered` if we didn't already
+                // enter (prevent race between their RPC to us and our
+                // RPC to them).
+                if (!_barrier_state[tag].is_node_entered(member_id)) {
+                    update_barrier(tag, member_id, result.entered);
+                }
+            }
+        }
+
+        if (all_sent) {
+            break;
+        } else {
+            co_await ss::sleep_abortable(500ms, _as);
+        }
+    }
+    auto& state = _barrier_state.at(tag);
+    vlog(clusterlog.debug, "barrier tx complete, waiting ({})", tag);
+    co_await state.wait_abortable(_as);
+    vlog(clusterlog.debug, "barrier exit [{}] ({})", _self, tag);
+}
+
+/**
+ * Call this when we get an RPC from another node that tells us
+ * their barrier state.
+ */
+feature_barrier_response feature_barrier_state::update_barrier(
+  feature_barrier_tag tag, model::node_id peer, bool entered) {
+    vassert(
+      ss::this_shard_id() == feature_manager::backend_shard,
+      "Called barrier on wrong shard");
+    vlog(
+      clusterlog.trace,
+      "update_barrier [{}] ({}, {}, {})",
+      _self,
+      tag,
+      peer,
+      entered);
+    auto i = _barrier_state.find(tag);
+    if (i == _barrier_state.end()) {
+        _barrier_state[tag] = feature_barrier_tag_state({{peer, entered}});
+        return {false, false};
+    } else {
+        i->second.node_enter(peer, entered);
+        bool all_in = true;
+        for (const auto& member_id : _members.all_broker_ids()) {
+            if (!i->second.is_node_entered(member_id)) {
+                vlog(
+                  clusterlog.debug,
+                  "update_barrier: not entered yet peer {} ({})",
+                  member_id,
+                  tag);
+                all_in = false;
+            }
+        }
+
+        if (all_in && !i->second.is_complete()) {
+            vlog(clusterlog.debug, "barrier all in [{}] ({})", _self, tag);
+            i->second.complete();
+        }
+
+        return {i->second.is_node_entered(_self), i->second.is_complete()};
+    }
+}
+
+} // namespace cluster

--- a/src/v/cluster/feature_barrier.h
+++ b/src/v/cluster/feature_barrier.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "rpc/types.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
+
+namespace cluster {
+
+class feature_barrier_tag_state {
+public:
+    feature_barrier_tag_state() {}
+
+    feature_barrier_tag_state(bool e)
+      : _exited(e) {}
+
+    feature_barrier_tag_state(std::pair<model::node_id, bool> p)
+      : _exited(false) {
+        _nodes_entered.insert(p);
+    }
+
+    void node_enter(model::node_id nid, bool entered) {
+        _nodes_entered[nid] = entered;
+    }
+
+    bool is_node_entered(model::node_id nid) {
+        auto i = _nodes_entered.find(nid);
+        if (i == _nodes_entered.end()) {
+            return false;
+        } else {
+            return i->second;
+        }
+    }
+
+    void complete() {
+        _exited = true;
+        _exit_wait.signal();
+    }
+
+    /**
+     * Wait for exited=true
+     */
+    ss::future<> wait_abortable(ss::abort_source& as);
+
+    bool is_complete() { return _exited; }
+
+private:
+    // Which peers have told us they entered the barrier
+    absl::flat_hash_map<model::node_id, bool> _nodes_entered;
+
+    // Have we passed through or pre-emptively cancelled the barrier?
+    bool _exited{false};
+    ss::condition_variable _exit_wait;
+};
+
+/**
+ * State for a one-shot tagged barrier.
+ *
+ * Sometimes, we want to wait not only for consensus on the state of
+ * a feature, but for all nodes to have seen that consensus result (i.e.
+ * for the feature_table on all nodes to reflect the new state).
+ *
+ * Consider a data migration in the `preparing` state, where nodes will stop
+ * writing to the old data location once in `preparing`: to be sure that there
+ * will be no more writes to the old data, we need to check that all peers
+ * have seen the preparing state.
+ *
+ * Subsequently, before cleaning up some old data, we might want to barrier
+ * on all nodes seeing the `active` state.
+ */
+class feature_barrier_state {
+public:
+    using rpc_fn_ret
+      = ss::future<result<rpc::client_context<feature_barrier_response>>>;
+    using rpc_fn = ss::noncopyable_function<rpc_fn_ret(
+      model::node_id, model::node_id, feature_barrier_tag, bool)>;
+
+    feature_barrier_state(
+      model::node_id self,
+      members_table& members,
+      ss::abort_source& as,
+      ss::gate& gate,
+      rpc_fn fn)
+      : _members(members)
+      , _as(as)
+      , _gate(gate)
+      , _self(self)
+      , _rpc_hook(std::move(fn)) {}
+
+    ss::future<> barrier(feature_barrier_tag tag);
+
+    void exit_barrier(feature_barrier_tag tag) {
+        _barrier_state[tag] = feature_barrier_tag_state(true);
+    }
+
+    struct update_barrier_result {
+        bool entered{false};
+        bool complete{false};
+    };
+
+    feature_barrier_response
+    update_barrier(feature_barrier_tag tag, model::node_id peer, bool entered);
+
+    /**
+     * Test helper.
+     */
+    const feature_barrier_tag_state&
+    testing_only_peek_state(const feature_barrier_tag& tag) {
+        return _barrier_state[tag];
+    }
+
+private:
+    members_table& _members;
+    ss::abort_source& _as;
+    ss::gate& _gate;
+
+    absl::node_hash_map<feature_barrier_tag, feature_barrier_tag_state>
+      _barrier_state;
+
+    model::node_id _self;
+
+    rpc_fn _rpc_hook;
+
+    ss::abort_source::subscription _abort_sub;
+};
+
+} // namespace cluster

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -451,4 +451,16 @@ service::feature_action(feature_action_request&& req, rpc::streaming_context&) {
     };
 }
 
+ss::future<feature_barrier_response> service::feature_barrier(
+  feature_barrier_request&& req, rpc::streaming_context&) {
+    auto result = co_await _feature_manager.invoke_on(
+      feature_manager::backend_shard,
+      [req = std::move(req)](feature_manager& fm) {
+          return fm.update_barrier(req.tag, req.peer, req.entered);
+      });
+
+    co_return feature_barrier_response{
+      .entered = result.entered, .complete = result.complete};
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -89,6 +89,9 @@ public:
     ss::future<feature_action_response>
     feature_action(feature_action_request&& req, rpc::streaming_context&) final;
 
+    ss::future<feature_barrier_response>
+    feature_barrier(feature_barrier_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(srcs
     controller_backend_test.cc
     configuration_change_test.cc
     idempotency_tests.cc
+    feature_barrier_test.cc
     tm_stm_tests.cc
     rm_stm_tests.cc
     controller_api_tests.cc

--- a/src/v/cluster/tests/feature_barrier_test.cc
+++ b/src/v/cluster/tests/feature_barrier_test.cc
@@ -239,3 +239,28 @@ FIXTURE_TEST(test_barrier_node_isolated, barrier_fixture) {
     f1.get();
     f2.get();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_barrier_encoding) {
+    feature_barrier_request req{
+      .tag = feature_barrier_tag{"ohai"},
+      .peer = model::node_id{2},
+      .entered = true};
+    auto req2 = req;
+
+    iobuf req_io = reflection::to_iobuf(std::move(req2));
+    iobuf_parser req_parser(std::move(req_io));
+    auto req_decoded = reflection::adl<feature_barrier_request>{}.from(
+      req_parser);
+    BOOST_REQUIRE_EQUAL(req.tag, req_decoded.tag);
+    BOOST_REQUIRE_EQUAL(req.peer, req_decoded.peer);
+    BOOST_REQUIRE_EQUAL(req.entered, req_decoded.entered);
+
+    feature_barrier_response resp{.entered = true, .complete = true};
+
+    iobuf resp_io = reflection::to_iobuf(std::move(resp));
+    iobuf_parser resp_parser(std::move(resp_io));
+    auto resp_decoded = reflection::adl<feature_barrier_response>{}.from(
+      resp_parser);
+    BOOST_REQUIRE_EQUAL(resp.entered, resp_decoded.entered);
+    BOOST_REQUIRE_EQUAL(resp.complete, resp_decoded.complete);
+}

--- a/src/v/cluster/tests/feature_barrier_test.cc
+++ b/src/v/cluster/tests/feature_barrier_test.cc
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/feature_manager.h"
+#include "cluster/members_table.h"
+#include "test_utils/fixture.h"
+#include "vlog.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using namespace std::chrono_literals;
+using namespace cluster;
+
+struct node_state {
+    ss::abort_source as;
+    ss::gate gate;
+    feature_barrier_state barrier_state;
+
+    node_state(
+      members_table& members,
+      model::node_id id,
+      feature_barrier_state::rpc_fn fn)
+      : barrier_state(id, members, as, gate, std::move(fn)) {}
+
+    ~node_state() {
+        as.request_abort();
+        gate.close().get();
+    }
+};
+
+struct barrier_fixture {
+    /**
+     * Populate members_table with `n` brokers
+     */
+    void create_brokers(int n) {
+        std::vector<model::broker> brokers;
+        for (int i = 0; i < n; ++i) {
+            brokers.push_back(model::broker(
+              model::node_id{i},
+              net::unresolved_address{},
+              net::unresolved_address{},
+              std::nullopt,
+              model::broker_properties{}));
+        }
+        members.update_brokers(model::offset{0}, brokers);
+    }
+
+    void create_node_state(model::node_id id) {
+        using namespace std::placeholders;
+
+        states[id] = ss::make_lw_shared<node_state>(
+          members,
+          id,
+          std::bind(&barrier_fixture::rpc_hook, this, _1, _2, _3, _4));
+    }
+
+    void kill(model::node_id id) { states.erase(id); }
+    void restart(model::node_id id) {
+        kill(id);
+        create_node_state(id);
+    }
+
+    feature_barrier_state::rpc_fn_ret rpc_hook(
+      model::node_id src,
+      model::node_id dst,
+      feature_barrier_tag tag,
+      bool src_entered) {
+        if (rpc_rx_errors.contains(dst)) {
+            co_return rpc_rx_errors[dst];
+        }
+        if (rpc_tx_errors.contains(src)) {
+            co_return rpc_tx_errors[src];
+        }
+
+        BOOST_REQUIRE(states.contains(dst));
+        BOOST_REQUIRE(states.contains(src));
+
+        auto update_result = states[dst]->barrier_state.update_barrier(
+          tag, src, src_entered);
+
+        auto client_context = rpc::client_context<feature_barrier_response>(
+          rpc::header{},
+          {.entered = update_result.entered,
+           .complete = update_result.complete});
+        co_return result<rpc::client_context<feature_barrier_response>>(
+          std::move(client_context));
+    }
+
+    ss::lw_shared_ptr<node_state> get_node_state(model::node_id id) {
+        auto r = states[id];
+        assert(r);
+        return r;
+    }
+
+    feature_barrier_state& get_barrier_state(model::node_id id) {
+        return get_node_state(id)->barrier_state;
+    }
+
+    std::map<model::node_id, ss::lw_shared_ptr<node_state>> states;
+
+    std::map<model::node_id, std::error_code> rpc_rx_errors;
+    std::map<model::node_id, std::error_code> rpc_tx_errors;
+
+    members_table members;
+};
+
+/**
+ * The no-op case for a single node cluster
+ */
+FIXTURE_TEST(test_barrier_single_node, barrier_fixture) {
+    create_brokers(1);
+    create_node_state(model::node_id{0});
+
+    // Should proceed immediately as it is the only node.
+    auto f = get_barrier_state(model::node_id{0})
+               .barrier(feature_barrier_tag{"test"});
+
+    BOOST_REQUIRE(f.available() && !f.failed());
+};
+
+/**
+ * The simple case where everyone enters the barrier and proceeds
+ * cleanly to completion.
+ */
+FIXTURE_TEST(test_barrier_simple, barrier_fixture) {
+    create_brokers(3);
+    create_node_state(model::node_id{0});
+    create_node_state(model::node_id{1});
+    create_node_state(model::node_id{2});
+
+    auto f0 = get_barrier_state(model::node_id{0})
+                .barrier(feature_barrier_tag{"test"});
+    auto f1 = get_barrier_state(model::node_id{1})
+                .barrier(feature_barrier_tag{"test"});
+
+    BOOST_REQUIRE(!f0.available());
+    BOOST_REQUIRE(!f1.available());
+
+    auto f2 = get_barrier_state(model::node_id{2})
+                .barrier(feature_barrier_tag{"test"});
+
+    ss::sleep(10ms).get();
+
+    BOOST_REQUIRE(f0.available());
+    BOOST_REQUIRE(f1.available());
+    BOOST_REQUIRE(f2.available());
+
+    // Now that all three have started running, all should complete
+    f0.get();
+    f1.get();
+    f2.get();
+}
+
+FIXTURE_TEST(test_barrier_node_restart, barrier_fixture) {
+    create_brokers(3);
+    create_node_state(model::node_id{0});
+    create_node_state(model::node_id{1});
+    create_node_state(model::node_id{2});
+
+    // Nodes 1+2 enter the barrier
+    auto f0 = get_barrier_state(model::node_id{0})
+                .barrier(feature_barrier_tag{"test"});
+    auto f1 = get_barrier_state(model::node_id{1})
+                .barrier(feature_barrier_tag{"test"});
+
+    BOOST_REQUIRE(!f0.available());
+    BOOST_REQUIRE(!f1.available());
+
+    // Node 3 enters the barrier
+    auto f2 = get_barrier_state(model::node_id{2})
+                .barrier(feature_barrier_tag{"test"});
+
+    // Prompt reactor to process outstanding futures
+    ss::sleep(10ms).get();
+
+    BOOST_REQUIRE(f0.available());
+    BOOST_REQUIRE(f1.available());
+
+    // Prompt reactor to process outstanding futures
+    ss::sleep(10ms).get();
+
+    restart(model::node_id{2});
+    f2 = get_barrier_state(model::node_id{2})
+           .barrier(feature_barrier_tag{"test"});
+
+    // Prompt reactor to process outstanding futures
+    ss::sleep(10ms).get();
+
+    BOOST_REQUIRE(f2.available());
+
+    // All futures are ready.
+    f0.get();
+    f1.get();
+    f2.get();
+}
+
+FIXTURE_TEST(test_barrier_node_isolated, barrier_fixture) {
+    create_brokers(3);
+    create_node_state(model::node_id{0});
+    create_node_state(model::node_id{1});
+    create_node_state(model::node_id{2});
+
+    rpc_rx_errors[model::node_id{2}] = cluster::make_error_code(
+      cluster::errc::timeout);
+    rpc_tx_errors[model::node_id{2}] = cluster::make_error_code(
+      cluster::errc::timeout);
+
+    auto f0 = get_barrier_state(model::node_id{0})
+                .barrier(feature_barrier_tag{"test"});
+    auto f1 = get_barrier_state(model::node_id{1})
+                .barrier(feature_barrier_tag{"test"});
+    auto f2 = get_barrier_state(model::node_id{2})
+                .barrier(feature_barrier_tag{"test"});
+
+    // Without comms to node 2, this barrier should block to complete
+    ss::sleep(1000ms).get();
+
+    rpc_rx_errors.clear();
+    rpc_tx_errors.clear();
+
+    // After comms are restored the barrier should succeed (waiting for
+    // the retry period in barrier())
+    ss::sleep(1000ms).get();
+
+    BOOST_REQUIRE(f0.available());
+    BOOST_REQUIRE(f1.available());
+    BOOST_REQUIRE(f2.available());
+
+    f0.get();
+    f1.get();
+    f2.get();
+}

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1235,4 +1235,47 @@ adl<cluster::feature_update_cmd_data>::from(iobuf_parser& in) {
     return {.logical_version = logical_version, .actions = std::move(actions)};
 }
 
+void adl<cluster::feature_barrier_request>::to(
+  iobuf& out, cluster::feature_barrier_request&& r) {
+    reflection::serialize(out, r.current_version, r.tag, r.peer, r.entered);
+}
+
+cluster::feature_barrier_request
+adl<cluster::feature_barrier_request>::from(iobuf_parser& parser) {
+    auto version = adl<uint8_t>{}.from(parser);
+    vassert(
+      version == cluster::feature_barrier_request::current_version,
+      "Unexpected version: {} (expected {})",
+      version,
+      cluster::feature_update_action::current_version);
+
+    auto tag = adl<cluster::feature_barrier_tag>{}.from(parser);
+    auto peer = adl<model::node_id>{}.from(parser);
+    auto entered = adl<bool>{}.from(parser);
+
+    return cluster::feature_barrier_request{
+      .tag = std::move(tag), .peer = peer, .entered = entered};
+}
+
+void adl<cluster::feature_barrier_response>::to(
+  iobuf& out, cluster::feature_barrier_response&& r) {
+    reflection::serialize(out, r.current_version, r.entered, r.complete);
+}
+
+cluster::feature_barrier_response
+adl<cluster::feature_barrier_response>::from(iobuf_parser& parser) {
+    auto version = adl<uint8_t>{}.from(parser);
+    vassert(
+      version == cluster::feature_barrier_response::current_version,
+      "Unexpected version: {} (expected {})",
+      version,
+      cluster::feature_update_action::current_version);
+
+    auto entered = adl<bool>{}.from(parser);
+    auto complete = adl<bool>{}.from(parser);
+
+    return cluster::feature_barrier_response{
+      .entered = entered, .complete = complete};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -855,6 +855,20 @@ struct feature_action_response {
     errc error;
 };
 
+using feature_barrier_tag
+  = named_type<ss::sstring, struct feature_barrier_tag_type>;
+
+struct feature_barrier_request {
+    feature_barrier_tag tag; // Each cooperative barrier must use a unique tag
+    model::node_id peer;
+    bool entered; // Has the requester entered?
+};
+
+struct feature_barrier_response {
+    bool entered;  // Has the respondent entered?
+    bool complete; // Has the respondent exited?
+};
+
 struct create_non_replicable_topics_request {
     static constexpr int8_t current_version = 1;
     std::vector<non_replicable_topic> topics;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -859,12 +859,14 @@ using feature_barrier_tag
   = named_type<ss::sstring, struct feature_barrier_tag_type>;
 
 struct feature_barrier_request {
+    static constexpr int8_t current_version = 1;
     feature_barrier_tag tag; // Each cooperative barrier must use a unique tag
     model::node_id peer;
     bool entered; // Has the requester entered?
 };
 
 struct feature_barrier_response {
+    static constexpr int8_t current_version = 1;
     bool entered;  // Has the respondent entered?
     bool complete; // Has the respondent exited?
 };
@@ -1079,6 +1081,18 @@ template<>
 struct adl<cluster::feature_update_cmd_data> {
     void to(iobuf&, cluster::feature_update_cmd_data&&);
     cluster::feature_update_cmd_data from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::feature_barrier_request> {
+    void to(iobuf&, cluster::feature_barrier_request&&);
+    cluster::feature_barrier_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::feature_barrier_response> {
+    void to(iobuf&, cluster::feature_barrier_response&&);
+    cluster::feature_barrier_response from(iobuf_parser&);
 };
 
 } // namespace reflection


### PR DESCRIPTION
## Cover letter

This functionality helps with data migrations by providing a way to synchronize all nodes tightly prior to entering or existing a period of re-writing shared structures.

## Release notes

* none