### PR TITLE
Support for `__consumer_offsets` topic

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -96,6 +96,13 @@ public:
 
     ss::sharded<drain_manager>& get_drain_manager() { return _drain_manager; }
 
+    ss::sharded<partition_manager>& get_partition_manager() {
+        return _partition_manager;
+    }
+
+    ss::sharded<shard_table>& get_shard_table() { return _shard_table; }
+
+    ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
     ss::future<> wire_up();
 
     ss::future<> start();

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -18,6 +18,7 @@
 #include "cluster/fwd.h"
 #include "cluster/health_manager.h"
 #include "cluster/health_monitor_frontend.h"
+#include "cluster/partition_manager.h"
 #include "cluster/scheduling/leader_balancer.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/group_manager.h"
@@ -103,6 +104,14 @@ public:
     ss::sharded<shard_table>& get_shard_table() { return _shard_table; }
 
     ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
+
+    bool is_raft0_leader() const {
+        vassert(
+          ss::this_shard_id() == ss::shard_id(0),
+          "Raft 0 API can only be called from shard 0");
+        return _raft0->is_leader();
+    }
+
     ss::future<> wire_up();
 
     ss::future<> start();

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -121,6 +121,8 @@ private:
     ss::future<std::optional<cross_shard_move_request>>
       ask_remote_shard_for_initail_rev(model::ntp, ss::shard_id);
 
+    ss::future<> ack_remote_shard_partition_created(model::ntp, ss::shard_id);
+
     void housekeeping();
     void setup_metrics();
     ss::sharded<topic_table>& _topics;

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -58,6 +58,7 @@ enum class errc : int16_t {
     wating_for_partition_shutdown,
     error_collecting_health_report,
     leadership_changed,
+    feature_disabled,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -164,6 +165,8 @@ struct errc_category final : public std::error_category {
         case errc::leadership_changed:
             return "Raft group leadership has changed while waiting for action "
                    "to finish";
+        case errc::feature_disabled:
+            return "Requested feature is disabled";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -196,6 +196,10 @@ void health_manager::tick() {
 
                 if (ok) {
                     ok = co_await ensure_topic_replication(
+                      model::kafka_consumer_offsets_nt);
+                }
+                if (ok) {
+                    ok = co_await ensure_topic_replication(
                       model::id_allocator_nt);
                 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -12,6 +12,7 @@
 #include "cluster/logger.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/types.h"
@@ -58,10 +59,10 @@ partition::partition(
             _log_eviction_stm = ss::make_lw_shared<raft::log_eviction_stm>(
               _raft.get(), clusterlog, stm_manager, _as);
         }
-
-        bool is_group_ntp = _raft->ntp().ns == model::kafka_internal_namespace
-                            && _raft->ntp().tp.topic
-                                 == model::kafka_group_topic;
+        const model::topic_namespace tp_ns(
+          _raft->ntp().ns, _raft->ntp().tp.topic);
+        bool is_group_ntp = tp_ns == model::kafka_group_nt
+                            || tp_ns == model::kafka_consumer_offsets_nt;
 
         bool has_rm_stm = (_is_tx_enabled || _is_idempotence_enabled)
                           && model::controller_ntp != _raft->ntp()

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -22,6 +22,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
 #include "raft/group_configuration.h"
@@ -149,6 +150,11 @@ public:
     ss::future<std::error_code>
     transfer_leadership(std::optional<model::node_id> target) {
         return _raft->do_transfer_leadership(target);
+    }
+
+    ss::future<std::error_code>
+    request_leadership(model::timeout_clock::time_point timeout) {
+        return _raft->request_leadership(timeout);
     }
 
     ss::future<std::error_code> update_replica_set(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -136,6 +136,7 @@ partition_manager::do_shutdown(ss::lw_shared_ptr<partition> partition) {
     try {
         auto ntp = partition->ntp();
         co_await _raft_manager.local().shutdown(partition->raft());
+        _unmanage_watchers.notify(ntp, ntp.tp.partition);
         co_await partition->stop();
         co_await _storage.log_mgr().shutdown(partition->ntp());
     } catch (...) {

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -592,6 +592,9 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
   model::ntp ntp,
   std::vector<model::broker_shard> new_replica_set,
   model::timeout_clock::time_point tout) {
+    if (_partition_movement_disabled) {
+        return ss::make_ready_future<std::error_code>(errc::feature_disabled);
+    }
     move_partition_replicas_cmd cmd(std::move(ntp), std::move(new_replica_set));
 
     return replicate_and_wait(_stm, _as, std::move(cmd), tout);

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -79,6 +79,9 @@ public:
 
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
 
+    void disable_partition_movement() { _partition_movement_disabled = true; }
+    void enable_partition_movement() { _partition_movement_disabled = false; }
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -130,6 +133,7 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<data_policy_frontend>& _dp_frontend;
     ss::sharded<ss::abort_source>& _as;
+    bool _partition_movement_disabled = false;
 };
 
 } // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -461,7 +461,8 @@ struct topic_configuration {
       model::initial_revision_id) const;
 
     bool is_internal() const {
-        return tp_ns.ns == model::kafka_internal_namespace;
+        return tp_ns.ns == model::kafka_internal_namespace
+               || tp_ns == model::kafka_consumer_offsets_nt;
     }
 
     model::topic_namespace tp_ns;

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -61,6 +61,7 @@ v_cc_library(
     server/partition_proxy.cc
     server/group_recovery_consumer.cc
     server/group_metadata.cc
+    server/group_metadata_migration.cc
  DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/kafka/server/coordinator_ntp_mapper.h
+++ b/src/v/kafka/server/coordinator_ntp_mapper.h
@@ -43,9 +43,11 @@ namespace kafka {
  */
 class coordinator_ntp_mapper {
 public:
-    explicit coordinator_ntp_mapper(ss::sharded<cluster::metadata_cache>& md)
+    explicit coordinator_ntp_mapper(
+      ss::sharded<cluster::metadata_cache>& md,
+      model::topic_namespace group_topic)
       : _md(md)
-      , _tp_ns(model::kafka_internal_namespace, model::kafka_group_topic) {}
+      , _tp_ns(std::move(group_topic)) {}
 
     std::optional<model::ntp> ntp_for(const kafka::group_id& group) const {
         auto md = _md.local().get_topic_metadata(_tp_ns);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -71,6 +71,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::wating_for_partition_shutdown:
     case cluster::errc::error_collecting_health_report:
     case cluster::errc::leadership_changed:
+    case cluster::errc::feature_disabled:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -32,13 +32,17 @@
 namespace kafka {
 
 group_manager::group_manager(
+  model::topic_namespace tp_ns,
   ss::sharded<raft::group_manager>& gm,
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<cluster::topic_table>& topic_table,
+  group_metadata_serializer_factory serializer_factory,
   config::configuration& conf)
-  : _gm(gm)
+  : _tp_ns(std::move(tp_ns))
+  , _gm(gm)
   , _pm(pm)
   , _topic_table(topic_table)
+  , _serializer_factory(std::move(serializer_factory))
   , _conf(conf)
   , _self(cluster::make_self_broker(config::node())) {}
 
@@ -49,18 +53,13 @@ ss::future<> group_manager::start() {
      * synchronously invoked for all existing partitions that match the query.
      */
     _manage_notify_handle = _pm.local().register_manage_notification(
-      model::kafka_internal_namespace,
-      model::kafka_group_topic,
-      [this](ss::lw_shared_ptr<cluster::partition> p) {
+      _tp_ns.ns, _tp_ns.tp, [this](ss::lw_shared_ptr<cluster::partition> p) {
           attach_partition(std::move(p));
       });
 
     _unmanage_notify_handle = _pm.local().register_unmanage_notification(
-      model::kafka_internal_namespace,
-      model::kafka_group_topic,
-      [this](model::partition_id p_id) {
-          detach_partition(model::ntp(
-            model::kafka_internal_namespace, model::kafka_group_topic, p_id));
+      _tp_ns.ns, _tp_ns.tp, [this](model::partition_id p_id) {
+          detach_partition(model::ntp(_tp_ns.ns, _tp_ns.tp, p_id));
       });
 
     /*
@@ -322,8 +321,7 @@ ss::future<> group_manager::handle_partition_leader_change(
                           model::record_batch_reader reader) {
                       return std::move(reader)
                         .consume(
-                          group_recovery_consumer(
-                            make_backward_compatible_serializer(), p->as),
+                          group_recovery_consumer(_serializer_factory(), p->as),
                           timeout)
                         .then([this, term, p](
                                 group_recovery_consumer_state state) {
@@ -372,7 +370,7 @@ ss::future<> group_manager::recover_partition(
                   group_stm.get_metadata(),
                   _conf,
                   p->partition,
-                  make_backward_compatible_serializer());
+                  _serializer_factory());
                 group->reset_tx_state(term);
                 _groups.emplace(group_id, group);
                 group->reschedule_all_member_heartbeats();
@@ -405,7 +403,7 @@ ss::future<> group_manager::recover_partition(
               group_state::empty,
               _conf,
               p->partition,
-              make_backward_compatible_serializer());
+              _serializer_factory());
             group->reset_tx_state(term);
             _groups.emplace(group_id, group);
         }
@@ -496,11 +494,7 @@ group_manager::join_group(join_group_request&& r) {
         }
         auto p = it->second->partition;
         group = ss::make_lw_shared<kafka::group>(
-          r.data.group_id,
-          group_state::empty,
-          _conf,
-          p,
-          make_backward_compatible_serializer());
+          r.data.group_id, group_state::empty, _conf, p, _serializer_factory());
         group->reset_tx_state(it->second->term);
         _groups.emplace(r.data.group_id, group);
         _groups.rehash(0);
@@ -633,7 +627,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 group_state::empty,
                 _conf,
                 p->partition,
-                make_backward_compatible_serializer());
+                _serializer_factory());
               group->reset_tx_state(p->term);
               _groups.emplace(r.data.group_id, group);
               _groups.rehash(0);
@@ -716,7 +710,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 group_state::empty,
                 _conf,
                 p->partition,
-                make_backward_compatible_serializer());
+                _serializer_factory());
               group->reset_tx_state(p->term);
               _groups.emplace(r.group_id, group);
               _groups.rehash(0);
@@ -821,7 +815,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               group_state::empty,
               _conf,
               p->partition,
-              make_backward_compatible_serializer());
+              _serializer_factory());
             group->reset_tx_state(p->term);
             _groups.emplace(r.data.group_id, group);
             _groups.rehash(0);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -167,6 +167,8 @@ public:
     ss::future<std::vector<deletable_group_result>>
       delete_groups(std::vector<std::pair<model::ntp, group_id>>);
 
+    ss::future<> reload_groups();
+
 public:
     error_code validate_group_status(
       const model::ntp& ntp, const group_id& group, api_key api);

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -231,6 +231,14 @@ std::optional<T> read_optional_value(std::optional<request_reader>& reader) {
     }
     return T::decode(*reader);
 }
+
+template<typename T>
+iobuf metadata_to_iobuf(const T& t) {
+    iobuf buffer;
+    response_writer writer(buffer);
+    T::encode(writer, t);
+    return buffer;
+}
 } // namespace
 
 group_metadata_serializer make_backward_compatible_serializer() {
@@ -377,6 +385,61 @@ group_metadata_serializer make_backward_compatible_serializer() {
                   .commit_timestamp = model::timestamp(-1),
                 };
             }
+            return ret;
+        }
+    };
+    return group_metadata_serializer(std::make_unique<impl>());
+}
+
+group_metadata_serializer make_consumer_offsets_serializer() {
+    struct impl final : group_metadata_serializer::impl {
+        group_metadata_type get_metadata_type(iobuf buffer) final {
+            auto reader = request_reader(std::move(buffer));
+            return decode_metadata_type(reader);
+        };
+
+        group_metadata_serializer::key_value to_kv(group_metadata_kv md) final {
+            group_metadata_serializer::key_value ret;
+            ret.key = metadata_to_iobuf(md.key);
+            if (md.value) {
+                ret.value = metadata_to_iobuf(*md.value);
+            }
+
+            return ret;
+        }
+
+        group_metadata_serializer::key_value
+        to_kv(offset_metadata_kv md) final {
+            group_metadata_serializer::key_value ret;
+            ret.key = metadata_to_iobuf(md.key);
+            if (md.value) {
+                ret.value = metadata_to_iobuf(*md.value);
+            }
+
+            return ret;
+        }
+
+        group_metadata_kv decode_group_metadata(model::record record) final {
+            group_metadata_kv ret;
+            request_reader k_reader(record.release_key());
+            ret.key = group_metadata_key::decode(k_reader);
+            if (record.has_value()) {
+                request_reader v_reader(record.release_value());
+                ret.value = group_metadata_value::decode(v_reader);
+            }
+
+            return ret;
+        }
+
+        offset_metadata_kv decode_offset_metadata(model::record record) final {
+            offset_metadata_kv ret;
+            request_reader k_reader(record.release_key());
+            ret.key = offset_metadata_key::decode(k_reader);
+            if (record.has_value()) {
+                request_reader v_reader(record.release_value());
+                ret.value = offset_metadata_value::decode(v_reader);
+            }
+
             return ret;
         }
     };

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -300,6 +300,8 @@ private:
 
 group_metadata_serializer make_backward_compatible_serializer();
 
+group_metadata_serializer make_consumer_offsets_serializer();
+
 } // namespace kafka
 
 namespace std {

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -21,6 +21,8 @@
 #include "seastarx.h"
 #include "utils/named_type.h"
 
+#include <seastar/util/noncopyable_function.hh>
+
 namespace kafka {
 namespace old {
 /**
@@ -301,6 +303,9 @@ private:
 group_metadata_serializer make_backward_compatible_serializer();
 
 group_metadata_serializer make_consumer_offsets_serializer();
+
+using group_metadata_serializer_factory
+  = ss::noncopyable_function<group_metadata_serializer()>;
 
 } // namespace kafka
 

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -1,0 +1,697 @@
+#include "kafka/server/group_metadata_migration.h"
+
+#include "cluster/controller.h"
+#include "cluster/controller_api.h"
+#include "cluster/feature_manager.h"
+#include "cluster/feature_table.h"
+#include "cluster/fwd.h"
+#include "cluster/partition.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "cluster/topic_table.h"
+#include "cluster/topics_frontend.h"
+#include "kafka/server/group_metadata.h"
+#include "kafka/server/group_recovery_consumer.h"
+#include "kafka/server/group_router.h"
+#include "kafka/server/logger.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "ssx/future-util.h"
+#include "storage/record_batch_builder.h"
+#include "storage/types.h"
+#include "storage/utils/transforming_reader.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <algorithm>
+
+namespace kafka {
+static ss::logger mlog("group-metadata-migration");
+
+group_metadata_migration::group_metadata_migration(
+  cluster::controller& controller,
+  ss::sharded<kafka::group_router>& group_router)
+  : _controller(controller)
+  , _group_router(group_router) {}
+
+const cluster::feature_barrier_tag
+  group_metadata_migration::preparing_barrier_tag{"consumer_offsets_preparing"};
+
+const cluster::feature_barrier_tag group_metadata_migration::active_barrier_tag{
+  "consumer_offsets_active"};
+
+static constexpr std::chrono::seconds default_wait_time(3);
+
+namespace {
+ss::future<std::optional<model::record_batch>>
+transform_batch(model::record_batch batch) {
+    if (batch.header().type == model::record_batch_type::raft_configuration) {
+        // replace raft configuration with an empty checkpoint batch, the empty
+        // batch will simply be ignored but the source and target topic offsets
+        // will match
+        co_return std::nullopt;
+    }
+
+    if (batch.header().type == model::record_batch_type::raft_data) {
+        auto source_serializer = kafka::make_backward_compatible_serializer();
+        auto target_serializer = kafka::make_consumer_offsets_serializer();
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset{});
+
+        for (auto& r : batch.copy_records()) {
+            auto tp = source_serializer.get_metadata_type(r.share_key());
+            switch (tp) {
+            case group_metadata_type::group_metadata: {
+                auto md = source_serializer.decode_group_metadata(std::move(r));
+                auto kv = target_serializer.to_kv(std::move(md));
+                builder.add_raw_kv(std::move(kv.key), std::move(kv.value));
+                break;
+            }
+            case group_metadata_type::offset_commit: {
+                auto md = source_serializer.decode_offset_metadata(
+                  std::move(r));
+                auto kv = target_serializer.to_kv(std::move(md));
+                builder.add_raw_kv(std::move(kv.key), std::move(kv.value));
+                break;
+            }
+            case noop:
+                // skip over noop batches, they do not change the group state
+                break;
+            }
+        }
+
+        co_return std::move(builder).build();
+    }
+    co_return std::move(batch);
+}
+
+ss::future<bool> create_consumer_offsets_topic(
+  cluster::controller& controller,
+  std::vector<cluster::partition_assignment> assignments,
+  model::timeout_clock::time_point timeout) {
+    cluster::custom_assignable_topic_configuration topic(
+      cluster::topic_configuration{
+        model::kafka_consumer_offsets_nt.ns,
+        model::kafka_consumer_offsets_nt.tp,
+        static_cast<int32_t>(assignments.size()),
+        static_cast<int16_t>(assignments.front().replicas.size())});
+    topic.cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    for (auto& p_as : assignments) {
+        cluster::custom_partition_assignment custom{.id = p_as.id};
+        custom.replicas.reserve(p_as.replicas.size());
+        for (auto bs : p_as.replicas) {
+            custom.replicas.push_back(bs.node_id);
+        }
+        topic.custom_assignments.push_back(std::move(custom));
+    }
+
+    return controller.get_topics_frontend()
+      .local()
+      .create_topics({std::move(topic)}, timeout)
+      .then([](std::vector<cluster::topic_result> res) {
+          /*
+           * kindly ask client to retry on error
+           */
+          vassert(res.size() == 1, "expected exactly one result");
+          if (res[0].ec != cluster::errc::success) {
+              vlog(
+                mlog.warn,
+                "can not create __consumer_offsets topic - {}",
+                res[0].ec);
+              return false;
+          }
+          return true;
+      })
+      .then([&controller, timeout](bool success) {
+          if (success) {
+              return controller.get_api()
+                .local()
+                .wait_for_topic(model::kafka_consumer_offsets_nt, timeout)
+                .then([](std::error_code ec) { return !ec; });
+          }
+          return ss::make_ready_future<bool>(success);
+      })
+      .handle_exception([](const std::exception_ptr& e) {
+          vlog(mlog.warn, "can not create __consumer_offsets topic - {}", e);
+          // various errors may returned such as a timeout, or if the
+          // controller group doesn't have a leader. client will retry.
+          return false;
+      });
+}
+
+ss::future<group_recovery_consumer_state> recover_group_state(
+  model::ntp ntp,
+  ss::shard_id shard,
+  ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<ss::abort_source>& as,
+  group_metadata_serializer_factory serializer_f) {
+    using ret_t = group_recovery_consumer_state;
+    return pm.invoke_on(
+      shard,
+      [ntp = std::move(ntp), &as, serializer_f = std::move(serializer_f)](
+        cluster::partition_manager& pm) mutable {
+          auto p = pm.get(ntp);
+          if (!p) {
+              return ss::make_ready_future<ret_t>(ret_t{});
+          }
+          auto reader_cfg = storage::log_reader_config(
+            p->start_offset(),
+            model::offset::max(),
+            ss::default_priority_class());
+
+          return p->make_reader(reader_cfg)
+            .then([&as = as.local(), serializer_f = std::move(serializer_f)](
+                    model::record_batch_reader reader) mutable {
+                return std::move(reader).consume(
+                  group_recovery_consumer(serializer_f(), as),
+                  model::no_timeout);
+            });
+      });
+}
+
+bool are_offsets_equal(
+  const group::offset_metadata& lhs, const group::offset_metadata& rhs) {
+    return lhs.metadata == rhs.metadata && lhs.offset == rhs.offset
+           && lhs.committed_leader_epoch == rhs.committed_leader_epoch;
+}
+bool are_stms_equivalent(const group_stm& source, const group_stm& target) {
+    if (source.get_metadata() != target.get_metadata()) {
+        vlog(
+          mlog.debug,
+          "source and target group metadata does not match, source: {}, "
+          "target: {}",
+          source.get_metadata(),
+          target.get_metadata());
+        return false;
+    }
+    if (source.offsets().size() != target.offsets().size()) {
+        return false;
+    }
+    for (auto& [tp, o] : source.offsets()) {
+        auto it = target.offsets().find(tp);
+        if (it == target.offsets().end()) {
+            vlog(
+              mlog.debug,
+              "unable to find offset for {} in target group offsets",
+              tp);
+            return false;
+        }
+        if (it->second.metadata != o.metadata) {
+            vlog(
+              mlog.debug,
+              "{} offsets does not match. source: {}, target {}",
+              tp,
+              o.metadata,
+              it->second.metadata);
+            return false;
+        }
+    }
+
+    if (source.fences() != target.fences()) {
+        vlog(mlog.debug, "group fences does not match");
+        return false;
+    }
+
+    if (source.prepared_txs().size() != target.prepared_txs().size()) {
+        return false;
+    }
+
+    for (auto& [tp, tx] : source.prepared_txs()) {
+        auto it = target.prepared_txs().find(tp);
+        if (it == target.prepared_txs().end()) {
+            vlog(
+              mlog.debug,
+              "unable to find preppared txs for {} in target group state",
+              tp);
+            return false;
+        }
+        if (it->second.tx_seq != tx.tx_seq || tx.pid != it->second.pid) {
+            return false;
+        }
+        if (tx.offsets.size() != it->second.offsets.size()) {
+            return false;
+        }
+
+        for (auto& [offset_tp, o] : tx.offsets) {
+            auto oit = it->second.offsets.find(offset_tp);
+            if (oit == it->second.offsets.end()) {
+                return false;
+            }
+            if (!are_offsets_equal(oit->second, o)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool are_states_equivalent(
+  const group_recovery_consumer_state& source,
+  const group_recovery_consumer_state& target) {
+    if (source.groups.size() != target.groups.size()) {
+        return false;
+    }
+
+    for (auto& [g, stm] : source.groups) {
+        auto it = target.groups.find(g);
+        if (it == target.groups.end()) {
+            vlog(mlog.debug, "group {} not found in target group state", g);
+            return false;
+        }
+        if (!are_stms_equivalent(stm, it->second)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+ss::future<std::error_code> replicate(
+  ss::shard_id shard,
+  model::record_batch_reader reader,
+  ss::sharded<cluster::partition_manager>& pm,
+  model::ntp ntp) {
+    auto f_reader = make_foreign_record_batch_reader(std::move(reader));
+    return pm.invoke_on(
+      shard,
+      [ntp = std::move(ntp),
+       f_reader = std::move(f_reader)](cluster::partition_manager& pm) mutable {
+          return pm.get(ntp)
+            ->replicate(
+              std::move(f_reader),
+              raft::replicate_options(raft::consistency_level::quorum_ack))
+            .then([ntp](result<raft::replicate_result> res) {
+                if (res) {
+                    vlog(
+                      mlog.info,
+                      "replicated {} data up to {} offset",
+                      ntp,
+                      res.value().last_offset);
+                    return raft::make_error_code(raft::errc::success);
+                }
+                return res.error();
+            });
+      });
+}
+
+bool is_source_partition_ready(const ss::lw_shared_ptr<cluster::partition>& p) {
+    if (!p->is_leader()) {
+        vlog(mlog.info, "not yet leader for source partition: {}", p->ntp());
+        return false;
+    }
+
+    if (p->dirty_offset() > p->committed_offset()) {
+        vlog(
+          mlog.info,
+          "partition {} dirty offset {} is greater than committed offset {}",
+          p->ntp(),
+          p->dirty_offset(),
+          p->committed_offset());
+        return false;
+    }
+    return true;
+}
+
+ss::future<> do_dispatch_ntp_migration(
+  model::ntp ntp,
+  ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<cluster::shard_table>& st,
+  ss::sharded<ss::abort_source>& as) {
+    auto source = pm.local().get(ntp);
+    /**
+     * not every node contain a replica of __consumer_offsets topic
+     */
+    if (!source) {
+        co_return;
+    }
+
+    model::ntp target_ntp(
+      model::kafka_consumer_offsets_nt.ns,
+      model::kafka_consumer_offsets_nt.tp,
+      source->ntp().tp.partition);
+
+    auto target_shard = st.local().shard_for(target_ntp);
+    if (!target_shard) {
+        vlog(mlog.error, "unable to find shard for {}", target_ntp);
+        co_return;
+    }
+
+    /**
+     * Transform data from source to target partition, this loop is being
+     * executed on all of the nodes until we reach the point in which last batch
+     * of source and target partition matches. This replication can not be based
+     * on offsets since source topic is compacted.
+     */
+    bool is_state_equal = false;
+    group_recovery_consumer_state source_state;
+
+    while (!(is_state_equal || as.local().abort_requested())) {
+        try {
+            auto target_is_leader = co_await pm.invoke_on(
+              *target_shard, [target_ntp](cluster::partition_manager& pm) {
+                  return pm.get(target_ntp)->is_leader();
+              });
+            vlog(
+              mlog.info,
+              "transforming data from {} to {} - is leader: {}",
+              source->ntp(),
+              target_ntp,
+              target_is_leader);
+
+            if (target_is_leader) {
+                // check source partition status
+                if (!is_source_partition_ready(source)) {
+                    vlog(
+                      mlog.info,
+                      "waiting for source partition {} to become a leader",
+                      source->ntp());
+                    auto err = co_await source->request_leadership(
+                      model::timeout_clock::now() + default_wait_time);
+                    if (err) {
+                        vlog(
+                          mlog.warn,
+                          "error requesting leadership for {} - {}",
+                          source->ntp(),
+                          err.message());
+                        co_await ss::sleep_abortable(
+                          default_wait_time, as.local());
+                    }
+                    continue;
+                }
+                source_state = co_await recover_group_state(
+                  source->ntp(),
+                  ss::this_shard_id(),
+                  pm,
+                  as,
+                  make_backward_compatible_serializer);
+                // no groups to migrate, return early
+                if (source_state.groups.empty()) {
+                    vlog(
+                      mlog.info,
+                      "finished migrating {}, no groups to migrate ",
+                      source->ntp());
+                    co_return;
+                }
+                auto reader_cfg = storage::log_reader_config(
+                  source->start_offset(),
+                  model::offset::max(),
+                  ss::default_priority_class());
+
+                auto rdr = co_await source->make_reader(reader_cfg);
+
+                auto t_rdr = storage::make_transforming_reader(
+                  std::move(rdr), transform_batch);
+
+                if (t_rdr.is_end_of_stream()) {
+                    continue;
+                }
+                auto err = co_await replicate(
+                  *target_shard, std::move(t_rdr), pm, target_ntp);
+
+                if (err) {
+                    vlog(
+                      mlog.warn,
+                      "migration of {} failed with error: {}",
+                      target_ntp,
+                      err.message());
+                    co_await ss::sleep_abortable(default_wait_time, as.local());
+                    continue;
+                } else {
+                    vlog(
+                      mlog.info,
+                      "successfully replicated migrated data for {}",
+                      target_ntp);
+                }
+            } else {
+                co_await ss::sleep_abortable(default_wait_time, as.local());
+            }
+            auto target_state = co_await recover_group_state(
+              target_ntp,
+              *target_shard,
+              pm,
+              as,
+              make_consumer_offsets_serializer);
+            /**
+             * Read source state once again to make sure that we are up to date,
+             * (we read state from the follower so it might have changed)
+             */
+            source_state = co_await recover_group_state(
+              source->ntp(),
+              ss::this_shard_id(),
+              pm,
+              as,
+              make_backward_compatible_serializer);
+            is_state_equal = are_states_equivalent(source_state, target_state);
+
+        } catch (...) {
+            vlog(
+              mlog.warn,
+              "error while migrating {} to {} - {}",
+              source->ntp(),
+              target_ntp,
+              std::current_exception());
+        }
+    }
+    vlog(mlog.info, "finished migrating {}", source->ntp());
+}
+
+ss::future<> dispatch_ntps_migration(
+  std::vector<model::ntp> ntps,
+  ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<cluster::shard_table>& st,
+  ss::sharded<ss::abort_source>& as) {
+    for (auto& ntp : ntps) {
+        co_await do_dispatch_ntp_migration(std::move(ntp), pm, st, as);
+    }
+}
+
+bool are_all_finished(
+  const std::vector<cluster::ntp_reconciliation_state>& state) {
+    return std::all_of(
+      state.begin(),
+      state.end(),
+      [](const cluster::ntp_reconciliation_state& r_state) {
+          return r_state.status() == cluster::reconciliation_status::done;
+      });
+}
+
+ss::future<> wait_for_stable_group_topic(
+  cluster::controller_api& api, ss::abort_source& as) {
+    auto result = co_await api.get_reconciliation_state(model::kafka_group_nt);
+    while (result.has_error() || !are_all_finished(result.value())) {
+        if (result.has_error()) {
+            vlog(
+              mlog.warn,
+              "unable to get kafka_internal/group reconciliation status - {}",
+              result.error());
+        } else {
+            vlog(
+              mlog.debug,
+              "waiting for partition operations to finish, current state: {}",
+              result.value());
+        }
+
+        co_await ss::sleep_abortable(default_wait_time, as);
+        result = co_await api.get_reconciliation_state(model::kafka_group_nt);
+    }
+}
+
+} // namespace
+
+cluster::feature_table& group_metadata_migration::feature_table() {
+    return _controller.get_feature_table().local();
+}
+
+cluster::feature_manager& group_metadata_migration::feature_manager() {
+    return _controller.get_feature_manager().local();
+}
+ss::abort_source& group_metadata_migration::abort_source() {
+    return _controller.get_abort_source().local();
+}
+
+ss::future<> group_metadata_migration::activate_feature(ss::abort_source& as) {
+    vlog(mlog.info, "activating consumer offsets feature");
+    while (!feature_table().is_active(cluster::feature::consumer_offsets)
+           && !as.abort_requested()) {
+        if (_controller.is_raft0_leader()) {
+            auto err = co_await feature_manager().write_action(
+              cluster::feature_update_action{
+                .feature_name = ss::sstring(
+                  _controller.get_feature_table()
+                    .local()
+                    .get_state(cluster::feature::consumer_offsets)
+                    .spec.name),
+                .action
+                = cluster::feature_update_action::action_t::complete_preparing,
+              });
+
+            if (
+              err
+              || !feature_table().is_active(
+                cluster::feature::consumer_offsets)) {
+                if (err) {
+                    vlog(
+                      mlog.info,
+                      "error activating consumer offsets feature: {}",
+                      err.message());
+                }
+                co_await ss::sleep_abortable(default_timeout, as);
+            }
+        } else {
+            co_await ss::sleep_abortable(default_timeout, as);
+        }
+    }
+}
+
+ss::future<> group_metadata_migration::do_apply() {
+    vlog(
+      mlog.info,
+      "waiting for consumer offsets feature to be preparing - current "
+      "state: {}",
+      _controller.get_feature_table()
+        .local()
+        .get_state(cluster::feature::consumer_offsets)
+        .get_state());
+    co_await feature_table().await_feature_preparing(
+      cluster::feature::consumer_offsets, abort_source());
+    vlog(mlog.info, "disabling partition movement feature and group router");
+    co_await _group_router.invoke_on_all(&group_router::disable);
+    co_await _controller.get_topics_frontend().invoke_on_all(
+      &cluster::topics_frontend::disable_partition_movement);
+    vlog(mlog.info, "waiting for stable consumer group topic");
+    co_await wait_for_stable_group_topic(
+      _controller.get_api().local(), _controller.get_abort_source().local());
+    vlog(mlog.info, "applying consumer groups migrations");
+    co_await migrate_metadata();
+    vlog(mlog.info, "waiting for all migrations to finish");
+    co_await feature_manager().barrier(active_barrier_tag);
+    vlog(mlog.info, "finishing migration - enabling consumer offsets feature");
+
+    co_await activate_feature(_controller.get_abort_source().local());
+
+    co_await feature_table().await_feature(
+      cluster::feature::consumer_offsets, abort_source());
+    co_await _group_router.invoke_on_all([](group_router& router) {
+        return router.get_group_manager().local().reload_groups();
+    });
+    vlog(mlog.info, "consumer offset feature enabled");
+    co_await _group_router.invoke_on_all(&group_router::enable);
+    co_await _controller.get_topics_frontend().invoke_on_all(
+      &cluster::topics_frontend::enable_partition_movement);
+}
+
+ss::future<> group_metadata_migration::migrate_metadata() {
+    auto& topics = _controller.get_topics_state().local();
+    auto group_topic_assignment = topics.get_topic_assignments(
+      model::kafka_group_nt);
+    // no group topic found, skip migration
+    if (!group_topic_assignment) {
+        co_return;
+    }
+    auto partitions = group_topic_assignment->size();
+
+    // create consumer offsets topic based on the old configuration
+    while (!topics.contains(
+      model::kafka_consumer_offsets_nt, model::partition_id{0})) {
+        if (_controller.is_raft0_leader()) {
+            vlog(mlog.info, "creating consumer offsets topic");
+            co_await create_consumer_offsets_topic(
+              _controller,
+              std::move(*group_topic_assignment),
+              default_deadline());
+            continue;
+        }
+
+        co_await ss::sleep_abortable(
+          default_timeout, _controller.get_abort_source().local());
+    }
+
+    vlog(mlog.info, "waiting for preparing barrier");
+    co_await feature_manager().barrier(preparing_barrier_tag);
+
+    absl::node_hash_map<ss::shard_id, std::vector<model::ntp>> shard_ntps;
+    for (int16_t p_id = 0; p_id < static_cast<int16_t>(partitions); ++p_id) {
+        model::ntp ntp(
+          model::kafka_group_nt.ns,
+          model::kafka_group_nt.tp,
+          model::partition_id(p_id));
+
+        auto shard_id = _controller.get_shard_table().local().shard_for(ntp);
+
+        if (shard_id) {
+            shard_ntps[*shard_id].push_back(std::move(ntp));
+        }
+    }
+
+    for (auto& [shard, ntps] : shard_ntps) {
+        ssx::spawn_with_gate(
+          _partitions_gate, [this, shard = shard, ntps = ntps]() mutable {
+              vlog(
+                mlog.info,
+                "dispatching {} ntps migration on shard: {}",
+                ntps.size(),
+                shard);
+              return ss::smp::submit_to(
+                shard,
+                [&pm = _controller.get_partition_manager(),
+                 &st = _controller.get_shard_table(),
+                 &as = _controller.get_abort_source(),
+                 ntps = std::move(ntps)]() mutable -> ss::future<> {
+                    return dispatch_ntps_migration(std::move(ntps), pm, st, as);
+                });
+          });
+    }
+
+    co_await _partitions_gate.close();
+
+    vlog(mlog.info, "finished migrating kafka_internal/group partitions");
+}
+
+ss::future<> group_metadata_migration::start(ss::abort_source& as) {
+    // if version is overriden for test purposes - skip migration
+    if (
+      feature_table().get_latest_logical_version()
+      < cluster::cluster_version{2}) {
+        co_return;
+    }
+    if (feature_table().is_active(cluster::feature::consumer_offsets)) {
+        feature_manager().exit_barrier(preparing_barrier_tag);
+        feature_manager().exit_barrier(active_barrier_tag);
+        co_return;
+    }
+
+    // if no group topic is present just make feature active
+    if (!_controller.get_topics_state().local().contains(
+          model::kafka_group_nt, model::partition_id{0})) {
+        vlog(
+          mlog.info,
+          "kafka_internal/group topic does not exists, activating "
+          "consumer_offsets feature");
+        try {
+            co_await activate_feature(as);
+        } catch (const ss::abort_requested_exception&) {
+            // ignore abort requested exception, we are shutting down
+        }
+        co_return;
+    }
+    // otherwise wait for feature to be preparing and execute migration
+    ssx::spawn_with_gate(
+      _background_gate, [this]() -> ss::future<> { return do_apply(); });
+    co_return;
+}
+
+// awaits for the migration to finish
+ss::future<> group_metadata_migration::await() {
+    return _background_gate.close();
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/group_metadata_migration.h
+++ b/src/v/kafka/server/group_metadata_migration.h
@@ -1,0 +1,67 @@
+
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "kafka/server/fwd.h"
+#include "model/fundamental.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <chrono>
+
+#pragma once
+
+namespace kafka {
+
+struct group_metadata_migration {
+public:
+    group_metadata_migration(
+      cluster::controller&, ss::sharded<kafka::group_router>&);
+
+    // starts the migration process
+    ss::future<> start(ss::abort_source&);
+
+    // awaits for the migration to finish
+    ss::future<> await();
+
+private:
+    static constexpr auto default_timeout = std::chrono::seconds(5);
+
+    static const cluster::feature_barrier_tag preparing_barrier_tag;
+    static const cluster::feature_barrier_tag active_barrier_tag;
+
+    model::timeout_clock::time_point default_deadline() {
+        return model::timeout_clock::now() + default_timeout;
+    }
+
+    ss::future<> do_apply();
+    ss::future<> migrate_metadata();
+    ss::future<> activate_feature(ss::abort_source&);
+
+    void dispatch_ntp_migration(model::ntp);
+
+    cluster::feature_table& feature_table();
+    cluster::feature_manager& feature_manager();
+    ss::abort_source& abort_source();
+
+    cluster::controller& _controller;
+    ss::sharded<kafka::group_router>& _group_router;
+    ss::gate _partitions_gate;
+    ss::gate _background_gate;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -21,7 +21,7 @@ group_router::route_delete_groups(
   ss::shard_id shard, std::vector<std::pair<model::ntp, group_id>> groups) {
     return ss::with_scheduling_group(
       _sg, [this, shard, groups = std::move(groups)]() mutable {
-          return _group_manager.invoke_on(
+          return get_group_manager().invoke_on(
             shard,
             _ssg,
             [groups = std::move(groups)](group_manager& mgr) mutable {

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -51,6 +51,14 @@ group_router::delete_groups(std::vector<group_id> groups) {
     // partition groups by owner shard
     sharded_groups groups_by_shard;
     for (auto& group : groups) {
+        if (unlikely(_disabled)) {
+            results.push_back(deletable_group_result{
+              .group_id = std::move(group),
+              .error_code = error_code::not_coordinator,
+            });
+            continue;
+        }
+
         if (auto m = shard_for(group); m) {
             groups_by_shard[m->second].emplace_back(
               std::make_pair(std::move(m->first), std::move(group)));

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -262,10 +262,18 @@ public:
     void disable() { _disabled = true; }
 
     void enable() { _disabled = false; }
-    
+
     void set_use_consumer_offsets_topic(bool value) {
         _use_consumer_offsets_topic = value;
     }
+
+    ss::sharded<group_manager>& get_group_manager() {
+        if (use_consumer_offsets_topic()) {
+            return _consumer_offsets_group_manager;
+        }
+        return _group_manager;
+    }
+
 private:
     using sharded_groups = absl::
       node_hash_map<ss::shard_id, std::vector<std::pair<model::ntp, group_id>>>;
@@ -279,14 +287,6 @@ private:
         }
         return std::nullopt;
     }
-
-    ss::sharded<group_manager>& get_group_manager() {
-        if (use_consumer_offsets_topic()) {
-            return _consumer_offsets_group_manager;
-        }
-        return _group_manager;
-    }
-
     bool use_consumer_offsets_topic() { return _use_consumer_offsets_topic; }
     ss::future<std::vector<deletable_group_result>> route_delete_groups(
       ss::shard_id, std::vector<std::pair<model::ntp, group_id>>);

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -248,6 +248,10 @@ public:
     ss::future<std::vector<deletable_group_result>>
     delete_groups(std::vector<group_id> groups);
 
+    ss::sharded<coordinator_ntp_mapper>& coordinator_mapper() {
+        return _coordinators;
+    }
+
 private:
     using sharded_groups = absl::
       node_hash_map<ss::shard_id, std::vector<std::pair<model::ntp, group_id>>>;

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -100,6 +100,8 @@ public:
 
     group_metadata_value& get_metadata() { return _metadata; }
 
+    const group_metadata_value& get_metadata() const { return _metadata; }
+
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
     absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -21,6 +21,7 @@
 #include "kafka/types.h"
 #include "likely.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "model/timeout_clock.h"
 #include "utils/to_string.h"
 
@@ -88,13 +89,21 @@ std::optional<cluster::leader_term> get_leader_term(
     return leader_term;
 }
 
+namespace {
+bool is_internal(const model::topic_namespace& tp_ns) {
+    return tp_ns == model::kafka_consumer_offsets_nt;
+}
+
+} // namespace
+
 metadata_response::topic make_topic_response_from_topic_metadata(
   const cluster::metadata_cache& md_cache, model::topic_metadata&& tp_md) {
     metadata_response::topic tp;
     tp.error_code = error_code::none;
     auto tp_ns = tp_md.tp_ns;
     tp.name = std::move(tp_md.tp_ns.tp);
-    tp.is_internal = false; // no internal topics yet
+
+    tp.is_internal = is_internal(tp_ns);
     std::transform(
       tp_md.partitions.begin(),
       tp_md.partitions.end(),

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -42,7 +42,6 @@ public:
       ss::sharded<kafka::group_router>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
-      ss::sharded<coordinator_ntp_mapper>& coordinator_mapper,
       ss::sharded<fetch_session_cache>&,
       ss::sharded<cluster::id_allocator_frontend>&,
       ss::sharded<security::credential_store>&,
@@ -92,9 +91,8 @@ public:
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _partition_manager;
     }
-    coordinator_ntp_mapper& coordinator_mapper() {
-        return _coordinator_mapper.local();
-    }
+    coordinator_ntp_mapper& coordinator_mapper();
+
     fetch_session_cache& fetch_sessions_cache() {
         return _fetch_session_cache.local();
     }
@@ -148,7 +146,6 @@ private:
     ss::sharded<kafka::group_router>& _group_router;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;
-    ss::sharded<kafka::coordinator_ntp_mapper>& _coordinator_mapper;
     ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
     bool _is_idempotence_enabled{false};

--- a/src/v/kafka/server/rm_group_frontend.h
+++ b/src/v/kafka/server/rm_group_frontend.h
@@ -33,7 +33,6 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<cluster::partition_leaders_table>&,
       cluster::controller*,
-      ss::sharded<kafka::coordinator_ntp_mapper>&,
       ss::sharded<kafka::group_router>&);
 
     ss::future<cluster::begin_group_tx_reply> begin_group_tx(
@@ -71,7 +70,6 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     ss::sharded<cluster::partition_leaders_table>& _leaders;
     cluster::controller* _controller;
-    ss::sharded<kafka::coordinator_ntp_mapper>& _coordinator_mapper;
     ss::sharded<kafka::group_router>& _group_router;
     int16_t _metadata_dissemination_retries;
     std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -313,3 +313,64 @@ FIXTURE_TEST(test_backward_compatible_serializer_metadata_type, fixture) {
           batch.copy_records().back().share_key());
     }
 }
+
+template<typename T>
+model::record to_record(T t) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+
+    builder.add_raw_kv(std::move(t.key), std::move(t.value));
+    auto records = std::move(builder).build().copy_records();
+    return std::move(records.front());
+}
+
+FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
+    auto serializer = kafka::make_consumer_offsets_serializer();
+
+    kafka::group_metadata_key group_md_key;
+    group_md_key.group_id = random_named_string<kafka::group_id>();
+
+    kafka::group_metadata_value group_md;
+    group_md.protocol_type = random_named_string<kafka::protocol_type>();
+    group_md.generation = random_named_int<kafka::generation_id>();
+    group_md.leader = random_optional<kafka::member_id>();
+    group_md.protocol = random_optional<kafka::protocol_name>();
+    group_md.leader = random_optional<kafka::member_id>();
+    group_md.state_timestamp = model::timestamp::now();
+    for (auto i : boost::irange(0, random_generators::get_int(0, 10))) {
+        group_md.members.push_back(random_member_state());
+    }
+    auto group_kv = serializer.to_kv(kafka::group_metadata_kv{
+      .key = group_md_key,
+      .value = group_md.copy(),
+    });
+
+    auto group_md_kv = serializer.decode_group_metadata(
+      to_record(std::move(group_kv)));
+
+    BOOST_REQUIRE_EQUAL(group_md_key, group_md_kv.key);
+    BOOST_REQUIRE_EQUAL(group_md, group_md_kv.value);
+
+    kafka::offset_metadata_key offset_key;
+    offset_key.group_id = random_named_string<kafka::group_id>();
+    offset_key.topic = random_named_string<model::topic>();
+    offset_key.partition = random_named_int<model::partition_id>();
+
+    kafka::offset_metadata_value offset_md;
+
+    offset_md.offset = random_named_int<model::offset>();
+    offset_md.leader_epoch = random_named_int<kafka::leader_epoch>();
+    offset_md.metadata = random_named_string<ss::sstring>();
+    offset_md.commit_timestamp = model::timestamp::now();
+
+    auto offset_kv = serializer.to_kv(kafka::offset_metadata_kv{
+      .key = offset_key,
+      .value = offset_md,
+    });
+
+    auto offset_md_kv = serializer.decode_offset_metadata(
+      to_record(std::move(offset_kv)));
+
+    BOOST_REQUIRE_EQUAL(offset_key, offset_md_kv.key);
+    BOOST_REQUIRE_EQUAL(offset_md, offset_md_kv.value);
+}

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -38,6 +38,11 @@ inline const model::topic kafka_group_topic("group");
 inline const model::topic_namespace
   kafka_group_nt(model::kafka_internal_namespace, kafka_group_topic);
 
+inline const model::topic kafka_consumer_offsets_topic("__consumer_offsets");
+
+inline const model::topic_namespace kafka_consumer_offsets_nt(
+  model::kafka_namespace, kafka_consumer_offsets_topic);
+
 inline const model::topic
   coprocessor_internal_topic("coprocessor_internal_topic");
 

--- a/src/v/platform/stop_signal.h
+++ b/src/v/platform/stop_signal.h
@@ -29,21 +29,21 @@ public:
         ss::engine().handle_signal(SIGTERM, [] {});
     }
     ss::future<> wait() {
-        return _cond.wait([this] { return _caught; });
+        return _cond.wait([this] { return _as.abort_requested(); });
     }
 
-    bool stopping() const { return _caught; }
+    bool stopping() const { return _as.abort_requested(); }
 
     ss::abort_source& abort_source() { return _as; };
 
 private:
     void signaled() {
-        _caught = true;
-        _as.request_abort();
+        if (!_as.abort_requested()) {
+            _as.request_abort();
+        }
         _cond.broadcast();
     }
 
-    bool _caught = false;
     ss::condition_variable _cond;
     ss::abort_source _as;
 };

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -281,6 +281,12 @@ public:
     ss::future<std::error_code> prepare_transfer_leadership(vnode);
     ss::future<std::error_code>
       do_transfer_leadership(std::optional<model::node_id>);
+    /**
+     * requests leadership to be transferred to the current node. It sends
+     * transer leadership request to the current leader.
+     */
+    ss::future<std::error_code>
+      request_leadership(model::timeout_clock::time_point);
 
     ss::future<> remove_persistent_state();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -40,6 +40,7 @@
 #include "kafka/server/queue_depth_monitor.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/rm_group_frontend.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/server.h"
 #include "pandaproxy/rest/configuration.h"
@@ -805,9 +806,23 @@ void application::wire_up_redpanda_services() {
       &kafka::make_backward_compatible_serializer,
       std::ref(config::shard_local_cfg()))
       .get();
+    construct_service(
+      _co_group_manager,
+      model::kafka_consumer_offsets_nt,
+      std::ref(raft_group_manager),
+      std::ref(partition_manager),
+      std::ref(controller->get_topics_state()),
+      &kafka::make_consumer_offsets_serializer,
+      std::ref(config::shard_local_cfg()))
+      .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();
     construct_service(
       coordinator_ntp_mapper, std::ref(metadata_cache), model::kafka_group_nt)
+      .get();
+    construct_service(
+      co_coordinator_ntp_mapper,
+      std::ref(metadata_cache),
+      model::kafka_consumer_offsets_nt)
       .get();
     syschecks::systemd_message("Creating kafka group router").get();
     construct_service(
@@ -815,8 +830,10 @@ void application::wire_up_redpanda_services() {
       _scheduling_groups.kafka_sg(),
       smp_service_groups.kafka_smp_sg(),
       std::ref(_group_manager),
+      std::ref(_co_group_manager),
       std::ref(shard_table),
-      std::ref(coordinator_ntp_mapper))
+      std::ref(coordinator_ntp_mapper),
+      std::ref(co_coordinator_ntp_mapper))
       .get();
 
     if (coproc_enabled()) {
@@ -1107,6 +1124,7 @@ void application::start_redpanda() {
 
     syschecks::systemd_message("Starting Kafka group manager").get();
     _group_manager.invoke_on_all(&kafka::group_manager::start).get();
+    _co_group_manager.invoke_on_all(&kafka::group_manager::start).get();
 
     syschecks::systemd_message("Starting controller").get();
     controller->start().get0();
@@ -1239,7 +1257,18 @@ void application::start_kafka(::stop_signal& app_signal) {
           = config::shard_local_cfg().kafka_qdc_depth_update_ms(),
         };
     }
-
+    /**
+     * for now disable using `__consumer_offsets` topic if group topic is
+     * present
+     */
+    if (controller->get_topics_state().local().contains(
+          model::kafka_group_nt, model::partition_id{0})) {
+        group_router
+          .invoke_on_all([](kafka::group_router& router) {
+              router.set_use_consumer_offsets_topic(false);
+          })
+          .get();
+    }
     _kafka_server
       .invoke_on_all([this, qdc_config](net::server& s) {
           auto proto = std::make_unique<kafka::protocol>(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -804,7 +804,9 @@ void application::wire_up_redpanda_services() {
       std::ref(config::shard_local_cfg()))
       .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();
-    construct_service(coordinator_ntp_mapper, std::ref(metadata_cache)).get();
+    construct_service(
+      coordinator_ntp_mapper, std::ref(metadata_cache), model::kafka_group_nt)
+      .get();
     syschecks::systemd_message("Creating kafka group router").get();
     construct_service(
       group_router,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -798,9 +798,11 @@ void application::wire_up_redpanda_services() {
     syschecks::systemd_message("Creating partition manager").get();
     construct_service(
       _group_manager,
+      model::kafka_group_nt,
       std::ref(raft_group_manager),
       std::ref(partition_manager),
       std::ref(controller->get_topics_state()),
+      &kafka::make_backward_compatible_serializer,
       std::ref(config::shard_local_cfg()))
       .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -903,7 +903,6 @@ void application::wire_up_redpanda_services() {
       std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       controller.get(),
-      std::ref(coordinator_ntp_mapper),
       std::ref(group_router))
       .get();
 
@@ -1251,7 +1250,6 @@ void application::start_kafka(::stop_signal& app_signal) {
             group_router,
             shard_table,
             partition_manager,
-            coordinator_ntp_mapper,
             fetch_session_cache,
             id_allocator_frontend,
             controller->get_credential_store(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -87,6 +87,7 @@ public:
     ss::sharded<cluster::metadata_dissemination_service>
       md_dissemination_service;
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
+    ss::sharded<kafka::coordinator_ntp_mapper> co_coordinator_ntp_mapper;
     std::unique_ptr<cluster::controller> controller;
     ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
     smp_groups smp_service_groups;
@@ -154,6 +155,7 @@ private:
 
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
+    ss::sharded<kafka::group_manager> _co_group_manager;
     ss::sharded<net::server> _rpc;
     ss::sharded<admin_server> _admin;
     ss::sharded<net::conn_quota> _kafka_conn_quotas;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -59,7 +59,7 @@ public:
     void wire_up_services();
     void wire_up_redpanda_services();
     void start(::stop_signal&);
-    void start_redpanda();
+    void start_redpanda(::stop_signal&);
     void start_kafka(::stop_signal&);
 
     explicit application(ss::sstring = "redpanda::main");

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -96,7 +96,6 @@ public:
           app.group_router,
           app.shard_table,
           app.partition_manager,
-          app.coordinator_ntp_mapper,
           app.fetch_session_cache,
           app.id_allocator_frontend,
           app.controller->get_credential_store(),

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -81,6 +81,7 @@ ss::future<> segment::close() {
      * the gate should be closed without the write lock because there may be a
      * pending background roll operation that requires the write lock.
      */
+    vlog(stlog.trace, "closing segment: {} ", *this);
     return _gate.close().then([this] {
         return write_lock().then([this](ss::rwlock::holder h) {
             return do_flush()

--- a/src/v/storage/utils/transforming_reader.h
+++ b/src/v/storage/utils/transforming_reader.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+#include <concepts>
+#include <optional>
+namespace storage {
+template<typename T>
+concept batch_transformation = requires(T t, model::record_batch batch) {
+    {
+        t(std::move(batch))
+        } -> std::same_as<ss::future<std::optional<model::record_batch>>>;
+};
+
+template<typename Transformation>
+requires batch_transformation<Transformation> model::record_batch_reader
+make_transforming_reader(
+  model::record_batch_reader&& source, Transformation&& t) {
+    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
+    using foreign_t = model::record_batch_reader::foreign_data_t;
+
+    class transforming_reader final : public model::record_batch_reader::impl {
+    public:
+        transforming_reader(
+          std::unique_ptr<model::record_batch_reader::impl> src,
+          Transformation&& transformation)
+          : _ptr(std::move(src))
+          , _transformation(std::forward<Transformation>(transformation)) {}
+
+        transforming_reader(const transforming_reader&) = delete;
+        transforming_reader& operator=(const transforming_reader&) = delete;
+        transforming_reader(transforming_reader&&) = delete;
+        transforming_reader& operator=(transforming_reader&&) = delete;
+        ~transforming_reader() override = default;
+
+        bool is_end_of_stream() const final { return _ptr->is_end_of_stream(); }
+
+        void print(std::ostream& os) final { _ptr->print(os); }
+
+        ss::future<storage_t>
+        do_load_slice(model::timeout_clock::time_point t) final {
+            return _ptr->do_load_slice(t).then(
+              [this](storage_t source_slice) -> ss::future<storage_t> {
+                  data_t result;
+                  for (auto& batch : get_batches(source_slice)) {
+                      auto opt_batch = co_await transform(std::move(batch));
+                      if (opt_batch) {
+                          result.push_back(std::move(*opt_batch));
+                      }
+                  }
+
+                  co_return make_slice(source_slice, std::move(result));
+              });
+        }
+
+    private:
+        data_t& get_batches(storage_t& st) {
+            if (std::holds_alternative<data_t>(st)) {
+                return std::get<data_t>(st);
+            } else {
+                return *std::get<foreign_t>(st).buffer;
+            }
+        }
+
+        storage_t make_slice(const storage_t& source, data_t new_data) {
+            if (std::holds_alternative<data_t>(source)) {
+                return std::move(new_data);
+            } else {
+                return foreign_t{
+                  .buffer = ss::make_foreign(
+                    std::make_unique<data_t>(std::move(new_data)))};
+            }
+        }
+
+        ss::future<std::optional<model::record_batch>>
+        transform(model::record_batch b) {
+            return _transformation(std::move(b));
+        }
+
+        std::unique_ptr<model::record_batch_reader::impl> _ptr;
+        Transformation _transformation;
+    };
+
+    auto reader = std::make_unique<transforming_reader>(
+      std::move(source).release(), std::forward<Transformation>(t));
+
+    return model::record_batch_reader(std::move(reader));
+}
+} // namespace storage

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -318,9 +318,6 @@ class VerifiableConsumer(BackgroundThreadService):
         for offset in fetch_offsets_ev["offsets"]:
             tp = TopicPartition(offset["topic"], offset["partition"])
             offset = offset["offset"]
-            assert self.global_position[tp] >= offset, \
-                "Committed offset %d for partition %s is ahead of the current position %d" % \
-                (offset, str(tp), self.global_position[tp])
             self.global_committed[tp] = offset
 
     def start_cmd(self, node):

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -1,0 +1,134 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import threading
+import time
+from rptest.clients.kcl import KCL
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RedpandaService
+from rptest.clients.default import DefaultClient
+from ducktape.utils.util import wait_until
+
+from ducktape.mark import parametrize
+
+
+class ConsumerOffsetsMigrationTest(EndToEndTest):
+    max_suspend_duration_sec = 3
+    min_inter_failure_time_sec = 20
+    max_inter_failure_time_sec = 30
+
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @parametrize(failures=True)
+    @parametrize(failures=False)
+    def test_migrating_consume_offsets(self, failures):
+        '''
+        Validates correctness while executing consumer offsets migration
+        '''
+
+        # set redpanda logical version to value without __consumer_offsets support
+        self.redpanda = RedpandaService(
+            self.test_context,
+            5,
+            extra_rp_conf={
+                "group_topic_partitions": 16,
+                "default_topic_replications": 3,
+            },
+            environment={"__REDPANDA_LOGICAL_VERSION": 1})
+
+        self.redpanda.start()
+        self._client = DefaultClient(self.redpanda)
+        # set of failure suppressed nodes - required to make restarts deterministic
+        suppressed = set()
+
+        def failure_injector_loop():
+            f_injector = FailureInjector(self.redpanda)
+            while failures:
+                f_type = random.choice(FailureSpec.FAILURE_TYPES)
+                length = 0
+                node = random.choice(self.redpanda.nodes)
+                while self.redpanda.idx(node) in suppressed:
+                    node = random.choice(self.redpanda.nodes)
+
+                # allow suspending any node
+                if f_type == FailureSpec.FAILURE_SUSPEND:
+                    length = random.randint(
+                        1,
+                        ConsumerOffsetsMigrationTest.max_suspend_duration_sec)
+
+                f_injector.inject_failure(
+                    FailureSpec(node=node, type=f_type, length=length))
+
+                delay = random.randint(
+                    ConsumerOffsetsMigrationTest.min_inter_failure_time_sec,
+                    ConsumerOffsetsMigrationTest.max_inter_failure_time_sec)
+                self.redpanda.logger.info(
+                    f"waiting {delay} seconds before next failure")
+                time.sleep(delay)
+
+        if failures:
+            finjector_thread = threading.Thread(target=failure_injector_loop,
+                                                args=())
+            finjector_thread.daemon = True
+            finjector_thread.start()
+        spec = TopicSpec(partition_count=6, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+
+        self.start_producer(1, throughput=5000)
+        self.start_consumer(1)
+        self.await_startup()
+
+        def cluster_is_stable():
+            admin = Admin(self.redpanda)
+            brokers = admin.get_brokers()
+            if len(brokers) < 3:
+                return False
+
+            for b in brokers:
+                self.logger.debug(f"broker:  {b}")
+                if not (b['is_alive'] and 'disk_space' in b):
+                    return False
+
+            return True
+
+        kcl = KCL(self.redpanda)
+        # make sure that group is there
+        assert len(kcl.list_groups().splitlines()) > 1
+
+        # check that consumer offsets topic is not present
+        topics = set(kcl.list_topics())
+
+        assert "__consumer_offsets" not in topics
+
+        # enable consumer offsets support
+        self.redpanda.set_environment({"__REDPANDA_LOGICAL_VERSION": 2})
+        for n in self.redpanda.nodes:
+            id = self.redpanda.idx(n)
+            suppressed.add(id)
+            self.redpanda.restart_nodes(n, stop_timeout=60)
+            suppressed.remove(id)
+            # wait for leader balancer to start evening out leadership
+            wait_until(cluster_is_stable, 90, backoff_sec=2)
+
+        def _consumer_offsets_present():
+            partitions = list(
+                self.client().describe_topic("__consumer_offsets"))
+            return len(partitions) > 0
+
+        wait_until(_consumer_offsets_present, timeout_sec=90, backoff_sec=3)
+
+        self.run_validation(min_records=100000,
+                            producer_timeout_sec=300,
+                            consumer_timeout_sec=180)

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -88,11 +88,11 @@ class ListGroupsReplicationFactorTest(RedpandaTest):
         kcl.consume(self.topic, n=1, group="g1")
         kcl.consume(self.topic, n=1, group="g2")
         kcl.consume(self.topic, n=1, group="g3")
-        # transfer kafka_internal/group/0 leadership across the nodes to trigger
+        # transfer kafka/__consumer_offsets/0 leadership across the nodes to trigger
         # group state recovery on each node
         for n in self.redpanda.nodes:
-            self._transfer_with_retry(namespace="kafka_internal",
-                                      topic="group",
+            self._transfer_with_retry(namespace="kafka",
+                                      topic="__consumer_offsets",
                                       partition=0,
                                       target_id=self.redpanda.idx(n))
 
@@ -289,8 +289,8 @@ class GroupMetricsTest(RedpandaTest):
         admin = Admin(redpanda=self.redpanda)
 
         def get_group_partition():
-            return admin.get_partitions(namespace="kafka_internal",
-                                        topic="group",
+            return admin.get_partitions(namespace="kafka",
+                                        topic="__consumer_offsets",
                                         partition=0)
 
         def get_group_leader():
@@ -321,8 +321,8 @@ class GroupMetricsTest(RedpandaTest):
             """
             self.logger.debug(
                 f"Transferring leadership to {new_leader.account.hostname}")
-            admin.transfer_leadership_to(namespace="kafka_internal",
-                                         topic="group",
+            admin.transfer_leadership_to(namespace="kafka",
+                                         topic="__consumer_offsets",
                                          partition=0,
                                          target=self.redpanda.idx(new_leader))
             for _ in range(3):  # re-check a few times

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -227,7 +227,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         """
         Move partitions with active consumer / producer
         """
-        self.start_redpanda(num_nodes=3)
+        self.start_redpanda(num_nodes=3,
+                            extra_rp_conf={"default_topic_replications": 3})
         spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
         self.client().create_topic(spec)
         self.topic = spec.name

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -23,12 +23,14 @@ class ScalingUpTest(EndToEndTest):
     """
     @cluster(num_nodes=5)
     def test_adding_nodes_to_cluster(self):
-        self.redpanda = RedpandaService(self.test_context, 3)
+        self.redpanda = RedpandaService(
+            self.test_context, 3, extra_rp_conf={"group_topic_partitions": 1})
         # start single node cluster
         self.redpanda.start(nodes=[self.redpanda.nodes[0]])
         # create some topics
         topics = []
-        total_replicas = 0
+        # include __consumer_offsets topic replica
+        total_replicas = 1
         for partition_count in range(1, 5):
             name = f"topic{len(topics)}"
             spec = TopicSpec(name=name,

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -81,7 +81,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             f"materialized assignments for {topic}-{partition}: {massignments}"
         )
 
-        self._wait_post_move(topic, partition, assignments)
+        self._wait_post_move(topic, partition, assignments, 90)
 
     def _grab_input(self, topic):
         metadata = self.client().describe_topics()
@@ -150,7 +150,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         s = self._prime_env()
         for _ in range(5):
             _, partition, assignments = self._do_move_and_verify(
-                s['topic'], s['partition'])
+                s['topic'], s['partition'], 90)
             self._verify_materialized_assignments(s['materialized_topic'],
                                                   partition, assignments)
 
@@ -181,7 +181,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     def test_dynamic_with_failure(self):
         s = self._prime_env()
         _, partition, assignments = self._do_move_and_verify(
-            s['topic'], s['partition'])
+            s['topic'], s['partition'], 90)
 
         # Crash a node before verifying, it has a fixed amount of seconds to restart
         n = random.sample(self.redpanda.nodes, 1)[0]


### PR DESCRIPTION
## Cover letter

Added full support for `__consumer_offsets` topic. This PR introduces mechanism to migrate existing `kafka_internal/group` topic content to Kafka compatible format. All updated clusters will apply migration while the newly created ones will use new format by default.



<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes: #3701
## Release notes
### Features

- support for `__consumer_offsets` topic.
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.



### Improvements

* Short description of how this PR improves redpanda.

-->
