### PR TITLE
cluster: enhanced unit test for feature barrier (using manual_clock)

### DIFF
--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -115,7 +115,7 @@ private:
       notification_id_type_invalid};
 
     // Barriers are only populated on shard 0
-    feature_barrier_state _barrier_state;
+    feature_barrier_state<ss::lowres_clock> _barrier_state;
 
     // The individually reported versions of nodes, which
     // are usually all the same but will differ during upgrades.


### PR DESCRIPTION
## Cover letter

Follows on from #3979 :
- Refactor feature_barrier_state to be generic on a `Clock` type.
- Convert unit test to use `manual_clock` to avoid needing long sleeps to check retry functionality
- Add cases to get 100% line coverage of feature_barrier.cc

## Release notes

* none
