### PR TITLE
Supporting request rate quotas - KIP-124

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -231,6 +231,14 @@ configuration::configuration()
        .visibility = visibility::user},
       2_GiB,
       {.min = 1_MiB})
+  , target_quota_time_rate(
+      *this,
+      "target_quota_time_rate",
+      "Target quota time rate measured in percentage (per quota window) above "
+      "which request is throttled - default disabled. Example: 200",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      {.min = 1})
   , cluster_id(
       *this,
       "cluster_id",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -80,6 +80,7 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds> default_window_sec;
     property<std::chrono::milliseconds> quota_manager_gc_sec;
     bounded_property<uint32_t> target_quota_byte_rate;
+    bounded_property<std::optional<uint32_t>> target_quota_time_rate;
     property<std::optional<ss::sstring>> cluster_id;
     property<bool> disable_metrics;
     property<bool> disable_public_metrics;

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -102,10 +102,6 @@ api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
         r.data.error_code = error_code::none;
     }
 
-    if (ctx.header().version > api_version(1)) {
-        r.data.throttle_time_ms = std::chrono::milliseconds(
-          ctx.throttle_delay_ms());
-    }
     if (
       r.data.error_code == error_code::none
       || r.data.error_code == error_code::unsupported_version) {

--- a/src/v/kafka/server/handlers/delete_topics.cc
+++ b/src/v/kafka/server/handlers/delete_topics.cc
@@ -88,9 +88,6 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
     }
 
     auto resp = create_response(std::move(res));
-    resp.data.throttle_time_ms = std::chrono::milliseconds(
-      ctx.throttle_delay_ms());
-
     for (auto& topic : unauthorized) {
         resp.data.responses.push_back(deletable_topic_result{
           .name = std::move(topic),

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -696,7 +696,6 @@ ss::future<response_ptr> op_context::send_response() && {
     fetch_response final_response;
     final_response.data.error_code = response.data.error_code;
     final_response.data.session_id = response.data.session_id;
-    final_response.data.throttle_time_ms = response.data.throttle_time_ms;
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -218,8 +218,6 @@ ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
 
     offset_for_leader_epoch_response response;
     response.data.topics = std::move(results);
-    response.data.throttle_time_ms = std::chrono::milliseconds(
-      ctx.throttle_delay_ms());
 
     // merge with unauthorized topics
     std::move(

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -60,6 +60,8 @@ public:
       , _default_window_width(
           config::shard_local_cfg().default_window_sec.bind())
       , _target_tp_rate(config::shard_local_cfg().target_quota_byte_rate.bind())
+      , _target_request_percentage(
+          config::shard_local_cfg().target_quota_time_rate.bind())
       , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
       , _max_delay(
           config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
@@ -121,6 +123,7 @@ private:
     config::binding<std::chrono::milliseconds> _default_window_width;
 
     config::binding<uint32_t> _target_tp_rate;
+    config::binding<std::optional<uint32_t>> _target_request_percentage;
     underlying_t _quotas;
 
     ss::timer<> _gc_timer;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -32,6 +32,7 @@
 #include <seastar/util/log.hh>
 
 #include <memory>
+#include <type_traits>
 
 namespace kafka {
 
@@ -54,6 +55,11 @@ struct request_header {
     bool is_flexible() const { return tags_size_bytes > 0; }
 
     friend std::ostream& operator<<(std::ostream&, const request_header&);
+};
+
+template<typename T>
+concept has_throttle_time_ms = requires(T a) {
+    {a.data.throttle_time_ms};
 };
 
 class request_context {
@@ -118,10 +124,9 @@ public:
         return _conn->server().tx_gateway_frontend();
     }
 
-    int32_t throttle_delay_ms() const {
+    std::chrono::milliseconds throttle_delay_ms() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
-                 _throttle_delay)
-          .count();
+          _throttle_delay);
     }
 
     kafka::group_router& groups() { return _conn->server().group_router(); }
@@ -158,6 +163,7 @@ public:
           ResponseType::api_type::key,
           ResponseType::api_type::name,
           r);
+
         /// KIP-511 bumps api_versions_request/response to 3, past the first
         /// supported flex version for this API, and makes an exception
         /// that there will be no tags in the response header.
@@ -174,6 +180,14 @@ public:
                 version = api_version(0);
             }
         }
+
+        /// Many responses contain a throttle_time_ms field, to prevent each
+        /// handler from manually having to set this value, it can be done in
+        /// one place here, with this concept check
+        if constexpr (has_throttle_time_ms<ResponseType>) {
+            r.data.throttle_time_ms = throttle_delay_ms();
+        }
+
         auto resp = std::make_unique<response>(is_flexible);
         r.encode(resp->writer(), version);
         return ss::make_ready_future<response_ptr>(std::move(resp));

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ rp_test(
 
 
 set(srcs
+  quota_manager_test.cc
   consumer_groups_test.cc
   member_test.cc
   group_test.cc

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/protocol/api_versions.h"
+#include "kafka/server/quota_manager.h"
+#include "random/generators.h"
+#include "redpanda/tests/fixture.h"
+#include "resource_mgmt/rate.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+void set_quota_manager_test_defaults(
+  int16_t num_windows,
+  std::chrono::milliseconds window_size,
+  uint32_t quota_rate,
+  std::chrono::milliseconds max_delay) {
+    /// Configure quota manager with known defaults otherwise if assumptions are
+    /// made on tests defaults values obtained from config settings, test would
+    /// fail if these defaults are later changed
+    auto& cfg = config::shard_local_cfg();
+    cfg.get("default_num_windows").set_value(num_windows);
+    cfg.get("default_window_sec").set_value(window_size);
+    cfg.get("target_quota_time_rate")
+      .set_value(std::optional<uint32_t>(quota_rate));
+    cfg.get("max_kafka_throttle_delay_ms").set_value(max_delay);
+}
+
+/// This test emmulates a single client making frequent requests to
+/// redpanda. Each request is given a random time interval (between 1-10ms),
+/// logged in the quota manager and tracked by a local instance of
+/// rate_tracker
+SEASTAR_THREAD_TEST_CASE(quota_manager_delay_rate_test) {
+    const auto num_windows = 10;
+    const auto window_size = 1000ms;
+    const auto quota_rate = 10;
+    const auto max_delay = 200ms;
+    set_quota_manager_test_defaults(
+      num_windows, window_size, quota_rate, max_delay);
+    const auto cid = "client_id_foo_1";
+    const auto target_rate = window_size * quota_rate * 0.01;
+    auto window_start = ss::lowres_clock::now();
+
+    /// If the local rate tracker determines the rate is higher then the static
+    /// preconfigured rate, check the value against the quota managers
+    rate_tracker rt(num_windows, window_size);
+    kafka::quota_manager qmgr;
+    for (auto i = 0; i < 100; ++i) {
+        for (auto j = 0; j < 100; ++j) {
+            /// Every iteration of j will take more time slices from the quota
+            /// each time taking another 1-10ms
+            const auto used = std::chrono::milliseconds(
+              random_generators::get_int(1, 10));
+            const auto next = window_start + used;
+            qmgr.record_time_quota(cid, window_start, next);
+            rt.record(used.count(), next);
+            auto rate = std::chrono::milliseconds(
+              static_cast<uint64_t>(rt.measure(next)));
+            /// Pass 0 to the bytes parameter to avoid the quota manager
+            /// calculating and returning a throttle by byte amount
+            auto observed_rate = qmgr.record_tp_and_throttle(cid, 0, next);
+            if (rate > target_rate) {
+                rate = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  rate - target_rate);
+                BOOST_CHECK_EQUAL(
+                  std::min(rate, max_delay), observed_rate.duration);
+            } else {
+                BOOST_CHECK_EQUAL(0ms, observed_rate.duration);
+            }
+            /// Incrementing this parameter may push the rate tracker to open a
+            /// new window
+            window_start += used;
+        }
+    }
+}
+
+FIXTURE_TEST(quota_manager_e2e_delay_rate, redpanda_thread_fixture) {
+    /// This test has very low quota limits to try to trigger the quota by rate
+    /// mechanism. Local testing has shown that the mechanism can be encountered
+    /// with these parameters.
+    const auto num_windows = 1;
+    const auto window_size = 10ms;
+    const auto quota_rate = 1;
+    /// Should never be encountered because the maximum throttle by rate is 1
+    /// window side, or 10ms in this test
+    const auto max_delay = 200ms;
+    set_quota_manager_test_defaults(
+      num_windows, window_size, quota_rate, max_delay);
+
+    /// Make 100 concurrent api_versions requests
+    auto r = boost::irange<int>(0, 100);
+    ss::parallel_for_each(r, [&](int) -> ss::future<> {
+        auto client = co_await make_kafka_client();
+        co_await client.connect();
+        auto response = co_await client.dispatch(
+          kafka::api_versions_request{.data{
+            .client_software_name = "redpanda",
+            .client_software_version = "x.x"}},
+          kafka::api_version(3));
+        /// Check that if throttling did occur, it was less than or equal to one
+        /// window length
+        BOOST_CHECK_LE(response.data.throttle_time_ms, window_size);
+        if (response.data.throttle_time_ms > 0ms) {
+            std::cout << "Throttle time ms: " << response.data.throttle_time_ms
+                      << std::endl;
+        }
+        co_await client.stop();
+    }).get();
+}

--- a/src/v/resource_mgmt/rate.h
+++ b/src/v/resource_mgmt/rate.h
@@ -41,12 +41,13 @@ public:
       , _window_size(window_size)
       , _current(0) {}
 
-    // record an observation and return the updated rate in units/second.
-    double record_and_measure(double v, const clock::time_point& now) {
+    void record(double v, const clock::time_point& now) {
         // update the current window
         maybe_advance_current(now);
         _windows[_current].count += v;
+    }
 
+    double measure(const clock::time_point& now) {
         // process historical samples
         double total = 0.;
         struct window* oldest = nullptr;
@@ -80,6 +81,12 @@ public:
         }
 
         return total / std::chrono::duration<double>(elapsed).count();
+    }
+
+    // record an observation and return the updated rate in units/second.
+    double record_and_measure(double v, const clock::time_point& now) {
+        record(v, now);
+        return measure(now);
     }
 
     clock::duration window_size() const { return _window_size; }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1330,6 +1330,24 @@ class RedpandaService(Service):
         if bad_lines:
             raise BadLogLines(bad_lines)
 
+    def search_log(self, pattern):
+        """
+        Test helper for grepping the redpanda log
+
+        :return:  true if any instances of `pattern` found
+        """
+        for node in self.nodes:
+            for line in node.account.ssh_capture(
+                    f"grep \"{pattern}\" {self.STDOUT_STDERR_CAPTURE} || true"
+            ):
+                # We got a match
+                self.logger.debug(
+                    f"Found {pattern} on node {node.name}: {line}")
+                return True
+
+        # Fall through, no matches
+        return False
+
     def decode_backtraces(self):
         """
         Decodes redpanda backtraces if any of them are present


### PR DESCRIPTION
[KIP-124](https://cwiki.apache.org/confluence/display/KAFKA/KIP-124+-+Request+rate+quotas#KIP124Requestratequotas-Metricsandsensors) is an accepted proposal to add request rate quotas to Kafka. It works by adding a new field `throttle_ms_time` to most responses. This field is 0 unless a previous request was throttled. Thresholds for throttling are configured within the redpanda config file. If a request exceeds a certain amount of bytes or time slice within the configurable window, the throttle will occur.

The behavior to throttle requests based on request size has already been implemented. This PR adds a little more logic to track the total duration of the most recent request, if the total time exceeds the maximum window size (and no delay was induced due to average size limit breaches) then the new throttle delay will be induced.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/5b80a26a5be87067de73f552347593bc94b3ef3a..0ba2f8ab957c6c268e6426891ad43db2ef0c022e)
- Adding logic to actually throttle if time quotas have been exceeded

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/0ba2f8ab957c6c268e6426891ad43db2ef0c022e..35f20775bfbd375ad87c641c6781e25b7c1908de)
- Fixed use after free bug introduced in previous force push

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/35f20775bfbd375ad87c641c6781e25b7c1908de..2b2ae4866db4d2684b076604d5fd9b94714b297b)
- Added new commit with unit test
- Fixed bug with incorrect calculation of delay

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2b2ae4866db4d2684b076604d5fd9b94714b297b..44eb15a11463c786f1c2f0ed492bfa86de33cdfc)
- Rebased dev to fix a conflict with `kafka/server/tests/CMakeLists.txt` where the same line was modified when adding a new test source file

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/44eb15a11463c786f1c2f0ed492bfa86de33cdfc..68cebe943ee1cfec568b898d8f6132fabe825580)
- Changed throttle api to return a `std::chrono::milliseconds` so callers no longer need to wrap value to cast to ms
- Beefed up unit test to test edge cases and randomized data set

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/68cebe943ee1cfec568b898d8f6132fabe825580..2c07dd3c739554bdb81c3a836f175871376a4b78)
- Use tmp to fill `throttle_response_ms` field instead of having to manually assign the member var everywhere.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2c07dd3c739554bdb81c3a836f175871376a4b78..7e9823d7f1a64fc21a1405035895a4de2c7f5085)
- Take the larger of the two quotas (bandwith / time) if both have been exceeded
- Fix error with application of time interval, was not applied after response was completed
 
Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/7e9823d7f1a64fc21a1405035895a4de2c7f5085..e2b592e6b368456b425bf26850c8593b2caf32d1)
- Change how request rates are calculated. Now the rate_tracker class is used for this as the KIP describes rates should be calculated. Previously only 1 logical time window was ever used.
- Modified the end of the time measurement interval for a request to be after all request stages have finished processing. Previously the measurement was taken after the first stage was completed.
- The introduction of the point above meant that referencing `quota_manager` within the `connection_context`'s  background loop needed to be done. To avoid crashes during shutdown (reference of already deallocated service) a change was made to modify the shutdown order of `kafka_server` 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/e2b592e6b368456b425bf26850c8593b2caf32d1..cfbcb11868201481d1cb429ee3ed4c74ff42ed7e)
- Rebase dev, conflict in `redpanda/application.cc`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/44388093c2e03ff9911a3faecf1dcc1275511cb8..339306b644181d51f0f81cb52997b1b80437736f)
- Fixed a bug introduced in a previous change that modified the shutdown order.
- Implemented Noahs feedback to use concepts instead of SFINAE w/ classical templates

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/339306b644181d51f0f81cb52997b1b80437736f..d8b9663d5726bfca243dcc638c136a07385e14bd)
- Used an optional property to enable switch for feature
- Added a unit test

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/d8b9663d5726bfca243dcc638c136a07385e14bd..6a87fc3284f03d52dfa77bd0b185acc8a1b6cdda)
- Rebase dev
- Make this throttling disabled by default
- Max throttle by time limited by one window width (default 1s)

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2330a1e55570eaf3937b8a53f3df8ce6b0f02c0f..f0dba8840e2fa14025e1c3cf079a1c1bd20346aa)
- Fixed bug where throttle would always be applied when feature is enabled
- Introduced ducktape test