### PR TITLE
remove brew tap step in github workflow action

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -100,7 +100,6 @@ jobs:
 
       - name: Install gon via HomeBrew for code signing and app notarization
         run: |
-          brew tap mitchellh/gon
           brew install mitchellh/gon/gon
 
       - name: Sign the mac binaries with Gon


### PR DESCRIPTION
within the github action to install `mitchellh/gon`, there is a syntax error for tap
https://github.com/redpanda-data/redpanda/runs/5503490558?check_suite_focus=true#step:6:1
```
Run brew tap mitchellh/gon
==> Tapping mitchellh/gon
Cloning into '/usr/local/Homebrew/Library/Taps/mitchellh/homebrew-gon'...
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/mitchellh/homebrew-gon/gon.rb
gon: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the mitchellh/gon tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/mitchellh/homebrew-gon/gon.rb:6

Error: Cannot tap mitchellh/gon: invalid syntax in tap!
Error: Process completed with exit code 1.
```
according to https://github.com/mitchellh/gon/pull/38 it looks like the `brew tap` command is no longer needed