### PR TITLE
cloud_storage: get access key ID from secret

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -93,6 +93,7 @@ func TestEnsureConfigMap(t *testing.T) {
 					},
 				},
 			} {
+				secret := secret // golangci-lint workaround for implicit memory aliasing
 				require.NoError(t, c.Create(context.TODO(), &secret))
 			}
 			cfgRes := resources.NewConfigMap(


### PR DESCRIPTION
EDIT: added terraform example and rational for the improvement.

## Cover letter

This is a small change to allow the cloud_storage Secret reference to also include the access key id. This makes managing access keys easier as a new key and secret will be generated together and can be managed by external systems like Terraform.

I have chosen some arbitrary keys to use in the Secret, and use the presence of those keys to "opt-in" to this new behavior. Happy to change the keys if desired.

Also, the behavior I have implemented is for the value of the access key in the Secret to take precedence, but could be convinced to ignore it unless the access_key in the Cluster resource was blank.

## Release notes

* none

### Features

This feature is backwards compatible with the existing secret reference and can be opt-ed in by using the key `secretKey` instead of the name of the secret. e.g.,

```yaml
kind: Secret
metadata:
  name: redpanda-storage-key
  namespace: kafka
data:
  accessKey: 12345
  secretKey: abcdef
```

The value of `accessKey` will overwrite the value in the Cluster resource.

Example using Terraform:

```terraform
resource "kubernetes_secret" "redpanda-storage-key" {
  metadata {
    namespace = "kafka"
    name = "redpanda-storage-key"
  }
  data = {
    "accessKey" = aws_iam_access_key.redpanda.id
    "secretKey" = aws_iam_access_key.redpanda.secret
  }
}
```

Then a Cluster resources that looks like this:

```yaml
kind: Cluster
apiVersion: redpanda.vectorized.io/v1alpha1
metadata:
  name: cluster
  namespace: kafka
spec:
  cloudStorage:
    accessKey: in-secret  # needed to pass validation, should this be made optional?
    secretKeyRef:
      name: redpanda-storage-key
      namespace: kafka
...
```

### Improvements

The big improvement is that if a key needs to be rotated or replaced for some other reason, I don't have to remember to output the key id and copy and paste it into another file. This simplifies secret management, which makes it easier to manage secrets securely.
