### PR TITLE
cloud_storage: fix segment download when dir is deleted

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -262,10 +262,11 @@ ss::future<> cache::put(
 
     ss::file tmp_cache_file;
     while (true) {
-        co_await ss::recursive_touch_directory(dir_path.string());
-        // recursive_delete_empty_directory may delete dir_path before we open
-        // file, in this case we recreate dir_path and try again
         try {
+            // recursive_delete_empty_directory may delete dir_path before we
+            // open file, in this case we recreate dir_path and try again
+            co_await ss::recursive_touch_directory(dir_path.string());
+
             auto flags = ss::open_flags::wo | ss::open_flags::create
                          | ss::open_flags::exclusive;
 


### PR DESCRIPTION
## Cover letter

This logic was basically already there, but the directory
creation was happening outside the exception handler.

This fixes a case where remote::download_segment would
fail to download because of a filesystem_error ENOENT,
which it interprets as unrecoverable.

Fixes https://github.com/redpanda-data/redpanda/issues/4005

## Release notes

* none