### PR TITLE
storage: fix integer overflow in max_timestamp

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -64,7 +64,7 @@ bool index_state::maybe_index(
         // We know that a segment cannot be > 4GB
         add_entry(
           batch_base_offset() - base_offset(),
-          last_timestamp() - base_timestamp(),
+          std::max(last_timestamp() - base_timestamp(), int64_t{0}),
           starting_position_in_file);
 
         retval = true;


### PR DESCRIPTION
## Cover letter

Batches with timestamps behind the base_timestamp of the segment could have negative relative timestamp, which overflows when cast to uint32_t to insert to index_state::relative_time_index.

index_state::relative_time_index is later used to update max_timestamp when truncating the log.  Hence max_timestamp shooting about 6 weeks into the future.

Fixes https://github.com/redpanda-data/redpanda/issues/3924

## Release notes

* none
