### PR TITLE
rpk: add is_alive info in 'redpanda admin broker ls'

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -22,6 +22,7 @@ type Broker struct {
 	NodeID           int    `json:"node_id"`
 	NumCores         int    `json:"num_cores"`
 	MembershipStatus string `json:"membership_status"`
+	IsAlive          *bool  `json:"is_alive"`
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.


### PR DESCRIPTION
## Cover letter

Let `rpk redpanda admin brokers ls` return the broker's health status.

As-is
```
NODE ID  NUM CORES  MEMBERSHIP STATUS
1        16         active
2        16         active
3        16         active
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/redpanda/issues/3998

## Release notes
* none

### Improvements

To-be
```
NODE_ID  NUM_CORES  MEMBERSHIP_STATUS  IS_ALIVE
1        16         active             true
2        16         active             true
3        16         active             true
```
