### PR TITLE
Partition movement metrics

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -122,7 +122,7 @@ private:
       ask_remote_shard_for_initail_rev(model::ntp, ss::shard_id);
 
     void housekeeping();
-
+    void setup_metrics();
     ss::sharded<topic_table>& _topics;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
@@ -153,6 +153,7 @@ private:
      * first created on current node before cross core move series
      */
     absl::node_hash_map<model::ntp, model::revision_id> _bootstrap_revisions;
+    ss::metrics::metric_groups _metrics;
 };
 
 std::vector<topic_table::delta> calculate_bootstrap_deltas(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -72,6 +72,7 @@ private:
     void handle_reallocation_finished(model::node_id);
     void reassign_replicas(partition_assignment&, partition_reallocation&);
     void calculate_reallocations_after_node_added(update_meta&) const;
+    void setup_metrics();
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;
     ss::sharded<partition_allocator>& _allocator;
@@ -90,6 +91,7 @@ private:
     std::chrono::milliseconds _retry_timeout;
     ss::timer<> _retry_timer;
     ss::condition_variable _new_updates;
+    ss::metrics::metric_groups _metrics;
 };
 
 } // namespace cluster

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -123,10 +123,20 @@ void consensus::setup_metrics() {
     _metrics.add_group(
       prometheus_sanitize::metrics_name("raft"),
       {sm::make_gauge(
-        "leader_for",
-        [this] { return is_leader(); },
-        sm::description("Number of groups for which node is a leader"),
-        labels)});
+         "leader_for",
+         [this] { return is_leader(); },
+         sm::description("Number of groups for which node is a leader"),
+         labels),
+       sm::make_gauge(
+         "configuration_change_in_progress",
+         [this] {
+             return is_leader()
+                    && _configuration_manager.get_latest().type()
+                         == configuration_type::joint;
+         },
+         sm::description("Indicates if current raft group configuration is in "
+                         "joint state i.e. configuration is being changed"),
+         labels)});
 }
 
 void consensus::do_step_down() {


### PR DESCRIPTION
## Cover letter
Added set of metrics to increase visibility of partition movement process:

`vectorized_cluster_members_backend_queued_node_operations` - Number of queued node operations
`vectorized_cluster_controller_pending_partition_operations` - Number of partitions with ongoing/requested operations (creation,move,deletion,update)
`vectorized_raft_configuration_change_in_progress` - Indicates if current raft group configuration is in  joint state i.e. configuration is being changed

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3991 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
