### PR TITLE
config: make metrics_reporter_url visible

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1128,8 +1128,7 @@ configuration::configuration()
       *this,
       "metrics_reporter_url",
       "cluster metrics reporter url",
-      {.needs_restart = needs_restart::no,
-       .visibility = visibility::deprecated},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       "https://m.rp.vectorized.io/v2")
   , features_auto_enable(
       *this,

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -459,7 +459,12 @@ bool property<T>::is_nullable() const {
 
 template<typename T>
 bool property<T>::is_array() const {
-    if constexpr (detail::is_collection<std::decay_t<T>>) {
+    if constexpr (
+      std::is_same_v<T, ss::sstring> || std::is_same_v<T, std::string>) {
+        // Special case for strings, which are collections but we do not
+        // want to report them that way.
+        return false;
+    } else if constexpr (detail::is_collection<std::decay_t<T>>) {
         return true;
     } else {
         return false;

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -297,11 +297,11 @@ SEASTAR_THREAD_TEST_CASE(property_metadata) {
     BOOST_TEST(cfg.nullable_string.is_array() == false);
 
     BOOST_TEST(cfg.required_string.type_name() == "string");
+    BOOST_TEST(cfg.required_string.is_array() == false);
     BOOST_TEST(
       config::to_string_view(cfg.required_string.get_visibility()) == "user");
 
     BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
 
     BOOST_TEST(cfg.an_int64_t.type_name() == "integer");
     BOOST_TEST(cfg.boolean.is_nullable() == false);


### PR DESCRIPTION
## Cover letter

It was kind of confusing to have this at a 'deprecated' visibility
level while it wasn't really deprecated.  This property is going
to get added to the docs, so to avoid further confusion we should
also make it visible in CLI+API.

## Release notes

* none
