### PR TITLE
storage: do not hold open FDs for all segments+indices

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -231,9 +231,8 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
     vlog(ctxlog.debug, "Uploading segment {} to {}", candidate, path);
 
     auto reset_func = [this, candidate] {
-        auto stream = candidate.source->reader().data_stream(
+        return candidate.source->reader().data_stream(
           candidate.file_offset, candidate.final_file_offset, _io_priority);
-        return stream;
     };
     co_return co_await _remote.upload_segment(
       _bucket, path, candidate.content_length, reset_func, fib);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -73,7 +73,7 @@ static void log_segment(const storage::segment& s) {
     vlog(
       test_log.info,
       "Log segment {}. Offsets: {} {}. Is compacted: {}. Is sealed: {}.",
-      s.reader().filename(),
+      s.filename(),
       s.offsets().base_offset,
       s.offsets().dirty_offset,
       s.is_compacted_segment(),
@@ -474,7 +474,7 @@ calculate_segment_stats(const ss::httpd::request& req) {
     counting_batch_consumer::stream_stats stats{};
     auto consumer = std::make_unique<counting_batch_consumer>(std::ref(stats));
     storage::continuous_batch_parser parser(
-      std::move(consumer), std::move(stream));
+      std::move(consumer), storage::segment_reader_handle(std::move(stream)));
     parser.consume().get();
     parser.close().get();
     return stats;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -393,9 +393,10 @@ void segment_matcher<Fixture>::verify_segment(
     auto segment = get_segment(ntp, name);
     auto pos = segment->offsets().base_offset;
     auto size = segment->size_bytes();
-    auto stream = segment->offset_data_stream(
-      pos, ss::default_priority_class());
-    auto tmp = stream.read_exactly(size).get0();
+    auto reader_handle
+      = segment->offset_data_stream(pos, ss::default_priority_class()).get();
+    auto tmp = reader_handle.stream().read_exactly(size).get0();
+    reader_handle.close().get();
     ss::sstring actual = {tmp.get(), tmp.size()};
     vlog(
       fixt_log.info,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -34,15 +34,16 @@ class remote {
 public:
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
-    using reset_input_stream = std::function<ss::input_stream<char>()>;
+    using reset_input_stream
+      = ss::noncopyable_function<ss::input_stream<char>()>;
 
     /// Functor that attempts to consume the input stream. If the connection
     /// is broken during the download the functor is responsible for he cleanup.
     /// The functor should be reenterable since it can be called many times.
     /// On success it should return content_length. On failure it should
     /// allow the exception from the input_stream to propagate.
-    using try_consume_stream
-      = std::function<ss::future<uint64_t>(uint64_t, ss::input_stream<char>)>;
+    using try_consume_stream = ss::noncopyable_function<ss::future<uint64_t>(
+      uint64_t, ss::input_stream<char>)>;
 
     /// Functor that should be provided by user when list_objects api is called.
     /// It receives every key that matches the query as well as it's modifiation

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/types.h"
 #include "random/simple_time_jitter.h"
 #include "s3/client.h"
+#include "storage/segment_reader.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
@@ -35,7 +36,7 @@ public:
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
     using reset_input_stream
-      = ss::noncopyable_function<ss::input_stream<char>()>;
+      = ss::noncopyable_function<ss::future<storage::segment_reader_handle>()>;
 
     /// Functor that attempts to consume the input stream. If the connection
     /// is broken during the download the functor is responsible for he cleanup.

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -21,6 +21,7 @@
 #include "model/record.h"
 #include "s3/client.h"
 #include "storage/parser.h"
+#include "storage/segment_reader.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
 #include "utils/retry_chain_node.h"
@@ -97,7 +98,7 @@ public:
 
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
-    ss::future<ss::input_stream<char>>
+    ss::future<storage::segment_reader_handle>
     data_stream(size_t pos, ss::io_priority_class);
 
     struct input_stream_with_offsets {

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -189,7 +189,7 @@ make_remote_segment_index_builder(
     auto parser = ss::make_lw_shared<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_index_builder>(
         ix, initial_delta, sampling_step),
-      std::move(stream));
+      storage::segment_reader_handle(std::move(stream)));
     return parser;
 }
 

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -115,10 +115,11 @@ FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream = [] {
+    auto reset_stream = []() -> ss::future<storage::segment_reader_handle> {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return make_iobuf_input_stream(std::move(out));
+        co_return storage::segment_reader_handle(
+          make_iobuf_input_stream(std::move(out)));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -139,10 +140,11 @@ FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream = [] {
+    auto reset_stream = []() -> ss::future<storage::segment_reader_handle> {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return make_iobuf_input_stream(std::move(out));
+        co_return storage::segment_reader_handle(
+          make_iobuf_input_stream(std::move(out)));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -162,10 +164,11 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream = [] {
+    auto reset_stream = []() -> ss::future<storage::segment_reader_handle> {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return make_iobuf_input_stream(std::move(out));
+        co_return storage::segment_reader_handle(
+          make_iobuf_input_stream(std::move(out)));
     };
     retry_chain_node fib(100ms, 20ms);
     auto upl_res
@@ -219,11 +222,13 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream = [] {
+    auto reset_stream = []() -> ss::future<storage::segment_reader_handle> {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return make_iobuf_input_stream(std::move(out));
+        co_return storage::segment_reader_handle(
+          make_iobuf_input_stream(std::move(out)));
     };
+
     retry_chain_node fib(100ms, 20ms);
 
     auto expected_notfound = remote.segment_exists(bucket, path, fib).get();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -138,7 +138,7 @@ configuration::configuration()
       "topic_fds_per_partition",
       "Required file handles per partition when creating topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      10,
+      5,
       {
         .min = 1,   // At least one FD per partition, required for appender.
         .max = 1000 // A system with 1M ulimit should be allowed to create at

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -13,6 +13,7 @@
 #include "bytes/bytes.h"
 #include "model/fundamental.h"
 #include "storage/compacted_index.h"
+#include "storage/types.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
@@ -144,6 +145,10 @@ inline ss::future<> compacted_index_writer::append(compacted_index::entry e) {
 inline ss::future<> compacted_index_writer::close() { return _impl->close(); }
 
 compacted_index_writer make_file_backed_compacted_index(
-  ss::sstring filename, ss::file, ss::io_priority_class p, size_t max_memory);
+  ss::sstring filename,
+  ss::io_priority_class p,
+  debug_sanitize_files debug,
+  bool truncate,
+  size_t max_memory);
 
 } // namespace storage

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -106,7 +106,7 @@ public:
     ss::future<> close();
 
 private:
-    std::unique_ptr<continuous_batch_parser> initialize(
+    ss::future<std::unique_ptr<continuous_batch_parser>> initialize(
       model::timeout_clock::time_point,
       std::optional<model::offset> next_cached_batch);
 

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -94,7 +94,7 @@ log_replayer::checkpoint
 log_replayer::recover_in_thread(const ss::io_priority_class& prio) {
     vlog(stlog.debug, "Recovering segment {}", *_seg);
     // explicitly not using the index to recover the full file
-    auto data_stream = _seg->reader().data_stream(0, prio);
+    auto data_stream = _seg->reader().data_stream(0, prio).get();
     auto consumer = std::make_unique<checksumming_consumer>(_seg, _ckpt);
     auto parser = continuous_batch_parser(
       std::move(consumer), std::move(data_stream), true);

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -100,7 +100,6 @@ log_replayer::recover_in_thread(const ss::io_priority_class& prio) {
       std::move(consumer), std::move(data_stream), true);
     try {
         parser.consume().get();
-        parser.close().get();
     } catch (...) {
         vlog(
           stlog.warn,
@@ -109,6 +108,7 @@ log_replayer::recover_in_thread(const ss::io_priority_class& prio) {
           _ckpt,
           std::current_exception());
     }
+    parser.close().get();
     return _ckpt;
 }
 

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -138,7 +138,7 @@ ss::future<result<stop_parser>> continuous_batch_parser::consume_header() {
             auto remaining = _header->size_bytes
                              - model::packed_record_batch_header_size;
             auto b = co_await verify_read_iobuf(
-              _input, remaining, "parser::skip_batch", _recovery);
+              get_stream(), remaining, "parser::skip_batch", _recovery);
 
             if (!b) {
                 co_return b.error();
@@ -216,7 +216,7 @@ static ss::future<result<model::record_batch_header>> read_header_impl(
 
 ss::future<result<model::record_batch_header>>
 continuous_batch_parser::read_header() {
-    return read_header_impl(_input, *_consumer, _recovery);
+    return read_header_impl(get_stream(), *_consumer, _recovery);
 }
 
 ss::future<result<stop_parser>> continuous_batch_parser::consume_one() {
@@ -244,7 +244,8 @@ void continuous_batch_parser::add_bytes_and_reset() {
 }
 ss::future<result<stop_parser>> continuous_batch_parser::consume_records() {
     auto sz = _header->size_bytes - model::packed_record_batch_header_size;
-    return verify_read_iobuf(_input, sz, "parser::consume_records", _recovery)
+    return verify_read_iobuf(
+             get_stream(), sz, "parser::consume_records", _recovery)
       .then([this](result<iobuf> record) -> result<stop_parser> {
           if (!record) {
               return record.error();
@@ -264,7 +265,7 @@ ss::future<result<size_t>> continuous_batch_parser::consume() {
                        _err = parser_errc(s.error().value());
                        return ss::stop_iteration::yes;
                    }
-                   if (_input.eof()) {
+                   if (get_stream().eof()) {
                        return ss::stop_iteration::yes;
                    }
                    if (s.value() == stop_parser::yes) {

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -18,6 +18,7 @@
 #include "storage/exceptions.h"
 #include "storage/failure_probes.h"
 #include "storage/parser_errc.h"
+#include "storage/segment_reader.h"
 #include "utils/vint.h"
 
 #include <seastar/core/byteorder.hh>
@@ -93,7 +94,7 @@ class continuous_batch_parser {
 public:
     continuous_batch_parser(
       std::unique_ptr<batch_consumer> consumer,
-      ss::input_stream<char> input,
+      segment_reader_handle input,
       bool recovery = false) noexcept
       : _consumer(std::move(consumer))
       , _input(std::move(input))
@@ -126,9 +127,11 @@ private:
     size_t consumed_batch_bytes() const;
     void add_bytes_and_reset();
 
+    ss::input_stream<char>& get_stream() { return _input.stream(); }
+
 private:
     std::unique_ptr<batch_consumer> _consumer;
-    ss::input_stream<char> _input;
+    segment_reader_handle _input;
 
     // If _recovery is true, we do not log unexpected data at the
     // end of the stream as an error (it is expected after an unclean

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -154,10 +154,10 @@ void probe::setup_metrics(const model::ntp& ntp) {
 }
 
 void probe::add_initial_segment(const segment& s) {
-    _partition_bytes += s.reader().file_size();
+    _partition_bytes += s.file_size();
 }
 void probe::delete_segment(const segment& s) {
-    _partition_bytes -= s.reader().file_size();
+    _partition_bytes -= s.file_size();
 }
 
 void readers_cache_probe::setup_metrics(const model::ntp& ntp) {

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -141,7 +141,7 @@ ss::future<> segment::do_close() {
     }
     // after appender flushes to make sure we make things visible
     // only after appender flush
-    f = f.then([this] { return _idx.close(); });
+    f = f.then([this] { return _idx.flush(); });
     return f;
 }
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -91,7 +91,7 @@ public:
     ss::future<bool> materialize_index();
 
     /// main read interface
-    ss::input_stream<char>
+    ss::future<segment_reader_handle>
       offset_data_stream(model::offset, ss::io_priority_class);
 
     const offset_tracker& offsets() const { return _tracker; }
@@ -112,7 +112,8 @@ public:
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible
     segment_reader& reader();
-    const segment_reader& reader() const;
+    size_t file_size() const { return _reader.file_size(); }
+    const ss::sstring& filename() const { return _reader.filename(); }
     segment_index& index();
     const segment_index& index() const;
     segment_appender_ptr release_appender();
@@ -338,7 +339,6 @@ inline bool segment::is_closed() const {
     return (_flags & bitflags::closed) == bitflags::closed;
 }
 inline segment_reader& segment::reader() { return _reader; }
-inline const segment_reader& segment::reader() const { return _reader; }
 inline segment_index& segment::index() { return _idx; }
 inline const segment_index& segment::index() const { return _idx; }
 inline segment_appender_ptr segment::release_appender() {

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -100,7 +100,8 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
   , _stable_offset(o._stable_offset)
   , _inflight(std::move(o._inflight))
   , _callbacks(std::exchange(o._callbacks, nullptr))
-  , _inactive_timer([this] { handle_inactive_timer(); }) {
+  , _inactive_timer([this] { handle_inactive_timer(); })
+  , _chunk_size(o._chunk_size) {
     o._closed = true;
 }
 

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -229,7 +229,7 @@ ss::future<> segment_index::flush() {
         co_await out.flush();
     });
 }
-ss::future<> segment_index::close() { co_await flush(); }
+
 std::ostream& operator<<(std::ostream& o, const segment_index& i) {
     return o << "{file:" << i.filename() << ", offsets:" << i.base_offset()
              << ", index:" << i._state << ", step:" << i._step

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -13,6 +13,7 @@
 #include "serde/serde.h"
 #include "storage/index_state.h"
 #include "storage/logger.h"
+#include "storage/segment_utils.h"
 #include "vassert.h"
 
 #include <seastar/core/coroutine.hh>
@@ -38,11 +39,35 @@ static inline segment_index::entry translate_index_entry(
 }
 
 segment_index::segment_index(
-  ss::sstring filename, ss::file f, model::offset base, size_t step)
+  ss::sstring filename,
+  model::offset base,
+  size_t step,
+  debug_sanitize_files sanitize)
   : _name(std::move(filename))
-  , _out(std::move(f))
-  , _step(step) {
+  , _step(step)
+  , _sanitize(sanitize) {
     _state.base_offset = base;
+}
+
+segment_index::segment_index(
+  ss::sstring filename, ss::file mock_file, model::offset base, size_t step)
+  : _name(std::move(filename))
+  , _step(step)
+  , _mock_file(mock_file) {
+    _state.base_offset = base;
+}
+
+ss::future<ss::file> segment_index::open() {
+    if (_mock_file) {
+        // Unit testing hook
+        return ss::make_ready_future<ss::file>(_mock_file.value());
+    }
+
+    return internal::make_handle(
+      std::filesystem::path{_name},
+      ss::open_flags::create | ss::open_flags::rw,
+      {},
+      _sanitize);
 }
 
 void segment_index::reset() {
@@ -155,49 +180,56 @@ ss::future<> segment_index::truncate(model::offset o) {
     co_return co_await flush();
 }
 
+/**
+ *
+ * @return true if decoded without errors, false on a serialization error
+ *         while loading.  On all other types of error (e.g. IO), throw.
+ */
 ss::future<bool> segment_index::materialize_index() {
-    auto size = co_await _out.size();
-    auto buf = co_await _out.dma_read_bulk<char>(0, size);
-    if (buf.empty()) {
-        co_return false;
-    }
-    iobuf b;
-    b.append(std::move(buf));
-    try {
-        _state = serde::from_iobuf<index_state>(std::move(b));
-        co_return true;
-    } catch (const serde::serde_exception& ex) {
-        vlog(
-          stlog.info,
-          "Rebuilding index_state after decoding failure: {}",
-          ex.what());
-        co_return false;
-    }
+    return ss::with_file(open(), [this](ss::file f) -> ss::future<bool> {
+        auto size = co_await f.size();
+        auto buf = co_await f.dma_read_bulk<char>(0, size);
+        if (buf.empty()) {
+            co_return false;
+        }
+        iobuf b;
+        b.append(std::move(buf));
+        try {
+            _state = serde::from_iobuf<index_state>(std::move(b));
+            co_return true;
+        } catch (const serde::serde_exception& ex) {
+            vlog(
+              stlog.info,
+              "Rebuilding index_state after decoding failure: {}",
+              ex.what());
+            co_return false;
+        }
+    });
 }
 
 ss::future<> segment_index::drop_all_data() {
     reset();
-    return _out.truncate(0);
+    return ss::with_file(open(), [](ss::file f) { return f.truncate(0); });
 }
 
 ss::future<> segment_index::flush() {
     if (!_needs_persistence) {
-        co_return;
+        return ss::now();
     }
     _needs_persistence = false;
-    co_await _out.truncate(0);
-    auto out = co_await ss::make_file_output_stream(ss::file(_out.dup()));
-    auto b = serde::to_iobuf(_state.copy());
-    for (const auto& f : b) {
-        co_await out.write(f.get(), f.size());
-    }
-    co_await out.flush();
-    co_await out.close();
+    return with_file(open(), [this](ss::file backing_file) -> ss::future<> {
+        co_await backing_file.truncate(0);
+        auto out = co_await ss::make_file_output_stream(
+          std::move(backing_file));
+
+        auto b = serde::to_iobuf(_state.copy());
+        for (const auto& f : b) {
+            co_await out.write(f.get(), f.size());
+        }
+        co_await out.flush();
+    });
 }
-ss::future<> segment_index::close() {
-    co_await flush();
-    co_await _out.close();
-}
+ss::future<> segment_index::close() { co_await flush(); }
 std::ostream& operator<<(std::ostream& o, const segment_index& i) {
     return o << "{file:" << i.filename() << ", offsets:" << i.base_offset()
              << ", index:" << i._state << ", step:" << i._step

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -14,6 +14,7 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "storage/index_state.h"
+#include "storage/types.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/unaligned.hh>
@@ -49,7 +50,18 @@ public:
     static constexpr size_t default_data_buffer_step = 4096 * 8;
 
     segment_index(
-      ss::sstring filename, ss::file, model::offset base, size_t step);
+      ss::sstring filename,
+      model::offset base,
+      size_t step,
+      debug_sanitize_files);
+
+    /** Constructor with mock file content for unit testing */
+    segment_index(
+      ss::sstring filename,
+      ss::file mock_file,
+      model::offset base,
+      size_t step);
+
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
     segment_index& operator=(segment_index&&) noexcept = default;
@@ -71,6 +83,8 @@ public:
     ss::future<> flush();
     ss::future<> truncate(model::offset);
 
+    ss::future<ss::file> open();
+
     /// \brief erases the underlying file and resets the index
     /// this is used during compacted index recovery, as we must first
     /// invalidate all indices, before we swap the data file
@@ -85,11 +99,15 @@ public:
 
 private:
     ss::sstring _name;
-    ss::file _out;
     size_t _step;
     size_t _acc{0};
     bool _needs_persistence{false};
     index_state _state;
+    debug_sanitize_files _sanitize;
+
+    // For unit testing only.  If this is set, then open() returns
+    // the contents of mock_file instead of opening the path in _name.
+    std::optional<ss::file> _mock_file;
 
     friend std::ostream& operator<<(std::ostream&, const segment_index&);
 };

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -79,7 +79,6 @@ public:
     const ss::sstring& filename() const { return _name; }
 
     ss::future<bool> materialize_index();
-    ss::future<> close();
     ss::future<> flush();
     ss::future<> truncate(model::offset);
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -55,13 +55,6 @@ public:
       size_t step,
       debug_sanitize_files);
 
-    /** Constructor with mock file content for unit testing */
-    segment_index(
-      ss::sstring filename,
-      ss::file mock_file,
-      model::offset base,
-      size_t step);
-
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
     segment_index& operator=(segment_index&&) noexcept = default;
@@ -104,9 +97,19 @@ private:
     index_state _state;
     debug_sanitize_files _sanitize;
 
+    /** Constructor with mock file content for unit testing */
+    segment_index(
+      ss::sstring filename,
+      ss::file mock_file,
+      model::offset base,
+      size_t step);
+
     // For unit testing only.  If this is set, then open() returns
     // the contents of mock_file instead of opening the path in _name.
     std::optional<ss::file> _mock_file;
+
+    friend class offset_index_utils_fixture;
+    friend class log_replayer_fixture;
 
     friend std::ostream& operator<<(std::ostream&, const segment_index&);
 };

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -9,7 +9,11 @@
 
 #include "storage/segment_reader.h"
 
+#include "ssx/future-util.h"
+#include "storage/logger.h"
+#include "storage/segment_utils.h"
 #include "vassert.h"
+#include "vlog.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
@@ -21,33 +25,133 @@ namespace storage {
 
 segment_reader::segment_reader(
   ss::sstring filename,
-  ss::file data_file,
-  size_t file_size,
   size_t buffer_size,
-  unsigned read_ahead) noexcept
+  unsigned read_ahead,
+  debug_sanitize_files sanitize) noexcept
   : _filename(std::move(filename))
-  , _data_file(std::move(data_file))
-  , _file_size(file_size)
   , _buffer_size(buffer_size)
-  , _read_ahead(read_ahead) {}
+  , _read_ahead(read_ahead)
+  , _sanitize(sanitize) {}
 
-ss::input_stream<char>
-segment_reader::data_stream(size_t pos, const ss::io_priority_class& pc) {
+segment_reader::~segment_reader() noexcept {
+    if (!_streams.empty() || _data_file_refcount > 0) {
+        vlog(
+          stlog.warn,
+          "Dropping segment_reader while handles exist on file {}",
+          _filename);
+    }
+
+    for (auto& i : _streams) {
+        i.detach();
+    }
+
+    _streams.clear();
+}
+
+segment_reader::segment_reader(segment_reader&& rhs) noexcept
+  : _filename(std::move(rhs._filename))
+  , _data_file(std::move(rhs._data_file))
+  , _data_file_refcount(rhs._data_file_refcount)
+  , _file_size(rhs._file_size)
+  , _buffer_size(rhs._buffer_size)
+  , _read_ahead(rhs._read_ahead)
+  , _sanitize(rhs._sanitize) {
+    for (auto& i : rhs._streams) {
+        i._parent = this;
+        i._hook.unlink();
+        _streams.push_back(i);
+    }
+}
+
+ss::future<> segment_reader::load_size() {
+    auto s = co_await stat();
+    set_file_size(s.st_size);
+};
+
+ss::future<segment_reader_handle>
+segment_reader::data_stream(size_t pos, const ss::io_priority_class pc) {
     vassert(
       pos <= _file_size,
       "cannot read negative bytes. Asked to read at position: '{}' - {}",
       pos,
       *this);
+
+    // note: this file _must_ be open in `ro` mode only. Seastar uses dma
+    // files with no shared buffer cache around them. When we use a writer
+    // w/ dma at the same time as the reader, we need a way to synchronize
+    // filesytem metadata. In order to prevent expensive synchronization
+    // primitives fsyncing both *reads* and *writes* we open this file in ro
+    // mode and if raft requires truncation, we open yet-another handle w/
+    // rw mode just for the truncation which gives us all the benefits of
+    // preventing x-file synchronization This is fine, because truncation to
+    // sealed segments are supposed to be very rare events. The hotpath of
+    // truncating the appender, is optimized.
+
     ss::file_input_stream_options options;
     options.buffer_size = _buffer_size;
     options.io_priority_class = pc;
     options.read_ahead = _read_ahead;
-    return make_file_input_stream(
-      _data_file, pos, _file_size - pos, std::move(options));
+
+    auto handle = co_await get();
+    handle.set_stream(make_file_input_stream(
+      _data_file, pos, _file_size - pos, std::move(options)));
+    co_return std::move(handle);
 }
 
-ss::input_stream<char> segment_reader::data_stream(
-  size_t pos_begin, size_t pos_end, const ss::io_priority_class& pc) {
+ss::future<segment_reader_handle> segment_reader::get() {
+    vlog(
+      stlog.trace,
+      "::get segment file {}, refcount={}",
+      _filename,
+      _data_file_refcount);
+    // Lock to prevent double-opens
+    auto units = co_await _open_lock.get_units();
+    if (!_data_file) {
+        vlog(stlog.debug, "Opening segment file {}", _filename);
+        _data_file = co_await internal::make_reader_handle(
+          std::filesystem::path(_filename), _sanitize);
+    }
+
+    _data_file_refcount++;
+    auto handle = segment_reader_handle(this);
+    co_return handle;
+}
+
+/**
+ * Release a reference to the file.
+ *
+ * This function may sleep, but will not access any memory
+ * belonging to the segment_reader after that: i.e. it is safe
+ * to deallocate or move the segment_reader while waiting for
+ * the future from put() to complete.
+ */
+ss::future<> segment_reader::put() {
+    vlog(
+      stlog.trace,
+      "::put segment file {}, refcount={}",
+      _filename,
+      _data_file_refcount);
+    vassert(_data_file_refcount > 0, "bad put() on {}", _filename);
+    _data_file_refcount--;
+    if (_data_file && _data_file_refcount == 0) {
+        vlog(stlog.debug, "Closing segment file {}", _filename);
+        // Note: a get() can now come in and open a fresh file handle: this
+        // means we strictly-speaking can consume >1 file descriptors from one
+        // segment_reader, but it's a rare+transient state.
+        auto data_file = std::exchange(_data_file, ss::file{});
+        co_await data_file.close();
+    }
+}
+
+ss::future<struct stat> segment_reader::stat() {
+    auto handle = co_await get();
+    auto r = co_await _data_file.stat();
+    co_await handle.close();
+    co_return r;
+}
+
+ss::future<segment_reader_handle> segment_reader::data_stream(
+  size_t pos_begin, size_t pos_end, const ss::io_priority_class pc) {
     vassert(
       pos_begin <= _file_size,
       "cannot read negative bytes. Asked to read at positions: '{}-{}' - {}",
@@ -64,8 +168,11 @@ ss::input_stream<char> segment_reader::data_stream(
     options.buffer_size = _buffer_size;
     options.io_priority_class = pc;
     options.read_ahead = _read_ahead;
-    return make_file_input_stream(
-      _data_file, pos_begin, pos_end - pos_begin, std::move(options));
+
+    auto handle = co_await get();
+    handle.set_stream(make_file_input_stream(
+      _data_file, pos_begin, pos_end - pos_begin, std::move(options)));
+    co_return handle;
 }
 
 ss::future<> segment_reader::truncate(size_t n) {
@@ -76,6 +183,14 @@ ss::future<> segment_reader::truncate(size_t n) {
             .then([f]() mutable { return f.close(); })
             .finally([f] {});
       });
+}
+
+ss::future<> segment_reader::close() {
+    if (_data_file) {
+        return _data_file.close();
+    } else {
+        return ss::now();
+    }
 }
 
 std::ostream& operator<<(std::ostream& os, const segment_reader& seg) {
@@ -89,4 +204,44 @@ std::ostream& operator<<(std::ostream& os, const segment_reader_ptr& seg) {
     }
     return os << "{{log_segment: null}}";
 }
+
+segment_reader_handle::segment_reader_handle(segment_reader* parent)
+  : _parent(parent) {
+    _parent->_streams.push_back(*this);
+}
+
+segment_reader_handle::~segment_reader_handle() {
+    vassert(!_stream.has_value(), "Must close before destroying");
+    vassert(_parent == nullptr, "Must close before destroying");
+}
+
+ss::future<> segment_reader_handle::close() {
+    if (_stream) {
+        co_await _stream.value().close();
+        _stream = std::nullopt;
+    }
+    _hook.unlink();
+
+    if (_parent) {
+        co_await _parent->put();
+        _parent = nullptr;
+    }
+}
+
+void segment_reader_handle::operator=(segment_reader_handle&& rhs) noexcept {
+    assert(&rhs != this);
+
+    if (_parent) {
+        // Where we move-assign a handle into a handle that's already,
+        // it's to reset a stream on the same underlying segment_reader,
+        // so we can be certain that the put() will not reduce the
+        // file handle refcount to zero, as `rhs` holds a reference.
+        vlog(stlog.trace, "Backgrounding put to {}", _parent->_filename);
+        ssx::background = _parent->put();
+    }
+    _stream = std::exchange(rhs._stream, std::nullopt);
+    _parent = std::exchange(rhs._parent, nullptr);
+    _hook.swap_nodes(rhs._hook);
+}
+
 } // namespace storage

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -58,9 +58,6 @@ public:
     /// truncates file starting at this phyiscal offset
     ss::future<> truncate(size_t sz);
 
-    /// flushes the file metadata
-    ss::future<> flush() { return _data_file.flush(); }
-
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
     ss::input_stream<char>

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -13,6 +13,9 @@
 
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "storage/types.h"
+#include "utils/intrusive_list_helpers.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
@@ -26,19 +29,94 @@
 
 namespace storage {
 
+class segment_reader;
+
+/**
+ * A segment reader handle confers the right to use a file descriptor
+ * opened by segment_reader, a clone of which is encapsulated in
+ * the handler's input_stream (if stream is set).
+ *
+ * We need this handle & associated reference counting to enable
+ * opening segment files on demand, and keeping them open as long
+ * as input_streams using the file are alive.
+ */
+class segment_reader_handle {
+private:
+    intrusive_list_hook _hook;
+    segment_reader* _parent{nullptr};
+
+    friend class segment_reader;
+
+    // A handle does not have to have a stream: it might have been
+    // created to just stat() a file for example.
+    std::optional<ss::input_stream<char>> _stream;
+
+public:
+    explicit segment_reader_handle(segment_reader* parent);
+
+    segment_reader_handle(segment_reader_handle&& rhs) noexcept {
+        _stream = std::exchange(rhs._stream, std::nullopt);
+        _parent = std::exchange(rhs._parent, nullptr);
+        _hook.swap_nodes(rhs._hook);
+    }
+
+    /**
+     * Special constructor for use in remote_segment, which doesn't
+     * implement open-on-demand behaviour.
+     */
+    explicit segment_reader_handle(ss::input_stream<char>&& s)
+      : _stream(std::move(s)) {}
+
+    void operator=(segment_reader_handle&& rhs) noexcept;
+
+    /**
+     * May only be called once per lifetime.  Use this immediately after
+     * construction.
+     */
+    void set_stream(ss::input_stream<char> s) {
+        vassert(!_stream.has_value(), "Called set_stream twice!");
+        _stream = std::move(s);
+    }
+
+    /**
+     * Move the input_stream out of this class: use this method
+     * if you are about to consume the stream through close and destruction.
+     *
+     * You must still call close on this handle before destroying it, even if
+     * you have closed the stream.
+     */
+    ss::input_stream<char> take_stream() {
+        auto r = std::move(_stream.value());
+        _stream.reset();
+        return r;
+    }
+
+    ss::input_stream<char>& stream() { return _stream.value(); }
+
+    ss::future<> close();
+
+    void detach() {
+        _parent = nullptr;
+        _hook.unlink();
+    }
+
+    ~segment_reader_handle();
+};
+
 class segment_reader {
 public:
     segment_reader(
       ss::sstring filename,
-      ss::file,
-      size_t file_size,
       size_t buffer_size,
-      unsigned read_ahead) noexcept;
-    ~segment_reader() noexcept = default;
-    segment_reader(segment_reader&&) noexcept = default;
+      unsigned read_ahead,
+      debug_sanitize_files) noexcept;
+    ~segment_reader() noexcept;
+    segment_reader(segment_reader&&) noexcept;
     segment_reader& operator=(segment_reader&&) noexcept = default;
     segment_reader(const segment_reader&) = delete;
     segment_reader& operator=(const segment_reader&) = delete;
+
+    ss::future<> load_size();
 
     /// max physical byte that this reader is allowed to fetch
     void set_file_size(size_t o) { _file_size = o; }
@@ -50,28 +128,48 @@ public:
     bool empty() const { return _file_size == 0; }
 
     /// close the underlying file handle
-    ss::future<> close() { return _data_file.close(); }
+    ss::future<> close();
 
     /// perform syscall stat
-    ss::future<struct stat> stat() { return _data_file.stat(); }
+    ss::future<struct stat> stat();
 
     /// truncates file starting at this phyiscal offset
     ss::future<> truncate(size_t sz);
 
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
-    ss::input_stream<char>
-    data_stream(size_t pos, const ss::io_priority_class&);
-    ss::input_stream<char>
-    data_stream(size_t pos_begin, size_t pos_end, const ss::io_priority_class&);
+    ss::future<segment_reader_handle>
+    data_stream(size_t pos, const ss::io_priority_class);
+    ss::future<segment_reader_handle>
+    data_stream(size_t pos_begin, size_t pos_end, const ss::io_priority_class);
 
 private:
     ss::sstring _filename;
+
+    // Protects open/close of _data_file, to avoid double-opening on
+    // concurrent calls to get()
+    mutex _open_lock;
+
+    // This is only initialized if _data_file_refcount is greater than zero
     ss::file _data_file;
+
+    uint32_t _data_file_refcount{0};
+
+    intrusive_list<segment_reader_handle, &segment_reader_handle::_hook>
+      _streams;
+
     size_t _file_size{0};
     size_t _buffer_size{0};
     unsigned _read_ahead{0};
+    debug_sanitize_files _sanitize;
 
+    // Acquire a handle to use the underlying file handle
+    ss::future<segment_reader_handle> get();
+
+    // Signal destruction of a segment_reader_handle
+    ss::future<> put();
+
+    friend class segment_reader_handle;
     friend std::ostream& operator<<(std::ostream&, const segment_reader&);
 };
 

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -216,7 +216,7 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
                       "Error materializing index:{}. Recovering parent "
                       "segment:{}. Details:{}",
                       s.index().filename(),
-                      s.reader().filename(),
+                      s.filename(),
                       std::current_exception());
                     to_recover_set.insert(&s);
                 }

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -254,7 +254,16 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
               vlog(stlog.info, "Removing empty segment: {}", segment);
               segment->close().get();
               ss::remove_file(segment->reader().filename()).get();
-              ss::remove_file(segment->index().filename()).get();
+              try {
+                  ss::remove_file(segment->index().filename()).get();
+              } catch (const std::filesystem::filesystem_error& e) {
+                  // Ignore ENOENT on deletion: segments are allowed to
+                  // exist without an index if redpanda shutdown without
+                  // a flush.
+                  if (e.code() != std::errc::no_such_file_or_directory) {
+                      throw;
+                  }
+              }
               return false;
           });
         // remove empty from to recover set

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -653,16 +653,11 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
     if (co_await ss::file_exists(index_name.string())) {
         co_await ss::remove_file(index_name.string());
     }
-    auto index_fd = co_await make_handle(
-      index_name.string(),
-      ss::open_flags::create | ss::open_flags::rw,
-      {},
-      cfg.sanitize);
     segment_index index(
       index_name.string(),
-      index_fd,
       offsets.base_offset,
-      segment_index::default_data_buffer_step);
+      segment_index::default_data_buffer_step,
+      cfg.sanitize);
 
     co_return ss::make_lw_shared<segment>(
       offsets,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -84,8 +84,10 @@ ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(
   int retries);
 
 /// make file handle with default opts
-ss::future<ss::file>
-make_writer_handle(const std::filesystem::path&, storage::debug_sanitize_files);
+ss::future<ss::file> make_writer_handle(
+  const std::filesystem::path&,
+  storage::debug_sanitize_files,
+  bool truncate = false);
 /// make file handle with default opts
 ss::future<ss::file>
 make_reader_handle(const std::filesystem::path&, storage::debug_sanitize_files);

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -17,6 +17,7 @@
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/segment_appender.h"
+#include "storage/types.h"
 #include "utils/vint.h"
 
 #include <seastar/core/file.hh>
@@ -43,9 +44,13 @@ public:
 
     spill_key_index(
       ss::sstring filename,
-      ss::file index_file,
       ss::io_priority_class,
-      size_t max_memory);
+      size_t max_memory,
+      bool truncate,
+      storage::debug_sanitize_files debug);
+
+    spill_key_index(ss::sstring name, ss::file dummy_file, size_t max_memory);
+
     spill_key_index(const spill_key_index&) = delete;
     spill_key_index& operator=(const spill_key_index&) = delete;
     spill_key_index(spill_key_index&&) noexcept = default;
@@ -54,6 +59,8 @@ public:
 
     // public
 
+    ss::future<> maybe_open();
+    ss::future<> open();
     ss::future<> index(const iobuf& key, model::offset, int32_t) final;
     ss::future<> index(bytes_view, model::offset, int32_t) final;
     ss::future<> index(bytes&&, model::offset, int32_t) final;
@@ -79,7 +86,10 @@ private:
     ss::future<> add_key(bytes b, value_type);
     ss::future<> spill(compacted_index::entry_type, bytes_view, value_type);
 
-    segment_appender _appender;
+    storage::debug_sanitize_files _debug;
+    ss::io_priority_class _pc;
+    bool _truncate;
+    std::optional<segment_appender> _appender;
     underlying_t _midx;
     size_t _max_mem;
     size_t _keys_mem_usage{0};

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -24,14 +24,18 @@
 
 #include <boost/test/unit_test_suite.hpp>
 
+storage::compacted_index_writer make_dummy_compacted_index(
+  tmpbuf_file::store_t& index_data, size_t max_memory) {
+    auto f = ss::file(ss::make_shared(tmpbuf_file(index_data)));
+    return storage::compacted_index_writer(
+      std::make_unique<storage::internal::spill_key_index>(
+        "dummy name", f, max_memory));
+}
+
 struct compacted_topic_fixture {};
 FIXTURE_TEST(format_verification, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      1_KiB);
+    auto idx = make_dummy_compacted_index(index_data, 1_KiB);
     const auto key = random_generators::get_bytes(1024);
     idx.index(key, model::offset(42), 66).get();
     idx.close().get();
@@ -60,11 +64,7 @@ FIXTURE_TEST(format_verification, compacted_topic_fixture) {
 }
 FIXTURE_TEST(format_verification_max_key, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      1_MiB);
+    auto idx = make_dummy_compacted_index(index_data, 1_MiB);
     const auto key = random_generators::get_bytes(1_MiB);
     idx.index(key, model::offset(42), 66).get();
     idx.close().get();
@@ -94,11 +94,7 @@ FIXTURE_TEST(format_verification_max_key, compacted_topic_fixture) {
 }
 FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      1_MiB);
+    auto idx = make_dummy_compacted_index(index_data, 1_MiB);
     const auto key = random_generators::get_bytes(20);
     idx.index(key, model::offset(42), 66).get();
     idx.close().get();
@@ -122,11 +118,7 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
 FIXTURE_TEST(
   format_verification_roundtrip_exceeds_capacity, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      1_MiB);
+    auto idx = make_dummy_compacted_index(index_data, 1_MiB);
     const auto key = random_generators::get_bytes(1_MiB);
     idx.index(key, model::offset(42), 66).get();
     idx.close().get();
@@ -152,12 +144,8 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      // FORCE eviction with every key basically
-      1_KiB);
+    // 1 KiB to FORCE eviction with every key basically
+    auto idx = make_dummy_compacted_index(index_data, 1_KiB);
 
     const auto key1 = random_generators::get_bytes(1_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
@@ -196,12 +184,8 @@ FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
 
 FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      // FORCE eviction with every key basically
-      1_KiB);
+    // 1 KiB to FORCE eviction with every key basically
+    auto idx = make_dummy_compacted_index(index_data, 1_KiB);
 
     const auto key1 = random_generators::get_bytes(1_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
@@ -265,12 +249,8 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
 FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
 
-    auto idx = storage::make_file_backed_compacted_index(
-      "dummy name",
-      ss::file(ss::make_shared(tmpbuf_file(index_data))),
-      ss::default_priority_class(),
-      // FORCE eviction with every key basically
-      1_KiB);
+    // 1 KiB to FORCE eviction with every key basically
+    auto idx = make_dummy_compacted_index(index_data, 1_KiB);
 
     const auto key1 = random_generators::get_bytes(128_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
@@ -306,12 +286,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
 
     // the main test
     tmpbuf_file::store_t final_data;
-    auto final_idx = storage::make_file_backed_compacted_index(
-      "dummy name - final idx",
-      ss::file(ss::make_shared(tmpbuf_file(final_data))),
-      ss::default_priority_class(),
-      // FORCE eviction with every key basically
-      1_KiB);
+    auto final_idx = make_dummy_compacted_index(final_data, 1_KiB);
 
     rdr.reset();
     rdr

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -52,11 +52,8 @@ struct context {
         auto indexer = segment_index(
           base_name + ".index", std::move(fidx), base, 4096);
         auto reader = segment_reader(
-          base_name,
-          ss::open_file_dma(base_name, ss::open_flags::ro).get0(),
-          appender->file_byte_offset(),
-          128_KiB,
-          10);
+          base_name, 128_KiB, 10, debug_sanitize_files::no);
+        reader.load_size().get();
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),
           std::move(reader),

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -28,7 +28,9 @@
 
 using namespace storage; // NOLINT
 
-struct context {
+namespace storage {
+class log_replayer_fixture {
+public:
     ss::lw_shared_ptr<segment> _seg;
     std::optional<log_replayer> replayer_opt;
     ss::sstring base_name = "test."
@@ -64,7 +66,7 @@ struct context {
         replayer_opt = log_replayer(*_seg);
     }
 
-    ~context() { _seg->close().get(); }
+    ~log_replayer_fixture() { _seg->close().get(); }
 
     void write_garbage() { do_write_garbage(base_name); }
 
@@ -103,9 +105,10 @@ struct context {
 
     log_replayer& replayer() { return *replayer_opt; }
 };
+} // namespace storage
 
 SEASTAR_THREAD_TEST_CASE(test_can_recover_single_batch) {
-    context ctx;
+    log_replayer_fixture ctx;
     auto batches = model::test::make_random_batches(model::offset(1), 1);
     auto last_offset = batches.back().last_offset();
     ctx.write(batches);
@@ -117,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_recover_single_batch) {
 
 SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
     {
-        context ctx;
+        log_replayer_fixture ctx;
         auto batches = model::test::make_random_batches(model::offset(1), 1);
         batches.back().header().crc = 10;
         ctx.write(batches);
@@ -126,7 +129,7 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
         BOOST_CHECK(!bool(recovered));
     }
     {
-        context ctx;
+        log_replayer_fixture ctx;
         auto batches = model::test::make_random_batches(model::offset(1), 1);
         batches.back().header().first_timestamp = model::timestamp(10);
         ctx.write(batches);
@@ -137,7 +140,7 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_malformed_segment) {
-    context ctx;
+    log_replayer_fixture ctx;
     ctx.write_garbage();
     ctx.initialize(model::offset(0));
     auto recovered = ctx.replayer().recover_in_thread(
@@ -146,7 +149,7 @@ SEASTAR_THREAD_TEST_CASE(test_malformed_segment) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_can_recover_multiple_batches) {
-    context ctx;
+    log_replayer_fixture ctx;
     auto batches = model::test::make_random_batches(model::offset(1), 10);
     auto last_offset = batches.back().last_offset();
     ctx.write(batches);
@@ -159,7 +162,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_recover_multiple_batches) {
 SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
     {
         // bad crc test
-        context ctx;
+        log_replayer_fixture ctx;
         auto batches = model::test::make_random_batches(model::offset(1), 10);
         batches.back().header().crc = 10;
         auto last_offset = (batches.end() - 2)->last_offset();
@@ -171,7 +174,7 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
     }
     {
         // timestamp test
-        context ctx;
+        log_replayer_fixture ctx;
         auto batches = model::test::make_random_batches(model::offset(1), 10);
         batches.back().header().first_timestamp = model::timestamp(10);
         auto last_offset = (batches.end() - 2)->last_offset();
@@ -184,7 +187,7 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
 }
 SEASTAR_THREAD_TEST_CASE(test_reset_index) {
     // bad crc test
-    context ctx;
+    log_replayer_fixture ctx;
     ctx.write_garbage_index(); // key
     auto batches = model::test::make_random_batches(model::offset(1), 10);
     auto last_offset = batches.back().last_offset();

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -28,7 +28,6 @@ struct context {
           _base_offset,
           storage::segment_index::default_data_buffer_step);
     }
-    ~context() { _idx->close().get(); }
 
     const model::record_batch_header
     modify_get(model::offset o, int32_t batch_size) {

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -69,6 +69,8 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             args += [
                 "--config", "cleanup.policy={}".format(spec.cleanup_policy)
             ]
+        if spec.segment_bytes is not None:
+            args += ["--config", f"segment.bytes={spec.segment_bytes}"]
         return self._run("kafka-topics.sh", args)
 
     def create_topic_partitions(self, topic, partitions):

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -50,7 +50,7 @@ class TopicSpec:
                  cleanup_policy=CLEANUP_DELETE,
                  compression_type=COMPRESSION_PRODUCER,
                  message_timestamp_type=TIMESTAMP_CREATE_TIME,
-                 segment_bytes=1 * (2 ^ 30),
+                 segment_bytes=None,
                  retention_bytes=None,
                  retention_ms=None,
                  redpanda_datapolicy=None,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -730,15 +730,20 @@ class RedpandaService(Service):
         # Fall through: no problematic lines found
         return True
 
-    def lsof_node(self, node: ClusterNode):
+    def lsof_node(self, node: ClusterNode, filter: Optional[str] = None):
         """
         Get the list of open files for a running node
+
+        :param filter: If given, this is a grep regex that will filter the files we list
+
         :return: yields strings
         """
         first = True
-        for line in node.account.ssh_capture(
-                f"lsof -nP -p {self.redpanda_pid(node)}"):
-            if first:
+        cmd = f"lsof -nP -p {self.redpanda_pid(node)}"
+        if filter is not None:
+            cmd += f" | grep {filter}"
+        for line in node.account.ssh_capture(cmd):
+            if first and not filter:
                 # First line is a header, skip it
                 first = False
                 continue

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -74,9 +74,13 @@ class Partition:
             segment.delete_indices(allow_fail)
 
     def recovered(self):
-        return all(
-            map(lambda s: s.recovered(),
-                (kv[1] for kv in self.segments.items())))
+        n_recovered = sum(1 for s in map(lambda s: s.recovered(), (
+            kv[1] for kv in self.segments.items())) if s is True)
+
+        # All but one should have index files: the one that doesn't is
+        # the currently open segment (segments don't get indices on disk
+        # until they're sealed)
+        return n_recovered >= len(self.segments) - 1
 
     def __repr__(self):
         return "part-{}-{}-{}".format(self.node.name, self.num, self.segments)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -735,7 +735,7 @@ class ClusterConfigTest(RedpandaTest):
         try:
             _, out = self._export_import_modify(
                 [("kafka_qdc_enable: false", "kafka_qdc_enable: rhubarb"),
-                 ("topic_fds_per_partition: 10",
+                 ("topic_fds_per_partition: 5",
                   "topic_fds_per_partition: 9999"),
                  ("default_num_windows: 10", "default_num_windows: 32768")],
                 all=True)

--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -119,9 +119,9 @@ class ResourceLimitsTest(RedpandaTest):
 
         rpk = RpkTool(self.redpanda)
 
-        # Default 10 fds per partition, we set ulimit down to 1000, so 100 should be the limit
+        # Default 5 fds per partition, we set ulimit down to 1000, so 100 should be the limit
         try:
-            rpk.create_topic("toobig", partitions=110, replicas=3)
+            rpk.create_topic("toobig", partitions=220, replicas=3)
         except RpkException as e:
             assert 'INVALID_PARTITIONS' in e.msg
         else:

--- a/tests/rptest/tests/storage_resources_test.py
+++ b/tests/rptest/tests/storage_resources_test.py
@@ -1,0 +1,105 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.rpk_producer import RpkProducer
+
+
+class StorageResourceTest(RedpandaTest):
+    """
+    Validate that the storage system is using the expected
+    resources, in terms of how many files are created and how
+    many concurrent file handles are held.
+    """
+
+    SEGMENT_SIZE = 2**20
+
+    topics = (
+        TopicSpec(
+            partition_count=1,
+            replication_factor=1,
+            # Enable compaction so that we can test the handling of compaction_index
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            segment_bytes=SEGMENT_SIZE), )
+
+    def _get_segments(self):
+        storage = self.redpanda.storage()
+        partitions = storage.partitions("kafka", self.topic)
+        p = list(partitions)[0]
+        segments = list(p.segments.values())
+
+        # Sort by offset, so that earliest-written segments are first
+        segments = sorted(segments, key=lambda s: int(s.name.split("-")[0]))
+
+        for s in segments:
+            self.logger.info(f"Got segment: {s}")
+        return segments
+
+    def _topic_fd_count(self):
+        """
+        How many file descriptors is redpanda consuming for our topic?
+        """
+        for f in self.redpanda.lsof_node(self.redpanda.nodes[0],
+                                         filter=self.topic):
+            self.logger.info(f"Open file: {f}")
+
+        return sum(1 for _ in self.redpanda.lsof_node(self.redpanda.nodes[0],
+                                                      filter=self.topic))
+
+    def _write(self, msg_size, msg_count):
+        producer = RpkProducer(self.test_context,
+                               self.redpanda,
+                               self.topic,
+                               msg_size,
+                               msg_count=msg_count,
+                               acks=-1)
+        producer.start()
+        producer.wait()
+        producer.free()
+
+    @cluster(num_nodes=2)
+    def test_files_and_fds(self):
+        """
+        Verify that the indices for a segment are not written out
+        until they are ready (avoid wastefully opening a file
+        handle prematurely)
+        """
+
+        msg_size = int(self.SEGMENT_SIZE / 8)
+
+        # Write enough data to half fill the first segment
+        self._write(msg_size, 4)
+
+        segments = self._get_segments()
+        assert len(segments) == 1
+        live_seg = segments[-1]
+        assert live_seg.base_index is None
+
+        assert self._topic_fd_count() == 1
+        assert live_seg.compaction_index is None
+
+        # Produce twice to get two batches (one batch would just result in overshooting
+        # the segment size limit)
+        self._write(msg_size, 8)
+        self._write(msg_size, 8)
+
+        segments = self._get_segments()
+        assert len(segments) >= 2
+        for sealed_seg in segments[0:-1]:
+            assert sealed_seg.base_index is not None
+            assert sealed_seg.compaction_index is not None
+        live_seg = segments[-1]
+        assert live_seg.base_index is None
+
+        # Even though there are two segments, only the latest one should
+        # be open.
+        assert self._topic_fd_count() == 1
+        assert live_seg.compaction_index is None


### PR DESCRIPTION
## Cover letter

Previously, there was no bound on the number of file handles that Redpanda will try to open.  The lower bound is `2 * partition_count * reboot count`.  i.e. if you create 100 partitions, then each time you restart redpanda there will be 200 more file handles open.

Each segment comes with a segment_reader, which previously embedded a file handle, which was then cloned off each time data_stream() was called to create an input_stream.  In this PR, this is changed to only open that per-reader `ss::file` object when we need it, and keep a reference count via a new `segment_reader_handle` RAII wrapper to input_stream.

Each segment also comes with a segment_index, which also embeds a file handle.  This one is pretty much totally pointless: indices are read and written occasionally, and in one go, so it is straightforward to open the file on-demand instead of keeping the handle around.

Note that this change does not do anything about the overall memory footprint of segment_index, which can be reduced by dropping the `index_state` for indices that haven't been touched in a while, and reloading it on demand.

Fixes https://github.com/redpanda-data/redpanda/issues/4057

## Release notes

### Improvements

* Redpanda now uses fewer file handles on systems with large partition counts.

