### PR TITLE
add requireClientAuth to kafka api

### DIFF
--- a/src/go/k8s/config/samples/mtls.yaml
+++ b/src/go/k8s/config/samples/mtls.yaml
@@ -20,6 +20,7 @@ spec:
      - port: 9092
        tls:
          enabled: true
+         requireClientAuth: true
     pandaproxyApi:
      - port: 8082
        tls:


### PR DESCRIPTION
we decided that you can use mtls with kafka api, so I added the requireClientAuth parameter to the api config. 