### PR TITLE
rpk: do not require lib/libexec files

### DIFF
--- a/src/go/rpk/pkg/redpanda/paths.go
+++ b/src/go/rpk/pkg/redpanda/paths.go
@@ -21,9 +21,6 @@ import (
 var redpandaInstallDirContent = []string{
 	"bin/rpk",
 	"bin/redpanda",
-	"lib",
-	"libexec/rpk",
-	"libexec/redpanda",
 }
 
 func GetIOConfigPath(configFileDirectory string) string {


### PR DESCRIPTION
## Cover letter

RPK has logic for probing for an installation
file by looking for redpanda binaries.  It
is not just looking for the actual entrypoints,
but also for the libexec files: this is an
implementation detail that rpk should not
care about.

Motivated by https://github.com/redpanda-data/vtools/pull/528 ,
in which rpk stops working when we change rpk to put its
binary in bin/rpk rather than in libexec with a wrapper script.

## Release notes

* none