### PR TITLE
Fix Index State Random Data Generation in Test

### DIFF
--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -21,7 +21,6 @@ static storage::index_state make_random_index_state() {
           random_generators::get_int<uint32_t>(),
           random_generators::get_int<uint32_t>(),
           random_generators::get_int<uint64_t>());
-        return st;
     }
 
     return st;


### PR DESCRIPTION
Test case generation was mistakenly creating tests with size=1 instead of a random size.