### PR TITLE
rptest: convert `@ignore` to `excluded`

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -25,3 +25,5 @@ quick:
   - tests/wasm_topics_test.py::WasmCreateTopicsTest.verify_materialized_topics_test
     # https://github.com/redpanda-data/redpanda/issues/3745
   - tests/wasm_topics_test.py::WasmDeleteTopicsTest.verify_materialized_topics_test
+    # https://github.com/redpanda-data/redpanda/issues/2569
+  - tests/topic_recovery_test.py::TopicRecoveryTest

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -19,3 +19,5 @@ quick:
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_binary_v2
     # https://github.com/redpanda-data/redpanda/issues/2501
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_json_v2
+    # https://github.com/redpanda-data/redpanda/issues/3880
+  - tests/full_node_recovery_test.py::FullNodeRecoveryTest.test_node_recovery

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -17,3 +17,5 @@ quick:
   - tests/availability_test.py::AvailabilityTests.test_availability_when_one_node_failed
     # https://github.com/redpanda-data/redpanda/issues/3454
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_binary_v2
+    # https://github.com/redpanda-data/redpanda/issues/2501
+  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_json_v2

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -21,3 +21,5 @@ quick:
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_json_v2
     # https://github.com/redpanda-data/redpanda/issues/3880
   - tests/full_node_recovery_test.py::FullNodeRecoveryTest.test_node_recovery
+    # https://github.com/redpanda-data/redpanda/issues/3858
+  - tests/wasm_topics_test.py::WasmCreateTopicsTest.verify_materialized_topics_test

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -15,3 +15,5 @@ quick:
   - tests/librdkafka_test.py
     # https://github.com/redpanda-data/redpanda/issues/3450
   - tests/availability_test.py::AvailabilityTests.test_availability_when_one_node_failed
+    # https://github.com/redpanda-data/redpanda/issues/3454
+  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_binary_v2

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -23,3 +23,5 @@ quick:
   - tests/full_node_recovery_test.py::FullNodeRecoveryTest.test_node_recovery
     # https://github.com/redpanda-data/redpanda/issues/3858
   - tests/wasm_topics_test.py::WasmCreateTopicsTest.verify_materialized_topics_test
+    # https://github.com/redpanda-data/redpanda/issues/3745
+  - tests/wasm_topics_test.py::WasmDeleteTopicsTest.verify_materialized_topics_test

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -13,3 +13,5 @@ quick:
 
   excluded:
   - tests/librdkafka_test.py
+    # https://github.com/redpanda-data/redpanda/issues/3450
+  - tests/availability_test.py::AvailabilityTests.test_availability_when_one_node_failed

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -9,7 +9,6 @@
 
 import random
 
-from ducktape.mark import ignore
 from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
@@ -34,7 +33,6 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @ignore  # temporarily disabled flaky test, see issue #3450
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
         self.redpanda = RedpandaService(

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -9,7 +9,7 @@
 
 import random
 from rptest.services.cluster import cluster
-from ducktape.mark import parametrize, ignore
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -34,7 +34,6 @@ class FullNodeRecoveryTest(EndToEndTest):
         super(FullNodeRecoveryTest, self).__init__(test_context=test_context,
                                                    extra_rp_conf=extra_rp_conf)
 
-    @ignore  # Temporarily disabled: see issue #3880
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(recovery_type=PARTIAL_RECOVERY)
     # enable when we implement support for leader epochs

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -117,8 +117,6 @@ class NodeOperationFuzzyTest(EndToEndTest):
     """
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    # @ignore failures=True mode for https://github.com/redpanda-data/redpanda/issues/3866
-    #@parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -12,7 +12,6 @@ import json
 import uuid
 import requests
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -765,7 +764,6 @@ class PandaProxyTest(RedpandaTest):
         rc_res = c0.remove()
         assert rc_res.status_code == requests.codes.no_content
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2501
     @cluster(num_nodes=3)
     def test_consumer_group_json_v2(self):
         """

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -679,7 +679,6 @@ class PandaProxyTest(RedpandaTest):
             })
         assert sc_res.status_code == requests.codes.no_content
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3454
     @cluster(num_nodes=3)
     def test_consumer_group_binary_v2(self):
         """

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -7,7 +7,6 @@
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.archival.s3_client import S3Client
 from rptest.services.redpanda import RedpandaService
@@ -1545,7 +1544,6 @@ class TopicRecoveryTest(RedpandaTest):
             time.sleep(20)
             test_case.after_restart_validation()
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_no_data(self):
         """If we're trying to recovery a topic which didn't have any data
@@ -1555,7 +1553,6 @@ class TopicRecoveryTest(RedpandaTest):
                                self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_topic_manifest(self):
         """If we're trying to recovery a topic which didn't have any data
@@ -1565,7 +1562,6 @@ class TopicRecoveryTest(RedpandaTest):
                                          self.rpk, self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_partition(self):
         """Test situation when one of the partition manifests are missing.
@@ -1578,7 +1574,6 @@ class TopicRecoveryTest(RedpandaTest):
                                      self.rpk, self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_missing_segment(self):
         """Test the handling of the missing segment. The segment is
@@ -1588,7 +1583,6 @@ class TopicRecoveryTest(RedpandaTest):
                                    self.s3_bucket, self.logger)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_fast1(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1602,7 +1596,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.s3_bucket, self.logger, topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_fast2(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1619,7 +1612,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.s3_bucket, self.logger, topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_fast3(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1639,7 +1631,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.s3_bucket, self.logger, topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift1(self):
         """Test handling of situations when the revision of the recovered
@@ -1653,7 +1644,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, 0)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift2(self):
         """Test handling of situations when the revision of the recovered
@@ -1667,7 +1657,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, -1)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_revision_shift3(self):
         """Test handling of situations when the revision of the recovered
@@ -1681,7 +1670,6 @@ class TopicRecoveryTest(RedpandaTest):
                                   self.s3_bucket, self.logger, topics, 1)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_size_based_retention(self):
         """Test topic recovery with size based retention policy.
@@ -1697,7 +1685,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention(self):
         """Test topic recovery with time based retention policy.
@@ -1714,7 +1701,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics, False)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention_with_legacy_manifest(self):
         """Test topic recovery with time based retention policy.
@@ -1731,7 +1717,6 @@ class TopicRecoveryTest(RedpandaTest):
                                        topics, True)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_restore_moved_partition1(self):
         """Test handling of the moved partition (it will have different revision id)."""
@@ -1745,7 +1730,6 @@ class TopicRecoveryTest(RedpandaTest):
                                           self.logger, topics, False)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_restore_moved_partition2(self):
         """Test handling of the moved partition (it will have different revision id)."""
@@ -1759,7 +1743,6 @@ class TopicRecoveryTest(RedpandaTest):
                                           self.logger, topics, True)
         self.do_run(test_case)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_cascading_restore(self):
         """Test handling of the situation when the topic is recovered several times in a row."""

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import ignore
 from rptest.services.cluster import cluster
 from rptest.tests.wasm_identity_test import WasmIdentityTest
 from rptest.wasm.wasm_script import WasmScript
@@ -62,7 +61,6 @@ class WasmDeleteTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3745
     @cluster(num_nodes=4)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -28,7 +28,6 @@ class WasmCreateTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # see: #3858
     @cluster(num_nodes=4)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()


### PR DESCRIPTION
## Cover letter

Refactor the ducktape tests to skip tests by using the `excluded` section of the [test suite](https://ducktape.readthedocs.io/en/latest/run_tests.html#test-suites) `test_suite_quick.yml` instead of decorating the test method with [@ignore](https://ducktape.readthedocs.io/en/latest/new_tests.html?highlight=ignore#ducktape.mark.ignore). The `test_suite_quick.yml` is the default test suite run on PR checks.

To run all of the tests, the `test_suite_all.yml` test suite can be used.

## Release notes

* none