### PR TITLE
test: disable leader balancer in RecreateTopicMetadataTest

### DIFF
--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -22,10 +22,14 @@ from rptest.tests.redpanda_test import RedpandaTest
 class RecreateTopicMetadataTest(RedpandaTest):
     def __init__(self, test_context):
 
-        super(RecreateTopicMetadataTest,
-              self).__init__(test_context=test_context,
-                             num_brokers=5,
-                             extra_rp_conf={})
+        super(RecreateTopicMetadataTest, self).__init__(
+            test_context=test_context,
+            num_brokers=5,
+            extra_rp_conf={
+                # Test does explicit leadership movements
+                # that the balancer would interfere with.
+                'enable_leader_balancer': False
+            })
 
     @cluster(num_nodes=6)
     @parametrize(replication_factor=3)


### PR DESCRIPTION
## Cover letter

This caused occasional timeouts when the test was
waiting for its own leadership transfers to complete.

Failed at https://buildkite.com/redpanda/redpanda/builds/8215#9e2c3979-13db-40da-b7a0-26ba0a0124a3

## Release notes

* none
