### PR TITLE
Stopping consumer group pending operations

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -535,6 +535,9 @@ public:
         return _partition;
     }
 
+    // shutdown group. cancel all pending operations
+    void shutdown();
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -103,7 +103,14 @@ ss::future<> group_manager::stop() {
         e.second->as.request_abort();
     }
 
-    return _gate.close();
+    return _gate.close().then([this] {
+        /**
+         * cancel all pending group opeartions
+         */
+        for (auto& [_, group] : _groups) {
+            group->shutdown();
+        }
+    });
 }
 
 void group_manager::detach_partition(const model::ntp& ntp) {

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -9,7 +9,7 @@
 
 import random
 from rptest.services.cluster import cluster
-from ducktape.mark import parametrize, ignore
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -34,7 +34,6 @@ class FullNodeRecoveryTest(EndToEndTest):
         super(FullNodeRecoveryTest, self).__init__(test_context=test_context,
                                                    extra_rp_conf=extra_rp_conf)
 
-    @ignore  # Temporarily disabled: see issue #3880
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(recovery_type=PARTIAL_RECOVERY)
     # enable when we implement support for leader epochs

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -36,8 +36,7 @@ class FullNodeRecoveryTest(EndToEndTest):
 
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(recovery_type=PARTIAL_RECOVERY)
-    # enable when we implement support for leader epochs
-    # @parametrize(recovery_type=FULL_RECOVERY)
+    @parametrize(recovery_type=FULL_RECOVERY)
     def test_node_recovery(self, recovery_type):
         self.start_redpanda(num_nodes=3)
         kafka_tools = KafkaCliTools(self.redpanda)
@@ -91,8 +90,10 @@ class FullNodeRecoveryTest(EndToEndTest):
 
         # start node with the same node id, and not empty seed server list to
 
+        # give node more time to start as it has to recover
         self.redpanda.start_node(stopped,
-                                 override_cfg_params={'seed_servers': seeds})
+                                 override_cfg_params={'seed_servers': seeds},
+                                 timeout=90)
 
         def all_topics_recovered():
             metric = self.redpanda.metrics_sample("under_replicated_replicas",


### PR DESCRIPTION
## Cover letter

Added stopping all pending group operations when `kafka::group_manager` is being shut down. Previously when members were waiting for join timer member response feature blocked Kafka server from stopping making redpanda shutdown very long.

Added interruption of all pending group member processes to prevent shutdown from being held by group members handling.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes: #3880  
Fixes: #3476

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
