### PR TITLE
gha/rpk: install gon without homebrew

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -98,9 +98,11 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
 
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name: Install gon for code signing and app notarization
         run: |
-          brew install mitchellh/gon/gon
+          curl -LO https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          unzip gon_macos.zip
+          rm gon_macos.zip
 
       - name: Sign the mac binaries with Gon
         working-directory: zip/
@@ -108,7 +110,7 @@ jobs:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
-          gon -log-level=info ../src/go/rpk/gon_${{ matrix.arch }}.json
+          ../gon -log-level=info ../src/go/rpk/gon_${{ matrix.arch }}.json
 
       - name: Upload signed Package
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Cover letter

Due to recent changes to how homebrew works, the tap form mitchellh/gon has stopped working (see https://github.com/mitchellh/gon/issues/56)

To avoid issues in the future, this commit changes the installation method so that `gon` is installed using curl/unzip rather than the homebrew tap. Since gon is written in Go, this is a single binary and installation is straight forward

## Release notes

* none
