### PR TITLE
Added slash command to create backport issues

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -1,0 +1,72 @@
+name: backport-command
+on:
+  repository_dispatch:
+    types: [backport-command]
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
+      TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
+    steps:
+      - name: Get assignees
+        env:
+          ASSIGNEES: ${{ toJson(github.event.client_payload.github.payload.issue.assignees) }}
+        id: assignees
+        run: echo ::set-output name=assignees::$(echo "$ASSIGNEES" | jq -r '.[].login' | paste -s -d ',' -)
+
+      - name: Get branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          BRANCH: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
+        id: branch
+        run: |
+          branches=$(gh api "/repos/${TARGET_ORG}/${TARGET_REPO}/branches" --jq .[].name | grep "$BRANCH")
+          if [[ $branches == "" ]]; then
+            exit 2
+          fi
+          echo ::set-output name=branch::"$BRANCH"
+
+      - name: Discover and create milestone
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          TARGET_MILESTONE: ${{ github.event.client_payload.slash_command.args.named.milestone }}
+        id: milestone
+        run: |
+          if [[ "${TARGET_MILESTONE}" == "auto" ]]; then
+            major=$(echo "${BACKPORT_BRANCH}" | grep -Eo '^(v[0-9][0-9].[0-9][0-9])')
+            latest_released=$(gh api "repos/${TARGET_ORG}/${TARGET_REPO}/releases" --jq '.[] | select(.draft==false).name'  | grep "${major}" | head -1)
+            assigne_milestone=$(echo ${latest_released} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+          else
+            assigne_milestone="${TARGET_MILESTONE}"
+          fi
+          if [[ $(gh api "repos/${TARGET_ORG}/${TARGET_REPO}/milestones" --jq .[].title | grep "${assigne_milestone}") == "" ]]; then
+            # the below fails of something goes wrong
+            gh api "repos/${TARGET_ORG}/${TARGET_REPO}/milestones" --silent --method POST -f title="${assigne_milestone}"
+            sleep 20 # wait for milestone creation to be propagated
+          fi
+          echo ::set-output name=milestone::${assigne_milestone}
+
+      - name: Create issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          TARGET_MILESTONE: ${{ steps.milestone.outputs.milestone }}
+          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
+          ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
+          ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.comment.html_url }}
+        run: |
+          gh issue create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
+            --repo "${TARGET_ORG}/${TARGET_REPO}" \
+            --assignee "${ORIG_ASSIGNEES}" \
+            --milestone "${TARGET_MILESTONE}" \
+            --body "Backport ${ORIG_ISSUE_URL} to branch ${BACKPORT_BRANCH}"
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@dc2f82020dc2c4e9bfed7e87eb4a09506afd431b
+        uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.VTOOLS_GITHUB_API_TOKEN }}
-          issue-type: pull-request
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          permission: read
+          issue-type: issue
           commands: |
-            chaos-test
+            backport
+          static-args: |
+            org=redpanda-data
+            repo=redpanda
+            milestone=auto


### PR DESCRIPTION
## Cover letter

### CI feature

`/backport <branch>`

This PR enables the `/backport` command on issue comments: it creates a new issue for tracking backports issues. it adds to the backport issue:
* same assignees as the original issue
* (by default) discovers and creates (if not exists) a milestone and assigns it to the backport issue

More context:
* The permission has been set to `read` which is the base permission for a member in GitHub redpanda-data org
*  Default args:
   ```
   org=redpanda-data
   repo=redpanda
   milestone=auto
   ```
> When setting the milestone to `auto` it gets the latest release for the provided branch name and adds `+1`. for example if the command is `/backport v21.11.x`, and the latest release with the prefix `v21.11` is `v21.11.11`, then the milestone will be `v21.11.12` and will be created if it doesn't exist.

comment in the issue that needs to be backported:
```
/backport v21.11.x # auto discover milestone
```
or
```
/backport v21.11.x milestone=v21.11.11 # explicitly add milestone
```
> need to add the gh token of our bot

examples:
* https://github.com/solonas-org/gh-slash-cmd-test/issues/1#issuecomment-1075385032 -> https://github.com/solonas-org/gh-slash-cmd-test/issues/21
* https://github.com/solonas-org/gh-slash-cmd-test/issues/1#issuecomment-1075415360 -> https://github.com/solonas-org/gh-slash-cmd-test/issues/22

Fixes: https://github.com/redpanda-data/devprod/issues/191