### PR TITLE
json: Move everything to use `throwing_allocator`

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -14,6 +14,8 @@
 #include "bytes/iobuf_ostreambuf.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"
+#include "json/istreamwrapper.h"
+#include "json/ostreamwrapper.h"
 #include "json/writer.h"
 #include "model/timestamp.h"
 #include "ssx/sformat.h"
@@ -22,9 +24,6 @@
 #include <seastar/core/coroutine.hh>
 
 #include <fmt/ostream.h>
-#include <rapidjson/istreamwrapper.h>
-#include <rapidjson/ostreamwrapper.h>
-#include <rapidjson/rapidjson.h>
 
 #include <charconv>
 
@@ -313,7 +312,7 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
     iobuf_istreambuf ibuf(result);
     std::istream stream(&ibuf);
     json::Document m;
-    rapidjson::IStreamWrapper wrapper(stream);
+    json::IStreamWrapper wrapper(stream);
     m.ParseStream(wrapper);
     update(m);
     co_return;
@@ -399,8 +398,8 @@ serialized_json_stream partition_manifest::serialize() const {
 }
 
 void partition_manifest::serialize(std::ostream& out) const {
-    rapidjson::OStreamWrapper wrapper(out);
-    json::Writer<rapidjson::OStreamWrapper> w(wrapper);
+    json::OStreamWrapper wrapper(out);
+    json::Writer<json::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -15,7 +15,6 @@
 #include "cloud_storage/types.h"
 #include "config/configuration.h"
 #include "hashing/xx.h"
-#include "json/json.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -20,6 +20,7 @@
 #include "json/istreamwrapper.h"
 #include "json/ostreamwrapper.h"
 #include "json/reader.h"
+#include "json/types.h"
 #include "json/writer.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
@@ -53,7 +54,7 @@ struct topic_manifest_handler
         }
     }
 
-    bool Key(const char* str, rapidjson::SizeType length, bool /*copy*/) {
+    bool Key(const char* str, json::SizeType length, bool /*copy*/) {
         switch (_state) {
         case state::expect_key:
             _key = key_string(str, length);
@@ -65,7 +66,7 @@ struct topic_manifest_handler
         }
     }
 
-    bool String(const char* str, rapidjson::SizeType length, bool /*copy*/) {
+    bool String(const char* str, json::SizeType length, bool /*copy*/) {
         std::string_view sv(str, length);
         switch (_state) {
         case state::expect_value:
@@ -124,7 +125,7 @@ struct topic_manifest_handler
         }
     }
 
-    bool EndObject(rapidjson::SizeType /*size*/) {
+    bool EndObject(json::SizeType /*size*/) {
         return _state == state::expect_key;
     }
 

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "hashing/xx.h"
+#include "json/encodings.h"
 #include "json/reader.h"
 #include "json/writer.h"
 #include "model/compression.h"
@@ -27,7 +28,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include <fmt/ostream.h>
-#include <rapidjson/encodings.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
@@ -40,8 +40,7 @@
 namespace cloud_storage {
 
 struct topic_manifest_handler
-  : public rapidjson::
-      BaseReaderHandler<rapidjson::UTF8<>, topic_manifest_handler> {
+  : public rapidjson::BaseReaderHandler<json::UTF8<>, topic_manifest_handler> {
     using key_string = ss::basic_sstring<char, uint32_t, 31>;
     bool StartObject() {
         switch (_state) {

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "hashing/xx.h"
+#include "json/reader.h"
 #include "json/writer.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
@@ -30,7 +31,6 @@
 #include <rapidjson/error/en.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
-#include <rapidjson/reader.h>
 
 #include <chrono>
 #include <optional>
@@ -280,7 +280,7 @@ ss::future<> topic_manifest::update(ss::input_stream<char> is) {
     std::istream stream(&ibuf);
 
     rapidjson::IStreamWrapper wrapper(stream);
-    rapidjson::Reader reader;
+    json::Reader reader;
     topic_manifest_handler handler;
     if (reader.Parse(wrapper, handler)) {
         vlog(cst_log.debug, "Parsed successfully!");

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -17,6 +17,8 @@
 #include "cluster/types.h"
 #include "hashing/xx.h"
 #include "json/encodings.h"
+#include "json/istreamwrapper.h"
+#include "json/ostreamwrapper.h"
 #include "json/reader.h"
 #include "json/writer.h"
 #include "model/compression.h"
@@ -29,8 +31,6 @@
 #include <boost/lexical_cast.hpp>
 #include <fmt/ostream.h>
 #include <rapidjson/error/en.h>
-#include <rapidjson/istreamwrapper.h>
-#include <rapidjson/ostreamwrapper.h>
 
 #include <chrono>
 #include <optional>
@@ -278,7 +278,7 @@ ss::future<> topic_manifest::update(ss::input_stream<char> is) {
     iobuf_istreambuf ibuf(result);
     std::istream stream(&ibuf);
 
-    rapidjson::IStreamWrapper wrapper(stream);
+    json::IStreamWrapper wrapper(stream);
     json::Reader reader;
     topic_manifest_handler handler;
     if (reader.Parse(wrapper, handler)) {
@@ -318,8 +318,8 @@ serialized_json_stream topic_manifest::serialize() const {
 }
 
 void topic_manifest::serialize(std::ostream& out) const {
-    rapidjson::OStreamWrapper wrapper(out);
-    json::Writer<rapidjson::OStreamWrapper> w(wrapper);
+    json::OStreamWrapper wrapper(out);
+    json::Writer<json::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -41,7 +41,7 @@
 namespace cloud_storage {
 
 struct topic_manifest_handler
-  : public rapidjson::BaseReaderHandler<json::UTF8<>, topic_manifest_handler> {
+  : public json::BaseReaderHandler<json::UTF8<>, topic_manifest_handler> {
     using key_string = ss::basic_sstring<char, uint32_t, 31>;
     bool StartObject() {
         switch (_state) {

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -148,8 +148,8 @@ ss::future<> config_manager::do_bootstrap() {
     config::shard_local_cfg().for_each([&update](
                                          const config::base_property& p) {
         if (!p.is_default()) {
-            rapidjson::StringBuffer buf;
-            rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+            json::StringBuffer buf;
+            json::Writer<json::StringBuffer> writer(buf);
             p.to_json(writer);
             ss::sstring key_str(p.name());
             ss::sstring val_str = buf.GetString();

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -21,7 +21,8 @@
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "hashing/secure.h"
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "model/namespace.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
@@ -43,7 +44,6 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/core.h>
-#include <rapidjson/stringbuffer.h>
 
 #include <stdexcept>
 
@@ -274,8 +274,8 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
 
 iobuf serialize_metrics_snapshot(
   const metrics_reporter::metrics_snapshot& snapshot) {
-    rapidjson::StringBuffer sb;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+    json::StringBuffer sb;
+    json::Writer<json::StringBuffer> writer(sb);
 
     json::rjson_serialize(writer, snapshot);
     iobuf out;
@@ -376,7 +376,7 @@ ss::future<> metrics_reporter::do_report_metrics() {
 
 namespace json {
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::metrics_snapshot& snapshot) {
     w.StartObject();
 
@@ -400,7 +400,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::node_disk_space& ds) {
     w.StartObject();
     w.Key("free");
@@ -411,7 +411,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::node_metrics& nm) {
     w.StartObject();
     w.Key("node_id");

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -109,12 +109,12 @@ private:
 } // namespace cluster
 namespace json {
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::metrics_snapshot& v);
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::node_disk_space& v);
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::node_metrics& v);
 } // namespace json

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -11,7 +11,8 @@
 
 #pragma once
 #include "config/validation_error.h"
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "seastarx.h"
 
 #include <seastar/util/bool_class.hh>
@@ -74,8 +75,7 @@ public:
     // this serializes the property value. a full configuration serialization is
     // performed in config_store::to_json where the json object key is taken
     // from the property name.
-    virtual void
-    to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const = 0;
+    virtual void to_json(json::Writer<json::StringBuffer>& w) const = 0;
 
     virtual void print(std::ostream&) const = 0;
     virtual bool set_value(YAML::Node) = 0;

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -114,7 +114,7 @@ public:
      *               callback should return false to exclude a property.
      */
     void to_json(
-      rapidjson::Writer<rapidjson::StringBuffer>& w,
+      json::Writer<json::StringBuffer>& w,
       std::optional<std::function<bool(base_property&)>> filter
       = std::nullopt) const {
         w.StartObject();
@@ -152,8 +152,8 @@ private:
 };
 
 inline YAML::Node to_yaml(const config_store& cfg) {
-    rapidjson::StringBuffer buf;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    json::StringBuffer buf;
+    json::Writer<json::StringBuffer> writer(buf);
     cfg.to_json(writer);
     return YAML::Load(buf.GetString());
 }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "oncore.h"
 #include "reflection/type_traits.h"
 #include "utils/intrusive_list_helpers.h"
@@ -20,8 +22,6 @@
 #include <seastar/util/noncopyable_function.hh>
 
 #include <boost/intrusive/list.hpp>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 namespace config {
 
@@ -108,7 +108,7 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const override {
+    void to_json(json::Writer<json::StringBuffer>& w) const override {
         json::rjson_serialize(w, _value);
     }
 

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -12,8 +12,7 @@
 namespace json {
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const config::data_directory_path& v) {
+  json::Writer<json::StringBuffer>& w, const config::data_directory_path& v) {
     w.StartObject();
 
     w.Key("data_directory");
@@ -23,7 +22,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::seed_server& v) {
+  json::Writer<json::StringBuffer>& w, const config::seed_server& v) {
     w.StartObject();
     w.Key("host");
     rjson_serialize(w, v.addr);
@@ -31,7 +30,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::key_cert& v) {
+  json::Writer<json::StringBuffer>& w, const config::key_cert& v) {
     w.StartObject();
     w.Key("key_file");
     w.String(v.key_file.c_str());
@@ -42,7 +41,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::tls_config& v) {
+  json::Writer<json::StringBuffer>& w, const config::tls_config& v) {
     w.StartObject();
     w.Key("enabled");
     w.Bool(v.is_enabled());
@@ -67,7 +66,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const std::vector<config::seed_server>& v) {
     w.StartArray();
     for (const auto& e : v) {
@@ -77,7 +76,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const custom_aggregate& v) {
+  json::Writer<json::StringBuffer>& w, const custom_aggregate& v) {
     w.StartObject();
 
     w.Key("string_value");
@@ -90,8 +89,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const config::endpoint_tls_config& v) {
+  json::Writer<json::StringBuffer>& w, const config::endpoint_tls_config& v) {
     w.StartObject();
 
     w.Key("name");
@@ -119,7 +117,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const std::vector<config::endpoint_tls_config>& v) {
     w.StartArray();
     for (const auto& e : v) {
@@ -133,30 +131,28 @@ void rjson_serialize(
  * Otherwise they would be JSON-ized as their integer representation.
  */
 template<typename T>
-static void
-stringize(rapidjson::Writer<rapidjson::StringBuffer>& w, const T& v) {
+static void stringize(json::Writer<json::StringBuffer>& w, const T& v) {
     w.String(fmt::format("{}", v));
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const model::compression& v) {
+  json::Writer<json::StringBuffer>& w, const model::compression& v) {
     stringize(w, v);
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const model::timestamp_type& v) {
+  json::Writer<json::StringBuffer>& w, const model::timestamp_type& v) {
     stringize(w, v);
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const model::cleanup_policy_bitflags& v) {
     stringize(w, v);
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const model::violation_recovery_policy& v) {
     stringize(w, v);
 }

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -17,56 +17,51 @@
 #include "config/tests/custom_aggregate.h"
 #include "config/tls_config.h"
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 namespace json {
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const config::data_directory_path& v);
+  json::Writer<json::StringBuffer>& w, const config::data_directory_path& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::seed_server& v);
+  json::Writer<json::StringBuffer>& w, const config::seed_server& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::key_cert& v);
+  json::Writer<json::StringBuffer>& w, const config::key_cert& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const config::tls_config& v);
+  json::Writer<json::StringBuffer>& w, const config::tls_config& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const std::vector<config::seed_server>& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const custom_aggregate& v);
+  json::Writer<json::StringBuffer>& w, const custom_aggregate& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const config::endpoint_tls_config& v);
+  json::Writer<json::StringBuffer>& w, const config::endpoint_tls_config& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const std::vector<config::endpoint_tls_config>& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const model::compression& v);
+  json::Writer<json::StringBuffer>& w, const model::compression& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const model::timestamp_type& v);
+  json::Writer<json::StringBuffer>& w, const model::timestamp_type& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const model::cleanup_policy_bitflags& v);
+  json::Writer<json::StringBuffer>& w, const model::cleanup_policy_bitflags& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  json::Writer<json::StringBuffer>& w,
   const model::violation_recovery_policy& v);
 
 } // namespace json

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "config/config_store.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -225,8 +227,8 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
                                   "}";
 
     // cfg -> json string
-    rapidjson::StringBuffer cfg_sb;
-    rapidjson::Writer<rapidjson::StringBuffer> cfg_writer(cfg_sb);
+    json::StringBuffer cfg_sb;
+    json::Writer<json::StringBuffer> cfg_writer(cfg_sb);
     cfg.to_json(cfg_writer);
     auto jstr = cfg_sb.GetString();
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -8,14 +8,13 @@
 // by the Apache License, Version 2.0
 
 #include "config/config_store.h"
+#include "json/document.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
-
-#include <rapidjson/document.h>
 
 #include <cstdint>
 #include <iostream>
@@ -233,11 +232,11 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
     auto jstr = cfg_sb.GetString();
 
     // json string -> rapidjson doc
-    rapidjson::Document res_doc;
+    json::Document res_doc;
     res_doc.Parse(jstr);
 
     // json string -> rapidjson doc
-    rapidjson::Document exp_doc;
+    json::Document exp_doc;
     exp_doc.Parse(expected_result);
 
     // test equivalence

--- a/src/v/json/_include_first.h
+++ b/src/v/json/_include_first.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "vassert.h"
+
+#define RAPIDJSON_HAS_STDSTRING 1
+#define RAPIDJSON_ASSERT(x) vassert(x, "Rapidjson ")

--- a/src/v/json/allocator.h
+++ b/src/v/json/allocator.h
@@ -9,14 +9,19 @@
 
 #pragma once
 
+#include "json/_include_first.h"
 #include "json/logger.h"
 #include "vlog.h"
 
 #include <fmt/format.h>
 #include <rapidjson/allocators.h>
+
 namespace json {
+
 class throwing_allocator {
 public:
+    static const bool kNeedFree = rapidjson::CrtAllocator::kNeedFree;
+
     void* Malloc(size_t size) {
         void* res = _rp_allocator.Malloc(size);
         if (!res && (0 != size)) {
@@ -46,4 +51,7 @@ public:
 private:
     [[no_unique_address]] rapidjson::CrtAllocator _rp_allocator;
 };
+
+using MemoryPoolAllocator = rapidjson::MemoryPoolAllocator<throwing_allocator>;
+
 } // namespace json

--- a/src/v/json/document.h
+++ b/src/v/json/document.h
@@ -9,14 +9,23 @@
 
 #pragma once
 
+#include "json/_include_first.h"
 #include "json/allocator.h"
+#include "json/encodings.h"
 
 #include <rapidjson/document.h>
-#include <rapidjson/encodings.h>
 
 namespace json {
-using Document = rapidjson::GenericDocument<
-  rapidjson::UTF8<>,
-  rapidjson::MemoryPoolAllocator<throwing_allocator>,
-  throwing_allocator>;
-}
+
+template<typename Encoding = json::UTF8<>>
+using GenericDocument = rapidjson::
+  GenericDocument<Encoding, MemoryPoolAllocator, throwing_allocator>;
+
+using Document = GenericDocument<>;
+
+template<typename Encoding = json::UTF8<>>
+using GenericValue = typename GenericDocument<Encoding>::ValueType;
+
+using Value = GenericValue<>;
+
+} // namespace json

--- a/src/v/json/encodings.h
+++ b/src/v/json/encodings.h
@@ -1,0 +1,21 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+
+#include <rapidjson/encodings.h>
+
+namespace json {
+
+template<typename CharType = char>
+using UTF8 = rapidjson::UTF8<CharType>;
+
+} // namespace json

--- a/src/v/json/istreamwrapper.h
+++ b/src/v/json/istreamwrapper.h
@@ -1,0 +1,23 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+
+#include <rapidjson/istreamwrapper.h>
+
+namespace json {
+
+template<typename StreamType>
+using BasicIStreamWrapper = rapidjson::BasicIStreamWrapper<StreamType>;
+
+using IStreamWrapper = rapidjson::IStreamWrapper;
+
+} // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -11,48 +11,38 @@
 
 namespace json {
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, short v) {
-    w.Int(v);
-}
+void rjson_serialize(json::Writer<json::StringBuffer>& w, short v) { w.Int(v); }
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, bool v) {
-    w.Bool(v);
-}
+void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v) { w.Bool(v); }
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, long long v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, int v) {
-    w.Int(v);
-}
+void rjson_serialize(json::Writer<json::StringBuffer>& w, int v) { w.Int(v); }
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, unsigned int v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v) {
     w.Uint(v);
 }
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, long v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, unsigned long v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v) {
     w.Uint64(v);
 }
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, double v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, double v) {
     w.Double(v);
 }
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, std::string_view v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view v) {
     w.String(v.data(), v.size());
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const ss::socket_address& v) {
+  json::Writer<json::StringBuffer>& w, const ss::socket_address& v) {
     w.StartObject();
 
     std::ostringstream a;
@@ -73,8 +63,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const net::unresolved_address& v) {
+  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v) {
     w.StartObject();
 
     w.Key("address");
@@ -87,22 +76,19 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const std::chrono::milliseconds& v) {
+  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const std::chrono::seconds& v) {
+  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const model::broker_endpoint& ep) {
+  json::Writer<json::StringBuffer>& w, const model::broker_endpoint& ep) {
     w.StartObject();
     w.Key("name");
     w.String(ep.name);

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -12,7 +12,8 @@
 #pragma once
 
 #include "json/_include_first.h"
-#include "likely.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
 #include "utils/named_type.h"
@@ -21,68 +22,58 @@
 #include <seastar/net/ip.hh>
 #include <seastar/net/socket_defs.hh>
 
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include <chrono>
 #include <type_traits>
 
 namespace json {
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, short v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, short v);
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, bool v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v);
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, long long v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v);
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, int v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, int v);
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, unsigned int v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v);
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, long v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, long v);
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, unsigned long v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v);
 
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, double v);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, double v);
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, std::string_view s);
+void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view s);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const ss::socket_address& v);
+  json::Writer<json::StringBuffer>& w, const ss::socket_address& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const net::unresolved_address& v);
+  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const std::chrono::milliseconds& v);
+  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const std::chrono::seconds& v);
+  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v);
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>&, const model::broker_endpoint&);
+  json::Writer<json::StringBuffer>&, const model::broker_endpoint&);
 
 template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
-void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, T v) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, T v) {
     rjson_serialize(w, static_cast<std::underlying_type_t<T>>(v));
 }
 
 template<typename T, typename Tag>
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const named_type<T, Tag>& v) {
+  json::Writer<json::StringBuffer>& w, const named_type<T, Tag>& v) {
     rjson_serialize(w, v());
 }
 
 template<typename T>
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const std::optional<T>& v) {
+  json::Writer<json::StringBuffer>& w, const std::optional<T>& v) {
     if (v) {
         rjson_serialize(w, *v);
         return;
@@ -92,7 +83,7 @@ void rjson_serialize(
 
 template<typename T, typename A>
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const std::vector<T, A>& v) {
+  json::Writer<json::StringBuffer>& w, const std::vector<T, A>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -11,22 +11,11 @@
 
 #pragma once
 
+#include "json/_include_first.h"
 #include "likely.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
 #include "utils/named_type.h"
-
-#include <fmt/core.h>
-
-#define RAPIDJSON_HAS_STDSTRING 1
-#define RAPIDJSON_ASSERT(x)                                                    \
-    do {                                                                       \
-        if (unlikely(!(x))) {                                                  \
-            std::cerr << "Rapidjson failure: " << __FILE__ << ":" << __LINE__  \
-                      << "' " << #x << " '";                                   \
-            std::terminate();                                                  \
-        }                                                                      \
-    } while (0)
 
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>

--- a/src/v/json/ostreamwrapper.h
+++ b/src/v/json/ostreamwrapper.h
@@ -1,0 +1,23 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+
+#include <rapidjson/ostreamwrapper.h>
+
+namespace json {
+
+template<typename StreamType>
+using BasicOStreamWrapper = rapidjson::BasicOStreamWrapper<StreamType>;
+
+using OStreamWrapper = rapidjson::OStreamWrapper;
+
+} // namespace json

--- a/src/v/json/prettywriter.h
+++ b/src/v/json/prettywriter.h
@@ -1,0 +1,32 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+#include "json/allocator.h"
+#include "json/encodings.h"
+
+#include <rapidjson/prettywriter.h>
+
+namespace json {
+
+template<
+  typename OutputStream,
+  typename SourceEncoding = json::UTF8<>,
+  typename TargetEncoding = json::UTF8<>,
+  unsigned writeFlags = rapidjson::kWriteDefaultFlags>
+using PrettyWriter = rapidjson::PrettyWriter<
+  OutputStream,
+  SourceEncoding,
+  TargetEncoding,
+  throwing_allocator,
+  writeFlags>;
+
+} // namespace json

--- a/src/v/json/reader.h
+++ b/src/v/json/reader.h
@@ -24,4 +24,7 @@ using GenericReader = rapidjson::
 
 using Reader = GenericReader<>;
 
+template<typename Encoding = UTF8<>, typename Derived = void>
+using BaseReaderHandler = rapidjson::BaseReaderHandler<Encoding, Derived>;
+
 } // namespace json

--- a/src/v/json/reader.h
+++ b/src/v/json/reader.h
@@ -1,0 +1,27 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/allocator.h"
+#include "json/encodings.h"
+
+#include <rapidjson/reader.h>
+
+namespace json {
+
+template<
+  typename SourceEncoding = json::UTF8<>,
+  typename TargetEncoding = json::UTF8<>>
+using GenericReader = rapidjson::
+  GenericReader<SourceEncoding, TargetEncoding, throwing_allocator>;
+
+using Reader = GenericReader<>;
+
+} // namespace json

--- a/src/v/json/schema.h
+++ b/src/v/json/schema.h
@@ -1,0 +1,32 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+#include "json/allocator.h"
+#include "json/document.h"
+
+#include <rapidjson/schema.h>
+
+namespace json {
+
+using SchemaDocument
+  = rapidjson::GenericSchemaDocument<Value, throwing_allocator>;
+
+template<
+  typename SchemaDocumentType,
+  typename OutputHandler = rapidjson::BaseReaderHandler<
+    typename SchemaDocumentType::SchemaType::EncodingType>>
+using GenericSchemaValidator = rapidjson::
+  GenericSchemaValidator<SchemaDocumentType, OutputHandler, throwing_allocator>;
+
+using SchemaValidator = GenericSchemaValidator<SchemaDocument>;
+
+} // namespace json

--- a/src/v/json/schema.h
+++ b/src/v/json/schema.h
@@ -12,6 +12,7 @@
 #include "json/_include_first.h"
 #include "json/allocator.h"
 #include "json/document.h"
+#include "json/reader.h"
 
 #include <rapidjson/schema.h>
 
@@ -22,7 +23,7 @@ using SchemaDocument
 
 template<
   typename SchemaDocumentType,
-  typename OutputHandler = rapidjson::BaseReaderHandler<
+  typename OutputHandler = json::BaseReaderHandler<
     typename SchemaDocumentType::SchemaType::EncodingType>>
 using GenericSchemaValidator = rapidjson::
   GenericSchemaValidator<SchemaDocumentType, OutputHandler, throwing_allocator>;

--- a/src/v/json/stream.h
+++ b/src/v/json/stream.h
@@ -1,0 +1,23 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+
+#include <rapidjson/stream.h>
+
+namespace json {
+
+template<typename Encoding = rapidjson::UTF8<>>
+using GenericStringStream = rapidjson::GenericStringStream<Encoding>;
+
+using StringStream = GenericStringStream<>;
+
+} // namespace json

--- a/src/v/json/stringbuffer.h
+++ b/src/v/json/stringbuffer.h
@@ -1,0 +1,26 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+#include "json/allocator.h"
+#include "json/encodings.h"
+
+#include <rapidjson/stringbuffer.h>
+
+namespace json {
+
+template<typename Encoding = json::UTF8<>>
+using GenericStringBuffer
+  = rapidjson::GenericStringBuffer<Encoding, throwing_allocator>;
+
+using StringBuffer = GenericStringBuffer<>;
+
+} // namespace json

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -109,11 +109,11 @@ SEASTAR_THREAD_TEST_CASE(json_serialization_test) {
     auto jstr = cfg_sb.GetString();
 
     // json string -> rapidjson doc - result
-    rapidjson::Document res_doc;
+    json::Document res_doc;
     res_doc.Parse(jstr);
 
     // json string -> rapidjson doc - expectation
-    rapidjson::Document exp_doc;
+    json::Document exp_doc;
     exp_doc.Parse(expected_result);
 
     BOOST_TEST(res_doc["full_name"].IsString());

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -7,15 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "json/document.h"
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
-
-#include <rapidjson/document.h>
 
 #include <optional>
 
@@ -41,8 +42,7 @@ struct personne_t {
 } // namespace
 
 void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const personne_t::nested& obj) {
+  json::Writer<json::StringBuffer>& w, const personne_t::nested& obj) {
     w.StartObject();
 
     w.Key("x");
@@ -57,8 +57,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const personne_t& p) {
+void rjson_serialize(json::Writer<json::StringBuffer>& w, const personne_t& p) {
     w.StartObject();
 
     w.Key("full_name");
@@ -104,8 +103,8 @@ SEASTAR_THREAD_TEST_CASE(json_serialization_test) {
     p1.height = 1.78;
     p1.obj = personne_t::nested{98, 78, 13.369};
 
-    rapidjson::StringBuffer cfg_sb;
-    rapidjson::Writer<rapidjson::StringBuffer> cfg_writer(cfg_sb);
+    json::StringBuffer cfg_sb;
+    json::Writer<json::StringBuffer> cfg_writer(cfg_sb);
     rjson_serialize(cfg_writer, p1);
     auto jstr = cfg_sb.GetString();
 

--- a/src/v/json/types.h
+++ b/src/v/json/types.h
@@ -15,6 +15,7 @@
 
 namespace json {
 
+using SizeType = rapidjson::SizeType;
 using Type = rapidjson::Type;
 
 } // namespace json

--- a/src/v/json/types.h
+++ b/src/v/json/types.h
@@ -1,0 +1,20 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/_include_first.h"
+
+#include <rapidjson/rapidjson.h>
+
+namespace json {
+
+using Type = rapidjson::Type;
+
+} // namespace json

--- a/src/v/json/writer.h
+++ b/src/v/json/writer.h
@@ -10,15 +10,15 @@
 #pragma once
 
 #include "json/allocator.h"
+#include "json/encodings.h"
 
-#include <rapidjson/encodings.h>
 #include <rapidjson/writer.h>
 
 namespace json {
 template<
   typename OutputStream,
-  typename SourceEncoding = rapidjson::UTF8<>,
-  typename TargetEncoding = rapidjson::UTF8<>,
+  typename SourceEncoding = json::UTF8<>,
+  typename TargetEncoding = json::UTF8<>,
   unsigned writeFlags = rapidjson::kWriteDefaultFlags>
 using Writer = rapidjson::Writer<
   OutputStream,

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -12,9 +12,6 @@
 #include "config/configuration.h"
 #include "units.h"
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 namespace kafka::client {
 using namespace std::chrono_literals;
 

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -96,7 +96,7 @@ public:
         iobuf_parser p{std::move(buf)};
         auto str = p.read_string(p.bytes_left());
         static_assert(str.padding(), "StringStream requires null termination");
-        rapidjson::Reader reader;
+        ::json::Reader reader;
         rapidjson::StringStream ss{str.c_str()};
         return reader.Parse(ss, w);
     };

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -13,11 +13,15 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
-#include "json/json.h"
+#include "json/reader.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "pandaproxy/json/types.h"
 #include "utils/base64.h"
 
 #include <seastar/core/loop.hh>
+
+#include <rapidjson/stream.h>
 
 #include <optional>
 
@@ -62,7 +66,7 @@ public:
     explicit rjson_serialize_impl(serialization_format fmt)
       : _fmt(fmt) {}
 
-    bool operator()(rapidjson::Writer<rapidjson::StringBuffer>& w, iobuf buf) {
+    bool operator()(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
         switch (_fmt) {
         case serialization_format::none:
             [[fallthrough]];
@@ -77,8 +81,7 @@ public:
         }
     }
 
-    bool
-    encode_base64(rapidjson::Writer<rapidjson::StringBuffer>& w, iobuf buf) {
+    bool encode_base64(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }
@@ -86,7 +89,7 @@ public:
         return w.String(iobuf_to_base64(buf));
     };
 
-    bool encode_json(rapidjson::Writer<rapidjson::StringBuffer>& w, iobuf buf) {
+    bool encode_json(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -14,14 +14,13 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "json/reader.h"
+#include "json/stream.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "pandaproxy/json/types.h"
 #include "utils/base64.h"
 
 #include <seastar/core/loop.hh>
-
-#include <rapidjson/stream.h>
 
 #include <optional>
 
@@ -97,7 +96,7 @@ public:
         auto str = p.read_string(p.bytes_left());
         static_assert(str.padding(), "StringStream requires null termination");
         ::json::Reader reader;
-        rapidjson::StringStream ss{str.c_str()};
+        ::json::StringStream ss{str.c_str()};
         return reader.Parse(ss, w);
     };
 

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -11,7 +11,8 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "model/metadata.h"
 
 namespace pandaproxy::json {
@@ -21,8 +22,7 @@ struct get_brokers_res {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const get_brokers_res& brokers) {
+  ::json::Writer<::json::StringBuffer>& w, const get_brokers_res& brokers) {
     w.StartObject();
     w.Key("brokers");
     ::json::rjson_serialize(w, brokers.ids);

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iobuf.h"
 #include "json/stringbuffer.h"
+#include "json/types.h"
 #include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
@@ -57,7 +58,7 @@ public:
     using rjson_parse_result = create_consumer_request;
     rjson_parse_result result;
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         switch (_state) {
         case state::empty:
             return false;
@@ -83,7 +84,7 @@ public:
         return true;
     }
 
-    bool Key(const char* str, rapidjson::SizeType len, bool) {
+    bool Key(const char* str, ::json::SizeType len, bool) {
         _state = string_switch<state>({str, len})
                    .match("name", state::name)
                    .match("format", state::format)
@@ -98,7 +99,7 @@ public:
 
     bool StartObject() { return _state == state::empty; }
 
-    bool EndObject(rapidjson::SizeType) { return _state != state::empty; }
+    bool EndObject(::json::SizeType) { return _state != state::empty; }
 };
 
 struct create_consumer_response {
@@ -129,7 +130,7 @@ public:
     using rjson_parse_result = create_consumer_response;
     rjson_parse_result result;
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto str_view{std::string_view{str, len}};
         switch (_state) {
         case state::empty:
@@ -144,7 +145,7 @@ public:
         return true;
     }
 
-    bool Key(const char* str, rapidjson::SizeType len, bool) {
+    bool Key(const char* str, ::json::SizeType len, bool) {
         _state = string_switch<state>({str, len})
                    .match("instance_id", state::instance_id)
                    .match("base_uri", state::base_uri)
@@ -155,7 +156,7 @@ public:
 
     bool StartObject() { return _state == state::empty; }
 
-    bool EndObject(rapidjson::SizeType) { return _state != state::empty; }
+    bool EndObject(::json::SizeType) { return _state != state::empty; }
 };
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -37,7 +37,7 @@ struct create_consumer_request {
     ss::sstring consumer_request_timeout_ms;
 };
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class create_consumer_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {
@@ -117,7 +117,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class create_consumer_response_handler final : public base_handler<Encoding> {
 private:
     enum class state { empty = 0, instance_id, base_uri };

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -12,7 +12,8 @@
 #pragma once
 
 #include "bytes/iobuf.h"
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
 #include "kafka/types.h"
@@ -22,10 +23,6 @@
 #include "utils/string_switch.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/reader.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <string_view>
 
@@ -110,7 +107,7 @@ struct create_consumer_response {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const create_consumer_response& res) {
     w.StartObject();
     w.Key("instance_id");

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -24,8 +26,8 @@ struct error_body {
     ss::sstring message;
 };
 
-inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w, const error_body& v) {
+inline void
+rjson_serialize(::json::Writer<::json::StringBuffer>& w, const error_body& v) {
     w.StartObject();
     w.Key("error_code");
     ::json::rjson_serialize(w, v.ec.value());

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -13,7 +13,8 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "model/fundamental.h"
@@ -28,10 +29,6 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <rapidjson/reader.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 namespace pandaproxy::json {
 
 template<>
@@ -45,8 +42,8 @@ public:
       , _tpv(tpv)
       , _base_offset(base_offset) {}
 
-    void operator()(
-      rapidjson::Writer<rapidjson::StringBuffer>& w, model::record record) {
+    void
+    operator()(::json::Writer<::json::StringBuffer>& w, model::record record) {
         w.StartObject();
         w.Key("topic");
         ::json::rjson_serialize(w, _tpv.topic);
@@ -74,8 +71,7 @@ public:
       : _fmt(fmt) {}
 
     void operator()(
-      rapidjson::Writer<rapidjson::StringBuffer>& w,
-      kafka::fetch_response&& res) {
+      ::json::Writer<::json::StringBuffer>& w, kafka::fetch_response&& res) {
         // Eager check for errors
         for (auto& v : res) {
             if (v.partition_response->error_code != kafka::error_code::none) {

--- a/src/v/pandaproxy/json/requests/offset_commit.h
+++ b/src/v/pandaproxy/json/requests/offset_commit.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "json/json.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
@@ -20,9 +19,6 @@
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 namespace pandaproxy::json {
 

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -11,15 +11,13 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 namespace pandaproxy::json {
 
@@ -43,7 +41,7 @@ partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
 }
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const kafka::offset_fetch_response_topic& v) {
     for (const auto& p : v.partitions) {
         w.StartObject();
@@ -60,7 +58,7 @@ inline void rjson_serialize(
 }
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const kafka::offset_fetch_response& v) {
     w.StartObject();
     w.Key("offsets");

--- a/src/v/pandaproxy/json/requests/partition_offsets.h
+++ b/src/v/pandaproxy/json/requests/partition_offsets.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "json/encodings.h"
+#include "json/types.h"
 #include "model/fundamental.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
@@ -80,7 +81,7 @@ public:
         }
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         if (state == state::topic) {
             result.back().topic = model::topic(ss::sstring(str, len));
             state = state::tpo;
@@ -89,7 +90,7 @@ public:
         return false;
     }
 
-    bool Key(const char* str, rapidjson::SizeType len, bool) {
+    bool Key(const char* str, ::json::SizeType len, bool) {
         auto key = std::string_view(str, len);
         if (state == state::empty && key == "partitions") {
             state = state::partitions;
@@ -122,7 +123,7 @@ public:
         return false;
     }
 
-    bool EndObject(rapidjson::SizeType size) {
+    bool EndObject(::json::SizeType size) {
         if (state == state::tpo) {
             state = state::partitions;
             return size == 3;
@@ -136,7 +137,7 @@ public:
 
     bool StartArray() { return state == state::partitions; }
 
-    bool EndArray(rapidjson::SizeType) { return state == state::partitions; }
+    bool EndArray(::json::SizeType) { return state == state::partitions; }
 };
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/partition_offsets.h
+++ b/src/v/pandaproxy/json/requests/partition_offsets.h
@@ -11,15 +11,13 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "json/encodings.h"
 #include "model/fundamental.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/encodings.h>
 
 namespace pandaproxy::json {
 
@@ -33,7 +31,7 @@ struct topic_partition_offset {
     };
 };
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class partition_offsets_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {

--- a/src/v/pandaproxy/json/requests/partitions.h
+++ b/src/v/pandaproxy/json/requests/partitions.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "json/encodings.h"
+#include "json/types.h"
 #include "model/fundamental.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
@@ -57,7 +58,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         if (state == state::topic) {
             result.back().topic = model::topic(ss::sstring(str, len));
             state = state::topic_partition;
@@ -66,7 +67,7 @@ public:
         return false;
     }
 
-    bool Key(const char* str, rapidjson::SizeType len, bool) {
+    bool Key(const char* str, ::json::SizeType len, bool) {
         auto key = std::string_view(str, len);
         if (state == state::empty && key == "partitions") {
             state = state::partitions;
@@ -97,7 +98,7 @@ public:
         return false;
     }
 
-    bool EndObject(rapidjson::SizeType size) {
+    bool EndObject(::json::SizeType size) {
         if (state == state::topic_partition) {
             state = state::partitions;
             return size == 2;
@@ -111,7 +112,7 @@ public:
 
     bool StartArray() { return state == state::partitions; }
 
-    bool EndArray(rapidjson::SizeType) { return state == state::partitions; }
+    bool EndArray(::json::SizeType) { return state == state::partitions; }
 };
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/partitions.h
+++ b/src/v/pandaproxy/json/requests/partitions.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "json/encodings.h"
 #include "model/fundamental.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
@@ -19,11 +19,9 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <rapidjson/encodings.h>
-
 namespace pandaproxy::json {
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class partitions_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -13,6 +13,8 @@
 
 #include "bytes/iobuf.h"
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
@@ -22,10 +24,6 @@
 #include "tristate.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/reader.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 namespace pandaproxy::json {
 
@@ -44,7 +42,7 @@ private:
     serialization_format _fmt = serialization_format::none;
     state state = state::empty;
 
-    using json_writer = rapidjson::Writer<rapidjson::StringBuffer>;
+    using json_writer = ::json::Writer<::json::StringBuffer>;
 
     // If we're parsing json_v2, and the field is key or value (implied by
     // _json_writer being set), then forward calls to json_writer.
@@ -252,12 +250,12 @@ public:
     }
 
 private:
-    rapidjson::StringBuffer _buf;
+    ::json::StringBuffer _buf;
     std::optional<json_writer> _json_writer;
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const kafka::produce_response::partition& v) {
     w.StartObject();
     w.Key("partition");
@@ -272,7 +270,7 @@ inline void rjson_serialize(
 }
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const kafka::produce_response::topic& v) {
     w.StartObject();
     w.Key("offsets");

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -27,7 +27,7 @@
 
 namespace pandaproxy::json {
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class produce_request_handler {
 private:
     enum class state {

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -14,6 +14,7 @@
 #include "bytes/iobuf.h"
 #include "json/json.h"
 #include "json/stringbuffer.h"
+#include "json/types.h"
 #include "json/writer.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/errors.h"
@@ -112,7 +113,7 @@ public:
         }
         return false;
     }
-    bool RawNumber(const Ch* str, rapidjson::SizeType len, bool b) {
+    bool RawNumber(const Ch* str, ::json::SizeType len, bool b) {
         if (auto res = maybe_json(&json_writer::RawNumber, str, len, b);
             res.has_value()) {
             return res.value();
@@ -144,9 +145,9 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool b) {
+    bool String(const Ch* str, ::json::SizeType len, bool b) {
         if (auto res = maybe_json<bool (json_writer::*)(
-              const Ch*, rapidjson::SizeType, bool)>(
+              const Ch*, ::json::SizeType, bool)>(
               &json_writer::String, str, len, b);
             res.has_value()) {
             return res.value();
@@ -171,9 +172,9 @@ public:
         return false;
     }
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool b) {
+    bool Key(const Ch* str, ::json::SizeType len, bool b) {
         if (auto res = maybe_json<bool (json_writer::*)(
-              const Ch*, rapidjson::SizeType, bool)>(
+              const Ch*, ::json::SizeType, bool)>(
               &json_writer::Key, str, len, b);
             res.has_value()) {
             return res.value();
@@ -219,7 +220,7 @@ public:
         return false;
     }
 
-    bool EndObject(rapidjson::SizeType s) {
+    bool EndObject(::json::SizeType s) {
         if (auto res = maybe_json(&json_writer::EndObject, s);
             res.has_value()) {
             return res.value();
@@ -242,7 +243,7 @@ public:
         return state == state::records;
     }
 
-    bool EndArray(rapidjson::SizeType s) {
+    bool EndArray(::json::SizeType s) {
         if (auto res = maybe_json(&json_writer::EndArray, s); res.has_value()) {
             return res.value();
         }

--- a/src/v/pandaproxy/json/requests/subscribe_consumer.h
+++ b/src/v/pandaproxy/json/requests/subscribe_consumer.h
@@ -22,10 +22,6 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <rapidjson/reader.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include <string_view>
 
 namespace pandaproxy::json {

--- a/src/v/pandaproxy/json/requests/subscribe_consumer.h
+++ b/src/v/pandaproxy/json/requests/subscribe_consumer.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iobuf.h"
 #include "json/encodings.h"
+#include "json/types.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/types.h"
 #include "pandaproxy/json/iobuf.h"
@@ -46,7 +47,7 @@ public:
     using rjson_parse_result = subscribe_consumer_request;
     rjson_parse_result result;
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         if (_state != state::topic_name) {
             return false;
         }
@@ -54,7 +55,7 @@ public:
         return true;
     }
 
-    bool Key(const char* str, rapidjson::SizeType len, bool) {
+    bool Key(const char* str, ::json::SizeType len, bool) {
         if (_state != state::topics || std::string_view(str, len) != "topics") {
             return false;
         }
@@ -68,7 +69,7 @@ public:
         _state = state::topic_name;
         return true;
     }
-    bool EndArray(rapidjson::SizeType) {
+    bool EndArray(::json::SizeType) {
         if (_state != state::topic_name) {
             return false;
         }
@@ -87,7 +88,7 @@ public:
         return true;
     }
 
-    bool EndObject(rapidjson::SizeType) { return _state == state::topics; }
+    bool EndObject(::json::SizeType) { return _state == state::topics; }
 };
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/subscribe_consumer.h
+++ b/src/v/pandaproxy/json/requests/subscribe_consumer.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
-#include "json/json.h"
+#include "json/encodings.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/types.h"
 #include "pandaproxy/json/iobuf.h"
@@ -30,7 +30,7 @@ struct subscribe_consumer_request {
     std::vector<model::topic> topics;
 };
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class subscribe_consumer_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -9,6 +9,8 @@
 
 #include "pandaproxy/json/requests/fetch.h"
 
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "kafka/client/test/utils.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
@@ -26,8 +28,6 @@
 
 #include <boost/test/tools/interface.hpp>
 #include <boost/test/tools/old/interface.hpp>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <type_traits>
 
@@ -71,8 +71,8 @@ SEASTAR_THREAD_TEST_CASE(test_produce_fetch_empty) {
     auto res = make_fetch_response({tp}, model::offset{0}, 0);
     auto fmt = ppj::serialization_format::binary_v2;
 
-    rapidjson::StringBuffer str_buf;
-    rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
+    ::json::StringBuffer str_buf;
+    ::json::Writer<::json::StringBuffer> w(str_buf);
     ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
 
     auto expected = R"([])";
@@ -89,8 +89,8 @@ SEASTAR_THREAD_TEST_CASE(test_produce_fetch_one) {
     auto res = make_fetch_response(tps, model::offset{42}, 1);
     auto fmt = ppj::serialization_format::binary_v2;
 
-    rapidjson::StringBuffer str_buf;
-    rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
+    ::json::StringBuffer str_buf;
+    ::json::Writer<::json::StringBuffer> w(str_buf);
     ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
 
     auto expected

--- a/src/v/pandaproxy/json/rjson_parse.h
+++ b/src/v/pandaproxy/json/rjson_parse.h
@@ -19,7 +19,7 @@ namespace pandaproxy::json {
 
 template<typename encoding = ::json::UTF8<>>
 class base_handler
-  : public rapidjson::BaseReaderHandler<encoding, base_handler<encoding>> {
+  : public ::json::BaseReaderHandler<encoding, base_handler<encoding>> {
 public:
     using Ch = typename encoding::Ch;
 

--- a/src/v/pandaproxy/json/rjson_parse.h
+++ b/src/v/pandaproxy/json/rjson_parse.h
@@ -11,14 +11,13 @@
 
 #pragma once
 
+#include "json/encodings.h"
 #include "json/reader.h"
 #include "pandaproxy/json/types.h"
 
-#include <rapidjson/encodings.h>
-
 namespace pandaproxy::json {
 
-template<typename encoding = rapidjson::UTF8<>>
+template<typename encoding = ::json::UTF8<>>
 class base_handler
   : public rapidjson::BaseReaderHandler<encoding, base_handler<encoding>> {
 public:

--- a/src/v/pandaproxy/json/rjson_parse.h
+++ b/src/v/pandaproxy/json/rjson_parse.h
@@ -11,11 +11,10 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "json/reader.h"
 #include "pandaproxy/json/types.h"
 
 #include <rapidjson/encodings.h>
-#include <rapidjson/reader.h>
 
 namespace pandaproxy::json {
 

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "json/json.h"
+#include "json/reader.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "pandaproxy/json/exceptions.h"
@@ -21,7 +22,6 @@
 #include <seastar/core/sstring.hh>
 
 #include <rapidjson/prettywriter.h>
-#include <rapidjson/reader.h>
 #include <rapidjson/stream.h>
 
 #include <stdexcept>
@@ -67,7 +67,7 @@ CONCEPT(requires std::is_same_v<
         typename Handler::rjson_parse_result>)
 typename Handler::rjson_parse_result
   rjson_parse(const char* const s, Handler&& handler) {
-    rapidjson::Reader reader;
+    ::json::Reader reader;
     rapidjson::StringStream ss(s);
     if (!reader.Parse(ss, handler)) {
         throw parse_error(reader.GetErrorOffset());
@@ -76,7 +76,7 @@ typename Handler::rjson_parse_result
 }
 
 inline ss::sstring minify(std::string_view json) {
-    rapidjson::Reader r;
+    ::json::Reader r;
     rapidjson::StringStream in(json.data());
     ::json::StringBuffer out;
     ::json::Writer<::json::StringBuffer> w{out};
@@ -85,7 +85,7 @@ inline ss::sstring minify(std::string_view json) {
 }
 
 inline ss::sstring prettify(std::string_view json) {
-    rapidjson::Reader r;
+    ::json::Reader r;
     rapidjson::StringStream in(json.data());
     ::json::StringBuffer out;
     rapidjson::PrettyWriter<::json::StringBuffer> w{out};

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "json/json.h"
+#include "json/prettywriter.h"
 #include "json/reader.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
@@ -21,7 +22,6 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <rapidjson/prettywriter.h>
 #include <rapidjson/stream.h>
 
 #include <stdexcept>
@@ -88,7 +88,7 @@ inline ss::sstring prettify(std::string_view json) {
     ::json::Reader r;
     rapidjson::StringStream in(json.data());
     ::json::StringBuffer out;
-    rapidjson::PrettyWriter<::json::StringBuffer> w{out};
+    ::json::PrettyWriter<::json::StringBuffer> w{out};
     r.Parse(in, w);
     return ss::sstring(out.GetString(), out.GetSize());
 }

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -14,6 +14,7 @@
 #include "json/json.h"
 #include "json/prettywriter.h"
 #include "json/reader.h"
+#include "json/stream.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "pandaproxy/json/exceptions.h"
@@ -21,8 +22,6 @@
 #include "utils/concepts-enabled.h"
 
 #include <seastar/core/sstring.hh>
-
-#include <rapidjson/stream.h>
 
 #include <stdexcept>
 
@@ -68,7 +67,7 @@ CONCEPT(requires std::is_same_v<
 typename Handler::rjson_parse_result
   rjson_parse(const char* const s, Handler&& handler) {
     ::json::Reader reader;
-    rapidjson::StringStream ss(s);
+    ::json::StringStream ss(s);
     if (!reader.Parse(ss, handler)) {
         throw parse_error(reader.GetErrorOffset());
     }
@@ -77,7 +76,7 @@ typename Handler::rjson_parse_result
 
 inline ss::sstring minify(std::string_view json) {
     ::json::Reader r;
-    rapidjson::StringStream in(json.data());
+    ::json::StringStream in(json.data());
     ::json::StringBuffer out;
     ::json::Writer<::json::StringBuffer> w{out};
     r.Parse(in, w);
@@ -86,7 +85,7 @@ inline ss::sstring minify(std::string_view json) {
 
 inline ss::sstring prettify(std::string_view json) {
     ::json::Reader r;
-    rapidjson::StringStream in(json.data());
+    ::json::StringStream in(json.data());
     ::json::StringBuffer out;
     ::json::PrettyWriter<::json::StringBuffer> w{out};
     r.Parse(in, w);

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
 #include "utils/concepts-enabled.h"
@@ -21,8 +23,6 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/reader.h>
 #include <rapidjson/stream.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <stdexcept>
 
@@ -30,8 +30,8 @@ namespace pandaproxy::json {
 
 template<typename T>
 ss::sstring rjson_serialize(const T& v) {
-    rapidjson::StringBuffer str_buf;
-    rapidjson::Writer<rapidjson::StringBuffer> wrt(str_buf);
+    ::json::StringBuffer str_buf;
+    ::json::Writer<::json::StringBuffer> wrt(str_buf);
 
     using ::json::rjson_serialize;
     using ::pandaproxy::json::rjson_serialize;
@@ -51,7 +51,7 @@ struct rjson_serialize_fmt_impl {
           std::forward<T>(t));
     }
     template<typename T>
-    void operator()(rapidjson::Writer<rapidjson::StringBuffer>& w, T&& t) {
+    void operator()(::json::Writer<::json::StringBuffer>& w, T&& t) {
         rjson_serialize_impl<std::remove_reference_t<T>>{fmt}(
           w, std::forward<T>(t));
     }
@@ -78,8 +78,8 @@ typename Handler::rjson_parse_result
 inline ss::sstring minify(std::string_view json) {
     rapidjson::Reader r;
     rapidjson::StringStream in(json.data());
-    rapidjson::StringBuffer out;
-    rapidjson::Writer<rapidjson::StringBuffer> w{out};
+    ::json::StringBuffer out;
+    ::json::Writer<::json::StringBuffer> w{out};
     r.Parse(in, w);
     return ss::sstring(out.GetString(), out.GetSize());
 }
@@ -87,8 +87,8 @@ inline ss::sstring minify(std::string_view json) {
 inline ss::sstring prettify(std::string_view json) {
     rapidjson::Reader r;
     rapidjson::StringStream in(json.data());
-    rapidjson::StringBuffer out;
-    rapidjson::PrettyWriter<rapidjson::StringBuffer> w{out};
+    ::json::StringBuffer out;
+    rapidjson::PrettyWriter<::json::StringBuffer> w{out};
     r.Parse(in, w);
     return ss::sstring(out.GetString(), out.GetSize());
 }

--- a/src/v/pandaproxy/json/test/iobuf.cc
+++ b/src/v/pandaproxy/json/test/iobuf.cc
@@ -10,7 +10,8 @@
 #include "pandaproxy/json/iobuf.h"
 
 #include "bytes/iobuf_parser.h"
-#include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "pandaproxy/json/rjson_util.h"
 
 #include <seastar/testing/thread_test_case.hh>
@@ -40,8 +41,8 @@ SEASTAR_THREAD_TEST_CASE(test_iobuf_serialize_binary) {
     auto expected = ss::sstring("\"cGFuZGFwcm94eQ==\"");
     in_buf.append(input.data(), input.size());
 
-    rapidjson::StringBuffer out_buf;
-    rapidjson::Writer<rapidjson::StringBuffer> w(out_buf);
+    ::json::StringBuffer out_buf;
+    ::json::Writer<::json::StringBuffer> w(out_buf);
     ppj::rjson_serialize_fmt(ppj::serialization_format::binary_v2)(
       w, std::move(in_buf));
     ss::sstring output{out_buf.GetString(), out_buf.GetSize()};

--- a/src/v/pandaproxy/json/test/parse.cc
+++ b/src/v/pandaproxy/json/test/parse.cc
@@ -1,0 +1,50 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf_parser.h"
+#include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/requests/produce.h"
+#include "pandaproxy/json/rjson_util.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/testing/perf_tests.hh>
+
+namespace pp = pandaproxy;
+namespace ppj = pp::json;
+
+auto make_binary_v2_handler() {
+    return ppj::produce_request_handler<>(ppj::serialization_format::binary_v2);
+}
+
+auto gen(size_t data_size) {
+    const ss::sstring beg{R"({"records": [)"};
+    const ss::sstring end{R"(]})"};
+    const ss::sstring rec{R"({"value": "dmVjdG9yaXplZA==","partition": 0})"};
+    ss::sstring buf{
+      ss::sstring::initialized_later{},
+      beg.length() + end.length() + data_size * (rec.length() + 1)};
+    for (size_t i = 0; i < data_size - 1; ++i) {
+        buf += rec;
+        buf += ",";
+    }
+    buf += rec;
+    buf += end;
+    return buf;
+}
+
+inline void parse_test(size_t data_size) {
+    auto input = gen(data_size);
+
+    perf_tests::start_measuring_time();
+    auto records = ppj::rjson_parse(input.c_str(), make_binary_v2_handler());
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(json_parse_test, binary) { parse_test(1 << 20); }

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -165,8 +165,8 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
       .local()
       .fetch_partition(std::move(tp), offset, max_bytes, timeout)
       .then([res_fmt, rp = std::move(rp)](kafka::fetch_response res) mutable {
-          rapidjson::StringBuffer str_buf;
-          rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
+          ::json::StringBuffer str_buf;
+          ::json::Writer<::json::StringBuffer> w(str_buf);
 
           ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
 
@@ -413,8 +413,8 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
 
         auto res = co_await client.consumer_fetch(
           group_id, name, timeout, max_bytes);
-        rapidjson::StringBuffer str_buf;
-        rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
+        ::json::StringBuffer str_buf;
+        ::json::Writer<::json::StringBuffer> w(str_buf);
 
         ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
 
@@ -464,8 +464,8 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
         auto res = co_await client.consumer_offset_fetch(
           group_id, member_id, std::move(req_data));
-        rapidjson::StringBuffer str_buf;
-        rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
+        ::json::StringBuffer str_buf;
+        ::json::Writer<::json::StringBuffer> w(str_buf);
         ppj::rjson_serialize(w, res);
         ss::sstring json_rslt = str_buf.GetString();
         rp.rep->write_body("json", json_rslt);

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -15,6 +15,7 @@
 #include "json/document.h"
 #include "json/encodings.h"
 #include "json/stringbuffer.h"
+#include "json/types.h"
 #include "json/writer.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
@@ -187,19 +188,19 @@ result<void> sanitize_avro_type(
 
 result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc) {
     switch (v.GetType()) {
-    case rapidjson::Type::kObjectType: {
+    case json::Type::kObjectType: {
         auto o = v.GetObject();
         return sanitize(o, alloc);
     }
-    case rapidjson::Type::kArrayType: {
+    case json::Type::kArrayType: {
         auto a = v.GetArray();
         return sanitize(a, alloc);
     }
-    case rapidjson::Type::kFalseType:
-    case rapidjson::Type::kTrueType:
-    case rapidjson::Type::kNullType:
-    case rapidjson::Type::kNumberType:
-    case rapidjson::Type::kStringType:
+    case json::Type::kFalseType:
+    case json::Type::kTrueType:
+    case json::Type::kNullType:
+    case json::Type::kNumberType:
+    case json::Type::kStringType:
         return outcome::success();
     }
     __builtin_unreachable();
@@ -265,7 +266,7 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
             return res.assume_error();
         }
 
-        if (t_it->value.GetType() == rapidjson::Type::kStringType) {
+        if (t_it->value.GetType() == json::Type::kStringType) {
             std::string_view type_sv = {
               t_it->value.GetString(), t_it->value.GetStringLength()};
             auto res = sanitize_avro_type(o, type_sv, alloc);
@@ -273,7 +274,7 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
                 return res.assume_error();
             }
         }
-        if (t_it->value.GetType() == rapidjson::Type::kArrayType) {
+        if (t_it->value.GetType() == json::Type::kArrayType) {
             auto a = t_it->value.GetArray();
             for (auto& m : a) {
                 if (m.IsString()) {

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -11,6 +11,11 @@
 
 #include "pandaproxy/schema_registry/avro.h"
 
+#include "json/allocator.h"
+#include "json/document.h"
+#include "json/encodings.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "utils/string_switch.h"
@@ -23,12 +28,7 @@
 #include <boost/outcome/std_result.hpp>
 #include <boost/outcome/success_failure.hpp>
 #include <fmt/core.h>
-#include <rapidjson/allocators.h>
-#include <rapidjson/document.h>
-#include <rapidjson/encodings.h>
 #include <rapidjson/error/en.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <string_view>
 
@@ -125,19 +125,12 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
     return writer.resolve(reader) != avro::RESOLVE_NO_MATCH;
 }
 
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>& v,
-  rapidjson::MemoryPoolAllocator<>& alloc);
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
-  rapidjson::MemoryPoolAllocator<>& alloc);
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Array& a,
-  rapidjson::MemoryPoolAllocator<>& alloc);
+result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc);
+result<void> sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc);
+result<void> sanitize(json::Value::Array& a, json::MemoryPoolAllocator& alloc);
 
 result<void> sanitize_union_symbol_name(
-  rapidjson::GenericValue<rapidjson::UTF8<>>& name,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+  json::Value& name, json::MemoryPoolAllocator& alloc) {
     // A name should have the leading dot stripped iff it's the only one
 
     if (!name.IsString() || name.GetStringLength() == 0) {
@@ -157,9 +150,8 @@ result<void> sanitize_union_symbol_name(
     return outcome::success();
 }
 
-result<void> sanitize_record(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& v,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+result<void>
+sanitize_record(json::Value::Object& v, json::MemoryPoolAllocator& alloc) {
     auto f_it = v.FindMember("fields");
     if (f_it == v.MemberEnd()) {
         return error_info{
@@ -173,9 +165,9 @@ result<void> sanitize_record(
 }
 
 result<void> sanitize_avro_type(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
+  json::Value::Object& o,
   std::string_view type_sv,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+  json::MemoryPoolAllocator& alloc) {
     auto type = string_switch<std::optional<avro::Type>>(type_sv)
                   .match("record", avro::Type::AVRO_RECORD)
                   .default_match(std::nullopt);
@@ -193,9 +185,7 @@ result<void> sanitize_avro_type(
     return outcome::success();
 }
 
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>& v,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc) {
     switch (v.GetType()) {
     case rapidjson::Type::kObjectType: {
         auto o = v.GetObject();
@@ -215,9 +205,8 @@ result<void> sanitize(
     __builtin_unreachable();
 }
 
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+result<void>
+sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
     if (auto it = o.FindMember("name"); it != o.MemberEnd()) {
         // A name should have the leading dot stripped iff it's the only one
         // Otherwise split on the last dot into a name and a namespace
@@ -262,8 +251,8 @@ result<void> sanitize(
                 }
             } else {
                 o.AddMember(
-                  rapidjson::Value("namespace", alloc),
-                  rapidjson::Value(
+                  json::Value("namespace"),
+                  json::Value(
                     new_namespace.data(), new_namespace.length(), alloc),
                   alloc);
             }
@@ -299,9 +288,7 @@ result<void> sanitize(
     return outcome::success();
 }
 
-result<void> sanitize(
-  rapidjson::GenericValue<rapidjson::UTF8<>>::Array& a,
-  rapidjson::MemoryPoolAllocator<>& alloc) {
+result<void> sanitize(json::Value::Array& a, json::MemoryPoolAllocator& alloc) {
     for (auto& m : a) {
         auto s = sanitize(m, alloc);
         if (s.has_error()) {
@@ -352,7 +339,7 @@ make_avro_schema_definition(std::string_view sv) {
 
 result<canonical_schema_definition>
 sanitize_avro_schema_definition(unparsed_schema_definition def) {
-    rapidjson::GenericDocument<rapidjson::UTF8<>> doc;
+    json::Document doc;
     constexpr auto flags = rapidjson::kParseDefaultFlags
                            | rapidjson::kParseStopWhenDoneFlag;
     const auto& raw = def.raw()();
@@ -377,9 +364,9 @@ sanitize_avro_schema_definition(unparsed_schema_definition def) {
           fmt::format("{} {}", res.assume_error().message(), raw)};
     }
 
-    rapidjson::GenericStringBuffer<rapidjson::UTF8<>> str_buf;
+    json::StringBuffer str_buf;
     str_buf.Reserve(raw.size());
-    rapidjson::Writer<rapidjson::StringBuffer> w{str_buf};
+    json::Writer<json::StringBuffer> w{str_buf};
 
     if (!doc.Accept(w)) {
         return error_info{error_code::schema_invalid, "Invalid schema"};

--- a/src/v/pandaproxy/schema_registry/requests/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/requests/compatibility.h
@@ -21,7 +21,7 @@ struct post_compatibility_res {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::post_compatibility_res& res) {
     w.StartObject();
     w.Key("is_compatible");

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -28,7 +28,7 @@ struct put_config_req_rep {
     compatibility_level compat{compatibility_level::none};
 };
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class put_config_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -82,7 +82,7 @@ public:
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::get_config_req_rep& res) {
     w.StartObject();
     w.Key(get_config_req_rep::field_name.data());
@@ -91,7 +91,7 @@ inline void rjson_serialize(
 }
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::put_config_req_rep& res) {
     w.StartObject();
     w.Key(put_config_req_rep::field_name.data());

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "json/types.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/errors.h"
@@ -46,7 +47,7 @@ public:
       : json::base_handler<Encoding>{json::serialization_format::none}
       , result() {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         if (_state == state::object && sv == put_config_req_rep::field_name) {
             _state = state::compatibility;
@@ -55,7 +56,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         if (_state == state::compatibility) {
             auto s = from_string_view<compatibility_level>(sv);
@@ -76,7 +77,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return std::exchange(_state, state::empty) == state::object;
     }
 };

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -21,7 +21,7 @@ struct get_schemas_ids_id_response {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const get_schemas_ids_id_response& res) {
     w.StartObject();
     w.Key("schema");

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
@@ -21,7 +21,7 @@ struct get_schemas_ids_id_versions_response {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const get_schemas_ids_id_versions_response& res) {
     w.StartArray();
     for (const auto& sv : res.subject_versions) {

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -23,7 +23,7 @@ struct post_subject_versions_version_response {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const post_subject_versions_version_response& res) {
     w.StartObject();
     w.Key("subject");

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -216,7 +216,7 @@ struct post_subject_versions_response {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::post_subject_versions_response& res) {
     w.StartObject();
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -26,7 +26,7 @@ struct post_subject_versions_request {
     canonical_schema schema;
 };
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class post_subject_versions_request_handler
   : public json::base_handler<Encoding> {
     enum class state {

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "json/types.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -59,7 +60,7 @@ public:
       : json::base_handler<Encoding>{json::serialization_format::none}
       , _schema{std::move(sub)} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::record: {
@@ -116,7 +117,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::schema: {
@@ -176,7 +177,7 @@ public:
         return false;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         switch (_state) {
         case state::record: {
             _state = state::empty;
@@ -206,7 +207,7 @@ public:
 
     bool StartArray() { return _state == state::references; }
 
-    bool EndArray(rapidjson::SizeType) {
+    bool EndArray(::json::SizeType) {
         return std::exchange(_state, state::record) == state::references;
     }
 };

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -13,9 +13,6 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include <type_traits>
 
 namespace ppj = pandaproxy::json;

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -13,9 +13,6 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include <type_traits>
 
 namespace ppj = pandaproxy::json;

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -13,6 +13,8 @@
 
 #include "bytes/iobuf_parser.h"
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "model/metadata.h"
 #include "model/record_utils.h"
 #include "pandaproxy/json/rjson_parse.h"
@@ -30,9 +32,6 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/std-coroutine.hh>
-
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 namespace pandaproxy::schema_registry {
 
@@ -159,7 +158,7 @@ struct schema_key {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::schema_key& key) {
     w.StartObject();
     w.Key("keytype");
@@ -318,7 +317,7 @@ struct schema_value {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::schema_value& val) {
     w.StartObject();
     w.Key("subject");
@@ -633,7 +632,7 @@ struct config_key {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::config_key& key) {
     w.StartObject();
     w.Key("keytype");
@@ -766,7 +765,7 @@ struct config_value {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  ::json::Writer<::json::StringBuffer>& w,
   const schema_registry::config_value& val) {
     w.StartObject();
     w.Key("compatibilityLevel");
@@ -856,8 +855,7 @@ struct delete_subject_key {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const delete_subject_key& key) {
+  ::json::Writer<::json::StringBuffer>& w, const delete_subject_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -998,8 +996,7 @@ struct delete_subject_value {
 };
 
 inline void rjson_serialize(
-  rapidjson::Writer<rapidjson::StringBuffer>& w,
-  const delete_subject_value& val) {
+  ::json::Writer<::json::StringBuffer>& w, const delete_subject_value& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.sub);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -64,7 +64,7 @@ from_string_view<topic_key_type>(std::string_view sv) {
 }
 
 // Just peek at the keytype. Allow other fields through.
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class topic_key_type_handler
   : public rapidjson::
       BaseReaderHandler<Encoding, topic_key_type_handler<Encoding>> {
@@ -180,7 +180,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class schema_key_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -353,7 +353,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class schema_value_handler final : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -656,7 +656,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class config_key_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -773,7 +773,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class config_value_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -874,7 +874,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class delete_subject_key_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -1003,7 +1003,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = rapidjson::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class delete_subject_value_handler : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -67,7 +67,7 @@ from_string_view<topic_key_type>(std::string_view sv) {
 // Just peek at the keytype. Allow other fields through.
 template<typename Encoding = ::json::UTF8<>>
 class topic_key_type_handler
-  : public rapidjson::
+  : public ::json::
       BaseReaderHandler<Encoding, topic_key_type_handler<Encoding>> {
     enum class state {
         empty = 0,
@@ -77,12 +77,12 @@ class topic_key_type_handler
     state _state = state::empty;
 
 public:
-    using Ch = typename rapidjson::BaseReaderHandler<Encoding>::Ch;
+    using Ch = typename ::json::BaseReaderHandler<Encoding>::Ch;
     using rjson_parse_result = ss::sstring;
     rjson_parse_result result;
 
     topic_key_type_handler()
-      : rapidjson::
+      : ::json::
         BaseReaderHandler<Encoding, topic_key_type_handler<Encoding>>{} {}
 
     bool Key(const Ch* str, ::json::SizeType len, bool) {

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -14,6 +14,7 @@
 #include "bytes/iobuf_parser.h"
 #include "json/json.h"
 #include "json/stringbuffer.h"
+#include "json/types.h"
 #include "json/writer.h"
 #include "model/metadata.h"
 #include "model/record_utils.h"
@@ -84,7 +85,7 @@ public:
       : rapidjson::
         BaseReaderHandler<Encoding, topic_key_type_handler<Encoding>>{} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         if (_state == state::object && sv == "keytype") {
             _state = state::keytype;
@@ -92,7 +93,7 @@ public:
         return true;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         if (_state == state::keytype) {
             result = ss::sstring{str, len};
             _state = state::object;
@@ -107,7 +108,7 @@ public:
         return true;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         if (_state == state::object) {
             _state = state::empty;
         }
@@ -202,7 +203,7 @@ public:
     schema_key_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::object: {
@@ -262,7 +263,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::keytype: {
@@ -290,7 +291,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return result.seq.has_value() == result.node.has_value()
                && std::exchange(_state, state::empty) == state::object;
     }
@@ -388,7 +389,7 @@ public:
     schema_value_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::object: {
@@ -489,7 +490,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::subject: {
@@ -561,7 +562,7 @@ public:
         return false;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         switch (_state) {
         case state::object: {
             _state = state::empty;
@@ -595,7 +596,7 @@ public:
 
     bool StartArray() { return _state == state::references; }
 
-    bool EndArray(rapidjson::SizeType) {
+    bool EndArray(::json::SizeType) {
         return std::exchange(_state, state::object) == state::references;
     }
 };
@@ -677,7 +678,7 @@ public:
     config_key_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         std::optional<state> s{string_switch<std::optional<state>>(sv)
                                  .match("keytype", state::keytype)
@@ -715,7 +716,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::keytype: {
@@ -747,7 +748,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return result.seq.has_value() == result.node.has_value()
                && std::exchange(_state, state::empty) == state::object;
     }
@@ -790,7 +791,7 @@ public:
     config_value_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         if (_state == state::object && sv == "compatibilityLevel") {
             _state = state::compatibility;
@@ -799,7 +800,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         if (_state == state::compatibility) {
             auto s = from_string_view<compatibility_level>(sv);
@@ -816,7 +817,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return std::exchange(_state, state::empty) == state::object;
     }
 };
@@ -895,7 +896,7 @@ public:
     delete_subject_key_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::object: {
@@ -948,7 +949,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::keytype: {
@@ -975,7 +976,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return result.seq.has_value() == result.node.has_value()
                && std::exchange(_state, state::empty) == state::object;
     }
@@ -1021,7 +1022,7 @@ public:
     delete_subject_value_handler()
       : json::base_handler<Encoding>{json::serialization_format::none} {}
 
-    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::object: {
@@ -1042,7 +1043,7 @@ public:
         return false;
     }
 
-    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+    bool String(const Ch* str, ::json::SizeType len, bool) {
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::subject: {
@@ -1077,7 +1078,7 @@ public:
         return std::exchange(_state, state::object) == state::empty;
     }
 
-    bool EndObject(rapidjson::SizeType) {
+    bool EndObject(::json::SizeType) {
         return std::exchange(_state, state::empty) == state::object;
     }
 };

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "http/client.h"
+#include "json/document.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/schema_registry/types.h"

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -82,7 +82,7 @@ inline auto get_subject_versions(
 
 inline std::vector<pps::schema_version>
 get_body_versions(const ss::sstring& body) {
-    rapidjson::Document doc;
+    json::Document doc;
     if (doc.Parse(body).HasParseError()) {
         throw ppj::parse_error(doc.GetErrorOffset());
     }
@@ -102,7 +102,7 @@ get_body_versions(const ss::sstring& body) {
 }
 
 inline int get_body_error_code(const ss::sstring& body) {
-    rapidjson::Document doc;
+    json::Document doc;
     if (doc.Parse(body).HasParseError()) {
         throw ppj::parse_error(doc.GetErrorOffset());
     }

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -22,13 +22,13 @@ constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
 constexpr std::string_view sv_string_def1{R"({"type": "string"})"};
 constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
 const pps::canonical_schema_definition string_def0{
-  pps::make_schema_definition<rapidjson::UTF8<>>(sv_string_def0).value(),
+  pps::make_schema_definition<json::UTF8<>>(sv_string_def0).value(),
   pps::schema_type::avro};
 const pps::canonical_schema_definition string_def1{
-  pps::make_schema_definition<rapidjson::UTF8<>>(sv_string_def1).value(),
+  pps::make_schema_definition<json::UTF8<>>(sv_string_def1).value(),
   pps::schema_type::avro};
 const pps::canonical_schema_definition int_def0{
-  pps::make_schema_definition<rapidjson::UTF8<>>(sv_int_def0).value(),
+  pps::make_schema_definition<json::UTF8<>>(sv_int_def0).value(),
   pps::schema_type::avro};
 const pps::subject subject0{"subject0"};
 const pps::subject subject1{"subject1"};

--- a/src/v/pandaproxy/schema_registry/test/util.cc
+++ b/src/v/pandaproxy/schema_registry/test/util.cc
@@ -41,15 +41,14 @@ constexpr std::string_view minified_avro_schema{
   R"({"namespace":"com.acme","protocol":"HelloWorld","doc":"Protocol Greetings","types":[{"name":"Greeting","type":"record","fields":[{"name":"message","type":"string"}]},{"name":"Curse","type":"error","fields":[{"name":"message","type":"string"}]}],"messages":{"hello":{"doc":"Say hello.","request":[{"name":"greeting","type":"Greeting"}],"response":"Greeting","errors":["Curse"]}}})"};
 
 BOOST_AUTO_TEST_CASE(test_make_schema_definition) {
-    auto res = pps::make_schema_definition<rapidjson::UTF8<>>(
-      example_avro_schema);
+    auto res = pps::make_schema_definition<json::UTF8<>>(example_avro_schema);
 
     BOOST_REQUIRE(res);
     BOOST_REQUIRE_EQUAL(res.value()(), minified_avro_schema);
 }
 
 BOOST_AUTO_TEST_CASE(test_make_schema_definition_failure) {
-    auto res = pps::make_schema_definition<rapidjson::UTF8<>>(
+    auto res = pps::make_schema_definition<json::UTF8<>>(
       "this should fail to parse");
 
     BOOST_REQUIRE(res.has_error());

--- a/src/v/pandaproxy/schema_registry/util.h
+++ b/src/v/pandaproxy/schema_registry/util.h
@@ -11,7 +11,10 @@
 
 #pragma once
 
+#include "json/document.h"
 #include "json/json.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 #include "likely.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -21,10 +24,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <exception>
 #include <utility>
@@ -43,7 +43,7 @@ make_schema_definition(std::string_view sv) {
     // Validate and minify
     // TODO (Ben): Minify. e.g.:
     // "schema": "{\"type\": \"string\"}" -> "schema": "\"string\""
-    rapidjson::GenericDocument<Encoding> doc;
+    ::json::GenericDocument<Encoding> doc;
     doc.Parse(sv.data(), sv.size());
     if (doc.HasParseError()) {
         return error_info{
@@ -53,9 +53,9 @@ make_schema_definition(std::string_view sv) {
             rapidjson::GetParseError_En(doc.GetParseError()),
             doc.GetErrorOffset())};
     }
-    rapidjson::GenericStringBuffer<Encoding> str_buf;
+    ::json::GenericStringBuffer<Encoding> str_buf;
     str_buf.Reserve(sv.size());
-    rapidjson::Writer<rapidjson::StringBuffer> w{str_buf};
+    ::json::Writer<::json::GenericStringBuffer<Encoding>> w{str_buf};
     doc.Accept(w);
     return unparsed_schema_definition::raw_string{
       ss::sstring{str_buf.GetString(), str_buf.GetSize()}};

--- a/src/v/raft/kvelldb/httpkvrsm.cc
+++ b/src/v/raft/kvelldb/httpkvrsm.cc
@@ -9,7 +9,9 @@
 
 #include "raft/kvelldb/httpkvrsm.h"
 
-#include "json/json.h"
+#include "json/document.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
 
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/json_path.hh>
@@ -41,8 +43,8 @@ bool try_parse_json_hash(
 }
 
 ss::sstring reject_as_json() {
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    json::StringBuffer buffer;
+    json::Writer<json::StringBuffer> writer(buffer);
 
     writer.StartObject();
     writer.Key("status");
@@ -80,8 +82,8 @@ ss::sstring cmd_result_as_json(raft::kvelldb::kvrsm::cmd_result result) {
         break;
     }
 
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    json::StringBuffer buffer;
+    json::Writer<json::StringBuffer> writer(buffer);
 
     writer.StartObject();
     writer.Key("status");

--- a/src/v/raft/kvelldb/httpkvrsm.cc
+++ b/src/v/raft/kvelldb/httpkvrsm.cc
@@ -24,7 +24,7 @@ bool try_parse_json_hash(
   ss::sstring json,
   std::vector<ss::sstring> keys,
   absl::flat_hash_map<ss::sstring, ss::sstring>& target) {
-    rapidjson::Document body;
+    json::Document body;
 
     if (body.Parse(json.c_str()).HasParseError()) {
         return false;
@@ -35,7 +35,7 @@ bool try_parse_json_hash(
             return false;
         }
 
-        rapidjson::Value& value = body[key];
+        json::Value& value = body[key];
         target.emplace(key, value.GetString());
     }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -29,6 +29,8 @@
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "finjector/hbadger.h"
+#include "json/document.h"
+#include "json/schema.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "kafka/types.h"
@@ -66,8 +68,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <fmt/core.h>
-#include <rapidjson/document.h>
-#include <rapidjson/schema.h>
 
 #include <limits>
 #include <stdexcept>
@@ -160,18 +160,18 @@ struct json_validator {
       : schema(make_schema_document(schema_text))
       , validator(schema) {}
 
-    static rapidjson::SchemaDocument
+    static json::SchemaDocument
     make_schema_document(const std::string& schema) {
-        rapidjson::Document doc;
+        json::Document doc;
         if (doc.Parse(schema).HasParseError()) {
             throw std::runtime_error(
               fmt::format("Invalid schema document: {}", schema));
         }
-        return rapidjson::SchemaDocument(doc);
+        return json::SchemaDocument(doc);
     }
 
-    const rapidjson::SchemaDocument schema;
-    rapidjson::SchemaValidator validator;
+    const json::SchemaDocument schema;
+    json::SchemaValidator validator;
 };
 
 static json_validator make_set_replicas_validator() {
@@ -205,8 +205,8 @@ static json_validator make_set_replicas_validator() {
  * as an empty request body causes a redpanda crash via a rapidjson
  * assertion when trying to GetObject on the resulting document.
  */
-static rapidjson::Document parse_json_body(ss::httpd::request const& req) {
-    rapidjson::Document doc;
+static json::Document parse_json_body(ss::httpd::request const& req) {
+    json::Document doc;
     doc.Parse(req.content.data());
     if (doc.Parse(req.content.data()).HasParseError()) {
         throw ss::httpd::bad_request_exception(
@@ -222,7 +222,7 @@ static rapidjson::Document parse_json_body(ss::httpd::request const& req) {
  * caller see what went wrong.
  */
 static void
-apply_validator(json_validator& validator, rapidjson::Document const& doc) {
+apply_validator(json_validator& validator, json::Document const& doc) {
     validator.validator.Reset();
     validator.validator.ResetError();
 
@@ -1137,7 +1137,7 @@ void admin_server::register_raft_routes() {
 
 // TODO: factor out generic serialization from seastar http exceptions
 static security::scram_credential
-parse_scram_credential(const rapidjson::Document& doc) {
+parse_scram_credential(const json::Document& doc) {
     if (!doc.IsObject()) {
         throw ss::httpd::bad_request_exception(fmt::format("Not an object"));
     }
@@ -1174,7 +1174,7 @@ parse_scram_credential(const rapidjson::Document& doc) {
 }
 
 static bool match_scram_credential(
-  const rapidjson::Document& doc, const security::scram_credential& creds) {
+  const json::Document& doc, const security::scram_credential& creds) {
     // Document is pre-validated via earlier parse_scram_credential call
     const auto password = ss::sstring(doc["password"].GetString());
     const auto algorithm = std::string_view(

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "json/json.h"
 #include "reflection/adl.h"
 #include "seastarx.h"
 #include "vlog.h"


### PR DESCRIPTION
## Cover letter

This will collide with #3792 

Alias `rapidjson` types in the `json` namespace to use the `throwing_allocator` from #3511 so that they throw `std::bad_alloc` instead of returning `nullptr`.

The latter commits work towards removing most `#include <rapidjson/.*>` and `rapidjson::.*` outside of the json library.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/999cd744e3244fb1a14efa98a7afaa05957ad83f..d2c56f2f77f5484f8825cfc0cadb4249636ed651)
* Switch `RAPIDJSON_ASSERT(x)` to `vassert(x, "Rapidjson ")`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/d2c56f2f77f5484f8825cfc0cadb4249636ed651..9a6bcdccab3b52507273735491812eb02ad45211)
* Rebase past #3792 
* All changes / collisions / etc. are limited to `cloud_storage/topic_manifest.cc`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/9a6bcdccab3b52507273735491812eb02ad45211..7595e9303be52514990a8df5f47564afabd91569)
* Missed an include

## Release notes

### Improvements

* Improved error handling when manipulating JSON in low memory situations.