### PR TITLE
test/segment_appender: assert no short reads on append test

### DIFF
--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -206,6 +206,9 @@ static void run_test_can_append_10MB_sequential_write_sequential_read(
         auto in = make_file_input_stream(f, i * one_meg);
         iobuf result = read_iobuf_exactly(in, one_meg).get0();
         iobuf tmp_o = original.share(i * one_meg, one_meg);
+        // read_iobuf_exactly can return a short read, but we do not expect that
+        // here.
+        BOOST_REQUIRE_EQUAL(one_meg, result.size_bytes());
         BOOST_REQUIRE_EQUAL(tmp_o, result);
         in.close().get();
     }


### PR DESCRIPTION
I introduced a bad change when resolving a merge conflict and was
surprised when `test_can_append_10MB` didn't fail when I only gave it
1MB data.

Adding this assert should help validate the expected behavior here
better; we should not be getting a short read when there is data
available.

Fixes #4077
