### PR TITLE
gha/rpk: bump golang version to 1.17.8

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.3
+        go-version: 1.17.8
       id: go
 
     - name: Set up Node


### PR DESCRIPTION
Bumps version of golang version used in github action workflows

## Release notes

* none