### PR TITLE
Fix consumer group migrations

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -49,7 +49,8 @@ group::group(
   group_state s,
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition,
-  group_metadata_serializer serializer)
+  group_metadata_serializer serializer,
+  enable_group_metrics group_metrics)
   : _id(std::move(id))
   , _state(s)
   , _state_timestamp(model::timestamp::now())
@@ -62,14 +63,16 @@ group::group(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
-  , _md_serializer(std::move(serializer)) {}
+  , _md_serializer(std::move(serializer))
+  , _enable_group_metrics(group_metrics) {}
 
 group::group(
   kafka::group_id id,
   group_metadata_value& md,
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition,
-  group_metadata_serializer serializer)
+  group_metadata_serializer serializer,
+  enable_group_metrics group_metrics)
   : _id(std::move(id))
   , _num_members_joining(0)
   , _new_member_added(false)
@@ -79,7 +82,8 @@ group::group(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
-  , _md_serializer(std::move(serializer)) {
+  , _md_serializer(std::move(serializer))
+  , _enable_group_metrics(group_metrics) {
     _state = md.members.empty() ? group_state::empty : group_state::stable;
     _generation = md.generation;
     _protocol_type = md.protocol_type;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -118,7 +118,8 @@ public:
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::topic_table>&,
       group_metadata_serializer_factory,
-      config::configuration& conf);
+      config::configuration& conf,
+      enable_group_metrics group_metrics);
 
     ss::future<> start();
     ss::future<> stop();
@@ -254,6 +255,7 @@ private:
     //
 
     model::broker _self;
+    enable_group_metrics _enable_group_metrics;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -526,9 +526,10 @@ ss::future<> group_metadata_migration::activate_feature(ss::abort_source& as) {
     vlog(mlog.info, "activating consumer offsets feature");
     while (!feature_table().is_active(cluster::feature::consumer_offsets)
            && !as.abort_requested()) {
-        if (
-          _controller.is_raft0_leader()
-          && feature_table().is_preparing(cluster::feature::consumer_offsets)) {
+        if (_controller.is_raft0_leader()) {
+            co_await feature_table().await_feature_preparing(
+              cluster::feature::consumer_offsets, as);
+
             auto err = co_await feature_manager().write_action(
               cluster::feature_update_action{
                 .feature_name = ss::sstring(

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -571,6 +571,10 @@ ss::future<> group_metadata_migration::do_apply() {
       cluster::feature::consumer_offsets, abort_source());
     vlog(mlog.info, "disabling partition movement feature and group router");
     co_await _group_router.invoke_on_all(&group_router::disable);
+    vlog(mlog.info, "shutting down source group manager");
+    co_await _group_router.local().get_group_manager().invoke_on_all(
+      &group_manager::stop);
+
     co_await _controller.get_topics_frontend().invoke_on_all(
       &cluster::topics_frontend::disable_partition_movement);
     vlog(mlog.info, "waiting for stable consumer group topic");

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -50,7 +50,8 @@ static group get() {
       group_state::empty,
       conf,
       nullptr,
-      make_backward_compatible_serializer());
+      make_backward_compatible_serializer(),
+      enable_group_metrics::no);
 }
 
 static const std::vector<member_protocol> test_group_protos = {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -708,6 +708,11 @@ void application::wire_up_redpanda_services() {
             _rpc.stop().get();
         }
     });
+
+    // metrics and quota management
+    syschecks::systemd_message("Adding kafka quota manager").get();
+    construct_service(quota_mgr).get();
+
     _deferred.emplace_back([this] {
         if (_kafka_server.local_is_initialized()) {
             _kafka_server.invoke_on_all(&net::server::wait_for_shutdown).get();
@@ -854,9 +859,6 @@ void application::wire_up_redpanda_services() {
         coprocessing->start().get();
     }
 
-    // metrics and quota management
-    syschecks::systemd_message("Adding kafka quota manager").get();
-    construct_service(quota_mgr).get();
     // rpc
     ss::sharded<net::server_configuration> rpc_cfg;
     rpc_cfg.start(ss::sstring("internal_rpc")).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -805,7 +805,8 @@ void application::wire_up_redpanda_services() {
       std::ref(partition_manager),
       std::ref(controller->get_topics_state()),
       &kafka::make_backward_compatible_serializer,
-      std::ref(config::shard_local_cfg()))
+      std::ref(config::shard_local_cfg()),
+      kafka::enable_group_metrics::no)
       .get();
     construct_service(
       _co_group_manager,
@@ -814,7 +815,8 @@ void application::wire_up_redpanda_services() {
       std::ref(partition_manager),
       std::ref(controller->get_topics_state()),
       &kafka::make_consumer_offsets_serializer,
-      std::ref(config::shard_local_cfg()))
+      std::ref(config::shard_local_cfg()),
+      kafka::enable_group_metrics::yes)
       .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();
     construct_service(

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -81,10 +81,10 @@ ss::future<> transport::connect(clock_type::duration connection_timeout) {
 
 ss::future<>
 transport::connect(rpc::clock_type::time_point connection_timeout) {
+    _correlation_idx = 0;
+    _last_seq = sequence_t{0};
+    _seq = sequence_t{0};
     return base_transport::connect(connection_timeout).then([this] {
-        _correlation_idx = 0;
-        _last_seq = sequence_t{0};
-        _seq = sequence_t{0};
         // background
         ssx::spawn_with_gate(_dispatch_gate, [this] {
             return do_reads().then_wrapped([this](ss::future<> f) {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -271,7 +271,7 @@ class RedpandaService(Service):
                                             "redpanda.profraw")
 
     CLUSTER_NAME = "my_cluster"
-    READY_TIMEOUT_SEC = 15
+    READY_TIMEOUT_SEC = 10
 
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -17,11 +17,11 @@ from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.services.failure_injector import FailureInjector, FailureSpec
 from rptest.tests.end_to_end import EndToEndTest
-from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RedpandaService, ResourceSettings
 from rptest.clients.default import DefaultClient
 from ducktape.utils.util import wait_until
 
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 
 
 class ConsumerOffsetsMigrationTest(EndToEndTest):
@@ -30,9 +30,8 @@ class ConsumerOffsetsMigrationTest(EndToEndTest):
     max_inter_failure_time_sec = 30
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @parametrize(failures=True)
-    @parametrize(failures=False)
-    def test_migrating_consume_offsets(self, failures):
+    @matrix(failures=[True, False], cpus=[1, 3])
+    def test_migrating_consume_offsets(self, failures, cpus):
         '''
         Validates correctness while executing consumer offsets migration
         '''
@@ -41,6 +40,7 @@ class ConsumerOffsetsMigrationTest(EndToEndTest):
         self.redpanda = RedpandaService(
             self.test_context,
             5,
+            resource_settings=ResourceSettings(num_cpus=cpus),
             extra_rp_conf={
                 "group_topic_partitions": 16,
                 "default_topic_replications": 3,

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -104,8 +104,12 @@ class ConsumerOffsetsMigrationTest(EndToEndTest):
             return True
 
         kcl = KCL(self.redpanda)
+
+        def _group_present():
+            return len(kcl.list_groups().splitlines()) > 1
+
         # make sure that group is there
-        assert len(kcl.list_groups().splitlines()) > 1
+        wait_until(_group_present, 10, 1)
 
         # check that consumer offsets topic is not present
         topics = set(kcl.list_topics())

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -26,8 +26,8 @@ from ducktape.mark import matrix
 
 class ConsumerOffsetsMigrationTest(EndToEndTest):
     max_suspend_duration_sec = 3
-    min_inter_failure_time_sec = 20
-    max_inter_failure_time_sec = 30
+    min_inter_failure_time_sec = 30
+    max_inter_failure_time_sec = 60
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @matrix(failures=[True, False], cpus=[1, 3])

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -123,9 +123,12 @@ class ConsumerOffsetsMigrationTest(EndToEndTest):
             wait_until(cluster_is_stable, 90, backoff_sec=2)
 
         def _consumer_offsets_present():
-            partitions = list(
-                self.client().describe_topic("__consumer_offsets"))
-            return len(partitions) > 0
+            try:
+                partitions = list(
+                    self.client().describe_topic("__consumer_offsets"))
+                return len(partitions) > 0
+            except:
+                return False
 
         wait_until(_consumer_offsets_present, timeout_sec=90, backoff_sec=3)
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -264,7 +264,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             for a in assignments:
                 # Bounce between core 0 and 1
                 a['core'] = (a['core'] + 1) % 2
-                admin.set_partition_replicas(topic, partition, assignments)
+            admin.set_partition_replicas(topic, partition, assignments)
             self._wait_post_move(topic, partition, assignments, 360)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)


### PR DESCRIPTION
## Cover letter

Fixed consumer offset migration issue that might lead to situation in which migration would not continue. The issue was caused by double registration of consumer group metrics. This situation might happen when old and new partition for the same group were created on the same shard. Fixed the problem by disabling metrics for all the groups managed by old group manager. This way old groups will not be reported in redpanda metrics endpoint and there will be no problem during migration.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes: #4051
Fixes: #4179 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
