### PR TITLE
tests: add ManyClientsTest

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -138,4 +138,16 @@ RUN python3 -m pip install --upgrade --force pip && \
 # copy python tools
 COPY --chown=0:0 tests/python /opt/python
 
+# Compile and install rust-based workload generator.
+# Install & remove compiler in the same step, to avoid bulking
+# out the resulting container image.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    export PATH="/root/.cargo/bin:${PATH}" && \
+    git clone https://github.com/redpanda-data/client-swarm.git && \
+    cd client-swarm && \
+    git reset --hard 9427df19 && \
+    cargo build --release && \
+    cp target/release/client-swarm /usr/local/bin && \
+    cd .. && rm -rf client-swarm && rm -rf /root/.cargo
+
 CMD service ssh start && tail -f /dev/null

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   n:
     image: vectorized/redpanda-test-node
     privileged: true
+    pids_limit: 32768
     ulimits:
       nofile:
         soft: 131072

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import sys
+import threading
+from ducktape.services.background_thread import BackgroundThreadService
+from ducktape.cluster.remoteaccount import RemoteCommandError
+
+
+class ProducerSwarm(BackgroundThreadService):
+    def __init__(self, context, redpanda, topic: str, producers: int,
+                 records_per_producer: int):
+        super(ProducerSwarm, self).__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+        self._topic = topic
+        self._producers = producers
+        self._records_per_producer = records_per_producer
+        self._stopping = threading.Event()
+
+    def _worker(self, idx, node):
+        cmd = f"RUST_LOG=INFO client-swarm producers {self._redpanda.brokers()} {self._topic} {self._producers} {self._records_per_producer}"
+
+        try:
+            for line in node.account.ssh_capture(cmd):
+                self.logger.debug(line.rstrip())
+
+                if self._stopping.is_set():
+                    break
+        except RemoteCommandError:
+            if not self._stopping.is_set():
+                raise
+
+    def stop_all(self):
+        self._stopping.set()
+        self.stop()
+
+    def stop_node(self, node):
+        node.account.kill_process("conn_test", clean_shutdown=False)

--- a/tests/rptest/tests/many_clients_test.py
+++ b/tests/rptest/tests/many_clients_test.py
@@ -1,0 +1,102 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST
+from rptest.services.cluster import cluster
+from rptest.services.rpk_consumer import RpkConsumer
+
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster_spec import ClusterSpec
+
+from rptest.services.producer_swarm import ProducerSwarm
+
+resource_settings = ResourceSettings(
+    num_cpus=2,
+
+    # Set a low memory size, such that there is only ~100k of memory available
+    # for dealing with each client.
+    memory_mb=384,
+
+    # Test nodes and developer workstations may have slow fsync.  For this test
+    # we need things to be consistently fast, so disable fsync (this test
+    # has nothing to do with verifying the correctness of the storage layer)
+    bypass_fsync=True)
+
+
+class ManyClientsTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        # We will send huge numbers of messages, so tune down the log verbosity
+        # as this is just a "did we stay up?" test
+        kwargs['log_level'] = "info"
+        kwargs['resource_settings'] = resource_settings
+        super().__init__(*args, **kwargs)
+
+    @cluster(num_nodes=6)
+    def test_many_clients(self):
+        """
+        Check that redpanda remains stable under higher numbers of clients
+        than usual.
+        """
+
+        if self.debug_mode:
+            self.logger.info("Skipping test, not suitable for debug mode")
+            # A phony allocation to satisfy the check that we used all
+            # the nodes in our `num_nodes` value.
+            alloc_nodes = self.test_context.cluster.alloc(
+                ClusterSpec.simple_linux(3))
+            self.test_context.cluster.free(alloc_nodes)
+            return
+
+        PARTITION_COUNT = 100
+        PRODUCER_COUNT = 4000
+        TOPIC_NAME = "manyclients"
+        RECORDS_PER_PRODUCER = 1000
+
+        self.client().create_topic(
+            TopicSpec(
+                name=TOPIC_NAME,
+                partition_count=PARTITION_COUNT,
+                retention_bytes=10 * 1024 * 1024,
+                segment_bytes=1024 * 1024 * 5,
+            ))
+
+        # Two consumers, just so that we are at least touching consumer
+        # group functionality, if not stressing the overall number of consumers.
+        consumer_a = RpkConsumer(self.test_context,
+                                 self.redpanda,
+                                 TOPIC_NAME,
+                                 group="testgroup",
+                                 save_msgs=False)
+        consumer_b = RpkConsumer(self.test_context,
+                                 self.redpanda,
+                                 TOPIC_NAME,
+                                 group="testgroup",
+                                 save_msgs=False)
+
+        producer = ProducerSwarm(self.test_context, self.redpanda, TOPIC_NAME,
+                                 PRODUCER_COUNT, RECORDS_PER_PRODUCER)
+        producer.start()
+        consumer_a.start()
+        consumer_b.start()
+
+        producer.wait()
+
+        def complete():
+            expect = PRODUCER_COUNT * RECORDS_PER_PRODUCER
+            self.logger.info(
+                f"Message counts: {consumer_a.message_count} {consumer_b.message_count} (vs {expect})"
+            )
+            return consumer_a.message_count + consumer_b.message_count >= expect
+
+        wait_until(complete,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="Consumers didn't see all messages")

--- a/tests/rptest/tests/many_partitions_test.py
+++ b/tests/rptest/tests/many_partitions_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import time
-import os
 import psutil
 
 from rptest.services.cluster import cluster
@@ -176,8 +175,7 @@ class ManyPartitionsTest(RedpandaTest):
 
         # Only run on release mode builds.  Debug builds are far too slow to handle
         # large partition counts.
-        self.logger.info(f"Environment: {os.environ}")
-        if os.environ.get('BUILD_TYPE', None) == 'debug':
+        if self.debug_mode:
             self.logger.info(
                 "Skipping test in debug mode (requires release build)")
             return
@@ -192,13 +190,14 @@ class ManyPartitionsTest(RedpandaTest):
         total_memory = psutil.virtual_memory().total
         self.logger.info(f"Memory: {total_memory}")
         if total_memory < resource_settings.memory_mb * 1024 * 1024 * 3:
-            if os.environ.get('CI', None) == 'false':
+            if self.ci_mode:
+                raise RuntimeError(
+                    f"Too little memory {total_memory} on test machine")
+            else:
                 self.logger.warn(
                     f"Skipping resource intensive test, running on low-memory machine with {total_memory} bytes of RAM"
                 )
-            else:
-                raise RuntimeError(
-                    f"Too little memory {total_memory} on test machine")
+                return
 
         disk_usage = psutil.disk_usage('/var')
         self.logger.info(f"Disk: {disk_usage}")

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -6,6 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+
+import os
+
 from ducktape.tests.test import Test
 from rptest.services.redpanda import RedpandaService
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -63,6 +66,23 @@ class RedpandaTest(Test):
         """
         assert len(self.topics) == 1
         return self.topics[0].name
+
+    @property
+    def debug_mode(self):
+        """
+        Useful for tests that want to change behaviour when running on
+        the much slower debug builds of redpanda, which generally cannot
+        keep up with significant quantities of data or partition counts.
+        """
+        return os.environ.get('BUILD_TYPE', None) == 'debug'
+
+    @property
+    def ci_mode(self):
+        """
+        Useful for tests that want to dynamically degrade/disable on low-resource
+        developer environments (e.g. laptops) but apply stricter checks in CI.
+        """
+        return os.environ.get('CI', None) != 'false'
 
     def setUp(self):
         self.redpanda.start()


### PR DESCRIPTION
## Cover letter

This automates execution of the tool formerly known as kafka_conn_test, now rebranded `client-swarm`.

It opens many thousands of connections to a redpanda cluster, producing concurrently.

The redpanda cluster is configured with small memory per-node, to stress the efficiency of handling all those connections concurrently.

## Release notes

* none