### PR TITLE
s/parser: fixed reading batches with header_crc equal to 0

### DIFF
--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -14,6 +14,7 @@
 #include "bytes/iobuf_ostreambuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/tests/utils.h"
+#include "bytes/utils.h"
 
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -644,4 +645,30 @@ SEASTAR_THREAD_TEST_CASE(iobuf_parser_peek) {
     auto dst_a = parser.peek(1000);
     auto dst_b = parser.copy(1000);
     BOOST_REQUIRE(dst_a == dst_b);
+}
+
+SEASTAR_THREAD_TEST_CASE(iobuf_is_zero_test) {
+    const auto a = random_generators::gen_alphanum_string(1024);
+    const auto b = bytes("abc");
+    std::array<char, 1024> zeros{0};
+    std::array<char, 1> one{1};
+
+    // non zero iobuf
+    iobuf non_zero_1;
+    non_zero_1.append(a.data(), a.size());
+    non_zero_1.append(b.data(), b.size());
+    BOOST_REQUIRE_EQUAL(is_zero(non_zero_1), false);
+
+    iobuf non_zero_2;
+    non_zero_2.append(zeros.data(), zeros.size());
+    non_zero_2.append(one.data(), one.size());
+    BOOST_REQUIRE_EQUAL(is_zero(non_zero_2), false);
+    // empty iobuf is not zero
+    iobuf empty;
+    BOOST_REQUIRE_EQUAL(is_zero(empty), false);
+
+    iobuf zero;
+    zero.append(zeros.data(), zeros.size());
+    zero.append(zeros.data(), zeros.size());
+    BOOST_REQUIRE_EQUAL(is_zero(zero), true);
 }

--- a/src/v/bytes/utils.h
+++ b/src/v/bytes/utils.h
@@ -21,3 +21,24 @@ inline void crc_extend_iobuf(crc::crc32c& crc, const iobuf& buf) {
         return ss::stop_iteration::no;
     });
 }
+
+inline bool is_zero(const char* data, size_t size) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return data[0] == 0 && memcmp(data, data + 1, size - 1) == 0;
+}
+
+inline bool is_zero(const iobuf& buffer) {
+    if (buffer.empty()) {
+        return false;
+    }
+    bool ret = true;
+    iobuf::iterator_consumer in(buffer.cbegin(), buffer.cend());
+    in.consume(buffer.size_bytes(), [&ret](const char* src, size_t len) {
+        if (!is_zero(src, len)) {
+            ret = false;
+            return ss::stop_iteration::yes;
+        }
+        return ss::stop_iteration::no;
+    });
+    return ret;
+}

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/utils.h"
 #include "likely.h"
 #include "model/record.h"
 #include "model/record_utils.h"
@@ -155,13 +156,14 @@ read_header_impl(ss::input_stream<char>& input, const Consumer& consumer) {
           consumer);
         co_return parser_errc::input_stream_not_enough_bytes;
     }
-
-    auto header = header_from_iobuf(std::move(b));
-
-    if (unlikely(header.header_crc == 0)) {
+    // check if iobuf is filled is zeros, this means that we are reading
+    // fallocated range filled with zeros
+    if (unlikely(is_zero(b))) {
         // happens when we fallocate the file
         co_return parser_errc::fallocated_file_read_zero_bytes_for_header;
     }
+    auto header = header_from_iobuf(std::move(b));
+
     if (auto computed_crc = model::internal_header_only_crc(header);
         unlikely(header.header_crc != computed_crc)) {
         vlog(


### PR DESCRIPTION
Fixes #4113

When redpanda is interrupted it may happen that some of the log segment
files will be fallocated but not truncated to valid range. In order to
recognize this situation and skip parsing `storage::parser` used only
`header_crc` field value. This lead to situation in which user could not
read a valid batch if its header crc happen to be equal to 0.

Fixed this issue by checking if other header fields are equal to 0 when
`header_crc` is.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

