### PR TITLE
[v21.11.x] storage: fix integer overflow in max_timestamp

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -81,7 +81,7 @@ bool index_state::maybe_index(
         // We know that a segment cannot be > 4GB
         add_entry(
           batch_base_offset() - base_offset(),
-          last_timestamp() - base_timestamp(),
+          std::max(last_timestamp() - base_timestamp(), int64_t{0}),
           starting_position_in_file);
 
         retval = true;


### PR DESCRIPTION
## Cover letter

Backport of PR https://github.com/redpanda-data/redpanda/pull/4010
Fixes https://github.com/redpanda-data/redpanda/issues/3924

(cherry picked from commit 3aacf0da09ba60b2c4f46c7eb6631ecc9f4c8950)

This fixes:
- Customer sees "segment with bogus max timestamp" warnings with partitions written via MirrorMaker 2
- retention.ms cleanup not working on such segments.

## Release notes

### Improvements

* An issue is fixed where out-of-order timestamps in input data could cause time-based retention cleanup to fail, and warning messages related to "bogus max timestamp".
