### PR TITLE
rptest: replace `@ignore` with `@ok_to_fail`

### DIFF
--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -9,7 +9,7 @@
 
 import random
 
-from ducktape.mark import ignore
+from ducktape.mark import ok_to_fail
 from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
@@ -34,7 +34,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @ignore  # temporarily disabled flaky test, see issue #3450
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3450
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
         self.redpanda = RedpandaService(

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -117,8 +117,6 @@ class NodeOperationFuzzyTest(EndToEndTest):
     """
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    # @ignore failures=True mode for https://github.com/redpanda-data/redpanda/issues/3866
-    #@parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -12,7 +12,7 @@ import json
 import uuid
 import requests
 from rptest.services.cluster import cluster
-from ducktape.mark import ignore
+from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -679,7 +679,7 @@ class PandaProxyTest(RedpandaTest):
             })
         assert sc_res.status_code == requests.codes.no_content
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3454
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3454
     @cluster(num_nodes=3)
     def test_consumer_group_binary_v2(self):
         """
@@ -766,7 +766,7 @@ class PandaProxyTest(RedpandaTest):
         rc_res = c0.remove()
         assert rc_res.status_code == requests.codes.no_content
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/2501
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/2501
     @cluster(num_nodes=3)
     def test_consumer_group_json_v2(self):
         """

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import ignore
+from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.tests.wasm_identity_test import WasmIdentityTest
 from rptest.wasm.wasm_script import WasmScript
@@ -28,7 +28,7 @@ class WasmCreateTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # see: #3858
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3858
     @cluster(num_nodes=4)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()
@@ -63,7 +63,7 @@ class WasmDeleteTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ignore  # https://github.com/redpanda-data/redpanda/issues/3745
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3745
     @cluster(num_nodes=4)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@6e2af9173a79feb8661c4c7a5776080721710a43',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@a60d8e93ac5f13554dae036465a28ece6e407df1',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9', 'psutil==5.9.0'


### PR DESCRIPTION
## Cover letter

As an alternative approach to PR #4040...

Refactor the ducktape tests to use the new `@ok_to_fail` decorator introduced in https://github.com/redpanda-data/ducktape/pull/4 instead of `@ignore` decorator.

## Release notes

* none