### PR TITLE
storage: validate index offsets on load

### DIFF
--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -242,6 +242,24 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
           good_end,
           good.end()); // remove all the ones we copied into recover
 
+        // Validate that the segments' indices do not claim to
+        // have overlapping offset ranges.  This is a form of corruption
+        // that can result from bugs when writing the segments+indices.
+        std::optional<segment_set::type> prev_seg = std::nullopt;
+        for (auto& seg : good) {
+            if (prev_seg.has_value()) {
+                auto prev = prev_seg.value();
+                if (seg->index().base_offset() <= prev->index().max_offset()) {
+                    vlog(
+                      stlog.error,
+                      "Index range conflict.  Indices: \n  {}\n  {}",
+                      prev->index(),
+                      seg->index());
+                }
+            }
+            prev_seg = seg;
+        }
+
         // remove empty segments
         auto non_empty_end = std::stable_partition(
           to_recover.begin(),


### PR DESCRIPTION
Previously, if an index had incorrect max_offset,
readers would hang trying to read it.

Signed-off-by: John Spray <jcs@vectorized.io>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
