### PR TITLE
config: put upper bound on append_chunk_size

### DIFF
--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
@@ -8,7 +8,6 @@ status:
   conditions:
   - type: ClusterConfigured
     status: "False"
-    message: "Invalid value provided for properties: append_chunk_size"
 ---
 
 apiVersion: kuttl.dev/v1beta1

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -675,10 +675,10 @@ configuration::configuration()
   , append_chunk_size(
       *this,
       "append_chunk_size",
-      "Size of direct write operations to disk",
+      "Size of direct write operations to disk in bytes",
       {.example = "32768", .visibility = visibility::tunable},
       16_KiB,
-      storage::internal::chunk_cache::validate_chunk_size)
+      {.min = 4096, .max = 32_MiB, .align = 4096})
   , storage_read_buffer_size(
       *this,
       "storage_read_buffer_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -155,7 +155,7 @@ struct configuration final : public config_store {
     property<bool> release_cache_on_segment_roll;
     property<std::chrono::milliseconds> segment_appender_flush_timeout_ms;
     property<std::chrono::milliseconds> fetch_session_eviction_timeout_ms;
-    property<size_t> append_chunk_size;
+    bounded_property<size_t> append_chunk_size;
     property<size_t> storage_read_buffer_size;
     property<int16_t> storage_read_readahead_count;
     property<size_t> segment_fallocation_step;

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -41,17 +41,6 @@ public:
     chunk_cache& operator=(const chunk_cache&) = delete;
     ~chunk_cache() noexcept = default;
 
-    /** Validator for chunk size configuration setting */
-    static std::optional<ss::sstring> validate_chunk_size(const size_t& value) {
-        if (value % alignment != 0) {
-            return "Chunk size must be multiple of 4096";
-        } else if (value < alignment) {
-            return "Chunk size must be at least 4096";
-        } else {
-            return std::nullopt;
-        }
-    }
-
     ss::future<> start() {
         const auto num_chunks = memory_groups::chunk_cache_min_memory()
                                 / _chunk_size;


### PR DESCRIPTION
## Cover letter

Previously, this could be set to an unreasonably
high value and cause redpanda to fail ot start.

Convert this to a bounded_property at the same time.

## Release notes

### Improvements

* The `append_chunk_size` configuration property now has an upper bound of 32MiB, to avoid issues when this was erroneously set to very high values.
