### PR TITLE
tests: rename si-verifier to kgo-verifier, and improve it.

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -114,7 +114,7 @@ RUN cd /tmp/go/sarama/produce_test && go mod tidy && go build
 RUN git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go && \
     cd /opt/franz-go/examples/bench && go mod tidy && go build
 
-RUN go install github.com/twmb/kcl@latest && \
+RUN go install github.com/twmb/kcl@v0.8.0 && \
     mv /root/go/bin/kcl /usr/local/bin/
 
 # Install the kgo-verifier tool

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -117,9 +117,9 @@ RUN git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go &
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/
 
-# Should fork to redpanda repo
-RUN git -C /opt clone https://github.com/jcsp/si-verifier.git && \
-    cd /opt/si-verifier && git reset --hard bcf4996d063e96497f8ff8be35d82fa1cec53180 && \
+# Install the kgo-verifier tool
+RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
+    cd /opt/kgo-verifier && git reset --hard 30c56af && \
     go mod tidy && go build
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -12,7 +12,7 @@ import threading
 from ducktape.services.background_thread import BackgroundThreadService
 
 # The franz-go root directory
-TESTS_DIR = os.path.join("/opt", "si-verifier")
+TESTS_DIR = os.path.join("/opt", "kgo-verifier")
 
 from enum import Enum
 
@@ -25,7 +25,7 @@ class ServiceStatus(Enum):
 
 class FranzGoVerifiableService(BackgroundThreadService):
     """
-    FranzGoVerifiableService is si-verifier service.
+    FranzGoVerifiableService is kgo-verifier service.
     To validate produced record user should run consumer and producer in one node.
     Use ctx.cluster.alloc(ClusterSpec.simple_linux(1)) to allocate node and pass it to constructor
     """
@@ -87,8 +87,8 @@ class FranzGoVerifiableService(BackgroundThreadService):
                     self.logger.debug("Killing pid %s" % {self._pid})
                     node.account.signal(self._pid, 9, allow_fail=True)
                 else:
-                    self.logger.debug("Killing si-verifier")
-                    node.account.kill_process("si-verifier",
+                    self.logger.debug("Killing kgo-verifier")
+                    node.account.kill_process("kgo-verifier",
                                               clean_shutdown=False)
             except RemoteCommandError as e:
                 if b"No such process" not in e.msg:
@@ -99,7 +99,7 @@ class FranzGoVerifiableService(BackgroundThreadService):
 
     def clean_node(self, node):
         self._redpanda.logger.info(f"{self.__class__.__name__}.clean_node")
-        node.account.kill_process("si-verifier", clean_shutdown=False)
+        node.account.kill_process("kgo-verifier", clean_shutdown=False)
         node.account.remove("valid_offsets*json", True)
 
     def start_node(self, node, clean=None):
@@ -144,7 +144,7 @@ class FranzGoVerifiableSeqConsumer(FranzGoVerifiableService):
             while not self._stopping.is_set(
             ) and not self._shutting_down.is_set():
                 cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs 0 --seq_read=1' % (
-                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    f"{TESTS_DIR}/kgo-verifier", self._redpanda.brokers(),
                     self._topic, self._msg_size)
                 self.execute_cmd(cmd, node)
         except Exception as ex:
@@ -174,7 +174,7 @@ class FranzGoVerifiableRandomConsumer(FranzGoVerifiableService):
             while not self._stopping.is_set(
             ) and not self._shutting_down.is_set():
                 cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs %s --parallel %s --seq_read=0' % (
-                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    f"{TESTS_DIR}/kgo-verifier", self._redpanda.brokers(),
                     self._topic, self._msg_size, self._rand_read_msgs,
                     self._parallel)
 
@@ -202,7 +202,7 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
         self._stopping.clear()
         try:
             cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs %s --rand_read_msgs 0 --seq_read=0' % (
-                f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                f"{TESTS_DIR}/kgo-verifier", self._redpanda.brokers(),
                 self._topic, self._msg_size, self._msg_count)
 
             self.execute_cmd(cmd, node)

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import os
+import json
 import threading
 from ducktape.services.background_thread import BackgroundThreadService
 
@@ -64,9 +65,12 @@ class FranzGoVerifiableService(BackgroundThreadService):
             if self._pid is None:
                 self._pid = line.strip()
 
-            self.logger.debug(line.rstrip())
             if self._stopping.is_set():
                 break
+
+            line = line.rstrip()
+            self.logger.debug(line)
+            yield line
 
     def save_exception(self, ex):
         if self._stopping.is_set():
@@ -130,12 +134,33 @@ class FranzGoVerifiableService(BackgroundThreadService):
             return super(FranzGoVerifiableService, self).free_all()
 
 
+class ConsumerStatus:
+    def __init__(self, valid_reads, invalid_reads, out_of_scope_invalid_reads):
+        self.valid_reads = valid_reads
+        self.invalid_reads = invalid_reads
+        self.out_of_scope_invalid_reads = out_of_scope_invalid_reads
+
+    @property
+    def total_reads(self):
+        # At time of writing, invalid reads is never nonzero, because the program
+        # terminates as soon as it sees an invalid read
+        return self.valid_reads + self.out_of_scope_invalid_reads
+
+    def __str__(self):
+        return f"ConsumerStatus<{self.valid_reads} {self.invalid_reads} {self.out_of_scope_invalid_reads}>"
+
+
 class FranzGoVerifiableSeqConsumer(FranzGoVerifiableService):
     def __init__(self, context, redpanda, topic, msg_size, nodes=None):
         super(FranzGoVerifiableSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes)
 
         self._shutting_down = threading.Event()
+        self._consumer_status = ConsumerStatus(0, 0, 0)
+
+    @property
+    def consumer_status(self):
+        return self._consumer_status
 
     def _worker(self, idx, node):
         self.status = ServiceStatus.RUNNING
@@ -146,7 +171,15 @@ class FranzGoVerifiableSeqConsumer(FranzGoVerifiableService):
                 cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs 0 --seq_read=1' % (
                     f"{TESTS_DIR}/kgo-verifier", self._redpanda.brokers(),
                     self._topic, self._msg_size)
-                self.execute_cmd(cmd, node)
+                for line in self.execute_cmd(cmd, node):
+                    if not line.startswith("{"):
+                        continue
+                    data = json.loads(line)
+                    self._consumer_status = ConsumerStatus(
+                        data['ValidReads'], data['InvalidReads'],
+                        data['OutOfScopeInvalidReads'])
+                    self.logger.info(f"SeqConsumer {self._consumer_status}")
+
         except Exception as ex:
             self.save_exception(ex)
         finally:
@@ -166,6 +199,11 @@ class FranzGoVerifiableRandomConsumer(FranzGoVerifiableService):
               self).__init__(context, redpanda, topic, msg_size, nodes)
         self._rand_read_msgs = rand_read_msgs
         self._parallel = parallel
+        self._consumer_status = ConsumerStatus(0, 0, 0)
+
+    @property
+    def consumer_status(self):
+        return self._consumer_status
 
     def _worker(self, idx, node):
         self.status = ServiceStatus.RUNNING
@@ -178,11 +216,30 @@ class FranzGoVerifiableRandomConsumer(FranzGoVerifiableService):
                     self._topic, self._msg_size, self._rand_read_msgs,
                     self._parallel)
 
-                self.execute_cmd(cmd, node)
+                for line in self.execute_cmd(cmd, node):
+                    if not line.startswith("{"):
+                        continue
+                    data = json.loads(line)
+                    self._consumer_status = ConsumerStatus(
+                        data['ValidReads'], data['InvalidReads'],
+                        data['OutOfScopeInvalidReads'])
+                    self.logger.info(f"RandomConsumer {self._consumer_status}")
+
         except Exception as ex:
             self.save_exception(ex)
         finally:
             self.status = ServiceStatus.FINISH
+
+
+class ProduceStatus:
+    def __init__(self, sent, acked, bad_offsets, restarts):
+        self.sent = sent
+        self.acked = acked
+        self.bad_offsets = bad_offsets
+        self.restarts = restarts
+
+    def __str__(self):
+        return f"ProduceStatus<{self.sent} {self.acked} {self.bad_offsets} {self.restarts}>"
 
 
 class FranzGoVerifiableProducer(FranzGoVerifiableService):
@@ -196,6 +253,11 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
         super(FranzGoVerifiableProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node)
         self._msg_count = msg_count
+        self._status = ProduceStatus(0, 0, 0, 0)
+
+    @property
+    def produce_status(self):
+        return self._status
 
     def _worker(self, idx, node):
         self.status = ServiceStatus.RUNNING
@@ -205,7 +267,14 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
                 f"{TESTS_DIR}/kgo-verifier", self._redpanda.brokers(),
                 self._topic, self._msg_size, self._msg_count)
 
-            self.execute_cmd(cmd, node)
+            for line in self.execute_cmd(cmd, node):
+                if line.startswith("{"):
+                    data = json.loads(line)
+                    self._status = ProduceStatus(data['Sent'], data['Acked'],
+                                                 data['BadOffsets'],
+                                                 data['Restarts'])
+                    self.logger.info(str(self._status))
+
         except Exception as ex:
             self.save_exception(ex)
         finally:


### PR DESCRIPTION
## Cover letter

This tool was brought into the tests following some manual use in SI testing.  Clean it up by:
- Fixing the name, the tool is not really SI specific
- Moving it to the redpanda-data org
- Adding status lines on stdout so that tests can more robustly state their progress+success conditions, rather than treating the tool as a black box that just succeeds or fails.

## Release notes

* none