### PR TITLE
tests: disable WasmPartitionMovementTest.test_dynamic_with_failure

### DIFF
--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -14,6 +14,7 @@ from rptest.services.verifiable_consumer import VerifiableConsumer
 
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
+from ducktape.mark import ignore
 
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.rpk import RpkTool
@@ -171,6 +172,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         # Since the identity copro was deployed, contents of logs should be identical
         assert set(self.records_consumed) == set(self.result_data)
 
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/4052
     @cluster(
         num_nodes=6,
         log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS + RESTART_LOG_ALLOW_LIST +


### PR DESCRIPTION
## Cover letter

Related: https://github.com/redpanda-data/redpanda/issues/4052

## Release notes

* none