### PR TITLE
schema_registry: Support default null type in union for Avro

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -60,7 +60,15 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
                     // if the reader's record schema has a field with no default
                     // value, and writer's schema does not have a field with the
                     // same name, an error is signalled.
-                    return false;
+
+                    // For union, the default must correspond to the first type.
+                    // The default may be null.
+                    const auto& r_leaf = reader.leafAt(int(r_idx));
+                    if (
+                      r_leaf->type() != avro::Type::AVRO_UNION
+                      || r_leaf->leafAt(0)->type() != avro::Type::AVRO_NULL) {
+                        return false;
+                    }
                 }
             }
             return true;

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -64,6 +64,9 @@ BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_compat) {
     // "adding a field with default is a backward compatible change
     BOOST_CHECK(check_compatible(schema2, schema1));
 
+    // "adding a union field with default is a backward compatible change
+    BOOST_CHECK(check_compatible(schema2_union_null_first, schema1));
+
     // "adding a field w/o default is NOT a backward compatible change
     BOOST_CHECK(!check_compatible(schema3, schema1));
 

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
@@ -145,6 +145,10 @@ const auto schema2
   = pps::make_avro_schema_definition(
       R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]})")
       .value();
+const auto schema2_union_null_first
+  = pps::make_avro_schema_definition(
+      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":["null","int"],"name":"f2_enum","default":null}]})")
+      .value();
 const auto schema3
   = pps::make_avro_schema_definition(
       R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2"}]})")


### PR DESCRIPTION
## Cover letter

For Avro, null type in a union is supported for backwards compatibility,
if it's also the default. The default value must be of the type of the
first type in the union.

This change allows that.

Fixes #4120

## Release notes

### Improvements

* Schema Registry: Support default null type in union for Avro
