### PR TITLE
config: add enum_property and use it for enum-ish properties

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -65,15 +65,15 @@ type ConfigPropertyItems struct {
 }
 
 type ConfigPropertyMetadata struct {
-	Type         string              `json:"type"`              // Swagger type like 'string', 'integer', 'array'
-	Description  string              `json:"description"`       // One liner human readable string
-	Nullable     bool                `json:"nullable"`          // If true, may be null
-	NeedsRestart bool                `json:"needs_restart"`     // If true, won't take effect until restart
-	Visibility   string              `json:"visibility"`        // One of 'user', 'deprecated', 'tunable'
-	Units        string              `json:"units,omitempty"`   // A unit like 'ms', or empty.
-	Example      string              `json:"example,omitempty"` // A non-default value for use in docs or tests
+	Type         string              `json:"type"`                  // Swagger type like 'string', 'integer', 'array'
+	Description  string              `json:"description"`           // One liner human readable string
+	Nullable     bool                `json:"nullable"`              // If true, may be null
+	NeedsRestart bool                `json:"needs_restart"`         // If true, won't take effect until restart
+	Visibility   string              `json:"visibility"`            // One of 'user', 'deprecated', 'tunable'
+	Units        string              `json:"units,omitempty"`       // A unit like 'ms', or empty.
+	Example      string              `json:"example,omitempty"`     // A non-default value for use in docs or tests
 	EnumValues   []string            `json:"enum_values,omitempty"` // Permitted values, or empty list.
-	Items        ConfigPropertyItems `json:"items,omitempty"`   // If this is an array, the contained value type
+	Items        ConfigPropertyItems `json:"items,omitempty"`       // If this is an array, the contained value type
 }
 
 type ConfigSchema map[string]ConfigPropertyMetadata

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -72,6 +72,7 @@ type ConfigPropertyMetadata struct {
 	Visibility   string              `json:"visibility"`        // One of 'user', 'deprecated', 'tunable'
 	Units        string              `json:"units,omitempty"`   // A unit like 'ms', or empty.
 	Example      string              `json:"example,omitempty"` // A non-default value for use in docs or tests
+	EnumValues   []string            `json:"enum_values,omitempty"` // Permitted values, or empty list.
 	Items        ConfigPropertyItems `json:"items,omitempty"`   // If this is an array, the contained value type
 }
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -53,7 +53,9 @@ func exportConfig(
 		// Preface each property with a descriptive comment
 		var commentTokens []string
 
-		if meta.Example != "" {
+		if len(meta.EnumValues) > 0 {
+			commentTokens = append(commentTokens, fmt.Sprintf("one of %s", strings.Join(meta.EnumValues, ", ")))
+		} else if meta.Example != "" {
 			commentTokens = append(commentTokens, fmt.Sprintf("e.g. '%s'", meta.Example))
 		}
 

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -105,6 +105,7 @@ public:
     virtual bool is_nullable() const = 0;
     virtual bool is_array() const = 0;
     virtual std::optional<std::string_view> example() const = 0;
+    virtual std::vector<ss::sstring> enum_values() const { return {}; };
 
     /**
      * Validation of a proposed new value before it has been assigned

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -298,7 +298,9 @@ configuration::configuration()
       "Describes how to recover from an invariant violation happened on the "
       "transaction coordinator level",
       {.example = "best_effort", .visibility = visibility::user},
-      model::violation_recovery_policy::crash)
+      model::violation_recovery_policy::crash,
+      {model::violation_recovery_policy::crash,
+       model::violation_recovery_policy::best_effort})
   , rm_sync_timeout_ms(
       *this,
       "rm_sync_timeout_ms",
@@ -323,7 +325,9 @@ configuration::configuration()
       "Describes how to recover from an invariant violation happened on the "
       "partition level",
       {.example = "best_effort", .visibility = visibility::user},
-      model::violation_recovery_policy::crash)
+      model::violation_recovery_policy::crash,
+      {model::violation_recovery_policy::crash,
+       model::violation_recovery_policy::best_effort})
   , fetch_reads_debounce_timeout(
       *this,
       "fetch_reads_debounce_timeout",
@@ -353,7 +357,8 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "LogAppendTime",
        .visibility = visibility::user},
-      model::timestamp_type::create_time)
+      model::timestamp_type::create_time,
+      {model::timestamp_type::create_time, model::timestamp_type::append_time})
   , log_compression_type(
       *this,
       "log_compression_type",
@@ -361,7 +366,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "snappy",
        .visibility = visibility::user},
-      model::compression::producer)
+      model::compression::producer,
+      {model::compression::none,
+       model::compression::gzip,
+       model::compression::snappy,
+       model::compression::lz4,
+       model::compression::zstd,
+       model::compression::producer})
   , fetch_max_bytes(
       *this,
       "fetch_max_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -88,16 +88,18 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
-    property<model::violation_recovery_policy> tm_violation_recovery_policy;
+    enum_property<model::violation_recovery_policy>
+      tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
     property<uint32_t> seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
-    property<model::violation_recovery_policy> rm_violation_recovery_policy;
+    enum_property<model::violation_recovery_policy>
+      rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
-    property<model::timestamp_type> log_message_timestamp_type;
-    property<model::compression> log_compression_type;
+    enum_property<model::timestamp_type> log_message_timestamp_type;
+    enum_property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
     property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
     bounded_property<std::optional<int64_t>> kafka_connection_rate_limit;

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(srcs
     bounded_property_test.cc
+    enum_property_test.cc
     config_store_test.cc
     socket_address_convert_test.cc
     tls_config_convert_test.cc

--- a/src/v/config/tests/enum_property_test.cc
+++ b/src/v/config/tests/enum_property_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/bounded_property.h"
+#include "config/config_store.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+namespace {
+
+struct test_config : public config::config_store {
+    config::enum_property<ss::sstring> enum_str;
+    config::enum_property<std::optional<ss::sstring>> opt_enum_str;
+
+    test_config()
+      : enum_str(
+        *this,
+        "enum_str",
+        "A string with only certain values allowed",
+        {},
+        "foo",
+        {"foo", "bar", "baz"})
+      , opt_enum_str(
+          *this,
+          "opt_enum_str",
+          "A string with only certain values allowed",
+          {},
+          "foo",
+          {std::nullopt, "foo", "bar", "baz"}) {}
+};
+
+SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
+    auto cfg = test_config();
+
+    auto valid_values = {"foo", "bar", "baz"};
+    auto invalid_values = {"fo", "fooo", "rhubarb", "", "\0"};
+
+    std::optional<config::validation_error> verr;
+    for (const auto& v : valid_values) {
+        verr = cfg.enum_str.validate(YAML::Load(v));
+        BOOST_CHECK(!verr.has_value());
+
+        verr = cfg.opt_enum_str.validate(YAML::Load(v));
+        BOOST_CHECK(!verr.has_value());
+    }
+
+    for (const auto& v : invalid_values) {
+        verr = cfg.enum_str.validate(YAML::Load(v));
+        BOOST_CHECK(verr.has_value());
+        BOOST_REQUIRE(
+          verr.value().error_message() == "Must be one of foo,bar,baz");
+
+        verr = cfg.opt_enum_str.validate(YAML::Load(v));
+        BOOST_CHECK(verr.has_value());
+    }
+
+    // Optional variant should also always consider null to be valid.
+    verr = cfg.opt_enum_str.validate(YAML::Load("~"));
+    BOOST_CHECK(!verr.has_value());
+}
+
+} // namespace

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -199,6 +199,11 @@
           "type": "string",
           "description": "Expected syntax of the property value"
         },
+        "enum_values": {
+          "type": "array",
+          "description": "Possible values of the property (in string-ized form)",
+          "items": {"type": "string"}
+        },
         "items": {
           "type": "cluster_config_property_metadata_items",
           "description": "Type of items in an array",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -861,6 +861,14 @@ void admin_server::register_cluster_config_routes() {
                     pm.type = ss::sstring(p.type_name());
                 }
 
+                auto enum_values = p.enum_values();
+                if (!enum_values.empty()) {
+                    // In swagger, this field would just be called 'enum', but
+                    // because we use C++ code generation for our structures,
+                    // we cannot use that reserved word
+                    pm.enum_values = enum_values;
+                }
+
                 const auto& example = p.example();
                 if (example.has_value()) {
                     pm.example = ss::sstring(example.value());


### PR DESCRIPTION
## Cover letter

This is a "fit and finish" thing.  These properties were already safely validated in that invalid values were rejected, but the message includes a std::runtime_error, and the description string doesn't tell the user what the valid values are.

## Release notes

* none