### PR TITLE
update github issue template links and wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: true
 contact_links:
   - name: 👋 Slack
-    url: https://vectorized.io/slack
-    about: Chat and ask questions in real time!
+    url: https://redpanda.com/slack
+    about: Chat about all things Redpanda. Join the conversation!
   - name: ❓ Github Discussions
     url: https://github.com/redpanda-data/redpanda/discussions
-    about: For longer, async, thoughtful discussions
+    about: Longer, more involved discussions
   - name: 💭 Product Feedback
-    url: https://vectorized.io/feedback/
+    url: https://redpanda.com/feedback
     about: Let us know how we can improve your experience
 
 


### PR DESCRIPTION
## Cover letter

Update github issue template links. The `about` wording for the links taken from #4058

## Release notes

* none