### PR TITLE
gha/lint: bump go to version 1.17.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.6
+        go-version: 1.17.8
       id: go
 
     - name: install crlfmt


### PR DESCRIPTION
this was missing from 83e4d57f1e

## Release notes

  * none