### PR TITLE
Added slash command to create pull requests

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -3,12 +3,57 @@ on:
   repository_dispatch:
     types: [backport-command]
 jobs:
-  backport:
+  # assumptions:
+  #   label "kind/backport" exists
+  #   the TARGET_REPO has been already forked into the bots account
+  # outputs the source of the comment (PR or issue)
+  backport-type:
+    outputs:
+      commented_on: ${{ steps.type.outputs.commented_on }}
     runs-on: ubuntu-latest
     env:
       TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
       TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
     steps:
+      - name: Get type of backport (issue or PR)
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
+          CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+        id: type
+        run: |
+          branches=$(gh api "/repos/${TARGET_ORG}/${TARGET_REPO}/branches" --jq '.[] | select(.name=='\"$ARG1\"')')
+          if [[ $branches == "" ]]; then
+            echo "Branch name not found"
+            exit 1
+          fi
+          if [[ $(echo $CLIENT_PAYLOAD | jq 'has("pull_request")') == true ]]; then
+            commented_on=pr
+          else
+            commented_on=issue
+          fi
+          echo "::set-output name=commented_on::$commented_on"
+
+  # creates backport issue if commented on issue, or
+  # creates backport PR if commented on PR
+  # eg /backport v21.11.x
+  type-branch:
+    needs: backport-type
+    runs-on: ubuntu-latest
+    env:
+      TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
+      TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
+    steps:
+      - name: Get user
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        id: user
+        run: |
+          username=$(gh api user --jq .login)
+          echo ::set-output name=username::"$username"
+          echo ::set-output name=repo::"$TARGET_REPO"
+          echo ::set-output name=email::"vbot@redpanda.com"
+
       - name: Get assignees
         env:
           ASSIGNEES: ${{ toJson(github.event.client_payload.github.payload.issue.assignees) }}
@@ -56,6 +101,7 @@ jobs:
           echo ::set-output name=milestone::${assigne_milestone}
 
       - name: Create issue
+        if: needs.backport-type.outputs.commented_on == 'issue'
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
           TARGET_MILESTONE: ${{ steps.milestone.outputs.milestone }}
@@ -64,11 +110,196 @@ jobs:
           ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
           ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.issue.html_url }}
         run: |
-          gh issue create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
+          orig_is_backport=$(echo "$ORIG_TITLE" | grep -Eo '\[v[0-9]{2}\.[0-9]{1,2}\.x\]' || true)
+          if [[ "$orig_is_backport" != "" ]]; then
+            msg="Seems that the issue is already a backport."
+            echo "$msg"
+            gh issue comment "$ORIG_ISSUE_URL" \
+              --body "$msg" \
+              --repo "$TARGET_ORG/$TARGET_REPO"
+            exit 1
+          fi
+          backport_issue_url=$(gh issue list --repo "${TARGET_ORG}/${TARGET_REPO}" \
+              --state open \
+              --search "[${BACKPORT_BRANCH}] ${ORIG_TITLE} in:title" \
+              --json url \
+              --milestone "${TARGET_MILESTONE}" \
+              --jq '.[0].url')
+          if [[ "$backport_issue_url" == "" ]]; then
+            gh issue create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
+              --label "kind/backport" \
+              --repo "${TARGET_ORG}/${TARGET_REPO}" \
+              --assignee "${ORIG_ASSIGNEES}" \
+              --milestone "${TARGET_MILESTONE}" \
+              --body "Backport ${ORIG_ISSUE_URL} to branch ${BACKPORT_BRANCH}"
+          else
+            gh issue comment "$ORIG_ISSUE_URL" --body "Backport issue already exists: $backport_issue_url"
+          fi
+
+      - name: Get reviewers of PR
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        env:
+          REVIEWERS: ${{ toJson(github.event.client_payload.pull_request.requested_reviewers) }}
+        id: reviewers
+        run: echo ::set-output name=reviewers::$(echo "$REVIEWERS" | jq -r '.[].login' | paste -s -d ',' -)
+
+      - name: Get commits of PR
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        env:
+          BACKPORT_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        id: backport_commits
+        run: |
+          backport_commits=$(gh api "repos/$TARGET_ORG/$TARGET_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
+          echo ::set-output name=backport_commits::$backport_commits
+
+      - uses: actions/checkout@v3
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        with:
+          repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+
+      - name: Backport commits and get details
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
+          BACKPORT_COMMITS: ${{ steps.backport_commits.outputs.backport_commits }}
+          IS_MERGED: ${{ github.event.client_payload.pull_request.merged }}
+          PR_BASE_BRANCH: ${{ github.event.client_payload.pull_request.base.ref }}
+          REPO_DEFAULT_BRANCH: ${{ github.event.client_payload.pull_request.base.repo.default_branch }}
+        id: pr_details
+        run: |
+          if [[ "$IS_MERGED" != true ]]; then
+            msg="The pull request is not merged yet. Cancelling backport..."
+            echo "$msg"
+            gh pr comment "$PR_NUMBER" \
+              --body "$msg" \
+              --repo "$TARGET_ORG/$TARGET_REPO"
+            exit 1
+          elif [[ "$PR_BASE_BRANCH" != "$REPO_DEFAULT_BRANCH" ]]; then
+            msg="The pull request's base branch is not the default one. Cancelling backport..."
+            echo "$msg"
+            gh pr comment "$PR_NUMBER" \
+              --body "$msg" \
+              --repo "$TARGET_ORG/$TARGET_REPO"
+            exit 1
+          fi
+          fixing_issue_urls=$(gh api graphql -f query='{
+              resource(url: "https://github.com/'${TARGET_ORG}'/'${TARGET_REPO}'/pull/'${PR_NUMBER}'") {
+                ... on PullRequest {
+                  closingIssuesReferences(first: 20) {
+                    nodes {
+                      url
+                    }
+                  }
+                }
+              }
+            }' --jq .data.resource.closingIssuesReferences.nodes.[].url)
+          # ensure unique branch
+          suffix=$(echo $(($RANDOM % 1000)))
+          git config --global user.email "${{ steps.user.outputs.email }}"
+          git config --global user.name "${{ steps.user.outputs.username }}"
+          git remote add upstream "https://github.com/$TARGET_ORG/$TARGET_REPO.git"
+          git fetch --all
+          git remote set-url origin "https://${{ steps.user.outputs.username }}:$GITHUB_TOKEN@github.com/${{ steps.user.outputs.username }}/$TARGET_REPO.git"
+          backport_issues_numbers=""
+          for issue_url in $fixing_issue_urls; do
+            backport_issues_numbers+=$(echo $issue_url | awk -F/ '{print $NF"-"}')
+          done
+          if [[ "$backport_issues_numbers" == "" ]]; then
+            backport_issues_numbers="fixes-to-"
+          fi
+          head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
+          git checkout -b $head_branch remotes/upstream/$BACKPORT_BRANCH
+          set +e
+          git cherry-pick -x $BACKPORT_COMMITS
+          if [[ "$?" != "0" ]]; then
+            msg="""Failed to run cherry-pick command. see [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            I executed the below command:
+            \`\`\`
+            git cherry-pick -x $BACKPORT_COMMITS
+            \`\`\`
+            """
+            gh pr comment "$PR_NUMBER" \
+              --body "$msg" \
+              --repo "$TARGET_ORG/$TARGET_REPO"
+            exit 1
+          fi
+          set -e
+          git push --set-upstream origin $head_branch
+          git remote rm upstream
+          echo ::set-output name=head_branch::$head_branch
+          echo ::set-output name=fixing_issue_urls::$fixing_issue_urls
+
+      - name: Create pull request
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          TARGET_MILESTONE: ${{ steps.milestone.outputs.milestone }}
+          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
+          ORIG_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
+          ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.issue.html_url }}
+          HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
+          FIXING_ISSUE_URLs: ${{ steps.pr_details.outputs.fixing_issue_urls }}
+          ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
+        run: |
+          backport_issue_urls=""
+          if [[ "$FIXING_ISSUE_URLs" != "" ]]; then
+            for FIXING_ISSUE_URL in $FIXING_ISSUE_URLs; do
+              orig_issue_number=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $NF}')
+              orig_org=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $4}')
+              orig_repo=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $5}')
+
+              if [[ "$orig_repo" != "${TARGET_REPO}" || "$orig_org" != "${TARGET_ORG}" ]]; then
+                break
+              fi
+
+              orig_issue_title=$(gh issue view "$orig_issue_number" \
+                --repo "${orig_org}/${orig_repo}" \
+                --json title --jq .title)
+
+              backport_issue_url=$(gh issue list --repo "${orig_org}/${orig_repo}" \
+                --state open \
+                --search "[${BACKPORT_BRANCH}] ${orig_issue_title} in:title" \
+                --json url \
+                --milestone "${TARGET_MILESTONE}" \
+                --jq '.[0].url')
+
+              if [[ "$backport_issue_url" == "" ]]; then
+                # backport issue does not exist and will be created
+                # get orig issue assignees
+                orig_issue_assingees=$(gh issue view "$orig_issue_number" \
+                  --repo "${orig_org}/${orig_repo}" \
+                  --json assignees --jq .assignees.[].login | paste -s -d ',' -)
+                # create issue
+                backport_issue_url=$(gh issue create --title "[${BACKPORT_BRANCH}] ${orig_issue_title}" \
+                  --label "kind/backport" \
+                  --repo "${orig_org}/${orig_repo}" \
+                  --assignee "${orig_issue_assingees}" \
+                  --milestone "${TARGET_MILESTONE}" \
+                  --body "Backport ${FIXING_ISSUE_URL} to branch ${BACKPORT_BRANCH}. Requested by PR $ORIG_PR_URL")
+              fi
+              backport_issue_urls+=$(echo "Fixes $backport_issue_url, ")
+            done
+            backport_issue_urls=$(echo $backport_issue_urls | sed 's/.$//')
+          fi
+
+          gh pr create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
+            --base "${BACKPORT_BRANCH}" \
+            --label "kind/backport" \
+            --head "${{ steps.user.outputs.username }}:${HEAD_BRANCH}" \
+            --draft \
             --repo "${TARGET_ORG}/${TARGET_REPO}" \
-            --assignee "${ORIG_ASSIGNEES}" \
+            --reviewer "${ORIG_REVIEWERS}" \
             --milestone "${TARGET_MILESTONE}" \
-            --body "Backport ${ORIG_ISSUE_URL} to branch ${BACKPORT_BRANCH}"
+            --body """Backport from pull request: ${ORIG_ISSUE_URL}
+            $backport_issue_urls
+            """
 
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           permission: read
-          issue-type: issue
+          issue-type: both
           commands: |
             backport
           static-args: |


### PR DESCRIPTION
## Cover letter

Followup https://github.com/redpanda-data/redpanda/pull/4075

Added additional jobs backport-type to get the backport that the user wants to create. The type-branch job creates the issue or the PR based on the source of the comment (issue or PR).

Examples:
* comment on issues:
`/backport v21.11.x`: Creates backport issue and adds milestone/assignees (introduced in https://github.com/redpanda-data/redpanda/pull/4075). It prevent creating duplicates!

* comment on PR:
`/backport v21.11.x`: 
  1. Queries PR description and gets the fixing issue (if exists)
  2. Queries all issues to find if there is a backport issue based on the linked issue of the orig PR
  3. Creates the backport issue if it doesn't exist
  4. cherry-pick and creates the draft PR from the forked repo
  5. adds milestone, reviewers

Fixes https://github.com/redpanda-data/devprod/issues/221