### PR TITLE
Run each archiver in its own fiber

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -66,7 +66,10 @@ ntp_archiver::ntp_archiver(
       _ntp);
     _start_term = _partition->term();
     vlog(
-      archival_log.debug, "created ntp_archiver {} in term", _ntp, _start_term);
+      archival_log.debug,
+      "created ntp_archiver {} in term {}",
+      _ntp,
+      _start_term);
 }
 
 ss::future<> ntp_archiver::stop() {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -466,10 +466,9 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
         }
 
         if (_partition->archival_meta_stm()) {
-            retry_chain_node rc_node(
-              _manifest_upload_timeout, _initial_backoff, &_rtcnode);
+            auto deadline = ss::lowres_clock::now() + _manifest_upload_timeout;
             auto error = co_await _partition->archival_meta_stm()->add_segments(
-              _manifest, rc_node);
+              _manifest, deadline, _as);
             if (
               error != cluster::errc::success
               && error != cluster::errc::not_leader) {

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -162,6 +162,8 @@ private:
     /// Launch the upload loop fiber.
     ss::future<> upload_loop();
 
+    bool upload_loop_can_continue() const;
+
     ntp_level_probe _probe;
     model::ntp _ntp;
     model::initial_revision_id _rev;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -64,15 +64,22 @@ public:
     /// \param svc_probe is a service level probe (optional)
     ntp_archiver(
       const storage::ntp_config& ntp,
+      storage::log_manager&,
       const configuration& conf,
       cloud_storage::remote& remote,
       ss::lw_shared_ptr<cluster::partition> part);
+
+    /// Start the fiber that will upload the partition data to the cloud
+    /// storage. Can be started only once.
+    void run_upload_loop();
 
     /// Stop archiver.
     ///
     /// \return future that will become ready when all async operation will be
     /// completed
     ss::future<> stop();
+
+    bool upload_loop_stopped() const { return _upload_loop_stopped; }
 
     /// Get NTP
     const model::ntp& get_ntp() const;
@@ -86,12 +93,7 @@ public:
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
-    ss::future<cloud_storage::download_result>
-    download_manifest(retry_chain_node& parent);
-
-    /// Upload manifest to the pre-defined S3 location
-    ss::future<cloud_storage::upload_result>
-    upload_manifest(retry_chain_node& parent);
+    ss::future<cloud_storage::download_result> download_manifest();
 
     const cloud_storage::partition_manifest& get_remote_manifest() const;
 
@@ -105,13 +107,9 @@ public:
     /// will pick not more than '_concurrency' candidates and start
     /// uploading them.
     ///
-    /// \param lm is a log manager instance
-    /// \param parent is a retry chain node of the caller
     /// \param lso_override last stable offset override
     /// \return future that returns number of uploaded/failed segments
     ss::future<batch_result> upload_next_candidates(
-      storage::log_manager& lm,
-      retry_chain_node& parent,
       std::optional<model::offset> last_stable_offset_override = std::nullopt);
 
     uint64_t estimate_backlog_size(cluster::partition_manager& pm);
@@ -140,33 +138,34 @@ private:
 
     /// Start upload without waiting for it to complete
     ss::future<scheduled_upload> schedule_single_upload(
-      storage::log_manager& lm,
-      model::offset last_uploaded_offset,
-      model::offset last_stable_offset,
-      retry_chain_node& parent);
+      model::offset last_uploaded_offset, model::offset last_stable_offset);
 
     /// Start all uploads
-    ss::future<std::vector<scheduled_upload>> schedule_uploads(
-      storage::log_manager& lm,
-      model::offset last_stable_offset,
-      retry_chain_node& parent);
+    ss::future<std::vector<scheduled_upload>>
+    schedule_uploads(model::offset last_stable_offset);
 
     /// Wait until all scheduled uploads will be completed
     ///
     /// Update the probe and manifest
     ss::future<ntp_archiver::batch_result> wait_all_scheduled_uploads(
-      std::vector<ntp_archiver::scheduled_upload> scheduled,
-      retry_chain_node& parent);
+      std::vector<ntp_archiver::scheduled_upload> scheduled);
 
     /// Upload individual segment to S3.
     ///
     /// \return true on success and false otherwise
     ss::future<cloud_storage::upload_result>
-    upload_segment(upload_candidate candidate, retry_chain_node& fib);
+    upload_segment(upload_candidate candidate);
+
+    /// Upload manifest to the pre-defined S3 location
+    ss::future<cloud_storage::upload_result> upload_manifest();
+
+    /// Launch the upload loop fiber.
+    ss::future<> upload_loop();
 
     ntp_level_probe _probe;
     model::ntp _ntp;
     model::initial_revision_id _rev;
+    storage::log_manager& _log_manager;
     cloud_storage::remote& _remote;
     ss::lw_shared_ptr<cluster::partition> _partition;
     model::term_id _start_term;
@@ -177,14 +176,19 @@ private:
     cloud_storage::partition_manifest _manifest;
     ss::gate _gate;
     ss::abort_source _as;
+    retry_chain_node _rtcnode;
+    retry_chain_logger _rtclog;
+    ss::lowres_clock::duration _initial_backoff;
+    ss::lowres_clock::duration _segment_upload_timeout;
+    ss::lowres_clock::duration _manifest_upload_timeout;
     ss::semaphore _mutex{1};
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};
     size_t _concurrency{4};
     ss::lowres_clock::time_point _last_upload_time;
-    ss::lowres_clock::duration _initial_backoff;
-    ss::lowres_clock::duration _segment_upload_timeout;
-    ss::lowres_clock::duration _manifest_upload_timeout;
+    ss::scheduling_group _upload_sg;
     ss::io_priority_class _io_priority;
+    bool _upload_loop_started = false;
+    bool _upload_loop_stopped = false;
 };
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -64,7 +64,7 @@ public:
     /// \param svc_probe is a service level probe (optional)
     ntp_archiver(
       const storage::ntp_config& ntp,
-      storage::log_manager&,
+      cluster::partition_manager&,
       const configuration& conf,
       cloud_storage::remote& remote,
       ss::lw_shared_ptr<cluster::partition> part);
@@ -112,7 +112,7 @@ public:
     ss::future<batch_result> upload_next_candidates(
       std::optional<model::offset> last_stable_offset_override = std::nullopt);
 
-    uint64_t estimate_backlog_size(cluster::partition_manager& pm);
+    uint64_t estimate_backlog_size();
 
 private:
     /// Information about started upload
@@ -165,7 +165,7 @@ private:
     ntp_level_probe _probe;
     model::ntp _ntp;
     model::initial_revision_id _rev;
-    storage::log_manager& _log_manager;
+    cluster::partition_manager& _partition_manager;
     cloud_storage::remote& _remote;
     ss::lw_shared_ptr<cluster::partition> _partition;
     model::term_id _start_term;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -180,11 +180,13 @@ private:
     ss::abort_source _as;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
-    ss::lowres_clock::duration _initial_backoff;
+    ss::lowres_clock::duration _cloud_storage_initial_backoff;
     ss::lowres_clock::duration _segment_upload_timeout;
     ss::lowres_clock::duration _manifest_upload_timeout;
     ss::semaphore _mutex{1};
-    simple_time_jitter<ss::lowres_clock> _backoff{100ms};
+    ss::lowres_clock::duration _upload_loop_initial_backoff;
+    ss::lowres_clock::duration _upload_loop_max_backoff;
+    simple_time_jitter<ss::lowres_clock> _backoff_jitter{100ms};
     size_t _concurrency{4};
     ss::lowres_clock::time_point _last_upload_time;
     ss::scheduling_group _upload_sg;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -99,7 +99,7 @@ scheduler_service_impl::get_archival_service_config(
         "cloud_storage_bucket")),
       .reconciliation_interval
       = config::shard_local_cfg().cloud_storage_reconciliation_ms.value(),
-      .initial_backoff
+      .cloud_storage_initial_backoff
       = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
       .segment_upload_timeout
       = config::shard_local_cfg()
@@ -107,6 +107,12 @@ scheduler_service_impl::get_archival_service_config(
       .manifest_upload_timeout
       = config::shard_local_cfg()
           .cloud_storage_manifest_upload_timeout_ms.value(),
+      .upload_loop_initial_backoff
+      = config::shard_local_cfg()
+          .cloud_storage_upload_loop_initial_backoff_ms.value(),
+      .upload_loop_max_backoff
+      = config::shard_local_cfg()
+          .cloud_storage_upload_loop_max_backoff_ms.value(),
       .svc_metrics_disabled = service_metrics_disabled(
         static_cast<bool>(disable_metrics)),
       .ntp_metrics_disabled = per_ntp_metrics_disabled(
@@ -131,7 +137,7 @@ scheduler_service_impl::scheduler_service_impl(
   , _probe(conf.svc_metrics_disabled)
   , _remote(remote)
   , _topic_manifest_upload_timeout(conf.manifest_upload_timeout)
-  , _initial_backoff(conf.initial_backoff)
+  , _initial_backoff(conf.cloud_storage_initial_backoff)
   , _upload_sg(conf.upload_scheduling_group) {}
 
 scheduler_service_impl::scheduler_service_impl(

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -97,7 +97,7 @@ scheduler_service_impl::get_archival_service_config(
       .bucket_name = s3::bucket_name(get_value_or_throw(
         config::shard_local_cfg().cloud_storage_bucket,
         "cloud_storage_bucket")),
-      .interval
+      .reconciliation_interval
       = config::shard_local_cfg().cloud_storage_reconciliation_ms.value(),
       .initial_backoff
       = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
@@ -126,7 +126,7 @@ scheduler_service_impl::scheduler_service_impl(
   : _conf(conf)
   , _partition_manager(pm)
   , _topic_table(tt)
-  , _jitter(conf.interval, 1ms)
+  , _jitter(conf.reconciliation_interval, 1ms)
   , _rtclog(archival_log, _rtcnode)
   , _probe(conf.svc_metrics_disabled)
   , _remote(remote)

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -119,8 +119,7 @@ private:
     ss::future<> upload_topic_manifest(
       model::topic_namespace topic_ns, model::initial_revision_id rev);
     /// Adds archiver to the reconciliation loop after fetching its manifest.
-    ss::future<ss::stop_iteration>
-    add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);
+    ss::future<> add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);
 
     configuration _conf;
     ss::sharded<cluster::partition_manager>& _partition_manager;

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -90,9 +90,6 @@ public:
 
     void rearm_timer();
 
-    /// Run next round of uploads
-    ss::future<> run_uploads();
-
     /// \brief Sync ntp-archivers with the content of the partition_manager
     ///
     /// This method can invoke asynchronous operations that can potentially
@@ -132,10 +129,8 @@ private:
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _timer;
     ss::gate _gate;
-    ss::abort_source _as;
     ss::semaphore _stop_limit;
     absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_archiver>> _archivers;
-    simple_time_jitter<ss::lowres_clock> _backoff{100ms};
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
     service_probe _probe;

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -13,8 +13,6 @@
 #include "cluster/partition_manager.h"
 #include "model/fundamental.h"
 #include "s3/client.h"
-#include "storage/api.h"
-#include "storage/log_manager.h"
 #include "storage/ntp_config.h"
 #include "storage/segment.h"
 #include "storage/segment_set.h"
@@ -56,12 +54,10 @@ public:
     scheduler_service_impl(
       const configuration& conf,
       ss::sharded<cloud_storage::remote>& remote,
-      ss::sharded<storage::api>& api,
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::topic_table>& tt);
     scheduler_service_impl(
       ss::sharded<cloud_storage::remote>& remote,
-      ss::sharded<storage::api>& api,
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::topic_table>& tt,
       ss::sharded<archival::configuration>& configs);
@@ -124,7 +120,6 @@ private:
     configuration _conf;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::topic_table>& _topic_table;
-    ss::sharded<storage::api>& _storage_api;
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _timer;
     ss::gate _gate;
@@ -146,7 +141,6 @@ public:
     /// \brief create scheduler service
     ///
     /// \param configuration is a archival cnfiguration
-    /// \param api is a storage api service instance
     /// \param pm is a partition_manager service instance
     using internal::scheduler_service_impl::scheduler_service_impl;
 

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -129,7 +129,6 @@ private:
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _timer;
     ss::gate _gate;
-    ss::semaphore _stop_limit;
     absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_archiver>> _archivers;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -127,13 +127,16 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       part->committed_offset(),
       *part);
 
-    archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, part);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      get_local_storage_api().log_mgr(),
+      arch_conf,
+      remote,
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
-    auto res = archiver
-                 .upload_next_candidates(get_local_storage_api().log_mgr(), fib)
-                 .get0();
+    auto res = archiver.upload_next_candidates().get();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
@@ -365,16 +368,19 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     auto [arch_conf, remote_conf] = get_configurations();
     cloud_storage::remote remote(
       remote_conf.connection_limit, remote_conf.client_config);
-    archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, part);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      get_local_storage_api().log_mgr(),
+      arch_conf,
+      remote,
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
 
-    archiver.download_manifest(fib).get();
+    archiver.download_manifest().get();
 
-    auto res = archiver
-                 .upload_next_candidates(get_local_storage_api().log_mgr(), fib)
-                 .get0();
+    auto res = archiver.upload_next_candidates().get();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
@@ -581,17 +587,19 @@ static void test_partial_upload_impl(
     auto [aconf, cconf] = get_configurations();
     cloud_storage::remote remote(cconf.connection_limit, cconf.client_config);
     aconf.time_limit = segment_time_limit(0s);
-    archival::ntp_archiver archiver(get_ntp_conf(), aconf, remote, part);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      test.get_local_storage_api().log_mgr(),
+      aconf,
+      remote,
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
 
-    archiver.download_manifest(fib).get();
+    archiver.download_manifest().get();
 
-    auto res = archiver
-                 .upload_next_candidates(
-                   test.get_local_storage_api().log_mgr(), fib, lso)
-                 .get0();
+    auto res = archiver.upload_next_candidates(lso).get();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
@@ -634,10 +642,7 @@ static void test_partial_upload_impl(
     }
 
     lso = last_upl2 + model::offset(1);
-    res = archiver
-            .upload_next_candidates(
-              test.get_local_storage_api().log_mgr(), fib, lso)
-            .get0();
+    res = archiver.upload_next_candidates(lso).get();
 
     BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -128,11 +128,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       *part);
 
     archival::ntp_archiver archiver(
-      get_ntp_conf(),
-      get_local_storage_api().log_mgr(),
-      arch_conf,
-      remote,
-      part);
+      get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -369,11 +365,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     cloud_storage::remote remote(
       remote_conf.connection_limit, remote_conf.client_config);
     archival::ntp_archiver archiver(
-      get_ntp_conf(),
-      get_local_storage_api().log_mgr(),
-      arch_conf,
-      remote,
-      part);
+      get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -588,11 +580,7 @@ static void test_partial_upload_impl(
     cloud_storage::remote remote(cconf.connection_limit, cconf.client_config);
     aconf.time_limit = segment_time_limit(0s);
     archival::ntp_archiver archiver(
-      get_ntp_conf(),
-      test.get_local_storage_api().log_mgr(),
-      aconf,
-      remote,
-      part);
+      get_ntp_conf(), test.app.partition_manager.local(), aconf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -104,9 +104,11 @@ get_configurations() {
     aconf.bucket_name = s3::bucket_name("test-bucket");
     aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
     aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
-    aconf.initial_backoff = 100ms;
+    aconf.cloud_storage_initial_backoff = 100ms;
     aconf.segment_upload_timeout = 1s;
     aconf.manifest_upload_timeout = 1s;
+    aconf.upload_loop_initial_backoff = 100ms;
+    aconf.upload_loop_max_backoff = 5s;
     aconf.time_limit = std::nullopt;
 
     cloud_storage::configuration cconf;

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -187,8 +187,6 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(ntp));
 
-    (void)service.run_uploads();
-
     // 2 partition manifests, 1 topic manifest, 2 segments
     const size_t num_requests_expected = 5;
     tests::cooperative_spin_wait_with_timeout(10s, [this] {

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -75,14 +75,13 @@ FIXTURE_TEST(test_reconciliation_manifest_download, archiver_fixture) {
 
     auto [arch_config, remote_config] = get_configurations();
     auto& pm = app.partition_manager;
-    auto& api = app.storage;
     auto& topics = app.controller->get_topics_state();
     ss::sharded<cloud_storage::remote> remote;
     remote
       .start_single(remote_config.connection_limit, remote_config.client_config)
       .get();
     archival::internal::scheduler_service_impl service(
-      arch_config, remote, api, pm, topics);
+      arch_config, remote, pm, topics);
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(pid0));
     BOOST_REQUIRE(service.contains(pid1));
@@ -110,14 +109,13 @@ FIXTURE_TEST(test_reconciliation_drop_ntp, archiver_fixture) {
 
     auto [arch_config, remote_config] = get_configurations();
     auto& pm = app.partition_manager;
-    auto& api = app.storage;
     auto& topics = app.controller->get_topics_state();
     ss::sharded<cloud_storage::remote> remote;
     remote
       .start_single(remote_config.connection_limit, remote_config.client_config)
       .get();
     archival::internal::scheduler_service_impl service(
-      arch_config, remote, api, pm, topics);
+      arch_config, remote, pm, topics);
 
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(ntp));
@@ -175,14 +173,13 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
 
     auto [arch_config, remote_config] = get_configurations();
     auto& pm = app.partition_manager;
-    auto& api = app.storage;
     auto& topics = app.controller->get_topics_state();
     ss::sharded<cloud_storage::remote> remote;
     remote
       .start_single(remote_config.connection_limit, remote_config.client_config)
       .get();
     archival::internal::scheduler_service_impl service(
-      arch_config, remote, api, pm, topics);
+      arch_config, remote, pm, topics);
 
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(ntp));

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -33,7 +33,7 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
       "manifest_upload_timeout: {}, time_limit: {}}}",
       cfg.bucket_name,
       std::chrono::milliseconds(cfg.reconciliation_interval),
-      std::chrono::milliseconds(cfg.initial_backoff),
+      std::chrono::milliseconds(cfg.cloud_storage_initial_backoff),
       std::chrono::milliseconds(cfg.segment_upload_timeout),
       std::chrono::milliseconds(cfg.manifest_upload_timeout),
       cfg.time_limit);

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -32,7 +32,7 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
       "segment_upload_timeout: {}, "
       "manifest_upload_timeout: {}, time_limit: {}}}",
       cfg.bucket_name,
-      std::chrono::milliseconds(cfg.interval),
+      std::chrono::milliseconds(cfg.reconciliation_interval),
       std::chrono::milliseconds(cfg.initial_backoff),
       std::chrono::milliseconds(cfg.segment_upload_timeout),
       std::chrono::milliseconds(cfg.manifest_upload_timeout),

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -44,12 +44,16 @@ struct configuration {
     s3::bucket_name bucket_name;
     /// Time interval to reconcile the set of archivers
     ss::lowres_clock::duration reconciliation_interval;
-    /// Initial backoff for uploads
-    ss::lowres_clock::duration initial_backoff;
+    /// Initial backoff for requests to cloud storage
+    ss::lowres_clock::duration cloud_storage_initial_backoff;
     /// Long upload timeout
     ss::lowres_clock::duration segment_upload_timeout;
     /// Shor upload timeout
     ss::lowres_clock::duration manifest_upload_timeout;
+    /// Initial backoff for upload loop in case there is nothing to upload
+    ss::lowres_clock::duration upload_loop_initial_backoff;
+    /// Max backoff for upload loop in case there is nothing to upload
+    ss::lowres_clock::duration upload_loop_max_backoff;
     /// Flag that indicates that service level metrics are disabled
     service_metrics_disabled svc_metrics_disabled;
     /// Flag that indicates that ntp-archiver level metrics are disabled

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -42,8 +42,8 @@ using segment_time_limit
 struct configuration {
     /// Bucket used to store all archived data
     s3::bucket_name bucket_name;
-    /// Time interval to run uploads & deletes
-    ss::lowres_clock::duration interval;
+    /// Time interval to reconcile the set of archivers
+    ss::lowres_clock::duration reconciliation_interval;
     /// Initial backoff for uploads
     ss::lowres_clock::duration initial_backoff;
     /// Long upload timeout

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -141,10 +141,8 @@ ss::future<consensus_ptr> partition_manager::manage(
         // data.
         auto timeout = config::shard_local_cfg()
                          .cloud_storage_segment_upload_timeout_ms.value();
-        auto backoff
-          = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
-        retry_chain_node rtc(timeout, backoff);
-        co_await p->archival_meta_stm()->add_segments(manifest, rtc);
+        auto deadline = ss::lowres_clock::now() + timeout;
+        co_await p->archival_meta_stm()->add_segments(manifest, deadline);
     }
 
     co_return c;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -880,6 +880,20 @@ configuration::configuration()
       "Interval at which the archival service runs reconciliation (ms)",
       {.visibility = visibility::tunable},
       1s)
+  , cloud_storage_upload_loop_initial_backoff_ms(
+      *this,
+      "cloud_storage_upload_loop_initial_backoff_ms",
+      "Initial backoff interval when there is nothing to upload for a "
+      "partition (ms)",
+      {.visibility = visibility::tunable},
+      100ms)
+  , cloud_storage_upload_loop_max_backoff_ms(
+      *this,
+      "cloud_storage_upload_loop_max_backoff_ms",
+      "Max backoff interval when there is nothing to upload for a "
+      "partition (ms)",
+      {.visibility = visibility::tunable},
+      10s)
   , cloud_storage_max_connections(
       *this,
       "cloud_storage_max_connections",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -879,7 +879,7 @@ configuration::configuration()
       "cloud_storage_reconciliation_interval_ms",
       "Interval at which the archival service runs reconciliation (ms)",
       {.visibility = visibility::tunable},
-      10s)
+      1s)
   , cloud_storage_max_connections(
       *this,
       "cloud_storage_max_connections",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -191,6 +191,10 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_bucket;
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
     property<std::chrono::milliseconds> cloud_storage_reconciliation_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_upload_loop_initial_backoff_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_upload_loop_max_backoff_ms;
     property<int16_t> cloud_storage_max_connections;
     property<bool> cloud_storage_disable_tls;
     property<int16_t> cloud_storage_api_endpoint_port;

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -174,6 +174,10 @@ struct ntp {
 
     bool operator!=(const ntp& other) const { return !(*this == other); }
 
+    bool operator<(const ntp& other) const {
+        return ns < other.ns || (ns == other.ns && tp < other.tp);
+    }
+
     ss::sstring path() const;
     std::filesystem::path topic_path() const;
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -788,7 +788,6 @@ void application::wire_up_redpanda_services() {
         construct_service(
           archival_scheduler,
           std::ref(cloud_storage_api),
-          std::ref(storage),
           std::ref(partition_manager),
           std::ref(controller->get_topics_state()),
           std::ref(arch_configs))

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ rp_test(
   SOURCES
     async_transforms.cc
     sformat.cc
+    future_util.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx

--- a/src/v/ssx/tests/future_util.cc
+++ b/src/v/ssx/tests/future_util.cc
@@ -1,0 +1,115 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/future-util.h"
+
+#include <seastar/core/manual_clock.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using namespace std::chrono_literals;
+
+SEASTAR_THREAD_TEST_CASE(with_timeout_abortable_test) {
+    // future ready -> timeout
+    {
+        auto f = seastar::make_ready_future<int>(123);
+        seastar::abort_source as;
+
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 100ms, as);
+
+        BOOST_CHECK_EQUAL(res.get(), 123);
+    }
+
+    // future ready -> timeout -> abort
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+
+        seastar::abort_source as;
+        auto abort_f = seastar::sleep<seastar::manual_clock>(150ms).then(
+          [&as] { as.request_abort(); });
+
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 100ms, as);
+
+        seastar::manual_clock::advance(50ms);
+        BOOST_CHECK_EQUAL(res.get(), 123);
+        seastar::manual_clock::advance(100ms);
+        abort_f.get();
+    }
+
+    // timeout -> future ready -> abort
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(150ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+
+        seastar::abort_source as;
+        auto abort_f = seastar::sleep<seastar::manual_clock>(200ms).then(
+          [&as] { as.request_abort(); });
+
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 100ms, as);
+
+        seastar::manual_clock::advance(100ms);
+        BOOST_CHECK_THROW(res.get(), seastar::timed_out_error);
+        seastar::manual_clock::advance(100ms);
+        abort_f.get();
+    }
+
+    // abort -> timeout -> future ready
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(150ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+
+        seastar::abort_source as;
+        auto abort_f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [&as] { as.request_abort(); });
+
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 100ms, as);
+
+        seastar::manual_clock::advance(50ms);
+        abort_f.get();
+        BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+        seastar::manual_clock::advance(100ms);
+    }
+
+    // abort -> future ready -> timeout
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(100ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+
+        seastar::abort_source as;
+        auto abort_f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [&as] { as.request_abort(); });
+
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 150ms, as);
+
+        seastar::manual_clock::advance(50ms);
+        abort_f.get();
+
+        BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+        seastar::manual_clock::advance(50ms);
+    }
+
+    // abort -> future created -> timeout
+    {
+        seastar::abort_source as;
+        as.request_abort();
+
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::now() + 100ms, as);
+
+        seastar::manual_clock::advance(100ms);
+        BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+    }
+}


### PR DESCRIPTION
## Cover letter

A lot of archival bugs reduced to several archivers running concurrently and not noticing that leadership changed. This PR restructures code so that each `ntp_archiver` process runs in its own fiber, instead of being externally driven by the `archival::service` object. This allows for early exits when the archiver notices that this shard is no longer the leader for a particular ntp.

Also a few things that are no longer relevant were removed.

Fixes #4007 

Fixes #4257

## Release notes
* none
