### PR TITLE
cluster: feature table tests & log cleanup

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -371,7 +371,7 @@ feature_manager::write_action(cluster::feature_update_action action) {
       "Invalid feature name '{}'",
       action.feature_name);
 
-    // Validate that teh feature is in a state compatible with the
+    // Validate that the feature is in a state compatible with the
     // requested transition.
     bool valid = true;
     auto state = _feature_table.local().get_state(feature_id_opt.value());
@@ -407,8 +407,10 @@ feature_manager::write_action(cluster::feature_update_action action) {
     if (!valid) {
         vlog(
           clusterlog.warn,
-          "Dropping feature action {}, feature not in expected state",
-          action);
+          "Dropping feature action {}, feature not in expected state "
+          "(state={})",
+          action,
+          state.get_state());
         return ss::make_ready_future<std::error_code>(cluster::errc::success);
     } else {
         // Construct and dispatch command to log

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -334,8 +334,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
                   max_version);
                 data.actions.push_back(cluster::feature_update_action{
                   .feature_name = ss::sstring(fs.spec.name),
-                  .action
-                  = feature_update_action::action_t ::administrative_activate});
+                  .action = feature_update_action::action_t::activate});
             }
         }
     }
@@ -386,7 +385,7 @@ feature_manager::write_action(cluster::feature_update_action action) {
         }
 
         break;
-    case cluster::feature_update_action::action_t::administrative_activate:
+    case cluster::feature_update_action::action_t::activate:
         if (
           state.get_state() != feature_state::state::available
           && state.get_state() != feature_state::state::disabled_clean
@@ -395,7 +394,7 @@ feature_manager::write_action(cluster::feature_update_action action) {
             valid = false;
         }
         break;
-    case cluster::feature_update_action::action_t::administrative_deactivate:
+    case cluster::feature_update_action::action_t::deactivate:
         if (
           state.get_state() == feature_state::state::disabled_clean
           || state.get_state() == feature_state::state::disabled_preparing

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -158,8 +158,7 @@ void feature_table::apply_action(const feature_update_action& fua) {
               fua,
               fstate.get_state());
         }
-    } else if (
-      fua.action == feature_update_action::action_t::administrative_activate) {
+    } else if (fua.action == feature_update_action::action_t::activate) {
         auto current_state = fstate.get_state();
         if (current_state == feature_state::state::disabled_clean) {
             if (_active_version >= fstate.spec.require_version) {
@@ -185,9 +184,7 @@ void feature_table::apply_action(const feature_update_action& fua) {
               fua,
               current_state);
         }
-    } else if (
-      fua.action
-      == feature_update_action::action_t::administrative_deactivate) {
+    } else if (fua.action == feature_update_action::action_t::deactivate) {
         auto current_state = fstate.get_state();
         if (
           current_state == feature_state::state::disabled_preparing

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -25,7 +25,7 @@ std::string_view to_string_view(feature f) {
     case feature::maintenance_mode:
         return "maintenance_mode";
     case feature::test_alpha:
-        return "test_alpha";
+        return "__test_alpha";
     }
     __builtin_unreachable();
 }

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -296,6 +296,9 @@ private:
     // feature_backend is a friend for routine updates when
     // applying raft0 log events.
     friend class feature_backend;
+
+    // Unit testing hook.
+    friend class feature_table_fixture;
 };
 
 } // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(srcs
     configuration_change_test.cc
     idempotency_tests.cc
     feature_barrier_test.cc
+    feature_table_test.cc
     tm_stm_tests.cc
     rm_stm_tests.cc
     controller_api_tests.cc

--- a/src/v/cluster/tests/feature_table_test.cc
+++ b/src/v/cluster/tests/feature_table_test.cc
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/feature_table.h"
+#include "test_utils/fixture.h"
+#include "vlog.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using namespace std::chrono_literals;
+using namespace cluster;
+using action_t = feature_update_action::action_t;
+
+class setenv_helper {
+public:
+    setenv_helper() { setenv("__REDPANDA_TEST_FEATURES", "TRUE", 1); }
+    ~setenv_helper() { unsetenv("__REDPANDA_TEST_FEATURES"); }
+};
+
+namespace cluster {
+class feature_table_fixture {
+public:
+    feature_table_fixture() {}
+
+    ~feature_table_fixture() { as.request_abort(); }
+
+    setenv_helper setenv_hack;
+    feature_table ft;
+    ss::abort_source as;
+    void set_active_version(cluster_version v) { ft.set_active_version(v); }
+    void apply_action(const feature_update_action& fua) {
+        ft.apply_action(fua);
+    }
+
+    /**
+     * Combine constructing action and applying it to table, for
+     * convenience.
+     */
+    void execute_action(
+      std::string_view feature_name, feature_update_action::action_t a) {
+        apply_action(feature_update_action{
+          .feature_name = ss::sstring(feature_name), .action = a});
+    }
+};
+} // namespace cluster
+
+static constexpr std::string_view mock_feature{"__test_alpha"};
+
+/**
+ * Check that the test feature is not visible in the table if we
+ * do not activate it with an environment variable.
+ */
+SEASTAR_THREAD_TEST_CASE(feature_table_test_hook_off) {
+    feature_table ft;
+    bool found{false};
+    for (const auto& s : ft.get_feature_state()) {
+        if (s.spec.name == mock_feature) {
+            found = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE(!found);
+}
+
+SEASTAR_THREAD_TEST_CASE(feature_table_strings) {
+    BOOST_REQUIRE_EQUAL(to_string_view(feature::test_alpha), mock_feature);
+    BOOST_REQUIRE_EQUAL(
+      to_string_view(feature::consumer_offsets), "consumer_offsets");
+    BOOST_REQUIRE_EQUAL(
+      to_string_view(feature::central_config), "central_config");
+    BOOST_REQUIRE_EQUAL(
+      to_string_view(feature::maintenance_mode), "maintenance_mode");
+}
+
+/**
+ * Check that the test feature shows up when environment variable
+ * is set (via the fixture, in this case)
+ */
+FIXTURE_TEST(feature_table_test_hook_on, feature_table_fixture) {
+    bool found{false};
+    for (const auto& s : ft.get_feature_state()) {
+        if (s.spec.name == mock_feature) {
+            found = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE(found);
+}
+
+/**
+ * Exercise the lifecycle of a synthetic test feature
+ */
+FIXTURE_TEST(feature_table_basic, feature_table_fixture) {
+    set_active_version(cluster_version{2});
+    BOOST_REQUIRE_EQUAL(ft.get_active_version(), cluster_version{2});
+
+    // Check we can get the list of all states and that our
+    // test feature is in it.
+    bool found{false};
+    for (const auto& s : ft.get_feature_state()) {
+        if (s.spec.name == mock_feature) {
+            found = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE(found);
+
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_alpha).get_state()
+      == feature_state::state::unavailable);
+
+    // The dummy test features requires version 2001.  The feature
+    // should go available, but not any further: the feature table
+    // relies on external stimulus to actually activate features.
+    set_active_version(cluster_version{2001});
+
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_alpha).get_state()
+      == feature_state::state::available);
+    BOOST_REQUIRE(!ft.is_active(feature::test_alpha));
+    BOOST_REQUIRE(!ft.is_preparing(feature::test_alpha));
+
+    auto f_active = ft.await_feature(feature::test_alpha, as);
+    auto f_preparing = ft.await_feature_preparing(feature::test_alpha, as);
+    BOOST_REQUIRE(!f_active.available());
+    BOOST_REQUIRE(!f_preparing.available());
+
+    // Disable the feature while it's only 'available'
+    execute_action(mock_feature, action_t::deactivate);
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_alpha).get_state()
+      == feature_state::state::disabled_clean);
+
+    // Construct an action to enable the feature
+    execute_action(mock_feature, action_t::activate);
+    BOOST_REQUIRE(ft.is_active(feature::test_alpha));
+
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(f_active.available());
+    BOOST_REQUIRE(f_preparing.available());
+    f_active.get();
+    f_preparing.get();
+
+    // Waiting on already-active should be immediate
+    auto f_active_immediate = ft.await_feature(feature::test_alpha, as);
+    BOOST_REQUIRE(f_active_immediate.available());
+    f_active_immediate.get();
+
+    // Disable the feature after it has been activated
+    execute_action(mock_feature, action_t::deactivate);
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_alpha).get_state()
+      == feature_state::state::disabled_active);
+
+    // Waiting on active while disabled should block
+    auto f_reactivated = ft.await_feature(feature::test_alpha, as);
+    BOOST_REQUIRE(!f_reactivated.available());
+    execute_action(mock_feature, action_t::activate);
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(f_reactivated.available());
+    f_reactivated.get();
+}
+
+/**
+ * Exercise a feature that goes through a preparing stage
+ */
+FIXTURE_TEST(feature_table_preparing, feature_table_fixture) {
+    set_active_version(cluster_version{1});
+    BOOST_REQUIRE_EQUAL(ft.get_active_version(), cluster_version{1});
+    BOOST_REQUIRE(
+      ft.get_state(feature::consumer_offsets).get_state()
+      == feature_state::state::unavailable);
+
+    auto f_active = ft.await_feature(feature::consumer_offsets, as);
+    auto f_preparing = ft.await_feature_preparing(
+      feature::consumer_offsets, as);
+    BOOST_REQUIRE(!f_preparing.available());
+
+    // consumer_offsets is an auto-activating feature, as soon
+    // as the cluster is upgraded it should go into preparing mode
+    set_active_version(cluster_version{2});
+    BOOST_REQUIRE_EQUAL(ft.get_active_version(), cluster_version{2});
+    BOOST_REQUIRE(
+      ft.get_state(feature::consumer_offsets).get_state()
+      == feature_state::state::available);
+    BOOST_REQUIRE(!ft.is_preparing(feature::consumer_offsets));
+    BOOST_REQUIRE(!ft.is_active(feature::consumer_offsets));
+
+    execute_action("consumer_offsets", action_t::activate);
+    BOOST_REQUIRE(ft.is_preparing(feature::consumer_offsets));
+    BOOST_REQUIRE(!ft.is_active(feature::consumer_offsets));
+
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(f_preparing.available());
+    f_preparing.get();
+
+    // While in preparing mode, it is still valid to deactivate+activate
+    // the feature.
+    execute_action("consumer_offsets", action_t::deactivate);
+    BOOST_REQUIRE(!ft.is_preparing(feature::consumer_offsets));
+    BOOST_REQUIRE(
+      ft.get_state(feature::consumer_offsets).get_state()
+      == feature_state::state::disabled_preparing);
+
+    // Re-activating the feature should revert it to preparing
+    execute_action("consumer_offsets", action_t::activate);
+    BOOST_REQUIRE(ft.is_preparing(feature::consumer_offsets));
+
+    // Finally, completing preparing should make the feature active
+    execute_action("consumer_offsets", action_t::complete_preparing);
+    BOOST_REQUIRE(ft.is_active(feature::consumer_offsets));
+    BOOST_REQUIRE(!ft.is_preparing(feature::consumer_offsets));
+
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(f_active.available());
+    f_active.get();
+}

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -366,11 +366,11 @@ std::ostream& operator<<(std::ostream& o, const feature_update_action& fua) {
     case feature_update_action::action_t::complete_preparing:
         action_name = "complete_preparing";
         break;
-    case feature_update_action::action_t::administrative_activate:
-        action_name = "administrative_activate";
+    case feature_update_action::action_t::activate:
+        action_name = "activate";
         break;
-    case feature_update_action::action_t::administrative_deactivate:
-        action_name = "administrative_deactivate";
+    case feature_update_action::action_t::deactivate:
+        action_name = "deactivate";
         break;
     }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -744,10 +744,11 @@ struct feature_update_action {
     enum class action_t : std::uint16_t {
         // Notify when a feature is done with preparing phase
         complete_preparing = 1,
-        // Notify when a feature is explicitly made available by administrator
-        administrative_activate = 2,
+        // Notify when a feature is made available, either by an administrator
+        // or via auto-activation policy
+        activate = 2,
         // Notify when a feature is explicitly disabled by an administrator
-        administrative_deactivate = 3
+        deactivate = 3
     };
 
     // Features have an internal bitflag representation, but it is not

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -522,7 +522,9 @@ ss::future<> group_metadata_migration::activate_feature(ss::abort_source& as) {
     vlog(mlog.info, "activating consumer offsets feature");
     while (!feature_table().is_active(cluster::feature::consumer_offsets)
            && !as.abort_requested()) {
-        if (_controller.is_raft0_leader()) {
+        if (
+          _controller.is_raft0_leader()
+          && feature_table().is_preparing(cluster::feature::consumer_offsets)) {
             auto err = co_await feature_manager().write_action(
               cluster::feature_update_action{
                 .feature_name = ss::sstring(

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1494,11 +1494,11 @@ void admin_server::register_features_routes() {
           cluster::feature_update_action action{.feature_name = feature_name};
           auto& new_state_str = doc["state"];
           if (new_state_str == "active") {
-              action.action = cluster::feature_update_action::action_t::
-                administrative_activate;
+              action.action
+                = cluster::feature_update_action::action_t::activate;
           } else if (new_state_str == "disabled") {
-              action.action = cluster::feature_update_action::action_t::
-                administrative_deactivate;
+              action.action
+                = cluster::feature_update_action::action_t::deactivate;
           } else {
               throw ss::httpd::bad_request_exception("Invalid state");
           }


### PR DESCRIPTION
## Cover letter

The primary changes here are:
- Adding unit tests for feature_table
- Fixing a harmless log warning that came from offset migration, when trying to mark the feature as active before it had been recognized as available on first startup.

## Release notes

* none
