### PR TITLE
raft: notify peers about startup to avoid vote/pre-vote

### DIFF
--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -105,6 +105,11 @@
             "name": "feature_barrier",
             "input_type": "feature_barrier_request",
             "output_type": "feature_barrier_response"
+        },
+        {
+            "name": "hello",
+            "input_type": "hello_request",
+            "output_type": "hello_reply"
         }
     ]
 }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -73,8 +73,8 @@ members_manager::members_manager(
 
 ss::future<> members_manager::start() {
     vlog(clusterlog.info, "starting cluster::members_manager...");
-    // join raft0
-    for (auto& b : _raft0->config().brokers()) {
+
+    for (auto c = _raft0->config(); auto& b : c.brokers()) {
         if (b.id() == _self.id()) {
             continue;
         }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -74,17 +74,24 @@ members_manager::members_manager(
 ss::future<> members_manager::start() {
     vlog(clusterlog.info, "starting cluster::members_manager...");
 
+    /*
+     * Initialize connections to cluster members. Since raft0 is a cluster-wide
+     * raft group this will create a connection to all known brokers. Once a
+     * connection is established a 'hello' request is sent to the node to allow
+     * it to react to the newly started node. See cluster::service::hello for
+     * more information about how this signal is used. A short timeout is used
+     * for the 'hello' request as this is a best effort optimization.
+     */
     for (auto c = _raft0->config(); auto& b : c.brokers()) {
         if (b.id() == _self.id()) {
             continue;
         }
-        co_await update_broker_client(
-          _self.id(),
-          _connection_cache,
-          b.id(),
-          b.rpc_address(),
-          _rpc_tls_config);
+        ssx::spawn_with_gate(_gate, [this, &b]() -> ss::future<> {
+            return initialize_broker_connection(b);
+        });
     }
+
+    co_return;
 }
 
 /**
@@ -845,6 +852,53 @@ std::ostream&
 operator<<(std::ostream& o, const members_manager::node_update& u) {
     fmt::print(o, "{{node_id: {}, type: {}}}", u.id, u.type);
     return o;
+}
+
+ss::future<>
+members_manager::initialize_broker_connection(const model::broker& broker) {
+    auto broker_id = broker.id();
+    co_await with_client<controller_client_protocol>(
+      _self.id(),
+      _connection_cache,
+      broker_id,
+      broker.rpc_address(),
+      _rpc_tls_config,
+      2s,
+      [self = _self.id()](controller_client_protocol c) {
+          return c.hello(hello_request{.peer = self}, rpc::client_opts(2s))
+            .then(&rpc::get_ctx_data<hello_reply>);
+      })
+      .then([broker_id](result<hello_reply> r) {
+          if (r) {
+              if (r.value().error != errc::success) {
+                  vlog(
+                    clusterlog.info,
+                    "Hello response from {} contained error {}",
+                    broker_id,
+                    r.value().error);
+              }
+              return;
+          }
+
+          /*
+           * In a rolling upgrade scenario the peer may not have the hello
+           * rpc endpoint available. hello is an optimization, so ignore.
+           */
+          if (r.error() == rpc::errc::method_not_found) {
+              vlog(
+                clusterlog.debug,
+                "Ignoring failed hello request to {}: {}",
+                broker_id,
+                r.error());
+              return;
+          }
+
+          vlog(
+            clusterlog.info,
+            "Hello response from {} failed: {}",
+            broker_id,
+            r.error());
+      });
 }
 
 } // namespace cluster

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -22,6 +22,7 @@
 #include "raft/errc.h"
 #include "raft/types.h"
 #include "random/generators.h"
+#include "redpanda/application.h"
 #include "reflection/adl.h"
 #include "storage/api.h"
 
@@ -865,7 +866,11 @@ members_manager::initialize_broker_connection(const model::broker& broker) {
       _rpc_tls_config,
       2s,
       [self = _self.id()](controller_client_protocol c) {
-          return c.hello(hello_request{.peer = self}, rpc::client_opts(2s))
+          hello_request req{
+            .peer = self,
+            .start_time = redpanda_start_time,
+          };
+          return c.hello(std::move(req), rpc::client_opts(2s))
             .then(&rpc::get_ctx_data<hello_reply>);
       })
       .then([broker_id](result<hello_reply> r) {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -94,6 +94,8 @@ private:
     void join_raft0();
     bool is_already_member() const;
 
+    ss::future<> initialize_broker_connection(const model::broker&);
+
     ss::future<result<join_node_reply>> dispatch_join_to_seed_server(
       seed_iterator it, join_node_request const& req);
     ss::future<result<join_node_reply>> dispatch_join_to_remote(

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -335,7 +335,11 @@ ss::future<set_maintenance_mode_reply> service::set_maintenance_mode(
  */
 ss::future<hello_reply>
 service::hello(hello_request&& req, rpc::streaming_context&) {
-    vlog(clusterlog.debug, "Handling hello request from node {}", req.peer);
+    vlog(
+      clusterlog.debug,
+      "Handling hello request from node {} with start time {}",
+      req.peer,
+      req.start_time.count());
     co_await _conn_cache.invoke_on_all(
       [peer = req.peer](rpc::connection_cache& cache) {
           if (cache.contains(peer)) {

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -13,6 +13,7 @@
 #include "cluster/controller_service.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
+#include "rpc/fwd.h"
 #include "rpc/types.h"
 
 #include <seastar/core/sharded.hh>
@@ -34,7 +35,8 @@ public:
       ss::sharded<config_frontend>&,
       ss::sharded<feature_manager>&,
       ss::sharded<feature_table>&,
-      ss::sharded<health_monitor_frontend>&);
+      ss::sharded<health_monitor_frontend>&,
+      ss::sharded<rpc::connection_cache>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -95,6 +97,9 @@ public:
     ss::future<set_maintenance_mode_reply> set_maintenance_mode(
       set_maintenance_mode_request&&, rpc::streaming_context&) final;
 
+    ss::future<hello_reply>
+    hello(hello_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -128,5 +133,6 @@ private:
     ss::sharded<feature_manager>& _feature_manager;
     ss::sharded<feature_table>& _feature_table;
     ss::sharded<health_monitor_frontend>& _hm_frontend;
+    ss::sharded<rpc::connection_cache>& _conn_cache;
 };
 } // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -904,6 +904,14 @@ struct config_update_reply {
     cluster::config_version latest_version{config_version_unset};
 };
 
+struct hello_request final {
+    model::node_id peer;
+};
+
+struct hello_reply {
+    errc error;
+};
+
 struct leader_term {
     leader_term(std::optional<model::node_id> leader, model::term_id term)
       : leader(leader)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -906,6 +906,9 @@ struct config_update_reply {
 
 struct hello_request final {
     model::node_id peer;
+
+    // milliseconds since epoch
+    std::chrono::milliseconds start_time;
 };
 
 struct hello_reply {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1347,6 +1347,13 @@ ss::future<vote_reply> consensus::do_vote(vote_request&& r) {
     // to have been recently restarted (have failed heartbeats
     // and an <= present term), reset their RPC backoff to get
     // a heartbeat sent out sooner.
+    //
+    // TODO: with the 'hello' RPC this optimization should not be
+    // necessary. however, leaving it in (1) should not conflict
+    // with the 'hello' RPC based version and (2) leaving this
+    // optimization in place for a release cycle means we can
+    // simplify a rolling upgrade scenario where nodes are mixed
+    // w.r.t. supporting the 'hello' RPC.
     if (is_leader() and r.term <= _term) {
         // Look up follower stats for the requester
         if (auto it = _fstats.find(r.node_id); it != _fstats.end()) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1187,7 +1187,8 @@ void application::start_redpanda(::stop_signal& app_signal) {
             std::ref(controller->get_config_frontend()),
             std::ref(controller->get_feature_manager()),
             std::ref(controller->get_feature_table()),
-            std::ref(controller->get_health_monitor()));
+            std::ref(controller->get_health_monitor()),
+            std::ref(_connection_cache));
 
           proto->register_service<cluster::metadata_dissemination_handler>(
             _scheduling_groups.cluster_sg(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -44,6 +44,10 @@
 
 namespace po = boost::program_options; // NOLINT
 
+inline const auto redpanda_start_time{
+  std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch())};
+
 class application {
 public:
     int run(int, char**);


### PR DESCRIPTION
## Cover letter

The PR #2071 provides a heuristic fix for leadership instability after
followers restart due to an interaction with leader rpc backoff rules and
follower timeouts (more information here #2048).

The heuristic works most of the time, but still depends on several moons to
align: failed heartbeats, prevote phase starting etc... This patch does away
with the heuristic and adds a new RPC for communicating an explicit startup
event to peers within a raft group via a new 'hello' rpc when a raft group
first starts.  Peers now use this startup message to reset backoff (as it did
with the heuristic) but the reset is more precise because it is tied a specific
event rather than attempting to infer the scenario of interest.

Fixes: https://github.com/redpanda-data/redpanda/issues/4083

## Release notes

### Improvements

* Improved behavior for restarted raft groups that reduces election churn.