### PR TITLE
schema_registry: Support avro references

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -21,6 +21,8 @@
 #include "pandaproxy/schema_registry/errors.h"
 #include "utils/string_switch.h"
 
+#include <seastar/core/coroutine.hh>
+
 #include <avro/Compiler.hh>
 #include <avro/Exception.hh>
 #include <avro/GenericDatum.hh>
@@ -334,16 +336,19 @@ canonical_schema_definition::raw_string avro_schema_definition::raw() const {
     return canonical_schema_definition::raw_string{_impl.toJson(false)};
 }
 
-result<avro_schema_definition>
-make_avro_schema_definition(std::string_view sv) {
+ss::future<avro_schema_definition>
+make_avro_schema_definition(sharded_store&, canonical_schema schema) {
+    std::optional<avro::Exception> ex;
     try {
-        return avro_schema_definition{avro::compileJsonSchemaFromMemory(
-          reinterpret_cast<const uint8_t*>(sv.data()), sv.length())};
+        auto def = std::move(schema).def().raw()();
+        co_return avro_schema_definition{avro::compileJsonSchemaFromMemory(
+          reinterpret_cast<const uint8_t*>(def.data()), def.length())};
     } catch (const avro::Exception& e) {
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format("Invalid schema {}", e.what())};
+        ex = e;
     }
+    co_return ss::coroutine::make_exception(as_exception(error_info{
+      error_code::schema_invalid,
+      fmt::format("Invalid schema {}", ex->what())}));
 }
 
 result<canonical_schema_definition>

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -12,11 +12,13 @@
 #pragma once
 
 #include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "pandaproxy/schema_registry/types.h"
 
 namespace pandaproxy::schema_registry {
 
-result<avro_schema_definition> make_avro_schema_definition(std::string_view sv);
+ss::future<avro_schema_definition>
+make_avro_schema_definition(sharded_store& store, canonical_schema schema);
 
 result<canonical_schema_definition>
 sanitize_avro_schema_definition(unparsed_schema_definition def);

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -84,7 +84,7 @@ sharded_store::make_canonical_schema(unparsed_schema schema) {
 ss::future<> sharded_store::validate_schema(canonical_schema schema) {
     switch (schema.type()) {
     case schema_type::avro: {
-        make_avro_schema_definition(schema.def().raw()()).value();
+        co_await make_avro_schema_definition(*this, schema);
         co_return;
     }
     case schema_type::protobuf:
@@ -102,7 +102,7 @@ sharded_store::make_valid_schema(canonical_schema schema) {
     // See #3596 for details, especially if modifying it.
     switch (schema.type()) {
     case schema_type::avro: {
-        co_return make_avro_schema_definition(schema.def().raw()()).value();
+        co_return co_await make_avro_schema_definition(*this, schema);
     }
     case schema_type::protobuf: {
         co_return co_await make_protobuf_schema_definition(*this, schema);

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -2,7 +2,6 @@ rp_test(
   UNIT_TEST
   BINARY_NAME pandaproxy_schema_registry_unit
   SOURCES
-    compatibility_avro.cc
     sanitize_avro.cc
     util.cc
     storage.cc
@@ -21,6 +20,7 @@ rp_test(
     consume_to_store.cc
     compatibility_store.cc
     compatibility_3rdparty.cc
+    compatibility_avro.cc
     compatibility_protobuf.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v_pandaproxy_schema_registry

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -12,12 +12,12 @@
 #include "pandaproxy/schema_registry/avro.h"
 #include "pandaproxy/schema_registry/types.h"
 
-#include <boost/test/unit_test.hpp>
+#include <seastar/testing/thread_test_case.hh>
 
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
-BOOST_AUTO_TEST_CASE(test_avro_type_promotion) {
+SEASTAR_THREAD_TEST_CASE(test_avro_type_promotion) {
     BOOST_REQUIRE(check_compatible(schema_long, schema_int));
     BOOST_REQUIRE(check_compatible(schema_float, schema_int));
     BOOST_REQUIRE(check_compatible(schema_double, schema_int));
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_avro_type_promotion) {
     BOOST_REQUIRE(check_compatible(schema_bytes, schema_string));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_enum) {
+SEASTAR_THREAD_TEST_CASE(test_avro_enum) {
     // Adding an enum field is ok
     BOOST_REQUIRE(check_compatible(enum3, enum2));
 
@@ -45,19 +45,19 @@ BOOST_AUTO_TEST_CASE(test_avro_enum) {
     BOOST_REQUIRE(check_compatible(enum2_mat, enum1_mat));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_union) {
+SEASTAR_THREAD_TEST_CASE(test_avro_union) {
     BOOST_REQUIRE(check_compatible(union2, union0));
 
     BOOST_REQUIRE(!check_compatible(union1, union0));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_array) {
+SEASTAR_THREAD_TEST_CASE(test_avro_array) {
     BOOST_REQUIRE(check_compatible(long_array, int_array));
 
     BOOST_REQUIRE(!check_compatible(int_array, long_array));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_compat) {
+SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_compat) {
     // Backward compatibility: A new schema is backward compatible if it can be
     // used to read the data written in the previous schema.
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_compat) {
     BOOST_CHECK(!check_compatible(schema6, schema7));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_transitive_compat) {
+SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_transitive_compat) {
     // Backward transitive compatibility: A new schema is backward compatible if
     // it can be used to read the data written in all previous schemas.
 
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_transitive_compat) {
     BOOST_CHECK(!check_compatible(schema3, schema1));
 }
 
-BOOST_AUTO_TEST_CASE(test_schemaregistry_basic_forwards_compatibility) {
+SEASTAR_THREAD_TEST_CASE(test_schemaregistry_basic_forwards_compatibility) {
     // Forward compatibility: A new schema is forward compatible if the previous
     // schema can read data written in this schema.
 
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_schemaregistry_basic_forwards_compatibility) {
     BOOST_CHECK(check_compatible(schema2, schema1));
 }
 
-BOOST_AUTO_TEST_CASE(
+SEASTAR_THREAD_TEST_CASE(
   test_schemaregistry_basic_forwards_transitive_compatibility) {
     // Forward transitive compatibility: A new schema is forward compatible
     // if all previous schemas can read data written in this schema.
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(
     BOOST_CHECK(!check_compatible(schema3, schema1));
 }
 
-BOOST_AUTO_TEST_CASE(test_basic_full_compatibility) {
+SEASTAR_THREAD_TEST_CASE(test_basic_full_compatibility) {
     // Full compatibility: A new schema is fully compatible if it’s both
     // backward and forward compatible.
 
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(test_basic_full_compatibility) {
     BOOST_CHECK(check_compatible(schema1, schema2));
 }
 
-BOOST_AUTO_TEST_CASE(test_basic_full_transitive_compatibility) {
+SEASTAR_THREAD_TEST_CASE(test_basic_full_transitive_compatibility) {
     // Full transitive compatibility: A new schema is fully compatible
     // if it’s both transitively backward and transitively forward
     // compatible with the entire schema history.
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(test_basic_full_transitive_compatibility) {
     BOOST_CHECK(!check_compatible(schema3, schema1));
 }
 
-BOOST_AUTO_TEST_CASE(test_avro_schema_definition) {
+SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition) {
     // Parsing Canonical Form requires fields to be ordered:
     // name, type, fields, symbols, items, values, size
     pps::canonical_schema_definition expected{

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
@@ -14,31 +14,38 @@
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
-const auto enum2 = pps::make_avro_schema_definition(R"({
+const auto enum2 = pps::sanitize_avro_schema_definition(
+                     {R"({
   "name": "test2",
   "type": "enum",
   "symbols": ["One", "Two"]
-})")
+})",
+                      pps::schema_type::avro})
                      .value();
 
-const auto enum3 = pps::make_avro_schema_definition(R"({
+const auto enum3 = pps::sanitize_avro_schema_definition(
+                     {R"({
   "name": "test2",
   "type": "enum",
   "symbols": ["One", "Two", "Three"]
-})")
+})",
+                      pps::schema_type::avro})
                      .value();
 
-const auto enum2_def = pps::make_avro_schema_definition(
-                         R"({
+const auto enum2_def = pps::sanitize_avro_schema_definition(
+                         {
+                           R"({
   "name": "test2",
   "type": "enum",
   "symbols": ["One", "Two"],
   "default": "One"
-})")
+})",
+                           pps::schema_type::avro})
                          .value();
 
-const auto enum1_mat = pps::make_avro_schema_definition(
-                         R"({
+const auto enum1_mat = pps::sanitize_avro_schema_definition(
+                         {
+                           R"({
   "type": "record",
   "name": "schema_enum",
   "fields": [
@@ -57,11 +64,13 @@ const auto enum1_mat = pps::make_avro_schema_definition(
       }
     }
   ]
-})")
+})",
+                           pps::schema_type::avro})
                          .value();
 
-const auto enum2_mat = pps::make_avro_schema_definition(
-                         R"({
+const auto enum2_mat = pps::sanitize_avro_schema_definition(
+                         {
+                           R"({
   "type": "record",
   "name": "schema_enum",
   "fields": [
@@ -81,28 +90,34 @@ const auto enum2_mat = pps::make_avro_schema_definition(
       }
     }
   ]
-})")
+})",
+                           pps::schema_type::avro})
                          .value();
 
-const auto union0 = pps::make_avro_schema_definition(R"({
+const auto union0 = pps::sanitize_avro_schema_definition(
+                      {R"({
     "name": "init",
     "type": "record",
     "fields": [{
         "name": "inner",
         "type": ["string", "int"]}]
-})")
+})",
+                       pps::schema_type::avro})
                       .value();
 
-const auto union1 = pps::make_avro_schema_definition(R"({
+const auto union1 = pps::sanitize_avro_schema_definition(
+                      {R"({
     "name": "init",
     "type": "record",
     "fields": [{
         "name": "inner",
         "type": ["null", "string"]}]
-})")
+})",
+                       pps::schema_type::avro})
                       .value();
 
-const auto union2 = pps::make_avro_schema_definition(R"({
+const auto union2 = pps::sanitize_avro_schema_definition(
+                      {R"({
     "name": "init",
     "type": "record",
     "fields": [{
@@ -118,80 +133,100 @@ const auto union2 = pps::make_avro_schema_definition(R"({
             }
         ]
     }]
-})")
+})",
+                       pps::schema_type::avro})
                       .value();
 
-const auto int_array = pps::make_avro_schema_definition(R"({
+const auto int_array = pps::sanitize_avro_schema_definition(
+                         {R"({
   "name": "test2",
   "type": "array",
   "items": "int"
-})")
+})",
+                          pps::schema_type::avro})
                          .value();
 
-const auto long_array = pps::make_avro_schema_definition(R"({
+const auto long_array = pps::sanitize_avro_schema_definition(
+                          {R"({
   "name": "test2",
   "type": "array",
   "items": "long"
-})")
+})",
+                           pps::schema_type::avro})
                           .value();
 
 // Schemas defined in AvroCompatibilityTest.java. Used here to ensure
 // compatibility with the schema-registry
 const auto schema1
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema2
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema2_union_null_first
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":["null","int"],"name":"f2_enum","default":null}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":["null","int"],"name":"f2_enum","default":null}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema3
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema4
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1_new","aliases":["f1"]}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1_new","aliases":["f1"]}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema6
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","doc":"doc of f1"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","doc":"doc of f1"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema7
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":["null","string","int"],"name":"f1","doc":"doc of f1"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":["null","string","int"],"name":"f1","doc":"doc of f1"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema8
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]},{"type":"string","name":"f3","default":"bar"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]},{"type":"string","name":"f3","default":"bar"}]})",
+       pps::schema_type::avro})
       .value();
-const auto badDefaultNullString_def = pps::make_avro_schema_definition(
-  R"({"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]})");
+const auto badDefaultNullString_def = pps::sanitize_avro_schema_definition(
+  {R"({"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]})",
+   pps::schema_type::avro});
 const auto schema_int
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"int"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"int"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema_long
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"long"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"long"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema_float
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"float"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"float"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema_double
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"double"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"double"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema_bytes
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"bytes"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"bytes"}]})",
+       pps::schema_type::avro})
       .value();
 const auto schema_string
-  = pps::make_avro_schema_definition(
-      R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]})")
+  = pps::sanitize_avro_schema_definition(
+      {R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]})",
+       pps::schema_type::avro})
       .value();

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -33,12 +33,14 @@
 
 namespace pps = pandaproxy::schema_registry;
 
-constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
-constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
 const pps::canonical_schema_definition string_def0{
-  pps::make_avro_schema_definition(sv_string_def0).value()};
+  pps::sanitize_avro_schema_definition(
+    {R"({"type":"string"})", pps::schema_type::avro})
+    .value()};
 const pps::canonical_schema_definition int_def0{
-  pps::make_avro_schema_definition(sv_int_def0).value()};
+  pps::sanitize_avro_schema_definition(
+    {R"({"type": "int"})", pps::schema_type::avro})
+    .value()};
 const pps::subject subject0{"subject0"};
 constexpr pps::topic_key_magic magic0{0};
 constexpr pps::topic_key_magic magic1{1};

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/test/avro_payloads.h"
 #include "pandaproxy/schema_registry/test/client_utils.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -16,6 +17,37 @@
 namespace pp = pandaproxy;
 namespace ppj = pp::json;
 namespace pps = pp::schema_registry;
+
+struct request {
+    pps::canonical_schema schema;
+};
+
+void rjson_serialize(
+  ::json::Writer<::json::StringBuffer>& w, const request& r) {
+    w.StartObject();
+    w.Key("schema");
+    ::json::rjson_serialize(w, r.schema.def().raw());
+    if (r.schema.type() != pps::schema_type::avro) {
+        w.Key("schemaType");
+        ::json::rjson_serialize(w, to_string_view(r.schema.type()));
+    }
+    if (!r.schema.refs().empty()) {
+        w.Key("references");
+        w.StartArray();
+        for (const auto& ref : r.schema.refs()) {
+            w.StartObject();
+            w.Key("name");
+            ::json::rjson_serialize(w, ref.name);
+            w.Key("subject");
+            ::json::rjson_serialize(w, ref.sub);
+            w.Key("version");
+            ::json::rjson_serialize(w, ref.version);
+            w.EndObject();
+        }
+        w.EndArray();
+    }
+    w.EndObject();
+}
 
 FIXTURE_TEST(
   schema_registry_post_subjects_subject_version, pandaproxy_test_fixture) {
@@ -141,4 +173,78 @@ FIXTURE_TEST(
           res.headers.at(boost::beast::http::field::content_type),
           to_header_value(ppj::serialization_format::schema_registry_v1_json));
     }
+}
+
+FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    const auto company_req = request{pps::canonical_schema{
+      pps::subject{"company-value"},
+      pps::canonical_schema_definition(
+        R"({
+  "namespace": "com.redpanda",
+  "type": "record",
+  "name": "company",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "name",
+      "type": "string"
+    },
+    {
+      "name": "address",
+      "type": "string"
+    }
+  ]
+})",
+        pps::schema_type::avro)}};
+
+    const auto employee_req = request{pps::canonical_schema{
+      pps::subject{"employee-value"},
+      pps::canonical_schema_definition(
+        R"({
+  "namespace": "com.redpanda",
+  "type": "record",
+  "name": "employee",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "name",
+      "type": "string"
+    },
+    {
+      "name": "company",
+      "type": "com.redpanda.company"
+    }
+  ]
+})",
+        pps::schema_type::avro),
+      {{"com.redpanda.company",
+        pps::subject{"company-value"},
+        pps::schema_version{1}}}}};
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    info("Post company schema (expect schema_id=1)");
+    auto res = post_schema(
+      client, company_req.schema.sub(), ppj::rjson_serialize(company_req));
+    BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
+    BOOST_REQUIRE_EQUAL(
+      res.headers.at(boost::beast::http::field::content_type),
+      to_header_value(ppj::serialization_format::schema_registry_v1_json));
+
+    info("Post employee schema (expect schema_id=2)");
+    res = post_schema(
+      client, employee_req.schema.sub(), ppj::rjson_serialize(employee_req));
+    BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
+    BOOST_REQUIRE_EQUAL(
+      res.headers.at(boost::beast::http::field::content_type),
+      to_header_value(ppj::serialization_format::schema_registry_v1_json));
 }


### PR DESCRIPTION
## Cover letter

Support references for Avro schema.

Fixes #4146 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/bba0e0814bc1ecc087cf5f149a64ec302843a27a..b58fc30beb942744c50ed68ee969ae561bbcdf75)
* Change range declaration to lvalue-ref
* Add a `std::move`
* Add newline back to the end of the file

## Release notes

### Features

* Schema Registry: Support references for Avro schema.