### PR TITLE
cloud_storage: cache::put checks that key is inside cache_dir

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -233,20 +233,36 @@ ss::future<> cache::put(
     vlog(cst_log.debug, "Trying to put {} to archival cache.", key.native());
     probe.put();
 
+    std::filesystem::path normal_cache_dir = _cache_dir.lexically_normal();
+    std::filesystem::path normal_key_path
+      = std::filesystem::path(normal_cache_dir / key).lexically_normal();
+
+    auto [p1, p2] = std::mismatch(
+      normal_cache_dir.begin(),
+      normal_cache_dir.end(),
+      normal_key_path.begin());
+    if (p1 != normal_cache_dir.end()) {
+        throw std::invalid_argument(fmt_with_ctx(
+          fmt::format,
+          "Tried to put {}, which is outside of cache_dir {}.",
+          normal_key_path.native(),
+          normal_cache_dir.native()));
+    }
+
     _files_in_progress.insert(key);
     probe.put_started();
     auto deferred = ss::defer([this, key] {
         _files_in_progress.erase(key);
         probe.put_ended();
     });
-    auto filename = (_cache_dir / key).filename();
+    auto filename = normal_key_path.filename();
     if (std::string_view(filename.native()).ends_with(tmp_extension)) {
         throw std::invalid_argument(fmt::format(
           "Cache file key {} is ending with tmp extension {}.",
-          filename.native(),
+          normal_key_path.native(),
           tmp_extension));
     }
-    auto dir_path = (_cache_dir / key).remove_filename();
+    auto dir_path = normal_key_path.remove_filename();
 
     // tmp file is used to protect against concurrent writes to the same
     // file. One tmp file is written only once by one thread. tmp file

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -209,8 +209,13 @@ FIXTURE_TEST(invalidate_outside_cache_dir_throws, cache_test_fixture) {
     target_dir.close().get();
 
     auto key = std::filesystem::path("../outside_cache/file.txt");
-    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
-    put_into_cache(data_string1, key);
+    auto flags = ss::open_flags::wo | ss::open_flags::create
+                 | ss::open_flags::exclusive;
+
+    auto dir_path = (CACHE_DIR / key).remove_filename();
+    ss::recursive_touch_directory(dir_path.string()).get();
+    auto tmp_cache_file
+      = ss::open_file_dma((CACHE_DIR / key).native(), flags).get();
 
     BOOST_CHECK_THROW(
       cache_service.invalidate(key).get(), std::invalid_argument);
@@ -233,10 +238,47 @@ FIXTURE_TEST(invalidate_prefix_outside_cache_dir_throws, cache_test_fixture) {
 
     // CACHE_DIR is "test_cache_dir"
     auto key = std::filesystem::path("../test_cache_dir_bar/file.txt");
-    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
-    put_into_cache(data_string1, key);
+    auto flags = ss::open_flags::wo | ss::open_flags::create
+                 | ss::open_flags::exclusive;
+    auto dir_path = (CACHE_DIR / key).remove_filename();
+    ss::recursive_touch_directory(dir_path.string()).get();
+    auto tmp_cache_file
+      = ss::open_file_dma((CACHE_DIR / key).native(), flags).get();
 
     BOOST_CHECK_THROW(
       cache_service.invalidate(key).get(), std::invalid_argument);
     BOOST_CHECK(ss::file_exists((CACHE_DIR / key).native()).get());
+}
+
+FIXTURE_TEST(put_outside_cache_dir_throws, cache_test_fixture) {
+    // make sure the cache directory is empty to get reliable results
+    ss::recursive_touch_directory(CACHE_DIR.native()).get();
+    auto target_dir = ss::open_directory(CACHE_DIR.native()).get();
+    target_dir
+      .list_directory([this](const ss::directory_entry& entry) -> ss::future<> {
+          auto entry_path = std::filesystem::path(CACHE_DIR)
+                            / std::filesystem::path(entry.name);
+          return ss::recursive_remove_directory(entry_path.native());
+      })
+      .done()
+      .get();
+    target_dir.close().get();
+
+    // CACHE_DIR is "test_cache_dir"
+    auto key = std::filesystem::path("../test_cache_dir_put/file.txt");
+    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
+    iobuf buf;
+    buf.append(data_string1.data(), data_string1.length());
+    auto input = make_iobuf_input_stream(std::move(buf));
+
+    BOOST_CHECK_EXCEPTION(
+      cache_service.put(key, input).get(),
+      std::invalid_argument,
+      [](std::invalid_argument e) {
+          return std::string(e.what()).find(
+                   "Tried to put test_cache_dir_put/file.txt, which is outside "
+                   "of cache_dir test_cache_dir.")
+                 != std::string::npos;
+      });
+    BOOST_CHECK(!ss::file_exists((CACHE_DIR / key).native()).get());
 }


### PR DESCRIPTION
## Cover letter

Add protection from using `cache::put` with key that leads outside of
cache directory. Use normalized cache item key to check that cache
service doesn't create files outside of `cache_dir`

Fixes: #3765

## Release notes
* none
