### PR TITLE
r/vote: do not wait for majority of responses from unique voters

### DIFF
--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -163,13 +163,8 @@ ss::future<bool> prevote_stm::do_prevote() {
     // dispatch requests to all voters
     _config->for_each_voter([this](vnode id) { (void)dispatch_prevote(id); });
 
-    // wait until majority
-    const size_t majority = (_config->unique_voter_count() / 2) + 1;
-
-    return _sem.wait(majority)
-      .then([this] { return process_replies(); })
-      // process results
-      .then([this]() { return _success; });
+    // process results
+    return process_replies().then([this]() { return _success; });
 }
 
 ss::future<> prevote_stm::process_replies() {


### PR DESCRIPTION
In joint consensus raft needs majority of both new and previous quorums
to make the decisions. Voting for new leader is one of the processes
that requires majority agreement from both quorums. In previous
implementation we waited for majority of the vote request responses.
This approach would make leader election much slower in situations where
quorums differ by one node.

Example:

current voters: `[1,2,4]`, previous voters: `[1,2,3]`

In this scenario to elect leader it is enough to wait from responses
from node 1 and 2 as they form majority in both quorums. In previous
implementation we wait for at least `(n/2)+1` responses. Where `n` is a
number of unique voter ids. In the example above `n = len([1,2,3,4]) =
4`. This way we had to wait for 3 replies while only 2 of the are enough
to elect new leader.

Changed implementation to check if we can make a definitive decision
about vote round result after receiving each of the replies. This way we
will always use smallest possible set of replies to make a decision.

## Release notes

### Improvements

* Faster leader election during partition moves

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
