### PR TITLE
tests: fix typo on compaction_recovery_test log_allow_list

### DIFF
--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -53,8 +53,8 @@ class CompactionRecoveryTest(RedpandaTest):
               self).__init__(test_context=test_context,
                              extra_rp_conf=extra_rp_conf)
 
-    @cluster(num_nodes=3)
-    def test_index_recovery(self, log_allow_list=RESTART_LOG_ALLOW_LIST):
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_index_recovery(self):
         partitions = self.produce_until_segments(3)
 
         for p in partitions:


### PR DESCRIPTION
## Cover letter

This is an easy mistake to make... the perils of using a dynamic language that'll ignore unused function arguments :-/

Fixes https://github.com/redpanda-data/redpanda/issues/4013

## Release notes

* none
