### PR TITLE
tests: reproducer for issues with consumer_offsets partition movement

### DIFF
--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -33,7 +33,7 @@ class PartitionMovementMixin():
 
         # remove random assignment(s). we allow no changes to be made to
         # exercise the code paths responsible for dealing with no-ops.
-        num_replacements = random.randint(0, replication_factor)
+        num_replacements = random.randint(1, replication_factor)
         selected = random.sample(assignments, num_replacements)
         for assignment in selected:
             assignments.remove(assignment)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -239,6 +239,36 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self._move_and_verify()
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
+    @cluster(num_nodes=5, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
+    def test_move_consumer_offsets_intranode(self):
+        """
+        Exercise moving the consumer_offsets/0 partition between shards
+        within the same nodes.  This reproduces certain bugs in the special
+        handling of this topic.
+        """
+        self.start_redpanda(num_nodes=3,
+                            extra_rp_conf={"default_topic_replications": 3})
+        spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+
+        admin = Admin(self.redpanda)
+        topic = "__consumer_offsets"
+        partition = 0
+
+        for _ in range(25):
+            assignments = self._get_assignments(admin, topic, partition)
+            for a in assignments:
+                # Bounce between core 0 and 1
+                a['core'] = (a['core'] + 1) % 2
+            admin.set_partition_replicas(topic, partition, assignments)
+            self._wait_post_move(topic, partition, assignments, 360)
+
+        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
     @cluster(num_nodes=5,
              log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
              RESTART_LOG_ALLOW_LIST)


### PR DESCRIPTION
## Cover letter

This is a more reliable reproducer for https://github.com/redpanda-data/redpanda/issues/4045

It reproduces the error where constructing the log on the new shard fails with a seastar::metrics::double_registration , when the same log has previously been allocated to this shard and failed to shut down fully.

At time of writing, this particular failure mode is still present even with the fixes in #4015 and #4089, and reproduced by this test.

Until the underlying bug is fixed, this is expected to fail CI.

## Release notes

* none