### PR TITLE
tests/redpanda: extend ready timeout

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -271,7 +271,7 @@ class RedpandaService(Service):
                                             "redpanda.profraw")
 
     CLUSTER_NAME = "my_cluster"
-    READY_TIMEOUT_SEC = 10
+    READY_TIMEOUT_SEC = 15
 
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"


### PR DESCRIPTION
As redpanda startup process gets more complicated it may take more time
to start and report ready status. Extended Redpanda ready timeout from
10s to 15s to make debug build tests more stable.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
