### PR TITLE
cloud_storage: Improve SI index compression

### DIFF
--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -35,6 +35,7 @@
 namespace cloud_storage {
 
 static constexpr size_t remote_segment_sampling_step_bytes = 64_KiB;
+
 class download_exception : public std::exception {
 public:
     explicit download_exception(download_result r, std::filesystem::path p);

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -274,10 +274,9 @@ FIXTURE_TEST(put_outside_cache_dir_throws, cache_test_fixture) {
     BOOST_CHECK_EXCEPTION(
       cache_service.put(key, input).get(),
       std::invalid_argument,
-      [](std::invalid_argument e) {
+      [](const std::invalid_argument& e) {
           return std::string(e.what()).find(
-                   "Tried to put test_cache_dir_put/file.txt, which is outside "
-                   "of cache_dir test_cache_dir.")
+                   "test_cache_dir_put/file.txt, which is outside of cache_dir")
                  != std::string::npos;
       });
     BOOST_CHECK(!ss::file_exists((CACHE_DIR / key).native()).get());

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     std::vector<size_t> file_offsets;
     int64_t rp = segment_base_rp_offset();
     int64_t kaf = segment_base_kaf_offset();
-    size_t fpos = 0;
+    size_t fpos = random_generators::get_int(1000, 2000);
     bool is_config = false;
     for (size_t i = 0; i < segment_num_batches; i++) {
         if (!is_config) {
@@ -57,10 +57,11 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
         is_config = random_generators::get_int(20) == 0;
         rp += batch_size;
         kaf += is_config ? batch_size - 1 : batch_size;
-        fpos += random_generators::get_int(1, 1000);
+        fpos += random_generators::get_int(1000, 2000);
     }
 
-    offset_index tmp_index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
+    offset_index tmp_index(
+      segment_base_rp_offset, segment_base_kaf_offset, 0U, 1000);
     model::offset last;
     model::offset klast;
     size_t flast;
@@ -71,7 +72,8 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
         flast = file_offsets.at(i);
     }
 
-    offset_index index(segment_base_rp_offset, segment_base_kaf_offset, 0U);
+    offset_index index(
+      segment_base_rp_offset, segment_base_kaf_offset, 0U, 1000);
     auto buf = tmp_index.to_iobuf();
     index.from_iobuf(std::move(buf));
 
@@ -128,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     }
     auto segment = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
-    offset_index ix(base_offset, base_offset, 0);
+    offset_index ix(base_offset, base_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(
       std::move(is), ix, model::offset(0), 0);
     auto result = parser->consume().get();

--- a/src/v/utils/tests/delta_for_test.cc
+++ b/src/v/utils/tests/delta_for_test.cc
@@ -20,19 +20,19 @@
 
 #include <stdexcept>
 
-template<class TVal>
+template<class TVal, class DeltaT>
 std::vector<TVal> populate_encoder(
-  deltafor_encoder<TVal>& c,
+  deltafor_encoder<TVal, DeltaT>& c,
   uint64_t initial_value,
-  const std::vector<TVal>& deltas) {
+  const std::vector<std::pair<TVal, TVal>>& deltas) {
     std::vector<TVal> result;
-    auto p = initial_value;
-    for (TVal delta : deltas) {
+    auto p = initial_value + deltas.front().first;
+    for (auto [min_delta, max_delta] : deltas) {
         std::array<TVal, details::FOR_buffer_depth> buf = {};
         for (int x = 0; x < details::FOR_buffer_depth; x++) {
             result.push_back(p);
             buf.at(x) = p;
-            p += random_generators::get_int(delta);
+            p += random_generators::get_int(min_delta, max_delta);
             if (p < buf.at(x)) {
                 throw std::out_of_range("delta can't be represented");
             }
@@ -42,37 +42,18 @@ std::vector<TVal> populate_encoder(
     return result;
 }
 
-BOOST_AUTO_TEST_CASE(roundtrip_test_2) {
-    static constexpr int64_t initial_value = 0;
-    deltafor_encoder<int64_t> enc(initial_value);
-    std::vector<int64_t> deltas = {
-      0LL,
-      10LL,
-      100LL,
-      1000LL,
-      10000LL,
-      100000LL,
-      1000000LL,
-      10000000LL,
-      100000000LL,
-      1000000000LL,
-      10000000000LL,
-      100000000000LL,
-      1000000000000LL,
-      10000000000000LL,
-      100000000000000LL,
-      1000000000000000LL,
-      10000000000000000LL,
-      100000000000000000LL,
-      1000000000000000000LL,
-    };
+template<class TVal, class DeltaT>
+void roundtrip_test(
+  const std::vector<std::pair<TVal, TVal>>& deltas, DeltaT delta) {
+    static constexpr TVal initial_value = 0;
+    deltafor_encoder<TVal, DeltaT> enc(initial_value, delta);
     auto expected = populate_encoder(enc, initial_value, deltas);
 
-    deltafor_decoder<int64_t> dec(
-      initial_value, enc.get_row_count(), enc.copy());
+    deltafor_decoder<TVal, DeltaT> dec(
+      initial_value, enc.get_row_count(), enc.copy(), delta);
 
-    std::vector<int64_t> actual;
-    std::array<int64_t, details::FOR_buffer_depth> buf{};
+    std::vector<TVal> actual;
+    std::array<TVal, details::FOR_buffer_depth> buf{};
     int cnt = 0;
     while (dec.read(buf)) {
         cnt++;
@@ -84,54 +65,110 @@ BOOST_AUTO_TEST_CASE(roundtrip_test_2) {
 }
 
 BOOST_AUTO_TEST_CASE(roundtrip_test_1) {
-    static constexpr uint64_t initial_value = 0;
-    deltafor_encoder<uint64_t> enc(initial_value);
-    std::vector<uint64_t> deltas = {
-      0ULL,
-      10ULL,
-      100ULL,
-      1000ULL,
-      10000ULL,
-      100000ULL,
-      1000000ULL,
-      10000000ULL,
-      100000000ULL,
-      1000000000ULL,
-      10000000000ULL,
-      100000000000ULL,
-      1000000000000ULL,
-      10000000000000ULL,
-      100000000000000ULL,
-      1000000000000000ULL,
-      10000000000000000ULL,
-      100000000000000000ULL,
-      1000000000000000000ULL,
+    std::vector<std::pair<int64_t, int64_t>> deltas = {
+      std::make_pair(0LL, 0LL),
+      std::make_pair(0LL, 10LL),
+      std::make_pair(0LL, 100LL),
+      std::make_pair(0LL, 1000LL),
+      std::make_pair(0LL, 10000LL),
+      std::make_pair(0LL, 100000LL),
+      std::make_pair(0LL, 1000000LL),
+      std::make_pair(0LL, 10000000LL),
+      std::make_pair(0LL, 100000000LL),
+      std::make_pair(0LL, 1000000000LL),
+      std::make_pair(0LL, 10000000000LL),
+      std::make_pair(0LL, 100000000000LL),
+      std::make_pair(0LL, 1000000000000LL),
+      std::make_pair(0LL, 10000000000000LL),
+      std::make_pair(0LL, 100000000000000LL),
+      std::make_pair(0LL, 1000000000000000LL),
+      std::make_pair(0LL, 10000000000000000LL),
+      std::make_pair(0LL, 100000000000000000LL),
+      std::make_pair(0LL, 1000000000000000000LL),
     };
-    auto expected = populate_encoder(enc, initial_value, deltas);
+    roundtrip_test<int64_t>(deltas, details::delta_xor());
+}
 
-    deltafor_decoder<uint64_t> dec(
-      initial_value, enc.get_row_count(), enc.copy());
+BOOST_AUTO_TEST_CASE(roundtrip_test_2) {
+    std::vector<std::pair<uint64_t, uint64_t>> deltas = {
+      std::make_pair(0ULL, 0ULL),
+      std::make_pair(0ULL, 10ULL),
+      std::make_pair(0ULL, 100ULL),
+      std::make_pair(0ULL, 1000ULL),
+      std::make_pair(0ULL, 10000ULL),
+      std::make_pair(0ULL, 100000ULL),
+      std::make_pair(0ULL, 1000000ULL),
+      std::make_pair(0ULL, 10000000ULL),
+      std::make_pair(0ULL, 100000000ULL),
+      std::make_pair(0ULL, 1000000000ULL),
+      std::make_pair(0ULL, 10000000000ULL),
+      std::make_pair(0ULL, 100000000000ULL),
+      std::make_pair(0ULL, 1000000000000ULL),
+      std::make_pair(0ULL, 10000000000000ULL),
+      std::make_pair(0ULL, 100000000000000ULL),
+      std::make_pair(0ULL, 1000000000000000ULL),
+      std::make_pair(0ULL, 10000000000000000ULL),
+      std::make_pair(0ULL, 100000000000000000ULL),
+      std::make_pair(0ULL, 1000000000000000000ULL),
+    };
+    roundtrip_test<uint64_t>(deltas, details::delta_xor());
+}
 
-    std::vector<uint64_t> actual;
-    std::array<uint64_t, details::FOR_buffer_depth> buf{};
-    int cnt = 0;
-    while (dec.read(buf)) {
-        cnt++;
-        std::copy(buf.begin(), buf.end(), std::back_inserter(actual));
-        buf = {};
-    }
-    BOOST_REQUIRE_EQUAL(cnt, deltas.size());
-    BOOST_REQUIRE(expected == actual);
+BOOST_AUTO_TEST_CASE(roundtrip_test_3) {
+    std::vector<std::pair<int64_t, int64_t>> deltas = {
+      std::make_pair(10LL, 10LL),
+      std::make_pair(10LL, 100LL),
+      std::make_pair(10LL, 1000LL),
+      std::make_pair(10LL, 10000LL),
+      std::make_pair(10LL, 100000LL),
+      std::make_pair(10LL, 1000000LL),
+      std::make_pair(10LL, 10000000LL),
+      std::make_pair(10LL, 100000000LL),
+      std::make_pair(10LL, 1000000000LL),
+      std::make_pair(10LL, 10000000000LL),
+      std::make_pair(10LL, 100000000000LL),
+      std::make_pair(10LL, 1000000000000LL),
+      std::make_pair(10LL, 10000000000000LL),
+      std::make_pair(10LL, 100000000000000LL),
+      std::make_pair(10LL, 1000000000000000LL),
+      std::make_pair(10LL, 10000000000000000LL),
+      std::make_pair(10LL, 100000000000000000LL),
+    };
+    roundtrip_test<int64_t>(deltas, details::delta_delta<int64_t>(10));
+}
+
+BOOST_AUTO_TEST_CASE(roundtrip_test_4) {
+    std::vector<std::pair<uint64_t, uint64_t>> deltas = {
+      std::make_pair(10ULL, 10ULL),
+      std::make_pair(10ULL, 100ULL),
+      std::make_pair(10ULL, 1000ULL),
+      std::make_pair(10ULL, 10000ULL),
+      std::make_pair(10ULL, 100000ULL),
+      std::make_pair(10ULL, 1000000ULL),
+      std::make_pair(10ULL, 10000000ULL),
+      std::make_pair(10ULL, 100000000ULL),
+      std::make_pair(10ULL, 1000000000ULL),
+      std::make_pair(10ULL, 10000000000ULL),
+      std::make_pair(10ULL, 100000000000ULL),
+      std::make_pair(10ULL, 1000000000000ULL),
+      std::make_pair(10ULL, 10000000000000ULL),
+      std::make_pair(10ULL, 100000000000000ULL),
+      std::make_pair(10ULL, 1000000000000000ULL),
+      std::make_pair(10ULL, 10000000000000000ULL),
+      std::make_pair(10ULL, 100000000000000000ULL),
+    };
+    roundtrip_test<uint64_t>(deltas, details::delta_delta<uint64_t>(10));
 }
 
 template<class TVal>
 void test_random_walk_roundtrip(int test_size, int max_delta) {
     static constexpr TVal initial_value = 0;
     deltafor_encoder<TVal> enc(initial_value);
-    std::vector<TVal> deltas;
+    std::vector<std::pair<TVal, TVal>> deltas;
     deltas.reserve(test_size);
     for (int i = 0; i < test_size; i++) {
-        deltas.push_back(random_generators::get_int(max_delta));
+        deltas.push_back(
+          std::make_pair(0, random_generators::get_int(max_delta)));
     }
     auto expected = populate_encoder(enc, initial_value, deltas);
 
@@ -195,4 +232,25 @@ BOOST_AUTO_TEST_CASE(random_walk_test_8) {
     static constexpr int test_size = 100000;
     static constexpr int max_delta = 100000;
     test_random_walk_roundtrip<int64_t>(test_size, max_delta);
+}
+
+BOOST_AUTO_TEST_CASE(test_compression_ratio) {
+    const int num_rows = 100000;
+    const int num_elements = num_rows * 16;
+    static constexpr uint64_t initial_value = 0;
+    static constexpr uint64_t min_step = 10000;
+    deltafor_encoder<uint64_t> enc_xor(initial_value);
+    deltafor_encoder<uint64_t, details::delta_delta<uint64_t>> enc_delta(
+      initial_value, details::delta_delta(min_step));
+    std::vector<std::pair<uint64_t, uint64_t>> deltas;
+    deltas.reserve(num_rows);
+    for (int i = 0; i < num_rows; i++) {
+        deltas.emplace_back(std::make_pair(min_step, min_step + 100));
+    }
+    populate_encoder(enc_xor, initial_value, deltas);
+    populate_encoder(enc_delta, initial_value, deltas);
+    BOOST_REQUIRE(
+      enc_xor.share().size_bytes() > enc_delta.share().size_bytes());
+    auto num_bytes_per_val = num_elements;
+    BOOST_REQUIRE(enc_delta.share().size_bytes() < num_bytes_per_val);
 }


### PR DESCRIPTION
## Cover letter

The index has three columns: redpanda offsets, kafka offsets, and the file offsets. The last column takes more space than expected because the index is built using sampling. The sampling step is 64KiB. This means that the distance between consequeuetive values is always larger than 65536. Because of that the values will always be using 2+ bytes of memory per element. This can be fixed by subtracting known sampling step size from every file pos when it's added to the index and adding the same value back when it's extracted from the index.

The commit adds new parameter 'sampling step' to the `offset_index` constructor. This parameter is used to adjust every filepos in the index to save space.

## Release notes


* none

