### PR TITLE
k8s: remove unused certificate as parameter

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -152,7 +152,6 @@ func (r *ClusterReconciler) Reconcile(
 		nodeportSvc.Key(),
 		pki.RedpandaNodeCert(),
 		pki.RedpandaOperatorClientCert(),
-		pki.RedpandaAdminCert(),
 		pki.AdminAPINodeCert(),
 		pki.AdminAPIClientCert(),
 		pki.PandaproxyAPINodeCert(),

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -91,7 +91,6 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		types.NamespacedName{},
 		types.NamespacedName{},
 		types.NamespacedName{},
-		types.NamespacedName{},
 		"",
 		res.ConfiguratorSettings{
 			ConfiguratorBaseImage: "vectorized/configurator",

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -92,7 +92,6 @@ type StatefulSetResource struct {
 	nodePortSvc                        corev1.Service
 	redpandaCertSecretKey              types.NamespacedName
 	internalClientCertSecretKey        types.NamespacedName
-	adminCertSecretKey                 types.NamespacedName
 	adminAPINodeCertSecretKey          types.NamespacedName
 	adminAPIClientCertSecretKey        types.NamespacedName
 	pandaproxyAPINodeCertSecretKey     types.NamespacedName
@@ -121,7 +120,6 @@ func NewStatefulSet(
 	nodePortName types.NamespacedName,
 	redpandaCertSecretKey types.NamespacedName,
 	internalClientCertSecretKey types.NamespacedName,
-	adminCertSecretKey types.NamespacedName,
 	adminAPINodeCertSecretKey types.NamespacedName,
 	adminAPIClientCertSecretKey types.NamespacedName,
 	pandaproxyAPINodeCertSecretKey types.NamespacedName,
@@ -143,7 +141,6 @@ func NewStatefulSet(
 		corev1.Service{},
 		redpandaCertSecretKey,
 		internalClientCertSecretKey,
-		adminCertSecretKey,
 		adminAPINodeCertSecretKey,
 		adminAPIClientCertSecretKey,
 		pandaproxyAPINodeCertSecretKey,

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -115,7 +115,6 @@ func TestEnsure(t *testing.T) {
 				types.NamespacedName{},
 				types.NamespacedName{},
 				types.NamespacedName{},
-				types.NamespacedName{},
 				"",
 				res.ConfiguratorSettings{
 					ConfiguratorBaseImage: "vectorized/configurator",


### PR DESCRIPTION
## Cover letter

I was preparing to cleanup that part of code and found out this
parameter is not used.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none