### PR TITLE
[v21.11.x] Forward-compatibility with 22.1.x controller log entries

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -81,6 +81,9 @@ static constexpr int8_t finish_reallocations_cmd_type = 2;
 static constexpr int8_t cluster_config_delta_cmd_type = 0;
 static constexpr int8_t cluster_config_status_cmd_type = 1;
 
+// feature_manager command types
+static constexpr int8_t feature_update_cmd_type = 0;
+
 using create_topic_cmd = controller_command<
   model::topic_namespace,
   topic_configuration_assignment,
@@ -193,6 +196,12 @@ using cluster_config_status_cmd = controller_command<
   cluster_config_status_cmd_data,
   cluster_config_status_cmd_type,
   model::record_batch_type::cluster_config_cmd>;
+
+using feature_update_cmd = controller_command<
+  feature_update_cmd_data,
+  int8_t, // unused
+  feature_update_cmd_type,
+  model::record_batch_type::feature_update>;
 
 // typelist utils
 // clang-format off

--- a/src/v/cluster/compat_backend.h
+++ b/src/v/cluster/compat_backend.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/commands.h"
+#include "cluster/errc.h"
+
+#include <seastar/core/future.hh>
+
+namespace cluster {
+/**
+ *
+ * This is a backend for mux_stm that consumes and ignores future-version
+ * message types, enabling us to start and run an older redpanda with
+ * a controller log that contains newer-versioned structures.
+ */
+class compat_backend {
+public:
+    compat_backend() noexcept {}
+
+    /**
+     * Ignore the message, it is not meaningful to this version of Redpanda
+     */
+    ss::future<std::error_code> apply_update(model::record_batch) {
+        return ss::make_ready_future<std::error_code>(cluster::errc::success);
+    }
+
+    bool is_batch_applicable(const model::record_batch& b) {
+        return b.header().type == model::record_batch_type::feature_update;
+    }
+
+private:
+    static constexpr auto accepted_commands
+      = make_commands_list<feature_update_cmd>();
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -109,6 +109,7 @@ ss::future<> controller::start() {
             std::ref(_partition_leaders),
             std::ref(_as));
       })
+      .then([this] { return _compat_backend.start(); })
       .then([this] {
           return _stm.start_single(
             std::ref(clusterlog),
@@ -118,7 +119,8 @@ ss::future<> controller::start() {
             std::ref(_security_manager),
             std::ref(_members_manager),
             std::ref(_data_policy_manager),
-            std::ref(_config_manager));
+            std::ref(_config_manager),
+            std::ref(_compat_backend));
       })
       .then([this] {
           return _members_frontend.start(
@@ -305,6 +307,7 @@ ss::future<> controller::stop() {
           .then([this] { return _hm_backend.stop(); })
           .then([this] { return _health_manager.stop(); })
           .then([this] { return _members_backend.stop(); })
+          .then([this] { return _compat_backend.stop(); })
           .then([this] { return _config_manager.stop(); })
           .then([this] { return _api.stop(); })
           .then([this] { return _backend.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/compat_backend.h"
 #include "cluster/config_frontend.h"
 #include "cluster/config_manager.h"
 #include "cluster/controller_stm.h"
@@ -128,6 +129,7 @@ private:
     ss::sharded<health_monitor_backend> _hm_backend;   // single instance
     ss::sharded<health_manager> _health_manager;
     ss::sharded<metrics_reporter> _metrics_reporter;
+    ss::sharded<compat_backend> _compat_backend; // single instance
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
 };

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/compat_backend.h"
 #include "cluster/config_manager.h"
 #include "cluster/data_policy_manager.h"
 #include "cluster/members_manager.h"
@@ -26,7 +27,8 @@ using controller_stm = raft::mux_state_machine<
   security_manager,
   members_manager,
   data_policy_manager,
-  config_manager>;
+  config_manager,
+  compat_backend>;
 
 static constexpr ss::shard_id controller_stm_shard = 0;
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1103,4 +1103,18 @@ adl<cluster::incremental_topic_custom_updates>::from(iobuf_parser& in) {
     return updates;
 }
 
+void adl<cluster::feature_update_cmd_data>::to(
+  iobuf& out, cluster::feature_update_cmd_data&& data) {
+    reflection::serialize(out, data.current_version, data.logical_version);
+}
+
+cluster::feature_update_cmd_data
+adl<cluster::feature_update_cmd_data>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    std::ignore = version;
+
+    auto logical_version = adl<cluster::cluster_version>{}.from(in);
+    return {.logical_version = logical_version};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -32,6 +32,17 @@ namespace cluster {
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
+// A cluster version is a logical protocol version describing the content
+// of the raft0 on disk structures, and available features.  These are
+// passed over the network via the health_manager, and persisted in
+// the feature_manager
+using cluster_version = named_type<int64_t, struct cluster_version_tag>;
+constexpr cluster_version invalid_version = cluster_version{-1};
+
+// The version that this redpanda node will report: increment this
+// on protocol changes to raft0 structures, like adding new services.
+constexpr cluster_version latest_version = cluster_version{1};
+
 struct allocate_id_request {
     model::timeout_clock::duration timeout;
 };
@@ -690,6 +701,16 @@ struct cluster_config_status_cmd_data {
     config_status status;
 };
 
+struct feature_update_cmd_data {
+    // To avoid ambiguity on 'versions' here: `current_version`
+    // is the encoding version of the struct, subsequent version
+    // fields are the payload.
+    static constexpr int8_t current_version = 0;
+
+    cluster_version logical_version;
+};
+std::ostream& operator<<(std::ostream&, const feature_update_cmd_data&);
+
 enum class reconciliation_status : int8_t {
     done,
     in_progress,
@@ -919,4 +940,11 @@ struct adl<cluster::incremental_topic_custom_updates> {
     void to(iobuf& out, cluster::incremental_topic_custom_updates&&);
     cluster::incremental_topic_custom_updates from(iobuf_parser&);
 };
+
+template<>
+struct adl<cluster::feature_update_cmd_data> {
+    void to(iobuf&, cluster::feature_update_cmd_data&&);
+    cluster::feature_update_cmd_data from(iobuf_parser&);
+};
+
 } // namespace reflection

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -350,6 +350,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::archival_metadata";
     case record_batch_type::cluster_config_cmd:
         return o << "batch_type::cluster_config_cmd";
+    case record_batch_type::feature_update:
+        return o << "batch_type::feature_update";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -38,6 +38,7 @@ enum class record_batch_type : int8_t {
     data_policy_management_cmd = 18, // data-policy management
     archival_metadata = 19,          // archival metadata updates
     cluster_config_cmd = 20,         // cluster config deltas and status
+    feature_update = 21,             // Node logical versions updates
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);


### PR DESCRIPTION
## Cover letter

The controller log asserts out if it sees entry types it doesn't recognize.  In this PR, we backport 22.1.x batch types, and add a simple no-op "backend" that ignores them.

This makes it somewhat practical (albeit still unsupported) to roll back from 22.1.x to 21.11.x in an emergency.

Fixes #4220

## Release notes

* none