### PR TITLE
cluster: fix assertion message on bad decode version

### DIFF
--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -145,8 +145,8 @@ int8_t read_and_assert_version(std::string_view type, iobuf_parser& parser) {
       version <= T::current_version,
       "unsupported version of {}, max_supported version: {}, read version: {}",
       type,
-      version,
-      T::current_version);
+      T::current_version,
+      version);
     return version;
 }
 


### PR DESCRIPTION
## Cover letter

These arguments were transposed.

## Release notes

* none