### PR TITLE
tests: mark test_move_consumer_offsets_intranode ok_to_fail

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -14,6 +14,7 @@ import requests
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
+from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -239,6 +240,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self._move_and_verify()
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
+    @ok_to_fail
     @cluster(num_nodes=5, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
     def test_move_consumer_offsets_intranode(self):
         """

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -264,7 +264,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             for a in assignments:
                 # Bounce between core 0 and 1
                 a['core'] = (a['core'] + 1) % 2
-                admin.set_partition_replicas(topic, partition, assignments)
+            admin.set_partition_replicas(topic, partition, assignments)
             self._wait_post_move(topic, partition, assignments, 360)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)


### PR DESCRIPTION
## Cover letter

In https://github.com/redpanda-data/redpanda/pull/4192 , we added a new test that actively exercises the movement of consumer offsets partition.

There was one fix in that PR, but I believe the test may also depend on fixes in https://github.com/redpanda-data/redpanda/pull/4095 to pass reliably.

## Release notes

* none