### PR TITLE
k/fetch: validate fetch offset against high watermark

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -218,7 +218,7 @@ ss::future<> archival_metadata_stm::handle_eviction() {
       rc_node);
 
     if (res == cloud_storage::download_result::notfound) {
-        _insync_offset = raft::details::prev_offset(_raft->start_offset());
+        _insync_offset = model::prev_offset(_raft->start_offset());
         set_next(_raft->start_offset());
         vlog(_logger.info, "handled log eviction, the manifest is absent");
         co_return;
@@ -246,7 +246,7 @@ ss::future<> archival_metadata_stm::handle_eviction() {
     // that in the skipped batches there won't be any new remote segments.
     _insync_offset = _last_offset;
     auto next_offset = std::max(
-      _raft->start_offset(), raft::details::next_offset(_insync_offset));
+      _raft->start_offset(), model::next_offset(_insync_offset));
     set_next(next_offset);
 
     vlog(
@@ -325,7 +325,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
     }
 
     if (meta.committed_offset > _last_offset) {
-        if (meta.base_offset > raft::details::next_offset(_last_offset)) {
+        if (meta.base_offset > model::next_offset(_last_offset)) {
             // To ensure forward progress, we print a warning and skip over the
             // hole.
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -334,7 +334,7 @@ partition::get_term_last_offset(model::term_id term) const {
     }
     // Kafka defines leader epoch last offset as a first offset of next leader
     // epoch
-    return raft::details::next_offset(*o);
+    return model::next_offset(*o);
 }
 
 std::optional<model::offset>
@@ -345,7 +345,7 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
     }
     // Kafka defines leader epoch last offset as a first offset of next leader
     // epoch
-    return raft::details::next_offset(*o);
+    return model::next_offset(*o);
 }
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -123,7 +123,7 @@ public:
      * consumers. Named high_watermark to be consistent with Kafka nomenclature.
      */
     model::offset high_watermark() const {
-        return raft::details::next_offset(_raft->last_visible_index());
+        return model::next_offset(_raft->last_visible_index());
     }
 
     model::term_id term() { return _raft->term(); }

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -304,7 +304,7 @@ ss::future<> persisted_stm::start() {
     if (maybe_snapshot) {
         stm_snapshot& snapshot = *maybe_snapshot;
 
-        auto next_offset = raft::details::next_offset(snapshot.header.offset);
+        auto next_offset = model::next_offset(snapshot.header.offset);
         if (next_offset >= _c->start_offset()) {
             co_await apply_snapshot(snapshot.header, std::move(snapshot.data));
         } else {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1060,7 +1060,7 @@ model::offset rm_stm::last_stable_offset() {
         return first_tx_start;
     }
 
-    return raft::details::next_offset(last_visible_index);
+    return model::next_offset(last_visible_index);
 }
 
 static void filter_intersecting(

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -146,12 +146,10 @@ static ss::future<read_result> do_read_from_ntp(
     auto kafka_partition = make_partition_proxy(
       ntp_config.ntp(), cluster_pm, coproc_pm);
     if (unlikely(!kafka_partition)) {
-        return ss::make_ready_future<read_result>(
-          error_code::unknown_topic_or_partition);
+        co_return read_result(error_code::unknown_topic_or_partition);
     }
     if (unlikely(!kafka_partition->is_leader())) {
-        return ss::make_ready_future<read_result>(
-          error_code::not_leader_for_partition);
+        co_return read_result(error_code::not_leader_for_partition);
     }
 
     /**
@@ -160,7 +158,7 @@ static ss::future<read_result> do_read_from_ntp(
     auto leader_epoch_err = details::check_leader_epoch(
       ntp_config.cfg.current_leader_epoch, *kafka_partition);
     if (leader_epoch_err != error_code::none) {
-        return ss::make_ready_future<read_result>(leader_epoch_err);
+        co_return read_result(leader_epoch_err);
     }
 
     if (config::shard_local_cfg().enable_transactions.value()) {
@@ -183,11 +181,10 @@ static ss::future<read_result> do_read_from_ntp(
           ntp_config.ntp(),
           ntp_config.cfg.start_offset,
           kafka_partition->start_offset());
-        return ss::make_ready_future<read_result>(
-          error_code::offset_out_of_range);
+        co_return read_result(error_code::offset_out_of_range);
     }
 
-    return read_from_partition(
+    co_return co_await read_from_partition(
       std::move(*kafka_partition), ntp_config.cfg, foreign_read, deadline);
 }
 

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -34,11 +34,11 @@ public:
     }
 
     model::offset high_watermark() const final {
-        return raft::details::next_offset(_partition->dirty_offset());
+        return model::next_offset(_partition->dirty_offset());
     }
 
     model::offset last_stable_offset() const final {
-        return raft::details::next_offset(_partition->dirty_offset());
+        return model::next_offset(_partition->dirty_offset());
     }
 
     bool is_leader() const final { return _partition->is_leader(); }

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -84,6 +84,11 @@ public:
 
     cluster::partition_probe& probe() final { return _probe; }
 
+    ss::future<bool> is_fetch_offset_valid(
+      model::offset fetch_offset, model::timeout_clock::time_point) final {
+        co_return fetch_offset >= start_offset();
+    }
+
 private:
     static model::offset offset_or_zero(model::offset o) {
         return o > model::offset(0) ? o : model::offset(0);

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -51,6 +51,9 @@ public:
             model::offset,
             ss::lw_shared_ptr<const storage::offset_translator_state>)
           = 0;
+        virtual ss::future<bool>
+          is_fetch_offset_valid(model::offset, model::timeout_clock::time_point)
+          = 0;
         virtual cluster::partition_probe& probe() = 0;
         virtual ~impl() noexcept = default;
     };
@@ -99,6 +102,11 @@ public:
     std::optional<model::offset>
     get_leader_epoch_last_offset(kafka::leader_epoch epoch) const {
         return _impl->get_leader_epoch_last_offset(epoch);
+    }
+
+    ss::future<bool> is_fetch_offset_valid(
+      model::offset o, model::timeout_clock::time_point deadline) {
+        return _impl->is_fetch_offset_valid(o, deadline);
     }
 
 private:

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -94,6 +94,9 @@ public:
         return leader_epoch_from_term(_partition->term());
     }
 
+    ss::future<bool> is_fetch_offset_valid(
+      model::offset, model::timeout_clock::time_point) final;
+
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -99,6 +99,20 @@ using ns = named_type<ss::sstring, struct model_ns_type>;
 
 using offset = named_type<int64_t, struct model_offset_type>;
 
+inline constexpr model::offset next_offset(model::offset o) {
+    if (o < model::offset{0}) {
+        return model::offset{0};
+    }
+    return o + model::offset{1};
+}
+
+inline constexpr model::offset prev_offset(model::offset o) {
+    if (o <= model::offset{0}) {
+        return model::offset{};
+    }
+    return o - model::offset{1};
+}
+
 struct topic_partition_view {
     topic_partition_view(model::topic_view tp, model::partition_id p)
       : topic(tp)

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -592,7 +592,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     if (term != _term) {
         co_return ret_t(make_error_code(errc::not_leader));
     }
-    vlog(_ctxlog.trace, "Linearizble offset: {}", _commit_index);
+    vlog(_ctxlog.trace, "Linearizable offset: {}", _commit_index);
     co_return ret_t(_commit_index);
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -343,7 +343,7 @@ consensus::success_reply consensus::update_follower_index(
           reply.last_flushed_log_index);
         idx.last_dirty_log_index = reply.last_dirty_log_index;
         idx.last_flushed_log_index = reply.last_flushed_log_index;
-        idx.next_index = details::next_offset(idx.last_dirty_log_index);
+        idx.next_index = model::next_offset(idx.last_dirty_log_index);
     }
 
     if (reply.result == append_entries_reply::status::success) {
@@ -361,7 +361,7 @@ consensus::success_reply consensus::update_follower_index(
             // missing entries
             idx.last_dirty_log_index = reply.last_dirty_log_index;
             idx.last_flushed_log_index = reply.last_flushed_log_index;
-            idx.next_index = details::next_offset(idx.last_dirty_log_index);
+            idx.next_index = model::next_offset(idx.last_dirty_log_index);
             idx.last_sent_offset = model::offset{};
         }
         return success_reply::no;
@@ -453,7 +453,7 @@ void consensus::successfull_append_entries_reply(
     idx.last_dirty_log_index = reply.last_dirty_log_index;
     idx.last_flushed_log_index = reply.last_flushed_log_index;
     idx.match_index = idx.last_dirty_log_index;
-    idx.next_index = details::next_offset(idx.last_dirty_log_index);
+    idx.next_index = model::next_offset(idx.last_dirty_log_index);
     idx.last_successful_received_seq = idx.last_received_seq;
     vlog(
       _ctxlog.trace,
@@ -708,7 +708,7 @@ ss::future<model::record_batch_reader> consensus::make_reader(
 
         return _consumable_offset_monitor
           .wait(
-            details::next_offset(_majority_replicated_index),
+            model::next_offset(_majority_replicated_index),
             *debounce_timeout,
             _as)
           .then([this, config]() mutable { return do_make_reader(config); });
@@ -1072,7 +1072,7 @@ ss::future<> consensus::do_start() {
                 _configuration_manager.get_highest_known_offset());
               return details::read_bootstrap_state(
                 _log,
-                details::next_offset(
+                model::next_offset(
                   _configuration_manager.get_highest_known_offset()),
                 _as);
           })
@@ -1107,7 +1107,7 @@ ss::future<> consensus::do_start() {
                 lstats.dirty_offset);
 
               auto f = _configuration_manager.truncate(
-                details::next_offset(lstats.dirty_offset));
+                model::next_offset(lstats.dirty_offset));
 
               /**
                * We read some batches from the log and have to update the
@@ -1623,7 +1623,7 @@ consensus::do_append_entries(append_entries_request&& r) {
             return ss::make_ready_future<append_entries_reply>(
               std::move(reply));
         }
-        auto truncate_at = details::next_offset(
+        auto truncate_at = model::next_offset(
           model::offset(r.meta.prev_log_index));
         vlog(
           _ctxlog.info,
@@ -1647,12 +1647,11 @@ consensus::do_append_entries(append_entries_request&& r) {
           })
           .then([this, truncate_at] {
               _last_quorum_replicated_index = std::min(
-                details::prev_offset(truncate_at),
-                _last_quorum_replicated_index);
+                model::prev_offset(truncate_at), _last_quorum_replicated_index);
               // update flushed offset since truncation may happen to already
               // flushed entries
               _flushed_offset = std::min(
-                details::prev_offset(truncate_at), _flushed_offset);
+                model::prev_offset(truncate_at), _flushed_offset);
 
               return _configuration_manager.truncate(truncate_at).then([this] {
                   _probe.configuration_update();
@@ -1742,7 +1741,7 @@ ss::future<> consensus::truncate_to_latest_snapshot() {
     // _last_snapshot_index and thus can still need offset translation info.
     return _log
       .truncate_prefix(storage::truncate_prefix_config(
-        details::next_offset(_last_snapshot_index), _scheduling.default_iopc))
+        model::next_offset(_last_snapshot_index), _scheduling.default_iopc))
       .then([this] {
           return _configuration_manager.prefix_truncate(_last_snapshot_index);
       })
@@ -1931,7 +1930,7 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
     // Release the lock when truncating the log because it can take some
     // time while we wait for readers to be evicted.
     co_await _log.truncate_prefix(storage::truncate_prefix_config(
-      details::next_offset(last_included_index), _scheduling.default_iopc));
+      model::next_offset(last_included_index), _scheduling.default_iopc));
 
     co_await _op_lock.with([this, last_included_index] {
         return _configuration_manager.prefix_truncate(last_included_index)
@@ -1977,7 +1976,7 @@ consensus::do_write_snapshot(model::offset last_included_index, iobuf&& data) {
       .cluster_time = clock_type::time_point::min(),
       .log_start_delta = offset_translator_delta(
         _offset_translator.state()->delta(
-          details::next_offset(last_included_index))),
+          model::next_offset(last_included_index))),
     };
 
     return details::persist_snapshot(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -511,7 +511,6 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     if (_vstate != vote_state::leader) {
         co_return result<model::offset>(make_error_code(errc::not_leader));
     }
-    co_await flush_log();
     // store current commit index
     auto cfg = config();
     auto dirty_offset = _log.offsets().dirty_offset;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -255,7 +255,7 @@ public:
     timequery(storage::timequery_config cfg);
 
     model::offset start_offset() const {
-        return details::next_offset(_last_snapshot_index);
+        return model::next_offset(_last_snapshot_index);
     }
 
     model::offset dirty_offset() const { return _log.offsets().dirty_offset; }

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -463,7 +463,7 @@ ss::future<> create_offset_translator_state_for_pre_existing_partition(
   model::offset max_rp_offset) {
     // Prepare offset_translator state in kvstore
     storage::offset_translator_state ot_state(
-      ntp_cfg.ntp(), raft::details::prev_offset(min_rp_offset), 0);
+      ntp_cfg.ntp(), model::prev_offset(min_rp_offset), 0);
     co_await api.kvs().put(
       storage::kvstore::key_space::offset_translator,
       raft::offset_translator::kvstore_offsetmap_key(group),
@@ -471,7 +471,7 @@ ss::future<> create_offset_translator_state_for_pre_existing_partition(
     co_await api.kvs().put(
       storage::kvstore::key_space::offset_translator,
       raft::offset_translator::kvstore_highest_known_offset_key(group),
-      reflection::to_iobuf(raft::details::prev_offset(max_rp_offset)));
+      reflection::to_iobuf(model::prev_offset(max_rp_offset)));
 }
 
 ss::future<> create_raft_state_for_pre_existing_partition(

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -61,20 +61,6 @@ Iterator find_machine(Iterator begin, Iterator end, model::node_id id) {
       begin, end, [id](decltype(*begin) b) { return b.id() == id; });
 }
 
-inline constexpr model::offset next_offset(model::offset o) {
-    if (o < model::offset{0}) {
-        return model::offset{0};
-    }
-    return o + model::offset{1};
-}
-
-inline constexpr model::offset prev_offset(model::offset o) {
-    if (o <= model::offset{0}) {
-        return model::offset{};
-    }
-    return o - model::offset{1};
-}
-
 class term_assigning_reader : public model::record_batch_reader::impl {
 public:
     using data_t = model::record_batch_reader::data_t;

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -166,7 +166,7 @@ ss::future<> offset_translator::sync_with_log(
 
     // Trim the offset2delta map to log dirty_offset (discrepancy can
     // happen if the offsets map was persisted, but the log wasn't flushed).
-    if (_state->truncate(details::next_offset(log_offsets.dirty_offset))) {
+    if (_state->truncate(model::next_offset(log_offsets.dirty_offset))) {
         ++_map_version;
     }
 
@@ -176,7 +176,7 @@ ss::future<> offset_translator::sync_with_log(
     }
 
     // read the log to insert the remaining entries into map
-    model::offset start_offset = details::next_offset(_highest_known_offset);
+    model::offset start_offset = model::next_offset(_highest_known_offset);
     auto reader_cfg = storage::log_reader_config(
       start_offset, log_offsets.dirty_offset, ss::default_priority_class(), as);
     auto reader = co_await log.make_reader(reader_cfg);
@@ -224,7 +224,7 @@ ss::future<> offset_translator::truncate(model::offset offset) {
         ++_map_version;
     }
 
-    model::offset prev = details::prev_offset(offset);
+    model::offset prev = model::prev_offset(offset);
     _highest_known_offset = std::min(prev, _highest_known_offset);
 
     vlog(_logger.info, "truncate at offset: {}, new state: {}", offset, _state);

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -349,7 +349,7 @@ ss::future<> recovery_stm::handle_install_snapshot_reply(
 
     // snapshot received by the follower, continue with recovery
     (*meta)->match_index = _ptr->_last_snapshot_index;
-    (*meta)->next_index = details::next_offset(_ptr->_last_snapshot_index);
+    (*meta)->next_index = model::next_offset(_ptr->_last_snapshot_index);
     (*meta)->last_sent_offset = _ptr->_last_snapshot_index;
     return close_snapshot_reader();
 }
@@ -377,7 +377,7 @@ ss::future<> recovery_stm::replicate(
     // collect metadata for append entries request
     // last persisted offset is last_offset of batch before the first one in the
     // reader
-    auto prev_log_idx = details::prev_offset(_base_batch_offset);
+    auto prev_log_idx = model::prev_offset(_base_batch_offset);
     model::term_id prev_log_term;
 
     // get term for prev_log_idx batch
@@ -465,7 +465,7 @@ ss::future<> recovery_stm::replicate(
                   return;
               }
               meta.value()->next_index = std::max(
-                model::offset(0), details::prev_offset(_base_batch_offset));
+                model::offset(0), model::prev_offset(_base_batch_offset));
               meta.value()->last_sent_offset = model::offset{};
               vlog(
                 _ctxlog.trace,

--- a/src/v/raft/tests/consensus_utils_test.cc
+++ b/src/v/raft/tests/consensus_utils_test.cc
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_filling_gaps) {
 
     for (auto& b : without_gaps) {
         BOOST_REQUIRE_EQUAL(b.base_offset(), first_expected);
-        first_expected = raft::details::next_offset(b.last_offset());
+        first_expected = model::next_offset(b.last_offset());
     }
 }
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_filling_first_gap) {
 
     for (auto& b : without_gaps) {
         BOOST_REQUIRE_EQUAL(b.base_offset(), first_expected);
-        first_expected = raft::details::next_offset(b.last_offset());
+        first_expected = model::next_offset(b.last_offset());
     }
 }
 
@@ -121,6 +121,6 @@ BOOST_AUTO_TEST_CASE(test_filling_gaps_larger_than_batch_size) {
 
     for (auto& b : without_gaps) {
         BOOST_REQUIRE_EQUAL(b.base_offset(), first_expected);
-        first_expected = raft::details::next_offset(b.last_offset());
+        first_expected = model::next_offset(b.last_offset());
     }
 }

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -274,14 +274,6 @@ FIXTURE_TEST(immutability_test, offset_translator_fixture) {
     validate_offsets_immutable(truncate_at + 1);
 }
 
-static model::offset next_offset(model::offset o) {
-    if (o() < 0) {
-        return model::offset{0};
-    } else {
-        return o + model::offset{1};
-    }
-}
-
 static ss::future<std::vector<model::offset>>
 collect_base_offsets(storage::log log) {
     struct consumer {
@@ -488,7 +480,7 @@ struct fuzz_checker {
             BOOST_REQUIRE_EQUAL(hwm_lo, _tr->state()->to_log_offset(hwm_ko));
         }
 
-        int64_t start_log_offset = next_offset(_snapshot_offset)();
+        int64_t start_log_offset = model::next_offset(_snapshot_offset)();
         if (start_log_offset >= _kafka_offsets.size()) {
             // empty log
             return;

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -15,24 +15,6 @@
 
 namespace storage {
 
-namespace {
-
-inline constexpr model::offset next_offset(model::offset o) {
-    if (o < model::offset{0}) {
-        return model::offset{0};
-    }
-    return o + model::offset{1};
-}
-
-inline constexpr model::offset prev_offset(model::offset o) {
-    if (o <= model::offset{0}) {
-        return model::offset{};
-    }
-    return o - model::offset{1};
-}
-
-} // namespace
-
 int64_t offset_translator_state::delta(model::offset o) const {
     if (_last_offset2batch.empty()) {
         return 0;
@@ -45,7 +27,7 @@ int64_t offset_translator_state::delta(model::offset o) const {
           "{})",
           _ntp,
           o,
-          next_offset(_last_offset2batch.begin()->first))};
+          model::next_offset(_last_offset2batch.begin()->first))};
     }
 
     auto delta = std::prev(it)->second.next_delta;
@@ -73,7 +55,7 @@ model::offset offset_translator_state::to_log_offset(
         return data_offset;
     }
 
-    model::offset min_log_offset = next_offset(
+    model::offset min_log_offset = model::next_offset(
       _last_offset2batch.begin()->first);
 
     model::offset min_data_offset
@@ -105,7 +87,7 @@ model::offset offset_translator_state::to_log_offset(
 
     while (interval_end_it != _last_offset2batch.end()) {
         model::offset max_do_this_interval
-          = prev_offset(interval_end_it->second.base_offset)
+          = model::prev_offset(interval_end_it->second.base_offset)
             - model::offset{delta};
         if (max_do_this_interval >= data_offset) {
             break;
@@ -161,7 +143,7 @@ void offset_translator_state::add_gap(
 
 bool offset_translator_state::add_absolute_delta(
   model::offset offset, int64_t delta) {
-    auto prev = prev_offset(offset);
+    auto prev = model::prev_offset(offset);
 
     if (_last_offset2batch.empty()) {
         vassert(

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -30,10 +30,6 @@ class MultiRestartTest(EndToEndTest):
         super(MultiRestartTest, self).__init__(test_context=test_context,
                                                extra_rp_conf=extra_rp_conf)
 
-    def tearDown(self):
-        self.s3_client.empty_bucket(self.s3_bucket_name)
-        super().tearDown()
-
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_recovery_after_multiple_restarts(self):
         # If a debug build has to do a restart across a significant


### PR DESCRIPTION
Added validation of fetch partition start offset against partition high watermark. Previously we only validated fetch start offset against partition start offset and requests with fetch start offsets larger than high watermark returned empty record set. Kafka is more strict when validating fetch start offset and for requests with requested offset larger than high watermark it returns `offset_out_of_range` error.

Fixes: #4181
Depends on: #4555