### PR TITLE
Reset state base transport

### DIFF
--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -41,6 +41,7 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
           server_address()));
     }
     try {
+        reset_state();
         auto resolved_address = co_await net::resolve_dns(server_address());
         ss::connected_socket fd = co_await connect_with_timeout(
           resolved_address, timeout);

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -51,6 +51,11 @@ public:
 
     virtual ss::future<>
       connect(clock_type::time_point = clock_type::time_point::max());
+
+    // override this method to reset internal state when connection attempt is
+    // being made
+    virtual void reset_state() {}
+
     ss::future<> stop();
     void shutdown() noexcept;
 

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -79,11 +79,14 @@ ss::future<> transport::connect(clock_type::duration connection_timeout) {
     return connect(connection_timeout + rpc::clock_type::now());
 }
 
-ss::future<>
-transport::connect(rpc::clock_type::time_point connection_timeout) {
+void transport::reset_state() {
     _correlation_idx = 0;
     _last_seq = sequence_t{0};
     _seq = sequence_t{0};
+}
+
+ss::future<>
+transport::connect(rpc::clock_type::time_point connection_timeout) {
     return base_transport::connect(connection_timeout).then([this] {
         // background
         ssx::spawn_with_gate(_dispatch_gate, [this] {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -61,6 +61,8 @@ public:
     ss::future<result<client_context<Output>>>
       send_typed(Input, uint32_t, rpc::client_opts);
 
+    void reset_state() final;
+
 private:
     using sequence_t = named_type<uint64_t, struct sequence_tag>;
     struct entry {


### PR DESCRIPTION
## Cover letter
Added `base_transport::reset_state` virtual method allowing deriving classes to implement state reset that has to be done when reconnecting underlying socket.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
