### PR TITLE
r/consensus: added more context to stepdown log

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -141,12 +141,13 @@ void consensus::setup_metrics() {
          labels)});
 }
 
-void consensus::do_step_down() {
+void consensus::do_step_down(std::string_view ctx) {
     _hbeat = clock_type::now();
     if (_vstate == vote_state::leader) {
         vlog(
           _ctxlog.info,
-          "Stepping down as leader in term {}, dirty offset {}",
+          "[{}] Stepping down as leader in term {}, dirty offset {}",
+          ctx,
           _term,
           _log.offsets().dirty_offset);
     }
@@ -163,7 +164,7 @@ void consensus::maybe_step_down() {
                 }
 
                 if (majority_hbeat + _jit.base_duration() < clock_type::now()) {
-                    do_step_down();
+                    do_step_down("heartbeats_majority");
                     if (_leader_id) {
                         _leader_id = std::nullopt;
                         trigger_leadership_notification();
@@ -1424,7 +1425,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request&& r) {
         reply.term = r.term;
         _term = r.term;
         _voted_for = {};
-        do_step_down();
+        do_step_down("voter_term_greater");
         if (_leader_id) {
             _leader_id = std::nullopt;
             trigger_leadership_notification();
@@ -1512,7 +1513,7 @@ consensus::do_append_entries(append_entries_request&& r) {
      * it updates its target priority to the initial value
      */
     _target_priority = voter_priority::max();
-    do_step_down();
+    do_step_down("append_entries_term_greater");
     if (r.meta.term > _term) {
         vlog(
           _ctxlog.debug,
@@ -1816,7 +1817,7 @@ consensus::do_install_snapshot(install_snapshot_request&& r) {
     if (r.term > _term) {
         _term = r.term;
         _voted_for = {};
-        do_step_down();
+        do_step_down("install_snapshot_term_greater");
         return do_install_snapshot(std::move(r));
     }
 
@@ -2341,7 +2342,7 @@ ss::future<> consensus::maybe_commit_configuration(ss::semaphore_units<> u) {
                   vlog(
                     _ctxlog.trace,
                     "current node is not longer group member, stepping down");
-                  do_step_down();
+                  do_step_down("not_longer_member");
               }
           });
     }
@@ -2866,7 +2867,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                           // (If we accepted more writes, our log could get
                           //  ahead of new leader, and it could lose election)
                           auto units = co_await _op_lock.get_units();
-                          do_step_down();
+                          do_step_down("leadership_transfer");
                           if (_leader_id) {
                               _leader_id = std::nullopt;
                               trigger_leadership_notification();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -246,7 +246,7 @@ public:
             if (term > _term) {
                 _term = term;
                 _voted_for = {};
-                do_step_down();
+                do_step_down("external_stepdown");
             }
         });
     }
@@ -359,7 +359,7 @@ private:
       = ss::bool_class<struct update_last_quorum_index>;
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
-    void do_step_down();
+    void do_step_down(std::string_view);
     ss::future<vote_reply> do_vote(vote_request&&);
     ss::future<append_entries_reply>
     do_append_entries(append_entries_request&&);


### PR DESCRIPTION
Added more context to `stepping down` log entry. Now we will be able to
check what was the actual reason of a node stepping down.

fixes #4210 

## Release notes
### Improvements
- make debugging raft issues easier
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements


-->
