### PR TITLE
Add a version field in the operator's status

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -286,6 +286,9 @@ type ClusterStatus struct {
 	// Indicates cluster is upgrading
 	// +optional
 	Upgrading bool `json:"upgrading"`
+	// Current version of the cluster.
+	// +optional
+	Version string `json:"version"`
 	// Current state of the cluster.
 	// +optional
 	Conditions []ClusterCondition `json:"conditions,omitempty"`

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -905,6 +905,9 @@ spec:
               upgrading:
                 description: Indicates cluster is upgrading
                 type: boolean
+              version:
+                description: Current version of the cluster.
+                type: string
             type: object
         type: object
     served: true

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -50,3 +50,12 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+
+---
+
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster-and-node-port
+status:
+  version: "v21.11.1"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -78,3 +78,12 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+
+---
+
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster-and-node-port
+status:
+  version: "v21.11.2"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -39,3 +39,12 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+
+---
+
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster-and-node-port
+status:
+  version: "dev"


### PR DESCRIPTION
## Cover letter

Currently, the agent needs to retrieve the statefulset resource to ensure the upgrade has started (for the desired version).

The operator should provide a "version" status field that shows the current version. That would be in addition to the "upgrading" field currently available.

This way we wouldn't need to rely on the statefulset resource.

## Release notes

### Improvements

* Cluster status stanza will have version field for convenience.

