### PR TITLE
kafka: add `kafka_connections_max_overrides`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -812,10 +812,20 @@ configuration::configuration()
   , kafka_connections_max_per_ip(
       *this,
       "kafka_connections_max_per_ip",
-      "Maximum number of Kafka client connections from each IP addreess, per "
+      "Maximum number of Kafka client connections from each IP address, per "
       "broker",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , kafka_connections_max_overrides(
+      *this,
+      "kafka_connections_max_overrides",
+      "Per-IP overrides of kafka connection count limit, list of "
+      "<ip>:<count> strings",
+      {.needs_restart = needs_restart::no,
+       .example = R"(['127.0.0.1:90', '50.20.1.1:40'])",
+       .visibility = visibility::user},
+      {},
+      validate_connection_rate)
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -179,6 +179,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> members_backend_retry_ms;
     property<std::optional<uint32_t>> kafka_connections_max;
     property<std::optional<uint32_t>> kafka_connections_max_per_ip;
+    property<std::vector<ss::sstring>> kafka_connections_max_overrides;
 
     // Archival storage
     property<bool> cloud_storage_enabled;

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -29,6 +29,7 @@ class conn_quota;
 struct conn_quota_config {
     config::binding<std::optional<uint32_t>> max_connections;
     config::binding<std::optional<uint32_t>> max_connections_per_ip;
+    config::binding<std::vector<ss::sstring>> max_connections_overrides;
 };
 
 /**
@@ -199,6 +200,8 @@ private:
         return const_cast<conn_quota&>(*this).get_remote_allowance(addr);
     };
 
+    void apply_overrides();
+
     /**
      * A note on types:
      * - the home_allowance instances in the `ip_home` map need to
@@ -218,6 +221,9 @@ private:
     absl::flat_hash_map<inet_address_key, ss::lw_shared_ptr<home_allowance>>
       ip_home;
     absl::flat_hash_map<inet_address_key, remote_allowance> ip_remote;
+
+    // Parsed content of _cfg.max_connections_overrides.
+    absl::flat_hash_map<inet_address_key, uint32_t> overrides;
 
     // Apply a configuration change
     void

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -974,6 +974,8 @@ void application::wire_up_redpanda_services() {
             = config::shard_local_cfg().kafka_connections_max.bind(),
             .max_connections_per_ip
             = config::shard_local_cfg().kafka_connections_max_per_ip.bind(),
+            .max_connections_overrides
+            = config::shard_local_cfg().kafka_connections_max_overrides.bind(),
           };
       })
       .get();

--- a/tests/rptest/tests/connection_limits_test.py
+++ b/tests/rptest/tests/connection_limits_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import re
+import socket
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
@@ -15,6 +15,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.clients.types import TopicSpec
 from rptest.services.metrics_check import MetricCheck
+from rptest.util import expect_exception
 
 REJECTED_METRIC = "vectorized_kafka_rpc_connections_rejected_total"
 
@@ -98,3 +99,73 @@ class ConnectionLimitsTest(RedpandaTest):
             m.evaluate([(REJECTED_METRIC, lambda a, b: b == a)])
             for m in metrics
         ])
+
+    @cluster(num_nodes=3)
+    def test_overrides(self):
+        """
+        Check that per-IP overrides are applied correctly.  More
+        detailed tests are in the unit test: this is a smoke test
+        that some overrides work end to end.
+        """
+        def setup_producers():
+            producer_a = RpkProducer(self.test_context,
+                                     self.redpanda,
+                                     self.topic,
+                                     msg_size=16384,
+                                     msg_count=1,
+                                     quiet=True,
+                                     produce_timeout=5)
+            producer_a_addr = socket.gethostbyname(producer_a.nodes[0].name)
+
+            producer_b = RpkProducer(self.test_context,
+                                     self.redpanda,
+                                     self.topic,
+                                     msg_size=16384,
+                                     msg_count=1,
+                                     quiet=True,
+                                     produce_timeout=5)
+            producer_b_addr = socket.gethostbyname(producer_b.nodes[0].name)
+
+            return producer_a, producer_a_addr, producer_b, producer_b_addr
+
+        producer_a, producer_a_addr, producer_b, producer_b_addr = setup_producers(
+        )
+
+        self.logger.info(
+            f"producer_a: {producer_a_addr}, producer_b: {producer_b_addr}")
+
+        self.redpanda.set_cluster_config(
+            {"kafka_connections_max_overrides": [
+                f"{producer_a_addr}:0",
+            ]})
+
+        self.logger.info(f"Trying producer_a, should be blocked")
+        with expect_exception(Exception,
+                              lambda e: 'timeout' in str(e).lower()):
+            producer_a.start()
+            producer_a.wait()
+
+        self.logger.info(f"Tearing down producer_a")
+        with expect_exception(Exception,
+                              lambda e: 'timeout' in str(e).lower()):
+            producer_a.stop()
+        producer_a.free()
+
+        self.logger.info(f"Trying producer_b, should be OK")
+        producer_b.start()
+        producer_b.wait()
+        producer_b.free()
+
+        self.redpanda.set_cluster_config(
+            {"kafka_connections_max_overrides": []})
+
+        producer_a, producer_a_addr, producer_b, producer_b_addr = setup_producers(
+        )
+
+        # Both producers should work now
+        producer_a.start()
+        producer_b.start()
+        producer_a.wait()
+        producer_b.wait()
+        producer_a.free()
+        producer_b.free()


### PR DESCRIPTION
## Cover letter

This is followup to where `kafka_connections_max` and `kafka_connections_max_per_ip` were added.  This change adds an "overrides" config property that lets the user target particular client addresses for special treatment.

This can be used as a field-expedient firewall, or for environments where certain hosts are known to run large numbers of clients.

## Release notes

### Features

* Configuration property `kafka_connections_max_overrides` is added, enabling setting connection count limits on individual client IPs.
