### PR TITLE
Do not update connections with old config

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -275,11 +275,6 @@ members_manager::apply_raft_configuration_batch(model::record_batch b) {
       "Current batch contains {} records",
       b.record_count());
 
-    // members manager already seen this configuration, skip
-    if (b.base_offset() < _last_seen_configuration_offset) {
-        co_return make_error_code(errc::success);
-    }
-
     auto cfg = reflection::from_iobuf<raft::group_configuration>(
       b.copy_records().front().release_value());
 

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -121,7 +121,6 @@ private:
     ss::future<std::error_code>
       apply_raft_configuration_batch(model::record_batch);
 
-    model::offset _last_seen_configuration_offset;
     std::vector<config::seed_server> _seed_servers;
     model::broker _self;
     simple_time_jitter<model::timeout_clock> _join_retry_jitter;

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -136,6 +136,7 @@ private:
     ss::gate _gate;
     ss::queue<node_update> _update_queue;
     ss::abort_source::subscription _queue_abort_subscription;
+    model::offset _last_connection_update_offset;
 };
 
 std::ostream&


### PR DESCRIPTION
## Cover letter

Cluster members manager listens to `raft0` configuration updates and use
the configuration contained brokers list to update connection list.
Currently when node is restarted it uses latest `raft0` configuration to
updates its connections and send hello requests to other cluster
members. Added fix preventing us from updating connections with
configuration older than used previously. Connection updates are made in
an incremental manner i.e. we use diff of current and previous brokers
lists to remove and create connections. Applying updates out of order
would result in some of the connections not being removed.


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
