### PR TITLE
Infinite retention

### DIFF
--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -110,7 +110,7 @@ struct configuration final : public config_store {
     property<bool> enable_transactions;
     property<uint32_t> abort_index_segment_size;
     // same as log.retention.ms in kafka
-    property<std::chrono::milliseconds> delete_retention_ms;
+    retention_duration_property delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -23,7 +23,12 @@
 
 #include <boost/intrusive/list.hpp>
 
+#include <chrono>
+#include <optional>
+
 namespace config {
+
+using namespace std::chrono_literals;
 
 template<class T>
 class binding;
@@ -591,6 +596,44 @@ private:
     }
 
     std::vector<T> _values;
+};
+
+class retention_duration_property final
+  : public property<std::optional<std::chrono::milliseconds>> {
+public:
+    using property::property;
+    void set_value(std::any v) final {
+        update_value(std::any_cast<std::chrono::milliseconds>(std::move(v)));
+    }
+    bool set_value(YAML::Node n) final {
+        return update_value(n.as<std::chrono::milliseconds>());
+    }
+
+    void print(std::ostream& o) const final {
+        o << name() << ":";
+
+        if (is_secret() && !is_default()) {
+            o << secret_placeholder;
+        } else {
+            o << _value.value_or(-1ms);
+        }
+    }
+
+    // serialize the value. the key is taken from the property name at the
+    // serialization point in config_store::to_json to avoid users from being
+    // forced to consume the property as a json object.
+    void to_json(json::Writer<json::StringBuffer>& w) const final {
+        json::rjson_serialize(w, _value.value_or(-1ms));
+    }
+
+private:
+    bool update_value(std::chrono::milliseconds value) {
+        if (value < 0ms) {
+            return property::update_value(std::nullopt);
+        } else {
+            return property::update_value(value);
+        }
+    }
 };
 
 }; // namespace config

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs
     bounded_property_test.cc
     enum_property_test.cc
+    retention_property_test.cc
     config_store_test.cc
     socket_address_convert_test.cc
     tls_config_convert_test.cc

--- a/src/v/config/tests/retention_property_test.cc
+++ b/src/v/config/tests/retention_property_test.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/config_store.h"
+#include "config/property.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
+#include <optional>
+
+namespace {
+using namespace std::chrono_literals;
+
+struct test_config : public config::config_store {
+    config::retention_duration_property valid_retention;
+    config::retention_duration_property inf_retention;
+    config::retention_duration_property default_retention;
+
+    test_config()
+      : valid_retention(
+        *this,
+        "valid_retention",
+        "A positive value",
+        {.needs_restart = config::needs_restart::no,
+         .visibility = config::visibility::user},
+        10080min)
+      , inf_retention(
+          *this,
+          "inf_retention",
+          "-1 should be interpreted as infinity",
+          {.needs_restart = config::needs_restart::no,
+           .visibility = config::visibility::user},
+          10080min)
+      , default_retention(
+          *this,
+          "default_retention",
+          "not set retention config should return default value",
+          {.needs_restart = config::needs_restart::no,
+           .visibility = config::visibility::user},
+          10080min) {}
+};
+
+SEASTAR_THREAD_TEST_CASE(test_retention_property) {
+    auto cfg = test_config();
+
+    cfg.valid_retention.set_value(YAML::Load("4095"));
+    BOOST_CHECK(cfg.valid_retention() == std::chrono::milliseconds(4095));
+
+    cfg.valid_retention.set_value(std::chrono::milliseconds(809098));
+    BOOST_CHECK(cfg.valid_retention() == std::chrono::milliseconds(809098));
+
+    cfg.inf_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(cfg.inf_retention() == std::nullopt);
+
+    cfg.inf_retention.set_value(std::chrono::milliseconds(-1));
+    BOOST_CHECK(cfg.inf_retention() == std::nullopt);
+
+    BOOST_CHECK(cfg.default_retention().value() == std::optional(10080min));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_retention_property_polymorphism) {
+    auto cfg = test_config();
+    using base = config::property<std::optional<std::chrono::milliseconds>>;
+
+    base& valid_retention = cfg.valid_retention;
+    valid_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(valid_retention() == std::nullopt);
+
+    base& inf_retention = cfg.inf_retention;
+    inf_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(inf_retention() == std::nullopt);
+
+    inf_retention.set_value(std::chrono::milliseconds(-1));
+    BOOST_CHECK(inf_retention() == std::nullopt);
+
+    base& default_retention = cfg.default_retention;
+    BOOST_CHECK(default_retention().value() == std::optional(10080min));
+}
+} // namespace

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -333,8 +333,8 @@ static void report_broker_config(
       "log.retention.ms",
       config::shard_local_cfg().delete_retention_ms,
       include_synonyms,
-      [](const std::chrono::milliseconds& ms) {
-          return ssx::sformat("{}", ms.count());
+      [](const std::optional<std::chrono::milliseconds>& ret) {
+          return ssx::sformat("{}", ret.value_or(-1ms).count());
       });
 
     add_broker_config_if_requested(

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -536,7 +536,8 @@ FIXTURE_TEST(
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}", config::shard_local_cfg().delete_retention_ms.value().count()),
+        "{}",
+        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
       new_describe_resp);
     assert_property_value(
       test_tp, "retention.bytes", "4096", new_describe_resp);
@@ -632,7 +633,8 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}", config::shard_local_cfg().delete_retention_ms.value().count()),
+        "{}",
+        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
       new_describe_resp);
 }
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -64,8 +64,9 @@ struct log_config {
           config::mock_binding<std::optional<size_t>>(std::nullopt))
       , compaction_interval(config::mock_binding<std::chrono::milliseconds>(
           std::chrono::minutes(10)))
-      , delete_retention(config::mock_binding<std::chrono::milliseconds>(
-          std::chrono::minutes(10080))) {}
+      , delete_retention(
+          config::mock_binding<std::optional<std::chrono::milliseconds>>(
+            std::chrono::minutes(10080))) {}
 
     log_config(
       storage_type type,
@@ -88,7 +89,7 @@ struct log_config {
       ss::io_priority_class compaction_priority,
       config::binding<std::optional<size_t>> ret_bytes,
       config::binding<std::chrono::milliseconds> compaction_ival,
-      config::binding<std::chrono::milliseconds> del_ret,
+      config::binding<std::optional<std::chrono::milliseconds>> del_ret,
       with_cache c,
       batch_cache::reclaim_options recopts,
       std::chrono::milliseconds rdrs_cache_eviction_timeout,
@@ -130,7 +131,7 @@ struct log_config {
     config::binding<std::optional<size_t>> retention_bytes;
     config::binding<std::chrono::milliseconds> compaction_interval;
     // same as delete.retention.ms in kafka - default 1 week
-    config::binding<std::chrono::milliseconds> delete_retention;
+    config::binding<std::optional<std::chrono::milliseconds>> delete_retention;
     with_cache cache = with_cache::yes;
     batch_cache::reclaim_options reclaim_opts{
       .growth_window = std::chrono::seconds(3),


### PR DESCRIPTION
## Cover letter

`delete_retention_ms` should interpret `-1` as infinite retention, e.i.
 never delete data. New subclass `retention_property` overloads
 `set_value` method to change `-1` to `max_int`.

Fixes #4171

## Release notes
* `delete_retention_ms` interprets `-1` as infinite retention, e.i.
 never delete data. This is Kafka-compatible and in line with existing documentation