### PR TITLE
Reset leaders table

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -179,6 +179,8 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
     return _leaders.local().get_leader(model::controller_ntp);
 }
 
+void metadata_cache::reset_leaders() { _leaders.local().reset(); }
+
 /**
  * hard coded defaults
  */

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -136,6 +136,8 @@ public:
     /// If present returns a leader of raft0 group
     std::optional<model::node_id> get_controller_leader_id();
 
+    void reset_leaders();
+
     model::compression get_default_compression() const;
     model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;
     model::compaction_strategy get_default_compaction_strategy() const;

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -96,6 +96,8 @@ public:
       model::term_id,
       std::optional<model::node_id>);
 
+    void reset() { _leaders.clear(); }
+
 private:
     // optimized to reduce number of ntp copies
     struct leader_key {

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -69,6 +69,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/transaction.json.h
 )
 
+seastar_generate_swagger(
+  TARGET debug_swagger
+  VAR debug_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/debug.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/debug.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS 
@@ -93,7 +100,7 @@ target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger cluster_config_swagger raft_swagger
     security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger
-    transaction_swagger features_swagger)
+    transaction_swagger features_swagger debug_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1,0 +1,26 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/debug",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/debug/reset_leaders",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Reset information about leaders for node",
+                    "type": "void",
+                    "nickname": "reset_leaders_info",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        }
+    ]
+}

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -183,6 +183,7 @@ private:
     void register_partition_routes();
     void register_hbadger_routes();
     void register_transaction_routes();
+    void register_debug_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -331,10 +331,11 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership?target={target_id}"
         self._request("POST", path)
 
-    def get_partition_leader(self, *, namespace, topic, partition):
+    def get_partition_leader(self, *, namespace, topic, partition, node=None):
         partition_info = self.get_partitions(topic=topic,
                                              partition=partition,
-                                             namespace=namespace)
+                                             namespace=namespace,
+                                             node=node)
 
         return partition_info['leader_id']
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -408,3 +408,12 @@ class Admin:
         self.redpanda.logger.info(
             f"Getting maintenance status on node {node.name}/{id}")
         return self._request("get", "maintenance", node=node).json()
+
+    def reset_leaders_info(self, node):
+        """
+        Reset info for leaders on node
+        """
+        id = self.redpanda.idx(node)
+        self.redpanda.logger.info(f"Reset leaders info on {node.name}/{id}")
+        url = "debug/reset_leaders"
+        return self._request("post", url, node=node)

--- a/tests/rptest/tests/leaders_info_api_test.py
+++ b/tests/rptest/tests/leaders_info_api_test.py
@@ -68,3 +68,26 @@ class LeadersInfoApiTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1,
                    err_msg="Can not refresh leaders")
+
+
+class LeadersInfoApiEndToEndTest(EndToEndTest):
+    @cluster(num_nodes=5)
+    def reset_leaders_info_end_to_end_test(self):
+        self.start_redpanda(num_nodes=3)
+        self.admin = Admin(self.redpanda)
+
+        self.spec = TopicSpec(partition_count=3, replication_factor=3)
+
+        self.client().create_topic(self.spec)
+        self.topic = self.spec.name
+
+        self.start_producer(1, throughput=100)
+        self.start_consumer(1)
+        self.await_startup(min_records=100, timeout_sec=180)
+
+        for node in self.redpanda.nodes:
+            self.admin.reset_leaders_info(node)
+
+        self.run_validation(min_records=10000,
+                            producer_timeout_sec=180,
+                            consumer_timeout_sec=180)


### PR DESCRIPTION
## Cover letter

This pr implements new admin_api request to reset leaders_table on node.

On some cases leaders_table can not be updated long time. So client request can be failed in this cases.
New request allows us force leaders table by hand, after it shard should be refresh all info about leaders.

```
"path": "/v1/debug/reset_leaders",
"operations": [
    {
        "method": "POST",
        "summary": "Reset information about leaders for node",
      ...
  }
```

## Release notes

* Add `/v1/debug/reset_leaders` request to reset leaders info on node