### PR TITLE
CODEOWNERS: remove docs/ hook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,6 @@
 # docs, prose, legal
 #
 licenses           @senior7515 @dswang
-*.md               @coral-waters
-/docs              @coral-waters
 /CONTRIBUTING.md   @dotnwat
 
 #


### PR DESCRIPTION
## Cover letter

The user-facing docs have moved elsewhere, so
we don't need github to notify Coral on RFCs
unless a developer actively asks.

## Release notes

* none
