### PR TITLE
CODEOWNERS: address syntax error checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,7 +61,7 @@ licenses           @senior7515 @dswang
 /src/v/rpc             @mmaslankaprv        @jcsp
 /src/v/s3              @lazin
 /src/v/security        @dotnwat
-/src/v/serde           @felixguendling      @benpope
+/src/v/serde           @benpope
 /src/v/ssx             @benpope
 /src/v/storage         @dotnwat             @lenaan      @vadimplh
 /src/v/syschecks       @mmaslankaprv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ licenses           @senior7515 @dswang
 #
 # cloud
 #
-/src/go/k8s   @vectorizedio/k8s
+/src/go/k8s   @redpanda-data/k8s
 
 #
 # build


### PR DESCRIPTION
update `CODEOWNERS` to address errors  during syntax [check](https://github.blog/changelog/2022-02-17-codeowners-improvements-syntax-errors-preview-of-who-will-be-requested-and-more/)