### PR TITLE
storage: Filter timequery for raft_data

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -316,9 +316,8 @@ ss::future<> partition::stop() {
     return f;
 }
 
-ss::future<std::optional<storage::timequery_result>> partition::timequery(
-  model::timestamp t, model::offset offset_limit, ss::io_priority_class p) {
-    storage::timequery_config cfg(t, offset_limit, p);
+ss::future<std::optional<storage::timequery_result>>
+partition::timequery(storage::timequery_config cfg) {
     return _raft->timequery(cfg);
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -135,7 +135,7 @@ public:
     const model::ntp& ntp() const { return _raft->ntp(); }
 
     ss::future<std::optional<storage::timequery_result>>
-      timequery(model::timestamp, model::offset, ss::io_priority_class);
+      timequery(storage::timequery_config);
 
     bool is_leader() const { return _raft->is_leader(); }
     bool has_followers() const { return _raft->has_followers(); }

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -121,7 +121,10 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
-      timestamp, offset_limit, kafka_read_priority(), std::nullopt});
+      timestamp,
+      offset_limit,
+      kafka_read_priority(),
+      {model::record_batch_type::raft_data}});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -120,8 +120,8 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 ? kafka_partition->last_stable_offset()
                                 : kafka_partition->high_watermark();
 
-    auto res = co_await kafka_partition->timequery(
-      timestamp, offset_limit, kafka_read_priority());
+    auto res = co_await kafka_partition->timequery(storage::timequery_config{
+      timestamp, offset_limit, kafka_read_priority()});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -121,7 +121,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
-      timestamp, offset_limit, kafka_read_priority()});
+      timestamp, offset_limit, kafka_read_priority(), std::nullopt});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -69,11 +69,8 @@ public:
           co_await _partition->make_reader(cfg));
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) final {
-        storage::timequery_config cfg(ts, offset_limit, io_pc);
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) final {
         return _partition->timequery(cfg);
     };
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -44,7 +44,7 @@ public:
           std::optional<model::timeout_clock::time_point>)
           = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
-          timequery(model::timestamp, model::offset, ss::io_priority_class) = 0;
+          timequery(storage::timequery_config) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
           aborted_transactions(
             model::offset,
@@ -87,11 +87,9 @@ public:
         return _impl->make_reader(cfg, deadline);
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) {
-        return _impl->timequery(ts, offset_limit, io_pc);
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) {
+        return _impl->timequery(cfg);
     }
 
     cluster::partition_probe& probe() { return _impl->probe(); }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -146,12 +146,9 @@ replicated_partition::aborted_transactions(
 }
 
 ss::future<std::optional<storage::timequery_result>>
-replicated_partition::timequery(
-  model::timestamp ts,
-  model::offset offset_limit,
-  ss::io_priority_class io_pc) {
-    return _partition->timequery(ts, offset_limit, io_pc)
-      .then([this](std::optional<storage::timequery_result> r) {
+replicated_partition::timequery(storage::timequery_config cfg) {
+    return _partition->timequery(cfg).then(
+      [this](std::optional<storage::timequery_result> r) {
           if (r) {
               r->offset = _translator->from_log_offset(r->offset);
           }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -65,10 +65,8 @@ public:
         co_return r.error();
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) final;
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) final;
 
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -871,7 +871,7 @@ disk_log_impl::make_reader(timequery_config config) {
             0,
             2048, // We just need one record batch
             cfg.prio,
-            std::nullopt,
+            cfg.type_filter,
             cfg.time,
             cfg.abort_source);
           return model::make_record_batch_reader<log_reader>(

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -47,7 +47,8 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
         storage::timequery_config config(
           model::timestamp(ts),
           log.offsets().dirty_offset,
-          ss::default_priority_class());
+          ss::default_priority_class(),
+          std::nullopt);
 
         auto res = log.timequery(config).get0();
         BOOST_TEST(res);
@@ -68,7 +69,8 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
         storage::timequery_config config(
           model::timestamp(ts),
           log.offsets().dirty_offset,
-          ss::default_priority_class());
+          ss::default_priority_class(),
+          std::nullopt);
 
         auto offset = (ts - 100) * 5 + 100;
 
@@ -100,7 +102,8 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
     storage::timequery_config config(
       model::timestamp(1200),
       log.offsets().dirty_offset,
-      ss::default_priority_class());
+      ss::default_priority_class(),
+      std::nullopt);
 
     auto empty_res = log.timequery(config).get0();
     BOOST_TEST(!empty_res);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -74,7 +74,15 @@ std::ostream& operator<<(std::ostream& o, const timequery_result& a) {
     return o << "{offset:" << a.offset << ", time:" << a.time << "}";
 }
 std::ostream& operator<<(std::ostream& o, const timequery_config& a) {
-    return o << "{max_offset:" << a.max_offset << ", time:" << a.time << "}";
+    o << "{max_offset:" << a.max_offset << ", time:" << a.time
+      << ", type_filter:";
+    if (a.type_filter) {
+        o << *a.type_filter;
+    } else {
+        o << "nullopt";
+    }
+    o << "}";
+    return o;
 }
 
 std::ostream&

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -157,14 +157,17 @@ struct timequery_config {
       model::timestamp t,
       model::offset o,
       ss::io_priority_class iop,
+      std::optional<model::record_batch_type> type_filter,
       opt_abort_source_t as = std::nullopt) noexcept
       : time(t)
       , max_offset(o)
       , prio(iop)
+      , type_filter(type_filter)
       , abort_source(as) {}
     model::timestamp time;
     model::offset max_offset;
     ss::io_priority_class prio;
+    std::optional<model::record_batch_type> type_filter;
     opt_abort_source_t abort_source;
 
     friend std::ostream& operator<<(std::ostream& o, const timequery_config&);


### PR DESCRIPTION
## Cover letter

When performing a timequery, ignore batches that are not `raft_data`.

Fix #2397

### Reviewer notes

I don't know if `timequery` is performed by subsystems other than kafka, but if that's the case, then perhaps the `storage::log_reader_config::type_filter` should be passed down through `storage::timequery_config`.

## Release notes

### Improvements

* list_offsets by time now ignores control batches
