### PR TITLE
Ducktape backtraces

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -150,4 +150,15 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     cp target/release/client-swarm /usr/local/bin && \
     cd .. && rm -rf client-swarm && rm -rf /root/.cargo
 
+# Seastar addrress to line utility
+RUN apt update && \
+    apt install -y \
+      file && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/scripts && \
+    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/addr2line.py -o /opt/scripts/addr2line.py && \
+    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line && \
+    chmod +x /opt/scripts/seastar-addr2line
+
 CMD service ssh start && tail -f /dev/null

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -34,6 +34,7 @@ def cluster(log_allow_list=None, **kwargs):
             try:
                 r = f(self, *args, **kwargs)
             except:
+                self.redpanda.decode_backtraces()
                 self.redpanda.raise_on_crash()
                 raise
             else:


### PR DESCRIPTION
## Cover letter

Redpanda logs may contain backtraces related with reactor stalls,
assertions, segmentation faults and sanitizer errors. Added redpanda
logs post processing step to decode backtraces with use of seastar
`addr2line` tool. If backtraces are present in redpanda logs they will
be stored in `redpanda_backtrace.log` file present in node logs
directory.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
