### PR TITLE
tests: run Redpanda with lower --memory by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -186,7 +186,9 @@ class ResourceSettings:
             num_cpus = 3
 
         if memory_mb is None:
-            memory_mb = 6000
+            # Redpanda's default limit on memory per shard
+            # is 1GB
+            memory_mb = 3096
 
         self._num_cpus = num_cpus
         self._memory_mb = memory_mb


### PR DESCRIPTION
## Cover letter

6GB per node was far outside the physical memory available
on ARM m5 test nodes, when we run one docker container
per core, and a significant number of those docker containers
contain a redpanda process.

3GB per node is still in excess of the physical memory (which is 2GB per core on m5), but less gratuitously so.

Related: https://github.com/redpanda-data/redpanda/issues/4247

## Release notes

* none