### PR TITLE
rpk: add first set of maintenance mode commands

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -47,6 +47,13 @@ type BasicCredentials struct {
 	Password string
 }
 
+// GenericErrorBody is the JSON decodable body that is produced by generic error
+// handling in the admin server when a seastar http exception is thrown.
+type GenericErrorBody struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
 // AdminAPI is a client to interact with Redpanda's admin server.
 type AdminAPI struct {
 	urls                []string
@@ -546,6 +553,12 @@ func (a *AdminAPI) sendAndReceive(
 	}
 
 	return res, nil
+}
+
+func (he HttpError) DecodeGenericErrorBody() (GenericErrorBody, error) {
+	var resp GenericErrorBody
+	err := json.Unmarshal(he.Body, &resp)
+	return resp, err
 }
 
 func (he HttpError) Error() string {

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -53,3 +53,13 @@ func (a *AdminAPI) RecommissionBroker(node int) error {
 		nil,
 	)
 }
+
+// EnableMaintenanceMode enables maintenance mode for a node.
+func (a *AdminAPI) EnableMaintenanceMode(nodeId int) error {
+	return a.sendAny(
+		http.MethodPut,
+		fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeId),
+		nil,
+		nil,
+	)
+}

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -63,3 +63,13 @@ func (a *AdminAPI) EnableMaintenanceMode(nodeId int) error {
 		nil,
 	)
 }
+
+// DisableMaintenanceMode disables maintenance mode for a node.
+func (a *AdminAPI) DisableMaintenanceMode(nodeId int) error {
+	return a.sendAny(
+		http.MethodDelete,
+		fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeId),
+		nil,
+		nil,
+	)
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -12,6 +12,7 @@ package cmd
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/maintenance"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	"github.com/spf13/afero"
@@ -56,6 +57,7 @@ func NewClusterCommand(fs afero.Fs) *cobra.Command {
 	command.AddCommand(offsets)
 
 	command.AddCommand(config.NewConfigCommand(fs))
+	command.AddCommand(maintenance.NewMaintenanceCommand(fs))
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package maintenance
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newDisableCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable <broker-id>",
+		Short: "Disable maintenance mode for a node.",
+		Long:  `Disable maintenance mode for a node.`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			nodeId, err := strconv.Atoi(args[0])
+			if err != nil {
+				out.MaybeDie(err, "could not parse node id: %s: %v", args[0], err)
+			}
+
+			if nodeId < 0 {
+				out.Die("invalid node id: %d", nodeId)
+			}
+
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			err = client.DisableMaintenanceMode(nodeId)
+			if he := (*admin.HttpError)(nil); errors.As(err, &he) {
+				if he.Response.StatusCode == 404 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Not found: %s", body.Message)
+					}
+				}
+			}
+
+			out.MaybeDie(err, "error disabling maintenance mode: %v", err)
+			fmt.Printf("Successfully disabled maintenance mode for node %d\n", nodeId)
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package maintenance
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newEnableCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable <node-id>",
+		Short: "Enable maintenance mode for a node.",
+		Long: `Enable maintenance mode for a node.
+
+This command enables maintenance mode for the node with the specified ID. If a
+node exists that is already in maintenance mode then an error will be returned.
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			nodeId, err := strconv.Atoi(args[0])
+			if err != nil {
+				out.MaybeDie(err, "could not parse node id: %s: %v", args[0], err)
+			}
+
+			if nodeId < 0 {
+				out.Die("invalid node id: %d", nodeId)
+			}
+
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			err = client.EnableMaintenanceMode(nodeId)
+			var he *admin.HttpError
+			if errors.As(err, &he) {
+				if he.Response.StatusCode == 404 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Not found: %s", body.Message)
+					}
+				} else if he.Response.StatusCode == 400 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Cannot enable maintenance mode: %s", body.Message)
+					}
+				}
+			}
+
+			out.MaybeDie(err, "error enabling maintenance mode for node %d: %v", nodeId, err)
+			fmt.Printf("Successfully enabled maintenance mode for node %d\n", nodeId)
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
@@ -63,7 +63,9 @@ Currently leadership is not transferred for partitions with one replica.
 		&adminCAFile,
 	)
 
-	cmd.AddCommand(newEnableCommand(fs))
+	cmd.AddCommand(
+		newEnableCommand(fs),
+		newDisableCommand(fs))
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package maintenance
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewMaintenanceCommand(fs afero.Fs) *cobra.Command {
+	var (
+		adminURL       string
+		adminEnableTLS bool
+		adminCertFile  string
+		adminKeyFile   string
+		adminCAFile    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "Toggle a node's maintenance mode.",
+		Long: `Interact with cluster maintenance mode.
+
+Maintenance mode is a state that a node may be placed into in which the node
+may be shutdown or restarted with minimal disruption to client workloads. The
+primary use of maintenance mode is to perform a rolling upgrade in which each
+node is placed into maintenance mode prior to upgrading the node.
+
+Use the 'enable' and 'disable' subcommands to place a node into maintenance mode
+or remove it, respectively. Only one node at a time may be in maintenance mode.
+
+When a node is placed into maintenance mode the following occurs:
+
+Leadership draining. All raft leadership is transferred to another eligible
+node, and the node in maintenance mode rejects new leadership requests. By
+transferring leadership off of the node in maintenance mode all client traffic
+and requests are directed to other nodes minimizing disruption to client
+workloads when the node is shutdown.
+
+Currently leadership is not transferred for partitions with one replica.
+`,
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&adminURL,
+		config.FlagAdminHosts2,
+		"",
+		"Comma-separated list of admin API addresses (<IP>:<port>")
+
+	common.AddAdminAPITLSFlags(cmd,
+		&adminEnableTLS,
+		&adminCertFile,
+		&adminKeyFile,
+		&adminCAFile,
+	)
+
+	cmd.AddCommand(newEnableCommand(fs))
+
+	return cmd
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 import subprocess
 import re
 import typing
+from ducktape.cluster.cluster import ClusterNode
 
 DEFAULT_TIMEOUT = 30
 
@@ -469,3 +470,13 @@ class RpkTool:
 
     def _rpk_binary(self):
         return self._redpanda.find_binary("rpk")
+
+    def cluster_maintenance_enable(self, node):
+        node_id = self._redpanda.idx(node) if isinstance(node,
+                                                         ClusterNode) else node
+        cmd = [
+            self._rpk_binary(), "--api-urls",
+            self._admin_host(), "cluster", "maintenance", "enable",
+            str(node_id)
+        ]
+        return self._execute(cmd)

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -480,3 +480,13 @@ class RpkTool:
             str(node_id)
         ]
         return self._execute(cmd)
+
+    def cluster_maintenance_disable(self, node):
+        node_id = self._redpanda.idx(node) if isinstance(node,
+                                                         ClusterNode) else node
+        cmd = [
+            self._rpk_binary(), "--api-urls",
+            self._admin_host(), "cluster", "maintenance", "disable",
+            str(node_id)
+        ]
+        return self._execute(cmd)

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -113,13 +113,19 @@ class MaintenanceTest(RedpandaTest):
                 backoff_sec=5,
                 err_msg=f"expected {node.name} maintenance mode: {expect}")
 
+    def _maintenance_disable(self, node):
+        if self._use_rpk:
+            self.rpk.cluster_maintenance_disable(node)
+        else:
+            self.admin.maintenance_stop(node)
+
     @cluster(num_nodes=3)
     @matrix(use_rpk=[True, False])
     def test_maintenance(self, use_rpk):
         self._use_rpk = use_rpk
         target = random.choice(self.redpanda.nodes)
         self._enable_maintenance(target)
-        self.admin.maintenance_stop(target)
+        self._maintenance_disable(target)
         self._disable_maintenance(target)
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -134,7 +140,7 @@ class MaintenanceTest(RedpandaTest):
             self.redpanda.restart_nodes(node)
             self._verify_cluster(node, True)
 
-            self.admin.maintenance_stop(node)
+            self._maintenance_disable(node)
             self._disable_maintenance(node)
             self._verify_cluster(node, False)
 


### PR DESCRIPTION
## Cover letter

Adds `rpk cluster maintenance (enable|disable) <node-id>` command to rpk for turning maintenance mode on and off for a specific node. This is a lightweight wrapper around the admin interface. The ducktape test usage of the raw admin interface is replaced with rpk usage for maintenance mode control.

A follow up PR will add additional capabilities that are useful for operator, ansible, or manual usage which is status reporting and blocking behavior that will allow the command to act as a barrier by waiting on leadership to drain.

## Release notes

### Features

* Adds rpk commands for enabling and disabling node maintenance mode.