### PR TITLE
[admin] Get leaders info request

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -181,6 +181,11 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
 
 void metadata_cache::reset_leaders() { _leaders.local().reset(); }
 
+cluster::partition_leaders_table::leaders_info_t
+metadata_cache::get_leaders() const {
+    return _leaders.local().get_leaders();
+}
+
 /**
  * hard coded defaults
  */

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
+#include "cluster/partition_leaders_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -137,6 +138,7 @@ public:
     std::optional<model::node_id> get_controller_leader_id();
 
     void reset_leaders();
+    cluster::partition_leaders_table::leaders_info_t get_leaders() const;
 
     model::compression get_default_compression() const;
     model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -198,4 +198,23 @@ ss::future<model::node_id> partition_leaders_table::wait_for_leader(
       });
 }
 
+partition_leaders_table::leaders_info_t
+partition_leaders_table::get_leaders() const {
+    leaders_info_t ans;
+    ans.reserve(_leaders.size());
+    for (const auto& leader_info : _leaders) {
+        leader_info_t info{
+          .tp_ns = leader_info.first.tp_ns,
+          .pid = leader_info.first.pid,
+          .current_leader = leader_info.second.current_leader,
+          .previous_leader = leader_info.second.previous_leader,
+          .last_stable_leader_term = leader_info.second.last_stable_leader_term,
+          .update_term = leader_info.second.update_term,
+          .partition_revision = leader_info.second.partition_revision,
+        };
+        ans.push_back(std::move(info));
+    }
+    return ans;
+}
+
 } // namespace cluster

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -98,6 +98,21 @@ public:
 
     void reset() { _leaders.clear(); }
 
+    struct leader_info_t {
+        model::topic_namespace tp_ns;
+        model::partition_id pid;
+
+        std::optional<model::node_id> current_leader;
+        std::optional<model::node_id> previous_leader;
+        model::term_id last_stable_leader_term;
+        model::term_id update_term;
+        model::revision_id partition_revision;
+    };
+
+    using leaders_info_t = std::vector<leader_info_t>;
+
+    leaders_info_t get_leaders() const;
+
 private:
     // optimized to reduce number of ntp copies
     struct leader_key {

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -21,6 +21,64 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/partition_leaders_table",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get information about leaders from partition_leaders_table for node",
+                    "type": "array",
+                    "items": {
+                        "type": "leader_info"
+                    },
+                    "nickname": "get_leaders_info",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
-    ]
+    ],
+    "models": {
+        "leader_info": {
+            "id": "leader_info",
+            "description": "Leader info",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "topic"
+                },
+                "partition_id": {
+                    "type": "long",
+                    "description": "partition"
+                },
+                "leader": {
+                    "type": "long",
+                    "description": "current leader"
+                },
+                "previous_leader": {
+                    "type": "long",
+                    "description": "previous leader"
+                },
+                "last_stable_leader_term": {
+                    "type": "long",
+                    "description": "last stable leader term"
+                },
+                "update_term": {
+                    "type": "long",
+                    "description": "update term"
+                },
+                "partition_revision": {
+                    "type": "long",
+                    "description": "partition revision"
+                }
+            }
+        }
+    }
 }

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -418,3 +418,12 @@ class Admin:
         self.redpanda.logger.info(f"Reset leaders info on {node.name}/{id}")
         url = "debug/reset_leaders"
         return self._request("post", url, node=node)
+
+    def get_leaders_info(self, node):
+        """
+        Get info for leaders on node
+        """
+        id = self.redpanda.idx(node)
+        self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
+        url = "debug/partition_leaders_table"
+        return self._request("get", url, node=node).json()


### PR DESCRIPTION
## Cover letter

This debug API to understand what current node thinks about leaders.

Because it is debug request we only execute it on one core, without merging ans.

```
"path": "/v1/debug/partition_leaders_table",
            "operations": [
                {
                    "method": "GET",
                    "summary": "Get information about leaders for node",
```
## Release notes
* New admin api request `/v1/debug/partition_leaders_table`

