### PR TITLE
compile with {fmt} v8

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -162,6 +162,17 @@ ExternalProject_Add(cryptopp
      ${common_cmake_args}
     -DBUILD_TESTING=OFF)
 
+ExternalProject_Add(fmt
+  URL https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz
+  URL_MD5 fe7f1585844b14c647bd332ad5562832
+  INSTALL_DIR @REDPANDA_DEPS_INSTALL_DIR@
+  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
+  DEPENDS ${default_depends}
+  CMAKE_ARGS
+     ${common_cmake_args}
+     -DFMT_DOC=OFF
+     -DFMT_TEST=OFF)
+
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
   GIT_TAG 5531940ecd6fa6e5a30bbce8e0573db6f721d343

--- a/src/v/bytes/details/out_of_range.h
+++ b/src/v/bytes/details/out_of_range.h
@@ -17,7 +17,7 @@
 namespace details {
 [[maybe_unused]] [[noreturn]] [[gnu::cold]] static void
 throw_out_of_range(const char* fmt, size_t A, size_t B) {
-    throw std::out_of_range(fmt::format(fmt, A, B));
+    throw std::out_of_range(fmt::format(fmt::runtime(fmt), A, B));
 }
 inline void check_out_of_range(size_t sz, size_t capacity) {
     if (unlikely(sz > capacity)) {

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -32,6 +32,26 @@ std::string_view to_string_view(feature f) {
     __builtin_unreachable();
 }
 
+std::string_view to_string_view(feature_state::state s) {
+    switch (s) {
+    case feature_state::state::unavailable:
+        return "unavailable";
+    case feature_state::state::available:
+        return "available";
+    case feature_state::state::preparing:
+        return "preparing";
+    case feature_state::state::active:
+        return "active";
+    case feature_state::state::disabled_active:
+        return "disabled_active";
+    case feature_state::state::disabled_preparing:
+        return "disabled_preparing";
+    case feature_state::state::disabled_clean:
+        return "disabled_clean";
+    }
+    __builtin_unreachable();
+};
+
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
 static constexpr cluster_version latest_version = cluster_version{3};

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -218,6 +218,7 @@ private:
 };
 
 std::string_view to_string_view(feature);
+std::string_view to_string_view(feature_state::state);
 
 /**
  * To enable all shards to efficiently check enablement of features
@@ -309,3 +310,13 @@ private:
 };
 
 } // namespace cluster
+
+template<>
+struct fmt::formatter<cluster::feature_state::state> final
+  : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto
+    format(const cluster::feature_state::state& s, FormatContext& ctx) const {
+        return formatter<string_view>::format(cluster::to_string_view(s), ctx);
+    }
+};

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -81,7 +81,8 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         auto leader_opt = _leaders.local().get_leader(model::id_allocator_ntp);
         if (unlikely(!leader_opt)) {
             error = vformat(
-              "can't find {} in the leaders cache", model::id_allocator_ntp);
+              fmt::runtime("can't find {} in the leaders cache"),
+              model::id_allocator_ntp);
             vlog(
               clusterlog.trace,
               "waiting for {} to fill leaders cache, retries left: {}",
@@ -109,11 +110,11 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         }
 
         if (likely(r.ec != errc::replication_error)) {
-            error = vformat("id allocation failed with {}", r.ec);
+            error = vformat(fmt::runtime("id allocation failed with {}"), r.ec);
             break;
         }
 
-        error = vformat("id allocation failed with {}", r.ec);
+        error = vformat(fmt::runtime("id allocation failed with {}"), r.ec);
         vlog(
           clusterlog.trace, "id allocation failed, retries left: {}", retries);
         co_await sleep_abortable(delay_ms, _as);

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -107,7 +107,8 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
     std::optional<std::string> error;
     while (!aborted && 0 < retries--) {
         if (!leader_opt) {
-            error = vformat("can't find {} in the leaders cache", ntp);
+            error = vformat(
+              fmt::runtime("can't find {} in the leaders cache"), ntp);
             vlog(
               txlog.trace,
               "can't find {} in the leaders cache, retries left: {}",
@@ -127,8 +128,9 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
               ntp, pid, tx_seq, transaction_timeout_ms);
             if (result.ec == tx_errc::leader_not_found) {
                 error = vformat(
-                  "local execution of begin_tx({},...) failed with 'not a "
-                  "leader'",
+                  fmt::runtime(
+                    "local execution of begin_tx({},...) failed with 'not a "
+                    "leader'"),
                   ntp);
                 vlog(
                   txlog.trace,
@@ -171,8 +173,9 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
           result.etag);
         if (result.ec == tx_errc::leader_not_found) {
             error = vformat(
-              "remote execution of begin_tx({},...) on {} failed with 'not a "
-              "leader'",
+              fmt::runtime(
+                "remote execution of begin_tx({},...) on {} failed with 'not a "
+                "leader'"),
               ntp,
               leader);
             vlog(

--- a/src/v/compression/internal/gzip_compressor.cc
+++ b/src/v/compression/internal/gzip_compressor.cc
@@ -21,7 +21,7 @@
 namespace compression::internal {
 [[noreturn]] [[gnu::cold]] static void
 throw_zstream_error(const char* fmt, int ret) {
-    throw std::runtime_error(fmt::format(fmt, ret, zError(ret)));
+    throw std::runtime_error(fmt::format(fmt::runtime(fmt), ret, zError(ret)));
 }
 
 inline void throw_if_zstream_error(const char* fmt, int code) {

--- a/src/v/compression/internal/lz4_frame_compressor.cc
+++ b/src/v/compression/internal/lz4_frame_compressor.cc
@@ -28,7 +28,8 @@ static constexpr size_t lz4f_footer_size = 4;
 
 [[noreturn]] [[gnu::cold]] static void
 throw_lz4_error(const char* fmt, LZ4F_errorCode_t err) {
-    throw std::runtime_error(fmt::format(fmt, LZ4F_getErrorName(err)));
+    throw std::runtime_error(
+      fmt::format(fmt::runtime(fmt), LZ4F_getErrorName(err)));
 }
 static inline void check_lz4_error(const char* fmt, LZ4F_errorCode_t code) {
     if (unlikely(LZ4F_isError(code))) {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -351,6 +351,25 @@ struct broker_v0 {
 } // namespace internal
 } // namespace model
 
+template<>
+struct fmt::formatter<model::isolation_level> final
+  : fmt::formatter<std::string_view> {
+    using isolation_level = model::isolation_level;
+    template<typename FormatContext>
+    auto format(const isolation_level& s, FormatContext& ctx) const {
+        std::string_view str = "unknown";
+        switch (s) {
+        case isolation_level::read_uncommitted:
+            str = "read_uncommitted";
+            break;
+        case isolation_level::read_committed:
+            str = "read_committed";
+            break;
+        }
+        return formatter<string_view>::format(str, ctx);
+    }
+};
+
 namespace std {
 template<>
 struct hash<model::broker_shard> {

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -50,11 +50,7 @@ public:
         _errors.emplace_back(err{level::warn, line, column, message});
     }
 
-    error_info error() const {
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format("{}", fmt::join(_errors, "; "))};
-    }
+    error_info error() const;
 
 private:
     friend struct fmt::formatter<err>;
@@ -83,11 +79,7 @@ public:
           level::warn, filename, element_name, descriptor, location, message});
     }
 
-    error_info error() const {
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format("{}", fmt::join(_errors, "; "))};
-    }
+    error_info error() const;
 
 private:
     enum class level {
@@ -392,7 +384,7 @@ struct fmt::formatter<pandaproxy::schema_registry::io_error_collector::err> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const type::err& e, FormatContext& ctx) {
+    auto format(const type::err& e, FormatContext& ctx) const {
         return format_to(
           ctx.out(),
           "{}: line: '{}', col: '{}', msg: '{}'",
@@ -410,7 +402,7 @@ struct fmt::formatter<pandaproxy::schema_registry::dp_error_collector::err> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const type::err& e, FormatContext& ctx) {
+    auto format(const type::err& e, FormatContext& ctx) const {
         return format_to(
           ctx.out(),
           "{}: subject: '{}', element_name: '{}', descriptor: '{}', location: "
@@ -423,3 +415,17 @@ struct fmt::formatter<pandaproxy::schema_registry::dp_error_collector::err> {
           e.message);
     }
 };
+
+namespace pandaproxy::schema_registry {
+
+error_info io_error_collector::error() const {
+    return error_info{
+      error_code::schema_invalid, fmt::format("{}", fmt::join(_errors, "; "))};
+}
+
+error_info dp_error_collector::error() const {
+    return error_info{
+      error_code::schema_invalid, fmt::format("{}", fmt::join(_errors, "; "))};
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -44,6 +44,28 @@
 #include <algorithm>
 #include <iterator>
 
+template<>
+struct fmt::formatter<raft::consensus::vote_state> final
+  : fmt::formatter<std::string_view> {
+    using vote_state = raft::consensus::vote_state;
+    template<typename FormatContext>
+    auto format(const vote_state& s, FormatContext& ctx) const {
+        std::string_view str = "unknown";
+        switch (s) {
+        case vote_state::follower:
+            str = "follower";
+            break;
+        case vote_state::candidate:
+            str = "candidate";
+            break;
+        case vote_state::leader:
+            str = "leader";
+            break;
+        }
+        return formatter<string_view>::format(str, ctx);
+    }
+};
+
 namespace raft {
 
 static std::vector<model::record_batch_type>

--- a/src/v/rpc/demo/demo_utils.h
+++ b/src/v/rpc/demo/demo_utils.h
@@ -13,6 +13,7 @@
 #include "reflection/for_each_field.h"
 #include "rpc/demo/types.h"
 #include "seastarx.h"
+#include "ssx/sformat.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/fstream.hh>

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -15,6 +15,7 @@
 #include "rpc/backoff_policy.h"
 #include "rpc/transport.h"
 #include "rpc/types.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -162,12 +162,11 @@ std::ostream& operator<<(std::ostream& os, const principal_mapper& p) {
 // explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the
 // header, whch breaks compilation in another part of the codebase.
 template<>
-std::back_insert_iterator<fmt::detail::buffer<char>>
-fmt::formatter<security::tls::rule>::format(
-  const security::tls::rule& r,
-  fmt::basic_format_context<
-    std::back_insert_iterator<fmt::detail::buffer<char>>,
-    char>& ctx) {
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::tls::rule, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  security::tls::rule const& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
     if (r._is_default) {
         return format_to(ctx.out(), "DEFAULT");
     }
@@ -187,14 +186,10 @@ fmt::formatter<security::tls::rule>::format(
 }
 
 template<>
-std::back_insert_iterator<fmt::detail::buffer<char>>
-fmt::formatter<security::tls::principal_mapper>::format<
-  fmt::basic_format_context<
-    std::back_insert_iterator<fmt::detail::buffer<char>>,
-    char>>(
-  const security::tls::principal_mapper& r,
-  fmt::basic_format_context<
-    std::back_insert_iterator<fmt::detail::buffer<char>>,
-    char>& ctx) {
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::tls::principal_mapper, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  security::tls::principal_mapper const& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
     return format_to(ctx.out(), "[{}]", fmt::join(r._rules, ", "));
 }

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -91,7 +91,8 @@ struct fmt::formatter<security::tls::rule> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
 };
 
 template<>
@@ -101,5 +102,6 @@ struct fmt::formatter<security::tls::principal_mapper> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
 };

--- a/src/v/ssx/tests/sformat_bench.cc
+++ b/src/v/ssx/tests/sformat_bench.cc
@@ -17,7 +17,8 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-const auto identifier = fmt::format("{}", boost::uuids::random_generator()());
+const auto identifier = fmt::format(
+  fmt::runtime("{}"), boost::uuids::random_generator()());
 
 struct fmt_format {
     template<typename... Args>
@@ -39,9 +40,10 @@ void run_test(Fun fun, size_t data_size) {
     vec.reserve(data_size);
     perf_tests::start_measuring_time();
     for (int i = 0; i < data_size; ++i) {
-        vec.emplace_back(fun("{}", identifier));
+        vec.emplace_back(fun(fmt::runtime("{}"), identifier));
     }
-    perf_tests::do_not_optimize(Ret{fun("{}", fmt::join(vec, ","))});
+    perf_tests::do_not_optimize(
+      Ret{fun(fmt::runtime("{}"), fmt::join(vec, ","))});
     perf_tests::stop_measuring_time();
 }
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -51,7 +51,33 @@
 #include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <roaring/roaring.hh>
+
+template<>
+struct fmt::formatter<storage::compacted_index::recovery_state> {
+    using recovery_state = storage::compacted_index::recovery_state;
+    constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    template<typename FormatContext>
+    auto format(const recovery_state& s, FormatContext& ctx) const {
+        std::string_view str = "unknown";
+        switch (s) {
+        case recovery_state::missing:
+            str = "missing";
+            break;
+        case recovery_state::needsrebuild:
+            str = "needsrebuild";
+            break;
+        case recovery_state::recovered:
+            str = "recovered";
+            break;
+        case recovery_state::nonrecovered:
+            str = "nonrecovered";
+            break;
+        }
+        return format_to(ctx.out(), "{}", str);
+    }
+};
 
 namespace storage::internal {
 using namespace storage; // NOLINT

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -58,9 +58,9 @@ ss::future<> systemd_raw_message(ss::sstring out);
 ss::future<> systemd_notify_ready();
 
 template<typename... Args>
-ss::future<> systemd_message(const char* fmt, Args&&... args) {
+ss::future<> systemd_message(fmt::format_string<Args...> fmt, Args&&... args) {
     ss::sstring s = ssx::sformat(
-      "STATUS={}\n", ssx::sformat(fmt, std::forward<Args>(args)...));
+      "STATUS={}\n", fmt::format(fmt, std::forward<Args>(args)...));
     return systemd_raw_message(std::move(s));
 }
 

--- a/src/v/utils/prefix_logger.h
+++ b/src/v/utils/prefix_logger.h
@@ -61,9 +61,8 @@ public:
     template<typename... Args>
     ss::sstring format(const char* format, Args&&... args) const {
         auto line_fmt = ss::sstring("{} - ") + format;
-        return ssx::sformat(
-          fmt::string_view(line_fmt.begin(), line_fmt.length()),
-          _prefix,
+        return fmt::format(
+          fmt::runtime(fmt::string_view(line_fmt.begin(), line_fmt.length())),
           std::forward<Args>(args)...);
     }
 

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -258,13 +258,15 @@ public:
     /// Generate formattend log prefix and add custom string into it:
     /// Example: [fiber42~3~1|2|100ms ns/topic/42]
     template<typename... Args>
-    ss::sstring operator()(const char* format_str, Args&&... args) const {
+    ss::sstring
+    operator()(fmt::format_string<Args...> format_str, Args&&... args) const {
         fmt::memory_buffer mbuf;
-        mbuf.push_back('[');
-        format(mbuf);
-        mbuf.push_back(' ');
-        fmt::format_to(mbuf, format_str, std::forward<Args>(args)...);
-        mbuf.push_back(']');
+        auto bii = std::back_insert_iterator(mbuf);
+        bii = '[';
+        format(bii);
+        bii = ' ';
+        fmt::format_to(bii, format_str, std::forward<Args>(args)...);
+        bii = ']';
         return ss::sstring(mbuf.data(), mbuf.size());
     }
 
@@ -304,7 +306,7 @@ public:
     ss::lowres_clock::time_point get_deadline() const;
 
 private:
-    void format(fmt::memory_buffer& str) const;
+    void format(std::back_insert_iterator<fmt::memory_buffer>& bii) const;
 
     uint16_t add_child();
 
@@ -358,7 +360,9 @@ public:
       , _node(node)
       , _ctx(std::move(context)) {}
     template<typename... Args>
-    void log(ss::log_level lvl, const char* format, Args&&... args) const {
+    void
+    log(ss::log_level lvl, fmt::format_string<Args...> format, Args&&... args)
+      const {
         if (_log.is_enabled(lvl)) {
             auto lambda = [&](ss::logger& logger, ss::log_level lvl) {
                 auto msg = ssx::sformat(format, std::forward<Args>(args)...);
@@ -376,23 +380,23 @@ public:
         }
     }
     template<typename... Args>
-    void error(const char* format, Args&&... args) const {
+    void error(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::error, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void warn(const char* format, Args&&... args) const {
+    void warn(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::warn, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void info(const char* format, Args&&... args) const {
+    void info(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::info, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void debug(const char* format, Args&&... args) const {
+    void debug(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::debug, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void trace(const char* format, Args&&... args) const {
+    void trace(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::trace, format, std::forward<Args>(args)...);
     }
 


### PR DESCRIPTION
## Cover letter

now that {fmt} v8 is released. and would be great if we can compile against it. in this changeset

- since fmt v8 differentiate compile-time fmt string from the runt-time fmt string. the former is a static one and can be validated at compile-time, the later can only be validated at runt-time. so in this change, the format string are passed in different ways accordingly for better performance and compile-time validation.
- to simplify the handling of difference API of v8 and pre-v8, fmt is also packaged as yet another dependency
- fmt v8 does not format scoped enums. so add a bunch of `fmt::format()` specialization for better debugging experience.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes

* none