### PR TITLE
[DRAFT] Drain command

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -17,11 +17,20 @@ import (
 
 const brokersEndpoint = "/v1/brokers"
 
+type dSpace struct {
+	Path	string	`json:"path"`
+	Free	int64	`json:"free"`
+	Total	int64	`json:"total"`
+}
+
 // Broker is the information returned from the Redpanda admin broker endpoints.
 type Broker struct {
-	NodeID           int    `json:"node_id"`
-	NumCores         int    `json:"num_cores"`
-	MembershipStatus string `json:"membership_status"`
+	NodeID           int   		`json:"node_id"`
+	NumCores         int   		`json:"num_cores"`
+	MembershipStatus string		`json:"membership_status"`
+	IsAlive		 bool		`json:"is_alive"`
+	DiskSpaceItems	 []dSpace	`json:"disk_space"`
+	Version		 string		`json:"version"`
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -139,3 +139,21 @@ func AddAdminAPITLSFlags(
 
 	return command
 }
+
+func AddBrokersFlag(
+	command *cobra.Command,
+        brokers *[]string,
+) *cobra.Command {
+        command.PersistentFlags().StringSliceVar(
+                brokers,
+                "brokers",
+                []string{},
+                "Comma-separated list of broker ip:port pairs (e.g."+
+                        " --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' )."+
+                        " Alternatively, you may set the REDPANDA_BROKERS environment"+
+                        " variable with the comma-separated list of broker addresses.",
+        )
+
+	return command
+}
+

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -34,6 +34,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		adminCertFile  string
 		adminKeyFile   string
 		adminCAFile    string
+		clusterBrokers []string
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -58,6 +59,11 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		&adminCertFile,
 		&adminKeyFile,
 		&adminCAFile,
+	)
+
+	common.AddBrokersFlag(
+		cmd,
+		&clusterBrokers,
 	)
 
 	cmd.AddCommand(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -13,6 +13,7 @@ package admin
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions"
 	configcmd "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
@@ -68,6 +69,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 
 	cmd.AddCommand(
 		brokers.NewCommand(fs),
+		partitions.NewCommand(fs),
 		configcmd.NewCommand(fs),
 	)
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -12,14 +12,17 @@
 package brokers
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
 )
 
 // NewCommand returns the brokers admin command.
@@ -31,6 +34,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
+		newListPartitionsCommand(fs),
 		newDecommissionBroker(fs),
 		newRecommissionBroker(fs),
 	)
@@ -38,29 +42,81 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 }
 
 func newListCommand(fs afero.Fs) *cobra.Command {
-	return &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List the brokers in your cluster.",
+        return &cobra.Command{
+                Use:     "list",
+                Aliases: []string{"ls"},
+                Short:   "List the brokers in your cluster.",
+                Args:    cobra.ExactArgs(0),
+                Run: func(cmd *cobra.Command, _ []string) {
+                        p := config.ParamsFromCommand(cmd)
+                        cfg, err := p.Load(fs)
+                        out.MaybeDie(err, "unable to load config: %v", err)
+
+                        cl, err := admin.NewClient(fs, cfg)
+                        out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+                        bs, err := cl.Brokers()
+                        out.MaybeDie(err, "unable to request brokers: %v", err)
+
+                        tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
+                        defer tw.Flush()
+                        for _, b := range bs {
+                                tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+                        }
+                },
+        }
+}
+
+func newListPartitionsCommand(fs afero.Fs) *cobra.Command {
+	var (
+		brokerId string
+	)
+	cmd :=  &cobra.Command{
+		Use:     "list-partitions",
+		Aliases: []string{"ls-ps"},
+		Short:   "List the partitions in a broker in your cluster.",
 		Args:    cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			cl, err := admin.NewClient(fs, cfg)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			//cl, err := admin.NewClient(fs, cfg)
+			//out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			bs, err := cl.Brokers()
-			out.MaybeDie(err, "unable to request brokers: %v", err)
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+                        defer adm.Close()
 
-			tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
+			var m kadm.Metadata
+                        m, err = adm.Metadata(context.Background(), args...)
+                        out.MaybeDie(err, "unable to request metadata: %v", err)
+
+			tw := out.NewTable("TOPIC", "PARTITION", "IS_LEADER")
 			defer tw.Flush()
-			for _, b := range bs {
-				tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+
+			brokerIdInt, err := strconv.Atoi(brokerId)
+			out.MaybeDie(err, "unable to parse brokerId: %v", err)
+
+			for _, t := range m.Topics.Sorted() {
+				for _, pt := range t.Partitions.Sorted() {
+					for _, rs := range pt.Replicas {
+						if int(rs) == brokerIdInt {
+							var isLeader = "NO"
+							if int(pt.Leader) == brokerIdInt {
+								isLeader = "YES"
+							}
+							tw.Print(t.Topic , pt.Partition, isLeader)
+						}
+					}
+				}
 			}
 		},
 	}
+
+	cmd.Flags().StringVar(&brokerId, "broker-id", "b", "print the partitions on broker id")
+
+	return cmd
 }
 
 func newDecommissionBroker(fs afero.Fs) *cobra.Command {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -14,6 +14,7 @@ package partitions
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -32,6 +33,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
+		newMoveAllCommand(fs),
 	)
 	return cmd
 }
@@ -89,4 +91,110 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	cmd.Flags().BoolVarP(&leaderOnly, "leader-only", "l", false, "print the partitions on broker which are leaders")
 
 	return cmd
+}
+
+func newMoveAllCommand(fs afero.Fs) *cobra.Command {
+	var (
+		sourceBrokerId string
+		destinationBrokerIds string
+	)
+        cmd :=  &cobra.Command{
+                Use:     "move-all --source-broker-id [SOURCE BROKER ID] --destination-broker-ids [DESTINATION BROKER IDs]",
+                Aliases: []string{"mv-all"},
+                Short:   "Move all the partitions from a source broker to multiple destination brokers in a cluster.",
+                Args:    cobra.ExactArgs(0),
+                Run: func(cmd *cobra.Command, args []string) {
+
+			p := config.ParamsFromCommand(cmd)
+                        cfg, err := p.Load(fs)
+                        out.MaybeDie(err, "unable to load config: %v", err)
+
+                        adm, err := kafka.NewAdmin(fs, p, cfg)
+                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+
+			var m kadm.Metadata
+                        m, err = adm.Metadata(context.Background())
+                        out.MaybeDie(err, "unable to request metadata: %v", err)
+
+                        // Check if Destination Broker list does not have Source Broker ID
+                        destinationBrokersMap := make(map[int]NodePartitionCount)
+                        for _, db := range strings.Split(destinationBrokerIds, ",") {
+                        	dbId, err := strconv.Atoi(db)
+                        	out.MaybeDie(err, "unable to parse destination broker id: %v", err)
+                        	leaderPartitions, replicaPartitions := getTopicPartitionMap(m, dbId)
+                        	destinationBrokersMap[dbId] = NodePartitionCount{len(leaderPartitions), len(replicaPartitions)}
+                        }
+
+                        tw := out.NewTable("DESTINATION", "LEADER_PARTITION_COUNT", "REPLICA_PARTITION_COUNT")
+                        defer tw.Flush()
+
+                        /*
+                        For debugging leader and replica count
+                        for dbId, db := range destinationBrokersMap {
+                        	tw.Print(dbId, db.leaderCount, db.replicaCount)	
+                        }
+                        */
+                        
+			brokerId, err := strconv.Atoi(sourceBrokerId)
+			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, brokerId)
+
+                        for _, t := range leaderPartitions {				
+				// Transfer leadership to the replica on a broker, which has lower number of leaders
+				tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));				
+				// Verify that no leadership is present on the current broker before proceeding
+			}
+
+			for _, t := range replicaPartitions {
+                                tw.Print(t.topic, t.partition, "NO")
+                                break
+                        }
+		},
+	}
+
+	cmd.Flags().StringVar(&sourceBrokerId, "source-broker-id", "", "Source Broker Id")
+	cmd.Flags().StringVar(&destinationBrokerIds, "destination-broker-ids", "", "Destination Broker Ids")
+
+	return cmd
+}
+
+type NodePartitionCount struct {
+	leaderCount int
+	replicaCount int
+}
+
+type TopicPartition struct {
+	topic string
+	partition int32
+	replicas []int32
+}
+
+func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []TopicPartition) {
+
+	var leaderPartitions []TopicPartition
+	var replicaPartitions []TopicPartition
+
+	for _, t := range m.Topics.Sorted() {
+	        for _, pt := range t.Partitions.Sorted() {
+                	for _, rs := range pt.Replicas {
+                        	if int(rs) == brokerId {
+                                        if int(pt.Leader) == brokerId {
+                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        } else {
+                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+					}
+                                }
+                        }
+                }
+        }
+
+	return leaderPartitions,replicaPartitions
+}
+
+func remove(s []int32, r int32) []int32 {
+    for i, v := range s {
+        if v == r {
+            return append(s[:i], s[i+1:]...)
+        }
+    }
+    return s
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package partitions contains commands to talk to the Redpanda's admin partitions
+// endpoints.
+package partitions
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+// NewCommand returns the partitions admin command.
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "partitions",
+		Short: "View and configure Redpanda partitions through the admin listener.",
+		Args:  cobra.ExactArgs(0),
+	}
+	cmd.AddCommand(
+		newListCommand(fs),
+	)
+	return cmd
+}
+
+func newListCommand(fs afero.Fs) *cobra.Command {
+	var (
+		leaderOnly bool
+	)
+	cmd :=  &cobra.Command{
+		Use:     "list [BROKER ID]",
+		Aliases: []string{"ls"},
+		Short:   "List the partitions in a broker in the cluster.",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			brokerId, err := strconv.Atoi(args[0])
+                        out.MaybeDie(err, "invalid broker %s: %v", args[0], err)
+                        if brokerId < 0 {
+                                out.Die("invalid negative broker id %v", brokerId)
+                        }
+
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+                        defer adm.Close()
+
+			var m kadm.Metadata
+                        m, err = adm.Metadata(context.Background())
+                        out.MaybeDie(err, "unable to request metadata: %v", err)
+
+			tw := out.NewTable("TOPIC", "PARTITION", "IS_LEADER")
+			defer tw.Flush()
+
+			for _, t := range m.Topics.Sorted() {
+				for _, pt := range t.Partitions.Sorted() {
+					for _, rs := range pt.Replicas {
+						if int(rs) == brokerId {
+							var isLeader = "NO"
+							if int(pt.Leader) == brokerId {
+								isLeader = "YES"
+							}
+							tw.Print(t.Topic , pt.Partition, isLeader)
+						}
+					}
+				}
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&leaderOnly, "leader-only", "l", false, "print the partitions on broker which are leaders")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -12,16 +12,24 @@
 package partitions
 
 import (
+	"fmt"
+	"errors"
 	"context"
 	"strconv"
+	"sort"
+	"bufio"
+	"os"
 	"strings"
+	"math"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // NewCommand returns the partitions admin command.
@@ -33,7 +41,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
-		newMoveAllCommand(fs),
+		newDrainCommand(fs),
 	)
 	return cmd
 }
@@ -93,67 +101,153 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	return cmd
 }
 
-func newMoveAllCommand(fs afero.Fs) *cobra.Command {
+func newDrainCommand(fs afero.Fs) *cobra.Command {
 	var (
-		sourceBrokerId string
-		destinationBrokerIds string
+		destinationBrokerId int
 	)
         cmd :=  &cobra.Command{
-                Use:     "move-all --source-broker-id [SOURCE BROKER ID] --destination-broker-ids [DESTINATION BROKER IDs]",
-                Aliases: []string{"mv-all"},
-                Short:   "Move all the partitions from a source broker to multiple destination brokers in a cluster.",
-                Args:    cobra.ExactArgs(0),
+                Use:     "move-from [SOURCE BROKER ID] --destination-broker-id [DESTINATION BROKER ID]",
+                Aliases: []string{"mv-frm"},
+                Short:   "Move partitions from a source broker to a destination broker in a cluster.",
+                Args:    cobra.ExactArgs(1),
                 Run: func(cmd *cobra.Command, args []string) {
 
 			p := config.ParamsFromCommand(cmd)
-                        cfg, err := p.Load(fs)
-                        out.MaybeDie(err, "unable to load config: %v", err)
+			cfg, err := p.Load(fs)
+	        out.MaybeDie(err, "unable to load config: %v", err)
 
-                        adm, err := kafka.NewAdmin(fs, p, cfg)
-                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+            adm, err := kafka.NewAdmin(fs, p, cfg)
+            out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+
+            kgocl, err := kafka.NewFranzClient(fs, p, cfg)
+            out.MaybeDie(err, "unable to initialize franz-go client: %v", err)
 
 			var m kadm.Metadata
-                        m, err = adm.Metadata(context.Background())
-                        out.MaybeDie(err, "unable to request metadata: %v", err)
+            m, err = adm.Metadata(context.Background())
+            out.MaybeDie(err, "unable to request metadata: %v", err)
 
-                        // Check if Destination Broker list does not have Source Broker ID
-                        destinationBrokersMap := make(map[int]NodePartitionCount)
-                        for _, db := range strings.Split(destinationBrokerIds, ",") {
-                        	dbId, err := strconv.Atoi(db)
-                        	out.MaybeDie(err, "unable to parse destination broker id: %v", err)
-                        	leaderPartitions, replicaPartitions := getTopicPartitionMap(m, dbId)
-                        	destinationBrokersMap[dbId] = NodePartitionCount{len(leaderPartitions), len(replicaPartitions)}
-                        }
+			sourceBrokerId, err := strconv.Atoi(args[0])
+			out.MaybeDie(err, "unable to parse source broker id: %v", err)
+            
+			bs, err := cl.Brokers()
+            out.MaybeDie(err, "unable to request brokers: %v", err)            
 
-                        tw := out.NewTable("DESTINATION", "LEADER_PARTITION_COUNT", "REPLICA_PARTITION_COUNT")
-                        defer tw.Flush()
+            // Checking if source and destination broker Ids are not same
+            if destinationBrokerId == sourceBrokerId {
+            	out.MaybeDie(errors.New(""),"",errors.New("Destination broker list cannot have source broker id in it."))
+            }
 
-                        /*
-                        For debugging leader and replica count
-                        for dbId, db := range destinationBrokersMap {
-                        	tw.Print(dbId, db.leaderCount, db.replicaCount)	
-                        }
-                        */
-                        
-			brokerId, err := strconv.Atoi(sourceBrokerId)
-			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, brokerId)
+            // Checking if source and destination broker Ids exist
+            sourceBrokerCheck := false
+            destinationBrokerCheck := false
+            for _, brokerId := range bs {
+            	if brokerId.NodeID == sourceBrokerId && sourceBrokerCheck == false {
+            		sourceBrokerCheck = true
+            	}
+            	if brokerId.NodeID == destinationBrokerId && destinationBrokerCheck == false {
+            		destinationBrokerCheck = true
+            	}
+            }
+            if !(sourceBrokerCheck && destinationBrokerCheck) {
+            	out.Die("Source or Destination broker is invalid.")
+            }
 
-                        for _, t := range leaderPartitions {				
-				// Transfer leadership to the replica on a broker, which has lower number of leaders
-				tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));				
+			// for storing disk usage for all brokers
+			allBrokerDiskUsageMap := getBrokerDiskUsageMap(bs)			
+
+			// Get all the partitions on the source broker
+			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, sourceBrokerId)
+
+			// For each partition, try to fix it on the destination brokers
+			for _, t := range leaderPartitions {
+				//tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));
+				t.partition = t.partition + 1
 				// Verify that no leadership is present on the current broker before proceeding
 			}
 
+			// Fetching partition sizes
+			var req kmsg.DescribeLogDirsRequest
+
 			for _, t := range replicaPartitions {
-                                tw.Print(t.topic, t.partition, "NO")
-                                break
-                        }
+				var partitions []int32
+				partitions = append(partitions, t.partition)
+				req.Topics = append(req.Topics, kmsg.DescribeLogDirsRequestTopic{
+					Topic:      t.topic,
+					Partitions: partitions,
+				})
+			}
+
+			kresps := kgocl.RequestSharded(context.Background(), &req)
+
+			tw := out.NewTable()
+			header := func(name string) {				
+				tw.Print(name)
+				tw.Print(strings.Repeat("=", len(name)))
+				tw.Print()
+			}
+
+			header("DRAIN PLAN")			
+			
+			var totalPartitionSize int64
+			for _, kresp := range kresps {
+				resp := kresp.Resp.(*kmsg.DescribeLogDirsResponse)
+				sort.Slice(resp.Dirs, func(i, j int) bool { return resp.Dirs[i].Dir < resp.Dirs[j].Dir })
+				for _, dir := range resp.Dirs {
+					sort.Slice(dir.Topics, func(i, j int) bool { return dir.Topics[i].Topic < dir.Topics[j].Topic })
+					for _, topic := range dir.Topics {
+						sort.Slice(topic.Partitions, func(i, j int) bool { return topic.Partitions[i].Partition < topic.Partitions[j].Partition })
+						for _, partition := range topic.Partitions {							
+							totalPartitionSize = totalPartitionSize + partition.Size
+						}
+					}
+				}
+				break //TODO: REVISIT WHY DO WE NEED TO BREAK HERE
+			}
+
+			oldFDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100
+			newDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free) - float64(totalPartitionSize)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100			
+
+			header("DESTINATION BROKER DETAILS")
+			tw.PrintColumn("BROKER ID", "CURRENT DISK USAGE %", "PROPOSED DISK USAGE %", "PARTITIONS TO DRAIN", "DATA TO DRAIN")
+			tw.Print(destinationBrokerId, math.Round(oldFDiskUsage*100)/100, math.Round(newDiskUsage*100)/100, len(req.Topics), totalPartitionSize)
+			// If the new free disk is < 10% of total usage, we terminate the move of partitions
+			if newDiskUsage < 10 {
+            	out.Die("New Free Disk Space will be less than 10% of Total Disk Space. Aborting Move.")
+            }            
+            
+            tw.Flush()
+
+            fmt.Println()
+            reader := bufio.NewReader(os.Stdin)            
+			fmt.Print("Are you sure you want to proceed with the drain?(y/n): ")
+			inp, _ := reader.ReadString('\n')
+			input := strings.TrimRight(inp, "\n")
+
+			if !(input == "y" || input == "n") {
+				out.Die("Invalid input: %v", inp)
+			} else if input == "n" {
+				out.Die("Aborting the drain.")		
+			}
+
+			fmt.Println("Continue with the drain.")
+/*
+			for _, t := range replicaPartitions {
+				pa, err := cl.UpdateReplicas("kafka", t.topic, int(t.partition), sourceBrokerId, destinationBrokerId)
+				if err != nil {
+					out.MaybeDie(err, "Not able to drain partition: %v", pa.Topic, err)
+				} else {
+					fmt.Println("Partition is drained out. ", t.topic, " - ", t.partition)
+				}				
+				break
+			}
+*/
 		},
 	}
 
-	cmd.Flags().StringVar(&sourceBrokerId, "source-broker-id", "", "Source Broker Id")
-	cmd.Flags().StringVar(&destinationBrokerIds, "destination-broker-ids", "", "Destination Broker Ids")
-
+	cmd.Flags().IntVar(&destinationBrokerId, "destination-broker-id", -1, "Destination Broker Id")
 	return cmd
 }
 
@@ -163,9 +257,15 @@ type NodePartitionCount struct {
 }
 
 type TopicPartition struct {
-	topic string
-	partition int32
-	replicas []int32
+	topic 		string
+	partition 	int32
+	replicas 	[]int32
+	size	 	int64
+}
+
+type DiskUsage struct {
+	free int64
+	total int64
 }
 
 func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []TopicPartition) {
@@ -178,9 +278,9 @@ func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []To
                 	for _, rs := range pt.Replicas {
                         	if int(rs) == brokerId {
                                         if int(pt.Leader) == brokerId {
-                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
                                         } else {
-                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
 					}
                                 }
                         }
@@ -190,6 +290,17 @@ func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []To
 	return leaderPartitions,replicaPartitions
 }
 
+func getBrokerDiskUsageMap(bs []admin.Broker) (map[int]DiskUsage) {
+
+	dBrokerDiskUsage := make(map[int]DiskUsage)
+
+        for _, b := range bs {
+        	dBrokerDiskUsage[b.NodeID] = DiskUsage{b.DiskSpaceItems[0].Free, b.DiskSpaceItems[0].Total}
+        }
+	return dBrokerDiskUsage
+
+}
+
 func remove(s []int32, r int32) []int32 {
     for i, v := range s {
         if v == r {
@@ -197,4 +308,14 @@ func remove(s []int32, r int32) []int32 {
         }
     }
     return s
+}
+
+func getLeastUsedBroker(dBrokerDiskUsageMap map[int]DiskUsage) {
+	broker := dBrokerDiskUsageMap[0]
+	for i := 1; i < len(dBrokerDiskUsageMap); i++ {
+		if dBrokerDiskUsageMap[i].free > broker.free {
+			broker = dBrokerDiskUsageMap[i]
+		}
+	}
+	fmt.Println(broker)
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -71,11 +71,14 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 				for _, pt := range t.Partitions.Sorted() {
 					for _, rs := range pt.Replicas {
 						if int(rs) == brokerId {
-							var isLeader = "NO"
+							var isLeader bool
 							if int(pt.Leader) == brokerId {
-								isLeader = "YES"
+								isLeader = true
+								tw.Print(t.Topic , pt.Partition, isLeader)
 							}
-							tw.Print(t.Topic , pt.Partition, isLeader)
+							if !leaderOnly && !isLeader {
+								tw.Print(t.Topic , pt.Partition, isLeader)
+							}
 						}
 					}
 				}

--- a/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
@@ -25,7 +25,7 @@ func NewRedpandaDarwinCommand(
 ) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "redpanda",
-		Short: "Interact with a local Redpanda process",
+		Short: "Interact with a remote Redpanda process",
 	}
 
 	command.AddCommand(admin.NewCommand(fs))

--- a/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build darwin
+// +build darwin
+
+package cmd
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	rp "github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewRedpandaDarwinCommand(
+	fs afero.Fs, mgr config.Manager, launcher rp.Launcher,
+) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "redpanda",
+		Short: "Interact with a local Redpanda process",
+	}
+
+	command.AddCommand(admin.NewCommand(fs))
+
+	return command
+}

--- a/src/go/rpk/pkg/cli/cmd/root_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/root_darwin.go
@@ -10,6 +10,7 @@
 package cmd
 
 import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -19,4 +20,5 @@ import (
 func addPlatformDependentCmds(
 	fs afero.Fs, mgr config.Manager, cmd *cobra.Command,
 ) {
+	cmd.AddCommand(NewRedpandaDarwinCommand(fs, mgr, redpanda.NewLauncher()))
 }


### PR DESCRIPTION
`rpk redpanda admin partitions move-from [SOURCE_BROKER] --destination-broker-ids [DESTINATION_BROKER_IDS]` 

We should be able to drain partitions from a source broker to multiple destination brokers.