### PR TITLE
Fixed assertition when handling fetch requests

### DIFF
--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -54,6 +54,12 @@ struct op_context {
     // decode request and initialize budgets
     op_context(request_context&& ctx, ss::smp_service_group ssg);
 
+    op_context(op_context&&) = delete;
+    op_context(const op_context&) = delete;
+    op_context& operator=(const op_context&) = delete;
+    op_context& operator=(op_context&&) = delete;
+    ~op_context() noexcept = default;
+
     // reserve space for a new topic in the response
     void start_response_topic(const fetch_request::topic& topic);
 

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -12,6 +12,7 @@
 #include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/handler.h"
 #include "kafka/types.h"
+#include "utils/intrusive_list_helpers.h"
 
 namespace kafka {
 
@@ -21,34 +22,37 @@ using fetch_handler = handler<fetch_api, 4, 11>;
  * Fetch operation context
  */
 struct op_context {
-    class response_iterator {
+    class response_placeholder {
     public:
-        using difference_type = void;
-        using pointer = fetch_response::iterator::pointer;
-        using reference = fetch_response::iterator::reference;
-        using iterator_category = std::forward_iterator_tag;
-
-        response_iterator(fetch_response::iterator, op_context* ctx);
-
-        reference operator*() noexcept { return *_it; }
-
-        pointer operator->() noexcept { return &(*_it); }
-
-        response_iterator& operator++();
-
-        const response_iterator operator++(int);
-
-        bool operator==(const response_iterator& o) const noexcept;
-
-        bool operator!=(const response_iterator& o) const noexcept;
+        response_placeholder(fetch_response::iterator, op_context* ctx);
 
         void set(fetch_response::partition_response&&);
+
+        const model::topic& topic() { return _it->partition->name; }
+        model::partition_id partition_id() {
+            return _it->partition_response->partition_index;
+        }
+
+        bool empty() { return _it->partition_response->records->empty(); }
+        bool has_error() {
+            return _it->partition_response->error_code != error_code::none;
+        }
+        void move_to_end() {
+            _ctx->iteration_order.erase(
+              _ctx->iteration_order.iterator_to(*this));
+            _ctx->iteration_order.push_back(*this);
+        }
+        intrusive_list_hook _hook;
 
     private:
         fetch_response::iterator _it;
         op_context* _ctx;
     };
 
+    using iteration_order_t
+      = intrusive_list<response_placeholder, &response_placeholder::_hook>;
+    using response_iterator = iteration_order_t::iterator;
+    using response_placeholder_ptr = response_placeholder*;
     void reset_context();
 
     // decode request and initialize budgets
@@ -58,7 +62,11 @@ struct op_context {
     op_context(const op_context&) = delete;
     op_context& operator=(const op_context&) = delete;
     op_context& operator=(op_context&&) = delete;
-    ~op_context() noexcept = default;
+    ~op_context() {
+        iteration_order.clear_and_dispose([](response_placeholder* ph) {
+            delete ph; // NOLINT
+        });
+    }
 
     // reserve space for a new topic in the response
     void start_response_topic(const fetch_request::topic& topic);
@@ -97,16 +105,21 @@ struct op_context {
 
     ss::future<response_ptr> send_response() &&;
 
-    response_iterator response_begin(bool enable_filtering = false) {
-        return response_iterator(response.begin(enable_filtering), this);
-    }
+    response_iterator response_begin() { return iteration_order.begin(); }
 
-    response_iterator response_end() {
-        return response_iterator(response.end(), this);
-    }
+    response_iterator response_end() { return iteration_order.end(); }
     template<typename Func>
     void for_each_fetch_partition(Func&& f) const {
-        if (session_ctx.is_full_fetch() || session_ctx.is_sessionless()) {
+        /**
+         * Iterate over original request only if it is sessionless or initial
+         * full fetch request. For not initial full fetch requests we may
+         * leverage the fetch session stored partitions as session was populated
+         * during initial pass. Using session stored partitions will account for
+         * the partitions already read and move to the end of iteration order
+         */
+        if (
+          session_ctx.is_sessionless()
+          || (session_ctx.is_full_fetch() && initial_fetch)) {
             std::for_each(
               request.cbegin(),
               request.cend(),
@@ -143,6 +156,7 @@ struct op_context {
 
     bool initial_fetch = true;
     fetch_session_ctx session_ctx;
+    iteration_order_t iteration_order;
 };
 
 struct fetch_config {
@@ -262,10 +276,10 @@ struct read_result {
 struct shard_fetch {
     void push_back(
       ntp_fetch_config config,
-      op_context::response_iterator it,
+      op_context::response_placeholder_ptr r_ph,
       std::unique_ptr<hdr_hist::measurement> m) {
         requests.push_back(std::move(config));
-        responses.push_back(it);
+        responses.push_back(r_ph);
         metrics.push_back(std::move(m));
     }
 
@@ -281,7 +295,7 @@ struct shard_fetch {
     }
     ss::shard_id shard;
     std::vector<ntp_fetch_config> requests;
-    std::vector<op_context::response_iterator> responses;
+    std::vector<op_context::response_placeholder_ptr> responses;
     std::vector<std::unique_ptr<hdr_hist::measurement>> metrics;
 
     friend std::ostream& operator<<(std::ostream& o, const shard_fetch& sf) {

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -17,6 +17,8 @@
 
 #include <seastar/core/smp.hh>
 
+#include <fmt/ostream.h>
+
 #include <chrono>
 #include <limits>
 
@@ -311,11 +313,9 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
           make_partition_response(1));
         return response;
     };
-    kafka::op_context ctx(
-      make_request_context(), ss::default_smp_service_group());
+    auto fetch_request = make_request_context();
     auto response = make_test_fetch_response();
-    ctx.response = make_test_fetch_response();
-    auto wrapper_iterator = ctx.response_begin();
+
     int i = 0;
 
     for (auto it = response.begin(); it != response.end(); ++it) {
@@ -330,13 +330,7 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
             BOOST_REQUIRE_EQUAL(
               it->partition_response->partition_index(), i - 4);
         }
-        BOOST_REQUIRE_EQUAL(
-          it->partition->name, wrapper_iterator->partition->name);
-        BOOST_REQUIRE_EQUAL(
-          wrapper_iterator->partition_response->partition_index,
-          wrapper_iterator->partition_response->partition_index);
         ++i;
-        ++wrapper_iterator;
     }
 };
 

--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+import threading
+from ducktape.services.background_thread import BackgroundThreadService
+
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from ducktape.utils.util import wait_until
+
+
+class KafkaCliConsumer(BackgroundThreadService):
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 group=None,
+                 offset=None,
+                 partitions=None,
+                 isolation_level=None,
+                 consumer_properties={}):
+        super(KafkaCliConsumer, self).__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+        self._topic = topic
+        self._group = group
+        self._offset = offset
+        self._partitions = partitions
+        self._isolation_level = isolation_level
+        self._consumer_properties = consumer_properties
+        self._stopping = threading.Event()
+        assert self._partitions is not None or self._group is not None, "either partitions or group have to be set"
+
+        self._cli = KafkaCliTools(self._redpanda)
+        self._messages = []
+
+    def script(self):
+        return self._cli._script("kafka-console-consumer.sh")
+
+    def _worker(self, _, node):
+        self._stopping.clear()
+        try:
+
+            cmd = [self.script()]
+            cmd += ["--topic", self._topic]
+            if self._group is not None:
+                cmd += ["--group", str(self._group)]
+            if self._offset is not None:
+                cmd += ['--offset', str(self._offset)]
+            if self._partitions is not None:
+                cmd += ['--partition', ','.join(self._partitions)]
+            if self._isolation_level is not None:
+                cmd += ["--isolation-level", str(self._isolation_level)]
+            for k, v in self._consumer_properties.items():
+                cmd += ['--consumer-property', f"{k}={v}"]
+
+            cmd += ["--bootstrap-server", self._redpanda.brokers()]
+
+            for line in node.account.ssh_capture(' '.join(cmd)):
+                line.strip()
+                self.logger.debug(f"consumed: '{line}'")
+                self._messages.append(line)
+
+                if self._stopping.is_set():
+                    break
+
+        except:
+            if self._stopping.is_set():
+                # Expect a non-zero exit code when killing during teardown
+                pass
+            else:
+                raise
+        finally:
+            self.done = True
+
+    def wait_for_messages(self, messages, timeout=30):
+        wait_until(lambda: len(self._messages) >= messages,
+                   timeout,
+                   backoff_sec=2)
+
+    def stop_node(self, node):
+        self._stopping.set()
+        node.account.kill_process("java", clean_shutdown=False)

--- a/tests/rptest/tests/fetch_long_poll_test.py
+++ b/tests/rptest/tests/fetch_long_poll_test.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from collections import defaultdict
+from time import sleep
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+from rptest.services.cluster import cluster
+from ducktape.mark import parametrize
+
+from rptest.clients.kcl import KCL
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.kafka_cli_consumer import KafkaCliConsumer
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class FetchTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        self._ctx = test_ctx
+        super(FetchTest, self).__init__(test_ctx,
+                                        num_brokers=3,
+                                        *args,
+                                        extra_rp_conf={},
+                                        **kwargs)
+
+    @cluster(num_nodes=4)
+    def fetch_long_poll_test(self):
+        """
+        Test if redpanda is able to debounce fetches when consumer requests
+        to wait for data
+        """
+        partition_count = 20
+        total_messages = 10
+        topic = TopicSpec(partition_count=partition_count,
+                          replication_factor=3)
+
+        # create topic
+        self.client().create_topic(specs=topic)
+        rpk = RpkTool(self.redpanda)
+
+        consumer = KafkaCliConsumer(self.test_context,
+                                    self.redpanda,
+                                    topic=topic.name,
+                                    group='test-gr-1',
+                                    consumer_properties={
+                                        'fetch.min.bytes': 1024,
+                                        'fetch.max.wait.ms': 1000,
+                                    })
+        consumer.start()
+        for p in range(0, total_messages + 1):
+            rpk.produce(topic.name,
+                        f"k-{p}",
+                        f"v-test-{p}",
+                        partition=p % partition_count)
+            # sleep for 2 seconds every each message
+            # to prevent fetch handler from returning fast
+            sleep(2)
+
+        consumer.wait_for_messages(10)
+        consumer.stop()
+        consumer.wait()


### PR DESCRIPTION
## Cover letter

In Kafka to prevent starvation when handling fetch request for
partitions which are stored in the fetch session server moves the
partition to end whenever some data were already read for that
partition. This way partition list rotates and all partitions have
chance to be read during multiple fetch requests.

In redpanda we implemented moving partition to the end of list in fetch
session but we did not implemented changing order of iteration in
response. This might lead to assertion being triggered as fetch handler
tried to set response in the placeholder that belonged to different
partition. This situation may only take place if consumer is using long
poll technique.

When consumer requests to wait for requested number of bytes
(`fetch.min.bytes` parameter) in redpanda we may issue multiple reads.
Each consecutive read should change response placeholders iteration
order if some of the partitions were moved to the end in 'fill partition
responses' phase. This will prevent assertion from being triggered as
order of partitions when iterating over fetch session and fetch response
will be the same.

Fixes: #3336

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
