### PR TITLE
tests: make mirror_maker_test more robust 

### DIFF
--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -20,6 +20,12 @@ class KafkaServiceAdapter:
     def start(self, add_principals=""):
         return self._kafka_service.start(add_principals)
 
+    def __getattribute__(self, name):
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            return getattr(self._kafka_service, name)
+
     # required for rpk
     def find_binary(self, name):
         rp_install_path_root = self._context.globals.get(

--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -45,6 +45,25 @@ class TestMirrorMakerService(EndToEndTest):
     def setUp(self):
         self.zk.start()
 
+    def tearDown(self):
+        # ducktape handle service teardown automatically, but it is hard
+        # to tell what went wrong if one of the services hangs.  Do it
+        # explicitly here with some logging, to enable debugging issues
+        # like https://github.com/redpanda-data/redpanda/issues/4270
+
+        self.logger.info(
+            f"Stopping source broker ({self.source_broker.__class__.__name__})..."
+        )
+        self.source_broker.stop()
+        self.logger.info(
+            f"Awaiting source broker ({self.source_broker.__class__.__name__})..."
+        )
+        self.logger.info(f"tearDown complete")
+
+        self.logger.info("Stopping zookeeper...")
+        self.zk.stop()
+        self.logger.info("Awaiting zookeeper...")
+
     def start_brokers(self, source_type=kafka_source):
         if source_type == TestMirrorMakerService.redpanda_source:
             self.source_broker = RedpandaService(self.test_context,


### PR DESCRIPTION
## Cover letter

Address issues seen in the new mirrormaker test:
- Explicit teardown so that we have a better shot at seeing what's breaking if something is hanging during shutdown
- Catch the RpkException that triggered the failure that probably tripped the unclean teardown path

Plus a bonus fix for decode_backtraces to handle the case where redpanda never started.

Related: #4270

## Release notes

* none
