### PR TITLE
Persisted_stm: fix sync timing out in case of acks=1

### DIFF
--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -21,6 +21,8 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 
+from ducktape.mark import matrix
+
 from collections import namedtuple, defaultdict
 import time
 import os
@@ -410,7 +412,8 @@ class ArchivalTest(RedpandaTest):
         validate(check_upload, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_retention_archival_coordination(self):
+    @matrix(acks=[1, -1])
+    def test_retention_archival_coordination(self, acks):
         """
         Test that only archived segments can be evicted and that eviction
         restarts once the segments have been archived.
@@ -426,7 +429,8 @@ class ArchivalTest(RedpandaTest):
             produce_until_segments(redpanda=self.redpanda,
                                    topic=self.topic,
                                    partition_idx=0,
-                                   count=10)
+                                   count=10,
+                                   acks=acks)
 
             # Sleep some time sufficient for log eviction under normal conditions
             # and check that no segment has been evicted (because we can't upload


### PR DESCRIPTION
## Cover letter

Previously, if the user produced with acks=1, persisted_stm::sync always timed out because we tried to wait until `commit_index` reached the current dirty offset and, even though we flushed on the leader, the followers didn't flush and `commit_index` didn't move.

Instead, now we sync only up to the last offset before the start of the current term. This upholds the contract of `persisted_stm::sync` ("it waits until the state machine is caught up with all the events written by the previous leaders") and we don't have to do any additional flushes because after election the new leader replicates the configuration batch and always does it with acks=-1.

Fixes #4224

## Release notes
### Bug fixes
* Fix retention settings not working with acks=1 and enabled shadow indexing
