### PR TITLE
Backport v21.11.x pr4246 pr4276

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -360,9 +360,8 @@ ss::future<> partition::stop() {
     return f;
 }
 
-ss::future<std::optional<storage::timequery_result>> partition::timequery(
-  model::timestamp t, model::offset offset_limit, ss::io_priority_class p) {
-    storage::timequery_config cfg(t, offset_limit, p);
+ss::future<std::optional<storage::timequery_result>>
+partition::timequery(storage::timequery_config cfg) {
     return _raft->timequery(cfg);
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -135,7 +135,7 @@ public:
     const model::ntp& ntp() const { return _raft->ntp(); }
 
     ss::future<std::optional<storage::timequery_result>>
-      timequery(model::timestamp, model::offset, ss::io_priority_class);
+      timequery(storage::timequery_config);
 
     bool is_leader() const { return _raft->is_leader(); }
 

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -106,7 +106,10 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
-      timestamp, offset_limit, kafka_read_priority(), std::nullopt});
+      timestamp,
+      offset_limit,
+      kafka_read_priority(),
+      {model::record_batch_type::raft_data}});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -106,7 +106,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
-      timestamp, offset_limit, kafka_read_priority()});
+      timestamp, offset_limit, kafka_read_priority(), std::nullopt});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -105,8 +105,8 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                                 ? kafka_partition->last_stable_offset()
                                 : kafka_partition->high_watermark();
 
-    auto res = co_await kafka_partition->timequery(
-      timestamp, offset_limit, kafka_read_priority());
+    auto res = co_await kafka_partition->timequery(storage::timequery_config{
+      timestamp, offset_limit, kafka_read_priority()});
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -57,12 +57,9 @@ public:
         co_return storage::translating_reader(co_await _log.make_reader(cfg));
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) final {
-        storage::timequery_config cfg(ts, offset_limit, io_pc);
-        return _log.timequery(cfg);
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) final {
+        return _partition->timequery(cfg);
     };
 
     ss::future<std::vector<cluster::rm_stm::tx_range>> aborted_transactions(

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -39,7 +39,7 @@ public:
           std::optional<model::timeout_clock::time_point>)
           = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
-          timequery(model::timestamp, model::offset, ss::io_priority_class) = 0;
+          timequery(storage::timequery_config) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
           aborted_transactions(
             model::offset,
@@ -82,11 +82,9 @@ public:
         return _impl->make_reader(cfg, deadline);
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) {
-        return _impl->timequery(ts, offset_limit, io_pc);
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) {
+        return _impl->timequery(cfg);
     }
 
     cluster::partition_probe& probe() { return _impl->probe(); }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -144,12 +144,9 @@ replicated_partition::aborted_transactions(
 }
 
 ss::future<std::optional<storage::timequery_result>>
-replicated_partition::timequery(
-  model::timestamp ts,
-  model::offset offset_limit,
-  ss::io_priority_class io_pc) {
-    return _partition->timequery(ts, offset_limit, io_pc)
-      .then([this](std::optional<storage::timequery_result> r) {
+replicated_partition::timequery(storage::timequery_config cfg) {
+    return _partition->timequery(cfg).then(
+      [this](std::optional<storage::timequery_result> r) {
           if (r) {
               r->offset = _translator->from_log_offset(r->offset);
           }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -62,10 +62,8 @@ public:
         co_return r.error();
     }
 
-    ss::future<std::optional<storage::timequery_result>> timequery(
-      model::timestamp ts,
-      model::offset offset_limit,
-      ss::io_priority_class io_pc) final;
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) final;
 
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -7,9 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/list_offsets.h"
+#include "kafka/protocol/produce.h"
+#include "model/metadata.h"
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/io_priority.h"
+#include "storage/tests/utils/random_batch.h"
 #include "test_utils/async.h"
 
 #include <seastar/core/smp.hh>
@@ -131,4 +135,73 @@ FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
     BOOST_CHECK(
       resp.data.topics[0].partitions[0].timestamp == model::timestamp(-1));
     BOOST_CHECK(resp.data.topics[0].partitions[0].offset > model::offset(0));
+}
+
+kafka::produce_request
+make_produce_request(model::topic_partition tp, model::record_batch&& batch) {
+    std::vector<kafka::produce_request::partition> partitions;
+    partitions.emplace_back(kafka::produce_request::partition{
+      .partition_index{tp.partition},
+      .records = kafka::produce_request_record_data(std::move(batch))});
+
+    std::vector<kafka::produce_request::topic> topics;
+    topics.emplace_back(kafka::produce_request::topic{
+      .name{std::move(tp.topic)}, .partitions{std::move(partitions)}});
+    std::optional<ss::sstring> t_id;
+    int16_t acks = -1;
+    return kafka::produce_request(t_id, acks, std::move(topics));
+}
+
+FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get0();
+    model::ntp ntp(
+      model::kafka_namespace,
+      model::topic(random_generators::gen_alphanum_string(8)),
+      model::partition_id(0));
+
+    add_topic(model::topic_namespace_view{ntp}, 1).get();
+    wait_for_partition_offset(ntp, model::offset(0)).get0();
+
+    auto client = make_kafka_client().get0();
+    client.connect().get();
+
+    // 3 batches of 2 records, with timestamps, 0, 1, 2.
+    const size_t batch_count = 3;
+    const size_t record_count = 2;
+    std::vector<model::record_batch> batches;
+    batches.reserve(batch_count);
+    for (long i = 0; i < batch_count; ++i) {
+        batches.push_back(make_random_batch(storage::test::record_batch_spec{
+          .count = record_count, .timestamp{i}}));
+        auto req = make_produce_request(ntp.tp, batches.back().share());
+        auto res = client.dispatch(std::move(req), kafka::api_version(7)).get();
+        const auto& topics = res.data.responses;
+        BOOST_REQUIRE_EQUAL(topics.size(), 1);
+        const auto& parts = topics[0].partitions;
+        BOOST_REQUIRE_EQUAL(parts.size(), 1);
+        BOOST_REQUIRE_EQUAL(parts[0].error_code, kafka::error_code::none);
+    }
+
+    for (long i = 0; i < batch_count; ++i) {
+        // fetch timestamp i, expect offset 2 * i.
+        kafka::list_offsets_request req;
+        req.data.topics = {{
+          .name = ntp.tp.topic,
+          .partitions = {{
+            .partition_index = ntp.tp.partition,
+            .timestamp = model::timestamp(i),
+          }},
+        }};
+
+        auto resp = client.dispatch(req, kafka::api_version(1)).get0();
+
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+        BOOST_CHECK(
+          resp.data.topics[0].partitions[0].timestamp == model::timestamp(i));
+        BOOST_CHECK(
+          resp.data.topics[0].partitions[0].offset == model::offset(i * 2));
+    }
+
+    client.stop().then([&client] { client.shutdown(); }).get();
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -868,7 +868,7 @@ disk_log_impl::make_reader(timequery_config config) {
             0,
             2048, // We just need one record batch
             cfg.prio,
-            std::nullopt,
+            cfg.type_filter,
             cfg.time,
             cfg.abort_source);
           return model::make_record_batch_reader<log_reader>(

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -47,7 +47,8 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
         storage::timequery_config config(
           model::timestamp(ts),
           log.offsets().dirty_offset,
-          ss::default_priority_class());
+          ss::default_priority_class(),
+          std::nullopt);
 
         auto res = log.timequery(config).get0();
         BOOST_TEST(res);
@@ -68,7 +69,8 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
         storage::timequery_config config(
           model::timestamp(ts),
           log.offsets().dirty_offset,
-          ss::default_priority_class());
+          ss::default_priority_class(),
+          std::nullopt);
 
         auto offset = (ts - 100) * 5 + 100;
 
@@ -100,7 +102,8 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
     storage::timequery_config config(
       model::timestamp(1200),
       log.offsets().dirty_offset,
-      ss::default_priority_class());
+      ss::default_priority_class(),
+      std::nullopt);
 
     auto empty_res = log.timequery(config).get0();
     BOOST_TEST(!empty_res);

--- a/src/v/storage/tests/utils/random_batch.h
+++ b/src/v/storage/tests/utils/random_batch.h
@@ -25,9 +25,9 @@ struct record_batch_spec {
     std::optional<int> records{std::nullopt};
     model::record_batch_type bt{model::record_batch_type::raft_data};
     bool enable_idempotence{false};
-    int64_t producer_id{0};
-    int16_t producer_epoch{0};
-    int32_t base_sequence{0};
+    int64_t producer_id{-1};
+    int16_t producer_epoch{-1};
+    int32_t base_sequence{-1};
     bool is_transactional{false};
 };
 

--- a/src/v/storage/tests/utils/random_batch.h
+++ b/src/v/storage/tests/utils/random_batch.h
@@ -13,6 +13,7 @@
 
 #include "model/record.h"
 #include "model/record_batch_reader.h"
+#include "model/timestamp.h"
 #include "random/generators.h"
 
 namespace storage::test {
@@ -29,6 +30,7 @@ struct record_batch_spec {
     int16_t producer_epoch{-1};
     int32_t base_sequence{-1};
     bool is_transactional{false};
+    std::optional<model::timestamp> timestamp;
 };
 
 /**

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -48,7 +48,15 @@ std::ostream& operator<<(std::ostream& o, const timequery_result& a) {
     return o << "{offset:" << a.offset << ", time:" << a.time << "}";
 }
 std::ostream& operator<<(std::ostream& o, const timequery_config& a) {
-    return o << "{max_offset:" << a.max_offset << ", time:" << a.time << "}";
+    o << "{max_offset:" << a.max_offset << ", time:" << a.time
+      << ", type_filter:";
+    if (a.type_filter) {
+        o << *a.type_filter;
+    } else {
+        o << "nullopt";
+    }
+    o << "}";
+    return o;
 }
 
 std::ostream&

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -143,14 +143,17 @@ struct timequery_config {
       model::timestamp t,
       model::offset o,
       ss::io_priority_class iop,
+      std::optional<model::record_batch_type> type_filter,
       opt_abort_source_t as = std::nullopt) noexcept
       : time(t)
       , max_offset(o)
       , prio(iop)
+      , type_filter(type_filter)
       , abort_source(as) {}
     model::timestamp time;
     model::offset max_offset;
     ss::io_priority_class prio;
+    std::optional<model::record_batch_type> type_filter;
     opt_abort_source_t abort_source;
 
     friend std::ostream& operator<<(std::ostream& o, const timequery_config&);


### PR DESCRIPTION
Backport #4246 #4276 

## Cover letter

When performing a timequery, ignore batches that are not `raft_data`.

Fix #4274

### Reviewer notes

I don't know if `timequery` is performed by subsystems other than kafka, but if that's the case, then perhaps the `storage::log_reader_config::type_filter` should be passed down through `storage::timequery_config`.

## Release notes

### Improvements

* list_offsets by time now ignores control batches
