### PR TITLE
cluster: catch raft group that fall through the leadership blockade

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -185,7 +185,7 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     }
 
     vlog(
-      clusterlog.info, "changing node {} to maintenance state", target->first);
+      clusterlog.info, "marking node {} in maintenance state", target->first);
 
     target->second->set_maintenance_state(model::maintenance_state::active);
 

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -164,7 +164,16 @@ ss::future<bool> prevote_stm::do_prevote() {
     _config->for_each_voter([this](vnode id) { (void)dispatch_prevote(id); });
 
     // process results
-    return process_replies().then([this]() { return _success; });
+    return process_replies().then([this]() {
+        if (_success && _ptr->_node_priority_override == zero_voter_priority) {
+            vlog(
+              _ctxlog.debug,
+              "Ignoring successful pre-vote. Node priority too low: {}",
+              _ptr->_node_priority_override.value());
+            _success = false;
+        }
+        return _success;
+    });
 }
 
 ss::future<> prevote_stm::process_replies() {

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -227,6 +227,15 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
         return ss::now();
     }
 
+    if (_ptr->_node_priority_override == zero_voter_priority) {
+        vlog(
+          _ctxlog.debug,
+          "Ignoring successful vote. Node priority too low: {}",
+          _ptr->_node_priority_override.value());
+        _ptr->_vstate = consensus::vote_state::follower;
+        return ss::now();
+    }
+
     std::vector<vnode> acks;
     for (auto& [id, r] : _replies) {
         if (r.get_state() == vmeta::state::vote_granted) {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -338,9 +338,10 @@ void admin_server::log_request(
   const ss::httpd::request& req, const request_auth_result& auth_state) const {
     vlog(
       logger.debug,
-      "[{}] {}",
+      "[{}] {} {}",
       auth_state.get_username().size() > 0 ? auth_state.get_username()
                                            : "_anonymous",
+      req._method,
       req.get_url());
 }
 

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -58,13 +58,13 @@ class MaintenanceTest(RedpandaTest):
         mode and all of the work associated with that has completed.
         """
         self.logger.debug(
-            "Checking that node {node.name} has a leadership role")
+            f"Checking that node {node.name} has a leadership role")
         wait_until(lambda: self._has_leadership_role(node),
                    timeout_sec=60,
                    backoff_sec=10)
 
         self.logger.debug(
-            "Checking that node {node.name} is not in maintenance mode")
+            f"Checking that node {node.name} is not in maintenance mode")
         status = self.admin.maintenance_status(node)
         assert status[
             "draining"] == False, f"Node {node.name} in maintenance mode"
@@ -72,18 +72,18 @@ class MaintenanceTest(RedpandaTest):
         self.admin.maintenance_start(node)
 
         self.logger.debug(
-            "Waiting for node {node.name} to enter maintenance mode")
+            f"Waiting for node {node.name} to enter maintenance mode")
         wait_until(lambda: self._in_maintenance_mode(node),
                    timeout_sec=30,
                    backoff_sec=5)
 
-        self.logger.debug("Waiting for node {node.name} leadership to drain")
+        self.logger.debug(f"Waiting for node {node.name} leadership to drain")
         wait_until(lambda: not self._has_leadership_role(node),
                    timeout_sec=60,
                    backoff_sec=10)
 
         self.logger.debug(
-            "Waiting for node {node.name} maintenance mode to complete")
+            f"Waiting for node {node.name} maintenance mode to complete")
         wait_until(lambda: self._in_maintenance_mode_fully(node),
                    timeout_sec=60,
                    backoff_sec=10)

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -82,10 +82,18 @@ class MaintenanceTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=5)
 
+        def has_drained():
+            """
+            as we wait for leadership to drain, also print out maintenance mode
+            status. this is useful for debugging to detect if maintenance mode
+            has been lost or disabled for some unexpected reason.
+            """
+            status = self.admin.maintenance_status(node)
+            self.logger.debug(f"Maintenance status for {node.name}: {status}")
+            return not self._has_leadership_role(node),
+
         self.logger.debug(f"Waiting for node {node.name} leadership to drain")
-        wait_until(lambda: not self._has_leadership_role(node),
-                   timeout_sec=60,
-                   backoff_sec=10)
+        wait_until(has_drained, timeout_sec=60, backoff_sec=10)
 
         self.logger.debug(
             f"Waiting for node {node.name} maintenance mode to complete")

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -32,7 +32,12 @@ class MaintenanceTest(RedpandaTest):
         """
         id = self.redpanda.idx(node)
         partitions = self.admin.get_partitions(node=node)
-        return len(list(filter(lambda p: p["leader"] == id, partitions))) > 0
+        has_leadership = False
+        for p in partitions:
+            if p["leader"] == id:
+                self.logger.debug(f"{node.name} has leadership for {p}")
+                has_leadership = True
+        return has_leadership
 
     def _in_maintenance_mode(self, node):
         status = self.admin.maintenance_status(node)


### PR DESCRIPTION
## Cover letter

A natural race exists when blocking leadership of node that occurs if
leadership blocking races with an election. One way to solve this would
be to add more states into consensus or hold the consensus lock (or
other lock) over a much wider range of code / fibers in order to provide
a synchronization point that the drain manager could use.

Alternatively, we can accept that the race exists and treat it similarly
to how we use abort sources to shutdown services. We allow the race to
exist, but check for blocking at strategic locations. These locations
are after a pre-vote: if the pre-vote was successful but leadership is
blocked then we do not proceed to the voting phase.

If leadership blocking occurs after voting starts then if the vote would
have been successful we treat it as a failed vote.

Fixes: #4236 
Fixes: #4228 

## Release notes

* Fixes issue in leadership draining that may allow some raft group leadership to return.
