### PR TITLE
Revert "k8s: remove produce-consume test"

### DIFF
--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster-sample
+status:
+  readyReplicas: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-sample
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-sample
+status:
+  replicas: 3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-sample
+  labels:
+    test: produce-consume
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: false

--- a/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - sleep 10 ; rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+      restartPolicy: Never
+  backoffLimit: 12
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/produce-consume/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: produce-message
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: produce-message
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              echo {"test":"message"} |
+              rpk topic produce test
+              --brokers "cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-1.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-2.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092"
+              -v -n 1 -k "test-key"
+      restartPolicy: Never
+  backoffLimit: 12
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/produce-consume/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/03-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: consume-message
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/e2e/produce-consume/03-consume-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/03-consume-message.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: consume-message
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafkacat
+          image: confluentinc/cp-kafkacat:5.5.3
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              kafkacat -b cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092
+              -C -t test -c1
+              -f '\nKey (%K bytes): %k\t\nValue (%S bytes): %s\nTimestamp: %T\tPartition: %p\tOffset: %o\n--\n'
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/produce-consume/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/04-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-test-topic
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-test-topic
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - rpk topic delete test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1


### PR DESCRIPTION
This reverts commit 1484a97a4259df9e7c51e437ece8d9a483fdb8f3.

after running several times, it seems that this is not failing anymore

fixes #2484 

## Release notes

* none

