### PR TITLE
Removed `header_crc` assertiton

### DIFF
--- a/src/v/storage/segment_appender_utils.cc
+++ b/src/v/storage/segment_appender_utils.cc
@@ -26,9 +26,6 @@
 namespace storage {
 
 iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
-#ifndef NDEBUG
-    vassert(h.header_crc != 0, "Header cannot have an unset crc:{}", h);
-#endif
     iobuf b;
     reflection::serialize(
       b,


### PR DESCRIPTION



## Cover letter

Header crc with value equal to 0 is a perfectly valid crc value. Removed
assertion validating header_crc not to be equal to 0.

