### PR TITLE
[v21.11.x] Backport "Persisted_stm: fix sync timing out in case of acks=1"

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -241,10 +241,26 @@ ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
     }
     _is_catching_up = true;
 
-    auto dirty = _c->dirty_offset();
-    co_await _c->refresh_commit_index();
-
-    auto is_synced = co_await do_sync(timeout, dirty, term);
+    // To guarantee that we have caught up with all records written by previous
+    // leaders, we choose the last offset before the start of the current term
+    // as the sync offset. Because the leader replicates the configuration batch
+    // at the start of the term, this offset is guaranteed to be less than
+    // committed index, so we won't need any additional flushes even if the
+    // client produces with acks=1.
+    model::offset sync_offset;
+    auto log_offsets = _c->log().offsets();
+    if (log_offsets.dirty_offset_term == term) {
+        if (log_offsets.last_term_start_offset > model::offset{0}) {
+            sync_offset = log_offsets.last_term_start_offset - model::offset{1};
+        } else {
+            sync_offset = model::offset{};
+        }
+    } else {
+        // We haven't been able to append the configuration batch at the start
+        // of the term yet.
+        sync_offset = log_offsets.dirty_offset;
+    }
+    auto is_synced = co_await do_sync(timeout, sync_offset, term);
 
     _is_catching_up = false;
     for (auto& sync_waiter : _sync_waiters) {

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -24,6 +24,8 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 
+from ducktape.mark import matrix
+
 from collections import namedtuple, defaultdict
 import time
 import os
@@ -404,7 +406,8 @@ class ArchivalTest(RedpandaTest):
         validate(check_upload, self.logger, 90)
 
     @cluster(num_nodes=3)
-    def test_retention_archival_coordination(self):
+    @matrix(acks=[1, -1])
+    def test_retention_archival_coordination(self, acks):
         """
         Test that only archived segments can be evicted and that eviction
         restarts once the segments have been archived.
@@ -420,7 +423,8 @@ class ArchivalTest(RedpandaTest):
             produce_until_segments(redpanda=self.redpanda,
                                    topic=self.topic,
                                    partition_idx=0,
-                                   count=10)
+                                   count=10,
+                                   acks=acks)
 
             # Sleep some time sufficient for log eviction under normal conditions
             # and check that no segment has been evicted (because we can't upload


### PR DESCRIPTION
## Cover letter

Backport #4277 to v21.11.x

Fixes #4288