### PR TITLE
Backport4227: Infinite retention

### DIFF
--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -96,7 +96,7 @@ struct configuration final : public config_store {
     property<bool> enable_transactions;
     property<uint32_t> abort_index_segment_size;
     // same as log.retention.ms in kafka
-    property<std::chrono::milliseconds> delete_retention_ms;
+    retention_duration_property delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(srcs
+    retention_property_test.cc
     config_store_test.cc
     socket_address_convert_test.cc
     tls_config_convert_test.cc

--- a/src/v/config/tests/retention_property_test.cc
+++ b/src/v/config/tests/retention_property_test.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/config_store.h"
+#include "config/property.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
+#include <optional>
+
+namespace {
+using namespace std::chrono_literals;
+
+struct test_config : public config::config_store {
+    config::retention_duration_property valid_retention;
+    config::retention_duration_property inf_retention;
+    config::retention_duration_property default_retention;
+
+    test_config()
+      : valid_retention(
+        *this,
+        "valid_retention",
+        "A positive value",
+        {.needs_restart = config::needs_restart::no,
+         .visibility = config::visibility::user},
+        10080min)
+      , inf_retention(
+          *this,
+          "inf_retention",
+          "-1 should be interpreted as infinity",
+          {.needs_restart = config::needs_restart::no,
+           .visibility = config::visibility::user},
+          10080min)
+      , default_retention(
+          *this,
+          "default_retention",
+          "not set retention config should return default value",
+          {.needs_restart = config::needs_restart::no,
+           .visibility = config::visibility::user},
+          10080min) {}
+};
+
+SEASTAR_THREAD_TEST_CASE(test_retention_property) {
+    auto cfg = test_config();
+
+    cfg.valid_retention.set_value(YAML::Load("4095"));
+    BOOST_CHECK(cfg.valid_retention() == std::chrono::milliseconds(4095));
+
+    cfg.valid_retention.set_value(std::chrono::milliseconds(809098));
+    BOOST_CHECK(cfg.valid_retention() == std::chrono::milliseconds(809098));
+
+    cfg.inf_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(cfg.inf_retention() == std::nullopt);
+
+    cfg.inf_retention.set_value(std::chrono::milliseconds(-1));
+    BOOST_CHECK(cfg.inf_retention() == std::nullopt);
+
+    BOOST_CHECK(cfg.default_retention().value() == std::optional(10080min));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_retention_property_polymorphism) {
+    auto cfg = test_config();
+    using base = config::property<std::optional<std::chrono::milliseconds>>;
+
+    base& valid_retention = cfg.valid_retention;
+    valid_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(valid_retention() == std::nullopt);
+
+    base& inf_retention = cfg.inf_retention;
+    inf_retention.set_value(YAML::Load("-1"));
+    BOOST_CHECK(inf_retention() == std::nullopt);
+
+    inf_retention.set_value(std::chrono::milliseconds(-1));
+    BOOST_CHECK(inf_retention() == std::nullopt);
+
+    base& default_retention = cfg.default_retention;
+    BOOST_CHECK(default_retention().value() == std::optional(10080min));
+}
+} // namespace

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -333,8 +333,8 @@ static void report_broker_config(
       "log.retention.ms",
       config::shard_local_cfg().delete_retention_ms,
       include_synonyms,
-      [](const std::chrono::milliseconds& ms) {
-          return ssx::sformat("{}", ms.count());
+      [](const std::optional<std::chrono::milliseconds>& ret) {
+          return ssx::sformat("{}", ret.value_or(-1ms).count());
       });
 
     add_broker_config_if_requested(

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -536,7 +536,8 @@ FIXTURE_TEST(
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}", config::shard_local_cfg().delete_retention_ms.value().count()),
+        "{}",
+        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
       new_describe_resp);
     assert_property_value(
       test_tp, "retention.bytes", "4096", new_describe_resp);
@@ -632,7 +633,8 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}", config::shard_local_cfg().delete_retention_ms.value().count()),
+        "{}",
+        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
       new_describe_resp);
 }
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -96,8 +96,14 @@ static inline logs_type::iterator find_next_non_compacted_log(logs_type& logs) {
 }
 
 ss::future<> log_manager::housekeeping() {
-    auto collection_threshold = model::timestamp(
-      model::timestamp::now().value() - _config.delete_retention.count());
+    // files created before this threshold will be collected
+    model::timestamp collection_threshold;
+    if (!_config.delete_retention) {
+        collection_threshold = model::timestamp(0);
+    } else {
+        collection_threshold = model::timestamp(
+          model::timestamp::now().value() - _config.delete_retention->count());
+    }
     /**
      * Note that this loop does a double find - which is not fast. This solution
      * is the tradeoff to *not* lock the segment during log_manager::remove(ntp)
@@ -339,10 +345,12 @@ std::ostream& operator<<(std::ostream& o, const log_config& c) {
     } else {
         o << "nullopt";
     }
-    return o << ", compaction_interval_ms:" << c.compaction_interval.count()
-             << ", delete_reteion_ms:" << c.delete_retention.count()
-             << ", with_cache:" << c.cache
-             << ", relcaim_opts:" << c.reclaim_opts << "}";
+    return o
+           << ", compaction_interval_ms:" << c.compaction_interval.count()
+           << ", delete_retention_ms:"
+           << c.delete_retention.value_or(std::chrono::milliseconds(-1)).count()
+           << ", with_cache:" << c.cache << ", reclaim_opts:" << c.reclaim_opts
+           << "}";
 }
 std::ostream& operator<<(std::ostream& o, const log_manager& m) {
     return o << "{config:" << m._config << ", logs.size:" << m._logs.size()

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -79,7 +79,7 @@ struct log_config {
       ss::io_priority_class compaction_priority,
       std::optional<size_t> ret_bytes,
       std::chrono::milliseconds compaction_ival,
-      std::chrono::milliseconds del_ret,
+      std::optional<std::chrono::milliseconds> del_ret,
       with_cache c,
       batch_cache::reclaim_options recopts,
       std::chrono::milliseconds rdrs_cache_eviction_timeout,
@@ -121,7 +121,8 @@ struct log_config {
     std::optional<size_t> retention_bytes = std::nullopt;
     std::chrono::milliseconds compaction_interval = std::chrono::minutes(10);
     // same as delete.retention.ms in kafka - default 1 week
-    std::chrono::milliseconds delete_retention = std::chrono::minutes(10080);
+    std::optional<std::chrono::milliseconds> delete_retention
+      = std::chrono::minutes(10080);
     with_cache cache = with_cache::yes;
     batch_cache::reclaim_options reclaim_opts{
       .growth_window = std::chrono::seconds(3),


### PR DESCRIPTION
## Cover letter

`delete_retention_ms` should interpret `-1` as infinite retention, e.i.
 never delete data. New subclass `retention_property` overloads
 `set_value` method to change `-1` to `max_int`.

Fixes #4219

## Release notes
* `delete_retention_ms` interprets `-1` as infinite retention, i.e.
 never delete data. Docs don't need to be updated since this 
 is Kafka-compatible and in line with existing documentation
