### PR TITLE
rpk redpanda admin command for MacOS

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -139,3 +139,21 @@ func AddAdminAPITLSFlags(
 
 	return command
 }
+
+func AddBrokersFlag(
+	command *cobra.Command,
+        brokers *[]string,
+) *cobra.Command {
+        command.PersistentFlags().StringSliceVar(
+                brokers,
+                "brokers",
+                []string{},
+                "Comma-separated list of broker ip:port pairs (e.g."+
+                        " --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' )."+
+                        " Alternatively, you may set the REDPANDA_BROKERS environment"+
+                        " variable with the comma-separated list of broker addresses.",
+        )
+
+	return command
+}
+

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -34,6 +34,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		adminCertFile  string
 		adminKeyFile   string
 		adminCAFile    string
+		clusterBrokers []string
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -58,6 +59,11 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		&adminCertFile,
 		&adminKeyFile,
 		&adminCAFile,
+	)
+
+	common.AddBrokersFlag(
+		cmd,
+		&clusterBrokers,
 	)
 
 	cmd.AddCommand(

--- a/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
@@ -25,7 +25,7 @@ func NewRedpandaDarwinCommand(
 ) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "redpanda",
-		Short: "Interact with a remote Redpanda process",
+		Short: "Interact with a local/remote Redpanda process",
 	}
 
 	command.AddCommand(admin.NewCommand(fs))

--- a/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
@@ -25,7 +25,7 @@ func NewRedpandaDarwinCommand(
 ) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "redpanda",
-		Short: "Interact with a local Redpanda process",
+		Short: "Interact with a remote Redpanda process",
 	}
 
 	command.AddCommand(admin.NewCommand(fs))

--- a/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda_darwin.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build darwin
+// +build darwin
+
+package cmd
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	rp "github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewRedpandaDarwinCommand(
+	fs afero.Fs, mgr config.Manager, launcher rp.Launcher,
+) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "redpanda",
+		Short: "Interact with a local Redpanda process",
+	}
+
+	command.AddCommand(admin.NewCommand(fs))
+
+	return command
+}

--- a/src/go/rpk/pkg/cli/cmd/root_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/root_darwin.go
@@ -10,6 +10,7 @@
 package cmd
 
 import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -19,4 +20,5 @@ import (
 func addPlatformDependentCmds(
 	fs afero.Fs, mgr config.Manager, cmd *cobra.Command,
 ) {
+	cmd.AddCommand(NewRedpandaDarwinCommand(fs, mgr, redpanda.NewLauncher()))
 }


### PR DESCRIPTION
## Cover letter

This PR fixes the following:

`rpk redpanda admin` command is unavailable on MacOS. This problem is stated in - https://github.com/redpanda-data/redpanda/issues/3666

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/redpanda/issues/3666

## Release notes

* rpk redpanda admin command is now available on MacOS to interact with Remote RedPanda clusters.

## PR Testing Steps
**[This is only for Internal Reviewer to follow and test things out, we will remove this section when submitting upstream]**

- Clone the Repo
- Switch to admin_macos branch - `git checkout admin_macos`
- Go to the rpk directory - `cd src/go/rpk/`
- Run `./build.sh`

You should see a `rpk` binary under `darwin-amd64` directory.
- Run `./darwin-amd64/rpk help` and you should be able to see `redpanda admin` command now on MacOS.
- If you have not set the REDPANDA_BROKERS env var, please set it.
- You can try running `./darwin-amd64/rpk redpanda admin brokers list` command as well to see all brokers running in the your cluster.