### PR TITLE
ducky/Redpanda: account for grep exit code 1

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -785,9 +785,11 @@ class RedpandaService(Service):
                 f"Scanning node {node.account.hostname} log for errors...")
 
             for line in node.account.ssh_capture(
-                    f"grep -e ERROR -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE}"
+                    f"grep -e ERROR -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             ):
                 line = line.strip()
+
+                assert "No such file or directory" not in line
 
                 allowed = False
                 for a in allow_list:


### PR DESCRIPTION
## Cover letter
According to the grep man page, grep exits with code 1 if no lines were selected. So ducky raised RemoteCommandError.
This is not actually a failure though, grep simply did not find a match.

Account for exit code 1 by explicitly checking for file not found in the output.

## Release notes
Found while debugging CDT