### PR TITLE
Added cluster health overview support

### DIFF
--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -71,6 +71,9 @@ public:
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);
 
+    ss::future<cluster_health_overview>
+      get_cluster_health_overview(model::timeout_clock::time_point);
+
 private:
     /**
      * Struct used to track pending refresh request, it gives ability
@@ -109,7 +112,8 @@ private:
     ss::future<> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);
-
+    ss::future<std::error_code> maybe_refresh_cluster_health(
+      force_refresh, model::timeout_clock::time_point);
     ss::future<std::error_code> refresh_cluster_health_cache(force_refresh);
     ss::future<std::error_code>
       dispatch_refresh_cluster_health_request(model::node_id);

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -68,4 +68,12 @@ health_monitor_frontend::get_nodes_status(
           });
     });
 }
+
+ss::future<cluster_health_overview>
+health_monitor_frontend::get_cluster_health_overview(
+  model::timeout_clock::time_point deadline) {
+    return dispatch_to_backend([deadline](health_monitor_backend& be) {
+        return be.get_cluster_health_overview(deadline);
+    });
+}
 } // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -51,6 +51,19 @@ public:
     ss::future<result<std::vector<node_state>>>
       get_nodes_status(model::timeout_clock::time_point);
 
+    /**
+     *  Return cluster health overview
+     *
+     *  Health overview is based on the information available in health monitor.
+     *  Cluster is considered as healthy when follwing conditions are met:
+     *
+     * - all nodes that are are responding
+     * - all partitions have leaders
+     * - cluster controller is present (_raft0 leader)
+     */
+    ss::future<cluster_health_overview>
+      get_cluster_health_overview(model::timeout_clock::time_point);
+
 private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -104,6 +104,20 @@ struct cluster_health_report {
     operator<<(std::ostream&, const cluster_health_report&);
 };
 
+struct cluster_health_overview {
+    // is healthy is a main cluster indicator, it is intended as an simple flag
+    // that will allow all external cluster orchestrating processes to decide if
+    // they can proceed with next steps
+    bool is_healthy;
+
+    // additional human readable information that will make debugging cluster
+    // errors easier
+    std::optional<model::node_id> controller_id;
+    std::vector<model::node_id> all_nodes;
+    std::vector<model::node_id> nodes_down;
+    std::vector<model::ntp> leaderless_partitions;
+};
+
 using include_partitions_info = ss::bool_class<struct include_partitions_tag>;
 
 /**

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -75,6 +75,12 @@ seastar_generate_swagger(
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/debug.json
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/debug.json.h
 )
+seastar_generate_swagger(
+  TARGET cluster_swagger
+  VAR cluster_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/cluster.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/cluster.json.h
+)
 
 v_cc_library(
   NAME application
@@ -100,7 +106,7 @@ target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger cluster_config_swagger raft_swagger
     security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger
-    transaction_swagger features_swagger debug_swagger)
+    transaction_swagger features_swagger debug_swagger cluster_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/brokers",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/cluster/health_overview",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get cluster health overview",
+                    "type": "get_cluster_health_overview",
+                    "nickname": "get_cluster_health_overview",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        }
+    ],
+    "models": {
+        "cluster_health_overview": {
+            "id": "cluster_health_overview",
+            "description": "Returns simple overview of cluster status",
+            "properties": {
+                "is_healthy": {
+                    "type": "boolean",
+                    "description": "basic cluster health indicator"
+                },
+                "controller_id": {
+                    "type": "int",
+                    "description": "node that is currently a leader or `-1` if leader is not elected"
+                },
+                "all_nodes": {
+                    "type": "array",
+                    "items": {
+                        "type": "int"
+                    },
+                    "description": "ids of all nodes registered in the cluster"
+                },
+                "nodes_down": {
+                    "type": "array",
+                    "items": {
+                        "type": "int"
+                    },
+                    "description": "ids of all nodes being recognized as down"
+                },
+                "leaderless_partitions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "list of partitions for which no leader is elected"
+                }
+            }
+        }
+    }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -41,6 +41,7 @@
 #include "net/dns.h"
 #include "raft/types.h"
 #include "redpanda/admin/api-doc/broker.json.h"
+#include "redpanda/admin/api-doc/cluster.json.h"
 #include "redpanda/admin/api-doc/cluster_config.json.h"
 #include "redpanda/admin/api-doc/config.json.h"
 #include "redpanda/admin/api-doc/debug.json.h"
@@ -144,7 +145,8 @@ void admin_server::configure_admin_routes() {
     rb->register_api_file(_server._routes, "transaction");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "debug");
-
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "cluster");
     register_config_routes();
     register_cluster_config_routes();
     register_raft_routes();
@@ -157,6 +159,7 @@ void admin_server::configure_admin_routes() {
     register_hbadger_routes();
     register_transaction_routes();
     register_debug_routes();
+    register_cluster_routes();
 }
 
 struct json_validator {
@@ -2570,5 +2573,39 @@ void admin_server::register_debug_routes() {
           }
 
           co_return ss::json::json_return_type(ans);
+      });
+}
+
+void admin_server::register_cluster_routes() {
+    register_route<publik>(
+      ss::httpd::cluster_json::get_cluster_health_overview,
+      [this](std::unique_ptr<ss::httpd::request>)
+        -> ss::future<ss::json::json_return_type> {
+          vlog(logger.debug, "Requested cluster status");
+          auto health_overview = co_await _controller->get_health_monitor()
+                                   .local()
+                                   .get_cluster_health_overview(
+                                     model::time_from_now(
+                                       std::chrono::seconds(5)));
+          ss::httpd::cluster_json::cluster_health_overview ret;
+          ret.is_healthy = health_overview.is_healthy;
+          ret.all_nodes._set = true;
+          ret.nodes_down._set = true;
+          ret.leaderless_partitions._set = true;
+
+          ret.all_nodes = health_overview.all_nodes;
+          ret.nodes_down = health_overview.nodes_down;
+
+          for (auto& ntp : health_overview.leaderless_partitions) {
+              ret.leaderless_partitions.push(fmt::format(
+                "{}/{}/{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition));
+          }
+          if (health_overview.controller_id) {
+              ret.controller_id = health_overview.controller_id.value();
+          } else {
+              ret.controller_id = -1;
+          }
+
+          co_return ss::json::json_return_type(ret);
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -184,6 +184,7 @@ private:
     void register_hbadger_routes();
     void register_transaction_routes();
     void register_debug_routes();
+    void register_cluster_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -215,6 +215,11 @@ class Admin:
         """
         return self._request('get', "cluster_view", node=node).json()
 
+    def get_cluster_health_overview(self, node=None):
+
+        return self._request('get', "cluster/health_overview",
+                             node=node).json()
+
     def decommission_broker(self, id, node=None):
         """
         Decommission broker

--- a/tests/rptest/tests/cluster_health_overview_test.py
+++ b/tests/rptest/tests/cluster_health_overview_test.py
@@ -1,0 +1,88 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.rpk_producer import RpkProducer
+from rptest.tests.end_to_end import EndToEndTest
+
+from ducktape.utils.util import wait_until
+
+
+class ClusterHealthOverviewTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(ClusterHealthOverviewTest,
+              self).__init__(test_context=test_context, num_brokers=5)
+
+        self.admin = Admin(self.redpanda)
+
+    def create_topics(self):
+        topics = []
+        for i in range(0, 8):
+            topics.append(
+                TopicSpec(partition_count=random.randint(1, 6),
+                          replication_factor=3))
+
+        self.client().create_topic(topics)
+
+    def wait_until_healthy(self):
+        def is_healthy():
+            res = self.admin.get_cluster_health_overview()
+            return res['is_healthy'] == True and len(res['all_nodes']) == 5
+
+        wait_until(is_healthy, 30, 2)
+
+    @cluster(num_nodes=5)
+    def cluster_health_overview_baseline_test(self):
+        self.create_topics()
+
+        # in initial state after all nodes joined cluster should be healthy
+        self.wait_until_healthy()
+
+        # stop one node, cluster should become unhealthy with one node down
+        # reported and no leaderless partitions
+
+        first_down = random.choice(self.redpanda.nodes)
+        self.redpanda.stop_node(first_down)
+
+        def one_node_down():
+            hov = self.admin.get_cluster_health_overview()
+            return not hov['is_healthy'] and [self.redpanda.idx(first_down)
+                                              ] == hov['nodes_down']
+
+        wait_until(one_node_down, 30, 2)
+
+        # stop another node, cluster should start reporting leaderless
+        # partitions with two out of five nodes down
+
+        second_down = random.choice(self.redpanda.nodes)
+        while self.redpanda.idx(second_down) == self.redpanda.idx(first_down):
+            second_down = random.choice(self.redpanda.nodes)
+
+        self.redpanda.stop_node(second_down)
+
+        def two_nodes_down():
+            hov = self.admin.get_cluster_health_overview()
+            if hov['is_healthy'] or len(hov['nodes_down']) != 2:
+                return False
+
+            if len(hov['leaderless_partitions']) == 0:
+                return False
+            return True
+
+        wait_until(two_nodes_down, 30, 2)
+
+        # restart both nodes, cluster should be healthy back again
+        self.redpanda.start_node(first_down)
+        self.redpanda.start_node(second_down)
+
+        self.wait_until_healthy()


### PR DESCRIPTION
## Cover letter

Added an admin API endpoint `GET /v1/cluster/health_overview` returning simple overview of cluster health. The endpoint is intended to be used as a simple indicator of overall cluster health. It provides `is_healthy` flag that is a cluster health indicator. Additional fields avaialble in the overview should make debugging potenantial health issues easier

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes

### Features
- added `GET /v1/cluster/health_overview` admin api endpoint
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
