### PR TITLE
slash commands: Fix milestone auto mode bugs

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -35,9 +35,22 @@ jobs:
         id: milestone
         run: |
           if [[ "${TARGET_MILESTONE}" == "auto" ]]; then
-            major=$(echo "${BACKPORT_BRANCH}" | grep -Eo '^(v[0-9][0-9].[0-9][0-9])')
+            major=$(echo "${BACKPORT_BRANCH}" | grep -Eo '^(v[0-9][0-9].[0-9]+)')
+            set +e
+            set -o pipefail
             latest_released=$(gh api "repos/${TARGET_ORG}/${TARGET_REPO}/releases" --jq '.[] | select(.draft==false).name'  | grep "${major}" | head -1)
-            assigne_milestone=$(echo ${latest_released} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+            exit_code="$?"
+            set -e
+            if [[ "$exit_code" == "1" && "$latest_released" == "" ]]; then
+              # first milestone for the provided branch
+              assigne_milestone="$major.1"
+            elif [[ "$exit_code" == "0" ]]; then
+              # found latest release from this branch
+              assigne_milestone=$(echo ${latest_released} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+            else
+              echo "Unexpected error"
+              exit $exit_code
+            fi
           else
             assigne_milestone="${TARGET_MILESTONE}"
           fi


### PR DESCRIPTION
## Cover letter

* fixes branch input that is structured as v<2-digits>.<1-digit>
  eg `v22.1.x`
* fixes milestone creation if no release hasn't been created yet for the corresponding branch

The workaround is to add the milestone explicitly in the slash command, eg:

```
/backport v22.1.x milestone=v21.1.1
```


fixes https://github.com/redpanda-data/devprod/issues/243