### PR TITLE
[backport] admin_api: Added reset/get leaders_table requests

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -168,6 +168,11 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
 
 void metadata_cache::reset_leaders() { _leaders.local().reset(); }
 
+cluster::partition_leaders_table::leaders_info_t
+metadata_cache::get_leaders() const {
+    return _leaders.local().get_leaders();
+}
+
 /**
  * hard coded defaults
  */

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -166,6 +166,8 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
     return _leaders.local().get_leader(model::controller_ntp);
 }
 
+void metadata_cache::reset_leaders() { _leaders.local().reset(); }
+
 /**
  * hard coded defaults
  */

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
+#include "cluster/partition_leaders_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -130,6 +131,7 @@ public:
     std::optional<model::node_id> get_controller_leader_id();
 
     void reset_leaders();
+    cluster::partition_leaders_table::leaders_info_t get_leaders() const;
 
     model::compression get_default_compression() const;
     model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -129,6 +129,8 @@ public:
     /// If present returns a leader of raft0 group
     std::optional<model::node_id> get_controller_leader_id();
 
+    void reset_leaders();
+
     model::compression get_default_compression() const;
     model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;
     model::compaction_strategy get_default_compaction_strategy() const;

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -183,4 +183,22 @@ ss::future<model::node_id> partition_leaders_table::wait_for_leader(
       });
 }
 
+partition_leaders_table::leaders_info_t
+partition_leaders_table::get_leaders() const {
+    leaders_info_t ans;
+    ans.reserve(_leaders.size());
+    for (const auto& leader_info : _leaders) {
+        leader_info_t info{
+          .tp_ns = leader_info.first.tp_ns,
+          .pid = leader_info.first.pid,
+          .current_leader = leader_info.second.current_leader,
+          .previous_leader = leader_info.second.previous_leader,
+          .update_term = leader_info.second.update_term,
+          .partition_revision = leader_info.second.partition_revision,
+        };
+        ans.push_back(std::move(info));
+    }
+    return ans;
+}
+
 } // namespace cluster

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -92,6 +92,20 @@ public:
 
     void reset() { _leaders.clear(); }
 
+    struct leader_info_t {
+        model::topic_namespace tp_ns;
+        model::partition_id pid;
+
+        std::optional<model::node_id> current_leader;
+        std::optional<model::node_id> previous_leader;
+        model::term_id update_term;
+        model::revision_id partition_revision;
+    };
+
+    using leaders_info_t = std::vector<leader_info_t>;
+
+    leaders_info_t get_leaders() const;
+
 private:
     // optimized to reduce number of ntp copies
     struct leader_key {

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -90,6 +90,8 @@ public:
       model::term_id,
       std::optional<model::node_id>);
 
+    void reset() { _leaders.clear(); }
+
 private:
     // optimized to reduce number of ntp copies
     struct leader_key {

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -55,6 +55,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/hbadger.json.h
 )
 
+seastar_generate_swagger(
+  TARGET debug_swagger
+  VAR debug_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/debug.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/debug.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS 
@@ -77,7 +84,8 @@ add_executable(redpanda
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger cluster_config_swagger raft_swagger
-    security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger)
+    security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger
+    debug_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -21,6 +21,60 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/partition_leaders_table",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get information about leaders from partition_leaders_table for node",
+                    "type": "array",
+                    "items": {
+                        "type": "leader_info"
+                    },
+                    "nickname": "get_leaders_info",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
-    ]
+    ],
+    "models": {
+        "leader_info": {
+            "id": "leader_info",
+            "description": "Leader info",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "topic"
+                },
+                "partition_id": {
+                    "type": "long",
+                    "description": "partition"
+                },
+                "leader": {
+                    "type": "long",
+                    "description": "current leader"
+                },
+                "previous_leader": {
+                    "type": "long",
+                    "description": "previous leader"
+                },
+                "update_term": {
+                    "type": "long",
+                    "description": "update term"
+                },
+                "partition_revision": {
+                    "type": "long",
+                    "description": "partition revision"
+                }
+            }
+        }
+    }
 }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1,0 +1,26 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/debug",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/debug/reset_leaders",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Reset information about leaders for node",
+                    "type": "void",
+                    "nickname": "reset_leaders_info",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        }
+    ]
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1437,4 +1437,33 @@ void admin_server::register_debug_routes() {
 
           co_return ss::json::json_void();
       });
+
+    ss::httpd::debug_json::get_leaders_info.set(
+      _server._routes,
+      [this](std::unique_ptr<ss::httpd::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          vlog(logger.info, "Request to get leaders info");
+          using result_t = ss::httpd::debug_json::leader_info;
+          std::vector<result_t> ans;
+
+          auto leaders_info = _metadata_cache.local().get_leaders();
+          ans.reserve(leaders_info.size());
+          for (const auto& leader_info : leaders_info) {
+              result_t info;
+              info.ns = leader_info.tp_ns.ns;
+              info.topic = leader_info.tp_ns.tp;
+              info.partition_id = leader_info.pid;
+              info.leader = leader_info.current_leader.has_value()
+                              ? leader_info.current_leader.value()
+                              : -1;
+              info.previous_leader = leader_info.previous_leader.has_value()
+                                       ? leader_info.previous_leader.value()
+                                       : -1;
+              info.update_term = leader_info.update_term;
+              info.partition_revision = leader_info.partition_revision;
+              ans.push_back(std::move(info));
+          }
+
+          co_return ss::json::json_return_type(ans);
+      });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -81,6 +81,7 @@ private:
     void register_broker_routes();
     void register_partition_routes();
     void register_hbadger_routes();
+    void register_debug_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -277,3 +277,12 @@ class Admin:
         self.redpanda.logger.info(f"Reset leaders info on {node.name}/{id}")
         url = "debug/reset_leaders"
         return self._request("post", url, node=node)
+
+    def get_leaders_info(self, node):
+        """
+        Get info for leaders on node
+        """
+        id = self.redpanda.idx(node)
+        self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
+        url = "debug/partition_leaders_table"
+        return self._request("get", url, node=node).json()

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -260,3 +260,12 @@ class Admin:
         leader = self.redpanda.get_node(details['leader_id'])
         ret = self._request('post', path=path, node=leader)
         return ret.status_code == 200
+
+    def reset_leaders_info(self, node):
+        """
+        Reset info for leaders on node
+        """
+        id = self.redpanda.idx(node)
+        self.redpanda.logger.info(f"Reset leaders info on {node.name}/{id}")
+        url = "debug/reset_leaders"
+        return self._request("post", url, node=node)

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -226,6 +226,14 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership?target={target_id}"
         self._request("POST", path)
 
+    def get_partition_leader(self, *, namespace, topic, partition, node=None):
+        partition_info = self.get_partitions(topic=topic,
+                                             partition=partition,
+                                             namespace=namespace,
+                                             node=node)
+
+        return partition_info['leader_id']
+
     def transfer_leadership_to(self, *, namespace, topic, partition, target):
         """
         Looks up current ntp leader and transfer leadership to target node, 


### PR DESCRIPTION
## Cover letter

Backport #4259
Backport #4237

Fixes #4302 

## Release notes

* New admin api request /v1/debug/partition_leaders_table
* Add /v1/debug/reset_leaders request to reset leaders info on node