### PR TITLE
rpc: include ssx/sformat.h early

### DIFF
--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -15,6 +15,7 @@
 #include "rpc/backoff_policy.h"
 #include "rpc/transport.h"
 #include "rpc/types.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>


### PR DESCRIPTION
to get the fmt::formatter<seastar::sstring> instantiated before
it is implicit instantiated by Seastar library.

this change helps to address the FTBFS of
```
/usr/bin/clang++-15 -DFMT_LOCALE -DFMT_SHARED -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -DZSTD_STATIC_LINKING_ONLY -I/home/kefu/dev/redpanda/src/v -I/home/kefu/dev/redpanda/build/src/v -isystem /home/kefu/dev/redpanda/build/deps_install/include -isystem /home/kefu/dev/redpanda/build/deps_install/include/hdr -fPIC -fsanitize=undefined -fsanitize=address -fcolor-diagnostics -g -fPIC -Wall -Wextra -Werror -Wno-missing-field-initializers -std=c++20 -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Werror=unused-result "-Wno-error=#warnings" -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -std=c++20 -MD -MT src/v/rpc/CMakeFiles/v_rpc.dir/reconnect_transport.cc.o -MF src/v/rpc/CMakeFiles/v_rpc.dir/reconnect_transport.cc.o.d -o src/v/rpc/CMakeFiles/v_rpc.dir/reconnect_transport.cc.o -c /home/kefu/dev/redpanda/src/v/rpc/reconnect_transport.cc
In file included from /home/kefu/dev/redpanda/src/v/rpc/reconnect_transport.cc:13:
In file included from /home/kefu/dev/redpanda/src/v/raft/logger.h:14:
In file included from /home/kefu/dev/redpanda/src/v/model/fundamental.h:15:
/home/kefu/dev/redpanda/src/v/ssx/sformat.h:19:13: error: explicit specialization of 'fmt::formatter<seastar::basic_sstring<char, unsigned int, 15, true>>' after instantiation
struct fmt::formatter<seastar::sstring> {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/type_traits:971:30: note: implicit instantiation first required here
    : public __bool_constant<__is_constructible(_Tp, _Args...)>
                             ^
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
