### PR TITLE
Fix topic recovery for partition with missing segments

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -132,6 +132,9 @@ private:
     struct offset_range {
         model::offset min_offset;
         model::offset max_offset;
+
+        friend auto operator<=>(const offset_range&, const offset_range&)
+          = default;
     };
 
     /// Represents file path of the downloaded file with
@@ -144,6 +147,12 @@ private:
         offset_range range;
     };
 
+    /// Sort offsets and find out the useful offset range
+    /// without the gaps. Update download_part using this information.
+    void update_downloaded_offsets(
+      std::vector<partition_downloader::offset_range> dloffsets,
+      partition_downloader::download_part& dlpart);
+
     struct segment {
         partition_manifest::key manifest_key;
         partition_manifest::segment_meta meta;
@@ -154,7 +163,7 @@ private:
     /// The downloaded file will have a custom suffix
     /// which has to be changed. The downloaded file path
     /// is returned by the futue.
-    ss::future<offset_range>
+    ss::future<std::optional<offset_range>>
     download_segment_file(const segment& segm, const download_part& part);
 
     using offset_map_t = absl::btree_map<model::offset, segment>;


### PR DESCRIPTION


## Cover letter

It is possible to have a log with the gap after the recovery if at least one of
the segments is missing. In this case recovery doesn't take gaps into
account and created raft log may have them.

This PR fixes this by properly adjusting offsets. If there is a gap in the log
the recovery process will point starting offset to the next batch after the last
gap.

## Release notes


* Fix bug in topic recovery

