### PR TITLE
admin: report maintenance mode status for brokers

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -294,6 +294,8 @@ ss::future<> controller::start() {
             std::ref(_raft_manager),
             std::ref(_as),
             std::ref(_storage_node),
+            std::ref(_drain_manager),
+            std::ref(_feature_table),
             config::shard_local_cfg()
               .storage_space_alert_free_threshold_bytes.bind(),
             config::shard_local_cfg()

--- a/src/v/cluster/drain_manager.cc
+++ b/src/v/cluster/drain_manager.cc
@@ -270,4 +270,19 @@ ss::future<> drain_manager::do_restore() {
     co_return;
 }
 
+std::ostream&
+operator<<(std::ostream& os, const drain_manager::drain_status& ds) {
+    fmt::print(
+      os,
+      "{{finished: {}, errors: {}, partitions: {}, eligible: {}, transferring: "
+      "{}, failed: {}}}",
+      ds.finished,
+      ds.errors,
+      ds.partitions,
+      ds.eligible,
+      ds.transferring,
+      ds.failed);
+    return os;
+}
+
 } // namespace cluster

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -90,4 +90,6 @@ private:
     ss::abort_source _abort;
 };
 
+std::ostream& operator<<(std::ostream&, const drain_manager::drain_status&);
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -386,6 +386,17 @@ health_monitor_backend::get_cluster_health(
       "requesing cluster state report with filter: {}, force refresh: {}",
       filter,
       refresh);
+    auto ec = co_await maybe_refresh_cluster_health(refresh, deadline);
+    if (ec) {
+        co_return ec;
+    }
+
+    co_return build_cluster_report(filter);
+}
+
+ss::future<std::error_code>
+health_monitor_backend::maybe_refresh_cluster_health(
+  force_refresh refresh, model::timeout_clock::time_point deadline) {
     auto const need_refresh = refresh
                               || _last_refresh + max_metadata_age()
                                    < ss::lowres_clock::now();
@@ -411,8 +422,7 @@ health_monitor_backend::get_cluster_health(
             co_return errc::timeout;
         }
     }
-
-    co_return build_cluster_report(filter);
+    co_return errc::success;
 }
 
 cluster_health_report

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -696,4 +696,21 @@ std::chrono::milliseconds health_monitor_backend::max_metadata_age() {
     return config::shard_local_cfg().health_monitor_max_metadata_age();
 }
 
+ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
+health_monitor_backend::get_node_drain_status(
+  model::node_id node_id, model::timeout_clock::time_point deadline) {
+    auto ec = co_await maybe_refresh_cluster_health(
+      force_refresh::no, deadline);
+    if (ec) {
+        co_return ec;
+    }
+
+    auto it = _reports.find(node_id);
+    if (it == _reports.end()) {
+        co_return errc::node_does_not_exists;
+    }
+
+    co_return it->second.drain_status;
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -109,7 +109,8 @@ private:
     ss::future<> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);
-
+    ss::future<std::error_code> maybe_refresh_cluster_health(
+      force_refresh, model::timeout_clock::time_point);
     ss::future<std::error_code> refresh_cluster_health_cache(force_refresh);
     ss::future<std::error_code>
       dispatch_refresh_cluster_health_request(model::node_id);

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -73,6 +73,9 @@ public:
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);
 
+    ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
+      get_node_drain_status(model::node_id, model::timeout_clock::time_point);
+
 private:
     /**
      * Struct used to track pending refresh request, it gives ability

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -54,6 +54,8 @@ public:
       ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
       ss::sharded<storage::node_api>&,
+      ss::sharded<drain_manager>&,
+      ss::sharded<feature_table>&,
       config::binding<size_t> storage_min_bytes_threshold,
       config::binding<unsigned> storage_min_percent_threshold);
 
@@ -141,6 +143,8 @@ private:
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<raft::group_manager>& _raft_manager;
     ss::sharded<ss::abort_source>& _as;
+    ss::sharded<drain_manager>& _drain_manager;
+    ss::sharded<feature_table>& _feature_table;
 
     ss::lowres_clock::time_point _last_refresh;
     ss::lw_shared_ptr<abortable_refresh_request> _refresh_request;

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -68,4 +68,13 @@ health_monitor_frontend::get_nodes_status(
           });
     });
 }
+
+ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
+health_monitor_frontend::get_node_drain_status(
+  model::node_id node_id, model::timeout_clock::time_point deadline) {
+    return dispatch_to_backend([node_id, deadline](health_monitor_backend& be) {
+        return be.get_node_drain_status(node_id, deadline);
+    });
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -51,6 +51,13 @@ public:
     ss::future<result<std::vector<node_state>>>
       get_nodes_status(model::timeout_clock::time_point);
 
+    /**
+     * Return drain status for a given node.
+     */
+    ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
+    get_node_drain_status(
+      model::node_id node_id, model::timeout_clock::time_point deadline);
+
 private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "bytes/iobuf_parser.h"
+#include "cluster/drain_manager.h"
 #include "cluster/errc.h"
 #include "cluster/node/types.h"
 #include "cluster/types.h"
@@ -80,11 +81,40 @@ struct topic_status {
  * instance of time
  */
 struct node_health_report {
-    static constexpr int8_t current_version = 1;
+    static constexpr int8_t current_version = 2;
 
     model::node_id id;
     node::local_state local_state;
     std::vector<topic_status> topics;
+
+    /*
+     * nodes running old versions of redpanda will assert that they can decode
+     * a message they receive by requiring the encoded version to be <= to the
+     * latest that that node understands.
+     *
+     * when drain_status is added the version is bumped, which means that older
+     * nodes will crash if they try to decode such a message. this is common for
+     * many places in the code base, but node_health_report makes this problem
+     * particularly acute because nodes are polled automatically at a regular,
+     * short interval.
+     *
+     * one solution is to make the feature table available in free functions so
+     * that we can use it to query about maintenance mode cluster support in
+     * adl<T>. unfortunately that won't work well in our mult-node unit tests
+     * because thread_local references to the feature service will be clobbered.
+     *
+     * another option would be to add a constructor to node_health_report so
+     * that when a report was created we could record a `serialized_as` version
+     * and query the feature table at the call site. this doesn't work well
+     * because reflection/adl needs types to be default-constructable.
+     *
+     * the final solution, which isn't a panacea, is do the equivalent of the
+     * ctor trick described above but with a flag. it's not a universal solution
+     * because devs need to be aware and handle this manually. fortunately there
+     * is only one or two places where we create this object.
+     */
+    bool include_drain_status{false}; // not serialized
+    std::optional<drain_manager::drain_status> drain_status;
 
     friend std::ostream& operator<<(std::ostream&, const node_health_report&);
 };

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -227,6 +227,10 @@
                 "version": {
                     "type": "string",
                     "description": "Redpanda version"
+                },
+                "maintenance_status": {
+                    "type": "maintenance_status",
+                    "description": "Node maintenance status"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1574,6 +1574,31 @@ model::node_id parse_broker_id(const ss::httpd::request& req) {
     }
 }
 
+static ss::httpd::broker_json::maintenance_status fill_maintenance_status(
+  const std::optional<cluster::drain_manager::drain_status>& status) {
+    ss::httpd::broker_json::maintenance_status ret;
+    if (status) {
+        const auto& s = status.value();
+        ret.draining = true;
+        ret.finished = s.finished;
+        ret.errors = s.errors;
+        ret.partitions = s.partitions.value_or(0);
+        ret.transferring = s.transferring.value_or(0);
+        ret.eligible = s.eligible.value_or(0);
+        ret.failed = s.failed.value_or(0);
+    } else {
+        ret.draining = false;
+        // ensure that the output json has all fields
+        ret.finished = false;
+        ret.errors = false;
+        ret.partitions = 0;
+        ret.transferring = 0;
+        ret.eligible = 0;
+        ret.failed = 0;
+    }
+    return ret;
+}
+
 void admin_server::register_broker_routes() {
     register_route<user>(
       ss::httpd::broker_json::get_cluster_view,
@@ -1682,6 +1707,12 @@ void admin_server::register_broker_routes() {
                       "{}", ns.membership_state);
                     b.is_alive = (bool)ns.is_alive;
 
+                    // ensure maintenance status is filled in even if it isn't
+                    // found in the report below. if it is found then this
+                    // filler/default value will be replaced.
+                    b.maintenance_status = fill_maintenance_status(
+                      std::nullopt);
+
                     auto r_it = std::find_if(
                       h_report.value().node_reports.begin(),
                       h_report.value().node_reports.end(),
@@ -1697,6 +1728,8 @@ void admin_server::register_broker_routes() {
                             dsi.total = ds.total;
                             b.disk_space.push(dsi);
                         }
+                        b.maintenance_status = fill_maintenance_status(
+                          r_it->drain_status);
                     }
                 }
 
@@ -1707,19 +1740,33 @@ void admin_server::register_broker_routes() {
 
     register_route<user>(
       ss::httpd::broker_json::get_broker,
-      [this](std::unique_ptr<ss::httpd::request> req) {
+      [this](std::unique_ptr<ss::httpd::request> req)
+        -> ss::future<ss::json::json_return_type> {
           model::node_id id = parse_broker_id(*req);
           auto broker = _metadata_cache.local().get_broker(id);
           if (!broker) {
               throw ss::httpd::not_found_exception(
                 fmt::format("broker with id: {} not found", id));
           }
+
+          auto maybe_drain_status = co_await _controller->get_health_monitor()
+                                      .local()
+                                      .get_node_drain_status(
+                                        id, model::time_from_now(5s));
+          if (maybe_drain_status.has_error()) {
+              co_await throw_on_error(
+                *req, maybe_drain_status.error(), model::controller_ntp, id);
+          }
+
           ss::httpd::broker_json::broker ret;
           ret.node_id = (*broker)->id();
           ret.num_cores = (*broker)->properties().cores;
           ret.membership_status = fmt::format(
             "{}", (*broker)->get_membership_state());
-          return ss::make_ready_future<ss::json::json_return_type>(ret);
+          ret.maintenance_status = fill_maintenance_status(
+            maybe_drain_status.value());
+
+          co_return ret;
       });
 
     register_route<superuser>(

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -209,6 +209,15 @@ class Admin:
         """
         return self._request('get', "brokers", node=node).json()
 
+    def get_broker(self, id, node=None):
+        """
+        Return metadata about a broker.
+
+        This differs from the `brokers/` endpoint in that it may contain
+        additional context beyond what is reported for through `brokers/`.
+        """
+        return self._request('get', f"brokers/{id}", node=node).json()
+
     def get_cluster_view(self, node):
         """
         Return cluster_view.


### PR DESCRIPTION
## Cover letter

Adds support for nodes reporting their maintenance status to the health manager. Maintenance mode is then exported through the admin interface when fetching information about brokers.

## Release notes

* none
