### PR TITLE
tests: use --read-committed in RpkConsumer

### DIFF
--- a/tests/rptest/services/rpk_consumer.py
+++ b/tests/rptest/services/rpk_consumer.py
@@ -90,7 +90,9 @@ class RpkConsumer(BackgroundThreadService):
                 raise
 
     def _consume(self, node):
-        cmd = '%s topic consume --offset %s --pretty-print=false --brokers %s %s' % (
+        # Important to use --read-committed, because otherwise the output parsing would have
+        # to somehow handle when rpk errors out on a rewind of the consumed offset
+        cmd = '%s topic consume --read-committed --offset %s --pretty-print=false --brokers %s %s' % (
             self._redpanda.find_binary('rpk'),
             self._offset,
             self._redpanda.brokers(),


### PR DESCRIPTION
## Cover letter

Without this, it is quite legal for a consumer
to see the partitions offset go backward when
a leadership change happens.  This generates
an error output from RPK, which RpkConsumer
doesn't handle (and probably can't handle
in a general way).

I think most tests using this client are
intending to read committed offsets anyway.

Fixes tests failing after printing errors like:
> ```Consumer failed with error: 'Unexpected output line: 'ERR: topic manyclients partition 1: topic manyclients partition 1 lost records; the client consumed to offset 2676 but was reset to offset 2660_''. Retrying in 5 seconds.```

Fixes https://github.com/redpanda-data/redpanda/issues/4321

## Release notes

* none