### PR TITLE
kafka: ListOffsets returns -1 if no offset found

### DIFF
--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -130,11 +130,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
         co_return list_offsets_response::make_partition(
           id, res->time, res->offset, kafka_partition->leader_epoch());
     }
-    co_return list_offsets_response::make_partition(
-      id,
-      model::timestamp(-1),
-      kafka_partition->last_stable_offset(),
-      kafka_partition->leader_epoch());
+    co_return list_offsets_response::make_partition(id, error_code::none);
 }
 
 static ss::future<list_offset_partition_response> list_offsets_partition(


### PR DESCRIPTION
## Cover letter

ListOffset returns the earliest offset with timestamp greater or equal
to the timestamp specifed. If no such an offset is found, offsetsForTimes() method in Consumer 
should return null. See KIP-79

Also Apache Kafka behavior for reference: [link](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaApis.scala#L1082-L1099)

Fixes: #4308

## Release notes
* ListOffset returns the earliest offset with timestamp greater or equal
to the timestamp specifed. If no such an offset is found, offsetsForTimes() method in Consumer 
should return null. See KIP-79. Docs don't need to be updated
