### PR TITLE
Backport4322: kafka: ListOffsets returns -1 if no offset found

### DIFF
--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -115,8 +115,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
         co_return list_offsets_response::make_partition(
           id, res->time, res->offset);
     }
-    co_return list_offsets_response::make_partition(
-      id, model::timestamp(-1), kafka_partition->last_stable_offset());
+    co_return list_offsets_response::make_partition(id, error_code::none);
 }
 
 static ss::future<list_offset_partition_response> list_offsets_partition(

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -137,6 +137,43 @@ FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
     BOOST_CHECK(resp.data.topics[0].partitions[0].offset > model::offset(0));
 }
 
+FIXTURE_TEST(list_offsets_not_found, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+    auto ntp = make_data(model::revision_id(2));
+    auto shard = app.shard_table.local().shard_for(ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
+        return app.partition_manager.invoke_on(
+          *shard, [ntp](cluster::partition_manager& mgr) {
+              auto partition = mgr.get(ntp);
+              return partition
+                     && partition->committed_offset() >= model::offset(1);
+          });
+    }).get();
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    kafka::list_offsets_request req;
+    req.data.topics = {{
+      .name = ntp.tp.topic,
+      .partitions = {{
+        .partition_index = ntp.tp.partition,
+        .timestamp = model::timestamp::now(),
+      }},
+    }};
+
+    auto resp = client.dispatch(req, kafka::api_version(1)).get();
+    client.stop().then([&client] { client.shutdown(); }).get();
+
+    // request is asking for messages with timestamp => timestamp::now(),
+    // doesn't find it and returns an empty response
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+    BOOST_CHECK(
+      resp.data.topics[0].partitions[0].timestamp == model::timestamp(-1));
+    BOOST_CHECK(resp.data.topics[0].partitions[0].offset == model::offset(-1));
+}
+
 kafka::produce_request
 make_produce_request(model::topic_partition tp, model::record_batch&& batch) {
     std::vector<kafka::produce_request::partition> partitions;


### PR DESCRIPTION
Backport of #4322

## Cover letter

ListOffset returns the earliest offset with timestamp greater or equal
to the timestamp specifed. If no such an offset is found, offsetsForTimes() method in Consumer 
should return null. See KIP-79

Also Apache Kafka behavior for reference: [link](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaApis.scala#L1082-L1099)

Fixes: #4308

## Release notes
* ListOffset returns the earliest offset with timestamp greater or equal
to the timestamp specifed. If no such an offset is found, offsetsForTimes() method in Consumer 
should return null. See KIP-79. Docs don't need to be updated
