### PR TITLE
[21.11.x]: backport #3654, #3824, #4199

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -22,6 +22,7 @@
 #include "config/configuration.h"
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
+#include "vformat.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
@@ -80,7 +81,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
     while (!aborted && 0 < retries--) {
         auto leader_opt = _leaders.local().get_leader(model::id_allocator_ntp);
         if (unlikely(!leader_opt)) {
-            error = fmt::format(
+            error = vformat(
               "can't find {} in the leaders cache", model::id_allocator_ntp);
             vlog(
               clusterlog.trace,
@@ -109,11 +110,11 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         }
 
         if (likely(r.ec != errc::replication_error)) {
-            error = fmt::format("id allocation failed with {}", r.ec);
+            error = vformat("id allocation failed with {}", r.ec);
             break;
         }
 
-        error = fmt::format("id allocation failed with {}", r.ec);
+        error = vformat("id allocation failed with {}", r.ec);
         vlog(
           clusterlog.trace, "id allocation failed, retries left: {}", retries);
         aborted = !co_await sleep_abortable(delay_ms, _as);

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -21,6 +21,7 @@
 #include "errc.h"
 #include "rpc/connection_cache.h"
 #include "types.h"
+#include "vformat.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -57,14 +58,6 @@ bool rm_partition_frontend::is_leader_of(const model::ntp& ntp) const {
     }
     auto _self = _controller->self();
     return leader == _self;
-}
-
-// Workaround for arm64 coroutine crash. See
-// https://groups.google.com/g/seastar-dev/c/Nt6LizrwE9U for details.
-template<typename S, typename... Args>
-static __attribute__((noinline)) std::string
-format(const S& format_str, Args&&... args) {
-    return fmt::format(format_str, std::forward<Args>(args)...);
 }
 
 ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
@@ -114,7 +107,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
     std::optional<std::string> error;
     while (!aborted && 0 < retries--) {
         if (!leader_opt) {
-            error = format("can't find {} in the leaders cache", ntp);
+            error = vformat("can't find {} in the leaders cache", ntp);
             vlog(
               txlog.trace,
               "can't find {} in the leaders cache, retries left: {}",
@@ -133,7 +126,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
             result = co_await begin_tx_locally(
               ntp, pid, tx_seq, transaction_timeout_ms);
             if (result.ec == tx_errc::leader_not_found) {
-                error = format(
+                error = vformat(
                   "local execution of begin_tx({},...) failed with 'not a "
                   "leader'",
                   ntp);
@@ -177,7 +170,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
           result.ec,
           result.etag);
         if (result.ec == tx_errc::leader_not_found) {
-            error = format(
+            error = vformat(
               "remote execution of begin_tx({},...) on {} failed with 'not a "
               "leader'",
               ntp,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -199,6 +199,7 @@ rm_stm::rm_stm(
                          .abort_timed_out_transactions_interval_ms.value())
   , _abort_index_segment_size(
       config::shard_local_cfg().abort_index_segment_size.value())
+  , _seq_table_min_size(config::shard_local_cfg().seq_table_min_size.value())
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _transactional_id_expiration(
@@ -1014,10 +1015,37 @@ void rm_stm::compact_snapshot() {
     if (cutoff_timestamp <= _oldest_session.value()) {
         return;
     }
+
+    if (_log_state.seq_table.size() <= _seq_table_min_size) {
+        return;
+    }
+
+    if (_log_state.seq_table.size() == 0) {
+        return;
+    }
+
+    std::vector<model::timestamp::type> lw_tss;
+    lw_tss.reserve(_log_state.seq_table.size());
+    for (auto it = _log_state.seq_table.cbegin();
+         it != _log_state.seq_table.cend();
+         it++) {
+        lw_tss.push_back(it->second.last_write_timestamp);
+    }
+    std::sort(lw_tss.begin(), lw_tss.end());
+    auto pivot = lw_tss[lw_tss.size() - 1 - _seq_table_min_size];
+
+    if (pivot < cutoff_timestamp) {
+        cutoff_timestamp = pivot;
+    }
+
     auto next_oldest_session = model::timestamp::now();
+    auto size = _log_state.seq_table.size();
     for (auto it = _log_state.seq_table.cbegin();
          it != _log_state.seq_table.cend();) {
-        if (it->second.last_write_timestamp < cutoff_timestamp) {
+        if (
+          size > _seq_table_min_size
+          && it->second.last_write_timestamp <= cutoff_timestamp) {
+            size--;
             _log_state.seq_table.erase(it++);
         } else {
             next_oldest_session = std::min(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1324,8 +1324,8 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
         } else {
             seq_it->second.update(bid.last_seq, last_offset);
         }
-        seq_it->second.last_write_timestamp = bid.max_timestamp.value();
-        _oldest_session = std::min(_oldest_session, bid.max_timestamp);
+        seq_it->second.last_write_timestamp = bid.first_timestamp.value();
+        _oldest_session = std::min(_oldest_session, bid.first_timestamp);
     }
 
     if (bid.is_transactional) {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -344,6 +344,7 @@ private:
     std::chrono::milliseconds _tx_timeout_delay;
     std::chrono::milliseconds _abort_interval_ms;
     uint32_t _abort_index_segment_size;
+    uint32_t _seq_table_min_size;
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_autoabort_enabled{true};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -215,6 +215,7 @@ private:
     void compact_snapshot();
 
     ss::future<bool> sync(model::timeout_clock::duration);
+    bool check_tx_permitted();
 
     void track_tx(model::producer_identity, std::chrono::milliseconds);
     void abort_old_txes();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -255,6 +255,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       {.visibility = visibility::user},
       10s)
+  , seq_table_min_size(
+      *this,
+      "seq_table_min_size",
+      "Minimum size of the seq table non affected by compaction",
+      {.visibility = visibility::user},
+      1000)
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -81,6 +81,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
     property<model::violation_recovery_policy> tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
+    property<uint32_t> seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     property<model::violation_recovery_policy> rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -99,7 +99,7 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                     reply.data.producer_epoch);
               } else {
                   vlog(klog.warn, "failed to allocate pid, ec: {}", r.ec);
-                  reply.data.error_code = error_code::broker_not_available;
+                  reply.data.error_code = error_code::not_coordinator;
               }
 
               return ctx.respond(std::move(reply));

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -456,7 +456,7 @@ struct batch_identity {
           .last_seq = increment_sequence(
             hdr.base_sequence, hdr.last_offset_delta),
           .record_count = hdr.record_count,
-          .max_timestamp = hdr.max_timestamp,
+          .first_timestamp = hdr.first_timestamp,
           .is_transactional = hdr.attrs.is_transactional()};
     }
 
@@ -464,7 +464,7 @@ struct batch_identity {
     int32_t first_seq{0};
     int32_t last_seq{0};
     int32_t record_count;
-    timestamp max_timestamp;
+    timestamp first_timestamp;
     bool is_transactional{false};
 
     bool has_idempotent() { return pid.id >= 0; }

--- a/src/v/vformat.h
+++ b/src/v/vformat.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include <fmt/format.h>
+
+// Workaround for arm64 coroutine crash. See
+// https://groups.google.com/g/seastar-dev/c/Nt6LizrwE9U for details.
+template<typename S, typename... Args>
+static __attribute__((noinline)) std::string
+vformat(const S& format_str, Args&&... args) {
+    return fmt::format(format_str, std::forward<Args>(args)...);
+}

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -89,6 +89,10 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     git -C /opt clone --branch ducktape2 https://github.com/vectorizedio/kafka-streams-examples.git && \
     cd /opt/kafka-streams-examples && mvn -DskipTests=true clean package
 
+# Install our in-tree go tests
+COPY --chown=0:0 tests/go /tmp/go
+RUN cd /tmp/go/sarama/produce_test && go mod tidy && go build
+
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/
 

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -3,3 +3,4 @@
 !tests/docker/ssh
 !tests/setup.py
 !tests/python
+!tests/go

--- a/tests/go/sarama/produce_test/go.mod
+++ b/tests/go/sarama/produce_test/go.mod
@@ -1,0 +1,5 @@
+module produce_test
+
+go 1.16
+
+require github.com/Shopify/sarama v1.31.1

--- a/tests/go/sarama/produce_test/main.go
+++ b/tests/go/sarama/produce_test/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+var (
+	brokers = flag.String("brokers", "127.0.0.1:9092", "Th Redpanda brokers to connect to, as a comma separated list")
+	count   = flag.Int64("count", 100, "Optional count to run")
+)
+
+func main() {
+	flag.Parse()
+
+	brokerList := strings.Split(*brokers, ",")
+	fmt.Printf("Redpanda brokers: %s\n", strings.Join(brokerList, ", "))
+
+	topics := []string{
+		"topic1",
+	}
+
+	producer, err := newProducer(brokerList)
+	if err != nil {
+		fmt.Printf("Error creating producer, %v", err)
+		os.Exit(1)
+	}
+
+	err = runTest(producer, topics, *count)
+	if err != nil {
+		fmt.Printf("Error running test: %v", err)
+		os.Exit(1)
+	}
+}
+
+func newProducer(brokers []string) (sarama.SyncProducer, error) {
+	config := sarama.NewConfig()
+
+	config.Metadata.Full = false
+	config.Producer.Compression = sarama.CompressionZSTD
+	config.Producer.Idempotent = true // hard
+	config.Producer.Partitioner = sarama.NewReferenceHashPartitioner
+	config.Producer.RequiredAcks = sarama.WaitForAll // hard
+	config.Producer.Retry.Max = 10                   //hard
+	config.Producer.Return.Successes = true
+	config.Net.MaxOpenRequests = 1
+	config.Version = sarama.V2_1_0_0
+
+	producer, err := sarama.NewSyncProducer(brokers, config)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return producer, nil
+}
+
+func prepareMessage(
+	producer sarama.SyncProducer, topic string, message string,
+) *sarama.ProducerMessage {
+	producerMessage := &sarama.ProducerMessage{
+		Topic:     topic,
+		Partition: -1,
+		Value:     sarama.ByteEncoder(message),
+		Timestamp: time.Now(),
+	}
+
+	return producerMessage
+}
+
+func runTest(producer sarama.SyncProducer, topics []string, count int64) error {
+	fmt.Printf("Starting Sarama test\n")
+	message := "some message"
+
+	msg := prepareMessage(producer, topics[0], message)
+	_, _, err := producer.SendMessage(msg)
+
+	if err != nil {
+		return fmt.Errorf("SendMessage error: %w", err)
+	}
+
+	for i := 0; i < int(count); i++ {
+		msg := prepareMessage(producer, topics[0], message+strconv.Itoa(i))
+		_, _, err := producer.SendMessage(msg)
+		if err != nil {
+			return fmt.Errorf("SendMessage error: %w", err)
+		}
+	}
+
+	fmt.Printf("%d messages was written\n", count)
+	return nil
+}

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.errors import DucktapeError
+from time import sleep
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+import subprocess
+
+# Expected log errors in tests that test misbehaving
+# idempotency clients.
+TX_ERROR_LOGS = []
+
+NOT_LEADER_FOR_PARTITION = "Tried to send a message to a replica that is not the leader for some partition"
+
+
+class SaramaProduceTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(SaramaProduceTest, self).__init__(test_context=test_context,
+                                                extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
+    def test_produce(self):
+        verifier_bin = "/tmp/go/sarama/produce_test/produce_test"
+
+        self.redpanda.logger.info("creating topics")
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1")
+
+        self.redpanda.logger.info("testing sarama produce")
+        retries = 5
+        for i in range(0, retries):
+            try:
+                cmd = "{verifier_bin} --brokers {brokers}".format(
+                    verifier_bin=verifier_bin, brokers=self.redpanda.brokers())
+                subprocess.check_output(["/bin/sh", "-c", cmd],
+                                        stderr=subprocess.STDOUT)
+                self.redpanda.logger.info("sarama produce test passed")
+                break
+            except subprocess.CalledProcessError as e:
+                error = str(e.output)
+                self.redpanda.logger.info("sarama produce failed with " +
+                                          error)
+                if i + 1 != retries and NOT_LEADER_FOR_PARTITION in error:
+                    sleep(5)
+                    continue
+                raise DucktapeError("sarama produce failed with " + error)

--- a/tests/rptest/tests/idempotency_test.py
+++ b/tests/rptest/tests/idempotency_test.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+from confluent_kafka import (Producer, KafkaException)
+
+
+def on_delivery(err, msg):
+    if err is not None:
+        raise KafkaException(err)
+
+
+class IdempotencyTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(IdempotencyTest, self).__init__(test_context=test_context,
+                                              extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3)
+    def test_idempotency_compacted_topic(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1", config={"cleanup.policy": "compact"})
+
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "retries": 5
+        })
+        producer.produce("topic1",
+                         key="key1".encode('utf-8'),
+                         value="value1".encode('utf-8'),
+                         callback=on_delivery)
+        producer.flush()


### PR DESCRIPTION
Backports idempotency fixes without enabling it by default:

- https://github.com/redpanda-data/redpanda/pull/4199 (arm crush)
- https://github.com/redpanda-data/redpanda/pull/3824 (sarama comparability)
- https://github.com/redpanda-data/redpanda/pull/3654 (compaction)