### PR TITLE
rptests: fill out test_suite_ec2.yml w/ progress

### DIFF
--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -1,7 +1,10 @@
 # TODO work in progress getting clustered mode issues worked out
 ec2:
   included:
-    - tests
+    - tests/simple_e2e_test.py
+    - tests/wait_for_local_consumer_test.py
+    - tests/topic_autocreate_test.py
+    - tests/partition_movement_test.py
 
   excluded:
     - tests/retention_policy_test.py # Redpanda node failed to stop in 30 second


### PR DESCRIPTION
We can't run the existing "all tests/" suite as some tests currently cause
a hang in ec2 clustered ducktape environment.

Let's take the sparse approach and start building up tests that are
known working or have issues in progress.
