### PR TITLE
rpk: add broker version info in 'redpanda admin broker ls'

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -23,6 +23,7 @@ type Broker struct {
 	NumCores         int    `json:"num_cores"`
 	MembershipStatus string `json:"membership_status"`
 	IsAlive          *bool  `json:"is_alive"`
+	Version          string `json:"version`
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -62,13 +62,16 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			}
 			for _, b := range bs {
 				if b.IsAlive != nil {
-					headers = append(headers, "Is-Alive")
+					headers = append(headers, "Is-Alive", "Broker-Version")
 					orig := args
 					args = func(b *admin.Broker) []interface{} {
-						return append(orig(b), *b.IsAlive)
+						return append(orig(b), *b.IsAlive, b.Version)
 					}
 					break
 				}
+			}
+			if len(headers) == 3 {
+				headers = append(headers, "Broker-Version")
 			}
 			tw := out.NewTable(headers...)
 			defer tw.Flush()

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -70,9 +70,6 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 					break
 				}
 			}
-			if len(headers) == 3 {
-				headers = append(headers, "Broker-Version")
-			}
 			tw := out.NewTable(headers...)
 			defer tw.Flush()
 			for _, b := range bs {


### PR DESCRIPTION
## Cover letter

There's currently no way to identify the broker Redpanda version via rpk. 

as-is

```
NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE
1        16         active             true
2        16         active             true
3        16         active             true
```
### Improvements

`rpk redpanda admin brokers list` exposes the broker version in the output.

to-be

```
NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
1        16         active             true      v21.11.12 - 937b9fe0f2bc4e419fcae1b47cd6215e7968e2c9
2        16         active             true      v21.11.12 - 937b9fe0f2bc4e419fcae1b47cd6215e7968e2c9
3        16         active             true      v21.11.12 - 937b9fe0f2bc4e419fcae1b47cd6215e7968e2c9
```