### PR TITLE
tests: quieten exceptions during redpanda startup, fix a bug in mirrormaker test teardown

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -585,6 +585,10 @@ class RedpandaService(Service):
             status = None
             try:
                 status = Admin.ready(node).get("status")
+            except requests.exceptions.ConnectionError:
+                self.logger.debug(
+                    f"node {node.name} not yet accepting connections")
+                return False
             except:
                 self.logger.exception(
                     f"error on getting status from {node.account.hostname}")

--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -41,6 +41,7 @@ class TestMirrorMakerService(EndToEndTest):
         self.zk = ZookeeperService(self.test_context,
                                    num_nodes=1,
                                    version=V_3_0_0)
+        self.source_broker = None
 
     def setUp(self):
         self.zk.start()
@@ -51,14 +52,14 @@ class TestMirrorMakerService(EndToEndTest):
         # explicitly here with some logging, to enable debugging issues
         # like https://github.com/redpanda-data/redpanda/issues/4270
 
-        self.logger.info(
-            f"Stopping source broker ({self.source_broker.__class__.__name__})..."
-        )
-        self.source_broker.stop()
-        self.logger.info(
-            f"Awaiting source broker ({self.source_broker.__class__.__name__})..."
-        )
-        self.logger.info(f"tearDown complete")
+        if self.source_broker is not None:
+            self.logger.info(
+                f"Stopping source broker ({self.source_broker.__class__.__name__})..."
+            )
+            self.source_broker.stop()
+            self.logger.info(
+                f"Awaiting source broker ({self.source_broker.__class__.__name__})..."
+            )
 
         self.logger.info("Stopping zookeeper...")
         self.zk.stop()


### PR DESCRIPTION
## Cover letter

These were a couple of nits while looking at clustered ducktape output.

Fixes: #4358 

## Release notes

* none
