### PR TITLE
[v21.11.14] backport: do not step down when replicating configuration failed

### DIFF
--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -252,10 +252,11 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
           if (ec) {
               vlog(
                 _ctxlog.info,
-                "unable to replicate configuration as a leader, stepping down");
-              return _ptr->step_down(_ptr->_term + model::term_id(1));
+                "unable to replicate configuration as a leader - error code: "
+                "{} - {} ",
+                ec.value(),
+                ec.message());
           }
-          return ss::now();
       });
 }
 


### PR DESCRIPTION
In redpanda leader replicates a configuration after successful vote
round. Configuration replication success isn't required for the node to
hold the leadership.

In some scenarios, when majority of followers are behind the leader and
need recovery, configuration replication may timeout. This doesn't mean
however that leader should stepdown. In order to maintain leadership it
should continue recovering followers and step down only if there are no
heartbeat responses from majority of the followers.

Backport of PR #4342
Fixes #4353