### PR TITLE
tests: move test executables out of /tmp

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -33,11 +33,12 @@ RUN git -C /opt clone --branch ducktape2 https://github.com/redpanda-data/kafka-
     cd /opt/kafka-streams-examples && mvn -DskipTests=true clean package
 
 # Install our in-tree Java test clientst
-COPY --chown=0:0 tests/java /tmp/java
-RUN mvn clean package --batch-mode --file /tmp/java/kafka-verifier --define buildDir=/opt/kafka-verifier/
-RUN mvn clean package --batch-mode --file /tmp/java/compacted-log-verifier --define buildDir=/opt/compacted-log-verifier
-RUN mvn clean package --batch-mode --file /tmp/java/tx-verifier --define buildDir=/opt/tx-verifier
-RUN mvn clean package --batch-mode --file /tmp/java/e2e-verifiers --define buildDir=/opt/e2e-verifiers
+RUN mkdir -p /opt/redpanda-tests
+COPY --chown=0:0 tests/java /opt/redpanda-tests/java
+RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/kafka-verifier --define buildDir=/opt/kafka-verifier/
+RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/compacted-log-verifier --define buildDir=/opt/compacted-log-verifier
+RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/tx-verifier --define buildDir=/opt/tx-verifier
+RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/e2e-verifiers --define buildDir=/opt/e2e-verifiers
 
 # - install distro-packaged depedencies
 # - allow user env variables in ssh sessions
@@ -111,8 +112,8 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
 
 # Install our in-tree go tests
-COPY --chown=0:0 tests/go /tmp/go
-RUN cd /tmp/go/sarama/produce_test && go mod tidy && go build
+COPY --chown=0:0 tests/go /opt/redpanda-tests/go
+RUN cd /opt/redpanda-tests/go/sarama/produce_test && go mod tidy && go build
 
 # Install franz-go
 RUN git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go && \

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -321,7 +321,7 @@ class VerifiableConsumer(BackgroundThreadService):
             self.global_committed[tp] = offset
 
     def start_cmd(self, node):
-        cmd = "java -cp /tmp/java/e2e-verifiers/target/e2e-verifiers-1.0.jar"
+        cmd = "java -cp /opt/redpanda-tests/java/e2e-verifiers/target/e2e-verifiers-1.0.jar"
         cmd += " -Dlog4j.configuration=file:%s" % VerifiableConsumer.LOG4J_CONFIG
         cmd += " org.apache.kafka.tools.VerifiableConsumer"
         if self.on_record_consumed:

--- a/tests/rptest/services/verifiable_producer.py
+++ b/tests/rptest/services/verifiable_producer.py
@@ -259,7 +259,7 @@ class VerifiableProducer(BackgroundThreadService):
                         self.clean_shutdown_nodes.add(node)
 
     def start_cmd(self, idx):
-        cmd = "java -cp /tmp/java/e2e-verifiers/target/e2e-verifiers-1.0.jar"
+        cmd = "java -cp /opt/redpanda-tests/java/e2e-verifiers/target/e2e-verifiers-1.0.jar"
         cmd += " -Dlog4j.configuration=file:%s" % VerifiableProducer.LOG4J_CONFIG
         cmd += " org.apache.kafka.tools.VerifiableProducer "
         cmd += " --topic %s --broker-list %s" % (self.topic,

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -39,7 +39,7 @@ class SaramaProduceTest(RedpandaTest):
 
     @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
     def test_produce(self):
-        verifier_bin = "/tmp/go/sarama/produce_test/produce_test"
+        verifier_bin = "/opt/redpanda-tests/sarama/produce_test/produce_test"
 
         self.redpanda.logger.info("creating topics")
 


### PR DESCRIPTION
## Cover letter

Installing to /tmp is problematic in non-container environments
where the operating system might try to clean up /tmp on reboot.

The EC2 AMI build will need a quick corresponding update when this lands.

## Release notes

* none