### PR TITLE
tests: ensure wait_until_result progresses

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -70,8 +70,8 @@ def wait_until_result(condition, *args, **kwargs):
         cond = condition()
         if isinstance(cond, tuple):
             head, *tail = cond
-            if len(tail) == 0:
-                res == None
+            if not tail:
+                res = None
             elif len(tail) == 1:
                 res = tail[0]
             else:


### PR DESCRIPTION
## Cover letter

In wait_until_result the tail of the condition variable is used
for future iterations of the loop, if it is empty it should be
set to None. This change makes it explicit.

## Release notes

* none
