### PR TITLE
c/topics_table: return nullopt when assignment not found

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -562,7 +562,7 @@ topic_table::get_topic_assignments(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
         return it->second.configuration.assignments;
     }
-    return {};
+    return std::nullopt;
 }
 
 std::optional<model::timestamp_type>


### PR DESCRIPTION
Returning `std::nullopt` instead of `{}` when partition assignment is not found. Previously when `{}` was returned when no assignment was found it was implicitly returned as an `std::optional` containing an empty vector. Now when assignment for partition is not found we will return empty optional.

Fixes: #4356
