### PR TITLE
Fixed isolation availability issue

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -72,7 +72,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
 
     auto _self = _controller->self();
 
-    auto r = allocate_id_reply{0, errc::no_leader_controller};
+    auto r = allocate_id_reply{0, errc::not_leader};
 
     auto retries = _metadata_dissemination_retries;
     auto delay_ms = _metadata_dissemination_retry_delay_ms;

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -76,9 +76,8 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
 
     auto retries = _metadata_dissemination_retries;
     auto delay_ms = _metadata_dissemination_retry_delay_ms;
-    auto aborted = false;
     std::optional<std::string> error;
-    while (!aborted && 0 < retries--) {
+    while (!_as.abort_requested() && 0 < retries--) {
         auto leader_opt = _leaders.local().get_leader(model::id_allocator_ntp);
         if (unlikely(!leader_opt)) {
             error = vformat(
@@ -88,7 +87,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
               "waiting for {} to fill leaders cache, retries left: {}",
               model::id_allocator_ntp,
               retries);
-            aborted = !co_await sleep_abortable(delay_ms, _as);
+            co_await sleep_abortable(delay_ms, _as);
             continue;
         }
         auto leader = leader_opt.value();
@@ -117,7 +116,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         error = vformat("id allocation failed with {}", r.ec);
         vlog(
           clusterlog.trace, "id allocation failed, retries left: {}", retries);
-        aborted = !co_await sleep_abortable(delay_ms, _as);
+        co_await sleep_abortable(delay_ms, _as);
     }
 
     if (error) {

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -41,6 +41,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::invalid_topic_exception;
     case cluster::errc::no_eligible_allocation_nodes:
         return error_code::broker_not_available;
+    case cluster::errc::not_leader:
+        return error_code::not_coordinator;
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:
@@ -48,7 +50,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::seed_servers_exhausted:
     case cluster::errc::auto_create_topics_exception:
     case cluster::errc::partition_not_exists:
-    case cluster::errc::not_leader:
     case cluster::errc::partition_already_exists:
     case cluster::errc::waiting_for_recovery:
     case cluster::errc::update_in_progress:


### PR DESCRIPTION
## Cover letter

When `id_allocator` leader is not present we should return `not_coordinator` error to force client to refresh its metadata. Returning `no_controller` error does not force the client to refresh metadata as this error type is not expected for initialize producer id request.

Fixes #4360 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
