### PR TITLE
tests: enable running shadow indexing/archival tests on clustered ducktape

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -800,17 +800,17 @@ class RedpandaService(Service):
         return self._s3client.list_buckets()
 
     def delete_bucket_from_si(self):
-        if self._s3client:
-            failed_deletions = self._s3client.empty_bucket(
-                self._si_settings.cloud_storage_bucket)
-            assert len(failed_deletions) == 0
-            self._s3client.delete_bucket(
-                self._si_settings.cloud_storage_bucket)
+        assert self._s3client is not None
+
+        failed_deletions = self._s3client.empty_bucket(
+            self._si_settings.cloud_storage_bucket)
+        assert len(failed_deletions) == 0
+        self._s3client.delete_bucket(self._si_settings.cloud_storage_bucket)
 
     def get_objects_from_si(self):
-        if self._s3client:
-            return self._s3client.list_objects(
-                self._si_settings.cloud_storage_bucket)
+        assert self._s3client is not None
+        return self._s3client.list_objects(
+            self._si_settings.cloud_storage_bucket)
 
     def set_cluster_config(self, values: dict, expect_restart: bool = False):
         """
@@ -1025,7 +1025,8 @@ class RedpandaService(Service):
 
     def clean(self, **kwargs):
         super().clean(**kwargs)
-        self.delete_bucket_from_si()
+        if self._s3client:
+            self.delete_bucket_from_si()
 
     def clean_node(self, node, preserve_logs=False):
         node.account.kill_process("redpanda", clean_shutdown=False)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -799,6 +799,10 @@ class RedpandaService(Service):
         assert self._s3client is not None
         return self._s3client.list_buckets()
 
+    @property
+    def s3_client(self):
+        return self._s3client
+
     def delete_bucket_from_si(self):
         assert self._s3client is not None
 

--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -5,14 +5,10 @@ ec2:
 
   excluded:
     - tests/librdkafka_test.py # normally disabled
-    - tests/metrics_reporter_test.py # num_nodes / feature
-    - tests/archival_test.py # s3 setup
-    - tests/e2e_shadow_indexing_test.py # num_nodes / s3 setup
-    - tests/shadow_indexing_tx_test.py # s3 setup
-    - tests/topic_recovery_test.py # s3 setup
     - tests/wasm_filter_test.py # no wasm
     - tests/wasm_failure_recovery_test.py # no wasm
     - tests/wasm_identity_test.py # no wasm
     - tests/wasm_topics_test.py # no wasm
     - tests/wasm_redpanda_failure_recovery_test.py # no wasm
+    - tests/wasm_partition_movement_test.py # no wasm
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -8,26 +8,20 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RedpandaService
 from rptest.util import Scale
-from rptest.archival.s3_client import S3Client
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import (
     produce_until_segments,
     wait_for_segments_removal,
 )
 
-import uuid
-
 
 class EndToEndShadowIndexingTest(EndToEndTest):
     segment_size = 1048576  # 1 Mb
-    s3_host_name = "minio-s3"
-    s3_access_key = "panda-user"
-    s3_secret_key = "panda-secret"
-    s3_region = "panda-region"
     s3_topic_name = "panda-topic"
     topics = (TopicSpec(
         name=s3_topic_name,
@@ -39,43 +33,27 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         super(EndToEndShadowIndexingTest,
               self).__init__(test_context=test_context)
 
-        self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
         self.topic = EndToEndShadowIndexingTest.s3_topic_name
-        self._extra_rp_conf = dict(
-            cloud_storage_enabled=True,
-            cloud_storage_enable_remote_read=True,
-            cloud_storage_enable_remote_write=True,
-            cloud_storage_access_key=EndToEndShadowIndexingTest.s3_access_key,
-            cloud_storage_secret_key=EndToEndShadowIndexingTest.s3_secret_key,
-            cloud_storage_region=EndToEndShadowIndexingTest.s3_region,
-            cloud_storage_bucket=self.s3_bucket_name,
-            cloud_storage_disable_tls=True,
-            cloud_storage_api_endpoint=EndToEndShadowIndexingTest.s3_host_name,
-            cloud_storage_api_endpoint_port=9000,
+
+        si_settings = SISettings(
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,
             log_segment_size=EndToEndShadowIndexingTest.segment_size,  # 1MB
         )
+        self.s3_bucket_name = si_settings.cloud_storage_bucket
+
+        si_settings.load_context(self.logger, test_context)
 
         self.scale = Scale(test_context)
         self.redpanda = RedpandaService(
             context=test_context,
             num_brokers=3,
-            extra_rp_conf=self._extra_rp_conf,
+            si_settings=si_settings,
         )
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
-        self.s3_client = S3Client(
-            region=EndToEndShadowIndexingTest.s3_region,
-            access_key=EndToEndShadowIndexingTest.s3_access_key,
-            secret_key=EndToEndShadowIndexingTest.s3_secret_key,
-            endpoint=f"http://{EndToEndShadowIndexingTest.s3_host_name}:9000",
-            logger=self.logger,
-        )
 
     def setUp(self):
-        self.s3_client.empty_bucket(self.s3_bucket_name)
-        self.s3_client.create_bucket(self.s3_bucket_name)
         self.redpanda.start()
         for topic in EndToEndShadowIndexingTest.topics:
             self.kafka_tools.create_topic(topic)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -50,7 +50,11 @@ class EndToEndTest(Test):
       - Perform some action (e.g. partition movement)
       - Run validation
     """
-    def __init__(self, test_context, extra_rp_conf=None, extra_node_conf=None):
+    def __init__(self,
+                 test_context,
+                 extra_rp_conf=None,
+                 extra_node_conf=None,
+                 si_settings=None):
         super(EndToEndTest, self).__init__(test_context=test_context)
         if extra_rp_conf is None:
             self._extra_rp_conf = {}
@@ -65,7 +69,14 @@ class EndToEndTest(Test):
         self.topic = None
         self._client = None
 
-    def start_redpanda(self, num_nodes=1, extra_rp_conf=None):
+    def start_redpanda(self,
+                       num_nodes=1,
+                       extra_rp_conf=None,
+                       si_settings=None):
+        self.si_settings = si_settings
+        if self.si_settings:
+            self.si_settings.load_context(self.logger, self.test_context)
+
         if extra_rp_conf is not None:
             # merge both configurations, the extra_rp_conf passed in
             # paramter takes the precedence
@@ -78,6 +89,10 @@ class EndToEndTest(Test):
                                         extra_node_conf=self._extra_node_conf)
         self.redpanda.start()
         self._client = DefaultClient(self.redpanda)
+
+    @property
+    def s3_client(self):
+        return self.redpanda.s3_client
 
     def client(self):
         assert self._client is not None

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -25,10 +25,6 @@ class RedpandaTest(Test):
     # topic is defined by an instance of a TopicSpec.
     topics = []
 
-    GLOBAL_S3_ACCESS_KEY = "s3_access_key"
-    GLOBAL_S3_SECRET_KEY = "s3_secret_key"
-    GLOBAL_S3_REGION_KEY = "s3_region"
-
     def __init__(self,
                  test_context,
                  num_brokers=None,
@@ -56,26 +52,8 @@ class RedpandaTest(Test):
             else:
                 num_brokers = 1
 
-        cloud_storage_access_key = test_context.globals.get(
-            self.GLOBAL_S3_ACCESS_KEY, None)
-        cloud_storage_secret_key = test_context.globals.get(
-            self.GLOBAL_S3_SECRET_KEY, None)
-        cloud_storage_region = test_context.globals.get(
-            self.GLOBAL_S3_REGION_KEY, None)
-
-        # Enable S3 if AWS creds were given at globals
-        if cloud_storage_access_key and cloud_storage_secret_key:
-            if self.si_settings is not None:
-                self.logger.info("Running on AWS S3, setting credentials")
-                self.si_settings.cloud_storage_access_key = cloud_storage_access_key
-                self.si_settings.cloud_storage_secret_key = cloud_storage_secret_key
-                self.si_settings.endpoint_url = None  # None so boto auto-gens the endpoint url
-                self.si_settings.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
-                self.si_settings.cloud_storage_region = cloud_storage_region
-                self.si_settings.cloud_storage_api_endpoint_port = 443
-        else:
-            self.logger.debug(
-                'No AWS credentials supplied, assuming minio defaults')
+        if self.si_settings:
+            self.si_settings.load_context(self.logger, test_context)
 
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -72,7 +72,7 @@ class RedpandaTest(Test):
                 self.si_settings.endpoint_url = None  # None so boto auto-gens the endpoint url
                 self.si_settings.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
                 self.si_settings.cloud_storage_region = cloud_storage_region
-                self.si_settings.port = 443
+                self.si_settings.cloud_storage_api_endpoint_port = 443
         else:
             self.logger.debug(
                 'No AWS credentials supplied, assuming minio defaults')
@@ -111,6 +111,10 @@ class RedpandaTest(Test):
         developer environments (e.g. laptops) but apply stricter checks in CI.
         """
         return os.environ.get('CI', None) != 'false'
+
+    @property
+    def s3_client(self):
+        return self.redpanda.s3_client
 
     def setUp(self):
         self.redpanda.start()


### PR DESCRIPTION
## Cover letter

This follows on from https://github.com/redpanda-data/redpanda/pull/4380, to fix a couple of things and enable running SI tests on EC2 by converting them to use SISettings.

## Release notes

* none