### PR TITLE
rpk: Add golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,10 +40,16 @@ jobs:
         go mod download github.com/cockroachdb/crlfmt
         go install github.com/cockroachdb/crlfmt
 
-    - name: lint go files
+    - name: format go files
       run: |
         find . -name *.go -type f | xargs -n1 crlfmt -wrap=80 -ignore '_generated.deepcopy.go$$' -w
         git diff --exit-code
+
+    - name: lint rpk
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.45.2
+        working-directory: src/go/rpk/
 
   js:
     name: Lint js files

--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -1,0 +1,7 @@
+run:
+  allow-parallel-runners: true
+
+linters:
+  disable-all: true
+  enable:
+    - gosimple

--- a/src/go/rpk/pkg/cli/cmd/acl/common.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/common.go
@@ -201,9 +201,7 @@ func (a *acls) backcompatList() error {
 		{permDeny, a.listHosts, &a.denyHosts},
 	} {
 		if migrate.perm {
-			for _, value := range migrate.source {
-				*migrate.dest = append(*migrate.dest, value)
-			}
+			*migrate.dest = append(*migrate.dest, migrate.source...)
 		}
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -64,9 +64,7 @@ func AddKafkaFlags(
 		saslMechanism,
 		config.FlagSASLMechanism,
 		"",
-		fmt.Sprintf(
-			"The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.",
-		),
+		"The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.",
 	)
 
 	AddTLSFlags(command, enableTLS, certFile, keyFile, truststoreFile)

--- a/src/go/rpk/pkg/cli/cmd/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana.go
@@ -207,7 +207,7 @@ func (rowSet *RowSet) addRatioPanel(
 ) {
 	a := metricFamilies[m0]
 	b := metricFamilies[m1]
-	row, _ := rowSet.groupPanels[group]
+	row := rowSet.groupPanels[group]
 	panel := makeRatioPanel(a, b, help)
 	row.Panels = append(row.Panels, panel)
 	rowSet.groupPanels[group] = row

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -38,7 +38,7 @@ func NewIoTuneCmd(fs afero.Fs, mgr config.Manager) *cobra.Command {
 				return err
 			}
 			var evalDirectories []string
-			if directories != nil && len(directories) != 0 {
+			if len(directories) != 0 {
 				log.Infof("Overriding evaluation directories with '%v'",
 					directories)
 				evalDirectories = directories

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -200,7 +200,7 @@ func NewStartCommand(
 				sendEnv(fs, mgr, env, conf, !prestartCfg.checkEnabled, err)
 				return err
 			}
-			if kafkaApi != nil && len(kafkaApi) > 0 {
+			if len(kafkaApi) > 0 {
 				conf.Redpanda.KafkaApi = kafkaApi
 			}
 
@@ -219,7 +219,7 @@ func NewStartCommand(
 				sendEnv(fs, mgr, env, conf, !prestartCfg.checkEnabled, err)
 				return err
 			}
-			if proxyApi != nil && len(proxyApi) > 0 {
+			if len(proxyApi) > 0 {
 				if conf.Pandaproxy == nil {
 					conf.Pandaproxy = config.Default().Pandaproxy
 				}
@@ -241,7 +241,7 @@ func NewStartCommand(
 				sendEnv(fs, mgr, env, conf, !prestartCfg.checkEnabled, err)
 				return err
 			}
-			if schemaRegApi != nil && len(schemaRegApi) > 0 {
+			if len(schemaRegApi) > 0 {
 				if conf.SchemaRegistry == nil {
 					conf.SchemaRegistry = config.Default().SchemaRegistry
 				}
@@ -972,7 +972,7 @@ func stringOr(a, b string) string {
 }
 
 func stringSliceOr(a, b []string) []string {
-	if a != nil && len(a) != 0 {
+	if len(a) != 0 {
 		return a
 	}
 	return b

--- a/src/go/rpk/pkg/system/grub_test.go
+++ b/src/go/rpk/pkg/system/grub_test.go
@@ -195,9 +195,7 @@ func getGrubCmdLineOptsLine(configLines []string) []string {
 func calcMd5(lines []string) string {
 	var data []byte
 	for _, line := range lines {
-		for _, dataByte := range []byte(line + "\n") {
-			data = append(data, dataByte)
-		}
+		data = append(data, []byte(line+"\n")...)
 	}
 	hash := md5.Sum(data)
 	return hex.EncodeToString(hash[:16])

--- a/src/go/rpk/pkg/system/runtime_options.go
+++ b/src/go/rpk/pkg/system/runtime_options.go
@@ -31,7 +31,7 @@ func ReadRuntineOptions(fs afero.Fs, path string) (*RuntimeOptions, error) {
 	if len(lines) != 1 {
 		return nil, fmt.Errorf("Unable to parse options file '%s'", path)
 	}
-	activeOptionPattern := regexp.MustCompile("^\\[(.*)\\]$")
+	activeOptionPattern := regexp.MustCompile(`^\[(.*)\]$`)
 	options := strings.Fields(lines[0])
 
 	for _, opt := range options {

--- a/src/go/rpk/pkg/tuners/disk/block_devices.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices.go
@@ -275,7 +275,7 @@ func (b *blockDevices) isIRQNvmeFastPathIRQ(
 	irq, numberOfCpus int,
 ) (bool, error) {
 	nvmeFastPathQueuePattern := regexp.MustCompile(
-		"(\\s|^)nvme\\d+q(\\d+)(\\s|$)")
+		`(\s|^)nvme\d+q(\d+)(\s|$)`)
 	linesMap, err := b.irqProcFile.GetIRQProcFileLinesMap()
 	if err != nil {
 		return false, err

--- a/src/go/rpk/pkg/tuners/executors/commands/ethtool_change.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/ethtool_change.go
@@ -43,7 +43,7 @@ func (c *ethtoolChangeCommand) RenderScript(w *bufio.Writer) error {
 	fmt.Fprintf(w, "ethtool -K %s ", c.intf)
 	for feature, state := range c.config {
 		stateString := "on"
-		if state == false {
+		if !state {
 			stateString = "off"
 		}
 		fmt.Fprintf(w, "%s %s", feature, stateString)

--- a/src/go/rpk/pkg/tuners/hwloc/cpuset.go
+++ b/src/go/rpk/pkg/tuners/hwloc/cpuset.go
@@ -17,7 +17,7 @@ import (
 
 func TranslateToHwLocCpuSet(cpuset string) (string, error) {
 
-	cpuSetPattern := regexp.MustCompile("^(\\d+-)?(\\d+)(,(\\d+-)?(\\d+))*$")
+	cpuSetPattern := regexp.MustCompile(`^(\d+-)?(\d+)(,(\d+-)?(\d+))*$`)
 	if cpuset == "all" {
 		return cpuset, nil
 	}

--- a/src/go/rpk/pkg/tuners/irq/balance_service.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service.go
@@ -169,7 +169,7 @@ func (balanceService *balanceService) GetBannedIRQs() ([]int, error) {
 		return nil, fmt.Errorf("invalid format in '%s' - more than one line with '%s' key",
 			serviceInfo.configFile, serviceInfo.optionsKey)
 	}
-	bannedIRQPattern := regexp.MustCompile("\\-\\-banirq\\=(\\d+)")
+	bannedIRQPattern := regexp.MustCompile(`\-\-banirq\=(\d+)`)
 
 	bannedIRQsMatches := bannedIRQPattern.FindAllStringSubmatch(optionLines[0], -1)
 

--- a/src/go/rpk/pkg/tuners/irq/balance_service_test.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service_test.go
@@ -352,9 +352,7 @@ func TestAreIRQsStaticallyAssigned(t *testing.T) {
 func calcMd5(lines []string) string {
 	var data []byte
 	for _, line := range lines {
-		for _, dataByte := range []byte(line + "\n") {
-			data = append(data, dataByte)
-		}
+		data = append(data, []byte(line+"\n")...)
 	}
 	hash := md5.Sum(data)
 	return hex.EncodeToString(hash[:16])

--- a/src/go/rpk/pkg/tuners/irq/proc_file.go
+++ b/src/go/rpk/pkg/tuners/irq/proc_file.go
@@ -40,7 +40,7 @@ func (procFile *procFile) GetIRQProcFileLinesMap() (map[int]string, error) {
 		return nil, err
 	}
 	linesByIRQ := make(map[int]string)
-	irqPattern := regexp.MustCompile("^\\s*\\d+:.*$")
+	irqPattern := regexp.MustCompile(`^\s*\d+:.*$`)
 	for _, line := range lines {
 		if !irqPattern.MatchString(line) {
 			continue

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -134,7 +134,7 @@ func (n *nic) GetIRQs() ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	fastPathIRQsPattern := regexp.MustCompile("-TxRx-|-fp-|-Tx-Rx-|mlx\\d+-\\d+@")
+	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|-Tx-Rx-|mlx\d+-\d+@`)
 	var fastPathIRQs []int
 	for _, irq := range IRQs {
 		if fastPathIRQsPattern.MatchString(procFileLines[irq]) {
@@ -152,8 +152,8 @@ func (n *nic) GetIRQs() ([]int, error) {
 }
 
 func intelIrqToQueueIdx(irq int, procFileLines map[int]string) int {
-	intelFastPathIrqPattern := regexp.MustCompile("-TxRx-(\\d+)")
-	fdirPattern := regexp.MustCompile("fdir-TxRx-\\d+")
+	intelFastPathIrqPattern := regexp.MustCompile(`-TxRx-(\d+)`)
+	fdirPattern := regexp.MustCompile(`fdir-TxRx-\d+`)
 	procLine := procFileLines[irq]
 
 	intelFastPathMatch := intelFastPathIrqPattern.FindStringSubmatch(procLine)

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -71,7 +71,7 @@ func Test_nic_Slaves_ReturnAllSlavesOfAnInterface(t *testing.T) {
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0644)
-	afero.WriteFile(fs, "/sys/class/net/test0/bond/slaves", []byte(fmt.Sprint("sl0\nsl1\nsl2")), 0644)
+	afero.WriteFile(fs, "/sys/class/net/test0/bond/slaves", []byte("sl0\nsl1\nsl2"), 0644)
 	//when
 	slaves, err := nic.Slaves()
 	//then

--- a/src/go/rpk/pkg/utils/os.go
+++ b/src/go/rpk/pkg/utils/os.go
@@ -37,8 +37,5 @@ func IsAWSi3MetalInstance() bool {
 	}
 	log.Debugf("Running on '%s' EC2 instance", instanceType)
 
-	if instanceType == "i3.metal" {
-		return true
-	}
-	return false
+	return instanceType == "i3.metal"
 }


### PR DESCRIPTION
## Cover letter

Part of the ongoing plan to enable a set of linters rules in rpk to define standard rules and style guides in the repo, this wil help newcomers and not-full-time Go developers that which to contribute to rpk.

This first PR adds `golangci-lint` job in GitHub actions and only enables `gosimple` rule.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Part of the plan to solve #3244

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
