### PR TITLE
rpk: add cluster maintenance status and enable barrier

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -34,7 +34,7 @@ type Broker struct {
 	NumCores         int                `json:"num_cores"`
 	MembershipStatus string             `json:"membership_status"`
 	IsAlive          *bool              `json:"is_alive"`
-	Version          string             `json:"version`
+	Version          string             `json:"version"`
 	Maintenance      *MaintenanceStatus `json:"maintenance_status"`
 }
 

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -16,6 +16,7 @@ import (
 )
 
 const brokersEndpoint = "/v1/brokers"
+const brokerEndpoint = "/v1/brokers/%d"
 
 type MaintenanceStatus struct {
 	Draining     bool `json:"draining"`
@@ -44,6 +45,15 @@ func (a *AdminAPI) Brokers() ([]Broker, error) {
 		sort.Slice(bs, func(i, j int) bool { return bs[i].NodeID < bs[j].NodeID })
 	}()
 	return bs, a.sendAny(http.MethodGet, brokersEndpoint, nil, &bs)
+}
+
+// Broker queries one of the client's hosts and returns broker information.
+func (a *AdminAPI) Broker(node int) (Broker, error) {
+	var b Broker
+	err := a.sendAny(
+		http.MethodGet,
+		fmt.Sprintf(brokerEndpoint, node), nil, &b)
+	return b, err
 }
 
 // DecommissionBroker issues a decommission request for the given broker.

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -17,13 +17,24 @@ import (
 
 const brokersEndpoint = "/v1/brokers"
 
+type MaintenanceStatus struct {
+	Draining     bool `json:"draining"`
+	Finished     bool `json:"finished"`
+	Errors       bool `json:"errors"`
+	Partitions   int  `json:"partitions"`
+	Eligible     int  `json:"eligible"`
+	Transferring int  `json:"transferring"`
+	Failed       int  `json:"failed"`
+}
+
 // Broker is the information returned from the Redpanda admin broker endpoints.
 type Broker struct {
-	NodeID           int    `json:"node_id"`
-	NumCores         int    `json:"num_cores"`
-	MembershipStatus string `json:"membership_status"`
-	IsAlive          *bool  `json:"is_alive"`
-	Version          string `json:"version`
+	NodeID           int                `json:"node_id"`
+	NumCores         int                `json:"num_cores"`
+	MembershipStatus string             `json:"membership_status"`
+	IsAlive          *bool              `json:"is_alive"`
+	Version          string             `json:"version`
+	Maintenance      *MaintenanceStatus `json:"maintenance_status"`
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
@@ -65,7 +65,8 @@ Currently leadership is not transferred for partitions with one replica.
 
 	cmd.AddCommand(
 		newEnableCommand(fs),
-		newDisableCommand(fs))
+		newDisableCommand(fs),
+		newStatusCommand(fs))
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
@@ -1,0 +1,98 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package maintenance
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newMaintenanceReportTable() *out.TabWriter {
+	headers := []string{"Node-ID", "Draining", "Finished", "Errors",
+		"Partitions", "Eligible", "Transferring", "Failed"}
+	return out.NewTable(headers...)
+}
+
+func addBrokerMaintenanceReport(table *out.TabWriter, b admin.Broker) {
+	table.Print(
+		b.NodeID,
+		b.Maintenance.Draining,
+		b.Maintenance.Finished,
+		b.Maintenance.Errors,
+		b.Maintenance.Partitions,
+		b.Maintenance.Eligible,
+		b.Maintenance.Transferring,
+		b.Maintenance.Failed)
+}
+
+func newStatusCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Report maintenance status.",
+		Long: `Report maintenance status.
+
+This command reports maintenance status for each node in the cluster. The output
+is presented as a table with each row representing a node in the cluster.  The
+output can be used to monitor the progress of node draining.
+
+   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   1        false     false     false   0           0         0             0
+
+Field descriptions:
+
+        NODE-ID: the node ID
+       DRAINING: true if the node is actively draining leadership
+       FINISHED: leadership draining has completed
+         ERRORS: errors have been encountered while draining
+     PARTITIONS: number of partitions whose leadership has moved
+       ELIGIBLE: number of partitions with leadership eligible to move
+   TRANSFERRING: current active number of leadership transfers
+         FAILED: number of failed leadership transfers
+
+Notes:
+
+   - When errors are present further information will be available in the logs
+     for the corresponding node.
+
+   - Only partitions with more than one replica are eligible for leadership
+     transfer.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			brokers, err := client.Brokers()
+			out.MaybeDie(err, "unable to request brokers: %v", err)
+
+			if len(brokers) == 0 {
+				out.Die("No brokers found. Check broker address configuration.")
+			}
+
+			if brokers[0].Maintenance == nil {
+				out.Die("Maintenance mode is not supported in this cluster")
+			}
+
+			table := newMaintenanceReportTable()
+			defer table.Flush()
+			for _, broker := range brokers {
+				addBrokerMaintenanceReport(table, broker)
+			}
+		},
+	}
+	return cmd
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -481,7 +481,7 @@ class RpkTool:
     def _rpk_binary(self):
         return self._redpanda.find_binary("rpk")
 
-    def cluster_maintenance_enable(self, node):
+    def cluster_maintenance_enable(self, node, wait=False):
         node_id = self._redpanda.idx(node) if isinstance(node,
                                                          ClusterNode) else node
         cmd = [
@@ -489,6 +489,8 @@ class RpkTool:
             self._admin_host(), "cluster", "maintenance", "enable",
             str(node_id)
         ]
+        if wait:
+            cmd.append("--wait")
         return self._execute(cmd)
 
     def cluster_maintenance_disable(self, node):

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from collections import namedtuple
 import subprocess
 import re
 import typing
@@ -79,6 +78,17 @@ class RpkClusterInfoNode:
     def __init__(self, id, address):
         self.id = id
         self.address = address
+
+
+class RpkMaintenanceStatus(typing.NamedTuple):
+    node_id: int
+    draining: bool
+    finished: bool
+    errors: bool
+    partitions: int
+    eligible: int
+    transferring: int
+    failed: int
 
 
 class RpkTool:
@@ -490,3 +500,39 @@ class RpkTool:
             str(node_id)
         ]
         return self._execute(cmd)
+
+    def cluster_maintenance_status(self):
+        """
+        Run `rpk cluster maintenance status` and return the parsed results.
+        """
+        def parse(line):
+            # jerry@garcia:~/src/redpanda$ rpk cluster maintenance status
+            # NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+            # 1        false     false     false   0           0         0             0
+            line = line.split()
+            assert len(
+                line
+            ) == 8, f"`rpk cluster maintenance status` has changed: {line}"
+            line = [x.strip() for x in line]
+            if line[0] == "NODE-ID":
+                return None
+            return RpkMaintenanceStatus(node_id=int(line[0]),
+                                        draining=line[1] == "true",
+                                        finished=line[2] == "true",
+                                        errors=line[3] == "true",
+                                        partitions=int(line[4]),
+                                        eligible=int(line[5]),
+                                        transferring=int(line[6]),
+                                        failed=int(line[7]))
+
+        cmd = [
+            self._rpk_binary(),
+            "--api-urls",
+            self._admin_host(),
+            "cluster",
+            "maintenance",
+            "status",
+        ]
+
+        output = self._execute(cmd)
+        return list(filter(None, map(parse, output.splitlines())))


### PR DESCRIPTION
## Cover letter

* Adds a `status` sub-command to cluster maintenance mode which prints maintenance and node draining status.
* Adds a `--wait` option to cluster maintenance enabling that can be used as a barrier to wait until draining is complete
* Updates ducktape to take advantage of these two commands

Fixes: https://github.com/redpanda-data/redpanda/issues/4434

## Release notes

### Features

* Add ability to query maintenance status via rpk
* Add ability to rpk to wait for a node in maintenance mode to be drained