### PR TITLE
cloud_storage: retry gracefully on EPIPE errors

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -104,7 +104,8 @@ static error_outcome categorize_error(
         // - any other network error (no memory, bad socket, etc)
         if (auto code = cerr.code();
             code.value() != ECONNREFUSED && code.value() != ENETUNREACH
-            && code.value() != ETIMEDOUT && code.value() != ECONNRESET) {
+            && code.value() != ETIMEDOUT && code.value() != ECONNRESET
+            && code.value() != EPIPE) {
             vlog(ctxlog.error, "System error {}", cerr);
             result = error_outcome::fail;
         } else {


### PR DESCRIPTION
## Cover letter

This particular style of network error is fairly
common when talking to AWS S3, it turns out.

Noticed because it trips the log error detector
in ducktape tests.

## Release notes

* none