### PR TITLE
tests: improve LogLevelTest to not rely on initial level=trace

### DIFF
--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -15,19 +15,24 @@ from rptest.services.admin import Admin
 
 
 class LogLevelTest(RedpandaTest):
+    initial_log_level = "trace"
+
+    def __init__(self, *args, **kwargs):
+        # Set an explicit log level rather than relying on the externally
+        # configurable redpanda log level, so that the test knows where
+        # it will start.
+        super().__init__(*args, log_level=self.initial_log_level, **kwargs)
+
     @cluster(num_nodes=3)
     def test_log_level_control(self):
         admin = Admin(self.redpanda)
         node = self.redpanda.nodes[0]
 
-        # This test assumes the default log level while testing is trace
-        default_log_level = "trace"
-
         # set to warn level. message seen at trace
         with self.redpanda.monitor_log(node) as mon:
             admin.set_log_level("admin_api_server", "warn")
             mon.wait_until(
-                f"Set log level for {{admin_api_server}}: {default_log_level} -> warn",
+                f"Set log level for {{admin_api_server}}: {self.initial_log_level} -> warn",
                 timeout_sec=5,
                 backoff_sec=1,
                 err_msg="Never saw message")
@@ -57,7 +62,7 @@ class LogLevelTest(RedpandaTest):
         with self.redpanda.monitor_log(node) as mon:
             admin.set_log_level("admin_api_server", "debug", expires=5)
             mon.wait_until(
-                f"Expiring log level for {{admin_api_server}} to {default_log_level}",
+                f"Expiring log level for {{admin_api_server}} to {self.initial_log_level}",
                 timeout_sec=10,
                 backoff_sec=1,
                 err_msg="Never saw message")


### PR DESCRIPTION

## Cover letter

This is a very minor thing, but it periodically pops up
as a spurious failure when someone runs ducktape
with a different default log level than the one
we usually use in CI.

## Release notes

* none
