### PR TITLE
ducky: do common ops while the system is busy

### DIFF
--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -10,7 +10,9 @@
 import os
 import json
 import threading
+from rptest.services.redpanda import RedpandaService
 from ducktape.services.background_thread import BackgroundThreadService
+from ducktape.utils.util import wait_until
 
 # The franz-go root directory
 TESTS_DIR = os.path.join("/opt", "kgo-verifier")
@@ -279,3 +281,13 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
             self.save_exception(ex)
         finally:
             self.status = ServiceStatus.FINISH
+
+
+# Block until the producer has
+# written a minimum amount of data.
+def await_minimum_produced_records(redpanda: RedpandaService,
+                                   producer: FranzGoVerifiableProducer,
+                                   min_acked: int = 0) -> None:
+    wait_until(lambda: producer.produce_status.acked > min_acked,
+               timeout_sec=300,
+               backoff_sec=5)

--- a/tests/rptest/tests/prealloc_nodes.py
+++ b/tests/rptest/tests/prealloc_nodes.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.utils.util import wait_until
+from ducktape.tests.test import TestContext
+
+
+class PreallocNodesTest(RedpandaTest):
+    """
+    A mixin class that extends RedpandaTest to
+    preallocate ducktape nodes from the given test context.
+    """
+    def __init__(self, test_context: TestContext, node_prealloc_count: int,
+                 *args, **kwargs):
+        super(PreallocNodesTest, self).__init__(test_context, *args, **kwargs)
+        self.node_prealloc_count = node_prealloc_count
+
+        self.preallocated_nodes = test_context.cluster.alloc(
+            ClusterSpec.simple_linux(node_prealloc_count))
+
+        for node in self.preallocated_nodes:
+            self.logger.debug(f'Allocated node {node.name}')
+
+    def free_nodes(self):
+        # Free the normally allocated nodes (e.g. RedpandaService)
+        super().free_nodes()
+
+        assert len(self.preallocated_nodes) == self.node_prealloc_count
+
+        # Some tests may open huge numbers of connections, which can interfere
+        # with subsequent tests' use of the node. Clear them down first.
+        # For example, those tests that use FranzGoVerifiableProducer.
+        for node in self.preallocated_nodes:
+            wait_until(lambda: self.redpanda.sockets_clear(node),
+                       timeout_sec=120,
+                       backoff_sec=10)
+
+            # Free the hand-allocated nodes
+            self.logger.debug(f"Freeing node {node.name}")
+            self.test_context.cluster.free_single(node)


### PR DESCRIPTION
## Cover letter

One of the shadow indexing tests to run operations against a cluster under load. Intended for CDT.

Closes: #4464 

Changes from force-push `f3c36ed`:
- Move await minimum produced records to franz_go_verifiable_services
- Use dedicated nodes to scale based on CDT

Changes from force-push `061f459`:
- Fix blank line problems
- Reduce segment size & partition count
- Use large message size for dedicated nodes (e.g., CDT)

Changes from force-push `9571a16`:
- Resolve conflicts

Changes from force-push `2d4c395`:
- Add typing