### PR TITLE
cloud_storage: downgrade another log error to a warning

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -108,6 +108,9 @@ ss::future<> ntp_archiver::upload_loop() {
     while (upload_loop_can_continue()) {
         auto result = co_await upload_next_candidates();
         if (result.num_failed != 0) {
+            // The logic in class `remote` already does retries: if we get here,
+            // it means the upload failed after several retries, indicating
+            // something non-transient may be wrong.  Hence error severity.
             vlog(
               _rtclog.error,
               "Failed to upload {} segments out of {}",

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -351,7 +351,7 @@ ss::future<iobuf> client::response_stream::recv_some() {
             [err] { return ss::make_exception_future<iobuf>(err); });
       })
       .handle_exception_type([this](const std::system_error& ec) {
-          vlog(_ctxlog.error, "receive error {}", ec);
+          vlog(_ctxlog.warn, "receive error {}", ec);
           _client->shutdown();
           return ss::make_exception_future<iobuf>(ec);
       });
@@ -429,7 +429,10 @@ ss::future<> client::request_stream::send_some(iobuf&& seq) {
                     [err] { return ss::make_exception_future<>(err); });
               })
             .handle_exception_type([this](const std::system_error& ec) {
-                vlog(_ctxlog.error, "send error {}", ec);
+                // Things like EPIPE, ERESET.  This happens routinely
+                // when talking to AWS S3, even if we are not doing
+                // anything wrong.
+                vlog(_ctxlog.warn, "send error {}", ec);
                 _client->shutdown();
                 return ss::make_exception_future<>(ec);
             });


### PR DESCRIPTION
## Cover letter

The log messages in these commits came up while testing on AWS.

The one in ntp_archiver_service is _I think_ correct, as we only hit it after exhausting retries in remote.cc, but would appreciate confirmation of that.  It happens when running redpanda before https://github.com/redpanda-data/redpanda/pull/4392 is applied: each EPIPE is followed by one of these "Failed to upload" errors.

## Release notes

### Improvements

* Reduced verbosity of error logging when cloud storage backends experience transient connection failures.
