### PR TITLE
net: improve logging on unclean client disconnects

### DIFF
--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -13,6 +13,7 @@
 #include "likely.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "rpc/logger.h"
+#include "rpc/service.h"
 #include "seastar/core/coroutine.hh"
 #include "ssx/future-util.h"
 #include "ssx/sformat.h"
@@ -105,13 +106,43 @@ static inline void print_exceptional_future(
         return;
     }
 
-    vlog(
-      rpc::rpclog.error,
-      "{} - Error[{}] remote address: {} - {}",
-      proto->name(),
-      ctx,
-      address,
-      f.get_exception());
+    bool is_error = true;
+    std::exception_ptr ex;
+    try {
+        std::rethrow_exception(f.get_exception());
+    } catch (const std::out_of_range&) {
+        // Happens on unclean client disconnect, when io_iterator_consumer
+        // gets fewer bytes than it wanted
+        ex = std::current_exception();
+        is_error = false;
+    } catch (const rpc::rpc_internal_body_parsing_exception&) {
+        // Happens on unclean client disconnect, typically wrapping
+        // an out_of_range
+        ex = std::current_exception();
+        is_error = false;
+    } catch (...) {
+        // An unexpected exception: this could be anything, including
+        // a bug: report as an error.
+        ex = std::current_exception();
+        is_error = true;
+    }
+    if (is_error) {
+        vlog(
+          rpc::rpclog.error,
+          "{} - Error[{}] remote address: {} - {}",
+          proto->name(),
+          ctx,
+          address,
+          ex);
+    } else {
+        vlog(
+          rpc::rpclog.warn,
+          "{} - Exception[{}] remote address: {} - {}",
+          proto->name(),
+          ctx,
+          address,
+          ex);
+    }
 }
 
 static ss::future<> apply_proto(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -98,11 +98,6 @@ CHAOS_LOG_ALLOW_LIST = [
 
     # rpc - Service handler threw an exception: seastar::broken_promise (broken promise)"
     re.compile("rpc - Service handler threw an exception: seastar"),
-
-    # rpc - server.cc:91 - vectorized internal rpc protocol - Error[applying protocol] remote address: 172.18.0.10:60503 - rpc::rpc_internal_body_parsing_exception (Unable to parse received RPC request payload - std::out_of_range (parse_utils out of range. got:9726 bytes and expected:46927 bytes
-    re.compile(
-        "rpc - .*Unable to parse received RPC request payload - std::out_of_range"
-    ),
     re.compile(
         "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
     ),

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -96,9 +96,7 @@ class TopicDeleteStressTest(RedpandaTest):
                              num_brokers=3,
                              extra_rp_conf=extra_rp_conf)
 
-    # log_allow_list should not be needed here: it is a workaround pending
-    # investigation of https://github.com/redpanda-data/redpanda/issues/4326
-    @cluster(num_nodes=4, log_allow_list=["rpc - .* - std::out_of_range"])
+    @cluster(num_nodes=4)
     def stress_test(self):
         for i in range(10):
             spec = TopicSpec(partition_count=2,


### PR DESCRIPTION
## Cover letter
    
Uncleanly closed connections tend to generate parsing
errors, as parsers get fewer bytes than they wanted.
    
Avoid logging these as errors: client disconnects
are a normal part of operations.

## Release notes

* Redpanda emits fewer error log messages on unexpected client disconnections.
