### PR TITLE
Partitions subcommand

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -13,8 +13,8 @@ package admin
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions"
 	configcmd "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -13,6 +13,7 @@ package admin
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions"
 	configcmd "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
@@ -62,6 +63,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 
 	cmd.AddCommand(
 		brokers.NewCommand(fs),
+		partitions.NewCommand(fs),
 		configcmd.NewCommand(fs),
 	)
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -38,29 +38,29 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 }
 
 func newListCommand(fs afero.Fs) *cobra.Command {
-        return &cobra.Command{
-                Use:     "list",
-                Aliases: []string{"ls"},
-                Short:   "List the brokers in your cluster.",
-                Args:    cobra.ExactArgs(0),
-                Run: func(cmd *cobra.Command, _ []string) {
-                        p := config.ParamsFromCommand(cmd)
-                        cfg, err := p.Load(fs)
-                        out.MaybeDie(err, "unable to load config: %v", err)
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List the brokers in your cluster.",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
 
-                        cl, err := admin.NewClient(fs, cfg)
-                        out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-                        bs, err := cl.Brokers()
-                        out.MaybeDie(err, "unable to request brokers: %v", err)
+			bs, err := cl.Brokers()
+			out.MaybeDie(err, "unable to request brokers: %v", err)
 
-                        tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
-                        defer tw.Flush()
-                        for _, b := range bs {
-                                tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
-                        }
-                },
-        }
+			tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
+			defer tw.Flush()
+			for _, b := range bs {
+				tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+			}
+		},
+	}
 }
 
 func newDecommissionBroker(fs afero.Fs) *cobra.Command {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -12,17 +12,14 @@
 package brokers
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/twmb/franz-go/pkg/kadm"
 )
 
 // NewCommand returns the brokers admin command.
@@ -34,7 +31,6 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
-		newListPartitionsCommand(fs),
 		newDecommissionBroker(fs),
 		newRecommissionBroker(fs),
 	)
@@ -65,60 +61,6 @@ func newListCommand(fs afero.Fs) *cobra.Command {
                         }
                 },
         }
-}
-
-func newListPartitionsCommand(fs afero.Fs) *cobra.Command {
-	var (
-		brokerId string
-	)
-	cmd :=  &cobra.Command{
-		Use:     "list-partitions",
-		Aliases: []string{"ls-ps"},
-		Short:   "List the partitions in a broker in your cluster.",
-		Args:    cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-			p := config.ParamsFromCommand(cmd)
-			cfg, err := p.Load(fs)
-			out.MaybeDie(err, "unable to load config: %v", err)
-
-			//cl, err := admin.NewClient(fs, cfg)
-			//out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
-			adm, err := kafka.NewAdmin(fs, p, cfg)
-                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
-                        defer adm.Close()
-
-			var m kadm.Metadata
-                        m, err = adm.Metadata(context.Background(), args...)
-                        out.MaybeDie(err, "unable to request metadata: %v", err)
-
-			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
-
-			args := func(b *admin.Broker) []interface{} {
-				ret := []interface{}{b.NodeID, b.NumCores, b.MembershipStatus}
-				return ret
-			}
-			for _, b := range bs {
-				if b.IsAlive != nil {
-					headers = append(headers, "Is-Alive", "Broker-Version")
-					orig := args
-					args = func(b *admin.Broker) []interface{} {
-						return append(orig(b), *b.IsAlive, b.Version)
-					}
-					break
-				}
-			}
-			tw := out.NewTable(headers...)
-			defer tw.Flush()
-			for _, b := range bs {
-				tw.Print(args(&b)...)
-			}
-		},
-	}
-
-	cmd.Flags().StringVar(&brokerId, "broker-id", "b", "print the partitions on broker id")
-
-	return cmd
 }
 
 func newDecommissionBroker(fs afero.Fs) *cobra.Command {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -54,10 +54,26 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			bs, err := cl.Brokers()
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
-			tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
+			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
+
+			args := func(b *admin.Broker) []interface{} {
+				ret := []interface{}{b.NodeID, b.NumCores, b.MembershipStatus}
+				return ret
+			}
+			for _, b := range bs {
+				if b.IsAlive != nil {
+					headers = append(headers, "Is-Alive", "Broker-Version")
+					orig := args
+					args = func(b *admin.Broker) []interface{} {
+						return append(orig(b), *b.IsAlive, b.Version)
+					}
+					break
+				}
+			}
+			tw := out.NewTable(headers...)
 			defer tw.Flush()
 			for _, b := range bs {
-				tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+				tw.Print(args(&b)...)
 			}
 		},
 	}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package partitions contains commands to talk to the Redpanda's admin partitions
+// endpoints.
+package partitions
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+// NewCommand returns the partitions admin command.
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "partitions",
+		Short: "View and configure Redpanda partitions through the admin listener.",
+		Args:  cobra.ExactArgs(0),
+	}
+	cmd.AddCommand(
+		newListCommand(fs),
+	)
+	return cmd
+}
+
+func newListCommand(fs afero.Fs) *cobra.Command {
+	var (
+		leaderOnly bool
+	)
+	cmd :=  &cobra.Command{
+		Use:     "list [BROKER ID]",
+		Aliases: []string{"ls"},
+		Short:   "List the partitions in a broker in the cluster.",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			brokerId, err := strconv.Atoi(args[0])
+                        out.MaybeDie(err, "invalid broker %s: %v", args[0], err)
+                        if brokerId < 0 {
+                                out.Die("invalid negative broker id %v", brokerId)
+                        }
+
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+                        defer adm.Close()
+
+			var m kadm.Metadata
+                        m, err = adm.Metadata(context.Background())
+                        out.MaybeDie(err, "unable to request metadata: %v", err)
+
+			tw := out.NewTable("TOPIC", "PARTITION", "IS_LEADER")
+			defer tw.Flush()
+
+			for _, t := range m.Topics.Sorted() {
+				for _, pt := range t.Partitions.Sorted() {
+					for _, rs := range pt.Replicas {
+						if int(rs) == brokerId {
+							var isLeader = "NO"
+							if int(pt.Leader) == brokerId {
+								isLeader = "YES"
+							}
+							tw.Print(t.Topic , pt.Partition, isLeader)
+						}
+					}
+				}
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&leaderOnly, "leader-only", "l", false, "print the partitions on broker which are leaders")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -40,29 +40,29 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	var (
 		leaderOnly bool
 	)
-	cmd :=  &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list [BROKER ID]",
 		Aliases: []string{"ls"},
 		Short:   "List the partitions in a broker in the cluster.",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			brokerId, err := strconv.Atoi(args[0])
-                        out.MaybeDie(err, "invalid broker %s: %v", args[0], err)
-                        if brokerId < 0 {
-                                out.Die("invalid negative broker id %v", brokerId)
-                        }
+			out.MaybeDie(err, "invalid broker %s: %v", args[0], err)
+			if brokerId < 0 {
+				out.Die("invalid negative broker id %v", brokerId)
+			}
 
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
 			adm, err := kafka.NewAdmin(fs, p, cfg)
-                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
-                        defer adm.Close()
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
 
 			var m kadm.Metadata
-                        m, err = adm.Metadata(context.Background())
-                        out.MaybeDie(err, "unable to request metadata: %v", err)
+			m, err = adm.Metadata(context.Background())
+			out.MaybeDie(err, "unable to request metadata: %v", err)
 
 			tw := out.NewTable("TOPIC", "PARTITION", "IS_LEADER")
 			defer tw.Flush()
@@ -74,10 +74,10 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 							var isLeader bool
 							if int(pt.Leader) == brokerId {
 								isLeader = true
-								tw.Print(t.Topic , pt.Partition, isLeader)
+								tw.Print(t.Topic, pt.Partition, isLeader)
 							}
 							if !leaderOnly && !isLeader {
-								tw.Print(t.Topic , pt.Partition, isLeader)
+								tw.Print(t.Topic, pt.Partition, isLeader)
 							}
 						}
 					}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -64,7 +64,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			m, err = adm.Metadata(context.Background())
 			out.MaybeDie(err, "unable to request metadata: %v", err)
 
-			tw := out.NewTable("TOPIC", "PARTITION", "IS_LEADER")
+			tw := out.NewTable("TOPIC", "PARTITION", "IS-LEADER")
 			defer tw.Flush()
 
 			for _, t := range m.Topics.Sorted() {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -71,11 +71,14 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 				for _, pt := range t.Partitions.Sorted() {
 					for _, rs := range pt.Replicas {
 						if int(rs) == brokerId {
-							var isLeader = "NO"
+							var isLeader bool
 							if int(pt.Leader) == brokerId {
-								isLeader = "YES"
+								isLeader = true
+								tw.Print(t.Topic , pt.Partition, isLeader)
 							}
-							tw.Print(t.Topic , pt.Partition, isLeader)
+							if !leaderOnly && !isLeader {
+								tw.Print(t.Topic , pt.Partition, isLeader)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Cover letter

Added a new sub-command `partitions` to `rpk redpanda admin` command. Sub-command `list [BROKER ID]` is added for the sub-command `partitions`. In summary, the command would like this:

```
Usage:
rpk redpanda admin partitions list [BROKER ID] [flags]

Aliases:
  list, ls

Flags:
  -h, --help          help for list
  -l, --leader-only   print the partitions on broker which are leaders
```

## Release notes

* View live partitions on a broker

### Features

Lists partitions on a given broker with details such as whether each partition is a leader or a replica.
