### PR TITLE
tests: adds random action injector

### DIFF
--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -126,6 +126,14 @@ class RandomNodeProcessFailure(RandomNodeOp):
             self.failure_injector.inject_failure(
                 FailureSpec(FailureSpec.FAILURE_KILL, node))
             self.nodes_affected.add(node)
+
+            # Update started_nodes so validations are run on the correct
+            # set of nodes later.
+            try:
+                self.redpanda.started_nodes().remove(node)
+            except ValueError:
+                self.redpanda.logger.warn(
+                    f'failed to remove {node} from rp node list')
         else:
             self.redpanda.logger.warn(f'no usable node')
 

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -1,0 +1,153 @@
+import dataclasses
+import random
+import time
+from threading import Thread
+from typing import Optional
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.utils.util import wait_until
+
+from rptest.services.admin import Admin
+from rptest.services.failure_injector import FailureSpec, FailureInjector
+from rptest.services.redpanda import RedpandaService
+
+
+@dataclasses.dataclass
+class ActionConfig:
+    cluster_start_lead_time_sec: float
+    min_time_between_failures_sec: float
+    max_time_between_failures_sec: float
+    max_affected_nodes: Optional[int] = None
+
+    def random_time_in_range(self) -> float:
+        return random.uniform(self.min_time_between_failures_sec, self.max_time_between_failures_sec)
+
+
+class RandomNodeOp:
+    def __init__(self, redpanda: RedpandaService, config: ActionConfig, admin: Admin):
+        self.admin = admin
+        self.config = config
+        self.redpanda = redpanda
+        self.nodes_affected = set()
+
+    def limit_reached(self) -> bool:
+        raise NotImplementedError
+
+    def target_node(self) -> ClusterNode:
+        available = set(self.redpanda.nodes) - self.nodes_affected
+        return random.choice(list(available))
+
+    def action(self):
+        raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        if not self.limit_reached():
+            self.action()
+
+
+class RandomNodeDecommission(RandomNodeOp):
+    def limit_reached(self):
+        return len(self.nodes_affected) >= self.config.max_affected_nodes
+
+    def action(self):
+        node = self.target_node()
+        broker_id = next((i for i, n in enumerate(self.redpanda.nodes) if n == node))
+        self.redpanda.stop_node(node)
+        self.admin.decommission_broker(id=broker_id)
+        wait_until(
+            lambda: broker_id not in {b['node_id'] for b in self.admin.get_brokers()},
+            timeout_sec=120,
+            backoff_sec=2,
+            err_msg=f'Failed to decommission broker id {broker_id}'
+        )
+        self.nodes_affected.add(node)
+
+
+class RandomLeadershipTransfer(RandomNodeOp):
+    def limit_reached(self):
+        return False
+
+    def action(self):
+        pass
+
+
+class RandomNodeProcessFailure(RandomNodeOp):
+    def __init__(self, redpanda: RedpandaService, config: ActionConfig, admin: Admin):
+        super(RandomNodeProcessFailure, self).__init__(redpanda, config, admin)
+        self.failure_injector = FailureInjector(self.redpanda)
+
+    def limit_reached(self):
+        return len(self.nodes_affected) >= self.config.max_affected_nodes
+
+    def action(self):
+        node = self.target_node()
+        self.failure_injector.inject_failure(FailureSpec(FailureSpec.FAILURE_KILL, node))
+        self.nodes_affected.add(node)
+
+
+class ActionInjectorThread(Thread):
+    def __init__(
+            self,
+            config: ActionConfig,
+            redpanda: RedpandaService,
+            random_op: RandomNodeOp,
+            *args,
+            **kwargs,
+    ):
+        self.random_op = random_op
+        self.redpanda = redpanda
+        self.config = config
+        self._stop_requested = False
+        super().__init__(*args, **kwargs)
+
+    def run(self):
+        wait_until(
+            lambda: self.redpanda.healthy(),
+            timeout_sec=self.config.cluster_start_lead_time_sec,
+            backoff_sec=2,
+            err_msg=f'Cluster not ready to begin actions'
+        )
+
+        while not self._stop_requested:
+            time.sleep(self.config.random_time_in_range())
+            self.random_op()
+
+    def stop(self):
+        self._stop_requested = True
+
+
+class ActionCtx:
+    def __init__(self, config: ActionConfig, redpanda: RedpandaService, random_op: RandomNodeOp):
+        self.redpanda = redpanda
+        self.config = config
+        if config.max_affected_nodes is None:
+            config.max_affected_nodes = len(redpanda.nodes) // 2
+        self.thread = ActionInjectorThread(config, redpanda, random_op)
+
+    def __enter__(self):
+        self.thread.start()
+
+    def __exit__(self, *args, **kwargs):
+        self.thread.stop()
+
+
+def create_context_with_defaults(redpanda: RedpandaService, op_type):
+    admin = Admin(redpanda)
+    config = ActionConfig(
+        cluster_start_lead_time_sec=20,
+        min_time_between_failures_sec=2,
+        max_time_between_failures_sec=5,
+    )
+    return ActionCtx(config, redpanda, op_type(redpanda, config, admin))
+
+
+def random_process_kill(redpanda: RedpandaService):
+    return create_context_with_defaults(redpanda, RandomNodeProcessFailure)
+
+
+def random_decommission(redpanda: RedpandaService):
+    return create_context_with_defaults(redpanda, RandomNodeDecommission)
+
+
+def random_leadership_transfer(redpanda: RedpandaService):
+    return create_context_with_defaults(redpanda, RandomLeadershipTransfer)

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -18,6 +18,7 @@ class ActionConfig:
     cluster_start_lead_time_sec: float
     min_time_between_actions_sec: float
     max_time_between_actions_sec: float
+    reverse_action_on_next_cycle: bool = False
     max_affected_nodes: Optional[int] = None
 
     def random_time_in_range(self) -> float:
@@ -32,6 +33,8 @@ class RandomNodeOp:
         self.config = config
         self.redpanda = redpanda
         self.nodes_affected = set()
+        self.is_reversible = False
+        self.last_action_on_node = None
 
     def limit_reached(self) -> bool:
         raise NotImplementedError
@@ -46,32 +49,55 @@ class RandomNodeOp:
             )
             return selected
 
-    def action(self):
+    def action(self) -> ClusterNode:
         raise NotImplementedError
 
-    def __call__(self, *args, **kwargs):
-        if not self.limit_reached():
-            self.action()
+    def reverse(self, node: ClusterNode) -> ClusterNode:
+        raise NotImplementedError
+
+    def __call__(self, reverse=False, *args, **kwargs) -> ClusterNode:
+        if reverse:
+            if self.is_reversible and self.last_action_on_node is not None:
+                return self.reverse(node=self.last_action_on_node)
+            else:
+                self.redpanda.logger.warn(
+                    f'Ignoring reverse call with nothing to reverse')
+        elif not self.limit_reached():
+            return self.action()
 
 
 class RandomNodeDecommission(RandomNodeOp):
     def limit_reached(self):
         return len(self.nodes_affected) >= self.config.max_affected_nodes
 
-    def action(self):
-        node = self.target_node()
-        if node:
-            broker_id = next(
-                (i for i, n in enumerate(self.redpanda.nodes) if n == node))
-            self.redpanda.stop_node(node)
-            self.admin.decommission_broker(id=broker_id)
-            wait_until(lambda: broker_id not in
-                       {b['node_id']
-                        for b in self.admin.get_brokers()},
-                       timeout_sec=120,
-                       backoff_sec=2,
-                       err_msg=f'Failed to decommission broker id {broker_id}')
-            self.nodes_affected.add(node)
+    def action(self) -> ClusterNode:
+        brokers = self.admin.get_brokers()
+        node_to_decommission = random.choice(brokers)
+
+        broker_id = node_to_decommission['node_id']
+        self.redpanda.logger.warn(f'going to decom broker id {broker_id}')
+        self.admin.decommission_broker(id=node_to_decommission['node_id'])
+
+        def done():
+            return broker_id not in {
+                b['node_id']
+                for b in self.admin.get_brokers()
+            }
+
+        wait_until(done,
+                   timeout_sec=120,
+                   backoff_sec=2,
+                   err_msg=f'Failed to decommission broker id {broker_id}')
+        self.nodes_affected.add(broker_id)
+        self.last_action_on_node = broker_id
+        return self.last_action_on_node
+
+    def reverse(self, node) -> ClusterNode:
+        self.admin.recommission_broker(self.last_action_on_node)
+        self.nodes_affected.remove(self.last_action_on_node)
+        last_action_on_node = self.last_action_on_node
+        self.last_action_on_node = None
+        return last_action_on_node
 
 
 class RandomLeadershipTransfer(RandomNodeOp):
@@ -84,6 +110,7 @@ class RandomLeadershipTransfer(RandomNodeOp):
     ):
         super().__init__(redpanda, config, admin)
         self.topics = topics
+        self.is_reversible = False
 
     def limit_reached(self):
         return False
@@ -108,12 +135,16 @@ class RandomLeadershipTransfer(RandomNodeOp):
                            backoff_sec=2,
                            err_msg='Leadership transfer failed')
 
+    def reverse(self, node: ClusterNode):
+        raise NotImplementedError('Leadership transfer not reversible')
+
 
 class RandomNodeProcessFailure(RandomNodeOp):
     def __init__(self, redpanda: RedpandaService, config: ActionConfig,
                  admin: Admin):
         super(RandomNodeProcessFailure, self).__init__(redpanda, config, admin)
         self.failure_injector = FailureInjector(self.redpanda)
+        self.is_reversible = True
 
     def limit_reached(self):
         return len(self.nodes_affected) >= self.config.max_affected_nodes
@@ -126,6 +157,7 @@ class RandomNodeProcessFailure(RandomNodeOp):
             self.failure_injector.inject_failure(
                 FailureSpec(FailureSpec.FAILURE_KILL, node))
             self.nodes_affected.add(node)
+            self.last_action_on_node = node
 
             # Update started_nodes so validations are run on the correct
             # set of nodes later.
@@ -133,9 +165,29 @@ class RandomNodeProcessFailure(RandomNodeOp):
                 self.redpanda.started_nodes().remove(node)
             except ValueError:
                 self.redpanda.logger.warn(
-                    f'failed to remove {node} from rp node list')
+                    f'failed to remove {node.account.hostname} from rp node list'
+                )
+            finally:
+                return node
         else:
             self.redpanda.logger.warn(f'no usable node')
+
+    def reverse(self, node: ClusterNode):
+        self.failure_injector._start(self.last_action_on_node)
+        self.nodes_affected.remove(self.last_action_on_node)
+        self.redpanda.started_nodes().append(self.last_action_on_node)
+        last_action_on_node = self.last_action_on_node
+        self.last_action_on_node = None
+        return last_action_on_node
+
+
+@dataclasses.dataclass
+class ActionLogEntry:
+    node: ClusterNode
+    is_reverse_action: bool
+
+    def __repr__(self) -> str:
+        return f'Node: {self.node.account.hostname}, reverse? {self.is_reverse_action}'
 
 
 class ActionInjectorThread(Thread):
@@ -147,11 +199,12 @@ class ActionInjectorThread(Thread):
         *args,
         **kwargs,
     ):
+        super().__init__(*args, **kwargs)
         self.random_op = random_op
         self.redpanda = redpanda
         self.config = config
         self._stop_requested = Event()
-        super().__init__(*args, **kwargs)
+        self.action_log = []
 
     def run(self):
         wait_until(lambda: self.redpanda.healthy(),
@@ -160,7 +213,15 @@ class ActionInjectorThread(Thread):
                    err_msg=f'Cluster not ready to begin actions')
 
         while not self._stop_requested.is_set():
-            self.random_op()
+            if self.config.reverse_action_on_next_cycle:
+                result = self.random_op(reverse=True)
+                if result:
+                    self.action_log.append(
+                        ActionLogEntry(result, is_reverse_action=True))
+            result = self.random_op()
+            if result:
+                self.action_log.append(
+                    ActionLogEntry(result, is_reverse_action=False))
             time.sleep(self.config.random_time_in_range())
 
     def stop(self):
@@ -179,37 +240,42 @@ class ActionCtx:
     def __enter__(self):
         self.redpanda.logger.info(f'entering random failure ctx')
         self.thread.start()
+        return self
 
     def __exit__(self, *args, **kwargs):
         self.redpanda.logger.info(f'leaving random failure ctx')
         self.thread.stop()
         self.thread.join()
 
+    def action_log(self):
+        return self.thread.action_log
+
 
 def create_context_with_defaults(redpanda: RedpandaService,
                                  op_type,
                                  config: ActionConfig = None,
                                  *args,
-                                 **kwargs):
+                                 **kwargs) -> ActionCtx:
     admin = Admin(redpanda)
     config = config or ActionConfig(
         cluster_start_lead_time_sec=20,
         min_time_between_actions_sec=10,
         max_time_between_actions_sec=30,
+        reverse_action_on_next_cycle=True,
     )
     return ActionCtx(config, redpanda,
                      op_type(redpanda, config, admin, *args, **kwargs))
 
 
 def random_process_kills(redpanda: RedpandaService,
-                         config: ActionConfig = None):
+                         config: ActionConfig = None) -> ActionCtx:
     return create_context_with_defaults(redpanda,
                                         RandomNodeProcessFailure,
                                         config=config)
 
 
 def random_decommissions(redpanda: RedpandaService,
-                         config: ActionConfig = None):
+                         config: ActionConfig = None) -> ActionCtx:
     return create_context_with_defaults(redpanda,
                                         RandomNodeDecommission,
                                         config=config)
@@ -217,7 +283,7 @@ def random_decommissions(redpanda: RedpandaService,
 
 def random_leadership_transfers(redpanda: RedpandaService,
                                 topics,
-                                config: ActionConfig = None):
+                                config: ActionConfig = None) -> ActionCtx:
     return create_context_with_defaults(redpanda,
                                         RandomLeadershipTransfer,
                                         topics,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -6,17 +6,17 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-import random
 import json
+import random
+from typing import Optional, Callable, NamedTuple
+
 import requests
-import time
-from time import sleep
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.utils.util import wait_until
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
 from requests.packages.urllib3.util.retry import Retry
-from ducktape.utils.util import wait_until
-from ducktape.cluster.cluster import ClusterNode
-from typing import Optional, Callable, NamedTuple
+
 from rptest.util import wait_until_result
 
 DEFAULT_TIMEOUT = 30
@@ -410,6 +410,14 @@ class Admin:
         self.redpanda.logger.debug(f"decommissioning {path}")
         return self._request('put', path, node=node)
 
+    def recommission_broker(self, broker_id, node=None):
+        """
+        Recommission broker
+        """
+        path = f"brokers/{broker_id}/recommission"
+        self.redpanda.logger.debug(f"recommissioning {path}")
+        return self._request('put', path, node=node)
+
     def get_partitions(self,
                        topic=None,
                        partition=None,
@@ -421,7 +429,7 @@ class Admin:
         information like replica set assignments with core affinities.
         """
         assert (topic is None and partition is None) or \
-                (topic is not None and partition is not None)
+               (topic is not None and partition is not None)
         assert topic or namespace is None
         namespace = namespace or "kafka"
         path = "partitions"

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -13,7 +13,7 @@ from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
 
 
-def cluster(log_allow_list=None, **kwargs):
+def cluster(log_allow_list=None, allow_missing_process=False, **kwargs):
     """
     Drop-in replacement for Ducktape `cluster` that imposes additional
     redpanda-specific checks and defaults.
@@ -35,7 +35,7 @@ def cluster(log_allow_list=None, **kwargs):
                 r = f(self, *args, **kwargs)
             except:
                 self.redpanda.decode_backtraces()
-                self.redpanda.raise_on_crash()
+                self.redpanda.raise_on_crash(allow_missing_process=allow_missing_process)
                 raise
             else:
                 # Only do log inspections on tests that are otherwise

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -9,8 +9,8 @@
 
 import functools
 
-from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
+from ducktape.mark.resource import ClusterUseMetadata
 
 
 def cluster(log_allow_list=None, allow_missing_process=False, **kwargs):
@@ -35,7 +35,8 @@ def cluster(log_allow_list=None, allow_missing_process=False, **kwargs):
                 r = f(self, *args, **kwargs)
             except:
                 self.redpanda.decode_backtraces()
-                self.redpanda.raise_on_crash(allow_missing_process=allow_missing_process)
+                self.redpanda.raise_on_crash(
+                    allow_missing_process=allow_missing_process)
                 raise
             else:
                 # Only do log inspections on tests that are otherwise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -733,7 +733,7 @@ class RedpandaService(Service):
         assert node in self._started
         return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
 
-    def raise_on_crash(self):
+    def raise_on_crash(self, allow_missing_process=False):
         """
         Check if any redpanda nodes are unexpectedly not running,
         or if any logs contain segfaults or assertions.
@@ -758,7 +758,7 @@ class RedpandaService(Service):
             if crash_log:
                 crashes.append((node, line))
 
-        if not crashes:
+        if not crashes and not allow_missing_process:
             # Even if there is no assertion or segfault, look for unexpectedly
             # not-running processes
             for node in self._started:

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -33,10 +33,11 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         name=s3_topic_name,
         partition_count=1,
         replication_factor=3,
-    ),)
+    ), )
 
     def __init__(self, test_context):
-        super(EndToEndShadowIndexingBase, self).__init__(test_context=test_context)
+        super(EndToEndShadowIndexingBase,
+              self).__init__(test_context=test_context)
 
         self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
         self.topic = EndToEndShadowIndexingTest.s3_topic_name
@@ -101,7 +102,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_BYTES:
-                    5 * EndToEndShadowIndexingTest.segment_size,
+                5 * EndToEndShadowIndexingTest.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,
@@ -113,7 +114,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
 
 class EndToEndShadowIndexingTestWithFailures(EndToEndShadowIndexingBase):
-    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST, allow_missing_process=True)
+    @cluster(num_nodes=5,
+             log_allow_list=RESTART_LOG_ALLOW_LIST,
+             allow_missing_process=True)
     def test_write_with_node_failures(self):
         self.start_producer()
         produce_until_segments(
@@ -125,7 +128,10 @@ class EndToEndShadowIndexingTestWithFailures(EndToEndShadowIndexingBase):
 
         self.kafka_tools.alter_topic_config(
             self.topic,
-            {TopicSpec.PROPERTY_RETENTION_BYTES: 5 * EndToEndShadowIndexingTest.segment_size},
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES:
+                5 * EndToEndShadowIndexingTest.segment_size
+            },
         )
 
         with random_process_kills(self.redpanda):
@@ -137,4 +143,6 @@ class EndToEndShadowIndexingTestWithFailures(EndToEndShadowIndexingBase):
             self.run_validation()
 
             # at least one node should have had the redpanda process killed off
-            assert any(self.redpanda.pids(node) is None for node in self.redpanda.nodes)
+            assert any(
+                self.redpanda.pids(node) is None
+                for node in self.redpanda.nodes)

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -13,7 +13,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 from rptest.services.action_injector import random_process_kills
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RedpandaService, RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import Scale
 from rptest.util import (
@@ -125,7 +125,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
     override_default_topic_replication = EndToEndShadowIndexingBase.num_brokers
 
     @cluster(num_nodes=5,
-             log_allow_list=RESTART_LOG_ALLOW_LIST,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
              allow_missing_process=True)
     def test_write_with_node_failures(self):
         self.start_producer()


### PR DESCRIPTION
## Cover letter

Adds random action injector utilities, aimed to be used for e2e tests. The failures could be process failures, node decommission, leadership transfer etc, controlled by a context manager.

The action injector runs on a thread and periodically introduces changes on randomly selected nodes in the cluster.

## Release notes

* none

### Features

the new context manager can be used as

```
with random_process_kills(self.redpanda):
    do_something()
```