### PR TITLE
tests: context manager to add random failures

### DIFF
--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -1,0 +1,216 @@
+import dataclasses
+import random
+import time
+from threading import Thread, Event
+from typing import Optional, List
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.failure_injector import FailureSpec, FailureInjector
+from rptest.services.redpanda import RedpandaService
+
+
+@dataclasses.dataclass
+class ActionConfig:
+    cluster_start_lead_time_sec: float
+    min_time_between_actions_sec: float
+    max_time_between_actions_sec: float
+    max_affected_nodes: Optional[int] = None
+
+    def random_time_in_range(self) -> float:
+        return random.uniform(self.min_time_between_actions_sec,
+                              self.max_time_between_actions_sec)
+
+
+class RandomNodeOp:
+    def __init__(self, redpanda: RedpandaService, config: ActionConfig,
+                 admin: Admin):
+        self.admin = admin
+        self.config = config
+        self.redpanda = redpanda
+        self.nodes_affected = set()
+
+    def limit_reached(self) -> bool:
+        raise NotImplementedError
+
+    def target_node(self) -> ClusterNode:
+        available = set(self.redpanda.nodes) - self.nodes_affected
+        if available:
+            selected = random.choice(list(available))
+            names = {n.account.hostname for n in available}
+            self.redpanda.logger.info(
+                f'selected {selected.account.hostname} of {names} for operation'
+            )
+            return selected
+
+    def action(self):
+        raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        if not self.limit_reached():
+            self.action()
+
+
+class RandomNodeDecommission(RandomNodeOp):
+    def limit_reached(self):
+        return len(self.nodes_affected) >= self.config.max_affected_nodes
+
+    def action(self):
+        node = self.target_node()
+        if node:
+            broker_id = next(
+                (i for i, n in enumerate(self.redpanda.nodes) if n == node))
+            self.redpanda.stop_node(node)
+            self.admin.decommission_broker(id=broker_id)
+            wait_until(lambda: broker_id not in
+                       {b['node_id']
+                        for b in self.admin.get_brokers()},
+                       timeout_sec=120,
+                       backoff_sec=2,
+                       err_msg=f'Failed to decommission broker id {broker_id}')
+            self.nodes_affected.add(node)
+
+
+class RandomLeadershipTransfer(RandomNodeOp):
+    def __init__(
+        self,
+        redpanda: RedpandaService,
+        config: ActionConfig,
+        admin: Admin,
+        topics: List[TopicSpec],
+    ):
+        super().__init__(redpanda, config, admin)
+        self.topics = topics
+
+    def limit_reached(self):
+        return False
+
+    def action(self):
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                old_leader = self.admin.get_partition_leader(
+                    namespace='kafka', topic=topic, partition=partition)
+                self.admin.transfer_leadership_to(namespace='kafka',
+                                                  topic=topic,
+                                                  partition=partition,
+                                                  target=None)
+
+                def leader_is_changed():
+                    new_leader = self.admin.get_partition_leader(
+                        namespace='kafka', topic=topic, partition=partition)
+                    return new_leader != -1 and new_leader != old_leader
+
+                wait_until(leader_is_changed,
+                           timeout_sec=30,
+                           backoff_sec=2,
+                           err_msg='Leadership transfer failed')
+
+
+class RandomNodeProcessFailure(RandomNodeOp):
+    def __init__(self, redpanda: RedpandaService, config: ActionConfig,
+                 admin: Admin):
+        super(RandomNodeProcessFailure, self).__init__(redpanda, config, admin)
+        self.failure_injector = FailureInjector(self.redpanda)
+
+    def limit_reached(self):
+        return len(self.nodes_affected) >= self.config.max_affected_nodes
+
+    def action(self):
+        node = self.target_node()
+        if node:
+            self.redpanda.logger.info(
+                f'executing action on {node.account.hostname}')
+            self.failure_injector.inject_failure(
+                FailureSpec(FailureSpec.FAILURE_KILL, node))
+            self.nodes_affected.add(node)
+        else:
+            self.redpanda.logger.warn(f'no usable node')
+
+
+class ActionInjectorThread(Thread):
+    def __init__(
+        self,
+        config: ActionConfig,
+        redpanda: RedpandaService,
+        random_op: RandomNodeOp,
+        *args,
+        **kwargs,
+    ):
+        self.random_op = random_op
+        self.redpanda = redpanda
+        self.config = config
+        self._stop_requested = Event()
+        super().__init__(*args, **kwargs)
+
+    def run(self):
+        wait_until(lambda: self.redpanda.healthy(),
+                   timeout_sec=self.config.cluster_start_lead_time_sec,
+                   backoff_sec=2,
+                   err_msg=f'Cluster not ready to begin actions')
+
+        while not self._stop_requested.is_set():
+            self.random_op()
+            time.sleep(self.config.random_time_in_range())
+
+    def stop(self):
+        self._stop_requested.set()
+
+
+class ActionCtx:
+    def __init__(self, config: ActionConfig, redpanda: RedpandaService,
+                 random_op: RandomNodeOp):
+        self.redpanda = redpanda
+        self.config = config
+        if config.max_affected_nodes is None:
+            config.max_affected_nodes = len(redpanda.nodes) // 2
+        self.thread = ActionInjectorThread(config, redpanda, random_op)
+
+    def __enter__(self):
+        self.redpanda.logger.info(f'entering random failure ctx')
+        self.thread.start()
+
+    def __exit__(self, *args, **kwargs):
+        self.redpanda.logger.info(f'leaving random failure ctx')
+        self.thread.stop()
+        self.thread.join()
+
+
+def create_context_with_defaults(redpanda: RedpandaService,
+                                 op_type,
+                                 config: ActionConfig = None,
+                                 *args,
+                                 **kwargs):
+    admin = Admin(redpanda)
+    config = config or ActionConfig(
+        cluster_start_lead_time_sec=20,
+        min_time_between_actions_sec=10,
+        max_time_between_actions_sec=30,
+    )
+    return ActionCtx(config, redpanda,
+                     op_type(redpanda, config, admin, *args, **kwargs))
+
+
+def random_process_kills(redpanda: RedpandaService,
+                         config: ActionConfig = None):
+    return create_context_with_defaults(redpanda,
+                                        RandomNodeProcessFailure,
+                                        config=config)
+
+
+def random_decommissions(redpanda: RedpandaService,
+                         config: ActionConfig = None):
+    return create_context_with_defaults(redpanda,
+                                        RandomNodeDecommission,
+                                        config=config)
+
+
+def random_leadership_transfers(redpanda: RedpandaService,
+                                topics,
+                                config: ActionConfig = None):
+    return create_context_with_defaults(redpanda,
+                                        RandomLeadershipTransfer,
+                                        topics,
+                                        config=config)

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -9,11 +9,11 @@
 
 import functools
 
-from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
+from ducktape.mark.resource import ClusterUseMetadata
 
 
-def cluster(log_allow_list=None, **kwargs):
+def cluster(log_allow_list=None, allow_missing_process=False, **kwargs):
     """
     Drop-in replacement for Ducktape `cluster` that imposes additional
     redpanda-specific checks and defaults.
@@ -35,7 +35,8 @@ def cluster(log_allow_list=None, **kwargs):
                 r = f(self, *args, **kwargs)
             except:
                 self.redpanda.decode_backtraces()
-                self.redpanda.raise_on_crash()
+                self.redpanda.raise_on_crash(
+                    allow_missing_process=allow_missing_process)
                 raise
             else:
                 # Only do log inspections on tests that are otherwise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -886,7 +886,7 @@ class RedpandaService(Service):
         assert node in self._started
         return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
 
-    def raise_on_crash(self):
+    def raise_on_crash(self, allow_missing_process=False):
         """
         Check if any redpanda nodes are unexpectedly not running,
         or if any logs contain segfaults or assertions.
@@ -911,7 +911,7 @@ class RedpandaService(Service):
             if crash_log:
                 crashes.append((node, line))
 
-        if not crashes:
+        if not crashes and not allow_missing_process:
             # Even if there is no assertion or segfault, look for unexpectedly
             # not-running processes
             for node in self._started:

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -7,22 +7,27 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import RedpandaService
-from rptest.util import Scale
+from rptest.services.action_injector import random_process_kills
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import SISettings
 from rptest.tests.end_to_end import EndToEndTest
+from rptest.util import Scale
 from rptest.util import (
     produce_until_segments,
     wait_for_segments_removal,
 )
 
 
-class EndToEndShadowIndexingTest(EndToEndTest):
+class EndToEndShadowIndexingBase(EndToEndTest):
     segment_size = 1048576  # 1 Mb
     s3_topic_name = "panda-topic"
+
+    num_brokers = 3
+    override_default_topic_replication = None
+
     topics = (TopicSpec(
         name=s3_topic_name,
         partition_count=1,
@@ -30,24 +35,28 @@ class EndToEndShadowIndexingTest(EndToEndTest):
     ), )
 
     def __init__(self, test_context):
-        super(EndToEndShadowIndexingTest,
+        super(EndToEndShadowIndexingBase,
               self).__init__(test_context=test_context)
 
-        self.topic = EndToEndShadowIndexingTest.s3_topic_name
+        self.topic = EndToEndShadowIndexingBase.s3_topic_name
 
         si_settings = SISettings(
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,
-            log_segment_size=EndToEndShadowIndexingTest.segment_size,  # 1MB
+            log_segment_size=EndToEndShadowIndexingBase.segment_size,  # 1MB
         )
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 
         si_settings.load_context(self.logger, test_context)
 
+        if self.override_default_topic_replication:
+            self._extra_rp_conf[
+                'default_topic_replications'] = self.override_default_topic_replication
+
         self.scale = Scale(test_context)
         self.redpanda = RedpandaService(
             context=test_context,
-            num_brokers=3,
+            num_brokers=self.num_brokers,
             si_settings=si_settings,
         )
 
@@ -55,12 +64,14 @@ class EndToEndShadowIndexingTest(EndToEndTest):
 
     def setUp(self):
         self.redpanda.start()
-        for topic in EndToEndShadowIndexingTest.topics:
+        for topic in EndToEndShadowIndexingBase.topics:
             self.kafka_tools.create_topic(topic)
 
     def tearDown(self):
         self.s3_client.empty_bucket(self.s3_bucket_name)
 
+
+class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
     @cluster(num_nodes=5)
     def test_write(self):
         """Write at least 10 segments, set retention policy to leave only 5
@@ -78,13 +89,56 @@ class EndToEndShadowIndexingTest(EndToEndTest):
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_BYTES:
-                5 * EndToEndShadowIndexingTest.segment_size,
+                    5 * EndToEndShadowIndexingTest.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,
                                   topic=self.topic,
                                   partition_idx=0,
                                   count=6)
-
         self.start_consumer()
         self.run_validation()
+
+
+class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
+    override_default_topic_replication = EndToEndShadowIndexingBase.num_brokers
+
+    @cluster(num_nodes=5,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             allow_missing_process=True)
+    def test_write_with_node_failures(self):
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES:
+                    5 * EndToEndShadowIndexingTest.segment_size
+            },
+        )
+
+        with random_process_kills(self.redpanda) as ctx:
+            wait_for_segments_removal(redpanda=self.redpanda,
+                                      topic=self.topic,
+                                      partition_idx=0,
+                                      count=6)
+            self.start_consumer()
+            self.run_validation()
+
+        action_log = ctx.action_log()
+        assert action_log
+
+        # At least one process kill action is present
+        assert action_log[0].is_reverse_action is False
+
+        # If there was another action after process kill, it was revival,
+        # because we are running in reverse after action mode
+        if len(action_log) > 1:
+            assert action_log[1].is_reverse_action and action_log[
+                1].node == action_log[0].node

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -89,7 +89,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_BYTES:
-                    5 * EndToEndShadowIndexingTest.segment_size,
+                5 * EndToEndShadowIndexingTest.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,
@@ -119,7 +119,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_BYTES:
-                    5 * EndToEndShadowIndexingTest.segment_size
+                5 * EndToEndShadowIndexingTest.segment_size
             },
         )
 


### PR DESCRIPTION
## Cover letter

Adds random action injector utilities, aimed to be used for e2e tests. The failures could be process failures, node decommission, leadership transfer etc, controlled by a context manager.

The action injector runs on a thread and periodically introduces changes on randomly selected nodes in the cluster.

## Release notes

* none
