### PR TITLE
ducktape: GroupMetricsTest check if leader exists

### DIFF
--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -326,8 +326,10 @@ class GroupMetricsTest(RedpandaTest):
                                          partition=0,
                                          target=self.redpanda.idx(new_leader))
             for _ in range(3):  # re-check a few times
-                leader = self.redpanda.get_node(get_group_leader())
-                if leader == new_leader:
+                leader = get_group_leader()
+                self.logger.debug(f"Current leader: {leader}")
+                if leader != -1 and self.redpanda.get_node(
+                        leader) == new_leader:
                     return True
                 time.sleep(1)
             return False


### PR DESCRIPTION
## Cover letter
In failure attached by Lena here: https://github.com/redpanda-data/redpanda/issues/3394#issuecomment-1030205753
I found problem with leader check.

In group description Redpanda returns `{'ns': 'kafka_internal', 'topic': 'group', 'partition_id': 0, 'status': 'done', 'leader_id': -1, 'raft_group_id': 8, 'replicas': [{'node_id': 3, 'core': 0}, {'node_id': 2, 'core': 0}, {'node_id': 1, 'core': 0}]}`
Where `leader_id` is -1. `self.redpanda.get_node(leader) == new_leader` accepts this.

This happens because  `self.redpanda.get_node(idx) ` returns this `self.nodes[idx - 1]`

Fixes #3394