### PR TITLE
Optimized partition metadata lookup

### DIFF
--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -160,7 +160,7 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
         co_return true;
     }
 
-    for (const auto& partition : metadata->partitions) {
+    for (const auto& partition : metadata->get_assignments()) {
         model::ntp ntp(topic.ns, topic.tp, partition.id);
         if (!co_await ensure_partition_replication(std::move(ntp))) {
             co_return false;

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -167,7 +167,7 @@ void members_backend::calculate_reallocations(update_meta& meta) {
             if (!cfg.is_topic_replicable()) {
                 continue;
             }
-            for (auto& pas : cfg.get_configuration().assignments) {
+            for (const auto& pas : cfg.get_assignments()) {
                 if (is_in_replica_set(pas.replicas, meta.update.id)) {
                     partition_reallocation reallocation(
                       model::ntp(tp_ns.ns, tp_ns.tp, pas.id),
@@ -284,7 +284,7 @@ void members_backend::calculate_reallocations_after_node_added(
               meta.update.offset);
             continue;
         }
-        for (auto& p : metadata.get_configuration().assignments) {
+        for (const auto& p : metadata.get_assignments()) {
             std::erase_if(to_move_from_node, [](const replicas_to_move& v) {
                 return v.left_to_move == 0;
             });

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/metadata_cache.h"
 
+#include "cluster/fwd.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/members_table.h"
 #include "cluster/partition_leaders_table.h"
@@ -62,17 +63,29 @@ metadata_cache::get_source_topic(model::topic_namespace_view tp) const {
     return mt->second.get_source_topic();
 }
 
-std::optional<model::topic_metadata> metadata_cache::get_topic_metadata(
+std::optional<cluster::topic_metadata>
+metadata_cache::get_topic_metadata(model::topic_namespace_view tp) const {
+    return _topics_state.local().get_topic_metadata(tp);
+}
+
+std::optional<model::topic_metadata> metadata_cache::get_model_topic_metadata(
   model::topic_namespace_view tp, metadata_cache::with_leaders leaders) const {
     auto md = _topics_state.local().get_topic_metadata(tp);
     if (!md) {
-        return md;
-    }
-    if (leaders) {
-        fill_partition_leaders(_leaders.local(), *md);
+        return std::nullopt;
     }
 
-    return md;
+    model::topic_metadata metadata(md->get_configuration().tp_ns);
+    metadata.partitions.reserve(md->get_assignments().size());
+    for (const auto& p_as : md->get_assignments()) {
+        metadata.partitions.push_back(p_as.create_partition_metadata());
+    }
+
+    if (leaders) {
+        fill_partition_leaders(_leaders.local(), metadata);
+    }
+
+    return metadata;
 }
 std::optional<topic_configuration>
 metadata_cache::get_topic_cfg(model::topic_namespace_view tp) const {
@@ -84,15 +97,8 @@ metadata_cache::get_topic_timestamp_type(model::topic_namespace_view tp) const {
     return _topics_state.local().get_topic_timestamp_type(tp);
 }
 
-std::vector<model::topic_metadata> metadata_cache::all_topics_metadata(
-  metadata_cache::with_leaders leaders) const {
-    auto all_md = _topics_state.local().all_topics_metadata();
-    if (leaders) {
-        for (auto& md : all_md) {
-            fill_partition_leaders(_leaders.local(), md);
-        }
-    }
-    return all_md;
+const topic_table::underlying_t& metadata_cache::all_topics_metadata() const {
+    return _topics_state.local().all_topics_metadata();
 }
 
 std::optional<broker_ptr> metadata_cache::get_broker(model::node_id nid) const {
@@ -146,6 +152,10 @@ std::vector<model::node_id> metadata_cache::all_broker_ids() const {
 bool metadata_cache::contains(
   model::topic_namespace_view tp, const model::partition_id pid) const {
     return _topics_state.local().contains(tp, pid);
+}
+
+bool metadata_cache::contains(model::topic_namespace_view tp) const {
+    return _topics_state.local().contains(tp);
 }
 
 ss::future<model::node_id> metadata_cache::get_leader(

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -68,6 +68,11 @@ metadata_cache::get_topic_metadata(model::topic_namespace_view tp) const {
     return _topics_state.local().get_topic_metadata(tp);
 }
 
+std::optional<std::reference_wrapper<const cluster::topic_metadata>>
+metadata_cache::get_topic_metadata_ref(model::topic_namespace_view tn) const {
+    return _topics_state.local().get_topic_metadata_ref(tn);
+}
+
 std::optional<model::topic_metadata> metadata_cache::get_model_topic_metadata(
   model::topic_namespace_view tp, metadata_cache::with_leaders leaders) const {
     auto md = _topics_state.local().get_topic_metadata(tp);

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -81,6 +81,17 @@ public:
     std::optional<cluster::topic_metadata>
       get_topic_metadata(model::topic_namespace_view) const;
 
+    ///\brief Returns reference to metadata of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    ///
+    /// IMPORTANT: remember not to use the reference when its lifetime has to
+    /// span across multiple scheduling point. Reference returning method is
+    /// provided not to copy metadata object when used by synchronous parts of
+    /// code
+    std::optional<std::reference_wrapper<const cluster::topic_metadata>>
+      get_topic_metadata_ref(model::topic_namespace_view) const;
+
     ///\brief Returns configuration of single topic.
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/partition_leaders_table.h"
+#include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -72,8 +73,13 @@ public:
     ///\brief Returns metadata of single topic.
     ///
     /// If topic does not exists it returns an empty optional
-    std::optional<model::topic_metadata> get_topic_metadata(
+    std::optional<model::topic_metadata> get_model_topic_metadata(
       model::topic_namespace_view, with_leaders = with_leaders::yes) const;
+    ///\brief Returns metadata of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    std::optional<cluster::topic_metadata>
+      get_topic_metadata(model::topic_namespace_view) const;
 
     ///\brief Returns configuration of single topic.
     ///
@@ -87,9 +93,7 @@ public:
     std::optional<model::timestamp_type>
       get_topic_timestamp_type(model::topic_namespace_view) const;
 
-    /// Returns metadata of all topics.
-    std::vector<model::topic_metadata>
-      all_topics_metadata(with_leaders = with_leaders::yes) const;
+    const topic_table::underlying_t& all_topics_metadata() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
     std::vector<broker_ptr> all_brokers() const;
@@ -105,6 +109,7 @@ public:
     std::optional<broker_ptr> get_broker(model::node_id) const;
 
     bool contains(model::topic_namespace_view, model::partition_id) const;
+    bool contains(model::topic_namespace_view) const;
 
     bool contains(const model::ntp& ntp) const {
         return contains(model::topic_namespace_view(ntp), ntp.tp.partition);

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -219,7 +219,7 @@ metrics_reporter::build_metrics_snapshot() {
         }
 
         snapshot.topic_count++;
-        snapshot.partition_count += md.get_configuration().cfg.partition_count;
+        snapshot.partition_count += md.get_configuration().partition_count;
     }
 
     snapshot.nodes.reserve(metrics_map.size());

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -314,8 +314,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         if (!topic.second.is_topic_replicable()) {
             continue;
         }
-        for (const auto& partition :
-             topic.second.get_configuration().assignments) {
+        for (const auto& partition : topic.second.get_assignments()) {
             if (partition.group == transfer->group) {
                 ntp = model::ntp(topic.first.ns, topic.first.tp, partition.id);
                 break;
@@ -438,8 +437,7 @@ leader_balancer::find_leader_shard(const model::ntp& ntp) {
 
     // If the inital query was for a non_replicable ntp, the get_leader() call
     // would have returned its source topic
-    for (const auto& partition :
-         config_it->second.get_configuration().assignments) {
+    for (const auto& partition : config_it->second.get_assignments()) {
         if (partition.id != ntp.tp.partition) {
             continue;
         }
@@ -474,8 +472,7 @@ leader_balancer::index_type leader_balancer::build_index() {
         if (!topic.second.is_topic_replicable()) {
             continue;
         }
-        for (const auto& partition :
-             topic.second.get_configuration().assignments) {
+        for (const auto& partition : topic.second.get_assignments()) {
             if (partition.replicas.empty()) {
                 vlog(
                   clusterlog.warn,

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -148,7 +148,7 @@ service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
     md.reserve(res.size());
     for (const auto& r : res) {
         if (r.ec == errc::success) {
-            auto topic_md = _md_cache.local().get_topic_metadata(r.tp_ns);
+            auto topic_md = _md_cache.local().get_model_topic_metadata(r.tp_ns);
             auto topic_cfg = _md_cache.local().get_topic_cfg(r.tp_ns);
             if (topic_md && topic_cfg) {
                 md.push_back(std::move(topic_md.value()));

--- a/src/v/cluster/tests/create_partitions_test.cc
+++ b/src/v/cluster/tests/create_partitions_test.cc
@@ -45,15 +45,17 @@ FIXTURE_TEST(test_creating_partitions, rebalancing_tests_fixture) {
     auto tp_2_md = topics.local().get_topic_metadata(make_tp_ns("test-2"));
 
     // total 6 partitions
-    BOOST_REQUIRE_EQUAL(tp_1_md->partitions.size(), 6);
+    BOOST_REQUIRE_EQUAL(tp_1_md->get_assignments().size(), 6);
     for (auto i = 0; i < 6; ++i) {
-        BOOST_REQUIRE_EQUAL(tp_1_md->partitions[i].id, model::partition_id(i));
+        BOOST_REQUIRE(
+          tp_1_md->get_assignments().contains(model::partition_id(i)));
     }
 
     // total 9 partitions
-    BOOST_REQUIRE_EQUAL(tp_2_md->partitions.size(), 9);
+    BOOST_REQUIRE_EQUAL(tp_2_md->get_assignments().size(), 9);
     for (auto i = 0; i < 9; ++i) {
-        BOOST_REQUIRE_EQUAL(tp_2_md->partitions[i].id, model::partition_id(i));
+        BOOST_REQUIRE(
+          tp_2_md->get_assignments().contains(model::partition_id(i)));
     }
 }
 

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -201,12 +201,11 @@ public:
 
     std::vector<model::broker_shard>
     get_replicas(int source_node, const model::ntp& ntp) {
-        auto md = controller(source_node)
-                    ->get_topics_state()
-                    .local()
-                    .get_topic_metadata(model::topic_namespace_view(ntp));
-
-        return md->partitions.begin()->replicas;
+        return controller(source_node)
+          ->get_topics_state()
+          .local()
+          .get_partition_assignment(ntp)
+          ->replicas;
     }
 
     void wait_for_replica_set_partitions(

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -93,7 +93,7 @@ public:
                     .local()
                     .get_topic_metadata(model::topic_namespace_view(ntp));
 
-        return md->partitions.begin()->replicas;
+        return md->get_assignments().begin()->replicas;
     }
 
     void create_topic(cluster::topic_configuration cfg) {
@@ -204,10 +204,9 @@ public:
 
     void populate_all_topics_with_data() {
         auto md = get_local_cache(model::node_id(0)).all_topics_metadata();
-        for (auto& topic_metadata : md) {
-            for (auto& p : topic_metadata.partitions) {
-                model::ntp ntp(
-                  topic_metadata.tp_ns.ns, topic_metadata.tp_ns.tp, p.id);
+        for (auto& [tp_ns, topic_metadata] : md) {
+            for (auto& p : topic_metadata.get_assignments()) {
+                model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);
                 replicate_data(ntp, 10);
             }
         }

--- a/src/v/cluster/tests/replicas_rebalancing_tests.cc
+++ b/src/v/cluster/tests/replicas_rebalancing_tests.cc
@@ -16,11 +16,11 @@ absl::node_hash_map<model::node_id, size_t>
 calculate_replicas_per_node(const cluster::metadata_cache& cache) {
     absl::node_hash_map<model::node_id, size_t> ret;
 
-    for (auto& tp_md : cache.all_topics_metadata()) {
-        if (tp_md.tp_ns.ns == model::redpanda_ns) {
+    for (auto& [tp_ns, tp_md] : cache.all_topics_metadata()) {
+        if (tp_ns.ns == model::redpanda_ns) {
             continue;
         }
-        for (auto& p_md : tp_md.partitions) {
+        for (auto& p_md : tp_md.get_assignments()) {
             for (auto replica : p_md.replicas) {
                 ret[replica.node_id]++;
             }

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -84,20 +84,17 @@ FIXTURE_TEST(
     auto md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
-    std::sort(
-      md.begin(),
-      md.end(),
-      [](const model::topic_metadata& a, const model::topic_metadata& b) {
-          return a.tp_ns.tp < b.tp_ns.tp;
-      });
-    BOOST_REQUIRE_EQUAL(md[0].tp_ns, make_tp_ns("test_tp_1"));
-    BOOST_REQUIRE_EQUAL(md[1].tp_ns, make_tp_ns("test_tp_2"));
-    BOOST_REQUIRE_EQUAL(md[2].tp_ns, make_tp_ns("test_tp_3"));
 
-    BOOST_REQUIRE_EQUAL(md[0].partitions.size(), 1);
-    BOOST_REQUIRE_EQUAL(md[1].partitions.size(), 12);
-    BOOST_REQUIRE_EQUAL(md[2].partitions.size(), 8);
+    BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_1")), true);
+    BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_2")), true);
+    BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_3")), true);
 
+    BOOST_REQUIRE_EQUAL(
+      md.find(make_tp_ns("test_tp_1"))->second.get_assignments().size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      md.find(make_tp_ns("test_tp_2"))->second.get_assignments().size(), 12);
+    BOOST_REQUIRE_EQUAL(
+      md.find(make_tp_ns("test_tp_3"))->second.get_assignments().size(), 8);
     // Initial capacity
     // (cpus * max_allocations_per_core) - core0_extra_weight;
     // node 1, 8 cores
@@ -133,8 +130,10 @@ FIXTURE_TEST(
 
     auto md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
-    BOOST_REQUIRE_EQUAL(md[0].tp_ns, make_tp_ns("test_tp_1"));
-    BOOST_REQUIRE_EQUAL(md[0].partitions.size(), 1);
+
+    BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_1")), true);
+    BOOST_REQUIRE_EQUAL(
+      md.find(make_tp_ns("test_tp_1"))->second.get_assignments().size(), 1);
 
     BOOST_REQUIRE_EQUAL(
       current_cluster_capacity(allocator.local().state().allocation_nodes()),

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -502,6 +502,13 @@ topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     }
     return {};
 }
+std::optional<std::reference_wrapper<const topic_metadata>>
+topic_table::get_topic_metadata_ref(model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return it->second;
+    }
+    return {};
+}
 
 std::optional<topic_configuration>
 topic_table::get_topic_cfg(model::topic_namespace_view tp) const {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -118,6 +118,17 @@ public:
     std::optional<topic_metadata>
       get_topic_metadata(model::topic_namespace_view) const;
 
+    ///\brief Returns reference to metadata of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    ///
+    /// IMPORTANT: remember not to use the reference when its lifetime has to
+    /// span across multiple scheduling point. Reference returning method is
+    /// provided not to copy metadata object when used by synchronous parts of
+    /// code
+    std::optional<std::reference_wrapper<const topic_metadata>>
+      get_topic_metadata_ref(model::topic_namespace_view) const;
+
     ///\brief Returns configuration of single topic.
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -77,7 +77,7 @@ private:
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
     void update_allocations(std::vector<partition_assignment>);
-    void deallocate_topic(const model::topic_metadata&);
+    void deallocate_topic(const topic_metadata&);
     void reallocate_partition(
       const std::vector<model::broker_shard>&,
       const std::vector<model::broker_shard>&);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -162,8 +162,7 @@ ss::future<std::optional<model::node_id>> tx_gateway_frontend::get_tx_broker() {
               std::nullopt);
         }
 
-        auto md = _metadata_cache.local().get_topic_metadata(
-          model::tx_manager_nt);
+        auto md = _metadata_cache.local().contains(model::tx_manager_nt);
         if (!md) {
             return ss::make_ready_future<std::optional<model::node_id>>(
               std::nullopt);

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -365,7 +365,7 @@ reconciliation_backend::create_non_replicable_partition(
         }
         // Non-replicated topics are not integrated with shadow indexing yet,
         // so the initial_revision_id is set to invalid value.
-        auto ntp_cfg = tt_md->second.get_configuration().cfg.make_ntp_config(
+        auto ntp_cfg = tt_md->second.get_configuration().make_ntp_config(
           _data_directory,
           ntp.tp.partition,
           rev,

--- a/src/v/kafka/server/coordinator_ntp_mapper.h
+++ b/src/v/kafka/server/coordinator_ntp_mapper.h
@@ -50,14 +50,14 @@ public:
       , _tp_ns(std::move(group_topic)) {}
 
     std::optional<model::ntp> ntp_for(const kafka::group_id& group) const {
-        auto md = _md.local().get_topic_metadata(_tp_ns);
-        if (!md) {
+        auto cfg = _md.local().get_topic_cfg(_tp_ns);
+        if (!cfg) {
             return std::nullopt;
         }
         incremental_xxhash64 inc;
         inc.update(group);
         auto p = static_cast<model::partition_id::type>(
-          jump_consistent_hash(inc.digest(), md->partitions.size()));
+          jump_consistent_hash(inc.digest(), cfg->partition_count));
         return model::ntp(_tp_ns.ns, _tp_ns.tp, model::partition_id{p});
     }
 

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -97,7 +97,7 @@ transform_batch(model::record_batch batch) {
 
 ss::future<bool> create_consumer_offsets_topic(
   cluster::controller& controller,
-  std::vector<cluster::partition_assignment> assignments,
+  const cluster::assignments_set& assignments,
   model::timeout_clock::time_point timeout) {
     vassert(
       !assignments.empty(),
@@ -107,7 +107,7 @@ ss::future<bool> create_consumer_offsets_topic(
         model::kafka_consumer_offsets_nt.ns,
         model::kafka_consumer_offsets_nt.tp,
         static_cast<int32_t>(assignments.size()),
-        static_cast<int16_t>(assignments.front().replicas.size())});
+        static_cast<int16_t>(assignments.begin()->replicas.size())});
     topic.cfg.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
     for (auto& p_as : assignments) {

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -155,10 +155,8 @@ ss::future<response_ptr> create_partitions_handler::handle(
       error_code::invalid_topic_exception,
       "Topic does not exist",
       [&ctx](const create_partitions_topic& tp) {
-          return ctx.metadata_cache()
-            .get_topic_metadata(
-              model::topic_namespace(model::kafka_namespace, tp.name))
-            .has_value();
+          return ctx.metadata_cache().contains(
+            model::topic_namespace(model::kafka_namespace, tp.name));
       });
 
     // validate custom assignment

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -125,21 +125,16 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
         const auto topic_name = model::topic(it->name);
         model::topic_namespace_view tn(model::kafka_namespace, topic_name);
 
-        if (const auto& md = octx.rctx.metadata_cache().get_topic_metadata(tn);
-            md) {
+        if (octx.rctx.metadata_cache().contains(tn)) {
             /*
              * check if each partition exists
              */
             auto split = std::partition(
               it->partitions.begin(),
               it->partitions.end(),
-              [&md](const offset_commit_request_partition& p) {
-                  return std::any_of(
-                    md->partitions.cbegin(),
-                    md->partitions.cend(),
-                    [&p](const model::partition_metadata& pmd) {
-                        return pmd.id == p.partition_index;
-                    });
+              [&octx, &tn](const offset_commit_request_partition& p) {
+                  return octx.rctx.metadata_cache().contains(
+                    tn, p.partition_index);
               });
             /*
              * build responses for nonexistent topic partitions

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -48,7 +48,7 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
             continue;
         }
         // for each partition ask for leader
-        for (auto& pmd : md->partitions) {
+        for (auto& pmd : md->get_assignments()) {
             futures.push_back(md_cache.get_leader(
               model::ntp(r.tp_ns.ns, r.tp_ns.tp, pmd.id), timeout));
         }

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -42,13 +42,13 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
             continue;
         }
         // collect partitions
-        auto md = md_cache.get_topic_metadata(r.tp_ns);
+        auto md = md_cache.get_topic_metadata_ref(r.tp_ns);
         if (!md) {
             // topic already deleted
             continue;
         }
         // for each partition ask for leader
-        for (auto& pmd : md->get_assignments()) {
+        for (auto& pmd : md->get().get_assignments()) {
             futures.push_back(md_cache.get_leader(
               model::ntp(r.tp_ns.ns, r.tp_ns.tp, pmd.id), timeout));
         }

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -109,21 +109,16 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
         const auto topic_name = model::topic(it->name);
         model::topic_namespace_view tn(model::kafka_namespace, topic_name);
 
-        if (const auto& md = octx.rctx.metadata_cache().get_topic_metadata(tn);
-            md) {
+        if (octx.rctx.metadata_cache().contains(tn)) {
             /*
              * check if each partition exists
              */
             auto split = std::partition(
               it->partitions.begin(),
               it->partitions.end(),
-              [&md](const txn_offset_commit_request_partition& p) {
-                  return std::any_of(
-                    md->partitions.cbegin(),
-                    md->partitions.cend(),
-                    [&p](const model::partition_metadata& pmd) {
-                        return pmd.id == p.partition_index;
-                    });
+              [&octx, &tn](const txn_offset_commit_request_partition& p) {
+                  return octx.rctx.metadata_cache().contains(
+                    tn, p.partition_index);
               });
             /*
              * build responses for nonexistent topic partitions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -284,9 +284,10 @@ public:
                       r.tp_ns);
                     return md
                            && std::all_of(
-                             md->partitions.begin(),
-                             md->partitions.end(),
-                             [this, &r](const model::partition_metadata& p) {
+                             md->get_assignments().begin(),
+                             md->get_assignments().end(),
+                             [this,
+                              &r](const cluster::partition_assignment& p) {
                                  return app.shard_table.local().shard_for(
                                    model::ntp(r.tp_ns.ns, r.tp_ns.tp, p.id));
                              });


### PR DESCRIPTION
## Cover letter
Optimized per partition metadata lookup by storing partition metadata in
`absl::btree_set` the set provides fast lookup while keeping partitions
ordered. Limited number of times partition metadata are copied by
returning metadata object stored directly in a map.

Fixes: #4410 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4410

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
