### PR TITLE
[v22.1.x] tests: fix assertion in cluster_features_test

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -88,7 +88,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         assert initial_version == self.admin.get_features()['cluster_version']
 
         self.redpanda.restart_nodes([self.redpanda.nodes[2]])
-        wait_until(lambda: initial_version == self.admin.get_features()[
+        wait_until(lambda: new_version == self.admin.get_features()[
             'cluster_version'],
                    timeout_sec=5,
                    backoff_sec=1)


### PR DESCRIPTION
## Cover letter

Backport #4401 

Fixes https://github.com/redpanda-data/redpanda/issues/4417

---

This test was passing because it takes a moment
for the cluster to upgrade, so mistakenly assertion
the old version almost always works when our
check happens immediately after the last node restarts.

It should have been asserting that the new version
has appeared.

(cherry picked from commit a34869b23dcf4bd7ec9d927f289d8722349a31f2)

## Release notes

* none
