### PR TITLE
[v22.1.x] tests: temporarily allow out_of_range errs in TopicDeleteStressTest

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -96,7 +96,9 @@ class TopicDeleteStressTest(RedpandaTest):
                              num_brokers=3,
                              extra_rp_conf=extra_rp_conf)
 
-    @cluster(num_nodes=4)
+    # log_allow_list should not be needed here: it is a workaround pending
+    # investigation of https://github.com/redpanda-data/redpanda/issues/4326
+    @cluster(num_nodes=4, log_allow_list=["rpc - .* - std::out_of_range"])
     def stress_test(self):
         for i in range(10):
             spec = TopicSpec(partition_count=2,


### PR DESCRIPTION
## Cover letter

This is a lighter touch than marking the test ok_to_fail:
we are specifically just tolerating failures that result
from the unexpected RPC error.

Related: https://github.com/redpanda-data/redpanda/issues/4326
(cherry picked from commit 7bac61f941fb84f14d4c9098248a83f924853643)

Fixes: #4447

## Release notes

* none
