### PR TITLE
k8s: fix lint warnings and disabling gomnd

### DIFF
--- a/src/go/k8s/.golangci.yml
+++ b/src/go/k8s/.golangci.yml
@@ -48,7 +48,6 @@ linters:
     - gocritic
     - gocyclo
     - revive
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -84,6 +83,7 @@ linters:
   # - gochecknoglobals
   # - gocognit
   # - godot
+  # - gomnd
   # - godox
   # - goerr113
   # - maligned

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -301,7 +301,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	})
 
 	t.Run("scale up", func(t *testing.T) {
-		var scaleUp int32 = *redpandaCluster.Spec.Replicas + 1
+		scaleUp := *redpandaCluster.Spec.Replicas + 1
 		updatedScaleUp := redpandaCluster.DeepCopy()
 		updatedScaleUp.Spec.Replicas = &scaleUp
 		err := updatedScaleUp.ValidateUpdate(redpandaCluster)

--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -145,7 +144,7 @@ func main() {
 
 	log.Printf("Config: %s", string(cfgBytes))
 
-	if err := ioutil.WriteFile(c.configDestination, cfgBytes, 0600); err != nil {
+	if err := os.WriteFile(c.configDestination, cfgBytes, 0o600); err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to write the destination configuration file: %w", err))
 	}
 

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -392,7 +392,7 @@ func (r *StatefulSetResource) queryRedpandaStatus(
 		adminURL.Scheme = "https"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminURL.String(), http.NoBody)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
(cherry picked from commit 6d3f7413def1226e02e8e66f01f489a34e848563)

 Conflicts:
	src/go/k8s/pkg/resources/statefulset.go

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
