### PR TITLE
kafka: fix replication factor when creating __consumer_offsets

### DIFF
--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -128,7 +128,9 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           }
 
           return try_create_consumer_group_topic(
-                   ctx.coordinator_mapper(), ctx.topics_frontend())
+                   ctx.coordinator_mapper(),
+                   ctx.topics_frontend(),
+                   (int16_t)ctx.metadata_cache().all_brokers().size())
             .then([&ctx, request = std::move(request)](bool created) {
                 /*
                  * if the topic is successfully created then the metadata cache

--- a/src/v/kafka/server/rm_group_frontend.h
+++ b/src/v/kafka/server/rm_group_frontend.h
@@ -24,7 +24,8 @@ namespace kafka {
 
 ss::future<bool> try_create_consumer_group_topic(
   kafka::coordinator_ntp_mapper& mapper,
-  cluster::topics_frontend& topics_frontend);
+  cluster::topics_frontend& topics_frontend,
+  int16_t node_count);
 
 class rm_group_frontend {
 public:


### PR DESCRIPTION
## Cover letter

Previously this would be created with default_topic_replication
factor, and adjusted to internal_topic_replication_factor later
in health manager.

Instead, use internal_topic_replication_factor (or 1 if node
count is insufficient) during creation.

## Release notes

* none
