### PR TITLE
cluster,kafka: auto-populate cluster_id and prefix it with "redpanda."

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -315,9 +315,6 @@ ss::future<> controller::start() {
             std::ref(_as));
       })
       .then([this] {
-          if (!config::shard_local_cfg().enable_metrics_reporter()) {
-              return ss::now();
-          }
           return _metrics_reporter.invoke_on(0, &metrics_reporter::start);
       });
 }

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -312,6 +312,7 @@ ss::future<> controller::start() {
             std::ref(_members_table),
             std::ref(_tp_state),
             std::ref(_hm_frontend),
+            std::ref(_config_frontend),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -116,7 +116,13 @@ ss::future<> metrics_reporter::start() {
     _address = details::parse_url(
       config::shard_local_cfg().metrics_reporter_url());
     _tick_timer.set_callback([this] { report_metrics(); });
-    _tick_timer.arm(config::shard_local_cfg().metrics_reporter_tick_interval());
+
+    const auto initial_delay = 10s;
+
+    // A shorter initial wait than the tick interval, so that we
+    // give the cluster state a chance to stabilize, but also send
+    // a report reasonably promptly.
+    _tick_timer.arm(initial_delay);
     co_return;
 }
 

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -77,6 +77,7 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<health_monitor_frontend>&,
+      ss::sharded<config_frontend>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -90,12 +91,14 @@ private:
 
     ss::future<http::client> make_http_client();
     ss::future<> try_initialize_cluster_info();
+    ss::future<> propagate_cluster_id();
 
     ss::sstring _cluster_uuid;
     consensus_ptr _raft0;
     ss::sharded<members_table>& _members_table;
     ss::sharded<topic_table>& _topics;
     ss::sharded<health_monitor_frontend>& _health_monitor;
+    ss::sharded<config_frontend>& _config_frontend;
     ss::sharded<ss::abort_source>& _as;
     model::timestamp _creation_timestamp;
     prefix_logger _logger;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -393,7 +393,15 @@ ss::future<response_ptr> metadata_handler::handle(
         }
     }
 
-    reply.data.cluster_id = config::shard_local_cfg().cluster_id;
+    const auto cluster_id = config::shard_local_cfg().cluster_id();
+    if (cluster_id.has_value()) {
+        reply.data.cluster_id = ssx::sformat("redpanda.{}", cluster_id.value());
+    } else {
+        // Include a "redpanda." cluster ID even if we didn't initialize
+        // cluster_id yet, so that callers can identify which Kafka
+        // implementation they're talking to.
+        reply.data.cluster_id = "redpanda.initializing";
+    }
 
     auto leader_id = ctx.metadata_cache().get_controller_leader_id();
     reply.data.controller_id = leader_id.value_or(model::node_id(-1));

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -631,3 +631,28 @@ class RpkTool:
         ] + self._kafka_conn_settings()
         output = self._execute(cmd)
         return output
+
+    def cluster_metadata_id(self):
+        """
+        Calls 'cluster metadata' and returns the cluster ID, if set,
+        else None.  Don't return the rest of the output (brokers list)
+        because there are already other ways to get at that.
+        """
+        cmd = [
+            self._rpk_binary(), '--brokers',
+            self._redpanda.brokers(), 'cluster', 'metadata'
+        ]
+        output = self._execute(cmd)
+        lines = output.strip().split("\n")
+
+        # Output is like:
+        #
+        # CLUSTER
+        # =======
+        # foobar
+
+        # Output only has a "CLUSTER" section if cluster id is set
+        if lines[0] != "CLUSTER":
+            return None
+        else:
+            return lines[2]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -930,11 +930,15 @@ class RedpandaService(Service):
         """
         patch_result = self._admin.patch_cluster_config(upsert=values)
         new_version = patch_result['config_version']
+
+        # The version check is >= to permit other config writes to happen in
+        # the background, including the write to cluster_id that happens
+        # early in the cluster's lifetime
         wait_until(
-            lambda: set([
-                n['config_version']
+            lambda: all([
+                n['config_version'] >= new_version
                 for n in self._admin.get_cluster_config_status()
-            ]) == {new_version},
+            ]),
             timeout_sec=10,
             backoff_sec=0.5,
             err_msg=f"Config status versions did not converge on {new_version}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -374,7 +374,6 @@ class RedpandaService(Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
 
-    CLUSTER_NAME = "my_cluster"
     READY_TIMEOUT_SEC = 10
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
@@ -406,8 +405,7 @@ class RedpandaService(Service):
         'default_topic_partitions': 4,
         'enable_metrics_reporter': False,
         'superusers': [SUPERUSER_CREDENTIALS[0]],
-        'enable_auto_rebalance_on_node_add': True,
-        'cluster_id': CLUSTER_NAME
+        'enable_auto_rebalance_on_node_add': True
     }
 
     logs = {

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -100,6 +100,16 @@ class ClusterConfigTest(RedpandaTest):
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
 
+    def setUp(self):
+        super().setUp()
+
+        # wait for the two config versions:
+        # 1. The initial bootstrap where we "import" any cluster properties
+        #    that were in bootstrap.yaml
+        # 2. The metrics reporter's first tick, where it initializes
+        #    the cluster_id property.
+        self._wait_for_version_sync(2)
+
     @cluster(num_nodes=3)
     @parametrize(legacy=False)
     @parametrize(legacy=True)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -511,7 +511,10 @@ class ClusterConfigTest(RedpandaTest):
                 else:
                     valid_value = 1000.0
             elif p['type'] == 'string':
-                valid_value = "rhubarb"
+                if name.endswith("_url"):
+                    valid_value = "http://example.com"
+                else:
+                    valid_value = "rhubarb"
             elif p['type'] == 'boolean':
                 valid_value = not initial_config[name]
             elif p['type'] == "array" and p['items']['type'] == 'string':


### PR DESCRIPTION
## Cover letter

We already generate a unique ID in MetricsReporter.  Use this to initialize `cluster_id` in the cluster configuration if it isn't already set.

This is a slightly obscure place to do the initialization, but there wasn't an obviously better home, and I'm not sure this particulars piece of initialization is big enough to justify getting it's very own class within the controller.

Interesting things about the implementation here:
- I've put a dummy "redpanda.initializing" cluster ID in, for if a Kafka client asks before we've initialized the cluster ID.  I'm interested in feedback from Kowl folks on whether this is helpful or not -- is it better for us to say nothing, or to at least say enough to indicate that we are Redpanda?
- We do need at least two controller log messages before the cluster ID gets initialized.  On many systems this is immediate: the feature manager writes one message right away, and the configuration manager also writes a message if there are any non-default settings at all.  A system with a totally default configuration would have to wait until it saw its first user/topic creation though (that's where the "redpanda.initializing" dummy value would come into play)

## Release notes

### Improvements

* The Kafka cluster ID is now automatically populated with a "redpanda.<uuid>" string if not set by the user.
