### PR TITLE
[v22.1.x] Revert "operator: update kuttl tests to use maintenance mode hooks"

### DIFF
--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-bootstrap
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
   - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-bootstrap
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
     - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-redpanda-cluster-change.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-drift
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
   - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-tls
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
   - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/01-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-tls
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
     - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/01-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/01-redpanda-cluster-change.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/03-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-tls
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
     - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/03-redpanda-cluster-simple-tls.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/03-redpanda-cluster-simple-tls.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/04-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-tls
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
     - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/04-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/04-redpanda-cluster-change.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "vectorized/redpanda"
   version: "v21.11.11"
-  replicas: 2
+  replicas: 3
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "vectorized/redpanda"
   version: "v21.11.12"
-  replicas: 2
+  replicas: 3
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 3
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
   - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/01-assert.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration
 status:
-  replicas: 2
+  replicas: 1
   restarting: false
   conditions:
     - type: ClusterConfigured

--- a/src/go/k8s/tests/e2e/centralized-configuration/01-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/01-redpanda-cluster-change.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration/03-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/03-redpanda-cluster-change.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Cover letter

This reverts commit c4632e2001097235a4589ed8c24492c5e4407f5b.

Will fix tests in the dev branch.

Fixes #4451 
