### PR TITLE
kafka: fix undefined behavior in consumer group topic migration

### DIFF
--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -622,7 +622,10 @@ ss::future<> group_metadata_migration::migrate_metadata() {
               _controller,
               *group_topic_assignment,
               default_deadline());
-            continue;
+            if (topics.contains(
+                  model::kafka_consumer_offsets_nt, model::partition_id{0})) {
+                break;
+            }
         }
 
         co_await ss::sleep_abortable(

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -619,9 +619,7 @@ ss::future<> group_metadata_migration::migrate_metadata() {
         if (_controller.is_raft0_leader()) {
             vlog(mlog.info, "creating consumer offsets topic");
             co_await create_consumer_offsets_topic(
-              _controller,
-              *group_topic_assignment,
-              default_deadline());
+              _controller, *group_topic_assignment, default_deadline());
             if (topics.contains(
                   model::kafka_consumer_offsets_nt, model::partition_id{0})) {
                 break;

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -97,6 +97,9 @@ ss::future<bool> create_consumer_offsets_topic(
   cluster::controller& controller,
   std::vector<cluster::partition_assignment> assignments,
   model::timeout_clock::time_point timeout) {
+    vassert(
+      !assignments.empty(),
+      "cannot create consumer offsets topic with 0 partitions");
     cluster::custom_assignable_topic_configuration topic(
       cluster::topic_configuration{
         model::kafka_consumer_offsets_nt.ns,
@@ -602,7 +605,7 @@ ss::future<> group_metadata_migration::do_apply() {
 
 ss::future<> group_metadata_migration::migrate_metadata() {
     auto& topics = _controller.get_topics_state().local();
-    auto group_topic_assignment = topics.get_topic_assignments(
+    const auto group_topic_assignment = topics.get_topic_assignments(
       model::kafka_group_nt);
     // no group topic found, skip migration
     if (!group_topic_assignment) {
@@ -617,7 +620,7 @@ ss::future<> group_metadata_migration::migrate_metadata() {
             vlog(mlog.info, "creating consumer offsets topic");
             co_await create_consumer_offsets_topic(
               _controller,
-              std::move(*group_topic_assignment),
+              *group_topic_assignment,
               default_deadline());
             continue;
         }


### PR DESCRIPTION
## Cover letter

```
The sanitizer caught a `vector::front` dereference on an empty vector. The vector was here:

   create_consumer_offsets_topic:
     std::vector<cluster::partition_assignment> assignments (parameter)
     static_cast<int16_t>(assignments.front().replicas.size())} (dereference)

The caller was effectively:

    auto group_topic_assignment = topics.get_topic_assignments(
      model::kafka_group_nt);
    while (!topics.contains(
      model::kafka_consumer_offsets_nt, model::partition_id{0})) {
        if (_controller.is_raft0_leader()) {
            vlog(mlog.info, "creating consumer offsets topic");
            co_await create_consumer_offsets_topic(
              _controller,
              std::move(*group_topic_assignment), <--- MOVED-FROM VECTOR
              default_deadline());
            continue;
        }

So what was happening was that this loop is a retry loop. If the
consumer offset topic can't be created, it loops and tries again until
creation succeeds. But if the loop runs more than once an empty vector
will be passed because the first iteration moved from the vector.

We can see in the logs where the creation failed:

   WARN  2022-04-20 23:03:50,405 [shard 0] group-metadata-migration - group_metadata_migration.cc:129 - can not create __consumer_offsets topic - cluster::errc:7

And so this loop when it continued would have found that the topics
table didn't contain the topic and would try again.

The solution is to copy the vector to avoid this scenario. Also added an
assertion before interacting with the assumed-to-be-non-empty vector.

===

DEBUG 2022-04-20 23:03:50,404 [shard 1] cluster - controller_backend.cc:401 - Abort requested while reconciling topics
WARN  2022-04-20 23:03:50,404 [shard 0] cluster - topics_frontend.cc:473 - Unable to create topic - std::exception (std::exception)
DEBUG 2022-04-20 23:03:50,404 [shard 0] rpc - could not parse header from client: 172.18.0.10:59166
INFO  2022-04-20 23:03:50,404 [shard 1] rpc - simple_protocol.cc:85 - Error dispatching method: std::runtime_error (batched_output_stream is already closed. Ignoring: 91 bytes)
WARN  2022-04-20 23:03:50,405 [shard 0] group-metadata-migration - group_metadata_migration.cc:129 - can not create __consumer_offsets topic - cluster::errc:7
INFO  2022-04-20 23:03:50,405 [shard 2] rpc - simple_protocol.cc:85 - Error dispatching method: std::runtime_error (batched_output_stream is already closed. Ignoring: 46 bytes)
TRACE 2022-04-20 23:03:50,405 [shard 0] cluster - members_backend.cc:109 - error waiting for members updates - seastar::abort_requested_exception (abort requested)
DEBUG 2022-04-20 23:03:50,406 [shard 0] cluster - controller_backend.cc:401 - Abort requested while reconciling topics
DEBUG 2022-04-20 23:03:50,406 [shard 0] rpc - could not parse header from client: 172.18.0.6:60849
DEBUG 2022-04-20 23:03:50,407 [shard 0] rpc - could not parse header from client: 172.18.0.12:51078
INFO  2022-04-20 23:03:50,409 [shard 0] group-metadata-migration - group_metadata_migration.cc:617 - creating consumer offsets topic
/vectorized/llvm/bin/../include/c++/v1/vector:677:16: runtime error: reference binding to null pointer of type 'cluster::partition_assignment'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /vectorized/llvm/bin/../include/c++/v1/vector:677:16 in
../../../src/v/kafka/server/group_metadata_migration.cc:105:42: runtime error: member access within null pointer of type 'std::__vector_base<cluster::partition_assignment, std::allocator<cluster::partition_assignment>>::value_type' (aka 'cluster::partition_assignment')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../../src/v/kafka/server/group_metadata_migration.cc:105:42 in
AddressSanitizer:DEADLYSIGNAL
=================================================================
==879==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000018 (pc 0x56249b59fd30 bp 0x7ffdde7fa070 sp 0x7ffdde7fa040 T0)
==879==The signal is caused by a READ memory access.
==879==Hint: address points to the zero page.
    #0 0x56249b59fd30  (/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-04f2cbb0aac0ba019-1/redpanda/redpanda/vbuild/debug/clang/dist/local/redpanda/libexec/redpanda+0x2d8b8d30)

<clipped>

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-04f2cbb0aac0ba019-1/redpanda/redpanda/vbuild/debug/clang/dist/local/redpanda/libexec/redpanda+0x2d8b8d30)
==879==ABORTING
```

Fixes: #4356

## Release notes

* none