### PR TITLE
Use correct fn to move offset translator state

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -843,7 +843,7 @@ ss::future<std::error_code> controller_backend::process_partition_update(
               previous_shard);
             co_await raft::details::move_persistent_state(
               requested.group, *previous_shard, ss::this_shard_id(), _storage);
-            co_await raft::details::move_persistent_state(
+            co_await raft::offset_translator::move_persistent_state(
               requested.group, *previous_shard, ss::this_shard_id(), _storage);
 
             auto ec = co_await create_partition(


### PR DESCRIPTION
## Cover letter

The bug was actually fixed in #3433 but previously due to a typo `raft::details::move_persistent_state` was called
twice instead of calling `raft::offset_translator::move_persistent_state`.

A test will be added separately in #3532

Fixes #4466

## Release notes
### Bug fixes
* Fix a crash that could happen during shadow indexing reads after partition movement.