### PR TITLE
Post announcements to internal Slack channels on releases

### DIFF
--- a/.github/workflows/slack-messages.yml
+++ b/.github/workflows/slack-messages.yml
@@ -1,0 +1,31 @@
+name: Release Slack Message
+on:
+  release:
+    types: [published]
+
+env: 
+  MESSAGE: "Redpanda release ${{ github.event.release.tag_name }} has been published: ${{ github.event.release.html_url }}"
+
+jobs:
+  post-slack-message:
+    name: Post Slack Message
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Post to internal #releases channel"
+      id: internal_releases
+      uses: slackapi/slack-github-action@v1.18.0
+      with:
+        channel-id: ${{ secrets.INTERNAL_RELEASES_SLACK_CHANNEL }}
+        slack-message: ${{ env.MESSAGE }}
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.VBOTBUILDOVICH_SLACK_BOT_TOKEN }}
+
+    - name: "Post to internal #general channel"
+      id: internal_general
+      uses: slackapi/slack-github-action@v1.18.0
+      with:
+        channel-id: ${{ secrets.INTERNAL_GENERAL_SLACK_CHANNEL }}
+        slack-message: ${{ env.MESSAGE }}
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.VBOTBUILDOVICH_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Cover letter

This adds GitHub workflows to automatically post release announcements to internal Slack channels using [Technique 2: Slack App](https://github.com/marketplace/actions/slack-send#technique-2-slack-app).

## Release notes

* none