### PR TITLE
kafka: mTLS principal mapping

### DIFF
--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -24,6 +24,8 @@ std::string_view to_string_view(feature f) {
         return "consumer_offsets";
     case feature::maintenance_mode:
         return "maintenance_mode";
+    case feature::mtls_authentication:
+        return "mtls_authentication";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -23,6 +23,7 @@ enum class feature : std::uint64_t {
     central_config = 0x1,
     consumer_offsets = 0x2,
     maintenance_mode = 0x4,
+    mtls_authentication = 0x8,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -92,6 +93,12 @@ constexpr static std::array feature_schema{
     "maintenance_mode",
     feature::maintenance_mode,
     feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{3},
+    "mtls_authentication",
+    feature::mtls_authentication,
+    feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{2001},

--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
   DEPS
     v::json
     v::model
+    v::security
    boost_filesystem
    absl::node_hash_set
 )

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -40,9 +40,8 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
+void rjson_serialize_impl(
   json::Writer<json::StringBuffer>& w, const config::tls_config& v) {
-    w.StartObject();
     w.Key("enabled");
     w.Bool(v.is_enabled());
 
@@ -62,6 +61,16 @@ void rjson_serialize(
         w.String((*(v.get_truststore_file())).c_str());
     }
 
+    if (v.get_principal_mapping_rules()) {
+        w.Key("principal_mapping_rules");
+        w.String(*v.get_principal_mapping_rules());
+    }
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::tls_config& v) {
+    w.StartObject();
+    rjson_serialize_impl(w, v);
     w.EndObject();
 }
 
@@ -94,24 +103,7 @@ void rjson_serialize(
 
     w.Key("name");
     w.String(v.name.c_str());
-    w.Key("enabled");
-    w.Bool(v.config.is_enabled());
-
-    w.Key("require_client_auth");
-    w.Bool(v.config.get_require_client_auth());
-
-    if (v.config.get_key_cert_files()) {
-        w.Key("key_file");
-        w.String(v.config.get_key_cert_files()->key_file.c_str());
-
-        w.Key("cert_file");
-        w.String(v.config.get_key_cert_files()->cert_file.c_str());
-    }
-
-    if (v.config.get_truststore_file()) {
-        w.Key("truststore_file");
-        w.String((*(v.config.get_truststore_file())).c_str());
-    }
+    rjson_serialize_impl(w, v.config);
 
     w.EndObject();
 }

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -113,7 +113,9 @@ ss::future<> connection_context::handle_mtls_auth() {
           if (!_mtls_principal) {
               throw security::exception(
                 security::errc::invalid_credentials,
-                "failed to extract principal from distinguished name");
+                fmt::format(
+                  "failed to extract principal from distinguished name: {}",
+                  dn->subject));
           }
 
           vlog(

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -17,14 +17,18 @@
 #include "kafka/server/protocol_utils.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/request_context.h"
+#include "security/exceptions.h"
 #include "units.h"
+#include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/with_timeout.hh>
 
 #include <chrono>
 #include <memory>
+
 using namespace std::chrono_literals;
 
 namespace kafka {
@@ -64,8 +68,59 @@ ss::future<> connection_context::process_one_request() {
                       _rs.probe().header_corrupted();
                       return ss::make_ready_future<>();
                   }
-                  return dispatch_method_once(std::move(h.value()), s);
+                  return handle_mtls_auth().then(
+                    [this, h = std::move(h.value()), s]() mutable {
+                        return dispatch_method_once(std::move(h), s);
+                    });
               });
+      });
+}
+
+/*
+ * handle mtls authentication. this should only happen once when the connection
+ * is setup. even though this is called in the normal request handling path,
+ * this property should hold becuase:
+ *
+ * 1. is a noop if a mtls principal has been extracted
+ * 2. all code paths that don't set the principal throw and drop the connection
+ *
+ * NOTE: handle_mtls_auth is called after reading header off the wire. this is
+ * odd because we would expect that tls negotation etc... all happens before we
+ * here to the application layer. however, it appears that the way seastar works
+ * that we need to read some data off the wire to drive this process within the
+ * internal connection handling.
+ */
+ss::future<> connection_context::handle_mtls_auth() {
+    if (!_use_mtls || _mtls_principal.has_value()) {
+        return ss::now();
+    }
+    return ss::with_timeout(
+             model::timeout_clock::now() + 5s,
+             _rs.conn->get_distinguished_name())
+      .then([this](std::optional<ss::session_dn> dn) {
+          if (!dn.has_value()) {
+              throw security::exception(
+                security::errc::invalid_credentials,
+                "failed to fetch distinguished name");
+          }
+          /*
+           * for now it probably is fine to store the mapping per connection.
+           * but it seems like we could also share this across all connections
+           * with the same tls configuration.
+           */
+          _mtls_principal = _rs.conn->get_principal_mapping()->apply(
+            dn->subject);
+          if (!_mtls_principal) {
+              throw security::exception(
+                security::errc::invalid_credentials,
+                "failed to extract principal from distinguished name");
+          }
+
+          vlog(
+            _authlog.debug,
+            "got principal: {}, from distinguished name: {}",
+            *_mtls_principal,
+            dn->subject);
       });
 }
 

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -17,6 +17,7 @@
 #include "kafka/server/logger.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "security/mtls.h"
 #include "security/scram_algorithm.h"
 #include "utils/utf8.h"
 #include "vlog.h"
@@ -25,6 +26,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/log.hh>
 
@@ -33,6 +35,7 @@
 #include <chrono>
 #include <exception>
 #include <limits>
+#include <memory>
 
 namespace kafka {
 
@@ -106,7 +109,8 @@ ss::future<> protocol::apply(net::server::resources rs) {
       *this,
       std::move(rs),
       std::move(sasl),
-      config::shard_local_cfg().enable_sasl());
+      config::shard_local_cfg().enable_sasl(),
+      rs.conn->get_principal_mapping().has_value());
 
     return ss::do_until(
              [ctx] { return ctx->is_finished_parsing(); },

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -105,12 +105,17 @@ ss::future<> protocol::apply(net::server::resources rs) {
         ? security::sasl_server::sasl_state::initial
         : security::sasl_server::sasl_state::complete);
 
+    const auto enable_mtls_authentication
+      = rs.conn->get_principal_mapping().has_value()
+        && feature_table().local().is_active(
+          cluster::feature::mtls_authentication);
+
     auto ctx = ss::make_lw_shared<connection_context>(
       *this,
       std::move(rs),
       std::move(sasl),
       config::shard_local_cfg().enable_sasl(),
-      rs.conn->get_principal_mapping().has_value());
+      enable_mtls_authentication);
 
     return ss::do_until(
              [ctx] { return ctx->is_finished_parsing(); },

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -81,6 +81,7 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                               proto,
                               net::server::resources(nullptr, nullptr),
                               std::move(sasl),
+                              false,
                               false);
 
                           return kafka::request_context(

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -18,14 +18,16 @@ connection::connection(
   ss::sstring name,
   ss::connected_socket f,
   ss::socket_address a,
-  server_probe& p)
-  : addr(std::move(a))
+  server_probe& p,
+  std::optional<security::tls::principal_mapper> tls_pm)
+  : addr(a)
   , _hook(hook)
   , _name(std::move(name))
   , _fd(std::move(f))
   , _in(_fd.input())
   , _out(_fd.output())
-  , _probe(p) {
+  , _probe(p)
+  , _tls_pm(std::move(tls_pm)) {
     _hook.push_back(*this);
     _probe.connection_established();
 }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -16,6 +16,7 @@
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
+#include "security/mtls.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/abort_source.hh>
@@ -42,6 +43,7 @@ struct server_endpoint {
     ss::sstring name;
     ss::socket_address addr;
     ss::shared_ptr<ss::tls::server_credentials> credentials;
+    std::optional<security::tls::principal_mapper> principal_mapper;
 
     server_endpoint(ss::sstring name, ss::socket_address addr)
       : name(std::move(name))
@@ -56,9 +58,26 @@ struct server_endpoint {
       , credentials(std::move(creds)) {}
 
     server_endpoint(
+      ss::sstring name,
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds,
+      std::optional<security::tls::principal_mapper> principal_mapper)
+      : name(std::move(name))
+      , addr(addr)
+      , credentials(std::move(creds))
+      , principal_mapper(std::move(principal_mapper)) {}
+
+    server_endpoint(
       ss::socket_address addr,
       ss::shared_ptr<ss::tls::server_credentials> creds)
       : server_endpoint("", addr, std::move(creds)) {}
+
+    server_endpoint(
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds,
+      security::tls::principal_mapper principal_mapper)
+      : server_endpoint(
+        "", addr, std::move(creds), std::move(principal_mapper)) {}
 
     explicit server_endpoint(ss::socket_address addr)
       : server_endpoint("", addr) {}

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -403,6 +403,7 @@ public:
           *proto,
           net::server::resources(nullptr, nullptr),
           std::move(sasl),
+          false,
           false);
 
         kafka::request_header header;

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -57,7 +57,8 @@ FIXTURE_TEST(rpcgen_tls_integration, rpc_integration_fixture) {
                            true,
                            config::key_cert{"redpanda.key", "redpanda.crt"},
                            "root_certificate_authority.chain_cert",
-                           false)
+                           false,
+                           std::nullopt)
                            .get_credentials_builder()
                            .get0();
     configure_server(creds_builder);
@@ -133,7 +134,8 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     client_key.native(), client_crt.native()},
                                   client_ca.native(),
-                                  true)
+                                  true,
+                                  std::nullopt)
                                   .get_credentials_builder()
                                   .get0();
     // server credentials
@@ -146,7 +148,8 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     server_key.native(), server_crt.native()},
                                   server_ca.native(),
-                                  true)
+                                  true,
+                                  std::nullopt)
                                   .get_credentials_builder()
                                   .get0();
 

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     scram_credential.cc
     scram_authenticator.cc
     acl_store.cc
+    mtls.cc
   DEPS
     v::bytes
     absl::flat_hash_map

--- a/src/v/security/exceptions.h
+++ b/src/v/security/exceptions.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "security/errc.h"
+
+#include <fmt/core.h>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace security {
+
+struct exception final : public std::runtime_error {
+public:
+    explicit exception(errc e, std::string_view msg)
+      : std::runtime_error(
+        fmt::format("{}: {}", make_error_code(e).message(), msg)) {}
+};
+
+} // namespace security

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/mtls.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include <regex>
+#include <stdexcept>
+
+namespace security::tls {
+
+namespace detail {
+
+static constexpr const char* const rule_pattern{
+  R"((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))"};
+static constexpr const char* const rule_pattern_splitter{
+  R"(\s*((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))\s*(,\s*|$))"};
+
+std::regex make_regex(std::string_view sv) {
+    return std::regex{
+      sv.begin(),
+      sv.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize};
+}
+
+bool regex_search(
+  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+    return std::regex_search(
+      msg.begin(),
+      msg.end(),
+      match,
+      regex,
+      std::regex_constants::match_default);
+}
+
+bool regex_match(
+  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+    return std::regex_match(
+      msg.begin(),
+      msg.end(),
+      match,
+      regex,
+      std::regex_constants::match_default);
+}
+
+constexpr std::string_view trim(std::string_view s) {
+    constexpr auto ws = " \t\n\r\f\v";
+    s.remove_prefix(std::min(s.find_first_not_of(ws), s.size()));
+    s.remove_suffix(std::min(s.size() - s.find_last_not_of(ws) - 1, s.size()));
+    return s;
+}
+
+constexpr std::optional<std::string_view> make_sv(const std::csub_match& sm) {
+    return sm.matched
+             ? std::string_view{sm.first, static_cast<size_t>(sm.length())}
+             : std::optional<std::string_view>{std::nullopt};
+}
+
+std::vector<rule> parse_rules(std::optional<std::string_view> unparsed_rules) {
+    static const std::regex rule_splitter = make_regex(rule_pattern_splitter);
+    static const std::regex rule_parser = make_regex(rule_pattern);
+
+    std::string_view rules{trim(unparsed_rules.value_or("DEFAULT"))};
+
+    std::vector<rule> result;
+    std::cmatch rules_match;
+    while (!rules.empty() && regex_search(rules, rules_match, rule_splitter)) {
+        const auto& rule{rules_match[1]};
+
+        std::cmatch components_match;
+        if (!regex_search(*make_sv(rule), components_match, rule_parser)) {
+            throw std::runtime_error("Invalid rule: " + rule.str());
+        }
+        if (components_match.prefix().matched) {
+            throw std::runtime_error(
+              "Invalid rule - prefix: " + components_match.prefix().str());
+        }
+        if (components_match.suffix().matched) {
+            throw std::runtime_error(
+              "Invalid rule - suffix: " + components_match.suffix().str());
+        }
+
+        if (components_match[1].matched) {
+            result.emplace_back();
+        } else if (components_match[2].matched) {
+            const auto adjust_case = make_sv(components_match[6]);
+            result.emplace_back(
+              *make_sv(components_match[2]),
+              make_sv(components_match[4]),
+              rule::make_lower{adjust_case == "L"},
+              rule::make_upper{adjust_case == "U"});
+        }
+        rules = make_sv(rules_match.suffix()).value_or("");
+    }
+    return result;
+}
+
+} // namespace detail
+
+rule::rule(
+  std::string_view pattern,
+  std::optional<std::string_view> replacement,
+  make_lower to_lower,
+  make_upper to_upper)
+  : _regex{detail::make_regex(pattern)}
+  , _pattern{pattern}
+  , _replacement{replacement}
+  , _is_default{false}
+  , _to_lower{to_lower}
+  , _to_upper{to_upper} {}
+
+std::optional<ss::sstring> rule::apply(std::string_view dn) const {
+    if (_is_default) {
+        return ss::sstring{dn};
+    }
+
+    std::cmatch match;
+    if (!std::regex_match(dn.cbegin(), dn.cend(), match, _regex)) {
+        return {};
+    }
+
+    std::string result;
+    std::regex_replace(
+      std::back_inserter(result),
+      dn.begin(),
+      dn.end(),
+      _regex,
+      _replacement.value_or("").c_str());
+
+    if (_to_lower) {
+        boost::algorithm::to_lower(result, std::locale::classic());
+    } else if (_to_upper) {
+        boost::algorithm::to_upper(result, std::locale::classic());
+    }
+    return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const rule& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const principal_mapper& p) {
+    fmt::print(os, "{}", p);
+    return os;
+}
+
+} // namespace security::tls
+
+// explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the
+// header, whch breaks compilation in another part of the codebase.
+template<>
+std::back_insert_iterator<fmt::detail::buffer<char>>
+fmt::formatter<security::tls::rule>::format(
+  const security::tls::rule& r,
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>& ctx) {
+    if (r._is_default) {
+        return format_to(ctx.out(), "DEFAULT");
+    }
+    format_to(ctx.out(), "RULE:");
+    if (r._pattern.has_value()) {
+        format_to(ctx.out(), "{}", *r._pattern);
+    }
+    if (r._replacement.has_value()) {
+        format_to(ctx.out(), "/{}", *r._replacement);
+    }
+    if (r._to_lower) {
+        format_to(ctx.out(), "/L");
+    } else if (r._to_upper) {
+        format_to(ctx.out(), "/U");
+    }
+    return ctx.out();
+}
+
+template<>
+std::back_insert_iterator<fmt::detail::buffer<char>>
+fmt::formatter<security::tls::principal_mapper>::format<
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>>(
+  const security::tls::principal_mapper& r,
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>& ctx) {
+    return format_to(ctx.out(), "[{}]", fmt::join(r._rules, ", "));
+}

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/core.h>
+
+#include <iosfwd>
+#include <optional>
+#include <regex>
+#include <string_view>
+
+namespace security::tls {
+
+class rule {
+public:
+    using make_lower = ss::bool_class<struct make_lower_tag>;
+    using make_upper = ss::bool_class<struct make_upper_tag>;
+
+    rule() = default;
+
+    rule(
+      std::string_view pattern,
+      std::optional<std::string_view> replacement,
+      make_lower to_lower,
+      make_upper to_upper);
+
+    std::optional<ss::sstring> apply(std::string_view dn) const;
+
+private:
+    friend struct fmt::formatter<rule>;
+
+    friend std::ostream& operator<<(std::ostream& os, const rule& r);
+
+    std::regex _regex;
+    std::optional<ss::sstring> _pattern;
+    std::optional<ss::sstring> _replacement;
+    bool _is_default{true};
+    make_lower _to_lower{false};
+    make_upper _to_upper{false};
+};
+
+namespace detail {
+
+std::vector<rule> parse_rules(std::optional<std::string_view> unparsed_rules);
+
+} // namespace detail
+
+class principal_mapper {
+public:
+    explicit principal_mapper(std::optional<std::string_view> sv)
+      : _rules{detail::parse_rules(sv)} {}
+
+    std::optional<ss::sstring> apply(std::string_view sv) const {
+        for (const auto& r : _rules) {
+            if (auto p = r.apply(sv); p.has_value()) {
+                return {std::move(p).value()};
+            }
+        }
+        return std::nullopt;
+    }
+
+private:
+    friend struct fmt::formatter<principal_mapper>;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const principal_mapper& p);
+
+    std::vector<rule> _rules;
+};
+
+} // namespace security::tls
+
+template<>
+struct fmt::formatter<security::tls::rule> {
+    using type = security::tls::rule;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+};
+
+template<>
+struct fmt::formatter<security::tls::principal_mapper> {
+    using type = security::tls::principal_mapper;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+};

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     scram_algorithm_test.cc
     credential_store_test.cc
     authorizer_test.cc
+    mtls_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/security/tests/mtls_test.cc
+++ b/src/v/security/tests/mtls_test.cc
@@ -1,0 +1,135 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "random/generators.h"
+#include "security/mtls.h"
+#include "utils/base64.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <fmt/ostream.h>
+
+#include <regex>
+#include <stdexcept>
+
+namespace security::tls {
+
+/*
+ * Test coverage includes all of the relevant test cases found in upstream
+ * kafka's SslPrincipalMapperTest.
+ */
+
+namespace bdata = boost::unit_test::data;
+
+std::array<std::string_view, 8> mtls_valid_rules{
+  "DEFAULT",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, DEFAULT",
+  "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/",
+  "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L",
+  "RULE:^cn=(.?),ou=(.?),dc=(.?),dc=(.?)$/$1@$2/U",
+  "RULE:^CN=([^,ADEFLTU,]+)(,.*|$)/$1/",
+  "RULE:^CN=([^,DEFAULT,]+)(,.*|$)/$1/"};
+
+BOOST_DATA_TEST_CASE(test_mtls_valid_rules, bdata::make(mtls_valid_rules), c) {
+    BOOST_REQUIRE_NO_THROW(principal_mapper{c});
+}
+
+std::array<std::string_view, 10> mtls_invalid_rules{
+  "default",
+  "DEFAUL",
+  "DEFAULT/L",
+  "DEFAULT/U",
+  "RULE:CN=(.*?),OU=ServiceUsers.*/$1",
+  "rule:^CN=(.*?),OU=ServiceUsers.*$/$1/",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L/U",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/L",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/U",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/LU"};
+
+BOOST_DATA_TEST_CASE(
+  test_mtls_invalid_rules, bdata::make(mtls_invalid_rules), c) {
+    BOOST_REQUIRE_THROW(principal_mapper{c}, std::runtime_error);
+}
+
+struct record {
+    record(std::string_view e, std::string_view i)
+      : expected{e}
+      , input{i} {}
+    std::string_view expected;
+    std::string_view input;
+    friend std::ostream& operator<<(std::ostream& os, const record& r) {
+        fmt::print(os, "input: `{}`, expected: `{}`", r.input, r.expected);
+        return os;
+    }
+};
+
+static std::array<record, 5> mtls_principal_mapper_data{
+  record{"duke", "CN=Duke,OU=ServiceUsers,O=Org,C=US"},
+  {"duke@sme", "CN=Duke,OU=SME,O=mycp,L=Fulton,ST=MD,C=US"},
+  {"DUKE@SME", "cn=duke,ou=sme,dc=mycp,dc=com"},
+  {"DUKE", "cN=duke,OU=JavaSoft,O=Sun Microsystems"},
+  {"OU=JavaSoft,O=Sun Microsystems,C=US",
+   "OU=JavaSoft,O=Sun Microsystems,C=US"}};
+
+BOOST_DATA_TEST_CASE(
+  test_mtls_principal_mapper, bdata::make(mtls_principal_mapper_data), c) {
+    security::tls::principal_mapper mapper{
+      "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, "
+      "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L, "
+      "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1@$2/U, "
+      "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/U, "
+      "DEFAULT"};
+    BOOST_REQUIRE_EQUAL(c.expected, *mapper.apply(c.input));
+}
+
+static std::array<record, 17> mtls_rule_splitting_data{
+  record{"[]", ""},
+  {"[DEFAULT]", "DEFAULT"},
+  {"[RULE:/]", "RULE://"},
+  {"[RULE:/.*]", "RULE:/.*/"},
+  {"[RULE:/.*/L]", "RULE:/.*/L"},
+  {"[RULE:/, DEFAULT]", "RULE://,DEFAULT"},
+  {"[RULE:/, DEFAULT]", "  RULE:// ,  DEFAULT  "},
+  {"[RULE:   /     , DEFAULT]", "  RULE:   /     / ,  DEFAULT  "},
+  {"[RULE:  /     /U, DEFAULT]", "  RULE:  /     /U   ,DEFAULT  "},
+  {"[RULE:([A-Z]*)/$1/U, RULE:([a-z]+)/$1, DEFAULT]",
+   "  RULE:([A-Z]*)/$1/U   ,RULE:([a-z]+)/$1/,   DEFAULT  "},
+  {"[]", ",   , , ,      , , ,   "},
+  {"[RULE:/, DEFAULT]", ",,RULE://,,,DEFAULT,,"},
+  {"[RULE: /   , DEFAULT]", ",  , RULE: /   /    ,,,   DEFAULT, ,   "},
+  {"[RULE:   /  /U, DEFAULT]", "     ,  , RULE:   /  /U    ,,  ,DEFAULT, ,"},
+  {R"([RULE:\/\\\(\)\n\t/\/\/])", R"(RULE:\/\\\(\)\n\t/\/\//)"},
+  {R"([RULE:\**\/+/*/L, RULE:\/*\**/**])",
+   R"(RULE:\**\/+/*/L,RULE:\/*\**/**/)"},
+  {"[RULE:,RULE:,/,RULE:,\\//U, RULE:,/RULE:,, RULE:,RULE:,/L,RULE:,/L, RULE:, "
+   "DEFAULT, /DEFAULT, DEFAULT]",
+   "RULE:,RULE:,/,RULE:,\\//U,RULE:,/RULE:,/,RULE:,RULE:,/L,RULE:,/L,RULE:, "
+   "DEFAULT, /DEFAULT/,DEFAULT"},
+};
+BOOST_DATA_TEST_CASE(
+  test_mtls_rule_splitting, bdata::make(mtls_rule_splitting_data), c) {
+    BOOST_CHECK_EQUAL(c.expected, fmt::format("{}", principal_mapper(c.input)));
+}
+
+BOOST_AUTO_TEST_CASE(test_mtls_comma_with_whitespace) {
+    BOOST_CHECK_EQUAL(
+      "Tkac\\, Adam",
+      principal_mapper("RULE:^CN=((\\\\, *|\\w)+)(,.*|$)/$1/,DEFAULT")
+        .apply("CN=Tkac\\, Adam,OU=ITZ,DC=geodis,DC=cz")
+        .value_or(""));
+}
+
+} // namespace security::tls

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -340,9 +340,23 @@ class TLSProvider:
 
 
 class SecurityConfig:
+    # the system currently has a single principal mapping rule. this is
+    # sufficient to get our first mTLS tests put together, but isn't general
+    # enough to cover all the cases. one awkward thing that came up was: admin
+    # clients used by the service and clients used by tests both may need to
+    # have mappings. the internal admin client can use something fixed, but
+    # tests may want to use a variety of rules. currently it is hard to combine
+    # the rules, so instead we use a fixed mapping and arrange for certs to use
+    # a similar format. this will change when we get closer to GA and the
+    # configuration becomes more general.
+    PRINCIPAL_MAPPING_RULES = "RULE:^O=Redpanda,CN=(.*?)$/$1/L, DEFAULT"
+
     def __init__(self):
         self.enable_sasl = False
         self.tls_provider: Optional[TLSProvider] = None
+
+        # extract principal from mtls distinguished name
+        self.enable_mtls_identity = False
 
 
 class RedpandaService(Service):
@@ -1205,6 +1219,10 @@ class RedpandaService(Service):
                 cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
                 truststore_file=RedpandaService.TLS_CA_CRT_FILE,
             )
+            if self._security.enable_mtls_identity:
+                tls_config.update(
+                    dict(principal_mapping_rules=SecurityConfig.
+                         PRINCIPAL_MAPPING_RULES, ))
             doc = yaml.full_load(conf)
             doc["redpanda"].update(dict(kafka_api_tls=tls_config))
             conf = yaml.dump(doc)

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -88,7 +88,8 @@ class TLSCertManager:
     it is common for clients to take paths to these files, it is best to keep
     the instance alive for as long as the files are in use.
     """
-    def __init__(self):
+    def __init__(self, logger):
+        self._logger = logger
         self._dir = tempfile.TemporaryDirectory()
         self._ca = self._create_ca()
         self.certs = {}
@@ -97,7 +98,11 @@ class TLSCertManager:
         return os.path.join(self._dir.name, name)
 
     def _exec(self, cmd):
-        subprocess.check_output(cmd.split(), cwd=self._dir.name)
+        self._logger.info(f"Running command: {cmd}")
+        output = subprocess.check_output(cmd.split(),
+                                         cwd=self._dir.name,
+                                         stderr=subprocess.STDOUT)
+        self._logger.debug(output)
 
     def _create_ca(self):
         cfg = self._with_dir("ca.conf")

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -38,6 +38,9 @@ class AccessControlListTest(RedpandaTest):
     password = "password"
     algorithm = "SCRAM-SHA-256"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
     def setUp(self):
         # Skip starting redpanda, so that test can explicitly start
         # it with custom security settings

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -50,7 +50,7 @@ class AccessControlListTest(RedpandaTest):
 
     def _start_redpanda(self, use_tls):
         if use_tls:
-            self.tls = tls.TLSCertManager()
+            self.tls = tls.TLSCertManager(self.logger)
             self.cert = self.tls.create_cert(socket.gethostname(),
                                              name="client")
             self.security.tls_provider = MTLSProvider(self.tls)


### PR DESCRIPTION
## Cover letter

Fixes #3939

Configuration looks like:

```yaml
redpanda:
  kafka_api_tls:
    - cert_file: mtls_server.crt
      enabled: true
      key_file: mtls_server.key
      name: kafka-external
      require_client_auth: true
      principal_mapping_rules: "RULE:.*CN=([^,]+).*/$1/, DEFAULT"
      truststore_file: mtls_ca.crt
```

## Reviewer notes

TODO:

* Properly implement the replacement strategy
* Add ducktape tests

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/69aad920fdcd976d86bd5605fbc08b7bb5497c9d..0b98ddf4ac8a975fd04ba26339304605f3abf2cb)
* Replace `sasl_mechanism` with mostly Noahs suggestion.
* Improve config validation at startup
* Add a more appropriate exception type
* Improved logging / json serialization

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/0b98ddf4ac8a975fd04ba26339304605f3abf2cb..d7c82a16184658e0e694646f05fa8b7a24ba4682)
* Simplify auth log and reduce to debug level

## Release notes

### Features

* Support mTLS AuthN via propagation of the principal from the Subject (DN) of the client certificate
