### PR TITLE
Fetch long poll fix

### DIFF
--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -24,6 +24,7 @@ class KafkaCliConsumer(BackgroundThreadService):
                  offset=None,
                  partitions=None,
                  isolation_level=None,
+                 from_beginning=False,
                  consumer_properties={}):
         super(KafkaCliConsumer, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
@@ -32,6 +33,7 @@ class KafkaCliConsumer(BackgroundThreadService):
         self._offset = offset
         self._partitions = partitions
         self._isolation_level = isolation_level
+        self._from_beginning = from_beginning
         self._consumer_properties = consumer_properties
         self._stopping = threading.Event()
         assert self._partitions is not None or self._group is not None, "either partitions or group have to be set"
@@ -56,6 +58,8 @@ class KafkaCliConsumer(BackgroundThreadService):
                 cmd += ['--partition', ','.join(self._partitions)]
             if self._isolation_level is not None:
                 cmd += ["--isolation-level", str(self._isolation_level)]
+            if self._from_beginning:
+                cmd += ["--from-beginning"]
             for k, v in self._consumer_properties.items():
                 cmd += ['--consumer-property', f"{k}={v}"]
 

--- a/tests/rptest/tests/fetch_long_poll_test.py
+++ b/tests/rptest/tests/fetch_long_poll_test.py
@@ -49,6 +49,7 @@ class FetchTest(RedpandaTest):
                                     self.redpanda,
                                     topic=topic.name,
                                     group='test-gr-1',
+                                    from_beginning=True,
                                     consumer_properties={
                                         'fetch.min.bytes': 1024,
                                         'fetch.max.wait.ms': 1000,


### PR DESCRIPTION
## Cover letter

Fixed consumer setup in `fetch_long_poll` test leading to assertion fail. Now consume will always start consuming from the beginning of a topic.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4504 
ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
