### PR TITLE
Fix raft linearizable barrier

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -454,6 +454,7 @@ void consensus::successfull_append_entries_reply(
     idx.last_flushed_log_index = reply.last_flushed_log_index;
     idx.match_index = idx.last_dirty_log_index;
     idx.next_index = details::next_offset(idx.last_dirty_log_index);
+    idx.last_successful_received_seq = idx.last_received_seq;
     vlog(
       _ctxlog.trace,
       "Updated node {} match {} and next {} indices",

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -505,16 +505,13 @@ void consensus::dispatch_recovery(follower_index_metadata& idx) {
 
 ss::future<result<model::offset>> consensus::linearizable_barrier() {
     using ret_t = result<model::offset>;
-    struct state_snapshot {
-        model::offset linearizable_offset;
-        model::term_id term;
-    };
 
     ss::semaphore_units<> u = co_await _op_lock.get_units();
 
     if (_vstate != vote_state::leader) {
         co_return result<model::offset>(make_error_code(errc::not_leader));
     }
+    co_await flush_log();
     // store current commit index
     auto cfg = config();
     auto dirty_offset = _log.offsets().dirty_offset;
@@ -538,7 +535,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
           meta(),
           model::make_memory_record_batch_reader(
             ss::circular_buffer<model::record_batch>{}),
-          append_entries_request::flush_after_append::no);
+          append_entries_request::flush_after_append::yes);
         auto seq = next_follower_sequence(target);
         sequences.emplace(target, seq);
 
@@ -559,9 +556,9 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
         send_futures.push_back(std::move(f));
     });
     // release semaphore
-    // snapshot taken under the semaphore
-    state_snapshot snapshot{
-      .linearizable_offset = _commit_index, .term = _term};
+    // term snapshot taken under the semaphore
+    auto term = _term;
+
     u.return_all();
 
     // wait for responsens in background
@@ -575,7 +572,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
                 return true;
             }
             if (auto it = _fstats.find(id); it != _fstats.end()) {
-                return it->second.last_received_seq >= sequences[id];
+                return it->second.last_successful_received_seq >= sequences[id];
             }
             return false;
         });
@@ -584,18 +581,19 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     try {
         // we do not hold the lock while waiting
         co_await _follower_reply.wait(
-          [this, snapshot, &majority_sequences_updated] {
-              return majority_sequences_updated() || _term != snapshot.term;
+          [this, term, &majority_sequences_updated] {
+              return majority_sequences_updated() || _term != term;
           });
     } catch (const ss::broken_condition_variable& e) {
         co_return ret_t(make_error_code(errc::shutting_down));
     }
 
     // term have changed, not longer a leader
-    if (snapshot.term != _term) {
+    if (term != _term) {
         co_return ret_t(make_error_code(errc::not_leader));
     }
-    co_return ret_t(snapshot.linearizable_offset);
+    vlog(_ctxlog.trace, "Linearizble offset: {}", _commit_index);
+    co_return ret_t(_commit_index);
 }
 
 ss::future<result<replicate_result>> chain_stages(replicate_stages stages) {
@@ -2076,7 +2074,11 @@ append_entries_reply consensus::make_append_entries_reply(
 }
 
 ss::future<> consensus::flush_log() {
+    if (!_has_pending_flushes) {
+        return ss::now();
+    }
     _probe.log_flushed();
+    _has_pending_flushes = false;
     auto flushed_up_to = _log.offsets().dirty_offset;
     return _log.flush().then([this, flushed_up_to] {
         auto lstats = _log.offsets();
@@ -2100,7 +2102,6 @@ ss::future<> consensus::flush_log() {
           _flushed_offset,
           lstats,
           _log);
-        _has_pending_flushes = false;
     });
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -510,7 +510,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
         model::term_id term;
     };
 
-    std::optional<ss::semaphore_units<>> u = co_await _op_lock.get_units();
+    ss::semaphore_units<> u = co_await _op_lock.get_units();
 
     if (_vstate != vote_state::leader) {
         co_return result<model::offset>(make_error_code(errc::not_leader));
@@ -562,7 +562,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     // snapshot taken under the semaphore
     state_snapshot snapshot{
       .linearizable_offset = _commit_index, .term = _term};
-    u.reset();
+    u.return_all();
 
     // wait for responsens in background
     ssx::spawn_with_gate(_bg, [futures = std::move(send_futures)]() mutable {

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -739,18 +739,29 @@ FIXTURE_TEST(test_linarizable_barrier, raft_test_fixture) {
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
     auto r = leader_raft->linearizable_barrier().get();
+    BOOST_REQUIRE(leader_raft->committed_offset() >= r.value());
+    BOOST_REQUIRE_EQUAL(
+      leader_raft->committed_offset(), leader_raft->dirty_offset());
+};
 
-    std::vector<size_t> sizes;
-    if (r) {
-        auto logs = gr.read_all_logs();
-        for (auto& l : logs) {
-            sizes.push_back(l.second.size());
-        }
-        std::sort(sizes.begin(), sizes.end());
-        // at least 2 out of 3 nodes MUST have all entries replicated
-        BOOST_REQUIRE_GT(sizes[2], 1);
-        BOOST_REQUIRE_EQUAL(sizes[2], sizes[1]);
-    }
+FIXTURE_TEST(test_linarizable_barrier_leader_ack, raft_test_fixture) {
+    raft_group gr = raft_group(raft::group_id(0), 3);
+    gr.enable_all();
+    auto leader_id = wait_for_group_leader(gr);
+    auto leader_raft = gr.get_member(leader_id).consensus;
+
+    bool success = replicate_random_batches(
+                     gr, 5, raft::consistency_level::leader_ack)
+                     .get0();
+    BOOST_REQUIRE(success);
+
+    leader_id = wait_for_group_leader(gr);
+    leader_raft = gr.get_member(leader_id).consensus;
+    auto r = leader_raft->linearizable_barrier().get();
+
+    BOOST_REQUIRE(leader_raft->committed_offset() >= r.value());
+    BOOST_REQUIRE_EQUAL(
+      leader_raft->committed_offset(), leader_raft->dirty_offset());
 };
 
 FIXTURE_TEST(test_linarizable_barrier_single_node, raft_test_fixture) {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -131,6 +131,8 @@ struct follower_index_metadata {
 
     follower_req_seq last_sent_seq{0};
     follower_req_seq last_received_seq{0};
+    // sequence number of last received successfull append entries request
+    follower_req_seq last_successful_received_seq{0};
     bool is_learner = true;
     bool is_recovering = false;
 

--- a/tests/rptest/tests/many_partitions_test.py
+++ b/tests/rptest/tests/many_partitions_test.py
@@ -86,7 +86,7 @@ class ManyPartitionsTest(RedpandaTest):
                 # on weaker test nodes.
                 'raft_heartbeat_interval_ms': 450,
                 'raft_heartbeat_timeout_ms': 9000,
-                'election_timeout_ms': 4500,
+                'election_timeout_ms': 7500,
                 'replicate_append_timeout_ms': 9000,
                 'recovery_append_timeout_ms': 15000,
             },


### PR DESCRIPTION
## Cover letter

Changed implementation of linearizable barrier to actually update leader committed index when requested. Previously linearizable barrier did not check the result of heartbeat replies this way the only action caused by calling `linearizable_barrier` was actually follower liveness check. Changed `linearizable_barrier` implementation to actually update committed offset i.e. 
- wait for majority responses to be successful
- request flush on followers
- flush leader log if need

Thanks to this fix linearizable barrier will actually advance committed offset, caller will not have to wait in a loop for offset to be updated.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
