### PR TITLE
build: install unzip and support manjaro

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -40,6 +40,7 @@ deb_deps=(
   python3-venv
   rapidjson-dev
   zip
+  unzip
 )
 fedora_deps=(
   ccache
@@ -59,6 +60,7 @@ fedora_deps=(
   xxhash-devel
   xz
   zip
+  unzip
 )
 arch_deps=(
   ccache
@@ -77,6 +79,7 @@ arch_deps=(
   xxhash
   xz
   zip
+  unzip
 )
 
 case "$ID" in

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -90,7 +90,7 @@ case "$ID" in
   fedora)
     dnf install -y "${fedora_deps[@]}"
     ;;
-  arch)
+  arch | manjaro)
     pacman -Sy --needed --noconfirm "${arch_deps[@]}"
     ;;
   *)


### PR DESCRIPTION
- unzip utility is not installed by default.
- support Manjaro as Seastar does.