### PR TITLE
Support for flexible requests

### DIFF
--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -51,6 +51,12 @@ public:
         return {val, length_size};
     }
 
+    std::pair<uint32_t, uint8_t> read_unsigned_varint() {
+        auto [val, length_size] = unsigned_vint::deserialize(_in);
+        _in.skip(length_size);
+        return {val, length_size};
+    }
+
     ss::sstring read_string(size_t len) {
         ss::sstring str = ss::uninitialized_string(len);
         _in.consume_to(str.size(), str.begin());

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -54,6 +54,7 @@ v_cc_library(
     server/connection_context.cc
     server/protocol.cc
     server/protocol_utils.cc
+    server/flex_versions.cc
     server/logger.cc
     server/quota_manager.cc
     server/fetch_session_cache.cc

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "kafka/protocol/fwd.h"
+#include "kafka/server/flex_versions.h"
 #include "kafka/server/protocol_utils.h"
 #include "kafka/types.h"
 #include "net/transport.h"
@@ -154,6 +155,15 @@ private:
         wr.write(int16_t(version()));
         wr.write(int32_t(_correlation()));
         wr.write(std::string_view("test_client"));
+        vassert(
+          flex_versions::is_api_in_schema(key),
+          "Attempted to send request to non-existent API: {}",
+          key);
+        if (flex_versions::is_flexible_request(key, version)) {
+            /// Tags are unused by the client but to be protocol compliant
+            /// with flex versions at least a 0 byte must be written
+            wr.write_tags();
+        }
         _correlation = _correlation + correlation_id(1);
     }
 

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/protocol/api_versions.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/server/flex_versions.h"
 #include "kafka/server/protocol_utils.h"
@@ -57,8 +58,12 @@ private:
           "Attempted to send request to non-existent API: {}",
           key);
 
+        /// KIP-511 bumps api_versions_request/response to 3 the first flex
+        /// version for the API three however makes an exception that there will
+        /// be no tags in the response header.
         const auto is_flexible = flex_versions::is_flexible_request(
-          key, request_version);
+                                   key, request_version)
+                                 && key() != api_versions_api::key;
 
         // finalize by filling in the size prefix
         int32_t total_size = buf.size_bytes() - start_size;

--- a/src/v/kafka/protocol/request_reader.h
+++ b/src/v/kafka/protocol/request_reader.h
@@ -89,6 +89,10 @@ public:
       typename T = std::invoke_result_t<ElementParser, request_reader&>>
     std::vector<T> read_array(ElementParser&& parser) {
         auto len = read_int32();
+        if (len < 0) {
+            throw std::out_of_range(
+              "Attempt to read array with negative length");
+        }
         return do_read_array(len, std::forward<ElementParser>(parser));
     }
 
@@ -106,7 +110,6 @@ public:
 private:
     ss::sstring do_read_string(int16_t n) {
         if (unlikely(n < 0)) {
-            /// FIXME: maybe return empty string?
             throw std::out_of_range("Asked to read a negative byte string");
         }
         return _parser.read_string(n);

--- a/src/v/kafka/protocol/request_reader.h
+++ b/src/v/kafka/protocol/request_reader.h
@@ -14,6 +14,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf_parser.h"
 #include "kafka/protocol/batch_reader.h"
+#include "kafka/protocol/types.h"
 #include "likely.h"
 #include "seastarx.h"
 #include "utils/utf8.h"
@@ -173,9 +174,27 @@ public:
         return do_read_array(len - 1, std::forward<ElementParser>(parser));
     }
 
+    // Only relevent when reading flex requests
+    tagged_fields read_tags() {
+        tagged_fields tags;
+        auto num_tags = read_unsigned_varint(); // consume total num of tags
+        while (num_tags-- > 0) {
+            auto tag_id = read_unsigned_varint(); // consume tag id
+            auto size = read_unsigned_varint();   // consume size in bytes
+            tags.emplace_back(tag_id, _parser.share(size)); // consume tag
+        }
+        return tags;
+    }
+
     void consume_tags() {
-        /// Temporary stand-in for this commit to compile with new changes added
-        /// to our generator
+        // Reads tags only with the intention of moving ahead the parser read
+        // head to the next correct index
+        auto num_tags = read_unsigned_varint(); // consume total num of tags
+        while (num_tags-- > 0) {
+            (void)read_unsigned_varint();           // consume tag id
+            auto next_len = read_unsigned_varint(); // consume size in bytes
+            _parser.skip(next_len);                 // consume tag element
+        }
     }
 
 private:

--- a/src/v/kafka/protocol/request_reader.h
+++ b/src/v/kafka/protocol/request_reader.h
@@ -173,6 +173,11 @@ public:
         return do_read_array(len - 1, std::forward<ElementParser>(parser));
     }
 
+    void consume_tags() {
+        /// Temporary stand-in for this commit to compile with new changes added
+        /// to our generator
+    }
+
 private:
     ss::sstring do_read_string(int16_t n) {
         if (unlikely(n < 0)) {

--- a/src/v/kafka/protocol/response_writer.h
+++ b/src/v/kafka/protocol/response_writer.h
@@ -325,6 +325,8 @@ public:
         return _out->size_bytes() - start_size;
     }
 
+    uint32_t write_tags() { return write_unsigned_varint(0); }
+
 private:
     iobuf* _out;
 };

--- a/src/v/kafka/protocol/schemata/api_versions_request.json
+++ b/src/v/kafka/protocol/schemata/api_versions_request.json
@@ -16,6 +16,7 @@
 {
   "apiKey": 18,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "ApiVersionsRequest",
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
@@ -24,8 +25,8 @@
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ClientSoftwareName", "type": "string", "versions": "3+",
-      "about": "The name of the client." },
+      "ignorable": true, "about": "The name of the client." },
     { "name": "ClientSoftwareVersion", "type": "string", "versions": "3+",
-      "about": "The version of the client." }
+      "ignorable": true, "about": "The version of the client." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/api_versions_response.json
+++ b/src/v/kafka/protocol/schemata/api_versions_response.json
@@ -42,6 +42,33 @@
         "about": "The maximum supported version, inclusive." }
     ]},
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
-      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." }
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey", "ignorable": true,
+      "versions":  "3+", "tag": 0, "taggedVersions": "3+",
+      "about": "Features supported by the broker.",
+      "fields":  [
+        { "name": "Name", "type": "string", "versions": "3+", "mapKey": true,
+          "about": "The name of the feature." },
+        { "name": "MinVersion", "type": "int16", "versions": "3+",
+          "about": "The minimum supported version for the feature." },
+        { "name": "MaxVersion", "type": "int16", "versions": "3+",
+          "about": "The maximum supported version for the feature." }
+      ]
+    },
+    { "name": "FinalizedFeaturesEpoch", "type": "int64", "versions": "3+",
+      "tag": 1, "taggedVersions": "3+", "default": "-1", "ignorable": true,
+      "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch."},
+    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey", "ignorable": true,
+      "versions":  "3+", "tag": 2, "taggedVersions": "3+",
+      "about": "List of cluster-wide finalized features. The information is valid only if FinalizedFeaturesEpoch >= 0.",
+      "fields":  [
+        {"name": "Name", "type": "string", "versions":  "3+", "mapKey": true,
+          "about": "The name of the feature."},
+        {"name":  "MaxVersionLevel", "type": "int16", "versions":  "3+",
+          "about": "The cluster-wide finalized max version level for the feature."},
+        {"name":  "MinVersionLevel", "type": "int16", "versions":  "3+",
+          "about": "The cluster-wide finalized min version level for the feature."}
+      ]
+    }
   ]
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -431,6 +431,8 @@ STRUCT_TYPES = [
     "OffsetForLeaderPartition",
     "OffsetForLeaderTopicResult",
     "EpochEndOffset",
+    "SupportedFeatureKey",
+    "FinalizedFeatureKey",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())
@@ -1257,6 +1259,7 @@ SCHEMA = {
             ],
         },
         "fields": {"$ref": "#/definitions/fields"},
+        "listeners": { "type": "array", "optional": True }
     },
     "required": [
         "apiKey",

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -21,13 +21,6 @@
 #   path_type_map to override types, it would be more efficient to specify the
 #   same mapping using the field_name_type_map + a whitelist of request types.
 #
-#   - The current version does not handle flexible versions. It will be some
-#   time before we encounter clients requiring this, but in principle this
-#   generator should be extensible (see type maps below). Note that when the
-#   time comes to support flexible versions, there is a filter in the templates
-#   within this file that ignores such fields, and that filter should be
-#   removed.
-#
 #   - Handle ignorable fields. Currently we handle nullable fields properly. The
 #   ignorable flag on a field doesn't change the wire protocol, but gives
 #   instruction on how things should behave when there is missing data.
@@ -47,6 +40,7 @@ import sys
 import textwrap
 import jsonschema
 import jinja2
+import enum
 
 # Type overrides
 # ==============
@@ -304,15 +298,18 @@ field_name_type_map = {
 
 # primitive types
 basic_type_map = dict(
-    string=("ss::sstring", "read_string()", "read_nullable_string()"),
-    bytes=("bytes", "read_bytes()"),
+    string=("ss::sstring", "read_string()", "read_nullable_string()",
+            "read_flex_string()", "read_nullable_flex_string()"),
+    bytes=("bytes", "read_bytes()", None, "read_flex_bytes()", None),
     bool=("bool", "read_bool()"),
     int8=("int8_t", "read_int8()"),
     int16=("int16_t", "read_int16()"),
     int32=("int32_t", "read_int32()"),
     int64=("int64_t", "read_int64()"),
-    iobuf=("iobuf", None, "read_fragmented_nullable_bytes()"),
-    fetch_record_set=("batch_reader", None, "read_nullable_batch_reader()"),
+    iobuf=("iobuf", None, "read_fragmented_nullable_bytes()", None,
+           "read_fragmented_nullable_flex_bytes()"),
+    fetch_record_set=("batch_reader", None, "read_nullable_batch_reader()",
+                      None, "read_nullable_flex_batch_reader()"),
 )
 
 # Declare some fields as sensitive. Utmost care should be taken to ensure the
@@ -473,7 +470,13 @@ class VersionRange:
             max = int(match.group("max"))
             return min, max
 
-    def guard(self):
+    guard_modes = enum.Enum('guard_modes', 'GUARD, NO_GUARD, NO_SOURCE')
+
+    @property
+    def guard_enum(self):
+        return VersionRange.guard_modes
+
+    def _guard(self):
         """
         Generate the C++ bounds check.
         """
@@ -486,7 +489,29 @@ class VersionRange:
             if self.max != None:
                 cond.append(f"version <= api_version({self.max})")
             cond = " && ".join(cond)
-        return cond
+
+        return (self.guard_enum.NO_GUARD,
+                None) if cond == "" else (self.guard_enum.GUARD, cond)
+
+    def guard(self, flex, first_flex):
+        """
+        Optimize generated code by either omitting a guard or source itself
+        """
+        if first_flex < 0:
+            return self._guard()
+        elif not flex:
+            if self.min >= first_flex:
+                return self.guard_enum.NO_SOURCE, None
+        else:
+            if self.max == None:
+                if self.min <= first_flex:
+                    return self.guard_enum.NO_GUARD, None
+            elif self.max < first_flex:
+                return self.guard_enum.NO_SOURCE, None
+            elif self.max == first_flex:
+                return self.guard_enum.NO_GUARD, None
+
+        return self._guard()
 
     def __repr__(self):
         max = "+inf)" if self.max is None else f"{self.max}]"
@@ -551,6 +576,12 @@ class FieldType:
 class ScalarType(FieldType):
     def __init__(self, name):
         super().__init__(name)
+
+    @property
+    def potentially_flexible_type(self):
+        """Evaluates to true if the scalar type would be parsed as flex
+        if the version is high enough"""
+        return self.name == "string" or self.name == "bytes" or self.name == "iobuf"
 
 
 class StructType(FieldType):
@@ -697,14 +728,15 @@ class Field:
 
         raise Exception(f"No decoder for {(tn, fn)}")
 
-    @property
-    def decoder(self):
+    def decoder(self, flex):
         """
         There are two cases:
 
             1a. plain native: read_int32()
             1b. nullable native: read_nullable_string()
             1c. named types: named_type(read_int32())
+            1d. flexible types: read_flex_string()
+            1e. flexible nullable native: read_nullable_flex_string()
 
             2a. optional named types:
                 auto tmp = read_nullable_string()
@@ -718,6 +750,14 @@ class Field:
             # field then choose the non-nullable decoder for its element type.
             assert plain_decoder[1]
             return plain_decoder[1], named_type
+        if self.potentially_flexible_type:
+            if flex is True:
+                if self.nullable():
+                    assert plain_decoder[4]
+                    return plain_decoder[4], named_type
+                else:
+                    assert plain_decoder[3]
+                    return plain_decoder[3], named_type
         if self.nullable():
             assert plain_decoder[2]
             return plain_decoder[2], named_type
@@ -744,6 +784,11 @@ class Field:
     @property
     def is_array(self):
         return isinstance(self._type, ArrayType)
+
+    @property
+    def potentially_flexible_type(self):
+        return isinstance(self._type,
+                          ScalarType) and self._type.potentially_flexible_type
 
     @property
     def type_name(self):
@@ -824,6 +869,18 @@ class response;
 {%- endif %}
 
     friend std::ostream& operator<<(std::ostream&, const {{ struct.name }}&);
+{%- if first_flex > 0 %}
+private:
+    void encode_flex(response_writer&, api_version);
+    void encode_standard(response_writer&, api_version);
+{%- if op_type == "request" %}
+    void decode_flex(request_reader&, api_version);
+    void decode_standard(request_reader&, api_version);
+{%- else %}
+    void decode_flex(iobuf, api_version);
+    void decode_standard(iobuf, api_version);
+{%- endif %}
+{%- endif %}
 };
 
 }
@@ -840,18 +897,22 @@ SOURCE_TEMPLATE = """
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-{% macro version_guard(field) %}
-{%- set cond = field.versions().guard() %}
-{%- if cond %}
+{% macro version_guard(field, flex) %}
+{%- set guard_enum = field.versions().guard_enum %}
+{%- set e, cond = field.versions().guard(flex, first_flex) %}
+{%- if e == guard_enum.NO_GUARD %}
+{{- caller() }}
+{%- elif e == guard_enum.NO_SOURCE %}
+{%- elif e == guard_enum.GUARD %}
 if ({{ cond }}) {
 {{- caller() | indent }}
 }
 {%- else %}
-{{- caller() }}
+{{ fail("Unexpected enumeration encountered, type: VersionRange.guard_modes") }}
 {%- endif %}
 {%- endmacro %}
 
-{% macro field_encoder(field, obj) %}
+{% macro field_encoder(field, obj, flex) %}
 {%- if obj %}
 {%- set fname = obj + "." + field.name %}
 {%- else %}
@@ -859,23 +920,33 @@ if ({{ cond }}) {
 {%- endif %}
 {%- if field.is_array %}
 {%- if field.nullable() %}
+{%- if flex %}
+writer.write_nullable_flex_array({{ fname }}, [version]({{ field.value_type }}& v, response_writer& writer) {
+{%- else %}
 writer.write_nullable_array({{ fname }}, [version]({{ field.value_type }}& v, response_writer& writer) {
+{%- endif %}
+{%- else %}
+{%- if flex %}
+writer.write_flex_array({{ fname }}, [version]({{ field.value_type }}& v, response_writer& writer) {
 {%- else %}
 writer.write_array({{ fname }}, [version]({{ field.value_type }}& v, response_writer& writer) {
 {%- endif %}
-(void)version;
+    (void)version;
+{%- endif %}
 {%- if field.type().value_type().is_struct %}
-{{- struct_serde(field.type().value_type(), field_encoder, "v") | indent }}
+{{- struct_serde(field.type().value_type(), field_encoder, flex, "v") | indent }}
 {%- else %}
     writer.write(v);
 {%- endif %}
 });
+{%- elif flex and field.type().potentially_flexible_type %}
+writer.write_flex({{ fname }});
 {%- else %}
 writer.write({{ fname }});
 {%- endif %}
 {%- endmacro %}
 
-{% macro field_decoder(field, obj) %}
+{% macro field_decoder(field, obj, flex) %}
 {%- if obj %}
 {%- set fname = obj + "." + field.name %}
 {%- else %}
@@ -883,17 +954,25 @@ writer.write({{ fname }});
 {%- endif %}
 {%- if field.is_array %}
 {%- if field.nullable() %}
+{%- if flex %}
+{{ fname }} = reader.read_nullable_flex_array([version](request_reader& reader) {
+{%- else %}
 {{ fname }} = reader.read_nullable_array([version](request_reader& reader) {
+{%- endif %}
+{%- else %}
+{%- if flex %}
+{{ fname }} = reader.read_flex_array([version](request_reader& reader) {
 {%- else %}
 {{ fname }} = reader.read_array([version](request_reader& reader) {
 {%- endif %}
-(void)version;
+    (void)version;
+{%- endif %}
 {%- if field.type().value_type().is_struct %}
     {{ field.type().value_type().name }} v;
-{{- struct_serde(field.type().value_type(), field_decoder, "v") | indent }}
+{{- struct_serde(field.type().value_type(), field_decoder, flex, "v") | indent }}
     return v;
 {%- else %}
-{%- set decoder, named_type = field.decoder %}
+{%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
     return reader.{{ decoder }};
 {%- elif field.nullable() %}
@@ -910,7 +989,7 @@ writer.write({{ fname }});
 {%- endif %}
 });
 {%- else %}
-{%- set decoder, named_type = field.decoder %}
+{%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
 {{ fname }} = reader.{{ decoder }};
 {%- elif field.nullable() %}
@@ -930,10 +1009,10 @@ writer.write({{ fname }});
 {%- endif %}
 {%- endmacro %}
 
-{% macro struct_serde(struct, field_serde, obj = "") %}
+{% macro struct_serde(struct, field_serde, flex, obj = "") %}
 {%- for field in struct.fields %}
-{%- call version_guard(field) %}
-{{- field_serde(field, obj) }}
+{%- call version_guard(field, flex) %}
+{{- field_serde(field, obj, flex) }}
 {%- endcall %}
 {%- endfor %}
 {%- endmacro %}
@@ -941,20 +1020,95 @@ writer.write({{ fname }});
 namespace kafka {
 
 {%- if struct.fields %}
-void {{ struct.name }}::encode(response_writer& writer, [[maybe_unused]] api_version version) {
-{{- struct_serde(struct, field_encoder) | indent }}
+{%- if first_flex > 0 %}
+void {{ struct.name }}::encode(response_writer& writer, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        encode_flex(writer, version);
+    } else {
+        encode_standard(writer, version);
+    }
 }
 
+void {{ struct.name }}::encode_flex(response_writer& writer, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_encoder, True) | indent }}
+}
+
+void {{ struct.name }}::encode_standard([[maybe_unused]] response_writer& writer, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_encoder, False) | indent }}
+}
+
+{%- elif first_flex < 0 %}
+void {{ struct.name }}::encode(response_writer& writer, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_encoder, False) | indent }}
+}
+{%- else %}
+void {{ struct.name }}::encode(response_writer& writer, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_encoder, True) | indent }}
+}
+{%- endif %}
+
+
 {%- if op_type == "request" %}
+{%- if first_flex > 0 %}
+void {{ struct.name }}::decode(request_reader& reader, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        decode_flex(reader, version);
+    } else {
+        decode_standard(reader, version);
+    }
+}
+void {{ struct.name }}::decode_flex(request_reader& reader, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_decoder, True) | indent }}
+}
+
+void {{ struct.name }}::decode_standard([[maybe_unused]] request_reader& reader, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_decoder, False) | indent }}
+}
+{%- elif first_flex < 0 %}
 void {{ struct.name }}::decode(request_reader& reader, [[maybe_unused]] api_version version) {
-{{- struct_serde(struct, field_decoder) | indent }}
+{{- struct_serde(struct, field_decoder, False) | indent }}
+}
+{% else %}
+void {{ struct.name }}::decode(request_reader& reader, [[maybe_unused]] api_version version) {
+{{- struct_serde(struct, field_decoder, True) | indent }}
+}
+{%- endif %}
+{%- else %}
+
+{%- if first_flex > 0 %}
+void {{ struct.name }}::decode(iobuf buf, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        decode_flex(std::move(buf), version);
+    } else {
+        decode_standard(std::move(buf), version);
+    }
+}
+void {{ struct.name }}::decode_flex(iobuf buf, [[maybe_unused]] api_version version) {
+    request_reader reader(std::move(buf));
+
+{{- struct_serde(struct, field_decoder, True) | indent }}
+}
+void {{ struct.name }}::decode_standard(iobuf buf, [[maybe_unused]] api_version version) {
+    request_reader reader(std::move(buf));
+
+{{- struct_serde(struct, field_decoder, False) | indent }}
+}
+
+{%- elif first_flex < 0 %}
+void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) {
+    request_reader reader(std::move(buf));
+
+{{- struct_serde(struct, field_decoder, False) | indent }}
 }
 {%- else %}
 void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) {
     request_reader reader(std::move(buf));
 
-{{- struct_serde(struct, field_decoder) | indent }}
+{{- struct_serde(struct, field_decoder, True) | indent }}
 }
+{%- endif %}
+
+
 {%- endif %}
 {%- else %}
 {%- if op_type == "request" %}
@@ -1122,6 +1276,24 @@ def render_struct_comment(struct):
     return f"/*\n{comment} */"
 
 
+def parse_flexible_versions(flex_version):
+    # A first_flex value of 0 will produce code that is optimized to do no flex
+    # version branching, since all versions since inception were always flexible
+    #
+    # A first_flex value of -1 indicates the value of flexibleVersions was set to 'none'.
+    # These requests will always be interpreted as non-flex and produce no conditional to
+    # branch and parse a flex request.
+    #
+    # All other types of requests will produce code that checks for the flex version once
+    # (at the beginning of encode/decode) and will not add redundent checks i.e. check
+    # if its ok to serialize something at version 7 if it already branched due to flex and
+    # that flex version is already greater than 7.
+    if flex_version == "none":
+        return -1
+    r = VersionRange(flex_version)
+    return r.min
+
+
 if __name__ == "__main__":
     assert len(sys.argv) == 3
     outdir = pathlib.Path(sys.argv[1])
@@ -1151,15 +1323,25 @@ if __name__ == "__main__":
     # request or response
     op_type = msg["type"]
 
+    # either 'none' or 'VersionRange'
+    first_flex = parse_flexible_versions(msg["flexibleVersions"])
+
+    def fail(msg):
+        assert False, msg
+
     with open(hdr, 'w') as f:
         f.write(
             jinja2.Template(HEADER_TEMPLATE).render(
                 struct=struct,
                 render_struct_comment=render_struct_comment,
-                op_type=op_type))
+                op_type=op_type,
+                fail=fail,
+                first_flex=first_flex))
 
     with open(src, 'w') as f:
         f.write(
             jinja2.Template(SOURCE_TEMPLATE).render(struct=struct,
                                                     header=hdr.name,
-                                                    op_type=op_type))
+                                                    op_type=op_type,
+                                                    fail=fail,
+                                                    first_flex=first_flex))

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -587,7 +587,15 @@ class ScalarType(FieldType):
 class StructType(FieldType):
     def __init__(self, name, fields, path=()):
         super().__init__(snake_case(name))
-        self.fields = [Field.create(f, path) for f in fields]
+        self.fields = []
+        self.tags = []
+        for f in fields:
+            new_field = Field.create(f, path)
+            if new_field.is_tag:
+                self.tags.append(new_field)
+            else:
+                self.fields.append(new_field)
+        self.tags.sort(key=lambda x: x._tag)
         self.context_field = make_context_field(path)
 
     @property
@@ -636,6 +644,7 @@ class Field:
         self._default_value = self._field.get("default", "")
         if self._default_value == "null":
             self._default_value = ""
+        self._tag = self._field.get("tag", None)
         assert len(self._path)
 
     @staticmethod
@@ -780,6 +789,10 @@ class Field:
           "expected field '{}' to be missing or True; field path: {}, remaining path: {}" \
           .format(self._field["name"], self._path, d)
         return d
+
+    @property
+    def is_tag(self):
+        return self._tag is not None
 
     @property
     def is_array(self):
@@ -1015,6 +1028,13 @@ writer.write({{ fname }});
 {{- field_serde(field, obj, flex) }}
 {%- endcall %}
 {%- endfor %}
+{%- if flex %}
+{%- if field_serde.name == "field_decoder" %}
+reader.consume_tags();
+{%- elif field_serde.name == "field_encoder" %}
+writer.write_tags();
+{%- endif %}
+{%- endif %}
 {%- endmacro %}
 
 namespace kafka {

--- a/src/v/kafka/protocol/tests/CMakeLists.txt
+++ b/src/v/kafka/protocol/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ rp_test(
   BINARY_NAME
     test_kafka_protocol_single_thread
   SOURCES
+    field_parser_test.cc
     batch_reader_test.cc
   DEFINITIONS
     BOOST_TEST_DYN_LINK

--- a/src/v/kafka/protocol/tests/field_parser_test.cc
+++ b/src/v/kafka/protocol/tests/field_parser_test.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/protocol/request_reader.h"
+#include "kafka/protocol/response_writer.h"
+#include "kafka/protocol/types.h"
+#include "random/generators.h"
+
+#include <seastar/core/thread.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/iterator/counting_iterator.hpp>
+
+struct test_struct {
+    ss::sstring field_a;
+    int32_t field_b;
+
+    static test_struct make_random() {
+        return test_struct{
+          .field_a = random_generators::gen_alphanum_string(5),
+          .field_b = random_generators::get_int(0, 15)};
+    }
+
+    friend bool operator==(const test_struct& a, const test_struct& b) {
+        return a.field_a == b.field_a && a.field_b == b.field_b;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const test_struct& ts) {
+        os << "field_a: " << ts.field_a << " field_b: " << ts.field_b;
+        return os;
+    }
+};
+
+/// Only includes impls of supported types used in following unit tests
+template<typename T>
+void write_flex(T& type, iobuf& buf) {
+    kafka::response_writer writer(buf);
+    if constexpr (std::is_same_v<T, std::vector<test_struct>>) {
+        writer.write_flex_array(
+          type, [](test_struct& ts, kafka::response_writer& writer) {
+              writer.write_flex(ts.field_a);
+              writer.write(ts.field_b);
+              writer.write_tags();
+          });
+    } else if constexpr (std::is_same_v<
+                           T,
+                           std::optional<std::vector<test_struct>>>) {
+        writer.write_nullable_flex_array(
+          type, [](test_struct& ts, kafka::response_writer& writer) {
+              writer.write_flex(ts.field_a);
+              writer.write(ts.field_b);
+              writer.write_tags();
+          });
+    } else {
+        writer.write_flex(type);
+    }
+}
+
+template<typename T>
+T read_flex(iobuf buf) {
+    kafka::request_reader reader(std::move(buf));
+    if constexpr (std::is_same_v<T, ss::sstring>) {
+        return reader.read_flex_string();
+    } else if constexpr (std::is_same_v<T, std::optional<ss::sstring>>) {
+        return reader.read_nullable_flex_string();
+    } else if constexpr (std::is_same_v<T, bytes>) {
+        return reader.read_flex_bytes();
+    } else if constexpr (std::is_same_v<T, std::vector<test_struct>>) {
+        return reader.read_flex_array([](kafka::request_reader& reader) {
+            test_struct v;
+            v.field_a = reader.read_flex_string();
+            v.field_b = reader.read_int32();
+            reader.consume_tags();
+            return v;
+        });
+    } else if constexpr (std::is_same_v<
+                           T,
+                           std::optional<std::vector<test_struct>>>) {
+        return reader.read_nullable_flex_array(
+          [](kafka::request_reader& reader) {
+              test_struct v;
+              v.field_a = reader.read_flex_string();
+              v.field_b = reader.read_int32();
+              reader.consume_tags();
+              return v;
+          });
+    }
+}
+
+template<typename T>
+T serde_flex(T& type) {
+    iobuf buf;
+    write_flex(type, buf);
+    return read_flex<T>(std::move(buf));
+}
+
+SEASTAR_THREAD_TEST_CASE(serde_flex_types) {
+    auto gen_random_string = []() {
+        const auto str_len = random_generators::get_int(0, 20);
+        return random_generators::gen_alphanum_string(15);
+    };
+    {
+        /// flex strings
+        auto str = gen_random_string();
+        BOOST_CHECK_EQUAL(str, serde_flex(str));
+    }
+    {
+        /// optional flex strings
+        auto opt_str = std::optional<ss::sstring>(gen_random_string());
+        BOOST_CHECK(opt_str == serde_flex(opt_str));
+
+        {
+            /// .. of a value of nullopt
+            std::optional<ss::sstring> null_str;
+            BOOST_CHECK(null_str == serde_flex(null_str));
+        }
+    }
+    {
+        /// flex bytes
+        auto b = random_generators::get_bytes();
+        BOOST_CHECK(b == serde_flex(b));
+    }
+    {
+        /// flex array
+        std::vector<test_struct> v;
+        std::for_each(
+          boost::counting_iterator<int>(0),
+          boost::counting_iterator<int>(100),
+          [&v](int) { v.push_back(test_struct::make_random()); });
+        BOOST_CHECK_EQUAL(v, serde_flex(v));
+    }
+    {
+        /// optional flex array
+        std::optional<std::vector<test_struct>> v = std::vector<test_struct>();
+        std::for_each(
+          boost::counting_iterator<int>(0),
+          boost::counting_iterator<int>(100),
+          [&v](int) { v->push_back(test_struct::make_random()); });
+        BOOST_CHECK(v == serde_flex(v));
+
+        {
+            /// ... of a value of nullopt
+            std::optional<std::vector<test_struct>> null_vec;
+            BOOST_CHECK(null_vec == serde_flex(null_vec));
+        }
+    }
+    {
+        /// flex iobuf
+        auto str = gen_random_string();
+        iobuf data, writers_buf, copy;
+        data.append(str.begin(), str.length());
+        copy.append(str.begin(), str.length());
+        kafka::response_writer writer(writers_buf);
+        writer.write_flex(std::move(data));
+
+        kafka::request_reader reader(std::move(writers_buf));
+        auto result = reader.read_fragmented_nullable_flex_bytes();
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(iobuf_to_bytes(*result), iobuf_to_bytes(copy));
+    }
+}

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -9,11 +9,17 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "bytes/iobuf.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/types.h"
 #include "model/metadata.h"
 
+#include <tuple>
+#include <vector>
+
 namespace kafka {
+
+using tagged_fields = std::vector<std::tuple<uint32_t, iobuf>>;
 
 static constexpr model::node_id consumer_replica_id{-1};
 

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -277,7 +277,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
             return ss::make_ready_future<>();
         }
         auto remaining = size - request_header_size
-                         - hdr.client_id_buffer.size();
+                         - hdr.client_id_buffer.size() - hdr.tags_size_bytes;
         return read_iobuf_exactly(_rs.conn->input(), remaining)
           .then([this, hdr = std::move(hdr), sres = std::move(sres)](
                   iobuf buf) mutable {

--- a/src/v/kafka/server/flex_versions.cc
+++ b/src/v/kafka/server/flex_versions.cc
@@ -1,0 +1,77 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/flex_versions.h"
+
+#include "kafka/server/handlers/handlers.h"
+namespace kafka {
+
+template<typename T>
+concept HasMinFlex = requires(T) {
+    {T::min_flexible};
+};
+
+/// The only request that is never flexible is sasl_handshake_request - 17
+/// Older versions of our schema may also contain values of 'none' that map
+/// to -1
+static constexpr api_version never_flexible = api_version(-1);
+
+/// Not every value from 0 -> max_api_key is a valid request, non-supported
+/// requests will map to a value of api_key(-2)
+static constexpr api_version invalid_api = api_version(-2);
+
+template<typename RequestType>
+static constexpr api_version get_min_flex() {
+    /// Necessary until all requests provide a value for `::min_flexible`
+    if constexpr (HasMinFlex<RequestType>) {
+        return RequestType::min_flexible;
+    } else {
+        return never_flexible;
+    }
+}
+
+template<typename... RequestTypes>
+static constexpr size_t max_api_key(type_list<RequestTypes...>) {
+    /// Black magic here is an overload of std::max() that takes an
+    /// std::initializer_list
+    return std::max({RequestTypes::api::key()...});
+}
+
+template<typename... RequestTypes>
+static constexpr auto
+get_flexible_request_min_versions_list(type_list<RequestTypes...> r) {
+    /// An std::array where the indicies map to api_keys and values at an index
+    /// map to the first flex version for a given api. If an api doesn't exist
+    /// at an index -2 or \ref invalid_api will be the value at the index.
+    std::array<api_version, max_api_key(r) + 1> versions;
+    versions.fill(invalid_api);
+    ((versions[RequestTypes::api::key()] = get_min_flex<RequestTypes>()), ...);
+    return versions;
+}
+
+static constexpr auto g_flex_mapping = get_flexible_request_min_versions_list(
+  request_types());
+
+bool flex_versions::is_flexible_request(api_key key, api_version version) {
+    /// If bounds checking is desired call is_api_in_schema(key) beforehand
+    const api_version first_flex_version = g_flex_mapping[key()];
+    return (version >= first_flex_version)
+           && (first_flex_version != never_flexible);
+}
+
+bool flex_versions::is_api_in_schema(api_key key) noexcept {
+    constexpr auto max_version = g_flex_mapping.max_size() - 1;
+    if (key() < 0 || static_cast<size_t>(key()) > max_version) {
+        return false;
+    }
+    const api_version first_flex_version = g_flex_mapping[key()];
+    return first_flex_version != invalid_api;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/flex_versions.h
+++ b/src/v/kafka/server/flex_versions.h
@@ -1,0 +1,38 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+#include "kafka/types.h"
+
+namespace kafka {
+class flex_versions {
+public:
+    /**
+     * Returns true if the version provided for the given request is greater
+     * than or equal to the value provided for `flexibleVersions` in the schema
+     * definition for the request/response
+     *
+     * @param key api_key of request thats being queried
+     * @param version at what version of what api is this request flex
+     * @returns true if the request is flex, false if it isn't, throws
+     *   in instances where the api_key is not a valid api
+     */
+    static bool is_flexible_request(api_key key, api_version version);
+
+    /**
+     * Returns true/false if the key provided is a valid kafka request key
+     * This method never throws, useful to query if an api_key is valid
+     * before calling \ref is_flexible_request
+     *
+     * @param key api_key of request thats being queried
+     * @returns true if the api is a valid kafka request, false otherwise
+     */
+    static bool is_api_in_schema(api_key key) noexcept;
+};
+} // namespace kafka

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -14,50 +14,6 @@
 #include "kafka/server/response.h"
 
 namespace kafka {
-
-template<typename... Ts>
-struct type_list {};
-
-template<typename... Requests>
-requires(
-  KafkaApiHandler<Requests>,
-  ...) using make_request_types = type_list<Requests...>;
-
-using request_types = make_request_types<
-  produce_handler,
-  fetch_handler,
-  list_offsets_handler,
-  metadata_handler,
-  offset_fetch_handler,
-  find_coordinator_handler,
-  list_groups_handler,
-  api_versions_handler,
-  join_group_handler,
-  heartbeat_handler,
-  leave_group_handler,
-  sync_group_handler,
-  create_topics_handler,
-  offset_commit_handler,
-  describe_configs_handler,
-  alter_configs_handler,
-  delete_topics_handler,
-  describe_groups_handler,
-  sasl_handshake_handler,
-  sasl_authenticate_handler,
-  incremental_alter_configs_handler,
-  delete_groups_handler,
-  describe_acls_handler,
-  describe_log_dirs_handler,
-  create_acls_handler,
-  delete_acls_handler,
-  init_producer_id_handler,
-  add_partitions_to_txn_handler,
-  txn_offset_commit_handler,
-  add_offsets_to_txn_handler,
-  end_txn_handler,
-  create_partitions_handler,
-  offset_for_leader_epoch_handler>;
-
 template<typename RequestType>
 static auto make_api() {
     return api_versions_response_key{

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -14,7 +14,9 @@
 
 namespace kafka {
 
-struct api_versions_handler : public handler<api_versions_api, 0, 2> {
+struct api_versions_handler : public handler<api_versions_api, 0, 3> {
+    static constexpr api_version min_flexible = api_version(3);
+
     static ss::future<response_ptr>
       handle(request_context, ss::smp_service_group);
 

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -43,3 +43,48 @@
 #include "kafka/server/handlers/sasl_handshake.h"
 #include "kafka/server/handlers/sync_group.h"
 #include "kafka/server/handlers/txn_offset_commit.h"
+
+namespace kafka {
+template<typename... Ts>
+struct type_list {};
+
+template<typename... Requests>
+requires(
+  KafkaApiHandler<Requests>,
+  ...) using make_request_types = type_list<Requests...>;
+
+using request_types = make_request_types<
+  produce_handler,
+  fetch_handler,
+  list_offsets_handler,
+  metadata_handler,
+  offset_fetch_handler,
+  find_coordinator_handler,
+  list_groups_handler,
+  api_versions_handler,
+  join_group_handler,
+  heartbeat_handler,
+  leave_group_handler,
+  sync_group_handler,
+  create_topics_handler,
+  offset_commit_handler,
+  describe_configs_handler,
+  alter_configs_handler,
+  delete_topics_handler,
+  describe_groups_handler,
+  sasl_handshake_handler,
+  sasl_authenticate_handler,
+  incremental_alter_configs_handler,
+  delete_groups_handler,
+  describe_acls_handler,
+  describe_log_dirs_handler,
+  create_acls_handler,
+  delete_acls_handler,
+  init_producer_id_handler,
+  add_partitions_to_txn_handler,
+  txn_offset_commit_handler,
+  add_offsets_to_txn_handler,
+  end_txn_handler,
+  create_partitions_handler,
+  offset_for_leader_epoch_handler>;
+} // namespace kafka

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -41,7 +41,8 @@ parse_header(ss::input_stream<char>& src) {
 
     // There is a contradiction here with the proposed flexible header
     // introduced in KIP-482. The KIP details how client_id will be a compact
-    // string, however this is not the case
+    // string, however this is not the case:
+    // https://github.com/apache/kafka/pull/7479
     auto client_id_size = reader.read_int16();
     if (client_id_size == 0) {
         header.client_id = std::string_view();

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "kafka/server/flex_versions.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -37,8 +38,11 @@ parse_header(ss::input_stream<char>& src) {
     header.key = api_key(reader.read_int16());
     header.version = api_version(reader.read_int16());
     header.correlation = correlation_id(reader.read_int32());
-    auto client_id_size = reader.read_int16();
 
+    // There is a contradiction here with the proposed flexible header
+    // introduced in KIP-482. The KIP details how client_id will be a compact
+    // string, however this is not the case
+    auto client_id_size = reader.read_int16();
     if (client_id_size == 0) {
         header.client_id = std::string_view();
         co_return header;
@@ -64,7 +68,52 @@ parse_header(ss::input_stream<char>& src) {
     header.client_id = std::string_view(
       header.client_id_buffer.get(), header.client_id_buffer.size());
     validate_utf8(*header.client_id);
+
+    /// Conditionally handle v1 (flex) header
+    if (!flex_versions::is_api_in_schema(header.key)) {
+        /// User provided unsupported an invalid key that does not map
+        /// to any known kafka requests, code will throw when it eventually
+        /// reaches the request router
+    } else if (flex_versions::is_flexible_request(header.key, header.version)) {
+        auto [tags, bytes_read] = co_await parse_tags(src);
+        header.tags = std::move(tags);
+        header.tags_size_bytes = bytes_read;
+    }
     co_return header;
+}
+
+ss::future<std::pair<std::optional<tagged_fields>, size_t>>
+parse_tags(ss::input_stream<char>& src) {
+    size_t total_bytes_read = 0;
+    auto read_unsigned_vint =
+      [](size_t& total_bytes_read, ss::input_stream<char>& src) {
+          return unsigned_vint::stream_deserialize(src).then(
+            [&total_bytes_read](std::pair<uint32_t, size_t> pair) {
+                auto& [n, bytes_read] = pair;
+                total_bytes_read += bytes_read;
+                return n;
+            });
+      };
+
+    auto num_tags = co_await read_unsigned_vint(total_bytes_read, src);
+    if (num_tags == 0) {
+        /// In the likely event that no tags are parsed as headers, return
+        /// nullopt instead of an empty vector to reduce the memory overhead
+        /// (that will never be used) per request
+        co_return std::make_pair(std::nullopt, total_bytes_read);
+    }
+
+    tagged_fields tags;
+    while (num_tags-- > 0) {
+        auto tag_id = co_await read_unsigned_vint(total_bytes_read, src);
+        auto next_len = co_await read_unsigned_vint(total_bytes_read, src);
+        auto buf = co_await src.read_exactly(next_len);
+        iobuf data;
+        data.append(std::move(buf));
+        total_bytes_read += next_len;
+        tags.emplace_back(tag_id, std::move(data));
+    }
+    co_return std::make_pair(std::move(tags), total_bytes_read);
 }
 
 size_t parse_size_buffer(ss::temporary_buffer<char> buf) {

--- a/src/v/kafka/server/protocol_utils.h
+++ b/src/v/kafka/server/protocol_utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/protocol/types.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "kafka/types.h"
@@ -22,6 +23,9 @@
 #include <optional>
 
 namespace kafka {
+
+ss::future<std::pair<std::optional<tagged_fields>, size_t>>
+parse_tags(ss::input_stream<char>&);
 
 // TODO: move to iobuf_parser
 ss::future<std::optional<request_header>> parse_header(ss::input_stream<char>&);

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -14,6 +14,7 @@
 #include "cluster/security_frontend.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/protocol/request_reader.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/logger.h"
@@ -44,6 +45,13 @@ struct request_header {
     correlation_id correlation;
     ss::temporary_buffer<char> client_id_buffer;
     std::optional<std::string_view> client_id;
+
+    // value of std::nullopt indicates v0 request was parsed, 0 tag bytes will
+    // be parsed. If this is non-null a v1 (flex) request header is parsed in
+    // which the min number of bytes parsed must be at least 1.
+    std::optional<tagged_fields> tags;
+    size_t tags_size_bytes{0};
+    bool is_flexible() const { return tags_size_bytes > 0; }
 
     friend std::ostream& operator<<(std::ostream&, const request_header&);
 };

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -158,7 +158,7 @@ public:
           ResponseType::api_type::key,
           ResponseType::api_type::name,
           r);
-        auto resp = std::make_unique<response>();
+        auto resp = std::make_unique<response>(header().is_flexible());
         r.encode(resp->writer(), header().version);
         return ss::make_ready_future<response_ptr>(std::move(resp));
     }

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -342,11 +342,14 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
 std::ostream& operator<<(std::ostream& os, const request_header& header) {
     fmt::print(
       os,
-      "{{key:{}, version:{}, correlation_id:{}, client_id:{}}}",
+      "{{key:{}, version:{}, correlation_id:{}, client_id:{}, "
+      "number_of_tagged_fields: {}, tags_size_bytes:{}}}",
       header.key,
       header.version,
       header.correlation,
-      header.client_id.value_or(std::string_view("nullopt")));
+      header.client_id.value_or(std::string_view("nullopt")),
+      (header.tags ? header.tags->size() : 0),
+      header.tags_size_bytes);
     return os;
 }
 

--- a/src/v/kafka/server/response.h
+++ b/src/v/kafka/server/response.h
@@ -25,8 +25,9 @@ namespace kafka {
 
 class response {
 public:
-    response() noexcept
-      : _writer(_buf) {}
+    explicit response(bool flexible) noexcept
+      : _flexible(flexible)
+      , _writer(_buf) {}
 
     response_writer& writer() { return _writer; }
 
@@ -36,6 +37,12 @@ public:
 
     correlation_id correlation() const { return _correlation; }
     void set_correlation(correlation_id c) { _correlation = c; }
+
+    bool is_flexible() const { return _flexible; }
+
+    /// Currently unused
+    const std::optional<tagged_fields>& tags() const { return _tags; }
+    std::optional<tagged_fields>& tags() { return _tags; }
 
     /*
      * Marking a response as a noop means that it will be processed like any
@@ -49,6 +56,8 @@ public:
 private:
     bool _noop{false};
     correlation_id _correlation;
+    bool _flexible{false};
+    std::optional<tagged_fields> _tags;
     iobuf _buf;
     response_writer _writer;
 };

--- a/src/v/kafka/server/tests/api_versions_test.cc
+++ b/src/v/kafka/server/tests/api_versions_test.cc
@@ -18,23 +18,20 @@
 
 // https://github.com/apache/kafka/blob/eaccb92/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
 
-// version 3 is not supported
-#if 0
 FIXTURE_TEST(validate_latest_version, redpanda_thread_fixture) {
     auto client = make_kafka_client().get0();
     client.connect().get();
 
     kafka::api_versions_request request;
-    request.client_software_name = "name";
-    request.client_software_version = "version";
-    auto response = client.dispatch(request).get0();
-    BOOST_TEST(response.error == kafka::error_code::none);
+    request.data.client_software_name = "redpanda";
+    request.data.client_software_version = "x.x.x";
+    auto response = client.dispatch(request, kafka::api_version(3)).get0();
+    BOOST_TEST(response.data.error_code == kafka::error_code::none);
     client.stop().then([&client] { client.shutdown(); }).get();
 
     auto expected = kafka::get_supported_apis();
-    BOOST_TEST(response.apis == expected);
+    BOOST_TEST(response.data.api_keys == expected);
 }
-#endif
 
 FIXTURE_TEST(validate_v0, redpanda_thread_fixture) {
     auto client = make_kafka_client().get0();
@@ -48,21 +45,6 @@ FIXTURE_TEST(validate_v0, redpanda_thread_fixture) {
     auto expected = kafka::get_supported_apis();
     BOOST_TEST(response.data.api_keys == expected);
 }
-
-// version 3 is not supported
-#if 0
-FIXTURE_TEST(validate_v3, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
-    client.connect().get();
-
-    kafka::api_versions_request request;
-    auto response = client.dispatch(request, kafka::api_version(3)).get0();
-    client.stop().then([&client] { client.shutdown(); }).get();
-
-    // invalid since name/version are empty in the request
-    BOOST_TEST(response.error == kafka::error_code::invalid_request);
-}
-#endif
 
 FIXTURE_TEST(unsupported_version, redpanda_thread_fixture) {
     auto client = make_kafka_client().get0();

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -64,7 +64,8 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                   std::optional<kafka::request_header> oheader) {
                     auto header = std::move(oheader.value());
                     auto remaining = size - kafka::request_header_size
-                                     - header.client_id_buffer.size();
+                                     - header.client_id_buffer.size()
+                                     - header.tags_size_bytes;
                     /*
                      * read the request body
                      */

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     file_io.cc
     base64.cc
     retry_chain_node.cc
+    vint.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/tests/vint_test.cc
+++ b/src/v/utils/tests/vint_test.cc
@@ -31,8 +31,21 @@ void check_roundtrip_sweep(int64_t count) {
     }
 }
 
+void check_roundtrip_sweep_unsigned(const uint64_t count) {
+    for (uint64_t i = 0; i < count; i += 100000) {
+        const auto b = unsigned_vint::to_bytes(i);
+        const auto view = bytes_view(b);
+        const auto [deserialized, _] = unsigned_vint::deserialize(view);
+        BOOST_REQUIRE_EQUAL(deserialized, i);
+    }
+}
+
 } // namespace
 
 SEASTAR_THREAD_TEST_CASE(sanity_signed_sweep_64) {
     check_roundtrip_sweep(100000000);
+}
+
+SEASTAR_THREAD_TEST_CASE(sanity_unsigned_sweep_32) {
+    check_roundtrip_sweep_unsigned(100000000);
 }

--- a/src/v/utils/vint.cc
+++ b/src/v/utils/vint.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/vint.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace unsigned_vint {
+
+ss::future<std::pair<uint32_t, size_t>>
+stream_deserialize(ss::input_stream<char>& s) {
+    /// Consume up to 5 iterations (0-4) of reading 7 bits each time
+    constexpr auto limit = ((max_length - 1) * 7);
+    detail::var_decoder decoder(limit);
+    while (!s.eof()) {
+        auto buf = co_await s.read_exactly(1);
+        if (buf.empty() || decoder.accept(static_cast<uint8_t>(buf[0]))) {
+            break;
+        }
+    }
+    co_return std::make_pair(
+      static_cast<uint32_t>(decoder.result), decoder.bytes_read);
+}
+
+} // namespace unsigned_vint


### PR DESCRIPTION
This pull request adds support to encode and decode flexible requests. This change is necessitated by the fact that we are prevented from implementing features that are part of a Kafka API that is ahead of the first version for which flex was introduced for it. Below is a small write up of the three core issues to solve and my approaches to solving them.

## What is the flexible request format?

What is here described as `flex` means the following criterion must be followed for requests that have a version that surpasses the listed `flexibleVersion` value in its respective schema file. Redpanda must:
1. Encode & decode all strings and arrays as prefixed with unsigned variable length integers
2. Optional tag fields may exist after each structure. These also are prefixed with unsigned variable length integers and any of the subtypes that they may contain as well.
3. Tags may also be present in request and response headers. 

## Knowing when to parse a request as `flexible`

In this following example:
```
{
  "apiKey": 2,
  "type": "request",
  "name": "ListOffsetRequest",
  "validVersions": "0-5",
  "flexibleVersions": "6+",
...
```

If an incoming `ListOffsetRequest` contains a value of `6` or higher as its version, the request is to be parsed using the flex format.

To know when to interpret a request as `flexible`, redpanda, must know for each API what the first `flexibleVersion` is. To solve this problem it will now be necessary for developers to maintain the `min_flex_version` within the `kafka::handler` for each KafkaRequest type. Just how they do now with min/max version numbers. The compile time list will be exposed through a simple interface like the following: 

`flex_versions.h`
```
namespace kafka {
class flex_versions {
public:
    static bool is_flexible_request(api_key key, api_version version)
    static constexpr bool is_api_in_schema(api_key key) noexcept;
};
```

## Parsing a flexible request

Secondly the code generator must produce flex aware code. This means two things:

1. strings and arrays must be treated as COMPACT_* or flexible* strings and arrays.
2. optional tags may now exist after each structure in the schema

Flexible strings and arrays are structures which are prefixed with an unsigned variable length integer instead of a fixed length one to denote their sizes.

### Design decision on how to parse new flex structures

To make the conditional of when to parse a string/array as flex or non-flex two designs were discussed:

1. Make request_reader/writer an abstract class with two implementations, one for flex requests and another for non-flex.
2. Have our generator generate different stubs for flex methods such as `write_flex_string()` instead of `write_string()`

Method number two was chosen after some discussion, the main points being that our request reader and writer class should not be version dependent. They are agnostic to this currently and only simply know how to encode/decode all types that the protocol allows. We decided to keep this property.

Therefore the code generator was modified to introduce these new stubs. The resulting generated code looks something like this:

`join_group_request.h`
```
struct join_group_request_data {
...
    void encode(response_writer&, api_version);
    void decode(request_reader&, api_version);

...
private:
    void encode_flex(response_writer&, api_version);
    void encode_pre_flex(response_writer&, api_version);
    void decode_flex(request_reader&, api_version);
    void decode_pre_flex(request_reader&, api_version);
};
```

`join_group_request.cc`
```
void join_group_request_data::encode(response_writer& writer, api_version version) {
    if (version >= api_version(6)) {
        encode_flex(writer, version);
    } else {
        encode_pre_flex(writer, version);
    }
}
...
```

Before the actual parsing of each request a flex version conditional will be performed. If this is false, the generator should produce code that is identical to the code produced by the generator today.

A small optimization is performed here as not to populate the generated code with redundant conditionals, i.e. in the example
above it wouldn't make sense to generate code that is guarded by checks for versions `>= 6` since that was already performed. Similarly version checks `>` the flex version would make no sense within `encode_pre_flex`.

Finally the generator adds stubs to encode/decode tags after each structure:
```
...
    writer.write_flex_array(protocols, [version](join_group_request_protocol& v, response_writer& writer) {
        writer.write_flex(v.name);
        writer.write_flex(v.metadata);
        writer.write_tags();
    });
...
```

### Parsing flexible request headers / Making a flexible response

The final component is to support tags within request and response headers. The KIP mentions how requests that are interpreted as flex must expect tags within the request and response headers. Currently these will be unused but they must be parsed either way.

## Testing strategy

My plan is to bump to version of one request to beyond its flexible request limit. I chose `api_versions_request` since it is simple and has some special edge cases that need to be dealt with.

Our kafka client has been updated to be flex aware as well, and unit tests for this request have been checked in that are working with flex.

However I'm also considering bumping another request beyond flex. I'm not sure if kafka clients within our ducktape infra will hit `api_versions_request` at 3 or greater, since it is the request that one uses to determine the list of all supported requests, clients are free to choose any value for request version here.  

## Caveats

The generator hasn't been fully updated to understand the tag schema. Even though it generates the correct code, if we update the schemas to the head of what exists in kafka the generator will fail to understand the schema, since tags can have any kind
of type.

I am purposely kicking this problem down the road as we don't currently intend to turn on flex for every API all at once and it doesn't stop the core implementation (this PR) from working anyway. My small work around was to check-in a change that
fills in the `flexibleVersions` field for each request. Currently many of these are populated with `none` as the value.

## Release notes

- Bump supported version of `api_versions_request` and `api_versions_response` to `3`.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/60daa0e70f6f6e9760672a2461ae3b232cf5afab..6f59d472d12f4afa31a9cc53c48bed051d7781d5)
- Addressed self feedback about genericising `deserialize` method via Travis' suggestion

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/6f59d472d12f4afa31a9cc53c48bed051d7781d5..0b1bb9088528b0ce4c721badccbef0ca4d138cf6)
- Rebased against dev

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/0b1bb9088528b0ce4c721badccbef0ca4d138cf6..7e90a67e6a540722fd227565cf097824b4e93b5a)
- Fixed a bug where incorrectly genned flex code was causing ducktape tests to fail
- Fixed a bug where incorrect size was used in the response header
- Fixed a bug with write_tags() where tags were written in reverse
- Add read/write tags() to compliment ingest/consume
- Removed unused source added in previous revisions of this PR to `generator.py`
- Added unit tests for serializing and deserializing all flexible types

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/7e90a67e6a540722fd227565cf097824b4e93b5a..e8e84a3c052f095a5c27eea819962db161144295)
- Enhanced assert messages in api schema version checks
- Modified the flex code generator to handle a case where an API can never support flex (only 1 request does this SaslHandShakeRequest)
- Enhanced generated C++ flex code to perform bounds checking on flex array mapping so exceptions cannot occur.
- Fixed a bug in generator where flex code was generated instead of non-flex code in stubs that took an `iobuf` as the parameter
- Got rid of magic numbers in `vint.h`
- Added a test for the vint streaming deserializer

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/e8e84a3c052f095a5c27eea819962db161144295..f9bf21e68ff5914866dfa480ad5f18d3a1166f2a)
- Small one line change to fix python generated flex code in convenience function `is_flexible_request`.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/f9bf21e68ff5914866dfa480ad5f18d3a1166f2a..b23e2603de1993ed8cd13186536ebd8557fa204b)
- Adding bounds checks for deserializing arrays < 0
- Tagging `is_api_in_schema` method as `noexcept`
- Renaming `deserialize` overload to `stream_deserialize` and moving it into a source file to avoid odd compiler output

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/b23e2603de1993ed8cd13186536ebd8557fa204b..d627e21d06d55758942cb8354dbacbc7d7462268)
- Rebased dev to resolve small conflict of new test source file declaration in `src/v/kafka/protocol/tests/CMakeLists.txt`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/d627e21d06d55758942cb8354dbacbc7d7462268..25d39492b08cb2c59d3f826379c1637cad310705)
- Prevent vint test from timing out by reducing the problem set size

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/25d39492b08cb2c59d3f826379c1637cad310705..9c168818264c2f72fc3314d801597d93e3a624a7)
- Removing unnecessary label from utils test binary which was causing buildkite unit test failures

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/9c168818264c2f72fc3314d801597d93e3a624a7..b55677ac26d06076f54d247fd20f0b03bc3f52a1)
- Remove some code duplication in `generator.py`
- Fix bug where tags were written/consumed after arrays
- Fix issue with version omission enhancement, requests that == first flex version had unnecessary conditionals in generated code

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/b55677ac26d06076f54d247fd20f0b03bc3f52a1..97982428945c15929372fb6abfc1e162b0270824)
- Took Noah's advice to not modify schema files if they don't need to be (with the exception of APIVersionsRequest/Response) as that version is being bumped.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/97982428945c15929372fb6abfc1e162b0270824..6f84759db547554ff7137ad83c6c6f728ab4e09e)
- Rebased dev to resolve a small conflict in `request_context.h`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/6f84759db547554ff7137ad83c6c6f728ab4e09e..54612a613b6a5c00d6a1720d0480fe8329981d68)
- Fixed bug introduced by previous force push, generator must be aware of flexVersions equal to none in a smarter way. 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/54612a613b6a5c00d6a1720d0480fe8329981d68..cad0ad5829cbaeac293cddc618f16be2c6c2d5c6)
- Removed unused methods and mvars in generator.py

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/cad0ad5829cbaeac293cddc618f16be2c6c2d5c6..5a35e798680887a1c106c08b9c0120c31880684e)
- Fixed a bug where tags were not being serialized in responses. CI was green because API versions request is the only supported flex request as per this PR and it doesn't return flex responses.
- Edited the flex version generator to not generate a python flex versions file. It is not needed because `generator.py` has access to the first flex version for the API that it generates code for.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/5a35e798680887a1c106c08b9c0120c31880684e..d2c67679aa55d21734d465467dab63978344e2ee)
- Fixed a bug only prevelent when experimenting with versions we haven't yet bumped to flex. It occurred field version is fixed like `version:0`, and led to flex versions serializing this field instead of omitting it.
- Implemented Andrews suggestions, nits and better randomization of generated fields in test

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/d2c67679aa55d21734d465467dab63978344e2ee..8db03c1278c42b2627a5777233596d04ab17ed4f)
- Fixed a bug where serialization and deserialization of tag headers was incorrect. Size field was being decremented by 1

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/8db03c1278c42b2627a5777233596d04ab17ed4f..44833363f4a1bc70312216b901658b51922fd19a)
- Rebased dev to resolve conflict in `generator.py`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/19b63b5c2176aee19b04430c148c51cb591058bf..897eb4b8a263b5c28d318e417203f0ed67e91c8a)
- Fixed bug with not sending responses as flexible
- Modified generated code to perform unbounded array access instead of calling `at(n)` when checking if request is flexible

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2a243c909c44f80a608c3aad7754e7aa3d0b835e..4fbe20a1134de459236715d1d57e56091690b4d8)
- Dropped generating first flex versions source file in favor of creating compile time list depending on manual edits of the correct first flex version for each request, sort of how min/max version currently works