### PR TITLE
rpk: remove base58 encoding to node.uuid to avoid confusion

### DIFF
--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -277,7 +277,7 @@ func (m *manager) WriteNodeUUID(conf *Config) error {
 	if err != nil {
 		return err
 	}
-	conf.NodeUuid = base58Encode(id.String())
+	conf.NodeUuid = id.String()
 	return m.Write(conf)
 }
 


### PR DESCRIPTION
## Cover letter

Remove base58 encoding to node_uuid parameter in config file to avoid confusion.

Fixes #4458 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
