### PR TITLE
test: make docker-compose compatible with v2

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - '9000'
     healthcheck:
       interval: 30s
-      retries: '3'
+      retries: 3
       test:
       - CMD
       - curl
@@ -28,7 +28,7 @@ services:
     image: minio/minio:RELEASE.2021-03-26T00-00-41Z
     networks:
     - redpanda-test
-  n:
+  rp:
     image: vectorized/redpanda-test-node
     privileged: true
     pids_limit: 32768

--- a/tests/docker/ducktape_cluster.json.j2
+++ b/tests/docker/ducktape_cluster.json.j2
@@ -2,10 +2,10 @@
     "nodes": [
 {% for node_id in range(1, scale + 1) %}
         {
-            "externally_routable_ip": "docker_n_{{node_id}}",
+            "externally_routable_ip": "docker-rp-{{node_id}}",
             "ssh_config": {
-                "host": "docker_n_{{node_id}}",
-                "hostname": "docker_n_{{node_id}}",
+                "host": "docker-rp-{{node_id}}",
+                "hostname": "docker-rp-{{node_id}}",
                 "identityfile": "/root/.ssh/id_rsa",
                 "password": "UNUSED",
                 "port": 22,


### PR DESCRIPTION
## Cover letter

CI for this PR won't work until https://github.com/redpanda-data/vtools/pull/625 in vtools merges. But you can visit that vtools PR to see CI passing this change.

--

we have been using docker-compose v1 which names containers with
underscores (e.g. docker_n_3). this is problematic because underscore
is not a valid character in hostnames (but ok is domain names). much of
our ducktape infra and networking with docker compose assumes that these
container names are also routable hostnames. this has been fine--i think
many things are forgiving--but when i began to experiment with SSL
inside our ducktape docker environment i encountered more strictness.

Here is seastar complaining about the host names:

   INFO  2022-05-01 23:41:16,883 [shard 0] kafka - protocol.cc:123 -
   172.18.0.11:49754 errored, proto: kafka rpc protocol, sasl state:
       initial - std::__1::system_error (error GnuTLS:-82, A disallowed
       SNI server name has been received.)

in docker-compose v2 naming uses dashes by default instead of
underscores.

this pr makes changes necessary to support v2 of docker-compose, and
updates with the naming changes.

oddly, there were errors complaining that the `n` service name was
numeric.  changed this to `rp` after investigating for some time with no
apparent root cause. other changes were related to fields needing to be
integers.

## Release notes

* none
