### PR TITLE
Wait for offset to be committed in linearizable barrier

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -323,7 +323,8 @@ ss::future<> members_backend::reconcile() {
 
     // use linearizable barrier to make sure leader is up to date and all
     // changes are applied
-    auto barrier_result = co_await _raft0->linearizable_barrier();
+    auto barrier_result = co_await _raft0->linearizable_barrier(
+      model::timeout_clock::now() + _retry_timeout);
     if (
       barrier_result.has_error()
       || barrier_result.value() < _raft0->dirty_offset()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -143,8 +143,9 @@ public:
     void block_new_leadership() const { _raft->block_new_leadership(); }
     void unblock_new_leadership() const { _raft->unblock_new_leadership(); }
 
-    ss::future<result<model::offset>> linearizable_barrier() {
-        return _raft->linearizable_barrier();
+    ss::future<result<model::offset>>
+    linearizable_barrier(model::timeout_clock::time_point deadline) {
+        return _raft->linearizable_barrier(deadline);
     }
 
     ss::future<std::error_code>

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -216,7 +216,8 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      * after a short delay to account for transient issues on startup.
      */
     if (_need_controller_refresh) {
-        auto res = co_await _raft0->linearizable_barrier();
+        auto res = co_await _raft0->linearizable_barrier(
+          leader_transfer_rpc_timeout + model::timeout_clock::now());
         if (!res) {
             vlog(
               clusterlog.debug,

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -643,7 +643,7 @@ ss::future<std::error_code> topics_frontend::finish_moving_partition_replicas(
 ss::future<result<model::offset>> topics_frontend::stm_linearizable_barrier(
   model::timeout_clock::time_point timeout) {
     return _stm.invoke_on(controller_stm_shard, [timeout](controller_stm& stm) {
-        return stm.instert_linerizable_barrier(timeout);
+        return stm.instert_linearizable_barrier(timeout);
     });
 }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -270,12 +270,12 @@ ss::future<> group_manager::inject_noop(
   ss::lw_shared_ptr<cluster::partition> p,
   [[maybe_unused]] ss::lowres_clock::time_point timeout) {
     auto dirty_offset = p->dirty_offset();
-    auto barrier_offset = co_await p->linearizable_barrier();
+    auto barrier_offset = co_await p->linearizable_barrier(timeout);
     // synchronization provided by raft after future resolves is sufficient to
     // get an up-to-date commit offset as an upperbound for our reader.
     while (barrier_offset.has_value()
            && barrier_offset.value() < dirty_offset) {
-        barrier_offset = co_await p->linearizable_barrier();
+        barrier_offset = co_await p->linearizable_barrier(timeout);
     }
 }
 

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -52,9 +52,11 @@ public:
         return _partition->get_term_last_offset(model::term_id(epoch()));
     }
 
-    ss::future<std::error_code> linearizable_barrier() final {
-        return _partition->source_partition()->linearizable_barrier().then(
-          [](result<model::offset> r) {
+    ss::future<std::error_code>
+    linearizable_barrier(model::timeout_clock::time_point deadline) final {
+        return _partition->source_partition()
+          ->linearizable_barrier(deadline)
+          .then([](result<model::offset> r) {
               if (r) {
                   return raft::make_error_code(raft::errc::success);
               }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -38,7 +38,8 @@ public:
         virtual std::optional<model::offset>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
         virtual bool is_leader() const = 0;
-        virtual ss::future<std::error_code> linearizable_barrier() = 0;
+        virtual ss::future<std::error_code>
+          linearizable_barrier(model::timeout_clock::time_point) = 0;
         virtual ss::future<storage::translating_reader> make_reader(
           storage::log_reader_config,
           std::optional<model::timeout_clock::time_point>)
@@ -66,8 +67,9 @@ public:
         return _impl->last_stable_offset();
     }
 
-    ss::future<std::error_code> linearizable_barrier() {
-        return _impl->linearizable_barrier();
+    ss::future<std::error_code>
+    linearizable_barrier(model::timeout_clock::time_point deadline) {
+        return _impl->linearizable_barrier(deadline);
     }
 
     bool is_leader() const { return _impl->is_leader(); }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -57,8 +57,9 @@ public:
 
     bool is_leader() const final { return _partition->is_leader(); }
 
-    ss::future<std::error_code> linearizable_barrier() final {
-        auto r = co_await _partition->linearizable_barrier();
+    ss::future<std::error_code>
+    linearizable_barrier(model::timeout_clock::time_point timeout) final {
+        auto r = co_await _partition->linearizable_barrier(timeout);
         if (r) {
             co_return raft::errc::success;
         }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -141,7 +141,8 @@ public:
      * updated their commit indices to at least reaturned offset). For more
      * details see paragraph 6.4 of Raft protocol dissertation.
      */
-    ss::future<result<model::offset>> linearizable_barrier();
+    ss::future<result<model::offset>>
+      linearizable_barrier(model::timeout_clock::time_point);
 
     vnode self() const { return _self; }
     protocol_metadata meta() const;
@@ -536,7 +537,7 @@ private:
         }
         return false;
     }
-    ss::future<std::error_code> do_liearizable_barrier();
+    ss::future<std::error_code> do_liearizable_barrier(clock_type::time_point);
 
     // args
     vnode _self;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -536,6 +536,8 @@ private:
         }
         return false;
     }
+    ss::future<std::error_code> do_liearizable_barrier();
+
     // args
     vnode _self;
     raft::group_id _group;

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -144,7 +144,7 @@ ss::future<> state_machine::write_last_applied(model::offset o) {
     return _raft->write_last_applied(o);
 }
 
-ss::future<result<model::offset>> state_machine::instert_linerizable_barrier(
+ss::future<result<model::offset>> state_machine::instert_linearizable_barrier(
   model::timeout_clock::time_point timeout) {
     return ss::with_timeout(timeout, _raft->linearizable_barrier())
       .handle_exception_type([](const ss::timed_out_error&) {

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -146,10 +146,7 @@ ss::future<> state_machine::write_last_applied(model::offset o) {
 
 ss::future<result<model::offset>> state_machine::instert_linearizable_barrier(
   model::timeout_clock::time_point timeout) {
-    return ss::with_timeout(timeout, _raft->linearizable_barrier())
-      .handle_exception_type([](const ss::timed_out_error&) {
-          return result<model::offset>(errc::timeout);
-      });
+    return _raft->linearizable_barrier(timeout);
 }
 
 } // namespace raft

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -100,7 +100,7 @@ public:
      * details see paragraph 6.4 of Raft protocol dissertation.
      */
     ss::future<result<model::offset>>
-      instert_linerizable_barrier(model::timeout_clock::time_point);
+      instert_linearizable_barrier(model::timeout_clock::time_point);
 
 protected:
     void set_next(model::offset offset);

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -738,7 +738,9 @@ FIXTURE_TEST(test_linarizable_barrier, raft_test_fixture) {
 
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
-    auto r = leader_raft->linearizable_barrier().get();
+    auto r = leader_raft
+               ->linearizable_barrier(model::timeout_clock::now() + 30s)
+               .get();
     BOOST_REQUIRE(leader_raft->committed_offset() >= r.value());
     BOOST_REQUIRE_EQUAL(
       leader_raft->committed_offset(), leader_raft->dirty_offset());
@@ -757,7 +759,9 @@ FIXTURE_TEST(test_linarizable_barrier_leader_ack, raft_test_fixture) {
 
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
-    auto r = leader_raft->linearizable_barrier().get();
+    auto r = leader_raft
+               ->linearizable_barrier(model::timeout_clock::now() + 30s)
+               .get();
 
     BOOST_REQUIRE(leader_raft->committed_offset() >= r.value());
     BOOST_REQUIRE_EQUAL(
@@ -775,7 +779,9 @@ FIXTURE_TEST(test_linarizable_barrier_single_node, raft_test_fixture) {
 
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
-    auto r = leader_raft->linearizable_barrier().get();
+    auto r = leader_raft
+               ->linearizable_barrier(model::timeout_clock::now() + 30s)
+               .get();
 
     if (r) {
         auto logs = gr.read_all_logs();


### PR DESCRIPTION
Since Redpanda's raft implementation must support relaxed consistency
writes we must wait for dirty offset to be committed when setting
linearizable barrier. Otherwise the barrier would not guarantee
linearizability.

Fixes: #4518