### PR TITLE
[v22.1.x] tests: shrink default ResourceSettings to 2 core + 2GB RAM

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -184,8 +184,9 @@ class ResourceSettings:
     as test nodes.
     """
 
-    DEFAULT_NUM_CPUS = 3
-    DEFAULT_MEMORY_MB = 3096
+    DEFAULT_NUM_CPUS = 2
+    # Redpanda's default limit on memory per shard is 1GB
+    DEFAULT_MEMORY_MB = 2048
 
     def __init__(self,
                  *,
@@ -193,7 +194,6 @@ class ResourceSettings:
                  memory_mb: Optional[int] = None,
                  bypass_fsync: Optional[bool] = None,
                  nfiles: Optional[int] = None):
-
         self._num_cpus = num_cpus
         self._memory_mb = memory_mb
 
@@ -224,8 +224,6 @@ class ResourceSettings:
             num_cpus = self._num_cpus
 
         if self._memory_mb is None and not dedicated_node:
-            # Redpanda's default limit on memory per shard
-            # is 1GB
             memory_mb = self.DEFAULT_MEMORY_MB
         else:
             memory_mb = self._memory_mb


### PR DESCRIPTION
The previous shrink to 3GB helped a lot with reactor
stalls on ARM, but it wasn't enough to eliminate it
entirely.

C6g instances only have 1.5Gof RAM per core, so we're
still a little oversubscribed, but 2 cores + 2GB is
kind of our lowest sane bound (need at least 2 cores
to test concurrency issues, need at least 1GB RAM per
core to be within a supported configuration)

Related: https://buildkite.com/redpanda/redpanda/builds/9253#bdc15873-a3cb-455c-b0ae-5b74ca4c93b0
(cherry picked from commit 81ae403e892a844a98ce85a73d2a2eabb9d33fea)

