### PR TITLE
cluster: fix disabling leader balancer at runtime

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -156,6 +156,7 @@ void leader_balancer::trigger_balance() {
         vlog(
           clusterlog.info, "Cannot start rebalance until previous fiber exits");
         _timer.arm(_idle_timeout());
+        return;
     }
 
     if (!_enabled()) {
@@ -187,6 +188,10 @@ void leader_balancer::trigger_balance() {
 }
 
 ss::future<ss::stop_iteration> leader_balancer::balance() {
+    if (!_enabled()) {
+        co_return ss::stop_iteration::yes;
+    }
+
     /*
      * GC the muted and last leader indices
      */


### PR DESCRIPTION
## Cover letter

Previously, the ss::repeat loop would keep running
and eventually re-arm the timer when it ran out
of work, if it was running while enable_leader_balancer
was set to false.

Also fix the check for a background fiber in trigger_rebalance:
this check was meant to skip scheduling another background
task, but was actually proceeding to do so.

Fixes #4544

## Release notes

* none