### PR TITLE
[v22.1.x] ducktape: support TLS-enabled ducktape tests

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -563,3 +563,27 @@ class RpkTool:
                 self._sasl_mechanism,
             ]
         return flags
+
+    def acl_list(self):
+        """
+        Run `rpk acl list` and return the results.
+
+        If this client is not authorized to list ACLs then
+        ClusterAuthorizationError will be raised.
+
+        TODO: parse output into acl structures. currently ducktape tests lack
+        any structured representation of acls. however at the time of writing we
+        are interested only in an authz success/fail signal.
+        """
+        cmd = [
+            self._rpk_binary(),
+            "acl",
+            "list",
+        ] + self._kafka_conn_settings()
+
+        output = self._execute(cmd)
+
+        if "CLUSTER_AUTHORIZATION_FAILED" in output:
+            raise ClusterAuthorizationError("acl list")
+
+        return output

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -587,3 +587,20 @@ class RpkTool:
             raise ClusterAuthorizationError("acl list")
 
         return output
+
+    def acl_create_allow_cluster(self, username, op):
+        """
+        Add allow+describe+cluster ACL
+        """
+        cmd = [
+            self._rpk_binary(),
+            "acl",
+            "create",
+            "--allow-principal",
+            f"User:{username}",
+            "--operation",
+            op,
+            "--cluster",
+        ] + self._kafka_conn_settings()
+        output = self._execute(cmd)
+        return output

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -10,7 +10,9 @@
 import subprocess
 import re
 import typing
+from typing import Optional
 from ducktape.cluster.cluster import ClusterNode
+from rptest.services import tls
 
 DEFAULT_TIMEOUT = 30
 
@@ -107,11 +109,13 @@ class RpkTool:
                  redpanda,
                  username: str = None,
                  password: str = None,
-                 sasl_mechanism: str = None):
+                 sasl_mechanism: str = None,
+                 tls_cert: Optional[tls.Certificate] = None):
         self._redpanda = redpanda
         self._username = username
         self._password = password
         self._sasl_mechanism = sasl_mechanism
+        self._tls_cert = tls_cert
 
     def create_topic(self, topic, partitions=1, replicas=None, config=None):
         cmd = ["create", topic]
@@ -561,6 +565,15 @@ class RpkTool:
                 self._password,
                 "--sasl-mechanism",
                 self._sasl_mechanism,
+            ]
+        if self._tls_cert:
+            flags += [
+                "--tls-key",
+                self._tls_cert.key,
+                "--tls-cert",
+                self._tls_cert.crt,
+                "--tls-truststore",
+                self._tls_cert.ca.crt,
             ]
         return flags
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -34,6 +34,7 @@ from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.admin import Admin
 from rptest.clients.python_librdkafka import PythonLibrdkafka
+from rptest.services import tls
 
 Partition = collections.namedtuple('Partition',
                                    ['index', 'leader', 'replicas'])
@@ -351,9 +352,33 @@ class SISettings:
         return conf
 
 
+class TLSProvider:
+    """
+    Interface that RedpandaService uses to obtain TLS certificates.
+    """
+    @property
+    def ca(self) -> tls.CertificateAuthority:
+        raise NotImplementedError("ca")
+
+    def create_broker_cert(self, service: Service,
+                           node: ClusterNode) -> tls.Certificate:
+        """
+        Create a certificate for a broker.
+        """
+        raise NotImplementedError("create_broker_cert")
+
+    def create_service_client_cert(self, service: Service,
+                                   name: str) -> tls.Certificate:
+        """
+        Create a certificate for an internal service client.
+        """
+        raise NotImplementedError("create_service_client_cert")
+
+
 class SecurityConfig:
     def __init__(self):
         self.enable_sasl = False
+        self.tls_provider: Optional[TLSProvider] = None
 
 
 class RedpandaService(Service):
@@ -361,6 +386,9 @@ class RedpandaService(Service):
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
     CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
+    TLS_SERVER_KEY_FILE = "/etc/redpanda/server.key"
+    TLS_SERVER_CRT_FILE = "/etc/redpanda/server.crt"
+    TLS_CA_CRT_FILE = "/etc/redpanda/ca.crt"
     STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.log")
     BACKTRACE_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda_backtrace.log")
     WASM_STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT,
@@ -492,6 +520,9 @@ class RedpandaService(Service):
 
         self._saved_executable = False
 
+        self._tls_cert = None
+        self._init_tls()
+
     def set_environment(self, environment: dict[str, str]):
         self._environment = environment
 
@@ -507,6 +538,16 @@ class RedpandaService(Service):
 
     def set_security_settings(self, settings):
         self._security = settings
+        self._init_tls()
+
+    def _init_tls(self):
+        """
+        Call this if tls setting may have changed.
+        """
+        if self._security.tls_provider:
+            # build a cert for clients used internally to the service
+            self._tls_cert = self._security.tls_provider.create_service_client_cert(
+                self, "redpanda.service.admin")
 
     def sasl_enabled(self):
         return self._security.enable_sasl
@@ -571,6 +612,7 @@ class RedpandaService(Service):
                 raise
 
         if first_start:
+            self.write_tls_certs()
             self.write_bootstrap_cluster_config()
 
         for node in to_start:
@@ -612,6 +654,32 @@ class RedpandaService(Service):
 
         if self._si_settings is not None:
             self.start_si()
+
+    def write_tls_certs(self):
+        if not self._security.tls_provider:
+            return
+
+        ca = self._security.tls_provider.ca
+        for node in self.nodes:
+            cert = self._security.tls_provider.create_broker_cert(self, node)
+
+            self.logger.info(
+                f"Writing Redpanda node tls key file: {RedpandaService.TLS_SERVER_KEY_FILE}"
+            )
+            self.logger.debug(open(cert.key, "r").read())
+            node.account.copy_to(cert.key, RedpandaService.TLS_SERVER_KEY_FILE)
+
+            self.logger.info(
+                f"Writing Redpanda node tls cert file: {RedpandaService.TLS_SERVER_CRT_FILE}"
+            )
+            self.logger.debug(open(cert.crt, "r").read())
+            node.account.copy_to(cert.crt, RedpandaService.TLS_SERVER_CRT_FILE)
+
+            self.logger.info(
+                f"Writing Redpanda node tls ca cert file: {RedpandaService.TLS_CA_CRT_FILE}"
+            )
+            self.logger.debug(open(ca.crt, "r").read())
+            node.account.copy_to(ca.crt, RedpandaService.TLS_CA_CRT_FILE)
 
     def security_config(self):
         return self._security_config
@@ -1164,6 +1232,19 @@ class RedpandaService(Service):
                 doc["redpanda"].update(override_cfg_params)
             conf = yaml.dump(doc)
 
+        if self._security.tls_provider:
+            tls_config = dict(
+                enabled=True,
+                require_client_auth=True,
+                name="dnslistener",
+                key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+                cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+                truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+            )
+            doc = yaml.full_load(conf)
+            doc["redpanda"].update(dict(kafka_api_tls=tls_config))
+            conf = yaml.dump(doc)
+
         self.logger.info("Writing Redpanda node config file: {}".format(
             RedpandaService.NODE_CONFIG_FILE))
         self.logger.debug(conf)
@@ -1252,7 +1333,7 @@ class RedpandaService(Service):
                     f"registered: node {node.name} now visible in peer {peer.name}'s broker list ({admin_brokers})"
                 )
 
-        client = PythonLibrdkafka(self)
+        client = PythonLibrdkafka(self, tls_cert=self._tls_cert)
         brokers = client.brokers()
         broker = brokers.get(idx, None)
         if broker is None:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -351,6 +351,11 @@ class SISettings:
         return conf
 
 
+class SecurityConfig:
+    def __init__(self):
+        self.enable_sasl = False
+
+
 class RedpandaService(Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
@@ -434,13 +439,15 @@ class RedpandaService(Service):
                  resource_settings=None,
                  si_settings=None,
                  log_level: Optional[str] = None,
-                 environment: Optional[dict[str, str]] = None):
+                 environment: Optional[dict[str, str]] = None,
+                 security: SecurityConfig = SecurityConfig()):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._enable_rp = enable_rp
         self._extra_rp_conf = extra_rp_conf or dict()
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
+        self._security = security
 
         self._extra_node_conf = {}
         for node in self.nodes:
@@ -498,9 +505,11 @@ class RedpandaService(Service):
         assert node in self.nodes
         self._extra_node_conf[node] = conf
 
+    def set_security_settings(self, settings):
+        self._security = settings
+
     def sasl_enabled(self):
-        return self._extra_rp_conf and self._extra_rp_conf.get(
-            "enable_sasl", False)
+        return self._security.enable_sasl
 
     @property
     def dedicated_nodes(self):
@@ -1167,6 +1176,10 @@ class RedpandaService(Service):
                 "Setting custom cluster configuration options: {}".format(
                     self._extra_rp_conf))
             conf.update(self._extra_rp_conf)
+
+        if self._security.enable_sasl:
+            self.logger.debug("Enabling SASL in cluster configuration")
+            conf.update(dict(enable_sasl=True))
 
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -1,0 +1,162 @@
+import tempfile
+import typing
+import collections
+import pathlib
+import subprocess
+import os
+
+_ca_config_tmpl = """
+# OpenSSL CA configuration file
+[ ca ]
+default_ca = local_ca
+
+[ local_ca ]
+dir              = {dir}
+database         = $dir/index.txt
+serial           = $dir/serial.txt
+default_days     = 730
+default_md       = sha256
+copy_extensions  = copy
+unique_subject   = no
+
+# Used to create the CA certificate.
+[ req ]
+prompt             = no
+distinguished_name = distinguished_name
+x509_extensions    = extensions
+
+[ root_ca_distinguished_name ]
+commonName              = Test TLS CA
+stateOrProvinceName     = NY
+countryName             = US
+emailAddress            = hi@vectorized.io
+organizationName        = Redpanda
+organizationalUnitName  = Redpanda Test
+
+[ distinguished_name ]
+organizationName = Redpanda
+commonName       = Redpanda Test CA
+
+[ extensions ]
+keyUsage         = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+# Common policy for nodes and users.
+[ signing_policy ]
+organizationName = supplied
+commonName       = optional
+
+# Used to sign node certificates.
+[ signing_node_req ]
+keyUsage         = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth,clientAuth
+
+# Used to sign client certificates.
+[ signing_client_req ]
+keyUsage         = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth
+"""
+
+_node_config_tmpl = """
+# OpenSSL node configuration file
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = Redpanda
+{common_name}
+
+[ extensions ]
+subjectAltName = critical,DNS:{host}
+"""
+
+CertificateAuthority = collections.namedtuple("CertificateAuthority",
+                                              ["cfg", "key", "crt"])
+Certificate = collections.namedtuple("Certificate",
+                                     ["cfg", "key", "crt", "ca"])
+
+
+class TLSCertManager:
+    """
+    When a TLSCertManager is instantiated a new CA is automatically created and
+    certificates can be created immediately.
+
+    All of the generated files (keys, certs, etc...) are stored in a temporary
+    directory that will be deleted when the TLSCertManager is destroyed. Since
+    it is common for clients to take paths to these files, it is best to keep
+    the instance alive for as long as the files are in use.
+    """
+    def __init__(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self._ca = self._create_ca()
+        self.certs = {}
+
+    def _with_dir(self, name):
+        return os.path.join(self._dir.name, name)
+
+    def _exec(self, cmd):
+        subprocess.check_output(cmd.split(), cwd=self._dir.name)
+
+    def _create_ca(self):
+        cfg = self._with_dir("ca.conf")
+        key = self._with_dir("ca.key")
+        crt = self._with_dir("ca.crt")
+        idx = self._with_dir("index.txt")
+        srl = self._with_dir("serial.txt")
+
+        with open(f"{cfg}", "w") as f:
+            f.write(_ca_config_tmpl.format(dir=self._dir.name))
+
+        self._exec(f"openssl genrsa -out {key} 2048")
+
+        self._exec(f"openssl req -new -x509 -config {cfg} "
+                   f"-key {key} -out {crt} -days 365 -batch")
+
+        if os.path.exists(idx): os.remove(idx)
+        if os.path.exists(srl): os.remove(srl)
+        pathlib.Path(idx).touch()
+        with open(srl, "w") as f:
+            f.writelines(["01"])
+
+        return CertificateAuthority(cfg, key, crt)
+
+    @property
+    def ca(self):
+        return self._ca
+
+    def create_cert(self,
+                    host: str,
+                    *,
+                    common_name: typing.Optional[str] = None,
+                    name: typing.Optional[str] = None):
+        name = name or host
+        assert name not in self.certs, f"cert '{name}' already exists"
+
+        cfg = self._with_dir(f"{name}.conf")
+        key = self._with_dir(f"{name}.key")
+        csr = self._with_dir(f"{name}.csr")
+        crt = self._with_dir(f"{name}.crt")
+
+        with open(cfg, "w") as f:
+            if common_name is None:
+                common_name = ""
+            else:
+                common_name = f"commonName = {common_name}"
+            f.write(
+                _node_config_tmpl.format(host=host, common_name=common_name))
+
+        self._exec(f"openssl genrsa -out {key} 2048")
+
+        self._exec(f"openssl req -new -config {cfg} "
+                   f"-key {key} -out {csr} -batch")
+
+        self._exec(f"openssl ca -config {self.ca.cfg} -keyfile "
+                   f"{self.ca.key} -cert {self.ca.crt} -policy signing_policy "
+                   f"-extensions signing_node_req -in {csr} -out {crt} "
+                   f"-outdir {self._dir.name} -batch")
+
+        cert = Certificate(cfg, key, crt, self.ca)
+        self.certs[name] = cert
+        return cert

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -10,6 +10,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError
+from rptest.services.redpanda import SecurityConfig
 
 
 class AccessControlListTest(RedpandaTest):
@@ -17,11 +18,12 @@ class AccessControlListTest(RedpandaTest):
     algorithm = "SCRAM-SHA-256"
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(AccessControlListTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def get_client(self, username):

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -6,11 +6,30 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import socket
+from ducktape.mark import matrix
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError
-from rptest.services.redpanda import SecurityConfig
+from rptest.services.redpanda import SecurityConfig, TLSProvider
+from rptest.services import tls
+
+
+class MTLSProvider(TLSProvider):
+    def __init__(self, tls):
+        self.tls = tls
+
+    @property
+    def ca(self):
+        return self.tls.ca
+
+    def create_broker_cert(self, redpanda, node):
+        assert node in redpanda.nodes
+        return self.tls.create_cert(node.name)
+
+    def create_service_client_cert(self, _, name):
+        return self.tls.create_cert(socket.gethostname(), name=name)
 
 
 class AccessControlListTest(RedpandaTest):
@@ -18,26 +37,42 @@ class AccessControlListTest(RedpandaTest):
     algorithm = "SCRAM-SHA-256"
 
     def __init__(self, test_context):
-        security = SecurityConfig()
-        security.enable_sasl = True
-        super(AccessControlListTest,
-              self).__init__(test_context,
-                             num_brokers=3,
-                             security=security,
-                             extra_node_conf={'developer_mode': True})
+        self.security = SecurityConfig()
+        self.security.enable_sasl = True
+        super(AccessControlListTest, self).__init__(test_context,
+                                                    num_brokers=3,
+                                                    security=self.security)
+
+    def setUp(self):
+        # Skip starting redpanda, so that test can explicitly start
+        # it with custom security settings
+        return
+
+    def _start_redpanda(self, use_tls):
+        if use_tls:
+            self.tls = tls.TLSCertManager()
+            self.cert = self.tls.create_cert(socket.gethostname(),
+                                             name="client")
+            self.security.tls_provider = MTLSProvider(self.tls)
+            self.redpanda.set_security_settings(self.security)
+        else:
+            self.cert = None
+        self.redpanda.start()
 
     def get_client(self, username):
         return RpkTool(self.redpanda,
                        username=username,
                        password=self.password,
-                       sasl_mechanism=self.algorithm)
+                       sasl_mechanism=self.algorithm,
+                       tls_cert=self.cert)
 
     def get_super_client(self):
         username, password, _ = self.redpanda.SUPERUSER_CREDENTIALS
         return RpkTool(self.redpanda,
                        username=username,
                        password=password,
-                       sasl_mechanism=self.algorithm)
+                       sasl_mechanism=self.algorithm,
+                       tls_cert=self.cert)
 
     def prepare_users(self):
         """
@@ -56,10 +91,12 @@ class AccessControlListTest(RedpandaTest):
         client.acl_create_allow_cluster("cluster_describe", "describe")
 
     @cluster(num_nodes=3)
-    def test_describe_acls(self):
+    @matrix(use_tls=[True, False])
+    def test_describe_acls(self, use_tls):
         """
         security::acl_operation::describe, security::default_cluster_name
         """
+        self._start_redpanda(use_tls)
         self.prepare_users()
 
         try:

--- a/tests/rptest/tests/compatibility/franzgo_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_test.py
@@ -11,6 +11,7 @@ from rptest.services.cluster import cluster
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.franzgo_examples as FranzGoExamples
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 from rptest.clients.types import TopicSpec
 import math
 
@@ -27,11 +28,14 @@ class FranzGoBase(RedpandaTest):
         # idempotence is necessary for bench example
         extra_rp_conf = {
             "enable_idempotence": True,
-            "enable_sasl": enable_sasl
         }
         self._ctx = test_context
 
+        security = SecurityConfig()
+        security.enable_sasl = enable_sasl
+
         super(FranzGoBase, self).__init__(test_context=test_context,
+                                          security=security,
                                           extra_rp_conf=extra_rp_conf)
 
         self._max_records = 1000 if self.scale.local else 1000000

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -15,6 +15,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.sarama_examples as SaramaExamples
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 from rptest.clients.types import TopicSpec
 
 
@@ -132,9 +133,9 @@ class SaramaScramTest(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
-        super(SaramaScramTest, self).__init__(test_context,
-                                              extra_rp_conf=extra_rp_conf)
+        security = SecurityConfig()
+        security.enable_sasl = True
+        super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
     def test_sarama_sasl_scram(self):

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -19,6 +19,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 
 
 def create_topic_names(count):
@@ -826,14 +827,15 @@ class PandaProxySASLTest(RedpandaTest):
     Test pandaproxy can connect using SASL.
     """
     def __init__(self, context):
-        extra_rp_conf = dict(
-            auto_create_topics_enabled=False,
-            enable_sasl=True,
-        )
+        extra_rp_conf = dict(auto_create_topics_enabled=False, )
+
+        security = SecurityConfig()
+        security.enable_sasl = True
 
         super(PandaProxySASLTest, self).__init__(context,
                                                  num_brokers=3,
                                                  enable_pp=True,
+                                                 security=security,
                                                  extra_rp_conf=extra_rp_conf)
 
         http.client.HTTPConnection.debuglevel = 1

--- a/tests/rptest/tests/scram_pythonlib_test.py
+++ b/tests/rptest/tests/scram_pythonlib_test.py
@@ -11,17 +11,19 @@ from rptest.services.cluster import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import SecurityConfig
 from kafka import KafkaAdminClient
 from kafka.admin import NewTopic
 
 
 class ScramPythonLibTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(ScramPythonLibTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def make_superuser_client(self, password_override=None):

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -19,15 +19,17 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services.admin import Admin
+from rptest.services.redpanda import SecurityConfig
 
 
 class ScramTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(ScramTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def update_user(self, username):

--- a/tests/rptest/tests/scramful_eos_test.py
+++ b/tests/rptest/tests/scramful_eos_test.py
@@ -12,6 +12,7 @@ from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import SecurityConfig
 from time import sleep
 
 from confluent_kafka import (Producer, KafkaException)
@@ -39,10 +40,13 @@ class ScramfulEosTest(RedpandaTest):
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,
             "enable_auto_rebalance_on_node_add": False,
-            "enable_sasl": True
         }
 
+        security = SecurityConfig()
+        security.enable_sasl = True
+
         super(ScramfulEosTest, self).__init__(test_context=test_context,
+                                              security=security,
                                               extra_rp_conf=extra_rp_conf)
 
     def retry(self, func, retries, accepted_error_code):


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4505
  
  