### PR TITLE
[v22.1.x] Backport mTLS principal propagation

### DIFF
--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -24,6 +24,8 @@ std::string_view to_string_view(feature f) {
         return "consumer_offsets";
     case feature::maintenance_mode:
         return "maintenance_mode";
+    case feature::mtls_authentication:
+        return "mtls_authentication";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -23,6 +23,7 @@ enum class feature : std::uint64_t {
     central_config = 0x1,
     consumer_offsets = 0x2,
     maintenance_mode = 0x4,
+    mtls_authentication = 0x8,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -92,6 +93,12 @@ constexpr static std::array feature_schema{
     "maintenance_mode",
     feature::maintenance_mode,
     feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{3},
+    "mtls_authentication",
+    feature::mtls_authentication,
+    feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{2001},

--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
   DEPS
     v::json
     v::model
+    v::security
    boost_filesystem
    absl::node_hash_set
 )

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -40,9 +40,8 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
+void rjson_serialize_impl(
   json::Writer<json::StringBuffer>& w, const config::tls_config& v) {
-    w.StartObject();
     w.Key("enabled");
     w.Bool(v.is_enabled());
 
@@ -62,6 +61,16 @@ void rjson_serialize(
         w.String((*(v.get_truststore_file())).c_str());
     }
 
+    if (v.get_principal_mapping_rules()) {
+        w.Key("principal_mapping_rules");
+        w.String(*v.get_principal_mapping_rules());
+    }
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::tls_config& v) {
+    w.StartObject();
+    rjson_serialize_impl(w, v);
     w.EndObject();
 }
 
@@ -94,24 +103,7 @@ void rjson_serialize(
 
     w.Key("name");
     w.String(v.name.c_str());
-    w.Key("enabled");
-    w.Bool(v.config.is_enabled());
-
-    w.Key("require_client_auth");
-    w.Bool(v.config.get_require_client_auth());
-
-    if (v.config.get_key_cert_files()) {
-        w.Key("key_file");
-        w.String(v.config.get_key_cert_files()->key_file.c_str());
-
-        w.Key("cert_file");
-        w.String(v.config.get_key_cert_files()->cert_file.c_str());
-    }
-
-    if (v.config.get_truststore_file()) {
-        w.Key("truststore_file");
-        w.String((*(v.config.get_truststore_file())).c_str());
-    }
+    rjson_serialize_impl(w, v.config);
 
     w.EndObject();
 }

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -113,7 +113,9 @@ ss::future<> connection_context::handle_mtls_auth() {
           if (!_mtls_principal) {
               throw security::exception(
                 security::errc::invalid_credentials,
-                "failed to extract principal from distinguished name");
+                fmt::format(
+                  "failed to extract principal from distinguished name: {}",
+                  dn->subject));
           }
 
           vlog(

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -17,14 +17,18 @@
 #include "kafka/server/protocol_utils.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/request_context.h"
+#include "security/exceptions.h"
 #include "units.h"
+#include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/with_timeout.hh>
 
 #include <chrono>
 #include <memory>
+
 using namespace std::chrono_literals;
 
 namespace kafka {
@@ -64,8 +68,59 @@ ss::future<> connection_context::process_one_request() {
                       _rs.probe().header_corrupted();
                       return ss::make_ready_future<>();
                   }
-                  return dispatch_method_once(std::move(h.value()), s);
+                  return handle_mtls_auth().then(
+                    [this, h = std::move(h.value()), s]() mutable {
+                        return dispatch_method_once(std::move(h), s);
+                    });
               });
+      });
+}
+
+/*
+ * handle mtls authentication. this should only happen once when the connection
+ * is setup. even though this is called in the normal request handling path,
+ * this property should hold becuase:
+ *
+ * 1. is a noop if a mtls principal has been extracted
+ * 2. all code paths that don't set the principal throw and drop the connection
+ *
+ * NOTE: handle_mtls_auth is called after reading header off the wire. this is
+ * odd because we would expect that tls negotation etc... all happens before we
+ * here to the application layer. however, it appears that the way seastar works
+ * that we need to read some data off the wire to drive this process within the
+ * internal connection handling.
+ */
+ss::future<> connection_context::handle_mtls_auth() {
+    if (!_use_mtls || _mtls_principal.has_value()) {
+        return ss::now();
+    }
+    return ss::with_timeout(
+             model::timeout_clock::now() + 5s,
+             _rs.conn->get_distinguished_name())
+      .then([this](std::optional<ss::session_dn> dn) {
+          if (!dn.has_value()) {
+              throw security::exception(
+                security::errc::invalid_credentials,
+                "failed to fetch distinguished name");
+          }
+          /*
+           * for now it probably is fine to store the mapping per connection.
+           * but it seems like we could also share this across all connections
+           * with the same tls configuration.
+           */
+          _mtls_principal = _rs.conn->get_principal_mapping()->apply(
+            dn->subject);
+          if (!_mtls_principal) {
+              throw security::exception(
+                security::errc::invalid_credentials,
+                "failed to extract principal from distinguished name");
+          }
+
+          vlog(
+            _authlog.debug,
+            "got principal: {}, from distinguished name: {}",
+            *_mtls_principal,
+            dn->subject);
       });
 }
 

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -17,6 +17,7 @@
 #include "kafka/server/logger.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "security/mtls.h"
 #include "security/scram_algorithm.h"
 #include "utils/utf8.h"
 #include "vlog.h"
@@ -25,6 +26,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/log.hh>
 
@@ -33,6 +35,7 @@
 #include <chrono>
 #include <exception>
 #include <limits>
+#include <memory>
 
 namespace kafka {
 
@@ -106,7 +109,8 @@ ss::future<> protocol::apply(net::server::resources rs) {
       *this,
       std::move(rs),
       std::move(sasl),
-      config::shard_local_cfg().enable_sasl());
+      config::shard_local_cfg().enable_sasl(),
+      rs.conn->get_principal_mapping().has_value());
 
     return ss::do_until(
              [ctx] { return ctx->is_finished_parsing(); },

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -105,12 +105,17 @@ ss::future<> protocol::apply(net::server::resources rs) {
         ? security::sasl_server::sasl_state::initial
         : security::sasl_server::sasl_state::complete);
 
+    const auto enable_mtls_authentication
+      = rs.conn->get_principal_mapping().has_value()
+        && feature_table().local().is_active(
+          cluster::feature::mtls_authentication);
+
     auto ctx = ss::make_lw_shared<connection_context>(
       *this,
       std::move(rs),
       std::move(sasl),
       config::shard_local_cfg().enable_sasl(),
-      rs.conn->get_principal_mapping().has_value());
+      enable_mtls_authentication);
 
     return ss::do_until(
              [ctx] { return ctx->is_finished_parsing(); },

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -81,6 +81,7 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                               proto,
                               net::server::resources(nullptr, nullptr),
                               std::move(sasl),
+                              false,
                               false);
 
                           return kafka::request_context(

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -18,14 +18,16 @@ connection::connection(
   ss::sstring name,
   ss::connected_socket f,
   ss::socket_address a,
-  server_probe& p)
-  : addr(std::move(a))
+  server_probe& p,
+  std::optional<security::tls::principal_mapper> tls_pm)
+  : addr(a)
   , _hook(hook)
   , _name(std::move(name))
   , _fd(std::move(f))
   , _in(_fd.input())
   , _out(_fd.output())
-  , _probe(p) {
+  , _probe(p)
+  , _tls_pm(std::move(tls_pm)) {
     _hook.push_back(*this);
     _probe.connection_established();
 }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -16,6 +16,7 @@
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
+#include "security/mtls.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/abort_source.hh>
@@ -42,6 +43,7 @@ struct server_endpoint {
     ss::sstring name;
     ss::socket_address addr;
     ss::shared_ptr<ss::tls::server_credentials> credentials;
+    std::optional<security::tls::principal_mapper> principal_mapper;
 
     server_endpoint(ss::sstring name, ss::socket_address addr)
       : name(std::move(name))
@@ -56,9 +58,26 @@ struct server_endpoint {
       , credentials(std::move(creds)) {}
 
     server_endpoint(
+      ss::sstring name,
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds,
+      std::optional<security::tls::principal_mapper> principal_mapper)
+      : name(std::move(name))
+      , addr(addr)
+      , credentials(std::move(creds))
+      , principal_mapper(std::move(principal_mapper)) {}
+
+    server_endpoint(
       ss::socket_address addr,
       ss::shared_ptr<ss::tls::server_credentials> creds)
       : server_endpoint("", addr, std::move(creds)) {}
+
+    server_endpoint(
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds,
+      security::tls::principal_mapper principal_mapper)
+      : server_endpoint(
+        "", addr, std::move(creds), std::move(principal_mapper)) {}
 
     explicit server_endpoint(ss::socket_address addr)
       : server_endpoint("", addr) {}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -996,6 +996,7 @@ void application::wire_up_redpanda_services() {
               auto& tls_config = config::node().kafka_api_tls.value();
               for (const auto& ep : config::node().kafka_api()) {
                   ss::shared_ptr<ss::tls::server_credentials> credentails;
+                  std::optional<security::tls::principal_mapper> tls_pm;
                   // find credentials for this endpoint
                   auto it = find_if(
                     tls_config.begin(),
@@ -1024,10 +1025,20 @@ void application::wire_up_redpanda_services() {
                                   })
                                 .get0()
                             : nullptr;
+
+                      auto tls_pm_rules
+                        = it->config.get_principal_mapping_rules();
+                      if (tls_pm_rules) {
+                          tls_pm = security::tls::principal_mapper(
+                            tls_pm_rules);
+                      }
                   }
 
                   c.addrs.emplace_back(
-                    ep.name, net::resolve_dns(ep.address).get0(), credentails);
+                    ep.name,
+                    net::resolve_dns(ep.address).get0(),
+                    credentails,
+                    std::move(tls_pm));
               }
 
               c.disable_metrics = net::metrics_disabled(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -403,6 +403,7 @@ public:
           *proto,
           net::server::resources(nullptr, nullptr),
           std::move(sasl),
+          false,
           false);
 
         kafka::request_header header;

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -57,7 +57,8 @@ FIXTURE_TEST(rpcgen_tls_integration, rpc_integration_fixture) {
                            true,
                            config::key_cert{"redpanda.key", "redpanda.crt"},
                            "root_certificate_authority.chain_cert",
-                           false)
+                           false,
+                           std::nullopt)
                            .get_credentials_builder()
                            .get0();
     configure_server(creds_builder);
@@ -133,7 +134,8 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     client_key.native(), client_crt.native()},
                                   client_ca.native(),
-                                  true)
+                                  true,
+                                  std::nullopt)
                                   .get_credentials_builder()
                                   .get0();
     // server credentials
@@ -146,7 +148,8 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     server_key.native(), server_crt.native()},
                                   server_ca.native(),
-                                  true)
+                                  true,
+                                  std::nullopt)
                                   .get_credentials_builder()
                                   .get0();
 

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     scram_credential.cc
     scram_authenticator.cc
     acl_store.cc
+    mtls.cc
   DEPS
     v::bytes
     absl::flat_hash_map

--- a/src/v/security/exceptions.h
+++ b/src/v/security/exceptions.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "security/errc.h"
+
+#include <fmt/core.h>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace security {
+
+struct exception final : public std::runtime_error {
+public:
+    explicit exception(errc e, std::string_view msg)
+      : std::runtime_error(
+        fmt::format("{}: {}", make_error_code(e).message(), msg)) {}
+};
+
+} // namespace security

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/mtls.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include <regex>
+#include <stdexcept>
+
+namespace security::tls {
+
+namespace detail {
+
+static constexpr const char* const rule_pattern{
+  R"((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))"};
+static constexpr const char* const rule_pattern_splitter{
+  R"(\s*((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))\s*(,\s*|$))"};
+
+std::regex make_regex(std::string_view sv) {
+    return std::regex{
+      sv.begin(),
+      sv.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize};
+}
+
+bool regex_search(
+  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+    return std::regex_search(
+      msg.begin(),
+      msg.end(),
+      match,
+      regex,
+      std::regex_constants::match_default);
+}
+
+bool regex_match(
+  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+    return std::regex_match(
+      msg.begin(),
+      msg.end(),
+      match,
+      regex,
+      std::regex_constants::match_default);
+}
+
+constexpr std::string_view trim(std::string_view s) {
+    constexpr auto ws = " \t\n\r\f\v";
+    s.remove_prefix(std::min(s.find_first_not_of(ws), s.size()));
+    s.remove_suffix(std::min(s.size() - s.find_last_not_of(ws) - 1, s.size()));
+    return s;
+}
+
+constexpr std::optional<std::string_view> make_sv(const std::csub_match& sm) {
+    return sm.matched
+             ? std::string_view{sm.first, static_cast<size_t>(sm.length())}
+             : std::optional<std::string_view>{std::nullopt};
+}
+
+std::vector<rule> parse_rules(std::optional<std::string_view> unparsed_rules) {
+    static const std::regex rule_splitter = make_regex(rule_pattern_splitter);
+    static const std::regex rule_parser = make_regex(rule_pattern);
+
+    std::string_view rules{trim(unparsed_rules.value_or("DEFAULT"))};
+
+    std::vector<rule> result;
+    std::cmatch rules_match;
+    while (!rules.empty() && regex_search(rules, rules_match, rule_splitter)) {
+        const auto& rule{rules_match[1]};
+
+        std::cmatch components_match;
+        if (!regex_search(*make_sv(rule), components_match, rule_parser)) {
+            throw std::runtime_error("Invalid rule: " + rule.str());
+        }
+        if (components_match.prefix().matched) {
+            throw std::runtime_error(
+              "Invalid rule - prefix: " + components_match.prefix().str());
+        }
+        if (components_match.suffix().matched) {
+            throw std::runtime_error(
+              "Invalid rule - suffix: " + components_match.suffix().str());
+        }
+
+        if (components_match[1].matched) {
+            result.emplace_back();
+        } else if (components_match[2].matched) {
+            const auto adjust_case = make_sv(components_match[6]);
+            result.emplace_back(
+              *make_sv(components_match[2]),
+              make_sv(components_match[4]),
+              rule::make_lower{adjust_case == "L"},
+              rule::make_upper{adjust_case == "U"});
+        }
+        rules = make_sv(rules_match.suffix()).value_or("");
+    }
+    return result;
+}
+
+} // namespace detail
+
+rule::rule(
+  std::string_view pattern,
+  std::optional<std::string_view> replacement,
+  make_lower to_lower,
+  make_upper to_upper)
+  : _regex{detail::make_regex(pattern)}
+  , _pattern{pattern}
+  , _replacement{replacement}
+  , _is_default{false}
+  , _to_lower{to_lower}
+  , _to_upper{to_upper} {}
+
+std::optional<ss::sstring> rule::apply(std::string_view dn) const {
+    if (_is_default) {
+        return ss::sstring{dn};
+    }
+
+    std::cmatch match;
+    if (!std::regex_match(dn.cbegin(), dn.cend(), match, _regex)) {
+        return {};
+    }
+
+    std::string result;
+    std::regex_replace(
+      std::back_inserter(result),
+      dn.begin(),
+      dn.end(),
+      _regex,
+      _replacement.value_or("").c_str());
+
+    if (_to_lower) {
+        boost::algorithm::to_lower(result, std::locale::classic());
+    } else if (_to_upper) {
+        boost::algorithm::to_upper(result, std::locale::classic());
+    }
+    return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const rule& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const principal_mapper& p) {
+    fmt::print(os, "{}", p);
+    return os;
+}
+
+} // namespace security::tls
+
+// explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the
+// header, whch breaks compilation in another part of the codebase.
+template<>
+std::back_insert_iterator<fmt::detail::buffer<char>>
+fmt::formatter<security::tls::rule>::format(
+  const security::tls::rule& r,
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>& ctx) {
+    if (r._is_default) {
+        return format_to(ctx.out(), "DEFAULT");
+    }
+    format_to(ctx.out(), "RULE:");
+    if (r._pattern.has_value()) {
+        format_to(ctx.out(), "{}", *r._pattern);
+    }
+    if (r._replacement.has_value()) {
+        format_to(ctx.out(), "/{}", *r._replacement);
+    }
+    if (r._to_lower) {
+        format_to(ctx.out(), "/L");
+    } else if (r._to_upper) {
+        format_to(ctx.out(), "/U");
+    }
+    return ctx.out();
+}
+
+template<>
+std::back_insert_iterator<fmt::detail::buffer<char>>
+fmt::formatter<security::tls::principal_mapper>::format<
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>>(
+  const security::tls::principal_mapper& r,
+  fmt::basic_format_context<
+    std::back_insert_iterator<fmt::detail::buffer<char>>,
+    char>& ctx) {
+    return format_to(ctx.out(), "[{}]", fmt::join(r._rules, ", "));
+}

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/core.h>
+
+#include <iosfwd>
+#include <optional>
+#include <regex>
+#include <string_view>
+
+namespace security::tls {
+
+class rule {
+public:
+    using make_lower = ss::bool_class<struct make_lower_tag>;
+    using make_upper = ss::bool_class<struct make_upper_tag>;
+
+    rule() = default;
+
+    rule(
+      std::string_view pattern,
+      std::optional<std::string_view> replacement,
+      make_lower to_lower,
+      make_upper to_upper);
+
+    std::optional<ss::sstring> apply(std::string_view dn) const;
+
+private:
+    friend struct fmt::formatter<rule>;
+
+    friend std::ostream& operator<<(std::ostream& os, const rule& r);
+
+    std::regex _regex;
+    std::optional<ss::sstring> _pattern;
+    std::optional<ss::sstring> _replacement;
+    bool _is_default{true};
+    make_lower _to_lower{false};
+    make_upper _to_upper{false};
+};
+
+namespace detail {
+
+std::vector<rule> parse_rules(std::optional<std::string_view> unparsed_rules);
+
+} // namespace detail
+
+class principal_mapper {
+public:
+    explicit principal_mapper(std::optional<std::string_view> sv)
+      : _rules{detail::parse_rules(sv)} {}
+
+    std::optional<ss::sstring> apply(std::string_view sv) const {
+        for (const auto& r : _rules) {
+            if (auto p = r.apply(sv); p.has_value()) {
+                return {std::move(p).value()};
+            }
+        }
+        return std::nullopt;
+    }
+
+private:
+    friend struct fmt::formatter<principal_mapper>;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const principal_mapper& p);
+
+    std::vector<rule> _rules;
+};
+
+} // namespace security::tls
+
+template<>
+struct fmt::formatter<security::tls::rule> {
+    using type = security::tls::rule;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+};
+
+template<>
+struct fmt::formatter<security::tls::principal_mapper> {
+    using type = security::tls::principal_mapper;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator format(const type& r, FormatContext& ctx);
+};

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     scram_algorithm_test.cc
     credential_store_test.cc
     authorizer_test.cc
+    mtls_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/security/tests/mtls_test.cc
+++ b/src/v/security/tests/mtls_test.cc
@@ -1,0 +1,135 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "random/generators.h"
+#include "security/mtls.h"
+#include "utils/base64.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <fmt/ostream.h>
+
+#include <regex>
+#include <stdexcept>
+
+namespace security::tls {
+
+/*
+ * Test coverage includes all of the relevant test cases found in upstream
+ * kafka's SslPrincipalMapperTest.
+ */
+
+namespace bdata = boost::unit_test::data;
+
+std::array<std::string_view, 8> mtls_valid_rules{
+  "DEFAULT",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, DEFAULT",
+  "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/",
+  "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L",
+  "RULE:^cn=(.?),ou=(.?),dc=(.?),dc=(.?)$/$1@$2/U",
+  "RULE:^CN=([^,ADEFLTU,]+)(,.*|$)/$1/",
+  "RULE:^CN=([^,DEFAULT,]+)(,.*|$)/$1/"};
+
+BOOST_DATA_TEST_CASE(test_mtls_valid_rules, bdata::make(mtls_valid_rules), c) {
+    BOOST_REQUIRE_NO_THROW(principal_mapper{c});
+}
+
+std::array<std::string_view, 10> mtls_invalid_rules{
+  "default",
+  "DEFAUL",
+  "DEFAULT/L",
+  "DEFAULT/U",
+  "RULE:CN=(.*?),OU=ServiceUsers.*/$1",
+  "rule:^CN=(.*?),OU=ServiceUsers.*$/$1/",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L/U",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/L",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/U",
+  "RULE:^CN=(.*?),OU=ServiceUsers.*$/LU"};
+
+BOOST_DATA_TEST_CASE(
+  test_mtls_invalid_rules, bdata::make(mtls_invalid_rules), c) {
+    BOOST_REQUIRE_THROW(principal_mapper{c}, std::runtime_error);
+}
+
+struct record {
+    record(std::string_view e, std::string_view i)
+      : expected{e}
+      , input{i} {}
+    std::string_view expected;
+    std::string_view input;
+    friend std::ostream& operator<<(std::ostream& os, const record& r) {
+        fmt::print(os, "input: `{}`, expected: `{}`", r.input, r.expected);
+        return os;
+    }
+};
+
+static std::array<record, 5> mtls_principal_mapper_data{
+  record{"duke", "CN=Duke,OU=ServiceUsers,O=Org,C=US"},
+  {"duke@sme", "CN=Duke,OU=SME,O=mycp,L=Fulton,ST=MD,C=US"},
+  {"DUKE@SME", "cn=duke,ou=sme,dc=mycp,dc=com"},
+  {"DUKE", "cN=duke,OU=JavaSoft,O=Sun Microsystems"},
+  {"OU=JavaSoft,O=Sun Microsystems,C=US",
+   "OU=JavaSoft,O=Sun Microsystems,C=US"}};
+
+BOOST_DATA_TEST_CASE(
+  test_mtls_principal_mapper, bdata::make(mtls_principal_mapper_data), c) {
+    security::tls::principal_mapper mapper{
+      "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, "
+      "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L, "
+      "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1@$2/U, "
+      "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/U, "
+      "DEFAULT"};
+    BOOST_REQUIRE_EQUAL(c.expected, *mapper.apply(c.input));
+}
+
+static std::array<record, 17> mtls_rule_splitting_data{
+  record{"[]", ""},
+  {"[DEFAULT]", "DEFAULT"},
+  {"[RULE:/]", "RULE://"},
+  {"[RULE:/.*]", "RULE:/.*/"},
+  {"[RULE:/.*/L]", "RULE:/.*/L"},
+  {"[RULE:/, DEFAULT]", "RULE://,DEFAULT"},
+  {"[RULE:/, DEFAULT]", "  RULE:// ,  DEFAULT  "},
+  {"[RULE:   /     , DEFAULT]", "  RULE:   /     / ,  DEFAULT  "},
+  {"[RULE:  /     /U, DEFAULT]", "  RULE:  /     /U   ,DEFAULT  "},
+  {"[RULE:([A-Z]*)/$1/U, RULE:([a-z]+)/$1, DEFAULT]",
+   "  RULE:([A-Z]*)/$1/U   ,RULE:([a-z]+)/$1/,   DEFAULT  "},
+  {"[]", ",   , , ,      , , ,   "},
+  {"[RULE:/, DEFAULT]", ",,RULE://,,,DEFAULT,,"},
+  {"[RULE: /   , DEFAULT]", ",  , RULE: /   /    ,,,   DEFAULT, ,   "},
+  {"[RULE:   /  /U, DEFAULT]", "     ,  , RULE:   /  /U    ,,  ,DEFAULT, ,"},
+  {R"([RULE:\/\\\(\)\n\t/\/\/])", R"(RULE:\/\\\(\)\n\t/\/\//)"},
+  {R"([RULE:\**\/+/*/L, RULE:\/*\**/**])",
+   R"(RULE:\**\/+/*/L,RULE:\/*\**/**/)"},
+  {"[RULE:,RULE:,/,RULE:,\\//U, RULE:,/RULE:,, RULE:,RULE:,/L,RULE:,/L, RULE:, "
+   "DEFAULT, /DEFAULT, DEFAULT]",
+   "RULE:,RULE:,/,RULE:,\\//U,RULE:,/RULE:,/,RULE:,RULE:,/L,RULE:,/L,RULE:, "
+   "DEFAULT, /DEFAULT/,DEFAULT"},
+};
+BOOST_DATA_TEST_CASE(
+  test_mtls_rule_splitting, bdata::make(mtls_rule_splitting_data), c) {
+    BOOST_CHECK_EQUAL(c.expected, fmt::format("{}", principal_mapper(c.input)));
+}
+
+BOOST_AUTO_TEST_CASE(test_mtls_comma_with_whitespace) {
+    BOOST_CHECK_EQUAL(
+      "Tkac\\, Adam",
+      principal_mapper("RULE:^CN=((\\\\, *|\\w)+)(,.*|$)/$1/,DEFAULT")
+        .apply("CN=Tkac\\, Adam,OU=ITZ,DC=geodis,DC=cz")
+        .value_or(""));
+}
+
+} // namespace security::tls

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - '9000'
     healthcheck:
       interval: 30s
-      retries: '3'
+      retries: 3
       test:
       - CMD
       - curl
@@ -28,7 +28,7 @@ services:
     image: minio/minio:RELEASE.2021-03-26T00-00-41Z
     networks:
     - redpanda-test
-  n:
+  rp:
     image: vectorized/redpanda-test-node
     privileged: true
     pids_limit: 32768

--- a/tests/docker/ducktape_cluster.json.j2
+++ b/tests/docker/ducktape_cluster.json.j2
@@ -2,10 +2,10 @@
     "nodes": [
 {% for node_id in range(1, scale + 1) %}
         {
-            "externally_routable_ip": "docker_n_{{node_id}}",
+            "externally_routable_ip": "docker-rp-{{node_id}}",
             "ssh_config": {
-                "host": "docker_n_{{node_id}}",
-                "hostname": "docker_n_{{node_id}}",
+                "host": "docker-rp-{{node_id}}",
+                "hostname": "docker-rp-{{node_id}}",
                 "identityfile": "/root/.ssh/id_rsa",
                 "password": "UNUSED",
                 "port": 22,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -563,3 +563,27 @@ class RpkTool:
                 self._sasl_mechanism,
             ]
         return flags
+
+    def acl_list(self):
+        """
+        Run `rpk acl list` and return the results.
+
+        If this client is not authorized to list ACLs then
+        ClusterAuthorizationError will be raised.
+
+        TODO: parse output into acl structures. currently ducktape tests lack
+        any structured representation of acls. however at the time of writing we
+        are interested only in an authz success/fail signal.
+        """
+        cmd = [
+            self._rpk_binary(),
+            "acl",
+            "list",
+        ] + self._kafka_conn_settings()
+
+        output = self._execute(cmd)
+
+        if "CLUSTER_AUTHORIZATION_FAILED" in output:
+            raise ClusterAuthorizationError("acl list")
+
+        return output

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -587,3 +587,20 @@ class RpkTool:
             raise ClusterAuthorizationError("acl list")
 
         return output
+
+    def acl_create_allow_cluster(self, username, op):
+        """
+        Add allow+describe+cluster ACL
+        """
+        cmd = [
+            self._rpk_binary(),
+            "acl",
+            "create",
+            "--allow-principal",
+            f"User:{username}",
+            "--operation",
+            op,
+            "--cluster",
+        ] + self._kafka_conn_settings()
+        output = self._execute(cmd)
+        return output

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -10,7 +10,9 @@
 import subprocess
 import re
 import typing
+from typing import Optional
 from ducktape.cluster.cluster import ClusterNode
+from rptest.services import tls
 
 DEFAULT_TIMEOUT = 30
 
@@ -107,11 +109,13 @@ class RpkTool:
                  redpanda,
                  username: str = None,
                  password: str = None,
-                 sasl_mechanism: str = None):
+                 sasl_mechanism: str = None,
+                 tls_cert: Optional[tls.Certificate] = None):
         self._redpanda = redpanda
         self._username = username
         self._password = password
         self._sasl_mechanism = sasl_mechanism
+        self._tls_cert = tls_cert
 
     def create_topic(self, topic, partitions=1, replicas=None, config=None):
         cmd = ["create", topic]
@@ -561,6 +565,15 @@ class RpkTool:
                 self._password,
                 "--sasl-mechanism",
                 self._sasl_mechanism,
+            ]
+        if self._tls_cert:
+            flags += [
+                "--tls-key",
+                self._tls_cert.key,
+                "--tls-cert",
+                self._tls_cert.crt,
+                "--tls-truststore",
+                self._tls_cert.ca.crt,
             ]
         return flags
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -34,6 +34,7 @@ from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.admin import Admin
 from rptest.clients.python_librdkafka import PythonLibrdkafka
+from rptest.services import tls
 
 Partition = collections.namedtuple('Partition',
                                    ['index', 'leader', 'replicas'])
@@ -351,9 +352,33 @@ class SISettings:
         return conf
 
 
+class TLSProvider:
+    """
+    Interface that RedpandaService uses to obtain TLS certificates.
+    """
+    @property
+    def ca(self) -> tls.CertificateAuthority:
+        raise NotImplementedError("ca")
+
+    def create_broker_cert(self, service: Service,
+                           node: ClusterNode) -> tls.Certificate:
+        """
+        Create a certificate for a broker.
+        """
+        raise NotImplementedError("create_broker_cert")
+
+    def create_service_client_cert(self, service: Service,
+                                   name: str) -> tls.Certificate:
+        """
+        Create a certificate for an internal service client.
+        """
+        raise NotImplementedError("create_service_client_cert")
+
+
 class SecurityConfig:
     def __init__(self):
         self.enable_sasl = False
+        self.tls_provider: Optional[TLSProvider] = None
 
 
 class RedpandaService(Service):
@@ -361,6 +386,9 @@ class RedpandaService(Service):
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
     CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
+    TLS_SERVER_KEY_FILE = "/etc/redpanda/server.key"
+    TLS_SERVER_CRT_FILE = "/etc/redpanda/server.crt"
+    TLS_CA_CRT_FILE = "/etc/redpanda/ca.crt"
     STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.log")
     BACKTRACE_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda_backtrace.log")
     WASM_STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT,
@@ -492,6 +520,9 @@ class RedpandaService(Service):
 
         self._saved_executable = False
 
+        self._tls_cert = None
+        self._init_tls()
+
     def set_environment(self, environment: dict[str, str]):
         self._environment = environment
 
@@ -507,6 +538,16 @@ class RedpandaService(Service):
 
     def set_security_settings(self, settings):
         self._security = settings
+        self._init_tls()
+
+    def _init_tls(self):
+        """
+        Call this if tls setting may have changed.
+        """
+        if self._security.tls_provider:
+            # build a cert for clients used internally to the service
+            self._tls_cert = self._security.tls_provider.create_service_client_cert(
+                self, "redpanda.service.admin")
 
     def sasl_enabled(self):
         return self._security.enable_sasl
@@ -571,6 +612,7 @@ class RedpandaService(Service):
                 raise
 
         if first_start:
+            self.write_tls_certs()
             self.write_bootstrap_cluster_config()
 
         for node in to_start:
@@ -612,6 +654,32 @@ class RedpandaService(Service):
 
         if self._si_settings is not None:
             self.start_si()
+
+    def write_tls_certs(self):
+        if not self._security.tls_provider:
+            return
+
+        ca = self._security.tls_provider.ca
+        for node in self.nodes:
+            cert = self._security.tls_provider.create_broker_cert(self, node)
+
+            self.logger.info(
+                f"Writing Redpanda node tls key file: {RedpandaService.TLS_SERVER_KEY_FILE}"
+            )
+            self.logger.debug(open(cert.key, "r").read())
+            node.account.copy_to(cert.key, RedpandaService.TLS_SERVER_KEY_FILE)
+
+            self.logger.info(
+                f"Writing Redpanda node tls cert file: {RedpandaService.TLS_SERVER_CRT_FILE}"
+            )
+            self.logger.debug(open(cert.crt, "r").read())
+            node.account.copy_to(cert.crt, RedpandaService.TLS_SERVER_CRT_FILE)
+
+            self.logger.info(
+                f"Writing Redpanda node tls ca cert file: {RedpandaService.TLS_CA_CRT_FILE}"
+            )
+            self.logger.debug(open(ca.crt, "r").read())
+            node.account.copy_to(ca.crt, RedpandaService.TLS_CA_CRT_FILE)
 
     def security_config(self):
         return self._security_config
@@ -1164,6 +1232,19 @@ class RedpandaService(Service):
                 doc["redpanda"].update(override_cfg_params)
             conf = yaml.dump(doc)
 
+        if self._security.tls_provider:
+            tls_config = dict(
+                enabled=True,
+                require_client_auth=True,
+                name="dnslistener",
+                key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+                cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+                truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+            )
+            doc = yaml.full_load(conf)
+            doc["redpanda"].update(dict(kafka_api_tls=tls_config))
+            conf = yaml.dump(doc)
+
         self.logger.info("Writing Redpanda node config file: {}".format(
             RedpandaService.NODE_CONFIG_FILE))
         self.logger.debug(conf)
@@ -1252,7 +1333,7 @@ class RedpandaService(Service):
                     f"registered: node {node.name} now visible in peer {peer.name}'s broker list ({admin_brokers})"
                 )
 
-        client = PythonLibrdkafka(self)
+        client = PythonLibrdkafka(self, tls_cert=self._tls_cert)
         brokers = client.brokers()
         broker = brokers.get(idx, None)
         if broker is None:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -351,6 +351,11 @@ class SISettings:
         return conf
 
 
+class SecurityConfig:
+    def __init__(self):
+        self.enable_sasl = False
+
+
 class RedpandaService(Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
@@ -434,13 +439,15 @@ class RedpandaService(Service):
                  resource_settings=None,
                  si_settings=None,
                  log_level: Optional[str] = None,
-                 environment: Optional[dict[str, str]] = None):
+                 environment: Optional[dict[str, str]] = None,
+                 security: SecurityConfig = SecurityConfig()):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._enable_rp = enable_rp
         self._extra_rp_conf = extra_rp_conf or dict()
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
+        self._security = security
 
         self._extra_node_conf = {}
         for node in self.nodes:
@@ -498,9 +505,11 @@ class RedpandaService(Service):
         assert node in self.nodes
         self._extra_node_conf[node] = conf
 
+    def set_security_settings(self, settings):
+        self._security = settings
+
     def sasl_enabled(self):
-        return self._extra_rp_conf and self._extra_rp_conf.get(
-            "enable_sasl", False)
+        return self._security.enable_sasl
 
     @property
     def dedicated_nodes(self):
@@ -1167,6 +1176,10 @@ class RedpandaService(Service):
                 "Setting custom cluster configuration options: {}".format(
                     self._extra_rp_conf))
             conf.update(self._extra_rp_conf)
+
+        if self._security.enable_sasl:
+            self.logger.debug("Enabling SASL in cluster configuration")
+            conf.update(dict(enable_sasl=True))
 
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -88,7 +88,8 @@ class TLSCertManager:
     it is common for clients to take paths to these files, it is best to keep
     the instance alive for as long as the files are in use.
     """
-    def __init__(self):
+    def __init__(self, logger):
+        self._logger = logger
         self._dir = tempfile.TemporaryDirectory()
         self._ca = self._create_ca()
         self.certs = {}
@@ -97,7 +98,11 @@ class TLSCertManager:
         return os.path.join(self._dir.name, name)
 
     def _exec(self, cmd):
-        subprocess.check_output(cmd.split(), cwd=self._dir.name)
+        self._logger.info(f"Running command: {cmd}")
+        output = subprocess.check_output(cmd.split(),
+                                         cwd=self._dir.name,
+                                         stderr=subprocess.STDOUT)
+        self._logger.debug(output)
 
     def _create_ca(self):
         cfg = self._with_dir("ca.conf")

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -1,0 +1,162 @@
+import tempfile
+import typing
+import collections
+import pathlib
+import subprocess
+import os
+
+_ca_config_tmpl = """
+# OpenSSL CA configuration file
+[ ca ]
+default_ca = local_ca
+
+[ local_ca ]
+dir              = {dir}
+database         = $dir/index.txt
+serial           = $dir/serial.txt
+default_days     = 730
+default_md       = sha256
+copy_extensions  = copy
+unique_subject   = no
+
+# Used to create the CA certificate.
+[ req ]
+prompt             = no
+distinguished_name = distinguished_name
+x509_extensions    = extensions
+
+[ root_ca_distinguished_name ]
+commonName              = Test TLS CA
+stateOrProvinceName     = NY
+countryName             = US
+emailAddress            = hi@vectorized.io
+organizationName        = Redpanda
+organizationalUnitName  = Redpanda Test
+
+[ distinguished_name ]
+organizationName = Redpanda
+commonName       = Redpanda Test CA
+
+[ extensions ]
+keyUsage         = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+# Common policy for nodes and users.
+[ signing_policy ]
+organizationName = supplied
+commonName       = optional
+
+# Used to sign node certificates.
+[ signing_node_req ]
+keyUsage         = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth,clientAuth
+
+# Used to sign client certificates.
+[ signing_client_req ]
+keyUsage         = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth
+"""
+
+_node_config_tmpl = """
+# OpenSSL node configuration file
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = Redpanda
+{common_name}
+
+[ extensions ]
+subjectAltName = critical,DNS:{host}
+"""
+
+CertificateAuthority = collections.namedtuple("CertificateAuthority",
+                                              ["cfg", "key", "crt"])
+Certificate = collections.namedtuple("Certificate",
+                                     ["cfg", "key", "crt", "ca"])
+
+
+class TLSCertManager:
+    """
+    When a TLSCertManager is instantiated a new CA is automatically created and
+    certificates can be created immediately.
+
+    All of the generated files (keys, certs, etc...) are stored in a temporary
+    directory that will be deleted when the TLSCertManager is destroyed. Since
+    it is common for clients to take paths to these files, it is best to keep
+    the instance alive for as long as the files are in use.
+    """
+    def __init__(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self._ca = self._create_ca()
+        self.certs = {}
+
+    def _with_dir(self, name):
+        return os.path.join(self._dir.name, name)
+
+    def _exec(self, cmd):
+        subprocess.check_output(cmd.split(), cwd=self._dir.name)
+
+    def _create_ca(self):
+        cfg = self._with_dir("ca.conf")
+        key = self._with_dir("ca.key")
+        crt = self._with_dir("ca.crt")
+        idx = self._with_dir("index.txt")
+        srl = self._with_dir("serial.txt")
+
+        with open(f"{cfg}", "w") as f:
+            f.write(_ca_config_tmpl.format(dir=self._dir.name))
+
+        self._exec(f"openssl genrsa -out {key} 2048")
+
+        self._exec(f"openssl req -new -x509 -config {cfg} "
+                   f"-key {key} -out {crt} -days 365 -batch")
+
+        if os.path.exists(idx): os.remove(idx)
+        if os.path.exists(srl): os.remove(srl)
+        pathlib.Path(idx).touch()
+        with open(srl, "w") as f:
+            f.writelines(["01"])
+
+        return CertificateAuthority(cfg, key, crt)
+
+    @property
+    def ca(self):
+        return self._ca
+
+    def create_cert(self,
+                    host: str,
+                    *,
+                    common_name: typing.Optional[str] = None,
+                    name: typing.Optional[str] = None):
+        name = name or host
+        assert name not in self.certs, f"cert '{name}' already exists"
+
+        cfg = self._with_dir(f"{name}.conf")
+        key = self._with_dir(f"{name}.key")
+        csr = self._with_dir(f"{name}.csr")
+        crt = self._with_dir(f"{name}.crt")
+
+        with open(cfg, "w") as f:
+            if common_name is None:
+                common_name = ""
+            else:
+                common_name = f"commonName = {common_name}"
+            f.write(
+                _node_config_tmpl.format(host=host, common_name=common_name))
+
+        self._exec(f"openssl genrsa -out {key} 2048")
+
+        self._exec(f"openssl req -new -config {cfg} "
+                   f"-key {key} -out {csr} -batch")
+
+        self._exec(f"openssl ca -config {self.ca.cfg} -keyfile "
+                   f"{self.ca.key} -cert {self.ca.crt} -policy signing_policy "
+                   f"-extensions signing_node_req -in {csr} -out {crt} "
+                   f"-outdir {self._dir.name} -batch")
+
+        cert = Certificate(cfg, key, crt, self.ca)
+        self.certs[name] = cert
+        return cert

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -10,6 +10,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError
+from rptest.services.redpanda import SecurityConfig
 
 
 class AccessControlListTest(RedpandaTest):
@@ -17,11 +18,12 @@ class AccessControlListTest(RedpandaTest):
     algorithm = "SCRAM-SHA-256"
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(AccessControlListTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def get_client(self, username):

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -38,6 +38,9 @@ class AccessControlListTest(RedpandaTest):
     password = "password"
     algorithm = "SCRAM-SHA-256"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
     def setUp(self):
         # Skip starting redpanda, so that test can explicitly start
         # it with custom security settings

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -6,11 +6,30 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import socket
+from ducktape.mark import matrix
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError
-from rptest.services.redpanda import SecurityConfig
+from rptest.services.redpanda import SecurityConfig, TLSProvider
+from rptest.services import tls
+
+
+class MTLSProvider(TLSProvider):
+    def __init__(self, tls):
+        self.tls = tls
+
+    @property
+    def ca(self):
+        return self.tls.ca
+
+    def create_broker_cert(self, redpanda, node):
+        assert node in redpanda.nodes
+        return self.tls.create_cert(node.name)
+
+    def create_service_client_cert(self, _, name):
+        return self.tls.create_cert(socket.gethostname(), name=name)
 
 
 class AccessControlListTest(RedpandaTest):
@@ -18,26 +37,42 @@ class AccessControlListTest(RedpandaTest):
     algorithm = "SCRAM-SHA-256"
 
     def __init__(self, test_context):
-        security = SecurityConfig()
-        security.enable_sasl = True
-        super(AccessControlListTest,
-              self).__init__(test_context,
-                             num_brokers=3,
-                             security=security,
-                             extra_node_conf={'developer_mode': True})
+        self.security = SecurityConfig()
+        self.security.enable_sasl = True
+        super(AccessControlListTest, self).__init__(test_context,
+                                                    num_brokers=3,
+                                                    security=self.security)
+
+    def setUp(self):
+        # Skip starting redpanda, so that test can explicitly start
+        # it with custom security settings
+        return
+
+    def _start_redpanda(self, use_tls):
+        if use_tls:
+            self.tls = tls.TLSCertManager()
+            self.cert = self.tls.create_cert(socket.gethostname(),
+                                             name="client")
+            self.security.tls_provider = MTLSProvider(self.tls)
+            self.redpanda.set_security_settings(self.security)
+        else:
+            self.cert = None
+        self.redpanda.start()
 
     def get_client(self, username):
         return RpkTool(self.redpanda,
                        username=username,
                        password=self.password,
-                       sasl_mechanism=self.algorithm)
+                       sasl_mechanism=self.algorithm,
+                       tls_cert=self.cert)
 
     def get_super_client(self):
         username, password, _ = self.redpanda.SUPERUSER_CREDENTIALS
         return RpkTool(self.redpanda,
                        username=username,
                        password=password,
-                       sasl_mechanism=self.algorithm)
+                       sasl_mechanism=self.algorithm,
+                       tls_cert=self.cert)
 
     def prepare_users(self):
         """
@@ -56,10 +91,12 @@ class AccessControlListTest(RedpandaTest):
         client.acl_create_allow_cluster("cluster_describe", "describe")
 
     @cluster(num_nodes=3)
-    def test_describe_acls(self):
+    @matrix(use_tls=[True, False])
+    def test_describe_acls(self, use_tls):
         """
         security::acl_operation::describe, security::default_cluster_name
         """
+        self._start_redpanda(use_tls)
         self.prepare_users()
 
         try:

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -50,7 +50,7 @@ class AccessControlListTest(RedpandaTest):
 
     def _start_redpanda(self, use_tls):
         if use_tls:
-            self.tls = tls.TLSCertManager()
+            self.tls = tls.TLSCertManager(self.logger)
             self.cert = self.tls.create_cert(socket.gethostname(),
                                              name="client")
             self.security.tls_provider = MTLSProvider(self.tls)

--- a/tests/rptest/tests/compatibility/franzgo_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_test.py
@@ -11,6 +11,7 @@ from rptest.services.cluster import cluster
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.franzgo_examples as FranzGoExamples
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 from rptest.clients.types import TopicSpec
 import math
 
@@ -27,11 +28,14 @@ class FranzGoBase(RedpandaTest):
         # idempotence is necessary for bench example
         extra_rp_conf = {
             "enable_idempotence": True,
-            "enable_sasl": enable_sasl
         }
         self._ctx = test_context
 
+        security = SecurityConfig()
+        security.enable_sasl = enable_sasl
+
         super(FranzGoBase, self).__init__(test_context=test_context,
+                                          security=security,
                                           extra_rp_conf=extra_rp_conf)
 
         self._max_records = 1000 if self.scale.local else 1000000

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -15,6 +15,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.sarama_examples as SaramaExamples
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 from rptest.clients.types import TopicSpec
 
 
@@ -132,9 +133,9 @@ class SaramaScramTest(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
-        super(SaramaScramTest, self).__init__(test_context,
-                                              extra_rp_conf=extra_rp_conf)
+        security = SecurityConfig()
+        security.enable_sasl = True
+        super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
     def test_sarama_sasl_scram(self):

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -19,6 +19,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig
 
 
 def create_topic_names(count):
@@ -826,14 +827,15 @@ class PandaProxySASLTest(RedpandaTest):
     Test pandaproxy can connect using SASL.
     """
     def __init__(self, context):
-        extra_rp_conf = dict(
-            auto_create_topics_enabled=False,
-            enable_sasl=True,
-        )
+        extra_rp_conf = dict(auto_create_topics_enabled=False, )
+
+        security = SecurityConfig()
+        security.enable_sasl = True
 
         super(PandaProxySASLTest, self).__init__(context,
                                                  num_brokers=3,
                                                  enable_pp=True,
+                                                 security=security,
                                                  extra_rp_conf=extra_rp_conf)
 
         http.client.HTTPConnection.debuglevel = 1

--- a/tests/rptest/tests/scram_pythonlib_test.py
+++ b/tests/rptest/tests/scram_pythonlib_test.py
@@ -11,17 +11,19 @@ from rptest.services.cluster import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import SecurityConfig
 from kafka import KafkaAdminClient
 from kafka.admin import NewTopic
 
 
 class ScramPythonLibTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(ScramPythonLibTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def make_superuser_client(self, password_override=None):

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -19,15 +19,17 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services.admin import Admin
+from rptest.services.redpanda import SecurityConfig
 
 
 class ScramTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = dict(enable_sasl=True, )
+        security = SecurityConfig()
+        security.enable_sasl = True
         super(ScramTest,
               self).__init__(test_context,
                              num_brokers=3,
-                             extra_rp_conf=extra_rp_conf,
+                             security=security,
                              extra_node_conf={'developer_mode': True})
 
     def update_user(self, username):

--- a/tests/rptest/tests/scramful_eos_test.py
+++ b/tests/rptest/tests/scramful_eos_test.py
@@ -12,6 +12,7 @@ from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import SecurityConfig
 from time import sleep
 
 from confluent_kafka import (Producer, KafkaException)
@@ -39,10 +40,13 @@ class ScramfulEosTest(RedpandaTest):
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,
             "enable_auto_rebalance_on_node_add": False,
-            "enable_sasl": True
         }
 
+        security = SecurityConfig()
+        security.enable_sasl = True
+
         super(ScramfulEosTest, self).__init__(test_context=test_context,
+                                              security=security,
                                               extra_rp_conf=extra_rp_conf)
 
     def retry(self, func, retries, accepted_error_code):


### PR DESCRIPTION
## Cover letter

* Backport #4516
* Backport #4505
* Backport #4501 

## Release notes

### Features

* Support mTLS AuthN via propagation of the principal from the Subject (DN) of the client certificate
