### PR TITLE
Fix linearizable barrier

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -592,7 +592,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     if (term != _term) {
         co_return ret_t(make_error_code(errc::not_leader));
     }
-    vlog(_ctxlog.trace, "Linearizble offset: {}", _commit_index);
+    vlog(_ctxlog.trace, "Linearizable offset: {}", _commit_index);
     co_return ret_t(_commit_index);
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -511,7 +511,6 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     if (_vstate != vote_state::leader) {
         co_return result<model::offset>(make_error_code(errc::not_leader));
     }
-    co_await flush_log();
     // store current commit index
     auto cfg = config();
     auto dirty_offset = _log.offsets().dirty_offset;
@@ -535,7 +534,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
           meta(),
           model::make_memory_record_batch_reader(
             ss::circular_buffer<model::record_batch>{}),
-          append_entries_request::flush_after_append::yes);
+          append_entries_request::flush_after_append::no);
         auto seq = next_follower_sequence(target);
         sequences.emplace(target, seq);
 


### PR DESCRIPTION
## Cover letter

Fixed linearizable barrier semantics to make it the same as from before the changes introduced in 20330df1fef966dc6b832c1a7358aed0b7d20036. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4518
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
