### PR TITLE
r/recovery_stm: changed recovery stm append entries failure logging sev

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -431,7 +431,7 @@ ss::future<> recovery_stm::replicate(
       .then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
           if (!r) {
               vlog(
-                _ctxlog.error,
+                _ctxlog.warn,
                 "recovery append entries error: {}",
                 r.error().message());
               _stop_requested = true;


### PR DESCRIPTION
Changed severity of log entry notifying user about failed
`append_entries` request sent from `recovery_stm`. Those kind of
failures are first class citizen when nodes are restarted/isolated. This
shouldn't alarm users but they should be notified.
