### PR TITLE
[v22.1.x] kafka/server: run activate_feature in background

### DIFF
--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -30,8 +30,10 @@
 #include "storage/utils/transforming_reader.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/sleep.hh>
 
 #include <algorithm>
+#include <exception>
 
 namespace kafka {
 static ss::logger mlog("group-metadata-migration");
@@ -526,36 +528,40 @@ ss::future<> group_metadata_migration::activate_feature(ss::abort_source& as) {
     vlog(mlog.info, "activating consumer offsets feature");
     while (!feature_table().is_active(cluster::feature::consumer_offsets)
            && !as.abort_requested()) {
-        if (_controller.is_raft0_leader()) {
-            co_await feature_table().await_feature_preparing(
-              cluster::feature::consumer_offsets, as);
+        co_await do_activate_feature(as);
+    }
+}
 
-            auto err = co_await feature_manager().write_action(
-              cluster::feature_update_action{
-                .feature_name = ss::sstring(
-                  _controller.get_feature_table()
-                    .local()
-                    .get_state(cluster::feature::consumer_offsets)
-                    .spec.name),
-                .action
-                = cluster::feature_update_action::action_t::complete_preparing,
-              });
+ss::future<>
+group_metadata_migration::do_activate_feature(ss::abort_source& as) {
+    if (_controller.is_raft0_leader()) {
+        co_await feature_table().await_feature_preparing(
+          cluster::feature::consumer_offsets, as);
 
-            if (
-              err
-              || !feature_table().is_active(
-                cluster::feature::consumer_offsets)) {
-                if (err) {
-                    vlog(
-                      mlog.info,
-                      "error activating consumer offsets feature: {}",
-                      err.message());
-                }
-                co_await ss::sleep_abortable(default_timeout, as);
+        auto err = co_await feature_manager().write_action(
+          cluster::feature_update_action{
+            .feature_name = ss::sstring(
+              _controller.get_feature_table()
+                .local()
+                .get_state(cluster::feature::consumer_offsets)
+                .spec.name),
+            .action
+            = cluster::feature_update_action::action_t::complete_preparing,
+          });
+
+        if (
+          err
+          || !feature_table().is_active(cluster::feature::consumer_offsets)) {
+            if (err) {
+                vlog(
+                  mlog.info,
+                  "error activating consumer offsets feature: {}",
+                  err.message());
             }
-        } else {
             co_await ss::sleep_abortable(default_timeout, as);
         }
+    } else {
+        co_await ss::sleep_abortable(default_timeout, as);
     }
 }
 
@@ -680,23 +686,42 @@ ss::future<> group_metadata_migration::start(ss::abort_source& as) {
         co_return;
     }
 
-    // if no group topic is present just make feature active
-    if (!_controller.get_topics_state().local().contains(
-          model::kafka_group_nt, model::partition_id{0})) {
-        vlog(
-          mlog.info,
-          "kafka_internal/group topic does not exists, activating "
-          "consumer_offsets feature");
-        try {
-            co_await activate_feature(as);
-        } catch (const ss::abort_requested_exception&) {
-            // ignore abort requested exception, we are shutting down
-        }
+    _sub = as.subscribe([this]() noexcept { _as.request_abort(); });
+    if (!_sub) {
+        // Smbd finished redpanda
         co_return;
     }
-    // otherwise wait for feature to be preparing and execute migration
-    ssx::spawn_with_gate(
-      _background_gate, [this]() -> ss::future<> { return do_apply(); });
+
+    // Wait for feature to be preparing and execute migration
+    ssx::background
+      = ssx::spawn_with_gate_then(_background_gate, [this]() -> ss::future<> {
+            while (
+              !feature_table().is_active(cluster::feature::consumer_offsets)
+              && !_as.abort_requested()) {
+                if (!_controller.get_topics_state().local().contains(
+                      model::kafka_group_nt, model::partition_id{0})) {
+                    vlog(
+                      mlog.info,
+                      "kafka_internal/group topic does not exists, activating "
+                      "consumer_offsets feature");
+                    try {
+                        co_await do_activate_feature(_as);
+                        continue;
+                    } catch (const std::exception& e) {
+                        vlog(
+                          mlog.warn,
+                          "Got exception during activate consumer_offset "
+                          "feature "
+                          "{}",
+                          e);
+                    }
+                    co_await ss::sleep_abortable(default_timeout, _as);
+                } else {
+                    co_return co_await do_apply();
+                }
+            }
+        }).handle_exception_type([](ss::sleep_aborted&) {});
+
     co_return;
 }
 

--- a/src/v/kafka/server/group_metadata_migration.h
+++ b/src/v/kafka/server/group_metadata_migration.h
@@ -51,6 +51,7 @@ private:
     ss::future<> do_apply();
     ss::future<> migrate_metadata();
     ss::future<> activate_feature(ss::abort_source&);
+    ss::future<> do_activate_feature(ss::abort_source&);
 
     void dispatch_ntp_migration(model::ntp);
 
@@ -62,6 +63,13 @@ private:
     ss::sharded<kafka::group_router>& _group_router;
     ss::gate _partitions_gate;
     ss::gate _background_gate;
+
+    // We need to subscribe on stop_signal as to stop
+    // loop inside activate_feature. Because stop_signal
+    // does not wait background fiber and will dbe deleted
+    // before fiber will be stopped.
+    ss::optimized_optional<ss::abort_source::subscription> _sub;
+    ss::abort_source _as;
 };
 
 } // namespace kafka

--- a/src/v/platform/stop_signal.h
+++ b/src/v/platform/stop_signal.h
@@ -27,6 +27,10 @@ public:
     ~stop_signal() {
         ss::engine().handle_signal(SIGINT, [] {});
         ss::engine().handle_signal(SIGTERM, [] {});
+
+        // We should signal for unit tests, because some background tasks does
+        // not finish without it
+        signaled();
     }
     ss::future<> wait() {
         return _cond.wait([this] { return _as.abort_requested(); });


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4474
  Fixes https://github.com/redpanda-data/redpanda/issues/4563

Also includes backport for: https://github.com/redpanda-data/redpanda/pull/4547 which is a test for #4474
  