### PR TITLE
rpk: generate pool of available ports for container start command

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -175,28 +175,22 @@ func startCluster(
 		return err
 	}
 
+	reqPorts := n * 5 // we need 5 ports per node
+	ports, err := vnet.GetFreePortPool(int(reqPorts))
+	if err != nil {
+		return err
+	}
+
 	// Start a seed node.
-	seedID := uint(0)
-	seedKafkaPort, err := vnet.GetFreePort()
-	if err != nil {
-		return err
-	}
-	seedProxyPort, err := vnet.GetFreePort()
-	if err != nil {
-		return err
-	}
-	seedSchemaRegPort, err := vnet.GetFreePort()
-	if err != nil {
-		return err
-	}
-	seedRPCPort, err := vnet.GetFreePort()
-	if err != nil {
-		return err
-	}
-	seedMetricsPort, err := vnet.GetFreePort()
-	if err != nil {
-		return err
-	}
+	var (
+		seedID            uint
+		seedKafkaPort     = ports[0]
+		seedProxyPort     = ports[1]
+		seedSchemaRegPort = ports[2]
+		seedRPCPort       = ports[3]
+		seedMetricsPort   = ports[4]
+	)
+
 	seedState, err := common.CreateNode(
 		c,
 		seedID,
@@ -236,26 +230,14 @@ func startCluster(
 	for nodeID := uint(1); nodeID < n; nodeID++ {
 		id := nodeID
 		grp.Go(func() error {
-			kafkaPort, err := vnet.GetFreePort()
-			if err != nil {
-				return err
-			}
-			proxyPort, err := vnet.GetFreePort()
-			if err != nil {
-				return err
-			}
-			schemaRegPort, err := vnet.GetFreePort()
-			if err != nil {
-				return err
-			}
-			rpcPort, err := vnet.GetFreePort()
-			if err != nil {
-				return err
-			}
-			metricsPort, err := vnet.GetFreePort()
-			if err != nil {
-				return err
-			}
+			var (
+				kafkaPort     = ports[0+5*id]
+				proxyPort     = ports[1+5*id]
+				schemaRegPort = ports[2+5*id]
+				rpcPort       = ports[3+5*id]
+				metricsPort   = ports[4+5*id]
+			)
+
 			args := []string{
 				"--seeds",
 				net.JoinHostPort(

--- a/src/go/rpk/pkg/cli/cmd/container/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start_test.go
@@ -129,7 +129,8 @@ Please check your internet connection and try again.`,
 			expectedErrMsg: "Network create go boom",
 		},
 		{
-			name: "it should fail if inspecting the network fails",
+			name:  "it should fail if inspecting the network fails",
+			nodes: 1,
 			client: func(_ *testing.T) (common.Client, error) {
 				return &common.MockClient{
 					MockNetworkInspect: func(
@@ -147,7 +148,8 @@ Please check your internet connection and try again.`,
 			expectedErrMsg: "Can't inspect the network",
 		},
 		{
-			name: "it should fail if the network config is corrupted",
+			name:  "it should fail if the network config is corrupted",
+			nodes: 1,
 			client: func(_ *testing.T) (common.Client, error) {
 				return &common.MockClient{
 					MockNetworkInspect: func(
@@ -211,7 +213,8 @@ Please check your internet connection and try again.`,
 			expectedErrMsg: "Can't inspect",
 		},
 		{
-			name: "it should fail if creating the container fails",
+			name:  "it should fail if creating the container fails",
+			nodes: 1,
 			client: func(_ *testing.T) (common.Client, error) {
 				return &common.MockClient{
 					// NetworkInspect succeeds returning the

--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -45,7 +45,7 @@ func GetInterfacesByIps(addresses ...string) ([]string, error) {
 	return utils.GetKeys(nics), nil
 }
 
-func GetFreePort() (uint, error) {
+func getFreePort() (uint, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
@@ -57,4 +57,16 @@ func GetFreePort() (uint, error) {
 	}
 	defer l.Close()
 	return uint(l.Addr().(*net.TCPAddr).Port), nil
+}
+
+func GetFreePortPool(n int) ([]uint, error) {
+	var ports []uint
+	for i := 0; i < n; i++ {
+		p, err := getFreePort()
+		if err != nil {
+			return nil, err
+		}
+		ports = append(ports, p)
+	}
+	return ports, nil
 }


### PR DESCRIPTION
## Cover letter
This PR changes the way rpk handles the port assignment for each redpanda node when using `rpk container start` to fix a race between redpanda start and our `vnet.GetFreePot()`

Now it will preallocate all available ports before starting the nodes.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2418 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
