### PR TITLE
test: create directory for certs before copying

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -645,18 +645,24 @@ class RedpandaService(Service):
                 f"Writing Redpanda node tls key file: {RedpandaService.TLS_SERVER_KEY_FILE}"
             )
             self.logger.debug(open(cert.key, "r").read())
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.TLS_SERVER_KEY_FILE))
             node.account.copy_to(cert.key, RedpandaService.TLS_SERVER_KEY_FILE)
 
             self.logger.info(
                 f"Writing Redpanda node tls cert file: {RedpandaService.TLS_SERVER_CRT_FILE}"
             )
             self.logger.debug(open(cert.crt, "r").read())
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.TLS_SERVER_CRT_FILE))
             node.account.copy_to(cert.crt, RedpandaService.TLS_SERVER_CRT_FILE)
 
             self.logger.info(
                 f"Writing Redpanda node tls ca cert file: {RedpandaService.TLS_CA_CRT_FILE}"
             )
             self.logger.debug(open(ca.crt, "r").read())
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.TLS_CA_CRT_FILE))
             node.account.copy_to(ca.crt, RedpandaService.TLS_CA_CRT_FILE)
 
     def security_config(self):


### PR DESCRIPTION
## Cover letter

If the directory in which certs are copied to does not exist then an
error will be thrown. This PR ensure the target directory exists before
copying the cert files.

Fixes: https://github.com/redpanda-data/redpanda/issues/4552

Testing. I suppose other issues could cause this, but I simulated this scenario by manually manipulating paths and it produced the same error. Further, bootstrap config writing also initializes the target directory suggesting this may have been encountered before.

## Release notes

* none