### PR TITLE
Two stage processing in groups

### DIFF
--- a/src/v/kafka/protocol/join_group.h
+++ b/src/v/kafka/protocol/join_group.h
@@ -130,15 +130,9 @@ struct join_group_response final {
 };
 
 inline join_group_response
-_make_join_error(kafka::member_id member_id, error_code error) {
+make_join_error(kafka::member_id member_id, error_code error) {
     return join_group_response(
       error, no_generation, no_protocol, no_leader, std::move(member_id));
-}
-
-inline ss::future<join_group_response>
-make_join_error(kafka::member_id member_id, error_code error) {
-    return ss::make_ready_future<join_group_response>(
-      _make_join_error(std::move(member_id), error));
 }
 
 inline std::ostream&

--- a/src/v/kafka/protocol/sync_group.h
+++ b/src/v/kafka/protocol/sync_group.h
@@ -93,10 +93,6 @@ struct sync_group_response final {
     }
 };
 
-inline ss::future<sync_group_response> make_sync_error(error_code error) {
-    return ss::make_ready_future<sync_group_response>(error);
-}
-
 inline std::ostream&
 operator<<(std::ostream& os, const sync_group_response& r) {
     return os << r.data;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2042,7 +2042,6 @@ group::handle_offset_commit(offset_commit_request&& r) {
           offset_commit_response(r, error_code::rebalance_in_progress));
     } else {
         return offset_commit_stages(
-          ss::now(),
           ss::make_exception_future<offset_commit_response>(std::runtime_error(
             fmt::format("Unexpected group state {} for {}", _state, *this))));
     }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -443,7 +443,7 @@ bool group::leader_rejoined() {
     }
 }
 
-ss::future<join_group_response>
+group::join_group_stages
 group::handle_join_group(join_group_request&& r, bool is_new_group) {
     vlog(
       _ctxlog.trace,
@@ -452,8 +452,7 @@ group::handle_join_group(join_group_request&& r, bool is_new_group) {
       (is_new_group ? "new" : "existing"),
       *this);
 
-    auto ret = ss::make_ready_future<join_group_response>(
-      join_group_response(error_code::none));
+    auto ret = join_group_stages(join_group_response(error_code::none));
 
     if (r.data.member_id == unknown_member_id) {
         ret = join_group_unknown_member(std::move(r));
@@ -494,16 +493,17 @@ group::handle_join_group(join_group_request&& r, bool is_new_group) {
 }
 
 // DONE
-ss::future<join_group_response>
+
+group::join_group_stages
 group::join_group_unknown_member(join_group_request&& r) {
     if (in_state(group_state::dead)) {
         vlog(_ctxlog.trace, "Join rejected in state {}", _state);
-        return make_join_error(
-          unknown_member_id, error_code::coordinator_not_available);
+        return join_group_stages(make_join_error(
+          unknown_member_id, error_code::coordinator_not_available));
 
     } else if (!supports_protocols(r)) {
-        return make_join_error(
-          unknown_member_id, error_code::inconsistent_group_protocol);
+        return join_group_stages(make_join_error(
+          unknown_member_id, error_code::inconsistent_group_protocol));
     }
 
     auto new_member_id = group::generate_member_id(r);
@@ -520,13 +520,14 @@ group::join_group_unknown_member(join_group_request&& r) {
           "Requesting rejoin for unknown member with new id {}",
           new_member_id);
         add_pending_member(new_member_id, r.data.session_timeout_ms);
-        return make_join_error(new_member_id, error_code::member_id_required);
+        return join_group_stages(
+          make_join_error(new_member_id, error_code::member_id_required));
     } else {
         return add_member_and_rebalance(std::move(new_member_id), std::move(r));
     }
 }
 
-ss::future<join_group_response>
+group::join_group_stages
 group::join_group_known_member(join_group_request&& r) {
     if (in_state(group_state::dead)) {
         vlog(
@@ -534,12 +535,12 @@ group::join_group_known_member(join_group_request&& r) {
           "Join rejected in state {} for {}",
           _state,
           r.data.member_id);
-        return make_join_error(
-          r.data.member_id, error_code::coordinator_not_available);
+        return join_group_stages(make_join_error(
+          r.data.member_id, error_code::coordinator_not_available));
 
     } else if (!supports_protocols(r)) {
-        return make_join_error(
-          r.data.member_id, error_code::inconsistent_group_protocol);
+        return join_group_stages(make_join_error(
+          r.data.member_id, error_code::inconsistent_group_protocol));
 
     } else if (contains_pending_member(r.data.member_id)) {
         kafka::member_id new_member_id = std::move(r.data.member_id);
@@ -550,7 +551,8 @@ group::join_group_known_member(join_group_request&& r) {
           _ctxlog.trace,
           "Join rejected for unregistered member {}",
           r.data.member_id);
-        return make_join_error(r.data.member_id, error_code::unknown_member_id);
+        return join_group_stages(
+          make_join_error(r.data.member_id, error_code::unknown_member_id));
     }
 
     auto member = get_member(r.data.member_id);
@@ -592,8 +594,7 @@ group::join_group_known_member(join_group_request&& r) {
               member->id(),
               response);
 
-            return ss::make_ready_future<join_group_response>(
-              std::move(response));
+            return join_group_stages(std::move(response));
 
         } else {
             // <kafka>member has changed metadata, so force a rebalance</kafka>
@@ -626,21 +627,21 @@ group::join_group_known_member(join_group_request&& r) {
 
             vlog(_ctxlog.trace, "Handling idemponent group join {}", response);
 
-            return ss::make_ready_future<join_group_response>(
-              std::move(response));
+            return join_group_stages(std::move(response));
         }
 
     case group_state::empty:
         [[fallthrough]];
 
     case group_state::dead:
-        return make_join_error(r.data.member_id, error_code::unknown_member_id);
+        return join_group_stages(
+          make_join_error(r.data.member_id, error_code::unknown_member_id));
     }
 
     __builtin_unreachable();
 }
 
-ss::future<join_group_response> group::add_member_and_rebalance(
+group::join_group_stages group::add_member_and_rebalance(
   kafka::member_id member_id, join_group_request&& r) {
     auto member = ss::make_lw_shared<group_member>(
       std::move(member_id),
@@ -699,15 +700,15 @@ ss::future<join_group_response> group::add_member_and_rebalance(
       *this);
 
     try_prepare_rebalance();
-    return response;
+    return join_group_stages(std::move(response));
 }
 
-ss::future<join_group_response>
+group::join_group_stages
 group::update_member_and_rebalance(member_ptr member, join_group_request&& r) {
     auto response = update_member(
       std::move(member), r.native_member_protocols());
     try_prepare_rebalance();
-    return response;
+    return join_group_stages(std::move(response));
 }
 
 void group::try_prepare_rebalance() {
@@ -995,7 +996,7 @@ void group::shutdown() {
               error_code::not_coordinator, member->assignment()));
         } else if (member->is_joining()) {
             try_finish_joining_member(
-              member, _make_join_error(member_id, error_code::not_coordinator));
+              member, make_join_error(member_id, error_code::not_coordinator));
         }
     }
 }
@@ -1008,7 +1009,7 @@ void group::remove_member(member_ptr member) {
     // the member. We return UNKNOWN_MEMBER_ID so that the consumer will retry
     // the JoinGroup request if is still active.</kafka>
     try_finish_joining_member(
-      member, _make_join_error(no_member, error_code::unknown_member_id));
+      member, make_join_error(no_member, error_code::unknown_member_id));
 
     // TODO: (not blocker) avoid the double look-up. we could do the removal
     // from the index in the caller and then pass in the shared_ptr.
@@ -1071,20 +1072,21 @@ void group::remove_member(member_ptr member) {
     }
 }
 
-ss::future<sync_group_response>
-group::handle_sync_group(sync_group_request&& r) {
+group::sync_group_stages group::handle_sync_group(sync_group_request&& r) {
     vlog(_ctxlog.trace, "Handling sync group request {}", r);
 
     if (in_state(group_state::dead)) {
         vlog(_ctxlog.trace, "Sync rejected for group state {}", _state);
-        return make_sync_error(error_code::coordinator_not_available);
+        return sync_group_stages(
+          sync_group_response(error_code::coordinator_not_available));
 
     } else if (!contains_member(r.data.member_id)) {
         vlog(
           _ctxlog.trace,
           "Sync rejected for unregistered member {}",
           r.data.member_id);
-        return make_sync_error(error_code::unknown_member_id);
+        return sync_group_stages(
+          sync_group_response(error_code::unknown_member_id));
 
     } else if (r.data.generation_id != generation()) {
         vlog(
@@ -1092,7 +1094,8 @@ group::handle_sync_group(sync_group_request&& r) {
           "Sync rejected with out-of-date generation {} != {}",
           r.data.generation_id,
           generation());
-        return make_sync_error(error_code::illegal_generation);
+        return sync_group_stages(
+          sync_group_response(error_code::illegal_generation));
     }
 
     // the two states of interest are `completing rebalance` and `stable`.
@@ -1113,11 +1116,13 @@ group::handle_sync_group(sync_group_request&& r) {
     switch (state()) {
     case group_state::empty:
         vlog(_ctxlog.trace, "Sync rejected for group state {}", _state);
-        return make_sync_error(error_code::unknown_member_id);
+        return sync_group_stages(
+          sync_group_response(error_code::unknown_member_id));
 
     case group_state::preparing_rebalance:
         vlog(_ctxlog.trace, "Sync rejected for group state {}", _state);
-        return make_sync_error(error_code::rebalance_in_progress);
+        return sync_group_stages(
+          sync_group_response(error_code::rebalance_in_progress));
 
     case group_state::completing_rebalance: {
         auto member = get_member(r.data.member_id);
@@ -1135,7 +1140,7 @@ group::handle_sync_group(sync_group_request&& r) {
           "Handling idemponent group sync for member {} with reply {}",
           member,
           reply);
-        return ss::make_ready_future<sync_group_response>(std::move(reply));
+        return sync_group_stages(sync_group_response(std::move(reply)));
     }
 
     case group_state::dead:
@@ -1178,7 +1183,7 @@ model::record_batch group::checkpoint(const assignments_type& assignments) {
     return std::move(builder).build();
 }
 
-ss::future<sync_group_response> group::sync_group_completing_rebalance(
+group::sync_group_stages group::sync_group_completing_rebalance(
   member_ptr member, sync_group_request&& r) {
     // this response will be set by the leader when it arrives. the leader also
     // sets its own response which reduces the special cases in the code, but we
@@ -1192,7 +1197,7 @@ ss::future<sync_group_response> group::sync_group_completing_rebalance(
           _ctxlog.trace,
           "Non-leader member waiting for assignment {}",
           member->id());
-        return response;
+        return sync_group_stages(std::move(response));
     }
 
     vlog(_ctxlog.trace, "Completing group sync with leader {}", member->id());
@@ -1207,50 +1212,55 @@ ss::future<sync_group_response> group::sync_group_completing_rebalance(
     auto batch = checkpoint(assignments);
     auto reader = model::make_memory_record_batch_reader(std::move(batch));
 
-    return _partition
-      ->replicate(
-        std::move(reader),
-        raft::replicate_options(raft::consistency_level::quorum_ack))
-      .then([this,
-             response = std::move(response),
-             expected_generation = generation(),
-             assignments = std::move(assignments)](
-              result<raft::replicate_result> r) mutable {
-          /*
-           * the group's state has changed (e.g. another member joined). there's
-           * nothing to do now except have the client wait for an update.
-           */
-          if (
-            !in_state(group_state::completing_rebalance)
-            || expected_generation != generation()) {
-              vlog(_ctxlog.trace, "Group state changed while completing sync");
-              return std::move(response);
-          }
+    auto f = _partition
+               ->replicate(
+                 std::move(reader),
+                 raft::replicate_options(raft::consistency_level::quorum_ack))
+               .then([this,
+                      response = std::move(response),
+                      expected_generation = generation(),
+                      assignments = std::move(assignments)](
+                       result<raft::replicate_result> r) mutable {
+                   /*
+                    * the group's state has changed (e.g. another member
+                    * joined). there's nothing to do now except have the client
+                    * wait for an update.
+                    */
+                   if (
+                     !in_state(group_state::completing_rebalance)
+                     || expected_generation != generation()) {
+                       vlog(
+                         _ctxlog.trace,
+                         "Group state changed while completing sync");
+                       return std::move(response);
+                   }
 
-          if (r) {
-              // the group state was successfully persisted:
-              //   - save the member assignments; clients may re-request
-              //   - unblock any clients waiting on their assignment
-              //   - transition the group to the stable state
-              set_assignments(std::move(assignments));
-              finish_syncing_members(error_code::none);
-              set_state(group_state::stable);
-              vlog(_ctxlog.trace, "Successfully completed group sync");
-          } else {
-              vlog(
-                _ctxlog.trace,
-                "An error occurred completing group sync {}",
-                r.error());
-              // an error was encountered persisting the group state:
-              //   - clear all the member assignments
-              //   - propogate error back to waiting clients
-              clear_assignments();
-              finish_syncing_members(error_code::not_coordinator);
-              try_prepare_rebalance();
-          }
+                   if (r) {
+                       // the group state was successfully persisted:
+                       //   - save the member assignments; clients may
+                       //   re-request
+                       //   - unblock any clients waiting on their assignment
+                       //   - transition the group to the stable state
+                       set_assignments(std::move(assignments));
+                       finish_syncing_members(error_code::none);
+                       set_state(group_state::stable);
+                       vlog(_ctxlog.trace, "Successfully completed group sync");
+                   } else {
+                       vlog(
+                         _ctxlog.trace,
+                         "An error occurred completing group sync {}",
+                         r.error());
+                       // an error was encountered persisting the group state:
+                       //   - clear all the member assignments
+                       //   - propogate error back to waiting clients
+                       clear_assignments();
+                       finish_syncing_members(error_code::not_coordinator);
+                       try_prepare_rebalance();
+                   }
 
-          return std::move(response);
-      });
+                   return std::move(response);
+               });
+    return sync_group_stages(std::move(f));
 }
 
 ss::future<heartbeat_response> group::handle_heartbeat(heartbeat_request&& r) {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -141,6 +141,9 @@ public:
         ss::future<Result> result;
     };
     using offset_commit_stages = stages<offset_commit_response>;
+    using join_group_stages = stages<join_group_response>;
+    using sync_group_stages = stages<sync_group_response>;
+
     struct offset_metadata {
         model::offset log_offset;
         model::offset offset;
@@ -388,23 +391,21 @@ public:
     static kafka::member_id generate_member_id(const join_group_request& r);
 
     /// Handle join entry point.
-    ss::future<join_group_response>
+    join_group_stages
     handle_join_group(join_group_request&& r, bool is_new_group);
 
     /// Handle join of an unknown member.
-    ss::future<join_group_response>
-    join_group_unknown_member(join_group_request&& request);
+    join_group_stages join_group_unknown_member(join_group_request&& request);
 
     /// Handle join of a known member.
-    ss::future<join_group_response>
-    join_group_known_member(join_group_request&& request);
+    join_group_stages join_group_known_member(join_group_request&& request);
 
     /// Add a new member and initiate a rebalance.
-    ss::future<join_group_response> add_member_and_rebalance(
+    join_group_stages add_member_and_rebalance(
       kafka::member_id member_id, join_group_request&& request);
 
     /// Update an existing member and rebalance.
-    ss::future<join_group_response> update_member_and_rebalance(
+    join_group_stages update_member_and_rebalance(
       member_ptr member, join_group_request&& request);
 
     /// Transition to preparing rebalance if possible.
@@ -428,10 +429,10 @@ public:
     void remove_member(member_ptr member);
 
     /// Handle a group sync request.
-    ss::future<sync_group_response> handle_sync_group(sync_group_request&& r);
+    sync_group_stages handle_sync_group(sync_group_request&& r);
 
     /// Handle sync group in completing rebalance state.
-    ss::future<sync_group_response> sync_group_completing_rebalance(
+    sync_group_stages sync_group_completing_rebalance(
       member_ptr member, sync_group_request&& request);
 
     /// Complete syncing for members.

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -660,6 +660,13 @@ private:
     ctx_log _ctxlog;
     ctx_log _ctx_txlog;
     group_metadata_serializer _md_serializer;
+    /**
+     * flag indicating that the group rebalance is a result of initial join i.e.
+     * the group was in Empty state before it went into PreparingRebalance
+     * state. Initial join in progress flag will prevent completing join when
+     * all members joined but initial delay is still in progress
+     */
+    bool _initial_join_in_progress = false;
 
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;
     model::term_id _term;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -880,7 +880,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
     }
 
     auto stages = group->handle_offset_commit(std::move(r));
-    stages.committed = stages.committed.finally([group] {});
+    stages.result = stages.result.finally([group] {});
     return stages;
 }
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -126,10 +126,10 @@ public:
 
 public:
     /// \brief Handle a JoinGroup request
-    ss::future<join_group_response> join_group(join_group_request&& request);
+    group::join_group_stages join_group(join_group_request&& request);
 
     /// \brief Handle a SyncGroup request
-    ss::future<sync_group_response> sync_group(sync_group_request&& request);
+    group::sync_group_stages sync_group(sync_group_request&& request);
 
     /// \brief Handle a Heartbeat request
     ss::future<heartbeat_response> heartbeat(heartbeat_request&& request);

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -182,11 +182,11 @@ public:
       , _feature_table(feature_table) {}
 
     auto join_group(join_group_request&& request) {
-        return route(std::move(request), &group_manager::join_group);
+        return route_stages(std::move(request), &group_manager::join_group);
     }
 
     auto sync_group(sync_group_request&& request) {
-        return route(std::move(request), &group_manager::sync_group);
+        return route_stages(std::move(request), &group_manager::sync_group);
     }
 
     auto heartbeat(heartbeat_request&& request) {

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -35,24 +35,31 @@ static void decode_request(request_context& ctx, join_group_request& req) {
       fmt::format("{}", ctx.connection()->client_host()));
 }
 
-template<>
-ss::future<response_ptr> join_group_handler::handle(
+process_result_stages join_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     join_group_request request;
     decode_request(ctx, request);
 
     if (request.data.group_instance_id) {
-        co_return co_await ctx.respond(
-          join_group_response(error_code::unsupported_version));
+        return process_result_stages::single_stage(
+          ctx.respond(join_group_response(error_code::unsupported_version)));
     }
 
     if (!ctx.authorized(security::acl_operation::read, request.data.group_id)) {
-        co_return co_await ctx.respond(
-          join_group_response(error_code::group_authorization_failed));
+        return process_result_stages::single_stage(ctx.respond(
+          join_group_response(error_code::group_authorization_failed)));
     }
 
-    auto resp = co_await ctx.groups().join_group(std::move(request));
-    co_return co_await ctx.respond(std::move(resp));
+    auto stages = ctx.groups().join_group(std::move(request));
+    auto res = ss::do_with(
+      std::move(ctx),
+      [f = std::move(stages.result)](request_context& ctx) mutable {
+          return f.then([&ctx](join_group_response response) {
+              return ctx.respond(std::move(response));
+          });
+      });
+
+    return process_result_stages(std::move(stages.dispatched), std::move(res));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/join_group.h
+++ b/src/v/kafka/server/handlers/join_group.h
@@ -14,6 +14,10 @@
 
 namespace kafka {
 
-using join_group_handler = handler<join_group_api, 0, 4>;
-
-}
+struct join_group_handler {
+    using api = join_group_api;
+    static constexpr api_version min_supported = api_version(0);
+    static constexpr api_version max_supported = api_version(4);
+    static process_result_stages handle(request_context, ss::smp_service_group);
+};
+} // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -191,7 +191,7 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
           auto stages = octx.rctx.groups().offset_commit(
             std::move(octx.request));
           stages.dispatched.forward_to(std::move(dispatch));
-          return stages.committed.then([&octx](offset_commit_response resp) {
+          return stages.result.then([&octx](offset_commit_response resp) {
               if (unlikely(!octx.nonexistent_tps.empty())) {
                   /*
                    * copy over partitions for topics that had some partitions

--- a/src/v/kafka/server/handlers/sync_group.h
+++ b/src/v/kafka/server/handlers/sync_group.h
@@ -14,6 +14,11 @@
 
 namespace kafka {
 
-using sync_group_handler = handler<sync_group_api, 0, 3>;
+struct sync_group_handler {
+    using api = sync_group_api;
+    static constexpr api_version min_supported = api_version(0);
+    static constexpr api_version max_supported = api_version(3);
+    static process_result_stages handle(request_context, ss::smp_service_group);
+};
 
-}
+} // namespace kafka

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -73,6 +73,20 @@ struct process_dispatch<offset_commit_handler> {
         return offset_commit_handler::handle(std::move(ctx), g);
     }
 };
+template<>
+struct process_dispatch<join_group_handler> {
+    static process_result_stages
+    process(request_context&& ctx, ss::smp_service_group g) {
+        return join_group_handler::handle(std::move(ctx), g);
+    }
+};
+template<>
+struct process_dispatch<sync_group_handler> {
+    static process_result_stages
+    process(request_context&& ctx, ss::smp_service_group g) {
+        return sync_group_handler::handle(std::move(ctx), g);
+    }
+};
 
 template<typename Request>
 CONCEPT(requires(KafkaApiHandler<Request> || KafkaApiTwoPhaseHandler<Request>))


### PR DESCRIPTION
## Cover letter

Applied two stage processing to join and sync group requests.

All kafka handlers in redpanda process one request at a time per single
connection. When processing of one request finishes next request is read
from the wire and processed. Leveraging the two stage request processing
allows to process multiple requests at a time per single connection.
Only first stage of the request processing is serialized and blocks the
next request. Waiting for the second stage to finish is done in
background and do not block other requests.

Join and sync group requests may take long time to complete hence we do
not want block the connection while waiting for its completion.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
