### PR TITLE
rpk: fix wasm generate file search logic and improve err messages

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -32,7 +32,7 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "generate [PROJECT DIRECTORY]",
-		Short: "Create an npm template project for inline WASM engine.",
+		Short: "Create a npm template project for inline WASM engine.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			path, err := filepath.Abs(args[0])
@@ -41,7 +41,7 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 			out.MaybeDie(err, "unable to generate all manifest files: %v", err)
 		},
 	}
-	cmd.Flags().BoolVar(&skipVersion, "skip-version", false, "Omit version check from npm, use default instead")
+	cmd.Flags().BoolVar(&skipVersion, "skip-version", false, "omit wasm-api version check from npm, use default instead")
 	return cmd
 }
 
@@ -84,11 +84,11 @@ func getWasmApiVersion(wasmApi string) string {
 	return version
 }
 
-// Looks up the latest version of our client library using npm, defaulting
-// if anything fails.
+// latestClientApiVersion looks up the latest version of our client library using npm,
+// defaulting if anything fails.
 func latestClientApiVersion() string {
 	if _, err := exec.LookPath("npm"); err != nil {
-		fmt.Printf("npm not found, defaulting to client API verision %s.\n", defApiVersion)
+		fmt.Printf("npm not found, defaulting to client API version %s.\n", defApiVersion)
 		return defApiVersion
 	}
 
@@ -115,7 +115,7 @@ func executeGenerate(fs afero.Fs, path string, skipVersion bool) error {
 	for dir, templates := range generateManifest(version) {
 		for _, template := range templates {
 			file := filepath.Join(path, dir, template.name)
-			exist, err := afero.Exists(fs, path)
+			exist, err := afero.Exists(fs, file)
 			if err != nil {
 				return fmt.Errorf("unable to determine if file %q exists: %v", file, err)
 			}
@@ -125,7 +125,7 @@ func executeGenerate(fs afero.Fs, path string, skipVersion bool) error {
 		}
 	}
 	if len(preexisting) > 0 {
-		return fmt.Errorf("Files %v already exist, avoiding generation.", preexisting)
+		return fmt.Errorf("files already exist; try using a new directory or removing the existing files, existing: %v", preexisting)
 	}
 
 	if err := fs.MkdirAll(path, 0o755); err != nil {


### PR DESCRIPTION
## Cover letter

Currently, when we run `rpk wasm generate <project directory>` and the project directory already exists, rpk will falsely claim that some files exist.

This PR cover this fix and some error message improvements.

previously 
```
$ rpk wasm generate /tmp/foo 
unable to generate all manifest files: Files [/tmp/foo/src/main.js /tmp/foo/test/main.test.js /tmp/foo/package.json /tmp/foo/webpack.js] already exist, avoiding generation.

# neither main.js, main.test.js, package.json nor webpack.js exist
```

now if the directory exists but not the files, it will generate the template project. In case any of the generated files already exists then it will print 
```
$ rpk wasm generate /tmp/wasm-test

unable to generate all manifest files: files [/tmp/wasm-test/src/main.js /tmp/wasm-test/test/main.test.js /tmp/wasm-test/package.json /tmp/wasm-test/webpack.js] already exist.

try using a new directory name or removing the listed files
```

Fixes #4433

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
