### PR TITLE
Fix for kafka/protocol unit tests not running

### DIFF
--- a/src/v/kafka/protocol/tests/CMakeLists.txt
+++ b/src/v/kafka/protocol/tests/CMakeLists.txt
@@ -3,10 +3,26 @@ find_package(CppKafka CONFIG REQUIRED)
 rp_test(
   UNIT_TEST
   BINARY_NAME
-    test_kafka_protocol
+    test_kafka_protocol_unit
+  SOURCES
+    security_test.cc
+  DEFINITIONS
+    BOOST_TEST_DYN_LINK
+  LIBRARIES
+  Boost::unit_test_framework
+    v::kafka
+    v::storage_test_utils
+  LABELS
+    kafka
+    kafka_protocol
+)
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME
+    test_kafka_protocol_single_thread
   SOURCES
     batch_reader_test.cc
-    security_test.cc
   DEFINITIONS
     BOOST_TEST_DYN_LINK
   LIBRARIES


### PR DESCRIPTION
Cannot mix and match BOOST_AUTO* fixtures with other ones. Separating the tests that do use that into another binary solves the issue.

Release notes
- none