### PR TITLE
rpk: fix data race in container purge and stop

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/purge.go
+++ b/src/go/rpk/pkg/cli/cmd/container/purge.go
@@ -58,7 +58,7 @@ You may start a new local cluster with 'rpk container start'`,
 		grp.Go(func() error {
 			ctx, _ := common.DefaultCtx()
 			name := common.Name(id)
-			err = c.ContainerRemove(
+			err := c.ContainerRemove(
 				ctx,
 				name,
 				types.ContainerRemoveOptions{

--- a/src/go/rpk/pkg/cli/cmd/container/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/container/stop.go
@@ -65,7 +65,7 @@ You may start a new cluster with 'rpk container start'`,
 			// Redpanda sometimes takes a while to stop, so 20
 			// seconds is a safe estimate
 			timeout := 20 * time.Second
-			err = c.ContainerStop(
+			err := c.ContainerStop(
 				ctx,
 				common.Name(state.ID),
 				&timeout,


### PR DESCRIPTION
## Cover letter

Fixes 2 small data race bugs in container purge and stop

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #1299 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
