### PR TITLE
rpk: change exit status for topic command  failures

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
@@ -11,6 +11,7 @@ package topic
 
 import (
 	"context"
+	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -42,6 +43,13 @@ func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
 			resps, err := adm.CreatePartitions(context.Background(), num, topics...)
 			out.MaybeDie(err, "create partitions request failed: %v", err)
 
+			var exit1 bool
+			defer func() {
+				if exit1 {
+					os.Exit(1)
+				}
+			}()
+
 			tw := out.NewTable("topic", "error")
 			defer tw.Flush()
 
@@ -49,6 +57,7 @@ func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
 				msg := "OK"
 				if e := resp.Err; e != nil {
 					msg = e.Error()
+					exit1 = true
 				}
 				tw.Print(resp.Topic, msg)
 			}

--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -11,6 +11,7 @@ package topic
 
 import (
 	"context"
+	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -85,6 +86,13 @@ the cleanup.policy=compact config option set.
 			resp, err := req.RequestWith(context.Background(), cl)
 			out.MaybeDie(err, "unable to create topics %v: %v", topics, err)
 
+			var exit1 bool
+			defer func() {
+				if exit1 {
+					os.Exit(1)
+				}
+			}()
+
 			tw := out.NewTable("topic", "status")
 			defer tw.Flush()
 
@@ -92,6 +100,7 @@ the cleanup.policy=compact config option set.
 				msg := "OK"
 				if err := kerr.ErrorForCode(topic.ErrorCode); err != nil {
 					msg = err.Error()
+					exit1 = true
 				}
 				tw.Print(topic.Topic, msg)
 			}


### PR DESCRIPTION
## Cover letter

Change exit status code `0 -> 1` when there is a failure in topic creation or adding a partition to existing topics

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3397 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
