### PR TITLE
tests/rpk_producer: acks arg is an int, not a bool

### DIFF
--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -16,7 +16,7 @@ class RpkProducer(BackgroundThreadService):
                  topic: str,
                  msg_size: int,
                  msg_count: int,
-                 acks: Optional[bool] = None,
+                 acks: Optional[int] = None,
                  printable=False,
                  quiet: bool = False,
                  produce_timeout: Optional[int] = None):


### PR DESCRIPTION
Bug found with type annotations.

Callers pass in signed integers, which are also expected by RPK.

## Release notes
* none