### PR TITLE
rpk/config: Add ServerTLS:Other

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -928,6 +928,7 @@ schema_registry: {}
 					CertFile:          "/etc/certs/cert.crt",
 					Enabled:           true,
 					RequireClientAuth: true,
+					Other:             map[string]interface{}{"principal_mapping_rules": "DEFAULT"},
 				}}
 				return c
 			},
@@ -949,6 +950,7 @@ redpanda:
     enabled: true
     key_file: /etc/certs/cert.key
     name: outside
+    principal_mapping_rules: DEFAULT
     require_client_auth: true
     truststore_file: /etc/certs/ca.crt
   node_id: 0

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -127,12 +127,13 @@ func (t *TLS) Config(fs afero.Fs) (*tls.Config, error) {
 }
 
 type ServerTLS struct {
-	Name              string `yaml:"name,omitempty" mapstructure:"name,omitempty" json:"name"`
-	KeyFile           string `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
-	CertFile          string `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
-	TruststoreFile    string `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
-	Enabled           bool   `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty" json:"enabled"`
-	RequireClientAuth bool   `yaml:"require_client_auth,omitempty" mapstructure:"require_client_auth,omitempty" json:"requireClientAuth"`
+	Name              string                 `yaml:"name,omitempty" mapstructure:"name,omitempty" json:"name"`
+	KeyFile           string                 `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
+	CertFile          string                 `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
+	TruststoreFile    string                 `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
+	Enabled           bool                   `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty" json:"enabled"`
+	RequireClientAuth bool                   `yaml:"require_client_auth,omitempty" mapstructure:"require_client_auth,omitempty" json:"requireClientAuth"`
+	Other             map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type RpkConfig struct {

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -150,10 +150,12 @@ public:
           << "enabled: " << c.is_enabled() << " "
           << "key/cert files: " << c.get_key_cert_files() << " "
           << "ca file: " << c.get_truststore_file() << " "
-          << "client_auth_required: " << c.get_require_client_auth() << " "
-          << "principal_mapping_rules: " << c.get_principal_mapping_rules()
-          << " }";
-        return o;
+          << "client_auth_required: " << c.get_require_client_auth();
+        if (c.get_principal_mapping_rules()) {
+            o << " principal_mapping_rules: "
+              << c.get_principal_mapping_rules();
+        }
+        return o << " }";
     }
 
 private:

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -38,6 +38,13 @@ struct key_cert {
     bool operator==(const key_cert& rhs) const {
         return key_file == rhs.key_file && cert_file == rhs.cert_file;
     }
+
+    friend std::ostream& operator<<(std::ostream& o, const key_cert& c) {
+        o << "{ "
+          << "key_file: " << c.key_file << " "
+          << "cert_file: " << c.cert_file << " }";
+        return o;
+    }
 };
 
 class tls_config {
@@ -137,6 +144,18 @@ public:
 
     bool operator==(const tls_config& rhs) const = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const config::tls_config& c) {
+        o << "{ "
+          << "enabled: " << c.is_enabled() << " "
+          << "key/cert files: " << c.get_key_cert_files() << " "
+          << "ca file: " << c.get_truststore_file() << " "
+          << "client_auth_required: " << c.get_require_client_auth() << " "
+          << "principal_mapping_rules: " << c.get_principal_mapping_rules()
+          << " }";
+        return o;
+    }
+
 private:
     bool _enabled{false};
     std::optional<key_cert> _key_cert;
@@ -146,23 +165,6 @@ private:
 };
 
 } // namespace config
-namespace std {
-static inline ostream& operator<<(ostream& o, const config::key_cert& c) {
-    o << "{ "
-      << "key_file: " << c.key_file << " "
-      << "cert_file: " << c.cert_file << " }";
-    return o;
-}
-static inline ostream& operator<<(ostream& o, const config::tls_config& c) {
-    o << "{ "
-      << "enabled: " << c.is_enabled() << " "
-      << "key/cert files: " << c.get_key_cert_files() << " "
-      << "ca file: " << c.get_truststore_file() << " "
-      << "client_auth_required: " << c.get_require_client_auth() << " "
-      << "principal_mapping_rules: " << c.get_principal_mapping_rules() << " }";
-    return o;
-}
-} // namespace std
 
 namespace YAML {
 


### PR DESCRIPTION
## Cover letter

Support new server tls configuration introduced in #4501.

* Prevent `rpk` from stripping unknown fields on `ServerTLS`.
  * rpk doesn't need to know about `principal_mapping_rules`, so the fix is generic and will apply to any future fields that are added
* Refactor `operator<<` in config/tls_config as a hidden friend
* Don't print `principal_mapping_rules` if it's not set

## Release notes

### Improvements

* rpk: Support new server tls configuration.
