### PR TITLE
backport: Add new test for shadow indexing

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -614,9 +614,45 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                          replication_factor=3)
         self.client().create_topic(spec)
         self.topic = spec.name
-        self.start_producer(1)
+        self.start_producer(1, throughput=throughput)
         self.start_consumer(1)
         self.await_startup()
-        for _ in range(25):
+        for _ in range(moves):
             self._move_and_verify()
-        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+        self.run_validation(enable_idempotence=False,
+                            consumer_timeout_sec=45,
+                            min_records=records)
+
+    @cluster(num_nodes=5)
+    def test_cross_shard(self):
+        """
+        Test interaction between the shadow indexing and the partition movement.
+        Move partitions with SI enabled between shards.
+        """
+        throughput, records, moves, partitions = self._get_scale_params()
+
+        self.start_redpanda(num_nodes=3)
+        spec = TopicSpec(name="topic",
+                         partition_count=partitions,
+                         replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(1, throughput=throughput)
+        self.start_consumer(1)
+        self.await_startup()
+
+        admin = Admin(self.redpanda)
+        topic = self.topic
+        partition = 0
+
+        for _ in range(moves):
+            assignments = self._get_assignments(admin, topic, partition)
+            for a in assignments:
+                # Bounce between core 0 and 1
+                a['core'] = (a['core'] + 1) % 2
+            admin.set_partition_replicas(topic, partition, assignments)
+            self._wait_post_move(topic, partition, assignments, 360)
+
+        self.run_validation(enable_idempotence=False,
+                            consumer_timeout_sec=45,
+                            min_records=records)


### PR DESCRIPTION
## Cover letter

Backport PR https://github.com/redpanda-data/redpanda/pull/3532

Add test that checks that shadow indexing works as expected when the
partition movement is actively performed.

The CI check is not supposed to pass before https://github.com/redpanda-data/redpanda/pull/3492 is merged.
The PR was extracted from the https://github.com/redpanda-data/redpanda/pull/3492 because the test is flaky.
The test sometimes fails to fetch few offsets. This happens only in the release branch.
This is something unrelated to the issue https://github.com/redpanda-data/redpanda/issues/3316.