### PR TITLE
rpk: change brokers endpoint to cluster_view

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -12,11 +12,9 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"sort"
 )
 
 const brokersEndpoint = "/v1/brokers"
-const clusterViewEndpoint = "v1/cluster_view"
 
 type MaintenanceStatus struct {
 	Draining     bool `json:"draining"`
@@ -28,11 +26,6 @@ type MaintenanceStatus struct {
 	Failed       int  `json:"failed"`
 }
 
-type ClusterView struct {
-	Version int      `json:"version"`
-	Brokers []Broker `json:"brokers"`
-}
-
 // Broker is the information returned from the Redpanda admin broker endpoints.
 type Broker struct {
 	NodeID           int                `json:"node_id"`
@@ -41,16 +34,6 @@ type Broker struct {
 	IsAlive          *bool              `json:"is_alive"`
 	Version          string             `json:"version"`
 	Maintenance      *MaintenanceStatus `json:"maintenance_status"`
-}
-
-// Brokers queries one of the client's hosts and returns the list of brokers.
-func (a *AdminAPI) Brokers() ([]Broker, error) {
-	var cv ClusterView
-	defer func() {
-		sort.Slice(cv.Brokers, func(i, j int) bool { return cv.Brokers[i].NodeID < cv.Brokers[j].NodeID }) //nolint:revive // return inside this deferred function is for the sort's less function
-	}()
-	err := a.sendAny(http.MethodGet, clusterViewEndpoint, nil, &cv)
-	return cv.Brokers, err
 }
 
 // Broker queries one of the client's hosts and returns broker information.

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
@@ -78,7 +78,7 @@ Notes:
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			cv, err := client.ClusterView()
+			cv, host, err := client.ClusterView()
 			out.MaybeDie(err, "unable to request cluster view: %v", err)
 
 			if len(cv.Brokers) == 0 {
@@ -89,7 +89,7 @@ Notes:
 				out.Die("Maintenance mode is not supported in this cluster")
 			}
 
-			fmt.Printf("Cluster view version of the broker handling this request: %d\n", cv.Version)
+			fmt.Printf("From broker %d on cluster view version %d:\n", host, cv.Version)
 			table := newMaintenanceReportTable()
 			defer table.Flush()
 			for _, broker := range cv.Brokers {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -51,8 +51,8 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			bs, err := cl.Brokers()
-			out.MaybeDie(err, "unable to request brokers: %v", err)
+			cv, err := cl.ClusterView()
+			out.MaybeDie(err, "unable to request cluster view: %v", err)
 
 			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
 
@@ -60,7 +60,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 				ret := []interface{}{b.NodeID, b.NumCores, b.MembershipStatus}
 				return ret
 			}
-			for _, b := range bs {
+			for _, b := range cv.Brokers {
 				if b.IsAlive != nil {
 					headers = append(headers, "Is-Alive", "Broker-Version")
 					orig := args
@@ -70,9 +70,10 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 					break
 				}
 			}
+			fmt.Printf("Cluster view version of the broker handling this request: %d\n", cv.Version)
 			tw := out.NewTable(headers...)
 			defer tw.Flush()
-			for _, b := range bs {
+			for _, b := range cv.Brokers {
 				tw.Print(args(&b)...)
 			}
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -51,7 +51,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			cv, err := cl.ClusterView()
+			cv, host, err := cl.ClusterView()
 			out.MaybeDie(err, "unable to request cluster view: %v", err)
 
 			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
@@ -70,7 +70,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 					break
 				}
 			}
-			fmt.Printf("Cluster view version of the broker handling this request: %d\n", cv.Version)
+			fmt.Printf("From broker %d on cluster view version %d:\n", host, cv.Version)
 			tw := out.NewTable(headers...)
 			defer tw.Flush()
 			for _, b := range cv.Brokers {


### PR DESCRIPTION
## Cover letter

Deprecate `/v1/brokers` in favor of `/v1/cluster_view`

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3605 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
