### PR TITLE
rpk: change host flag help text for admin config print

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -55,7 +55,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&host, "host", "", "either an index into admin_api hosts to issue the request to, or a hostname")
+	cmd.Flags().StringVar(&host, "host", "", "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to")
 	cobra.MarkFlagRequired(cmd.Flags(), "host")
 
 	return cmd


### PR DESCRIPTION
## Cover letter

Attempt to improve help text for `rpk redpanda admin config print --host` flag

Fixes #4000 
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
