### PR TITLE
k8s: Remove defaults Redpanda configuration options

### DIFF
--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -135,16 +135,12 @@ var _ = BeforeEach(func() {
 	// Register some known properties for all tests
 	testAdminAPI.RegisterPropertySchema("auto_create_topics_enabled", admin.ConfigPropertyMetadata{NeedsRestart: false})
 	testAdminAPI.RegisterPropertySchema("cloud_storage_segment_max_upload_interval_sec", admin.ConfigPropertyMetadata{NeedsRestart: true})
-	testAdminAPI.RegisterPropertySchema("enable_idempotence", admin.ConfigPropertyMetadata{NeedsRestart: true})
-	testAdminAPI.RegisterPropertySchema("enable_transactions", admin.ConfigPropertyMetadata{NeedsRestart: true})
 	testAdminAPI.RegisterPropertySchema("log_segment_size", admin.ConfigPropertyMetadata{NeedsRestart: true})
 
 	// By default we set the following properties and they'll be loaded by redpanda from the .bootstrap.yaml
 	// So we initialize the test admin API with those
 	testAdminAPI.SetProperty("auto_create_topics_enabled", false)
 	testAdminAPI.SetProperty("cloud_storage_segment_max_upload_interval_sec", 1800)
-	testAdminAPI.SetProperty("enable_idempotence", false)
-	testAdminAPI.SetProperty("enable_transactions", false)
 	testAdminAPI.SetProperty("log_segment_size", 536870912)
 })
 

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -352,8 +352,6 @@ func (r *ConfigMapResource) CreateConfiguration(
 	}
 
 	cfg.SetAdditionalRedpandaProperty("auto_create_topics_enabled", r.pandaCluster.Spec.Configuration.AutoCreateTopics)
-	cfg.SetAdditionalRedpandaProperty("enable_idempotence", false)
-	cfg.SetAdditionalRedpandaProperty("enable_transactions", false)
 
 	if featuregates.ShadowIndex(r.pandaCluster.Spec.Version) {
 		intervalSec := 60 * 30 // 60s * 30 = 30 minutes

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -89,7 +89,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "28bea897f8e9276745f112ab0d60cfbd",
+			expectedHash:            "0cb36f0be0d64032a61eb51a5d2985ea",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -99,7 +99,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "862e93acfa2280dcb58e6a3170969232",
+			expectedHash: "4697714fe9b8f8bcaebb814b93f2b8f6",
 		},
 		{
 			name: "shadow index cache directory",
@@ -107,7 +107,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "2dd0ca25d4ae2e5aec0adc950b4b8236",
+			expectedHash: "2f51e71fa4b673fb105f98cb09cb7a00",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -157,12 +157,6 @@ func TestEnsure_ConfigMap(t *testing.T) {
 	if !strings.Contains(data, "auto_create_topics_enabled: false") {
 		t.Fatalf("expecting configmap containing 'auto_create_topics_enabled: false' but got %v", data)
 	}
-	if !strings.Contains(data, "enable_idempotence: false") {
-		t.Fatalf("expecting configmap containing 'enable_idempotence: false' but got %v", data)
-	}
-	if !strings.Contains(data, "enable_transactions: false") {
-		t.Fatalf("expecting configmap containing 'enable_transactions: false' but got %v", data)
-	}
 
 	// calling ensure for second time to see the resource does not get updated
 	err = cm.Ensure(context.Background())

--- a/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -25,7 +25,6 @@ spec:
      - port: 8082
     developerMode: true
   additionalConfiguration:
-    redpanda.enable_idempotence: "true"
     redpanda.default_topic_partitions: "3"
     pandaproxy_client.retries: "10"
     schema_registry.schema_registry_api: "[{'name':'external','address':'0.0.0.0','port':8081}]"

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
@@ -41,8 +41,6 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   default_topic_partitions: 3
   developer_mode: true
-  enable_idempotence: false
-  enable_transactions: false
   kafka_api:
   - address: 0.0.0.0
     name: kafka


### PR DESCRIPTION
## Cover letter

Enable idempotency by default in Kubernetes environment. 

## Release notes

* Enable idempotency by default.
