### PR TITLE
rpk: changes in cluster config:

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -35,6 +35,11 @@ func exportConfig(
 	sort.Strings(keys)
 
 	for _, name := range keys {
+		// We exclude cluster_id from exported config to avoid accidental
+		// duplication of the ID from one cluster to another
+		if name == "cluster_id" {
+			continue
+		}
 		meta := schema[name]
 		curValue := config[name]
 
@@ -181,7 +186,7 @@ to include all properties including these low level tunables.
 		"filename",
 		"f",
 		"",
-		"full path to file to export to, e.g. '/tmp/config.yml'",
+		"path to file to export to, e.g. './config.yml'",
 	)
 
 	return cmd

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
@@ -12,7 +12,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -84,8 +83,9 @@ If an empty string is given as the value, the property is reset to its default.`
 				// Special case 400 (validation) errors with friendly output
 				// about which configuration properties were invalid.
 				if he.Response.StatusCode == 400 {
-					fmt.Fprint(os.Stderr, formatValidationError(err, he))
-					out.Die("No changes were made.")
+					ve, err := formatValidationError(err, he)
+					out.MaybeDie(err, "error setting config: %v", err)
+					out.Die("No changes were made: %v", ve)
 				}
 			}
 


### PR DESCRIPTION
## Cover letter

This PR addresses some changes for `rpk cluster config`:

- cleanup temporary files after edit completion
- update help text for export to use a relative filename
- add `f` as a shorthand for `--filename` in import
- ignore `cluster_id` in import and export


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4585

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
