### PR TITLE
Fixed printing group instance id in `rpk group describe`

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/group/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/group/describe.go
@@ -180,7 +180,10 @@ func printDescribedGroup(
 		headers = append(headers, "INSTANCE-ID")
 		orig := args
 		args = func(r *describeRow) []interface{} {
-			return append(orig(r), r.instanceID)
+			if r.instanceID != nil {
+				return append(orig(r), *r.instanceID)
+			}
+			return append(orig(r), "")
 		}
 	}
 


### PR DESCRIPTION
Previously group instance id was printed as an address as pointer was
not dereferenced.
