### PR TITLE
k8s/configurator: remove unneeded log stmnt

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -142,8 +142,6 @@ func main() {
 		log.Fatalf("%s", fmt.Errorf("unable to marshal the configuration: %w", err))
 	}
 
-	log.Printf("Config: %s", string(cfgBytes))
-
 	if err := os.WriteFile(c.configDestination, cfgBytes, 0o600); err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to write the destination configuration file: %w", err))
 	}


### PR DESCRIPTION
# Cover letter

Removes an unnecessary log statement when the k8s configurator loads the config.
