### PR TITLE
config: redact secrets on bootstrap logging

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -145,18 +145,18 @@ void config_manager::start_bootstrap() {
 ss::future<> config_manager::do_bootstrap() {
     config_update_request update;
 
-    config::shard_local_cfg().for_each([&update](
-                                         const config::base_property& p) {
-        if (!p.is_default()) {
-            json::StringBuffer buf;
-            json::Writer<json::StringBuffer> writer(buf);
-            p.to_json(writer);
-            ss::sstring key_str(p.name());
-            ss::sstring val_str = buf.GetString();
-            vlog(clusterlog.info, "Importing property {}={}", key_str, val_str);
-            update.upsert.push_back({key_str, val_str});
-        }
-    });
+    config::shard_local_cfg().for_each(
+      [&update](const config::base_property& p) {
+          if (!p.is_default()) {
+              json::StringBuffer buf;
+              json::Writer<json::StringBuffer> writer(buf);
+              p.to_json(writer);
+              ss::sstring key_str(p.name());
+              ss::sstring val_str = buf.GetString();
+              vlog(clusterlog.info, "Importing property {}", p);
+              update.upsert.push_back({key_str, val_str});
+          }
+      });
 
     // Version of the first write
     _frontend.local().set_next_version(config_version{1});


### PR DESCRIPTION
## Cover letter

Fixes #4655

Avoid logging secrets on bootstrap logging by using base_property::print which replaces them with `[secret]`

## Release notes

* none