### PR TITLE
[v22.1.x] k8s/configurator: remove unneeded log stmnt

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -142,8 +142,6 @@ func main() {
 		log.Fatalf("%s", fmt.Errorf("unable to marshal the configuration: %w", err))
 	}
 
-	log.Printf("Config: %s", string(cfgBytes))
-
 	if err := os.WriteFile(c.configDestination, cfgBytes, 0o600); err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to write the destination configuration file: %w", err))
 	}


### PR DESCRIPTION
Fixes #4672

Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4652