### PR TITLE
rpk: change Invalid Partitions err message in topic creation

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -11,6 +11,8 @@ package topic
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -99,7 +101,11 @@ the cleanup.policy=compact config option set.
 			for _, topic := range resp.Topics {
 				msg := "OK"
 				if err := kerr.ErrorForCode(topic.ErrorCode); err != nil {
-					msg = err.Error()
+					if errors.Is(err, kerr.InvalidPartitions) && partitions > 0 {
+						msg = fmt.Sprintf("INVALID_PARTITIONS: unable to create topic with %d partitions due to hardware constraints", partitions)
+					} else {
+						msg = err.Error()
+					}
 					exit1 = true
 				}
 				tw.Print(topic.Topic, msg)


### PR DESCRIPTION
## Cover letter

Change invalid partitions error message in RPK for this case:

before
```
$ rpk topic create foobar -p 100000 --config rp.yaml
TOPIC   STATUS
foobar  INVALID_PARTITIONS: Number of partitions is below 1.
```

now
```
$ rpk topic create foobar -p 100000 --config rp.yaml
TOPIC   STATUS
foobar  INVALID_PARTITIONS: unable to create topic with 100000 partitions given current hardware constraints
```
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/redpanda/issues/4017

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
