### PR TITLE
rpk/k8s: enable gofumpt as default go formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,15 +34,15 @@ jobs:
         go-version: 1.17.8
       id: go
 
-    - name: install crlfmt
+    - name: install gofumpt
       working-directory: src/go/rpk
       run: |
-        go mod download github.com/cockroachdb/crlfmt
-        go install github.com/cockroachdb/crlfmt
+        go install mvdan.cc/gofumpt@v0.3.0
 
     - name: lint go files
+      working-directory: src/go
       run: |
-        find . -name *.go -type f | xargs -n1 crlfmt -wrap=80 -ignore '_generated.deepcopy.go$$' -w
+        find . -name *.go -type f | xargs -n1 gofumpt -w -lang=1.17
         git diff --exit-code
 
   js:

--- a/src/go/k8s/.golangci.yml
+++ b/src/go/k8s/.golangci.yml
@@ -36,6 +36,7 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
@@ -43,37 +44,39 @@ linters:
     - dupl
     - errcheck
     - exhaustive
+    - exportloopref
     - funlen
     - goconst
     - gocritic
     - gocyclo
-    - revive
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goimports
     - goprintffuncname
     - gosec
     - gosimple
     - govet
-    - vet
     - ineffassign
     - misspell
     - nakedret
+    - nestif
     - noctx
     - nolintlint
+    - prealloc
+    - revive
     - rowserrcheck
-    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck
+    - testpackage
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
+    - vet
     - whitespace
-    - asciicheck
-    - goerr113
-    - nestif
-    - prealloc
-    - testpackage
 
   # don't enable:
   # - gochecknoinits # the kubebuilder and kubernetes library enforce using init functions

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types_test.go
@@ -37,7 +37,8 @@ func TestRedpandaResourceRequirements(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: t.setRequestsMem,
 					corev1.ResourceCPU:    t.setRequestsCPU,
-				}},
+				},
+			},
 			Redpanda: corev1.ResourceList{
 				corev1.ResourceMemory: t.setRedpandaMem,
 				corev1.ResourceCPU:    t.setRedpandaCPU,

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -94,7 +94,8 @@ func TestDefault(t *testing.T) {
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
-						}},
+						},
+					},
 					Redpanda: nil,
 				},
 			},
@@ -118,7 +119,8 @@ func TestDefault(t *testing.T) {
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
-						}},
+						},
+					},
 					Redpanda: nil,
 				},
 			},
@@ -144,7 +146,8 @@ func TestDefault(t *testing.T) {
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
-						}},
+						},
+					},
 					Redpanda: nil,
 				},
 			},
@@ -170,7 +173,8 @@ func TestDefault(t *testing.T) {
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
-						}},
+						},
+					},
 					Redpanda: nil,
 				},
 			},
@@ -212,7 +216,8 @@ func TestValidateUpdate(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("0.9Gi"),
-					}},
+					},
+				},
 				Redpanda: nil,
 			},
 		},
@@ -222,7 +227,8 @@ func TestValidateUpdate(t *testing.T) {
 	updatedCluster.Spec.Replicas = &replicas1
 	updatedCluster.Spec.Configuration = v1alpha1.RedpandaConfig{
 		KafkaAPI: []v1alpha1.KafkaAPI{
-			{Port: 123,
+			{
+				Port: 123,
 				TLS: v1alpha1.KafkaAPITLS{
 					RequireClientAuth: true,
 					IssuerRef: &cmmeta.ObjectReference{
@@ -289,7 +295,8 @@ func TestValidateUpdate_NoError(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 						corev1.ResourceCPU:    resource.MustParse("1"),
-					}},
+					},
+				},
 				Redpanda: nil,
 			},
 		},
@@ -718,7 +725,8 @@ func TestCreation(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 					corev1.ResourceCPU:    resource.MustParse("2"),
-				}},
+				},
+			},
 			Redpanda: nil,
 		}
 
@@ -733,7 +741,8 @@ func TestCreation(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 					corev1.ResourceCPU:    resource.MustParse("2"),
-				}},
+				},
+			},
 			Redpanda: nil,
 		}
 		memory.Spec.Configuration.DeveloperMode = true
@@ -749,7 +758,8 @@ func TestCreation(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
 					corev1.ResourceCPU:    resource.MustParse("1"),
-				}},
+				},
+			},
 			Redpanda: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -772,7 +782,8 @@ func TestCreation(t *testing.T) {
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("3Gi"),
 					corev1.ResourceCPU:    resource.MustParse("1"),
-				}},
+				},
+			},
 			Redpanda: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -795,7 +806,8 @@ func TestCreation(t *testing.T) {
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2.223Gi"),
 					corev1.ResourceCPU:    resource.MustParse("1"),
-				}},
+				},
+			},
 			Redpanda: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -818,7 +830,8 @@ func TestCreation(t *testing.T) {
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
 					corev1.ResourceCPU:    resource.MustParse("1"),
-				}},
+				},
+			},
 			Redpanda: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -961,7 +974,8 @@ func TestCreation(t *testing.T) {
 				TLS: v1alpha1.KafkaAPITLS{
 					Enabled: true,
 				},
-				Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "InternalIP"}})
+				Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "InternalIP"},
+			})
 		err := rp.ValidateCreate()
 		assert.Error(t, err)
 	})
@@ -1095,7 +1109,8 @@ func validRedpandaCluster() *v1alpha1.Cluster {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 						corev1.ResourceCPU:    resource.MustParse("1"),
-					}},
+					},
+				},
 				Redpanda: nil,
 			},
 		},

--- a/src/go/k8s/apis/redpanda/v1alpha1/webhook_suite_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/webhook_suite_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,10 +36,12 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -114,7 +117,6 @@ var _ = BeforeSuite(func() {
 		conn.Close()
 		return nil
 	}).Should(Succeed())
-
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -36,7 +36,6 @@ const (
 )
 
 var _ = Describe("RedPandaCluster configuration controller", func() {
-
 	const (
 		timeout  = time.Second * 30
 		interval = time.Millisecond * 100
@@ -52,9 +51,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 	)
 
 	Context("When managing a RedpandaCluster with centralized config", func() {
-
 		It("Can initialize a cluster with centralized configuration", func() {
-
 			By("Allowing creation of a new cluster")
 			key, baseKey, redpandaCluster := getInitialTestCluster("central-initialize")
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
@@ -90,7 +87,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should interact with the admin API when doing changes", func() {
-
 			By("Allowing creation of a new cluster")
 			key, baseKey, redpandaCluster := getInitialTestCluster("central-changes")
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
@@ -148,7 +144,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should remove properties from the admin API when needed", func() {
-
 			By("Allowing creation of a new cluster")
 			key, baseKey, redpandaCluster := getInitialTestCluster("central-removal")
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
@@ -238,7 +233,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should restart the cluster only when strictly required", func() {
-
 			By("Allowing creation of a new cluster")
 			key, baseKey, redpandaCluster := getInitialTestCluster("central-restart")
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
@@ -340,7 +334,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should defer updating the centralized configuration when admin API is unavailable", func() {
-
 			testAdminAPI.SetUnavailable(true)
 
 			By("Allowing creation of a new cluster")
@@ -377,13 +370,10 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			By("Deleting the cluster")
 			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
 		})
-
 	})
 
 	Context("When reconciling a cluster without centralized configuration", func() {
-
 		It("Should behave like before", func() {
-
 			By("Allowing creation of a cluster with an old version")
 			key, baseKey, redpandaCluster := getInitialTestCluster("no-central")
 			redpandaCluster.Spec.Version = versionWithoutCentralizedConfiguration
@@ -427,13 +417,10 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			By("Deleting the cluster")
 			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
 		})
-
 	})
 
 	Context("When upgrading a cluster from a version without centralized configuration", func() {
-
 		It("Should do a single rolling upgrade", func() {
-
 			By("Allowing creation of a cluster with an old version")
 			key, baseKey, redpandaCluster := getInitialTestCluster("upgrading")
 			redpandaCluster.Spec.Version = versionWithoutCentralizedConfiguration
@@ -480,7 +467,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should be able to upgrade and change a cluster even if the admin API is unavailable", func() {
-
 			testAdminAPI.SetUnavailable(true)
 
 			By("Allowing creation of a cluster with an old version")
@@ -555,13 +541,10 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			By("Deleting the cluster")
 			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
 		})
-
 	})
 
 	Context("When setting invalid configuration on the cluster", func() {
-
 		It("Should reflect any invalid status in the condition", func() {
-
 			By("Allowing creation of a new cluster")
 			key, baseKey, redpandaCluster := getInitialTestCluster("condition-check")
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
@@ -642,7 +625,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should report direct validation errors in the condition", func() {
-
 			// admin API will return 400 bad request on invalid configuration (default behavior)
 			testAdminAPI.SetDirectValidationEnabled(true)
 
@@ -688,7 +670,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		})
 
 		It("Should report configuration errors present in the .bootstrap.yaml file", func() {
-
 			// Inject property before creating the cluster, simulating .bootstrap.yaml
 			const val = "nown"
 			_, err := testAdminAPI.PatchClusterConfig(map[string]interface{}{
@@ -730,7 +711,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 	})
 
 	Context("When external factors change configuration of a cluster", func() {
-
 		It("The drift detector restore all managed properties", func() {
 			// Registering two properties, one of them managed by the operator
 			const (

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var _ = Describe("RedPandaCluster controller", func() {
-
 	const (
 		timeout  = time.Second * 30
 		interval = time.Second * 1
@@ -152,14 +151,16 @@ var _ = Describe("RedPandaCluster controller", func() {
 				},
 				Spec: corev1.NodeSpec{},
 				Status: corev1.NodeStatus{
-					Addresses: []corev1.NodeAddress{{
-						Type:    corev1.NodeExternalIP,
-						Address: "9.8.7.6",
-					},
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeExternalIP,
+							Address: "9.8.7.6",
+						},
 						{
 							Type:    corev1.NodeInternalIP,
 							Address: "11.11.11.11",
-						}},
+						},
+					},
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), node)).Should(Succeed())
@@ -255,7 +256,6 @@ var _ = Describe("RedPandaCluster controller", func() {
 					len(rc.Status.Nodes.SchemaRegistry.ExternalNodeIPs) == 1 &&
 					len(rc.Status.Nodes.SchemaRegistry.Internal) > 0 &&
 					rc.Status.Nodes.SchemaRegistry.External == "" // Without subdomain the external address is empty
-
 			}, timeout, interval).Should(BeTrue())
 		})
 		It("creates redpanda cluster with tls enabled", func() {
@@ -329,7 +329,9 @@ var _ = Describe("RedPandaCluster controller", func() {
 									},
 								},
 								DefaultMode: &defaultMode,
-							}}},
+							},
+						},
+					},
 					corev1.Volume{
 						Name: "tlsca",
 						VolumeSource: corev1.VolumeSource{
@@ -342,7 +344,9 @@ var _ = Describe("RedPandaCluster controller", func() {
 									},
 								},
 								DefaultMode: &defaultMode,
-							}}}))
+							},
+						},
+					}))
 		})
 		It("creates redpanda cluster without external connectivity", func() {
 			resources := corev1.ResourceList{
@@ -494,7 +498,6 @@ var _ = Describe("RedPandaCluster controller", func() {
 				return err == nil &&
 					*sts.Spec.Replicas == replicas
 			}, timeout, interval).Should(BeTrue())
-
 		})
 		It("creates redpanda cluster with preferred address type", func() {
 			resources := corev1.ResourceList{
@@ -706,7 +709,6 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "nonexisting",
 			}})
 			Expect(err).To(Succeed())
-
 		})
 	})
 
@@ -727,7 +729,6 @@ var _ = Describe("RedPandaCluster controller", func() {
 		Expect(r.WithConfiguratorSettings(res.ConfiguratorSettings{
 			ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
 		}).SetupWithManager(k8sManager)).To(matcher)
-
 	},
 		Entry("Always image pull policy", "Always", Succeed()),
 		Entry("IfNotPresent image pull policy", "IfNotPresent", Succeed()),

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -43,11 +43,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var cfg *rest.Config
-var testAdminAPI *mockAdminAPI
-var testAdminAPIFactory adminutils.AdminAPIClientFactory
+var (
+	k8sClient           client.Client
+	testEnv             *envtest.Environment
+	cfg                 *rest.Config
+	testAdminAPI        *mockAdminAPI
+	testAdminAPIFactory adminutils.AdminAPIClientFactory
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/src/go/k8s/pkg/labels/labels_test.go
+++ b/src/go/k8s/pkg/labels/labels_test.go
@@ -39,21 +39,23 @@ func TestLabels(t *testing.T) {
 		pandaCluster *redpandav1alpha1.Cluster
 		expected     map[string]string
 	}{
-		{"empty inherited labels", testCluster, map[string]string{
-			"app.kubernetes.io/name":       "redpanda",
-			"app.kubernetes.io/instance":   "testcluster",
-			"app.kubernetes.io/component":  "redpanda",
-			"app.kubernetes.io/part-of":    "redpanda",
-			"app.kubernetes.io/managed-by": "redpanda-operator",
+		{
+			"empty inherited labels", testCluster, map[string]string{
+				"app.kubernetes.io/name":       "redpanda",
+				"app.kubernetes.io/instance":   "testcluster",
+				"app.kubernetes.io/component":  "redpanda",
+				"app.kubernetes.io/part-of":    "redpanda",
+				"app.kubernetes.io/managed-by": "redpanda-operator",
+			},
 		},
-		},
-		{"some inherited labels", withPartOfDefined, map[string]string{
-			"app.kubernetes.io/name":       "redpanda",
-			"app.kubernetes.io/instance":   "testcluster",
-			"app.kubernetes.io/component":  "redpanda",
-			"app.kubernetes.io/part-of":    "part-of-something-else",
-			"app.kubernetes.io/managed-by": "redpanda-operator",
-		},
+		{
+			"some inherited labels", withPartOfDefined, map[string]string{
+				"app.kubernetes.io/name":       "redpanda",
+				"app.kubernetes.io/instance":   "testcluster",
+				"app.kubernetes.io/component":  "redpanda",
+				"app.kubernetes.io/part-of":    "part-of-something-else",
+				"app.kubernetes.io/managed-by": "redpanda-operator",
+			},
 		},
 	}
 

--- a/src/go/k8s/pkg/networking/address_types_test.go
+++ b/src/go/k8s/pkg/networking/address_types_test.go
@@ -24,60 +24,65 @@ func TestGetPreferredAddress(t *testing.T) {
 		inputPreferredType corev1.NodeAddressType
 		expectedOutput     string
 	}{
-		{"missing node - no preference", nil,
+		{
+			"missing node - no preference", nil,
 			"", "",
 		},
-		{"missing node - with preference", nil,
+		{
+			"missing node - with preference", nil,
 			"some-preference", "",
 		},
-		{"node with external ip - no preference", &corev1.Node{
-			Status: corev1.NodeStatus{
-				Addresses: []corev1.NodeAddress{
-					{
-						Type:    corev1.NodeExternalIP,
-						Address: "ip-external",
-					},
-					{
-						Type:    corev1.NodeInternalIP,
-						Address: "ip-internal",
+		{
+			"node with external ip - no preference", &corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeExternalIP,
+							Address: "ip-external",
+						},
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "ip-internal",
+						},
 					},
 				},
-			},
-		}, "", "ip-external",
+			}, "", "ip-external",
 		},
-		{"node without external ip - no preference", &corev1.Node{
-			Status: corev1.NodeStatus{
-				Addresses: []corev1.NodeAddress{
-					{
-						Type:    corev1.NodeInternalIP,
-						Address: "ip-internal",
-					},
-					{
-						Type:    corev1.NodeInternalDNS,
-						Address: "dns-internal",
+		{
+			"node without external ip - no preference", &corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "ip-internal",
+						},
+						{
+							Type:    corev1.NodeInternalDNS,
+							Address: "dns-internal",
+						},
 					},
 				},
-			},
-		}, "", "",
+			}, "", "",
 		},
-		{"node with internal and external ip - prefer internal", &corev1.Node{
-			Status: corev1.NodeStatus{
-				Addresses: []corev1.NodeAddress{
-					{
-						Type:    corev1.NodeInternalDNS,
-						Address: "dns-internal",
-					},
-					{
-						Type:    corev1.NodeExternalIP,
-						Address: "ip-external",
-					},
-					{
-						Type:    corev1.NodeInternalIP,
-						Address: "ip-internal",
+		{
+			"node with internal and external ip - prefer internal", &corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalDNS,
+							Address: "dns-internal",
+						},
+						{
+							Type:    corev1.NodeExternalIP,
+							Address: "ip-external",
+						},
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "ip-internal",
+						},
 					},
 				},
-			},
-		}, corev1.NodeInternalIP, "ip-internal",
+			}, corev1.NodeInternalIP, "ip-internal",
 		},
 	}
 	for _, tt := range tests {

--- a/src/go/k8s/pkg/networking/ports_test.go
+++ b/src/go/k8s/pkg/networking/ports_test.go
@@ -33,7 +33,8 @@ func TestRedpandaPorts(t *testing.T) {
 					PandaproxyAPI:  []redpandav1alpha1.PandaproxyAPI{{Port: 333}, {External: redpandav1alpha1.ExternalConnectivityConfig{Enabled: true}}},
 					SchemaRegistry: &redpandav1alpha1.SchemaRegistryAPI{Port: 444, External: &redpandav1alpha1.ExternalConnectivityConfig{Enabled: true}},
 				},
-			}}, &networking.RedpandaPorts{
+			},
+		}, &networking.RedpandaPorts{
 			KafkaAPI: networking.PortsDefinition{
 				Internal: &resources.NamedServicePort{
 					Name: resources.InternalListenerName,
@@ -83,7 +84,8 @@ func TestRedpandaPorts(t *testing.T) {
 					PandaproxyAPI:  []redpandav1alpha1.PandaproxyAPI{{Port: 333}},
 					SchemaRegistry: &redpandav1alpha1.SchemaRegistryAPI{Port: 444},
 				},
-			}}, &networking.RedpandaPorts{
+			},
+		}, &networking.RedpandaPorts{
 			KafkaAPI: networking.PortsDefinition{
 				Internal: &resources.NamedServicePort{
 					Name: resources.InternalListenerName,
@@ -114,7 +116,8 @@ func TestRedpandaPorts(t *testing.T) {
 				Configuration: redpandav1alpha1.RedpandaConfig{
 					KafkaAPI: []redpandav1alpha1.KafkaAPI{{Port: 123}, {Port: 30001, External: redpandav1alpha1.ExternalConnectivityConfig{Enabled: true}}},
 				},
-			}}, &networking.RedpandaPorts{
+			},
+		}, &networking.RedpandaPorts{
 			KafkaAPI: networking.PortsDefinition{
 				Internal: &resources.NamedServicePort{
 					Name: resources.InternalListenerName,
@@ -126,7 +129,8 @@ func TestRedpandaPorts(t *testing.T) {
 				},
 			},
 		}},
-		{"kafka api external has bootstrap loadbalancer",
+		{
+			"kafka api external has bootstrap loadbalancer",
 			&redpandav1alpha1.Cluster{
 				Spec: redpandav1alpha1.ClusterSpec{
 					Configuration: redpandav1alpha1.RedpandaConfig{
@@ -144,7 +148,8 @@ func TestRedpandaPorts(t *testing.T) {
 							},
 						},
 					},
-				}},
+				},
+			},
 			&networking.RedpandaPorts{
 				KafkaAPI: networking.PortsDefinition{
 					Internal: &resources.NamedServicePort{
@@ -161,7 +166,8 @@ func TestRedpandaPorts(t *testing.T) {
 						Port:       1234,
 						TargetPort: 123 + 1,
 					},
-				}},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/src/go/k8s/pkg/resources/pdb_test.go
+++ b/src/go/k8s/pkg/resources/pdb_test.go
@@ -48,7 +48,7 @@ func TestEnsure_PDB(t *testing.T) {
 	clusterTwo.Spec.PodDisruptionBudget.MinAvailable = &two
 	pdbTwo := pdb.DeepCopy()
 	pdbTwo.Spec.MinAvailable = &two
-	var tests = []struct {
+	tests := []struct {
 		name           string
 		existingObject client.Object
 		pandaCluster   *redpandav1alpha1.Cluster

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -273,7 +273,7 @@ func preparePVCResource(
 func (r *StatefulSetResource) obj(
 	ctx context.Context,
 ) (k8sclient.Object, error) {
-	var clusterLabels = labels.ForCluster(r.pandaCluster)
+	clusterLabels := labels.ForCluster(r.pandaCluster)
 
 	annotations := r.pandaCluster.Spec.Annotations
 	if annotations == nil {
@@ -489,7 +489,8 @@ func (r *StatefulSetResource) obj(
 								{
 									LabelSelector: clusterLabels.AsAPISelector(),
 									Namespaces:    []string{r.pandaCluster.Namespace},
-									TopologyKey:   corev1.LabelHostname},
+									TopologyKey:   corev1.LabelHostname,
+								},
 							},
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 								{

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -69,7 +69,7 @@ func TestEnsure(t *testing.T) {
 	// Remove shadow-indexing-cache from the volume claim templates
 	stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates = stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates[:1]
 
-	var tests = []struct {
+	tests := []struct {
 		name           string
 		existingObject client.Object
 		pandaCluster   *redpandav1alpha1.Cluster
@@ -303,9 +303,7 @@ func pandaCluster() *redpandav1alpha1.Cluster {
 }
 
 func TestVersion(t *testing.T) {
-	var (
-		redpandaContainerName = "redpanda"
-	)
+	redpandaContainerName := "redpanda"
 
 	tests := []struct {
 		Containers      []corev1.Container

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -147,8 +147,10 @@ func (r *StatefulSetResource) rollingUpdate(
 		}
 
 		if !utils.IsPodReady(&pod) {
-			return &RequeueAfterError{RequeueAfter: RequeueDuration,
-				Msg: fmt.Sprintf("wait for %s pod to become ready", pod.Name)}
+			return &RequeueAfterError{
+				RequeueAfter: RequeueDuration,
+				Msg:          fmt.Sprintf("wait for %s pod to become ready", pod.Name),
+			}
 		}
 
 		headlessServiceWithPort := fmt.Sprintf("%s:%d", r.serviceFQDN,

--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  allow-parallel-runners: true
+
+# We opt out of all suggested linters and manually pick what we want.
+# Please do not use enable-all.
+linters:
+  disable-all: true
+  enable:
+  # Disabled by default
+    - gofmt
+    - gofumpt
+    - goimports
+    - whitespace

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go v1.25.43
 	github.com/beevik/ntp v0.3.0
 	github.com/cespare/xxhash v1.1.0
-	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/docker/docker v20.10.6+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -44,13 +43,10 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	mvdan.cc/sh/v3 v3.2.1
 )
 
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/cockroachdb/gostdlib v1.13.0 // indirect
-	github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d // indirect
 	github.com/containerd/containerd v1.4.8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -58,7 +54,6 @@ require (
 	github.com/godbus/dbus/v5 v5.0.3 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
-	github.com/google/renameio v0.1.0 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -79,23 +74,20 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/pkg/diff v0.0.0-20200914180035-5b29258ca4f7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tklauser/numcpus v0.1.0 // indirect
 	github.com/twmb/go-rbtree v1.0.0 // indirect
-	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
-	mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157 // indirect
 )

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -46,12 +46,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79 h1:4s0GWs4NXFK4JEeUc0Q1pRbL4oMbqh1DK70qeQ+viOA=
-github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79/go.mod h1:EOI6rrXIdP+4EXwM8837kmmb6IJesf7k7W6bUu8BDOg=
-github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOFmcXGaw=
-github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d h1:TNsiMS1Ij2aleP/05UNSPzsOu9eJm9mfUGLm7Ylt7Dg=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
 github.com/containerd/containerd v1.4.8 h1:H0wkS4AbVKTg9vyvBdCBrxoax8AMObKbNz9Fl2N0i4Y=
 github.com/containerd/containerd v1.4.8/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -125,7 +119,6 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
-github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -258,8 +251,6 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/diff v0.0.0-20200914180035-5b29258ca4f7 h1:+/+DxvQaYifJ+grD4klzrS5y+KJXldn/2YTl5JG+vZ8=
-github.com/pkg/diff v0.0.0-20200914180035-5b29258ca4f7/go.mod h1:zO8QMzTeZd5cpnIkz/Gn6iK0jDfGicM1nynOkkPIl28=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -287,15 +278,11 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
-github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
-github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sethgrid/pester v1.1.0 h1:IyEAVvwSUPjs2ACFZkBe5N59BBUpSIkQ71Hr6cM5A+w=
 github.com/sethgrid/pester v1.1.0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -354,7 +341,6 @@ github.com/twmb/tlscfg v1.2.0/go.mod h1:GameEQddljI+8Es373JfQEBvtI4dCTLKWGJbqT2k
 github.com/twmb/types v1.1.6 h1:PnQYJ8fMHkjPR4mgJkzqX1lYhfamNl5I2zuVBSZwLuE=
 github.com/twmb/types v1.1.6/go.mod h1:l7Lzw5AFc6JmI+fslBRUXHTG3J9RpvRpCUMXVBnjtJQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -368,8 +354,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
@@ -392,9 +376,6 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
-golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -411,8 +392,6 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -426,7 +405,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -445,11 +423,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -458,7 +432,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
@@ -492,12 +465,7 @@ golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200923014426-f5e916c686e1/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 h1:K+NlvTLy0oONtRtkl1jRD9xIhnItbG2PiE7YOdjPb+k=
-golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -542,7 +510,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -564,8 +531,4 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157 h1:VBYz8greWWP8BDpRX0v7SDv/8rNlZVmdHdO4ZSsHj/E=
-mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157/go.mod h1:Ge4atmRUYqueGppvJ7JNrtqpqokoJEFxYbP0Z+WeKS8=
-mvdan.cc/sh/v3 v3.2.1 h1:uQBpiGM+rEuHse3Q+W7ajuJUeOtFVJUN/6GeX4/dUWE=
-mvdan.cc/sh/v3 v3.2.1/go.mod h1:fPQmabBpREM/XQ9YXSU5ZFZ/Sm+PmKP9/vkFHgYKJEI=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -90,7 +90,6 @@ func TestAdminAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			urls := []string{}
 			calls := []testCall{}
 			mutex := sync.Mutex{}
@@ -162,6 +161,7 @@ func checkCallToAllNodes(
 		}
 	}
 }
+
 func checkCallToAnyNode(
 	t *testing.T, calls []testCall, path string, nNodes int,
 ) {
@@ -172,6 +172,7 @@ func checkCallToAnyNode(
 	}
 	require.Fail(t, fmt.Sprintf("path (%s) was expected to be called in any node but it wasn't called", path))
 }
+
 func checkCallToLeader(
 	t *testing.T, calls []testCall, path string, nNodes, leaderID int,
 ) {

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -15,8 +15,10 @@ import (
 	"sort"
 )
 
-const brokersEndpoint = "/v1/brokers"
-const brokerEndpoint = "/v1/brokers/%d"
+const (
+	brokersEndpoint = "/v1/brokers"
+	brokerEndpoint  = "/v1/brokers/%d"
+)
 
 type MaintenanceStatus struct {
 	Draining     bool `json:"draining"`

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -99,7 +99,6 @@ type ClusterConfigWriteResult struct {
 func (a *AdminAPI) PatchClusterConfig(
 	upsert map[string]interface{}, remove []string,
 ) (ClusterConfigWriteResult, error) {
-
 	body := map[string]interface{}{
 		"upsert": upsert,
 		"remove": remove,

--- a/src/go/rpk/pkg/api/admin/api_node_config.go
+++ b/src/go/rpk/pkg/api/admin/api_node_config.go
@@ -13,7 +13,7 @@ import "net/http"
 
 type NodeConfig struct {
 	NodeID int `json:"node_id"`
-	//TODO: add the rest of the fields
+	// TODO: add the rest of the fields
 }
 
 // NodeConfig returns a single node configuration.

--- a/src/go/rpk/pkg/cli/cmd/acl/common.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/common.go
@@ -149,7 +149,6 @@ func (a *acls) backcompatList() error {
 		len(a.allowHosts) > 0 ||
 		len(a.denyPrincipals) > 0 ||
 		len(a.denyHosts) > 0 {
-
 		if len(a.listPermissions) > 0 ||
 			len(a.listPrincipals) > 0 ||
 			len(a.listHosts) > 0 {

--- a/src/go/rpk/pkg/cli/cmd/acl/delete.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete.go
@@ -142,7 +142,6 @@ func deleteReqResp(
 		printDeleteFilters(printAllFilters, results)
 		fmt.Println()
 		printDeletionsHeader = true
-
 	}
 	if printDeletionsHeader {
 		out.Section("deletions")

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -92,7 +92,6 @@ func exportConfig(
 			default:
 				out.Die("Unexpected property value type: %s: %T", name, curValue)
 			}
-
 		} else {
 			scalarVal := ""
 			switch x := curValue.(type) {
@@ -115,7 +114,6 @@ func exportConfig(
 			} else {
 				fmt.Fprintf(&sb, "%s:\n", name)
 			}
-
 		}
 
 		_, err := file.Write([]byte(sb.String()))

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
@@ -92,11 +92,11 @@ central configuration store (and via 'rpk cluster config edit').
 
 			backupFileName := filepath.Base(configFile) + ".bak"
 			backupFile := filepath.Join(filepath.Dir(configFile), backupFileName)
-			err = afero.WriteFile(fs, backupFile, configIn, 0755)
+			err = afero.WriteFile(fs, backupFile, configIn, 0o755)
 			out.MaybeDie(err, "error writing backup config %q: %v", backupFile, err)
 			log.Infof("Backed up configuration file to %q", backupFileName)
 
-			err = afero.WriteFile(fs, configFile, configOut, 0755)
+			err = afero.WriteFile(fs, configFile, configOut, 0o755)
 			out.MaybeDie(err, "error writing config: %v", err)
 			log.Infof("Rewrote configuration file %q", configFile)
 		},

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
@@ -70,7 +70,7 @@ the setting as if it was set to the default.
 			out.MaybeDie(err, "Serialization error: %v", configCacheFile, err)
 
 			// Write back output
-			err = afero.WriteFile(fs, configCacheFile, outBytes, 0755)
+			err = afero.WriteFile(fs, configCacheFile, outBytes, 0o755)
 			out.MaybeDie(err, "Couldn't write %q: %v", configCacheFile, err)
 		},
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
@@ -23,9 +23,7 @@ import (
 )
 
 func newEnableCommand(fs afero.Fs) *cobra.Command {
-	var (
-		wait bool
-	)
+	var wait bool
 	cmd := &cobra.Command{
 		Use:   "enable <node-id>",
 		Short: "Enable maintenance mode for a node.",

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
@@ -18,8 +18,10 @@ import (
 )
 
 func newMaintenanceReportTable() *out.TabWriter {
-	headers := []string{"Node-ID", "Draining", "Finished", "Errors",
-		"Partitions", "Eligible", "Transferring", "Failed"}
+	headers := []string{
+		"Node-ID", "Draining", "Finished", "Errors",
+		"Partitions", "Eligible", "Transferring", "Failed",
+	}
 	return out.NewTable(headers...)
 }
 

--- a/src/go/rpk/pkg/cli/cmd/container/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/stop_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestStop(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		client         func() (common.Client, error)
@@ -178,7 +177,6 @@ func TestStop(t *testing.T) {
 					)
 				}
 			}
-
 		})
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -336,7 +336,7 @@ func executeBundle(
 	logsLimitBytes int,
 	timeout time.Duration,
 ) error {
-	mode := os.FileMode(0755)
+	mode := os.FileMode(0o755)
 	timestamp := time.Now().Unix()
 	filename := fmt.Sprintf("%d-bundle.zip", timestamp)
 	f, err := fs.OpenFile(

--- a/src/go/rpk/pkg/cli/cmd/generate/graf/dashboard.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/graf/dashboard.go
@@ -186,18 +186,14 @@ type Gauge struct {
 	ThresholdLabels  bool `json:"thresholdLabels"`
 }
 
-type Link struct {
-}
+type Link struct{}
 
-type Threshold struct {
-}
+type Threshold struct{}
 
-type AliasColors struct {
-}
+type AliasColors struct{}
 
 type Annotations struct {
 	List []Annotation `json:"list"`
 }
 
-type Annotation struct {
-}
+type Annotation struct{}

--- a/src/go/rpk/pkg/cli/cmd/generate/graf/dashboard_test.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/graf/dashboard_test.go
@@ -79,7 +79,6 @@ func defaultDashboard() graf.Dashboard {
 }
 
 func TestDashboardMarshalJSON(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		dashboard func() graf.Dashboard

--- a/src/go/rpk/pkg/cli/cmd/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana.go
@@ -27,8 +27,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var datasource string
-var jobName string
+var (
+	datasource string
+	jobName    string
+)
 
 const panelHeight = 6
 
@@ -216,7 +218,6 @@ func (rowSet *RowSet) addRatioPanel(
 func (rowSet *RowSet) addCachePerformancePanels(
 	metricFamilies map[string]*dto.MetricFamily,
 ) {
-
 	// are we generating for a broker that has these stats?
 	if _, ok := metricFamilies["vectorized_storage_log_cached_batches_read"]; !ok {
 		return

--- a/src/go/rpk/pkg/cli/cmd/group/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/group/describe.go
@@ -190,7 +190,6 @@ func printDescribedGroup(
 		args = func(r *describeRow) []interface{} {
 			return append(orig(r), r.clientID, r.host)
 		}
-
 	}
 
 	if useErr {

--- a/src/go/rpk/pkg/cli/cmd/iotune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune_test.go
@@ -82,7 +82,7 @@ func TestTimeoutDuration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			mgr := config.NewManager(fs)
-			err := afero.WriteFile(fs, configPath, []byte(validConfig), 0644)
+			err := afero.WriteFile(fs, configPath, []byte(validConfig), 0o644)
 			require.NoError(t, err)
 			cmd := cmd.NewIoTuneCmd(fs, mgr)
 			args := []string{"--config", configPath}

--- a/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
@@ -199,7 +199,6 @@ Remote sha256: %s
 					}
 					fmt.Println(msg + "Downloading and validating updated plugin...")
 					userAlreadyHas = true
-
 				}
 			}
 			if !userAlreadyHas {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -187,9 +187,7 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 }
 
 func initNode(mgr config.Manager) *cobra.Command {
-	var (
-		configPath string
-	)
+	var configPath string
 	c := &cobra.Command{
 		Use:   "init",
 		Short: "Init the node after install, by setting the node's UUID.",
@@ -266,7 +264,7 @@ func ownIP() (net.IP, error) {
 
 func isPrivate(ip net.IP) (bool, error) {
 	// The standard private subnet CIDRS
-	var privateCIDRs = []string{
+	privateCIDRs := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -221,7 +221,7 @@ func TestBootstrap(t *testing.T) {
 			mgr := config.NewManager(fs)
 			err = fs.MkdirAll(
 				filepath.Dir(configPath),
-				0644,
+				0o644,
 			)
 			require.NoError(t, err)
 			c := cmd.NewConfigCommand(fs, mgr)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -71,7 +71,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return configPath, afero.WriteFile(fs, configPath, bs, 0644)
+				return configPath, afero.WriteFile(fs, configPath, bs, 0o644)
 			},
 			expectedConfig: fillRpkConfig(configPath, config.ModeDev),
 			expectedOutput: fmt.Sprintf("Writing 'development' mode defaults to '%s'", configPath),
@@ -85,7 +85,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return configPath, afero.WriteFile(fs, configPath, bs, 0644)
+				return configPath, afero.WriteFile(fs, configPath, bs, 0o644)
 			},
 			expectedConfig: fillRpkConfig(configPath, config.ModeProd),
 			expectedOutput: fmt.Sprintf("Writing 'production' mode defaults to '%s'", configPath),
@@ -99,7 +99,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return configPath, afero.WriteFile(fs, configPath, bs, 0644)
+				return configPath, afero.WriteFile(fs, configPath, bs, 0o644)
 			},
 			expectedConfig: fillRpkConfig(configPath, config.ModeDev),
 			expectedOutput: fmt.Sprintf("Writing 'dev' mode defaults to '%s'", configPath),
@@ -113,7 +113,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return configPath, afero.WriteFile(fs, configPath, bs, 0644)
+				return configPath, afero.WriteFile(fs, configPath, bs, 0o644)
 			},
 			expectedConfig: fillRpkConfig(configPath, config.ModeProd),
 			expectedOutput: fmt.Sprintf("Writing 'prod' mode defaults to '%s'", configPath),
@@ -127,7 +127,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return configPath, afero.WriteFile(fs, configPath, bs, 0644)
+				return configPath, afero.WriteFile(fs, configPath, bs, 0o644)
 			},
 			expectedConfig: fillRpkConfig(configPath, config.ModeProd),
 			expectedOutput: fmt.Sprintf("Writing 'prod' mode defaults to '%s'", configPath),
@@ -141,7 +141,7 @@ func TestModeCommand(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return wdConfigPath, afero.WriteFile(fs, wdConfigPath, bs, 0644)
+				return wdConfigPath, afero.WriteFile(fs, wdConfigPath, bs, 0o644)
 			},
 			expectedOutput: "",
 			expectedErrMsg: "'invalidmode' is not a supported mode. Available modes: dev, development, prod, production",

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -164,7 +164,7 @@ func TestStartCommand(t *testing.T) {
 				fs,
 				config.Default().ConfigFile,
 				[]byte("^&notyaml"),
-				0755,
+				0o755,
 			)
 		},
 		expectedErrMsg: "An error happened while trying to read /etc/redpanda/redpanda.yaml: While parsing config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `^&notyaml` into map[string]interface {}",
@@ -200,7 +200,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			return fs.MkdirAll("/arbitrary/path", 0755)
+			return fs.MkdirAll("/arbitrary/path", 0o755)
 		},
 		postCheck: func(fs afero.Fs, _ *rp.RedpandaArgs, st *testing.T) {
 			path := "/arbitrary/path/redpanda.yaml"
@@ -240,7 +240,7 @@ func TestStartCommand(t *testing.T) {
   port: 9092
 `,
 			)
-			return fs.MkdirAll("/arbitrary/path", 0755)
+			return fs.MkdirAll("/arbitrary/path", 0o755)
 		},
 		after: func() {
 			for i, a := range os.Args {
@@ -312,7 +312,7 @@ func TestStartCommand(t *testing.T) {
   port: 9092
 `,
 			)
-			return fs.MkdirAll("/arbitrary/path", 0755)
+			return fs.MkdirAll("/arbitrary/path", 0o755)
 		},
 		after: func() {
 			for i, a := range os.Args {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -198,7 +198,6 @@ func promptConfirmation(msg string, in io.Reader) (bool, error) {
 			log.Infof("Unrecognized option '%s'", text)
 			continue
 		}
-
 	}
 }
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
@@ -185,6 +185,7 @@ to write the new data.
 
 For more information see 'man fstrim'.
 `
+
 const aioEventsTunerHelp = `
 Increases the maximum number of outstanding asynchronous IO operations if the
 current value is below a certain threshold. This allows redpanda to make as many

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -199,7 +199,6 @@ func (c *consumer) consume() {
 					done = c.markPartitionEnded(p.Topic, p.Partition)
 					return
 				}
-
 			}
 		})
 

--- a/src/go/rpk/pkg/cli/cmd/topic/describe_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/describe_test.go
@@ -21,7 +21,6 @@ func TestDescribePartitions(t *testing.T) {
 		expHeaders []string
 		expRows    [][]interface{}
 	}{
-
 		{
 			name: "all ok, no optional columns, one partition",
 

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -27,9 +27,7 @@ import (
 )
 
 func NewGenerateCommand(fs afero.Fs) *cobra.Command {
-	var (
-		skipVersion bool
-	)
+	var skipVersion bool
 	cmd := &cobra.Command{
 		Use:   "generate [PROJECT DIRECTORY]",
 		Short: "Create an npm template project for inline WASM engine.",

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -316,7 +316,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 		}
 	}
 
-	var seedServersSlice []*SeedServer //map[string]interface{}
+	var seedServersSlice []*SeedServer // map[string]interface{}
 	err := unmarshalKey(v, "redpanda.seed_servers", &seedServersSlice)
 	if err != nil {
 		log.Error(err)

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -94,7 +94,7 @@ func TestSet(t *testing.T) {
 			value:  "42.3",
 			format: "single",
 			check: func(st *testing.T, _ *Config, mgr *manager) {
-				//require.True(st, ok, "Config map is of the wrong type")
+				// require.True(st, ok, "Config map is of the wrong type")
 				require.Exactly(st, 42.3, mgr.v.Get("redpanda.float_field"))
 			},
 		},
@@ -103,7 +103,7 @@ func TestSet(t *testing.T) {
 			key:   "redpanda.float_field",
 			value: "42.3",
 			check: func(st *testing.T, _ *Config, mgr *manager) {
-				//require.True(st, ok, "Config map is of the wrong type")
+				// require.True(st, ok, "Config map is of the wrong type")
 				require.Exactly(st, 42.3, mgr.v.Get("redpanda.float_field"))
 			},
 		},
@@ -403,7 +403,7 @@ func TestRead(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if err = fs.MkdirAll(baseDir, 0755); err != nil {
+				if err = fs.MkdirAll(baseDir, 0o755); err != nil {
 					return err
 				}
 				_, err = utils.WriteBytes(fs, bs, path)
@@ -2089,7 +2089,7 @@ func TestWriteAndGenerateNodeUuid(t *testing.T) {
 	conf.ConfigFile = path
 	bs, err := yaml.Marshal(conf)
 	require.NoError(t, err)
-	err = fs.MkdirAll(baseDir, 0755)
+	err = fs.MkdirAll(baseDir, 0o755)
 	require.NoError(t, err)
 	_, err = utils.WriteBytes(fs, bs, path)
 	require.NoError(t, err)

--- a/src/go/rpk/pkg/config/find.go
+++ b/src/go/rpk/pkg/config/find.go
@@ -20,7 +20,7 @@ import (
 
 func FindConfigFile(fs afero.Fs) (string, error) {
 	log.Debugf("Looking for the redpanda config file")
-	var configPathProviders = []func() ([]string, error){
+	configPathProviders := []func() ([]string, error){
 		currentDirectory,
 		sysConfDirectory,
 		homeDirectory,

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -89,7 +89,6 @@ func (m *manager) FindOrGenerate(path string) (*Config, error) {
 			conf.ConfigFile, err = absPath(m.v.ConfigFileUsed())
 			return conf, err
 		}
-
 	}
 	return readOrGenerate(m.fs, m.v, path)
 }
@@ -479,7 +478,6 @@ func v21_1_4MapToNamedSocketAddressSlice(
 				return nil, err
 			}
 			return []NamedSocketAddress{sa}, nil
-
 		}
 	}
 	return data, nil
@@ -566,7 +564,7 @@ func absPath(path string) (string, error) {
 
 func createConfigDir(fs afero.Fs, configFile string) error {
 	dir := filepath.Dir(configFile)
-	err := fs.MkdirAll(dir, 0755)
+	err := fs.MkdirAll(dir, 0o755)
 	if err != nil {
 		return fmt.Errorf(
 			"Couldn't create config dir %s: %v",

--- a/src/go/rpk/pkg/kafka/client_franz.go
+++ b/src/go/rpk/pkg/kafka/client_franz.go
@@ -101,7 +101,6 @@ func MetaString(meta kgo.BrokerMetadata) string {
 func EachShard(
 	req kmsg.Request, shards []kgo.ResponseShard, fn func(kgo.ResponseShard),
 ) (allFailed bool) {
-
 	if len(shards) == 1 && shards[0].Err != nil {
 		shard := shards[0]
 		meta := ""

--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -17,7 +17,6 @@ import (
 )
 
 func GetInterfacesByIps(addresses ...string) ([]string, error) {
-
 	log.Debugf("Looking for interface with '%v' addresses", addresses)
 
 	ifaces, err := net.Interfaces()

--- a/src/go/rpk/pkg/os/proc.go
+++ b/src/go/rpk/pkg/os/proc.go
@@ -38,7 +38,6 @@ type proc struct{}
 func (proc *proc) RunWithSystemLdPath(
 	timeout time.Duration, command string, args ...string,
 ) ([]string, error) {
-
 	return run(timeout, command, SystemLdPathEnv(), args...)
 }
 

--- a/src/go/rpk/pkg/plugin/manifest_test.go
+++ b/src/go/rpk/pkg/plugin/manifest_test.go
@@ -24,7 +24,6 @@ func TestDownloadManifest(t *testing.T) {
 		exp    *Manifest
 		expErr bool
 	}{
-
 		// This first test is our golden test; we ensure we can decode
 		// every field properly, invalid fields are ignored, and things
 		// are returned in alphabetical order.

--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -120,7 +120,7 @@ func ListPlugins(fs afero.Fs, searchDirs []string) Plugins {
 			if len(name) == 0 { // e.g., ".rpk-"
 				continue
 			}
-			if info.Mode()&0111 == 0 {
+			if info.Mode()&0o111 == 0 {
 				continue // not executable; skip
 			}
 
@@ -140,7 +140,6 @@ func ListPlugins(fs afero.Fs, searchDirs []string) Plugins {
 				Path:      fullPath,
 				Arguments: arguments,
 			})
-
 		}
 	}
 

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -11,17 +11,17 @@ func TestListPlugins(t *testing.T) {
 	t.Parallel()
 
 	fs := testfs.FromMap(map[string]testfs.Fmode{
-		"/usr/local/sbin/.rpk-non_executable":    {0666, ""},
-		"/usr/local/sbin/.rpk-barely_executable": {0100, ""},
-		"/bin/.rpk-barely_executable":            {0100, "shadowed!"},
-		"/bin/.rpk.ac-barely_executable":         {0100, "also shadowed!"},
-		"/bin/.rpk.ac-auto_completed":            {0777, ""},
-		"/bin/has/dir/":                          {0777, ""},
-		"/bin/.rpk.ac-":                          {0777, "empty name ignored"},
-		"/bin/.rpk-":                             {0777, "empty name ignored"},
-		"/bin/.rpkunrelated":                     {0777, ""},
-		"/bin/rpk-nodot":                         {0777, ""},
-		"/unsearched/.rpk-valid_unused":          {0777, ""},
+		"/usr/local/sbin/.rpk-non_executable":    {0o666, ""},
+		"/usr/local/sbin/.rpk-barely_executable": {0o100, ""},
+		"/bin/.rpk-barely_executable":            {0o100, "shadowed!"},
+		"/bin/.rpk.ac-barely_executable":         {0o100, "also shadowed!"},
+		"/bin/.rpk.ac-auto_completed":            {0o777, ""},
+		"/bin/has/dir/":                          {0o777, ""},
+		"/bin/.rpk.ac-":                          {0o777, "empty name ignored"},
+		"/bin/.rpk-":                             {0o777, "empty name ignored"},
+		"/bin/.rpkunrelated":                     {0o777, ""},
+		"/bin/rpk-nodot":                         {0o777, ""},
+		"/unsearched/.rpk-valid_unused":          {0o777, ""},
 	})
 
 	got := ListPlugins(fs, []string{

--- a/src/go/rpk/pkg/redpanda/launcher_test.go
+++ b/src/go/rpk/pkg/redpanda/launcher_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func Test_collectRedpandaArgs(t *testing.T) {
-
 	tests := []struct {
 		name string
 		args RedpandaArgs

--- a/src/go/rpk/pkg/system/cgroup_test.go
+++ b/src/go/rpk/pkg/system/cgroup_test.go
@@ -25,7 +25,7 @@ func setUpCgroup(fs afero.Fs, file, val string, v2 bool) error {
 	}
 	fullPath := "/sys/fs/cgroup" + file
 	dir := filepath.Dir(fullPath)
-	if err := fs.MkdirAll("/proc/self/", 0755); err != nil {
+	if err := fs.MkdirAll("/proc/self/", 0o755); err != nil {
 		return err
 	}
 	var contents string
@@ -42,15 +42,15 @@ func setUpCgroup(fs afero.Fs, file, val string, v2 bool) error {
 		fs,
 		"/proc/self/cgroup",
 		[]byte(contents),
-		0644,
+		0o644,
 	)
 	if err != nil {
 		return err
 	}
-	if err = fs.MkdirAll(dir, 0755); err != nil {
+	if err = fs.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	return afero.WriteFile(fs, fullPath, []byte(val), 0644)
+	return afero.WriteFile(fs, fullPath, []byte(val), 0o644)
 }
 
 func TestReadCgroupProp(t *testing.T) {
@@ -264,7 +264,7 @@ func TestReadCgroupEmptyCgroup(t *testing.T) {
 		system.ReadCgroupMemLimitBytes,
 		system.ReadCgroupEffectiveCpusNo,
 	}
-	err := afero.WriteFile(fs, "/proc/self/cgroup", []byte{}, 0644)
+	err := afero.WriteFile(fs, "/proc/self/cgroup", []byte{}, 0o644)
 	assert.NoError(t, err)
 	for _, f := range funcs {
 		_, err := f(fs)

--- a/src/go/rpk/pkg/system/cpu_test.go
+++ b/src/go/rpk/pkg/system/cpu_test.go
@@ -69,7 +69,7 @@ power management:
 			fs,
 			"/proc/cpuinfo",
 			[]byte(contents),
-			0755,
+			0o755,
 		)
 	}
 	tests := []struct {
@@ -88,7 +88,7 @@ power management:
 				fs,
 				"/proc/cpuinfo",
 				[]byte(""),
-				0755,
+				0o755,
 			)
 		},
 	}, {

--- a/src/go/rpk/pkg/system/filesystem/fs.go
+++ b/src/go/rpk/pkg/system/filesystem/fs.go
@@ -19,13 +19,13 @@ import (
 
 func DirectoryIsWriteable(fs afero.Fs, path string) (bool, error) {
 	if exists, _ := afero.Exists(fs, path); !exists {
-		err := fs.MkdirAll(path, 0755)
+		err := fs.MkdirAll(path, 0o755)
 		if err != nil {
 			return false, nil
 		}
 	}
 	testFile := filepath.Join(path, "test_file")
-	err := afero.WriteFile(fs, testFile, []byte{0}, 0644)
+	err := afero.WriteFile(fs, testFile, []byte{0}, 0o644)
 	if err != nil {
 		return false, nil
 	}

--- a/src/go/rpk/pkg/system/filesystem/fs_test.go
+++ b/src/go/rpk/pkg/system/filesystem/fs_test.go
@@ -34,7 +34,6 @@ func TestDirectoryIsWriteable(t *testing.T) {
 				path: "/redpanda/data",
 			},
 			before: func(fs afero.Fs) {
-
 			},
 			wantErr: false,
 			want:    true,

--- a/src/go/rpk/pkg/system/grub.go
+++ b/src/go/rpk/pkg/system/grub.go
@@ -133,7 +133,8 @@ func (g *grub) MakeConfig() error {
 	}
 	for _, file := range []string{
 		"/boot/grub2/grub.cfg",
-		"/boot/efi/EFI/fedora/grub.cfg"} {
+		"/boot/efi/EFI/fedora/grub.cfg",
+	} {
 		if exists, _ := afero.Exists(g.fs, file); exists {
 			log.Debugf("Found 'grub.cfg' in %s", file)
 			err := g.executor.Execute(

--- a/src/go/rpk/pkg/system/memory.go
+++ b/src/go/rpk/pkg/system/memory.go
@@ -30,10 +30,8 @@ type MemInfo struct {
 }
 
 func GetTransparentHugePagesActive(fs afero.Fs) (bool, error) {
-
 	options, err := ReadRuntineOptions(fs,
 		"/sys/kernel/mm/transparent_hugepage/enabled")
-
 	if err != nil {
 		return false, err
 	}

--- a/src/go/rpk/pkg/system/metrics_test.go
+++ b/src/go/rpk/pkg/system/metrics_test.go
@@ -33,7 +33,7 @@ func TestGatherMetrics(t *testing.T) {
 				config.Default().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
-				0755,
+				0o755,
 			)
 		},
 		expectedErrMsg: "/proc/4194304/stat",
@@ -48,7 +48,7 @@ func TestGatherMetrics(t *testing.T) {
 				config.Default().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
-				0755,
+				0o755,
 			)
 			if err != nil {
 				return err
@@ -58,7 +58,7 @@ func TestGatherMetrics(t *testing.T) {
 				fs,
 				"/proc/4194304/stat",
 				[]byte(content),
-				0755,
+				0o755,
 			)
 		},
 		expectedErrMsg: `parsing "invalid-utime": invalid syntax`,
@@ -70,7 +70,7 @@ func TestGatherMetrics(t *testing.T) {
 				config.Default().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
-				0755,
+				0o755,
 			)
 			if err != nil {
 				return err
@@ -80,7 +80,7 @@ func TestGatherMetrics(t *testing.T) {
 				fs,
 				"/proc/4194304/stat",
 				[]byte(content),
-				0755,
+				0o755,
 			)
 		},
 		expectedErrMsg: `parsing "invalid-stime": invalid syntax`,

--- a/src/go/rpk/pkg/system/runtime_options_test.go
+++ b/src/go/rpk/pkg/system/runtime_options_test.go
@@ -64,9 +64,9 @@ func TestReadRuntineOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			err := fs.MkdirAll(filepath.Dir(path), 0755)
+			err := fs.MkdirAll(filepath.Dir(path), 0o755)
 			require.NoError(t, err)
-			err = afero.WriteFile(fs, path, tt.opts, 0644)
+			err = afero.WriteFile(fs, path, tt.opts, 0o644)
 			require.NoError(t, err)
 			got, err := ReadRuntineOptions(fs, path)
 			if tt.wantErr {

--- a/src/go/rpk/pkg/system/systemd/client.go
+++ b/src/go/rpk/pkg/system/systemd/client.go
@@ -68,7 +68,6 @@ func toActiveState(s string) ActiveState {
 		return ActiveStateMaintenance
 	}
 	return ActiveStateUnknown
-
 }
 
 type LoadState int

--- a/src/go/rpk/pkg/system/systemd/dbus.go
+++ b/src/go/rpk/pkg/system/systemd/dbus.go
@@ -36,7 +36,6 @@ func (c *dbusClient) Shutdown() error {
 func (c *dbusClient) StartUnit(name string) error {
 	_, err := c.conn.StartUnit(name, "replace", nil)
 	if err != nil {
-
 		logrus.Error("ERROR Starting unit ", err)
 	}
 	return err

--- a/src/go/rpk/pkg/system/systemd/mock.go
+++ b/src/go/rpk/pkg/system/systemd/mock.go
@@ -35,6 +35,7 @@ func NewMockClient(
 func (c *mockClient) Shutdown() error {
 	return c.shutdown()
 }
+
 func (c *mockClient) StartUnit(name string) error {
 	return c.startUnit(name)
 }

--- a/src/go/rpk/pkg/system/utils_linux.go
+++ b/src/go/rpk/pkg/system/utils_linux.go
@@ -22,5 +22,4 @@ func uname() (string, error) {
 	str += string(int8ToString(uname.Release)) + " "
 	str += string(int8ToString(uname.Version))
 	return str, nil
-
 }

--- a/src/go/rpk/pkg/tools.go
+++ b/src/go/rpk/pkg/tools.go
@@ -1,9 +1,0 @@
-//go:build tools
-// +build tools
-
-package main
-
-import (
-	_ "github.com/cockroachdb/crlfmt"
-	_ "mvdan.cc/sh/v3/cmd/shfmt"
-)

--- a/src/go/rpk/pkg/tuners/aggregated_tunable.go
+++ b/src/go/rpk/pkg/tuners/aggregated_tunable.go
@@ -28,7 +28,7 @@ func (t *aggregatedTunable) CheckIfSupported() (supported bool, reason string) {
 }
 
 func (t *aggregatedTunable) Tune() TuneResult {
-	var needReboot = false
+	needReboot := false
 	for _, tunable := range t.tunables {
 		result := tunable.Tune()
 		if result.IsFailed() {

--- a/src/go/rpk/pkg/tuners/aio.go
+++ b/src/go/rpk/pkg/tuners/aio.go
@@ -19,8 +19,10 @@ import (
 	"github.com/spf13/afero"
 )
 
-const maxAIOEvents = 1048576
-const maxAIOEventsFile = "/proc/sys/fs/aio-max-nr"
+const (
+	maxAIOEvents     = 1048576
+	maxAIOEventsFile = "/proc/sys/fs/aio-max-nr"
+)
 
 func NewMaxAIOEventsChecker(fs afero.Fs) Checker {
 	return NewIntChecker(

--- a/src/go/rpk/pkg/tuners/coredump/tuner.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner.go
@@ -56,7 +56,7 @@ func (t *tuner) Tune() tuners.TuneResult {
 	if err != nil {
 		return tuners.NewTuneError(err)
 	}
-	err = t.executor.Execute(commands.NewWriteFileModeCmd(t.fs, scriptFilePath, script, 0777))
+	err = t.executor.Execute(commands.NewWriteFileModeCmd(t.fs, scriptFilePath, script, 0o777))
 	if err != nil {
 		return tuners.NewTuneError(err)
 	}

--- a/src/go/rpk/pkg/tuners/coredump/tuner_test.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner_test.go
@@ -63,7 +63,7 @@ func TestTune(t *testing.T) {
 			info, err := script.Stat()
 			require.NoError(t, err)
 			// Check that the script is world-readable, writable and executable
-			expectedMode := os.FileMode(int(0777))
+			expectedMode := os.FileMode(int(0o777))
 			require.Equal(t, expectedMode, info.Mode())
 			expectedScript, err := renderTemplate(coredumpScriptTmpl, conf.Rpk)
 			require.NoError(t, err)

--- a/src/go/rpk/pkg/tuners/cpu/tuner.go
+++ b/src/go/rpk/pkg/tuners/cpu/tuner.go
@@ -135,7 +135,8 @@ func (tuner *tuner) getMaxCState() (uint, error) {
 func (tuner *tuner) disableCStates() error {
 	log.Info("Disabling CPU C-States ")
 	return tuner.grub.AddCommandLineOptions(
-		[]string{"intel_idle.max_cstate=0",
+		[]string{
+			"intel_idle.max_cstate=0",
 			"processor.max_cstate=1",
 		})
 }

--- a/src/go/rpk/pkg/tuners/disk/block_device.go
+++ b/src/go/rpk/pkg/tuners/disk/block_device.go
@@ -56,10 +56,9 @@ func deviceFromSystemPath(syspath string, fs afero.Fs) (BlockDevice, error) {
 		return nil, err
 	}
 
-	var parentPath = filepath.Dir(syspath)
+	parentPath := filepath.Dir(syspath)
 	var parent BlockDevice
 	if exists, _ := afero.Exists(fs, filepath.Join(parentPath, "uevent")); exists {
-
 		parent, err = deviceFromSystemPath(parentPath, fs)
 		if err != nil {
 			return nil, err

--- a/src/go/rpk/pkg/tuners/disk/block_device_test.go
+++ b/src/go/rpk/pkg/tuners/disk/block_device_test.go
@@ -30,7 +30,7 @@ func Test_deviceFromSystemPath(t *testing.T) {
 			syspath: "/sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0",
 			before: func(fs afero.Fs, syspath string) {
 				ueventFileLines := []string{"DEVNAME=node-name"}
-				fs.MkdirAll(syspath, 0755)
+				fs.MkdirAll(syspath, 0o755)
 				utils.WriteFileLines(fs, ueventFileLines,
 					filepath.Join(syspath, "uevent"))
 			},
@@ -45,7 +45,7 @@ func Test_deviceFromSystemPath(t *testing.T) {
 			syspath: "/sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1",
 			before: func(fs afero.Fs, syspath string) {
 				ueventFileLines := []string{"DEVNAME=child"}
-				fs.MkdirAll(syspath, 0755)
+				fs.MkdirAll(syspath, 0o755)
 				utils.WriteFileLines(fs, ueventFileLines,
 					filepath.Join(syspath, "uevent"))
 				parentPath := "/sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0"

--- a/src/go/rpk/pkg/tuners/disk/block_devices.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices.go
@@ -264,10 +264,14 @@ func (b *blockDevices) GetDiskInfoByType(
 			}
 		}
 	}
-	diskInfoByType[Nvme] = DevicesIRQs{utils.GetKeys(nvmeDisks),
-		utils.GetIntKeys(nvmeIRQs)}
-	diskInfoByType[NonNvme] = DevicesIRQs{utils.GetKeys(nonNvmeDisks),
-		utils.GetIntKeys(nonNvmeIRQs)}
+	diskInfoByType[Nvme] = DevicesIRQs{
+		utils.GetKeys(nvmeDisks),
+		utils.GetIntKeys(nvmeIRQs),
+	}
+	diskInfoByType[NonNvme] = DevicesIRQs{
+		utils.GetKeys(nonNvmeDisks),
+		utils.GetIntKeys(nonNvmeIRQs),
+	}
 	return diskInfoByType, nil
 }
 

--- a/src/go/rpk/pkg/tuners/disk/block_devices_test.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices_test.go
@@ -46,7 +46,8 @@ func Test_blockDevices_getDeviceControllerPath(t *testing.T) {
 		fs:            fs,
 		irqDeviceInfo: irqDeviceInfo,
 		irqProcFile:   irqProcFile,
-		proc:          proc}
+		proc:          proc,
+	}
 	devSystemPath := "/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0" +
 		"/target0:0:0/0:0:0:0/block/sda/sda1"
 	// when
@@ -70,7 +71,7 @@ func Test_blockDevices_getDeviceControllerPath(t *testing.T) {
 }
 
 func Test_blockDevices_isIRQNvmeFastPathIRQ(t *testing.T) {
-	//given
+	// given
 	fields := []struct {
 		name     string
 		procFile irq.ProcFile
@@ -116,7 +117,8 @@ func Test_blockDevices_isIRQNvmeFastPathIRQ(t *testing.T) {
 			},
 			expected: false,
 			numCpus:  8,
-		}}
+		},
+	}
 	for _, test := range fields {
 		t.Run(test.name, func(t *testing.T) {
 			// given
@@ -127,7 +129,8 @@ func Test_blockDevices_isIRQNvmeFastPathIRQ(t *testing.T) {
 				fs:            fs,
 				irqDeviceInfo: irqDeviceInfo,
 				irqProcFile:   test.procFile,
-				proc:          proc}
+				proc:          proc,
+			}
 			// when
 			isNvmeIRQ, err := blockDevices.isIRQNvmeFastPathIRQ(18, test.numCpus)
 			// then

--- a/src/go/rpk/pkg/tuners/disk/device_features.go
+++ b/src/go/rpk/pkg/tuners/disk/device_features.go
@@ -82,6 +82,7 @@ func (d *deviceFeatures) GetNomerges(device string) (int, error) {
 func (d *deviceFeatures) GetNomergesFeatureFile(device string) (string, error) {
 	return d.getQueueFeatureFile(deviceNode(device), "nomerges")
 }
+
 func (d *deviceFeatures) GetSchedulerFeatureFile(
 	device string,
 ) (string, error) {

--- a/src/go/rpk/pkg/tuners/disk/device_features_test.go
+++ b/src/go/rpk/pkg/tuners/disk/device_features_test.go
@@ -65,10 +65,10 @@ func TestDeviceFeatures_GetScheduler(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll(testDevicePath+"/queue", 0644)
+	fs.MkdirAll(testDevicePath+"/queue", 0o644)
 	afero.WriteFile(fs,
 		testDevicePath+"/queue/scheduler",
-		[]byte(noopSchedulerEnabled), 0644)
+		[]byte(noopSchedulerEnabled), 0o644)
 	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
 	scheduler, err := deviceFeatures.GetScheduler("fake")
@@ -88,10 +88,10 @@ func TestDeviceFeatures_GetSupportedScheduler(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll(testDevicePath+"/queue", 0644)
+	fs.MkdirAll(testDevicePath+"/queue", 0o644)
 	afero.WriteFile(fs,
 		testDevicePath+"/queue/scheduler",
-		[]byte(noopSchedulerEnabled), 0644)
+		[]byte(noopSchedulerEnabled), 0o644)
 	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
 	schedulers, err := deviceFeatures.GetSupportedSchedulers("fake")
@@ -114,10 +114,10 @@ func TestDeviceFeatures_GetNoMerges(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll(testDevicePath+"/queue", 0644)
+	fs.MkdirAll(testDevicePath+"/queue", 0o644)
 	afero.WriteFile(fs,
 		testDevicePath+"/queue/nomerges",
-		[]byte("2"), 0644)
+		[]byte("2"), 0o644)
 	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
 	nomerges, err := deviceFeatures.GetNomerges("fake")
@@ -137,10 +137,10 @@ func TestDeviceFeatures_GetWriteCache(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll(testDevicePath+"/queue", 0644)
+	fs.MkdirAll(testDevicePath+"/queue", 0o644)
 	afero.WriteFile(fs,
 		testDevicePath+"/queue/write_cache",
-		[]byte(CachePolicyWriteBack), 0644)
+		[]byte(CachePolicyWriteBack), 0o644)
 	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
 	cache, err := deviceFeatures.GetWriteCache("fake")

--- a/src/go/rpk/pkg/tuners/disk_nomerges_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disk_nomerges_tuner_test.go
@@ -28,7 +28,7 @@ func TestDeviceNomergesTuner_Tune(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
+	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0o644)
 	tuner := NewDeviceNomergesTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()

--- a/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
@@ -79,7 +79,7 @@ func TestDeviceSchedulerTuner_Tune(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
+	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0o644)
 	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()
@@ -102,7 +102,7 @@ func TestDeviceSchedulerTuner_IsSupported_Should_return_true(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
+	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0o644)
 	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	supported, _ := tuner.CheckIfSupported()
@@ -124,7 +124,7 @@ func TestDeviceSchedulerTuner_IsSupported_should_return_false(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
+	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0o644)
 	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	supported, _ := tuner.CheckIfSupported()
@@ -146,7 +146,7 @@ func TestDeviceSchedulerTuner_Tune_should_prefer_none_over_noop(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
+	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0o644)
 	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()

--- a/src/go/rpk/pkg/tuners/disks_irq_tuner.go
+++ b/src/go/rpk/pkg/tuners/disks_irq_tuner.go
@@ -245,7 +245,6 @@ func GetDefaultMode(
 	diskInfoByType map[disk.DiskType]disk.DevicesIRQs,
 	cpuMasks irq.CpuMasks,
 ) (irq.Mode, error) {
-
 	log.Debug("Calculating default mode for Disk IRQs")
 	nonNvmeDiskIRQs := diskInfoByType[disk.NonNvme]
 	if len(nonNvmeDiskIRQs.Devices) == 0 {

--- a/src/go/rpk/pkg/tuners/disks_irq_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disks_irq_tuner_test.go
@@ -103,7 +103,8 @@ func TestGetExpectedIRQsDistribution(t *testing.T) {
 							},
 							disk.Nvme: {
 								Devices: []string{"dev1"},
-								Irqs:    []int{12, 15, 18, 24}},
+								Irqs:    []int{12, 15, 18, 24},
+							},
 						}, nil
 					},
 				},

--- a/src/go/rpk/pkg/tuners/executors/commands/write_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_file.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-const defaultMode os.FileMode = 0644
+const defaultMode os.FileMode = 0o644
 
 type writeFileCommand struct {
 	fs      afero.Fs

--- a/src/go/rpk/pkg/tuners/executors/commands/write_file_test.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_file_test.go
@@ -46,7 +46,7 @@ content
 	if err != nil {
 		t.Errorf("an error happened while running stat: %v", err)
 	}
-	expectedMode := os.FileMode(0644)
+	expectedMode := os.FileMode(0o644)
 	if expectedMode != info.Mode() {
 		t.Errorf("expected the file to have mode %v, got %v", expectedMode, info.Mode())
 	}
@@ -55,7 +55,7 @@ content
 func TestWriteFileModeCmdExecuteExistingFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	path := "/usr/file"
-	mode := os.FileMode(0765)
+	mode := os.FileMode(0o765)
 
 	err := afero.WriteFile(fs, path, []byte{}, mode)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestWriteFileModeCmdExecuteExistingFile(t *testing.T) {
 
 	// Execute it with a different mode to check that it preserves
 	// the original mode
-	cmd := commands.NewWriteFileModeCmd(fs, path, "", 0644)
+	cmd := commands.NewWriteFileModeCmd(fs, path, "", 0o644)
 	if err := cmd.Execute(); err != nil {
 		t.Errorf("an error happened while executing: %v", err)
 	}
@@ -101,7 +101,7 @@ chmod %o %s
 `,
 		content,
 		path,
-		0644,
+		0o644,
 		path,
 	)
 
@@ -114,7 +114,7 @@ func TestWriteFileCmdRenderExistingFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	path := "/usr/file"
 	content := "content"
-	mode := os.FileMode(0765)
+	mode := os.FileMode(0o765)
 
 	// Create the file previously to check that the rendered
 	// script doesn't include a chmod command, preserving
@@ -124,7 +124,7 @@ func TestWriteFileCmdRenderExistingFile(t *testing.T) {
 		t.Errorf("got an error writing the file: %v", err)
 	}
 
-	cmd := commands.NewWriteFileModeCmd(fs, path, content, 0777)
+	cmd := commands.NewWriteFileModeCmd(fs, path, content, 0o777)
 
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -43,7 +43,7 @@ func (c *writeSizedFileCommand) Execute() error {
 	// handles returned by afero don't have a way to get their file descriptor
 	// (i.e. an Fd() method):
 	// https://github.com/spf13/afero/issues/234
-	f, err := os.OpenFile(c.path, os.O_WRONLY|os.O_CREATE, 0666)
+	f, err := os.OpenFile(c.path, os.O_WRONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/tuners/executors/script_rendering.go
+++ b/src/go/rpk/pkg/tuners/executors/script_rendering.go
@@ -26,7 +26,7 @@ type scriptRenderingExecutor struct {
 // FIXME: @david
 // This should also return an error.
 func NewScriptRenderingExecutor(fs afero.Fs, filename string) Executor {
-	file, err := fs.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+	file, err := fs.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o755)
 	if err != nil {
 		return &scriptRenderingExecutor{
 			deffered: err,

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -34,23 +34,21 @@ import (
 	"github.com/spf13/afero"
 )
 
-var (
-	allTuners = map[string]func(*tunersFactory, *TunerParams) tuners.Tunable{
-		"disk_irq":              (*tunersFactory).newDiskIRQTuner,
-		"disk_scheduler":        (*tunersFactory).newDiskSchedulerTuner,
-		"disk_nomerges":         (*tunersFactory).newDiskNomergesTuner,
-		"disk_write_cache":      (*tunersFactory).newGcpWriteCacheTuner,
-		"fstrim":                (*tunersFactory).newFstrimTuner,
-		"net":                   (*tunersFactory).newNetworkTuner,
-		"cpu":                   (*tunersFactory).newCpuTuner,
-		"aio_events":            (*tunersFactory).newMaxAIOEventsTuner,
-		"clocksource":           (*tunersFactory).newClockSourceTuner,
-		"swappiness":            (*tunersFactory).newSwappinessTuner,
-		"transparent_hugepages": (*tunersFactory).newTHPTuner,
-		"coredump":              (*tunersFactory).newCoredumpTuner,
-		"ballast_file":          (*tunersFactory).newBallastFileTuner,
-	}
-)
+var allTuners = map[string]func(*tunersFactory, *TunerParams) tuners.Tunable{
+	"disk_irq":              (*tunersFactory).newDiskIRQTuner,
+	"disk_scheduler":        (*tunersFactory).newDiskSchedulerTuner,
+	"disk_nomerges":         (*tunersFactory).newDiskNomergesTuner,
+	"disk_write_cache":      (*tunersFactory).newGcpWriteCacheTuner,
+	"fstrim":                (*tunersFactory).newFstrimTuner,
+	"net":                   (*tunersFactory).newNetworkTuner,
+	"cpu":                   (*tunersFactory).newCpuTuner,
+	"aio_events":            (*tunersFactory).newMaxAIOEventsTuner,
+	"clocksource":           (*tunersFactory).newClockSourceTuner,
+	"swappiness":            (*tunersFactory).newSwappinessTuner,
+	"transparent_hugepages": (*tunersFactory).newTHPTuner,
+	"coredump":              (*tunersFactory).newCoredumpTuner,
+	"ballast_file":          (*tunersFactory).newBallastFileTuner,
+}
 
 type TunerParams struct {
 	Mode          string
@@ -174,7 +172,6 @@ func (factory *tunersFactory) CreateTuner(
 func (factory *tunersFactory) newDiskIRQTuner(
 	params *TunerParams,
 ) tuners.Tunable {
-
 	return tuners.NewDiskIRQTuner(
 		factory.fs,
 		irq.ModeFromString(params.Mode),

--- a/src/go/rpk/pkg/tuners/fstrim_test.go
+++ b/src/go/rpk/pkg/tuners/fstrim_test.go
@@ -37,6 +37,7 @@ func (p *mockProc) RunWithSystemLdPath(
 	}
 	return []string{fstrimBinPath}, nil
 }
+
 func (*mockProc) IsRunning(_ time.Duration, _ string) bool {
 	return true
 }

--- a/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner.go
+++ b/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner.go
@@ -69,7 +69,6 @@ func tuneWriteCache(
 	deviceFeatures disk.DeviceFeatures,
 	executor executors.Executor,
 ) TuneResult {
-
 	featureFile, err := deviceFeatures.GetWriteCacheFeatureFile(device)
 	if err != nil {
 		return NewTuneError(err)

--- a/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner_test.go
@@ -63,7 +63,7 @@ func TestDeviceWriteCacheTuner_Tune(t *testing.T) {
 		},
 	}
 	fs := afero.NewMemMapFs()
-	fs.MkdirAll(devicePath+"/queue", 0644)
+	fs.MkdirAll(devicePath+"/queue", 0o644)
 	tuner := NewDeviceGcpWriteCacheTuner(fs, "fake", deviceFeatures, v, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()

--- a/src/go/rpk/pkg/tuners/hwloc/cpuset.go
+++ b/src/go/rpk/pkg/tuners/hwloc/cpuset.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TranslateToHwLocCpuSet(cpuset string) (string, error) {
-
 	cpuSetPattern := regexp.MustCompile("^(\\d+-)?(\\d+)(,(\\d+-)?(\\d+))*$")
 	if cpuset == "all" {
 		return cpuset, nil

--- a/src/go/rpk/pkg/tuners/irq/balance_service_test.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service_test.go
@@ -110,9 +110,11 @@ func Test_BalanceService_BanIRQsAndRestart(t *testing.T) {
 					return nil, nil
 				},
 			},
-			configFile: []string{"ONE_SHOT=true",
+			configFile: []string{
+				"ONE_SHOT=true",
 				"#IRQBALANCE_BANNED_CPUS=",
-				"IRQBALANCE_ARGS=\" --banirq=5\""},
+				"IRQBALANCE_ARGS=\" --banirq=5\"",
+			},
 			bannedIRQs: []int{12, 15},
 			dir:        "/etc/sysconfig",
 			before: func(fs afero.Fs, dir string, configFile []string) {
@@ -137,10 +139,12 @@ func Test_BalanceService_BanIRQsAndRestart(t *testing.T) {
 					return nil, nil
 				},
 			},
-			configFile: []string{"ONE_SHOT=true",
+			configFile: []string{
+				"ONE_SHOT=true",
 				"#IRQBALANCE_BANNED_CPUS=",
 				// IRQ 5 is already banned
-				"IRQBALANCE_ARGS=\" --banirq=5\""},
+				"IRQBALANCE_ARGS=\" --banirq=5\"",
+			},
 			bannedIRQs: []int{5, 12, 15},
 			dir:        "/etc/sysconfig",
 			before: func(fs afero.Fs, dir string, configFile []string) {
@@ -209,7 +213,6 @@ func Test_BalanceService_BanIRQsAndRestart(t *testing.T) {
 				_ = utils.WriteFileLines(fs,
 					[]string{"init"},
 					"/proc/1/comm")
-
 			},
 			assert: func(fs afero.Fs, dir string, configFile, backupContent []string) {
 				require.Equal(t, 2, len(backupContent))
@@ -243,7 +246,6 @@ func Test_BalanceService_BanIRQsAndRestart(t *testing.T) {
 			)
 			require.NoError(t, err)
 			tt.assert(fs, tt.dir, tt.configFile, backupFileContent)
-
 		})
 	}
 }
@@ -258,10 +260,12 @@ func Test_balanceService_GetBannedIRQs(t *testing.T) {
 			name: "Shall return all banned irq",
 			before: func(fs afero.Fs) {
 				_ = utils.WriteFileLines(fs,
-					[]string{"ONE_SHOT=true",
+					[]string{
+						"ONE_SHOT=true",
 						"#IRQBALANCE_BANNED_CPUS=",
 						"IRQBALANCE_ARGS=\"--other --banirq=123 --else=12" +
-							"--banirq=34 --banirq=48 --banirq=16\""},
+							"--banirq=34 --banirq=48 --banirq=16\"",
+					},
 					"/etc/sysconfig/irqbalance")
 			},
 			want: []int{123, 34, 48, 16},
@@ -270,9 +274,11 @@ func Test_balanceService_GetBannedIRQs(t *testing.T) {
 			name: "Shall return empty list as there are none banned IRQs",
 			before: func(fs afero.Fs) {
 				_ = utils.WriteFileLines(fs,
-					[]string{"ONE_SHOT=true",
+					[]string{
+						"ONE_SHOT=true",
 						"#IRQBALANCE_BANNED_CPUS=",
-						"IRQBALANCE_ARGS=\"--other --else --third\""},
+						"IRQBALANCE_ARGS=\"--other --else --third\"",
+					},
 					"/etc/sysconfig/irqbalance")
 			},
 		},
@@ -280,8 +286,10 @@ func Test_balanceService_GetBannedIRQs(t *testing.T) {
 			name: "Shall return empty list as there are no custom options line",
 			before: func(fs afero.Fs) {
 				_ = utils.WriteFileLines(fs,
-					[]string{"ONE_SHOT=true",
-						"#IRQBALANCE_BANNED_CPUS="},
+					[]string{
+						"ONE_SHOT=true",
+						"#IRQBALANCE_BANNED_CPUS=",
+					},
 					"/etc/sysconfig/irqbalance")
 			},
 		},

--- a/src/go/rpk/pkg/tuners/irq/cpu_masks.go
+++ b/src/go/rpk/pkg/tuners/irq/cpu_masks.go
@@ -70,7 +70,7 @@ func (masks *cpuMasks) CpuMaskForComputations(
 	mode Mode, cpuMask string,
 ) (string, error) {
 	log.Debugf("Computing CPU mask for '%s' mode and input CPU mask '%s'", mode, cpuMask)
-	var computationsMask = ""
+	computationsMask := ""
 	var err error
 	if mode == Sq {
 		// all but CPU0
@@ -124,14 +124,14 @@ func (masks *cpuMasks) SetMask(path string, mask string) error {
 	if _, err := masks.fs.Stat(path); err != nil {
 		return fmt.Errorf("SMP affinity file '%s' not exist", path)
 	}
-	var formattedMask = strings.Replace(mask, "0x", "", -1)
+	formattedMask := strings.Replace(mask, "0x", "", -1)
 	for strings.Contains(formattedMask, ",,") {
 		formattedMask = strings.Replace(formattedMask, ",,", ",0,", -1)
 	}
 
 	log.Debugf("Setting mask '%s' in '%s'", formattedMask, path)
 	err := masks.executor.Execute(
-		commands.NewWriteFileModeCmd(masks.fs, path, formattedMask, 0555))
+		commands.NewWriteFileModeCmd(masks.fs, path, formattedMask, 0o555))
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/tuners/irq/cpu_masks_test.go
+++ b/src/go/rpk/pkg/tuners/irq/cpu_masks_test.go
@@ -22,11 +22,11 @@ func Test_cpuMasks_ReadMask(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	cpuMasks := NewCpuMasks(fs, nil, executors.NewDirectExecutor())
 	setMask := "0xff0,,0x13"
-	afero.WriteFile(fs, "/test/cpu/0/smp_affinity", []byte{0}, 0644)
+	afero.WriteFile(fs, "/test/cpu/0/smp_affinity", []byte{0}, 0o644)
 	cpuMasks.SetMask("/test/cpu/0/smp_affinity", setMask)
-	//when
+	// when
 	readMask, err := cpuMasks.ReadMask("/test/cpu/0/smp_affinity")
-	//then
+	// then
 	require.Equal(t, setMask, readMask, "Set and Read masks must be equal")
 	require.NoError(t, err)
 }

--- a/src/go/rpk/pkg/tuners/irq/device_info.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info.go
@@ -24,10 +24,10 @@ type DeviceInfo interface {
 }
 
 func NewDeviceInfo(fs afero.Fs, procFile ProcFile) DeviceInfo {
-
 	return &deviceInfo{
 		procFile: procFile,
-		fs:       fs}
+		fs:       fs,
+	}
 }
 
 type deviceInfo struct {

--- a/src/go/rpk/pkg/tuners/irq/device_info_test.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info_test.go
@@ -66,7 +66,8 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 					return map[int]string{
 						1: "1:     184233          0          0       7985   IO-APIC   1-edge      i8042",
 						5: "5:          0          0          0          0   IO-APIC   5-edge      drv-virtio-1",
-						8: "8:          1          0          0          0   IO-APIC   8-edge      rtc0"}, nil
+						8: "8:          1          0          0          0   IO-APIC   8-edge      rtc0",
+					}, nil
 				},
 			},
 			before: func(fs afero.Fs) {
@@ -88,7 +89,8 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 					return map[int]string{
 						1: "1:     184233          0          0       7985   IO-APIC   1-edge      xen-dev1",
 						5: "5:          0          0          0          0   IO-APIC   5-edge      drv-virtio-1",
-						8: "8:          1          0          0          0   IO-APIC   8-edge      rtc0"}, nil
+						8: "8:          1          0          0          0   IO-APIC   8-edge      rtc0",
+					}, nil
 				},
 			},
 			before: func(fs afero.Fs) {

--- a/src/go/rpk/pkg/tuners/irq/proc_file_test.go
+++ b/src/go/rpk/pkg/tuners/irq/proc_file_test.go
@@ -21,7 +21,8 @@ var procFileLines = []string{
 	"       CPU0            CPU1       CPU2    CPU3                              ",
 	"1:     184233          0          0       7985   IO-APIC   1-edge      i8042",
 	"5:          0          0          0          0   IO-APIC   5-edge      parport0",
-	"8:          1          0          0          0   IO-APIC   8-edge      rtc0"}
+	"8:          1          0          0          0   IO-APIC   8-edge      rtc0",
+}
 
 var awsMiniProcFile = `
 CPU0       
@@ -66,7 +67,7 @@ PIW:          0   Posted-interrupt wakeup event
 
 func TestProcFile_GetIRQProcFileLinesMap(t *testing.T) {
 	// given
-	var fs = afero.NewMemMapFs()
+	fs := afero.NewMemMapFs()
 	_ = utils.WriteFileLines(fs, procFileLines, "/proc/interrupts")
 	procFile := NewProcFile(fs)
 	// when
@@ -81,8 +82,8 @@ func TestProcFile_GetIRQProcFileLinesMap(t *testing.T) {
 
 func TestProcFile_GetIRQProcFileLinesMap_AWS(t *testing.T) {
 	// given
-	var fs = afero.NewMemMapFs()
-	_ = afero.WriteFile(fs, "/proc/interrupts", []byte(awsMiniProcFile), 0644)
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/proc/interrupts", []byte(awsMiniProcFile), 0o644)
 	procFile := NewProcFile(fs)
 	// when
 	procFileLinesMap, err := procFile.GetIRQProcFileLinesMap()

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -330,7 +330,6 @@ func (f *netTunersFactory) tuneNonVirtualInterfaces(
 	tuneAction func(network.Nic) TuneResult,
 	supportedAction func() (bool, string),
 ) Tunable {
-
 	var tunables []Tunable
 	for _, iface := range interfaces {
 		nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, iface)

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -23,13 +23,12 @@ import (
 	"github.com/spf13/afero"
 )
 
-var (
-	driverMaxRssQueues = map[string]int{
-		"ixgbe":   16,
-		"ixgbevf": 4,
-		"i40e":    64,
-		"i40evf":  16}
-)
+var driverMaxRssQueues = map[string]int{
+	"ixgbe":   16,
+	"ixgbevf": 4,
+	"i40e":    64,
+	"i40evf":  16,
+}
 
 type NTupleStatus int
 
@@ -97,7 +96,7 @@ func (n *nic) IsBondIface() bool {
 }
 
 func (n *nic) Slaves() ([]Nic, error) {
-	var slaves = []Nic{}
+	slaves := []Nic{}
 	if n.IsBondIface() {
 		var slaveNames []string
 		log.Debugf("Reading slaves of '%s'", n.name)
@@ -185,7 +184,6 @@ func (n *nic) GetMaxRxQueueCount() (int, error) {
 	}
 
 	return MaxInt, nil
-
 }
 
 func (n *nic) GetRxQueueCount() (int, error) {

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -52,29 +52,29 @@ func (m *ethtoolMock) Features(iface string) (map[string]bool, error) {
 }
 
 func Test_nic_IsBondIface(t *testing.T) {
-	//given
+	// given
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
-	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0644)
-	//when
+	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0o644)
+	// when
 	bond := nic.IsBondIface()
-	//then
+	// then
 	require.True(t, bond)
 }
 
 func Test_nic_Slaves_ReturnAllSlavesOfAnInterface(t *testing.T) {
-	//given
+	// given
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
-	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0644)
-	afero.WriteFile(fs, "/sys/class/net/test0/bond/slaves", []byte(fmt.Sprint("sl0\nsl1\nsl2")), 0644)
-	//when
+	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/bond/slaves", []byte(fmt.Sprint("sl0\nsl1\nsl2")), 0o644)
+	// when
 	slaves, err := nic.Slaves()
-	//then
+	// then
 	require.NoError(t, err)
 	require.Len(t, slaves, 3)
 	require.Equal(t, slaves[0].Name(), "sl0")
@@ -83,14 +83,14 @@ func Test_nic_Slaves_ReturnAllSlavesOfAnInterface(t *testing.T) {
 }
 
 func Test_nic_Slaves_ReturnEmptyForNotBondInterface(t *testing.T) {
-	//given
+	// given
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
-	//when
+	// when
 	slaves, err := nic.Slaves()
-	//then
+	// then
 	require.NoError(t, err)
 	require.Empty(t, slaves)
 }
@@ -268,7 +268,7 @@ func Test_nic_GetRxQueueCount(t *testing.T) {
 			},
 			before: func(fs afero.Fs) {
 				for i := 0; i < 8; i++ {
-					afero.WriteFile(fs, fmt.Sprintf("/sys/class/net/test0/queues/rx-%d/rps_cpus", i), []byte{}, 0644)
+					afero.WriteFile(fs, fmt.Sprintf("/sys/class/net/test0/queues/rx-%d/rps_cpus", i), []byte{}, 0o644)
 				}
 			},
 			want: 8,
@@ -284,7 +284,7 @@ func Test_nic_GetRxQueueCount(t *testing.T) {
 			},
 			before: func(fs afero.Fs) {
 				for i := 0; i < 8; i++ {
-					afero.WriteFile(fs, fmt.Sprintf("/sys/class/net/test0/queues/rx-%d/rps_cpus", i), []byte{}, 0644)
+					afero.WriteFile(fs, fmt.Sprintf("/sys/class/net/test0/queues/rx-%d/rps_cpus", i), []byte{}, 0o644)
 				}
 			},
 			want: 4,

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -19,7 +19,6 @@ import (
 func getDefaultMode(
 	nic Nic, cpuMask string, cpuMasks irq.CpuMasks,
 ) (irq.Mode, error) {
-
 	if nic.IsHwInterface() {
 		rxQueuesCount, err := nic.GetRxQueueCount()
 		if err != nil {
@@ -74,7 +73,7 @@ func GetRpsCPUMask(
 	if err != nil {
 		return "", err
 	}
-	var effectiveMode = mode
+	effectiveMode := mode
 	if mode == irq.Default {
 		effectiveMode, err = getDefaultMode(nic, effectiveCPUMask, cpuMasks)
 		if err != nil {
@@ -96,7 +95,7 @@ func GetHwInterfaceIRQsDistribution(
 	if err != nil {
 		return nil, err
 	}
-	var effectiveMode = mode
+	effectiveMode := mode
 	if mode == irq.Default {
 		effectiveMode, err = getDefaultMode(nic, effectiveCPUMask, cpuMasks)
 		if err != nil {
@@ -171,7 +170,6 @@ func CollectIRQs(nic Nic) ([]int, error) {
 				return nil, err
 			}
 			IRQs = append(IRQs, slaveIRQs...)
-
 		}
 	}
 	return IRQs, nil

--- a/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
@@ -28,7 +28,7 @@ func setUpCgroup(fs afero.Fs, file, val string, v2 bool) error {
 	}
 	fullPath := "/sys/fs/cgroup" + file
 	dir := filepath.Dir(fullPath)
-	if err := fs.MkdirAll("/proc/self/", 0755); err != nil {
+	if err := fs.MkdirAll("/proc/self/", 0o755); err != nil {
 		return err
 	}
 	var contents string
@@ -45,15 +45,15 @@ func setUpCgroup(fs afero.Fs, file, val string, v2 bool) error {
 		fs,
 		"/proc/self/cgroup",
 		[]byte(contents),
-		0644,
+		0o644,
 	)
 	if err != nil {
 		return err
 	}
-	if err = fs.MkdirAll(dir, 0755); err != nil {
+	if err = fs.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	return afero.WriteFile(fs, fullPath, []byte(val), 0644)
+	return afero.WriteFile(fs, fullPath, []byte(val), 0o644)
 }
 
 func TestNtpCheckTimeout(t *testing.T) {

--- a/src/go/rpk/pkg/tuners/thp_test.go
+++ b/src/go/rpk/pkg/tuners/thp_test.go
@@ -48,7 +48,7 @@ func TestTHPTunerSupported(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
 			if tt.thpDir != "" {
-				err := fs.MkdirAll(tt.thpDir, 0755)
+				err := fs.MkdirAll(tt.thpDir, 0o755)
 				require.NoError(st, err)
 			}
 			exec := executors.NewDirectExecutor()
@@ -73,7 +73,7 @@ echo 'always' > /sys/kernel/mm/transparent_hugepage/enabled
 	scriptFileName := "script.sh"
 	exec := executors.NewScriptRenderingExecutor(fs, scriptFileName)
 	dir := "/sys/kernel/mm/transparent_hugepage"
-	err := fs.MkdirAll(dir, 0755)
+	err := fs.MkdirAll(dir, 0o755)
 	require.NoError(t, err)
 
 	_, err = fs.Create(filepath.Join(dir, "enabled"))
@@ -104,7 +104,7 @@ func TestTHPTunerDirectExecutor(t *testing.T) {
 	exec := executors.NewDirectExecutor()
 	dir := "/sys/kernel/mm/transparent_hugepage"
 	filePath := filepath.Join(dir, "enabled")
-	err := fs.MkdirAll(dir, 0755)
+	err := fs.MkdirAll(dir, 0o755)
 	require.NoError(t, err)
 
 	_, err = fs.Create(filePath)
@@ -153,7 +153,7 @@ func TestTHPCheck(t *testing.T) {
 		t.Run(tt.name, func(st *testing.T) {
 			fs := afero.NewMemMapFs()
 			dir := "/sys/kernel/mm/transparent_hugepage"
-			err := fs.MkdirAll(dir, 0755)
+			err := fs.MkdirAll(dir, 0o755)
 			require.NoError(t, err)
 
 			f, err := fs.Create(filepath.Join(dir, "enabled"))

--- a/src/go/rpk/pkg/utils/files.go
+++ b/src/go/rpk/pkg/utils/files.go
@@ -69,7 +69,7 @@ func CopyFile(fs afero.Fs, src string, dst string) error {
 	if err != nil {
 		return err
 	}
-	err = afero.WriteFile(fs, dst, input, 0644)
+	err = afero.WriteFile(fs, dst, input, 0o644)
 	return err
 }
 

--- a/src/go/rpk/pkg/yaml/yaml.go
+++ b/src/go/rpk/pkg/yaml/yaml.go
@@ -19,7 +19,7 @@ func Persist(fs afero.Fs, in interface{}, file string) error {
 	if err != nil {
 		return err
 	}
-	err = afero.WriteFile(fs, file, bytes, 0644)
+	err = afero.WriteFile(fs, file, bytes, 0o644)
 	return err
 }
 


### PR DESCRIPTION
## Cover letter

Backport for https://github.com/redpanda-data/redpanda/issues/4664 this is important because in dev branch this formatter change will be done and we want to avoid backport failing due to formatting mismatch

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4664

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
