### PR TITLE
Fix 4366: linearize fast idempotency retries

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -741,7 +741,12 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate(
                 })
                 .finally([u = std::move(unit)] {});
           } else if (bid.has_idempotent() && bid.first_seq <= bid.last_seq) {
-              return replicate_seq(bid, std::move(b), opts)
+              request_id rid{.pid = bid.pid, .seq = bid.first_seq};
+              return with_request_lock(
+                       rid,
+                       [this, bid, opts, b = std::move(b)]() mutable {
+                           return replicate_seq(bid, std::move(b), opts);
+                       })
                 .finally([u = std::move(unit)] {});
           }
 

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -350,3 +350,58 @@ FIXTURE_TEST(
     BOOST_REQUIRE(
       r == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }
+
+FIXTURE_TEST(test_rm_stm_passes_immediate_retry, mux_state_machine_fixture) {
+    start_raft();
+
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
+    stm.testing_only_disable_auto_abort();
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+    wait_for_meta_initialized();
+
+    auto count = 5;
+    auto rdr1 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid1 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+
+    // replicate caches only metadata so as long as batches have the same
+    // pid and seq numbers the duplicated request should yield the same
+    // offsets
+    auto rdr2 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid2 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+
+    auto f1 = stm.replicate(
+      bid1,
+      std::move(rdr1),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+    auto f2 = stm.replicate(
+      bid2,
+      std::move(rdr2),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+    auto r2 = f2.get();
+    auto r1 = f1.get();
+
+    BOOST_REQUIRE((bool)r1);
+    BOOST_REQUIRE((bool)r2);
+    BOOST_REQUIRE(r1.value().last_offset == r2.value().last_offset);
+}

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -64,6 +64,8 @@ public:
 
     bool ready() { return _sem.waiters() == 0 && _sem.available_units() == 1; }
 
+    size_t waiters() const noexcept { return _sem.waiters(); }
+
 private:
     ss::semaphore _sem;
 };


### PR DESCRIPTION
## Cover letter

When a client retries a request immediately and doesn't give time for the first request to be replicated it results in UNKNOWN_SERVER_ERROR. When the first request is still inflight and its status is unknown (it may equally succeed or fail) so Redpanda can't decide whether it should reject or accept the follow up attempt.

Fixing the problem by introducing a per request id mutex to make the follow up request wait until the first request is resolved.

Fixes #4366

## Release notes

* improve compatibility with franz-go