### PR TITLE
[v21.11.x] redpanda: shutdown quota manager after kafka server is stopped

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -692,6 +692,11 @@ void application::wire_up_redpanda_services() {
             _rpc.stop().get();
         }
     });
+
+    // metrics and quota management
+    syschecks::systemd_message("Adding kafka quota manager").get();
+    construct_service(quota_mgr).get();
+
     _deferred.emplace_back([this] {
         if (_kafka_server.local_is_initialized()) {
             _kafka_server.invoke_on_all(&rpc::server::wait_for_shutdown).get();
@@ -800,9 +805,6 @@ void application::wire_up_redpanda_services() {
         coprocessing->start().get();
     }
 
-    // metrics and quota management
-    syschecks::systemd_message("Adding kafka quota manager").get();
-    construct_service(quota_mgr).get();
     // rpc
     ss::sharded<rpc::server_configuration> rpc_cfg;
     rpc_cfg.start(ss::sstring("internal_rpc")).get();


### PR DESCRIPTION
Quota manager refrence is a part of request context. We need to make
sure that quota manager is available as long as the kafka server is
running. Moved quota manager initialization before waiting for Kafka
server shutdown to make sure that its reference is available for all
requests that are being processed.

(cherry picked from commit 32539953e14ed2bf9d91daaa4eb6523f6d592b12)
