### PR TITLE
[v22.1.x] cluster: fix disabling leader balancer at runtime

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -156,6 +156,7 @@ void leader_balancer::trigger_balance() {
         vlog(
           clusterlog.info, "Cannot start rebalance until previous fiber exits");
         _timer.arm(_idle_timeout());
+        return;
     }
 
     if (!_enabled()) {
@@ -187,6 +188,10 @@ void leader_balancer::trigger_balance() {
 }
 
 ss::future<ss::stop_iteration> leader_balancer::balance() {
+    if (!_enabled()) {
+        co_return ss::stop_iteration::yes;
+    }
+
     /*
      * GC the muted and last leader indices
      */


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4545
  Fixes https://github.com/redpanda-data/redpanda/issues/4675
  