### PR TITLE
archival_metadata_stm: return error code instead of throwing

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -145,7 +145,13 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
     } else {
         fut = ss::with_timeout(deadline, std::move(fut));
     }
-    auto result = co_await std::move(fut);
+
+    result<raft::replicate_result> result{{}};
+    try {
+        result = co_await std::move(fut);
+    } catch (const ss::timed_out_error&) {
+        result = errc::timeout;
+    }
 
     if (!result) {
         vlog(

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -93,8 +93,6 @@ class FranzGoVerifiableTest(FranzGoVerifiableBase):
 
 
 KGO_LOG_ALLOW_LIST = [
-    # archival - [fiber63 kafka/topic-vmumdxkmeg/33] - ntp_archiver_service.cc:96 - upload loop error: seastar::timed_out_error (timedout)
-    r'archival - .*upload loop error: seastar::timed_out_error \(timedout\)',
     # rpc - server.cc:116 - kafka rpc protocol - Error[applying protocol] remote address: 172.18.0.31:56896 - std::out_of_range (Invalid skip(n). Expected:1000097, but skipped:524404)
     r'rpc - .* - std::out_of_range'
 ]


### PR DESCRIPTION
## Cover letter

Previously, when replicating a metadata batch timed out, `seastar::timed_out_error` was thrown, which lead to "upload loop error" ERROR log messages. As timeouts are expected (that can happen during e.g. leadership transfers) we return cluster::errc instead that then gets logged in ntp_archiver_service as WARN.

Fixes #4590

## Release notes
* none
