### PR TITLE
operator: fix kuttl test definition on v22.1.x

### DIFF
--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "vectorized/redpanda"
   version: "v21.11.11"
-  replicas: 3
+  replicas: 2
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "vectorized/redpanda"
   version: "v21.11.12"
-  replicas: 3
+  replicas: 2
   resources:
     requests:
       cpu: 100m

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: "localhost/redpanda"
   version: "dev"
-  replicas: 3
+  replicas: 2
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Cover letter

Kuttl test is sometimes failing in the v22.1.x branch as this fix was not present.