### PR TITLE
ducktape/acls: Add more tests for mTLS authentication

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -349,7 +349,7 @@ class SecurityConfig:
     # the rules, so instead we use a fixed mapping and arrange for certs to use
     # a similar format. this will change when we get closer to GA and the
     # configuration becomes more general.
-    PRINCIPAL_MAPPING_RULES = "RULE:^O=Redpanda,CN=(.*?)$/$1/L, DEFAULT"
+    __DEFAULT_PRINCIPAL_MAPPING_RULES = "RULE:^O=Redpanda,CN=(.*?)$/$1/L, DEFAULT"
 
     def __init__(self):
         self.enable_sasl = False
@@ -357,6 +357,9 @@ class SecurityConfig:
 
         # extract principal from mtls distinguished name
         self.enable_mtls_identity = False
+
+        # The rules to extract principal from mtls
+        self.principal_mapping_rules = self.__DEFAULT_PRINCIPAL_MAPPING_RULES
 
 
 class RedpandaService(Service):
@@ -1244,8 +1247,8 @@ class RedpandaService(Service):
             )
             if self._security.enable_mtls_identity:
                 tls_config.update(
-                    dict(principal_mapping_rules=SecurityConfig.
-                         PRINCIPAL_MAPPING_RULES, ))
+                    dict(principal_mapping_rules=self._security.
+                         principal_mapping_rules, ))
             doc = yaml.full_load(conf)
             doc["redpanda"].update(dict(kafka_api_tls=tls_config))
             conf = yaml.dump(doc)

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -46,7 +46,7 @@ class AccessControlListTest(RedpandaTest):
         # it with custom security settings
         return
 
-    def prepare_cluster(self, use_tls, use_sasl):
+    def prepare_cluster(self, use_tls, use_sasl, principal_mapping_rules=None):
         self.security = SecurityConfig()
         self.security.enable_sasl = use_sasl
         self.security.enable_mtls_identity = use_tls and not use_sasl
@@ -72,6 +72,9 @@ class AccessControlListTest(RedpandaTest):
                 name="test_admin_client")
 
             self.security.tls_provider = MTLSProvider(self.tls)
+
+        if self.security.enable_mtls_identity and principal_mapping_rules is not None:
+            self.security.principal_mapping_rules = principal_mapping_rules
 
         self.redpanda.set_security_settings(self.security)
         self.redpanda.start()

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -13,7 +13,7 @@ from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
-from rptest.clients.rpk import RpkTool, ClusterAuthorizationError
+from rptest.clients.rpk import RpkTool, ClusterAuthorizationError, RpkException
 
 from rptest.services.redpanda import SecurityConfig, TLSProvider
 from rptest.services import tls
@@ -207,5 +207,5 @@ class AccessControlListTest(RedpandaTest):
             try:
                 self.get_client("cluster_describe").acl_list()
                 assert not fail, "list acls should have failed"
-            except ClusterAuthorizationError:
+            except (ClusterAuthorizationError, RpkException):
                 assert fail, "list acls should have succeeded"


### PR DESCRIPTION
## Cover letter

mTLS Principal Propagation was introduced in #4501 - this adds more testing.

## Reviewer notes

For the test that fails to match a principal "Match admin or empty", the `connection_context` throws a `security::exception`, which terminates the connection.

Catching `rptest.clients.rpk.RpkException: error: unable to list ACLs: EOF` is ok, but then the test fails with `BadLogLines`:

```
ERROR 2022-05-11 16:04:12,516 [shard 0] rpc - server.cc:116 - kafka rpc protocol - Error[applying protocol] - security::exception (security: Invalid credentials: failed to extract principal from distinguished name: O=Redpanda,CN=cluster_describe)">
```

It would be better not to log that at error level. I'm not sure if there's a better way to communicate an Authentication error.

Perhaps security::exception should be caught in `rpc/server.cc` and logged at a lower level?

## Release notes
* none
