### PR TITLE
rpk: change error in cluster health flag description

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -24,8 +24,8 @@ import (
 
 func NewHealthOverviewCommand(fs afero.Fs) *cobra.Command {
 	var (
-		wait bool
-		exit bool
+		watch bool
+		exit  bool
 
 		adminURL       string
 		adminEnableTLS bool
@@ -63,7 +63,7 @@ following conditions are met:
 					printHealthOverview(&ret)
 				}
 				lastOverview = ret
-				if !wait || exit && lastOverview.IsHealthy {
+				if !watch || exit && lastOverview.IsHealthy {
 					break
 				}
 				time.Sleep(2 * time.Second)
@@ -84,8 +84,8 @@ following conditions are met:
 		&adminCAFile,
 	)
 
-	cmd.Flags().BoolVarP(&wait, "watch", "w", false, "blocks and writes out all cluster health changes")
-	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "when used with wait, exits after cluster is back in healthy state")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "blocks and writes out all cluster health changes")
+	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "when used with watch, exits after cluster is back in healthy state")
 	return cmd
 }
 


### PR DESCRIPTION
## Cover letter
Fixes an error in the description of the flag `--exit-when-healthy`
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4633 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
