### PR TITLE
Increase default node start timeout in tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -380,7 +380,8 @@ class RedpandaService(Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
 
-    READY_TIMEOUT_SEC = 10
+    DEFAULT_NODE_READY_TIMEOUT_SEC = 10
+    WASM_READY_TIMEOUT_SEC = 10
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
 
@@ -777,7 +778,7 @@ class RedpandaService(Service):
             self.write_node_conf_file(node, override_cfg_params)
 
         if timeout is None:
-            timeout = self.READY_TIMEOUT_SEC
+            timeout = self.DEFAULT_NODE_READY_TIMEOUT_SEC
 
         if self.coproc_enabled():
             self.start_wasm_engine(node)
@@ -872,9 +873,9 @@ class RedpandaService(Service):
             self.logger.warn(f"Waiting for {wasm_port} to be available")
             wait_until(
                 lambda: not wasm_service_up(),
-                timeout_sec=RedpandaService.READY_TIMEOUT_SEC,
+                timeout_sec=RedpandaService.WASM_READY_TIMEOUT_SEC,
                 err_msg=
-                f"Wasm engine server shutdown within {RedpandaService.READY_TIMEOUT_SEC}s timeout",
+                f"Wasm engine server shutdown within {RedpandaService.WASM_READY_TIMEOUT_SEC}s timeout",
                 retry_on_exc=True)
 
         def start_wasm_service():
@@ -882,9 +883,9 @@ class RedpandaService(Service):
 
             wait_until(
                 wasm_service_up,
-                timeout_sec=RedpandaService.READY_TIMEOUT_SEC,
+                timeout_sec=RedpandaService.WASM_READY_TIMEOUT_SEC,
                 err_msg=
-                f"Wasm engine server startup within {RedpandaService.READY_TIMEOUT_SEC}s timeout",
+                f"Wasm engine server startup within {RedpandaService.WASM_READY_TIMEOUT_SEC}s timeout",
                 retry_on_exc=True)
 
         self.logger.debug(f"Node status prior to wasm_engine startup:")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -448,7 +448,8 @@ class RedpandaService(Service):
                  si_settings=None,
                  log_level: Optional[str] = None,
                  environment: Optional[dict[str, str]] = None,
-                 security: SecurityConfig = SecurityConfig()):
+                 security: SecurityConfig = SecurityConfig(),
+                 node_ready_timeout_s=None):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._enable_rp = enable_rp
@@ -456,6 +457,10 @@ class RedpandaService(Service):
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
         self._security = security
+
+        if node_ready_timeout_s is None:
+            node_ready_timeout_s = RedpandaService.DEFAULT_NODE_READY_TIMEOUT_SEC
+        self.node_ready_timeout_s = node_ready_timeout_s
 
         self._extra_node_conf = {}
         for node in self.nodes:
@@ -778,7 +783,7 @@ class RedpandaService(Service):
             self.write_node_conf_file(node, override_cfg_params)
 
         if timeout is None:
-            timeout = self.DEFAULT_NODE_READY_TIMEOUT_SEC
+            timeout = self.node_ready_timeout_s
 
         if self.coproc_enabled():
             self.start_wasm_engine(node)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -380,7 +380,7 @@ class RedpandaService(Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
 
-    DEFAULT_NODE_READY_TIMEOUT_SEC = 10
+    DEFAULT_NODE_READY_TIMEOUT_SEC = 20
     WASM_READY_TIMEOUT_SEC = 10
 
     DEDICATED_NODE_KEY = "dedicated_nodes"

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RedpandaStartupTest(RedpandaTest):
+    """
+    Tests that Redpanda starts within 10 seconds
+    """
+    def __init__(self, test_context):
+        super(RedpandaStartupTest, self).__init__(test_context=test_context,
+                                                  node_ready_timeout_s=10)
+
+    @cluster(num_nodes=3)
+    def test_startup(self):
+        pass


### PR DESCRIPTION
## Cover letter

We have 10 secs node started timeout, sometimes it isn't enough (environment issues) and may lead to flaky tests such as #4701. Increase the default timeout to avoid this kind of failures. However it is useful to check that Redpanda starts fast to avoid regressions, so introducing a test which explicitly checks that Redpanda starts in 10 seconds. If it fails we at least will have one specific flaky test instead of multiple different tests triggered by the same root cause.

Fixes #4701 

## Release notes

* none