### PR TITLE
tests: refine OMB tests

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -55,7 +55,7 @@ class OpenMessagingBenchmarkWorkers(Service):
             node.account.ssh(start_cmd)
             monitor.wait_until(
                 "Javalin has started",
-                timeout_sec=20,
+                timeout_sec=60,
                 backoff_sec=4,
                 err_msg=
                 "Open Messaging Benchmark worker service didn't finish startup"
@@ -216,7 +216,7 @@ class OpenMessagingBenchmark(Service):
             node.account.ssh(start_cmd)
             monitor.wait_until(
                 "Starting warm-up traffic",
-                timeout_sec=20,
+                timeout_sec=60,
                 backoff_sec=4,
                 err_msg="Open Messaging Benchmark service didn't start")
 

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -111,7 +111,7 @@ class OpenMessagingBenchmarkWorkers(Service):
 # Benchmark process service
 class OpenMessagingBenchmark(Service):
     PERSISTENT_ROOT = "/var/lib/openmessaging"
-    STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "becnhmark.log")
+    STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "benchmark.log")
     OPENMESSAGING_DIR = "/opt/openmessaging-benchmark"
     DRIVER_FILE = os.path.join(OPENMESSAGING_DIR,
                                "driver-redpanda/redpanda-ducktape.yaml")
@@ -161,7 +161,7 @@ class OpenMessagingBenchmark(Service):
         conf = self.render("omb_workload.yaml", **self.configuration)
 
         self.logger.debug(
-            "Open Messaging Bechmark: Workload configuration: \n %s", conf)
+            "Open Messaging Benchmark: Workload configuration: \n %s", conf)
         node.account.create_file(OpenMessagingBenchmark.WORKLOAD_FILE, conf)
 
     def _create_benchmark_driver_file(self, node):
@@ -169,7 +169,7 @@ class OpenMessagingBenchmark(Service):
         conf = self.render("omb_driver.yaml", redpanda_node=rp_node)
 
         self.logger.debug(
-            "Open Messaging Bechmark: Driver configuration: \n %s", conf)
+            "Open Messaging Benchmark: Driver configuration: \n %s", conf)
         node.account.create_file(OpenMessagingBenchmark.DRIVER_FILE, conf)
 
     def _create_workers(self):
@@ -186,7 +186,7 @@ class OpenMessagingBenchmark(Service):
 
     def start_node(self, node):
         idx = self.idx(node)
-        self.logger.info("Open Messaging Bechmark: benchmark node - %d on %s",
+        self.logger.info("Open Messaging Benchmark: benchmark node - %d on %s",
                          idx, node.account.hostname)
 
         self.clean_node(node)
@@ -199,7 +199,7 @@ class OpenMessagingBenchmark(Service):
         worker_nodes = self.workers.get_adresses()
 
         self.logger.info(
-            f"Starting Open Messaging Bechmark with workers: {worker_nodes}")
+            f"Starting Open Messaging Benchmark with workers: {worker_nodes}")
 
         start_cmd = f"cd {OpenMessagingBenchmark.OPENMESSAGING_DIR}; \
                     bin/benchmark \
@@ -266,7 +266,7 @@ class OpenMessagingBenchmark(Service):
         self.workers.stop()
         idx = self.idx(node)
         self.logger.info(
-            f"Stopping Open Messaging Bechmark node on {node.account.hostname}"
+            f"Stopping Open Messaging Benchmark node on {node.account.hostname}"
         )
         node.account.kill_process("openmessaging-benchmark", allow_fail=False)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -379,7 +379,7 @@ class RedpandaService(Service):
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
 
-    RAISE_ON_ERRORS_KEY = "raise_on_errors"
+    RAISE_ON_ERRORS_KEY = "raise_on_error"
 
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"

--- a/tests/rptest/tests/openmessaging_benchmark_test.py
+++ b/tests/rptest/tests/openmessaging_benchmark_test.py
@@ -26,9 +26,9 @@ class OpenBenchmarkTest(RedpandaTest):
     def test_default_omb_configuration(self):
         benchmark = OpenMessagingBenchmark(self._ctx, self.redpanda)
         benchmark.start()
-        becnhmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time(
         ) + OpenBenchmarkTest.BENCHMARK_WAIT_TIME_MIN
-        benchmark.wait(timeout_sec=becnhmark_time_min * 60)
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 
     @cluster(num_nodes=8)
@@ -36,9 +36,9 @@ class OpenBenchmarkTest(RedpandaTest):
         benchmark = OpenMessagingBenchmark(self._ctx, self.redpanda)
         benchmark.set_configuration({"topics": 2})
         benchmark.start()
-        becnhmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time(
         ) + OpenBenchmarkTest.BENCHMARK_WAIT_TIME_MIN
-        benchmark.wait(timeout_sec=becnhmark_time_min * 60)
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 
     @cluster(num_nodes=8)
@@ -49,9 +49,9 @@ class OpenBenchmarkTest(RedpandaTest):
             "consumer_per_subscription": 2
         })
         benchmark.start()
-        becnhmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time(
         ) + OpenBenchmarkTest.BENCHMARK_WAIT_TIME_MIN
-        benchmark.wait(timeout_sec=becnhmark_time_min * 60)
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 
     @cluster(num_nodes=7)
@@ -59,7 +59,7 @@ class OpenBenchmarkTest(RedpandaTest):
         benchmark = OpenMessagingBenchmark(self._ctx, self.redpanda)
         benchmark.set_configuration({"subscriptions_per_topic": 2})
         benchmark.start()
-        becnhmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time(
         ) + OpenBenchmarkTest.BENCHMARK_WAIT_TIME_MIN
-        benchmark.wait(timeout_sec=becnhmark_time_min * 60)
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()


### PR DESCRIPTION
## Cover letter

When testing on clustered ducktape, the OMB services are sometimes taking a surprisingly long time to start (there's a gap between the time we start the remote SSH call, and the service's log starting to see messages).  Raise the startup timeout to allow for that.

Also, fix clean_node -- on startup failures, if clean_node doesn't kill processes, then they can end up running on the nodes while subsequent tests are trying to run.

Fixes: #4711 

## Release notes

* none
