### PR TITLE
Drain cmd

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -43,6 +43,7 @@ type Broker struct {
 	MembershipStatus string             `json:"membership_status"`
 	IsAlive          *bool              `json:"is_alive"`
 	Version          string             `json:"version"`
+	DiskSpaceItems	 []dSpace	    `json:"disk_space"`
 	Maintenance      *MaintenanceStatus `json:"maintenance_status"`
 }
 

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -30,6 +30,12 @@ type MaintenanceStatus struct {
 	Failed       int  `json:"failed"`
 }
 
+type dSpace struct {
+	Path	string	`json:"path"`
+	Free	int64	`json:"free"`
+	Total	int64	`json:"total"`
+}
+
 // Broker is the information returned from the Redpanda admin broker endpoints.
 type Broker struct {
 	NodeID           int                `json:"node_id"`

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -12,16 +12,24 @@
 package partitions
 
 import (
+	"fmt"
+	"errors"
 	"context"
 	"strconv"
+	"sort"
+	"bufio"
+	"os"
 	"strings"
+	"math"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // NewCommand returns the partitions admin command.
@@ -33,7 +41,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
-		newMoveAllCommand(fs),
+		newDrainCommand(fs),
 	)
 	return cmd
 }
@@ -91,67 +99,153 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	return cmd
 }
 
-func newMoveAllCommand(fs afero.Fs) *cobra.Command {
+func newDrainCommand(fs afero.Fs) *cobra.Command {
 	var (
-		sourceBrokerId string
-		destinationBrokerIds string
+		destinationBrokerId int
 	)
         cmd :=  &cobra.Command{
-                Use:     "move-all --source-broker-id [SOURCE BROKER ID] --destination-broker-ids [DESTINATION BROKER IDs]",
-                Aliases: []string{"mv-all"},
-                Short:   "Move all the partitions from a source broker to multiple destination brokers in a cluster.",
-                Args:    cobra.ExactArgs(0),
+                Use:     "move-from [SOURCE BROKER ID] --destination-broker-id [DESTINATION BROKER ID]",
+                Aliases: []string{"mv-frm"},
+                Short:   "Move partitions from a source broker to a destination broker in a cluster.",
+                Args:    cobra.ExactArgs(1),
                 Run: func(cmd *cobra.Command, args []string) {
 
 			p := config.ParamsFromCommand(cmd)
-                        cfg, err := p.Load(fs)
-                        out.MaybeDie(err, "unable to load config: %v", err)
+			cfg, err := p.Load(fs)
+	        out.MaybeDie(err, "unable to load config: %v", err)
 
-                        adm, err := kafka.NewAdmin(fs, p, cfg)
-                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+            adm, err := kafka.NewAdmin(fs, p, cfg)
+            out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+
+            kgocl, err := kafka.NewFranzClient(fs, p, cfg)
+            out.MaybeDie(err, "unable to initialize franz-go client: %v", err)
 
 			var m kadm.Metadata
-                        m, err = adm.Metadata(context.Background())
-                        out.MaybeDie(err, "unable to request metadata: %v", err)
+            m, err = adm.Metadata(context.Background())
+            out.MaybeDie(err, "unable to request metadata: %v", err)
 
-                        // Check if Destination Broker list does not have Source Broker ID
-                        destinationBrokersMap := make(map[int]NodePartitionCount)
-                        for _, db := range strings.Split(destinationBrokerIds, ",") {
-                        	dbId, err := strconv.Atoi(db)
-                        	out.MaybeDie(err, "unable to parse destination broker id: %v", err)
-                        	leaderPartitions, replicaPartitions := getTopicPartitionMap(m, dbId)
-                        	destinationBrokersMap[dbId] = NodePartitionCount{len(leaderPartitions), len(replicaPartitions)}
-                        }
+			sourceBrokerId, err := strconv.Atoi(args[0])
+			out.MaybeDie(err, "unable to parse source broker id: %v", err)
+            
+			bs, err := cl.Brokers()
+            out.MaybeDie(err, "unable to request brokers: %v", err)            
 
-                        tw := out.NewTable("DESTINATION", "LEADER_PARTITION_COUNT", "REPLICA_PARTITION_COUNT")
-                        defer tw.Flush()
+            // Checking if source and destination broker Ids are not same
+            if destinationBrokerId == sourceBrokerId {
+            	out.MaybeDie(errors.New(""),"",errors.New("Destination broker list cannot have source broker id in it."))
+            }
 
-                        /*
-                        For debugging leader and replica count
-                        for dbId, db := range destinationBrokersMap {
-                        	tw.Print(dbId, db.leaderCount, db.replicaCount)	
-                        }
-                        */
-                        
-			brokerId, err := strconv.Atoi(sourceBrokerId)
-			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, brokerId)
+            // Checking if source and destination broker Ids exist
+            sourceBrokerCheck := false
+            destinationBrokerCheck := false
+            for _, brokerId := range bs {
+            	if brokerId.NodeID == sourceBrokerId && sourceBrokerCheck == false {
+            		sourceBrokerCheck = true
+            	}
+            	if brokerId.NodeID == destinationBrokerId && destinationBrokerCheck == false {
+            		destinationBrokerCheck = true
+            	}
+            }
+            if !(sourceBrokerCheck && destinationBrokerCheck) {
+            	out.Die("Source or Destination broker is invalid.")
+            }
 
-                        for _, t := range leaderPartitions {				
-				// Transfer leadership to the replica on a broker, which has lower number of leaders
-				tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));				
+			// for storing disk usage for all brokers
+			allBrokerDiskUsageMap := getBrokerDiskUsageMap(bs)			
+
+			// Get all the partitions on the source broker
+			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, sourceBrokerId)
+
+			// For each partition, try to fix it on the destination brokers
+			for _, t := range leaderPartitions {
+				//tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));
+				t.partition = t.partition + 1
 				// Verify that no leadership is present on the current broker before proceeding
 			}
 
+			// Fetching partition sizes
+			var req kmsg.DescribeLogDirsRequest
+
 			for _, t := range replicaPartitions {
-                                tw.Print(t.topic, t.partition, "NO")
-                                break
-                        }
+				var partitions []int32
+				partitions = append(partitions, t.partition)
+				req.Topics = append(req.Topics, kmsg.DescribeLogDirsRequestTopic{
+					Topic:      t.topic,
+					Partitions: partitions,
+				})
+			}
+
+			kresps := kgocl.RequestSharded(context.Background(), &req)
+
+			tw := out.NewTable()
+			header := func(name string) {				
+				tw.Print(name)
+				tw.Print(strings.Repeat("=", len(name)))
+				tw.Print()
+			}
+
+			header("DRAIN PLAN")			
+			
+			var totalPartitionSize int64
+			for _, kresp := range kresps {
+				resp := kresp.Resp.(*kmsg.DescribeLogDirsResponse)
+				sort.Slice(resp.Dirs, func(i, j int) bool { return resp.Dirs[i].Dir < resp.Dirs[j].Dir })
+				for _, dir := range resp.Dirs {
+					sort.Slice(dir.Topics, func(i, j int) bool { return dir.Topics[i].Topic < dir.Topics[j].Topic })
+					for _, topic := range dir.Topics {
+						sort.Slice(topic.Partitions, func(i, j int) bool { return topic.Partitions[i].Partition < topic.Partitions[j].Partition })
+						for _, partition := range topic.Partitions {							
+							totalPartitionSize = totalPartitionSize + partition.Size
+						}
+					}
+				}
+				break //TODO: REVISIT WHY DO WE NEED TO BREAK HERE
+			}
+
+			oldFDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100
+			newDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free) - float64(totalPartitionSize)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100			
+
+			header("DESTINATION BROKER DETAILS")
+			tw.PrintColumn("BROKER ID", "CURRENT DISK USAGE %", "PROPOSED DISK USAGE %", "PARTITIONS TO DRAIN", "DATA TO DRAIN")
+			tw.Print(destinationBrokerId, math.Round(oldFDiskUsage*100)/100, math.Round(newDiskUsage*100)/100, len(req.Topics), totalPartitionSize)
+			// If the new free disk is < 10% of total usage, we terminate the move of partitions
+			if newDiskUsage < 10 {
+            	out.Die("New Free Disk Space will be less than 10% of Total Disk Space. Aborting Move.")
+            }            
+            
+            tw.Flush()
+
+            fmt.Println()
+            reader := bufio.NewReader(os.Stdin)            
+			fmt.Print("Are you sure you want to proceed with the drain?(y/n): ")
+			inp, _ := reader.ReadString('\n')
+			input := strings.TrimRight(inp, "\n")
+
+			if !(input == "y" || input == "n") {
+				out.Die("Invalid input: %v", inp)
+			} else if input == "n" {
+				out.Die("Aborting the drain.")		
+			}
+
+			fmt.Println("Continue with the drain.")
+/*
+			for _, t := range replicaPartitions {
+				pa, err := cl.UpdateReplicas("kafka", t.topic, int(t.partition), sourceBrokerId, destinationBrokerId)
+				if err != nil {
+					out.MaybeDie(err, "Not able to drain partition: %v", pa.Topic, err)
+				} else {
+					fmt.Println("Partition is drained out. ", t.topic, " - ", t.partition)
+				}				
+				break
+			}
+*/
 		},
 	}
 
-	cmd.Flags().StringVar(&sourceBrokerId, "source-broker-id", "", "Source Broker Id")
-	cmd.Flags().StringVar(&destinationBrokerIds, "destination-broker-ids", "", "Destination Broker Ids")
-
+	cmd.Flags().IntVar(&destinationBrokerId, "destination-broker-id", -1, "Destination Broker Id")
 	return cmd
 }
 
@@ -161,9 +255,15 @@ type NodePartitionCount struct {
 }
 
 type TopicPartition struct {
-	topic string
-	partition int32
-	replicas []int32
+	topic 		string
+	partition 	int32
+	replicas 	[]int32
+	size	 	int64
+}
+
+type DiskUsage struct {
+	free int64
+	total int64
 }
 
 func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []TopicPartition) {
@@ -176,9 +276,9 @@ func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []To
                 	for _, rs := range pt.Replicas {
                         	if int(rs) == brokerId {
                                         if int(pt.Leader) == brokerId {
-                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
                                         } else {
-                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
 					}
                                 }
                         }
@@ -188,6 +288,17 @@ func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []To
 	return leaderPartitions,replicaPartitions
 }
 
+func getBrokerDiskUsageMap(bs []admin.Broker) (map[int]DiskUsage) {
+
+	dBrokerDiskUsage := make(map[int]DiskUsage)
+
+        for _, b := range bs {
+        	dBrokerDiskUsage[b.NodeID] = DiskUsage{b.DiskSpaceItems[0].Free, b.DiskSpaceItems[0].Total}
+        }
+	return dBrokerDiskUsage
+
+}
+
 func remove(s []int32, r int32) []int32 {
     for i, v := range s {
         if v == r {
@@ -195,4 +306,14 @@ func remove(s []int32, r int32) []int32 {
         }
     }
     return s
+}
+
+func getLeastUsedBroker(dBrokerDiskUsageMap map[int]DiskUsage) {
+	broker := dBrokerDiskUsageMap[0]
+	for i := 1; i < len(dBrokerDiskUsageMap); i++ {
+		if dBrokerDiskUsageMap[i].free > broker.free {
+			broker = dBrokerDiskUsageMap[i]
+		}
+	}
+	fmt.Println(broker)
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -14,6 +14,7 @@ package partitions
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -32,6 +33,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCommand(fs),
+		newMoveAllCommand(fs),
 	)
 	return cmd
 }
@@ -87,4 +89,110 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	cmd.Flags().BoolVarP(&leaderOnly, "leader-only", "l", false, "print the partitions on broker which are leaders")
 
 	return cmd
+}
+
+func newMoveAllCommand(fs afero.Fs) *cobra.Command {
+	var (
+		sourceBrokerId string
+		destinationBrokerIds string
+	)
+        cmd :=  &cobra.Command{
+                Use:     "move-all --source-broker-id [SOURCE BROKER ID] --destination-broker-ids [DESTINATION BROKER IDs]",
+                Aliases: []string{"mv-all"},
+                Short:   "Move all the partitions from a source broker to multiple destination brokers in a cluster.",
+                Args:    cobra.ExactArgs(0),
+                Run: func(cmd *cobra.Command, args []string) {
+
+			p := config.ParamsFromCommand(cmd)
+                        cfg, err := p.Load(fs)
+                        out.MaybeDie(err, "unable to load config: %v", err)
+
+                        adm, err := kafka.NewAdmin(fs, p, cfg)
+                        out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+
+			var m kadm.Metadata
+                        m, err = adm.Metadata(context.Background())
+                        out.MaybeDie(err, "unable to request metadata: %v", err)
+
+                        // Check if Destination Broker list does not have Source Broker ID
+                        destinationBrokersMap := make(map[int]NodePartitionCount)
+                        for _, db := range strings.Split(destinationBrokerIds, ",") {
+                        	dbId, err := strconv.Atoi(db)
+                        	out.MaybeDie(err, "unable to parse destination broker id: %v", err)
+                        	leaderPartitions, replicaPartitions := getTopicPartitionMap(m, dbId)
+                        	destinationBrokersMap[dbId] = NodePartitionCount{len(leaderPartitions), len(replicaPartitions)}
+                        }
+
+                        tw := out.NewTable("DESTINATION", "LEADER_PARTITION_COUNT", "REPLICA_PARTITION_COUNT")
+                        defer tw.Flush()
+
+                        /*
+                        For debugging leader and replica count
+                        for dbId, db := range destinationBrokersMap {
+                        	tw.Print(dbId, db.leaderCount, db.replicaCount)	
+                        }
+                        */
+                        
+			brokerId, err := strconv.Atoi(sourceBrokerId)
+			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, brokerId)
+
+                        for _, t := range leaderPartitions {				
+				// Transfer leadership to the replica on a broker, which has lower number of leaders
+				tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));				
+				// Verify that no leadership is present on the current broker before proceeding
+			}
+
+			for _, t := range replicaPartitions {
+                                tw.Print(t.topic, t.partition, "NO")
+                                break
+                        }
+		},
+	}
+
+	cmd.Flags().StringVar(&sourceBrokerId, "source-broker-id", "", "Source Broker Id")
+	cmd.Flags().StringVar(&destinationBrokerIds, "destination-broker-ids", "", "Destination Broker Ids")
+
+	return cmd
+}
+
+type NodePartitionCount struct {
+	leaderCount int
+	replicaCount int
+}
+
+type TopicPartition struct {
+	topic string
+	partition int32
+	replicas []int32
+}
+
+func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []TopicPartition) {
+
+	var leaderPartitions []TopicPartition
+	var replicaPartitions []TopicPartition
+
+	for _, t := range m.Topics.Sorted() {
+	        for _, pt := range t.Partitions.Sorted() {
+                	for _, rs := range pt.Replicas {
+                        	if int(rs) == brokerId {
+                                        if int(pt.Leader) == brokerId {
+                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+                                        } else {
+                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas})
+					}
+                                }
+                        }
+                }
+        }
+
+	return leaderPartitions,replicaPartitions
+}
+
+func remove(s []int32, r int32) []int32 {
+    for i, v := range s {
+        if v == r {
+            return append(s[:i], s[i+1:]...)
+        }
+    }
+    return s
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -12,15 +12,17 @@
 package partitions
 
 import (
-	"fmt"
-	"errors"
+//	"fmt"
+//	"errors"
 	"context"
 	"strconv"
 	"sort"
-	"bufio"
-	"os"
+//	"bufio"
+//	"os"
 	"strings"
-	"math"
+//	"math"
+//	"reflect"
+	"math/rand"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -30,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // NewCommand returns the partitions admin command.
@@ -99,16 +102,13 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	return cmd
 }
 
-func newDrainCommand(fs afero.Fs) *cobra.Command {
-	var (
-		destinationBrokerId int
-	)
-        cmd :=  &cobra.Command{
-                Use:     "move-from [SOURCE BROKER ID] --destination-broker-id [DESTINATION BROKER ID]",
-                Aliases: []string{"mv-frm"},
-                Short:   "Move partitions from a source broker to a destination broker in a cluster.",
-                Args:    cobra.ExactArgs(1),
-                Run: func(cmd *cobra.Command, args []string) {
+func newDrainCommand(fs afero.Fs) *cobra.Command {	
+    cmd :=  &cobra.Command{
+        Use:     "drain [BROKER ID]",
+        Aliases: []string{"dr"},
+        Short:   "Move partitions from a source broker to all other brokers in a cluster based on disk usage.",
+        Args:    cobra.ExactArgs(1),
+        Run: func(cmd *cobra.Command, args []string) {
 
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
@@ -133,52 +133,44 @@ func newDrainCommand(fs afero.Fs) *cobra.Command {
 			bs, err := cl.Brokers()
             out.MaybeDie(err, "unable to request brokers: %v", err)            
 
-            // Checking if source and destination broker Ids are not same
-            if destinationBrokerId == sourceBrokerId {
-            	out.MaybeDie(errors.New(""),"",errors.New("Destination broker list cannot have source broker id in it."))
-            }
-
-            // Checking if source and destination broker Ids exist
-            sourceBrokerCheck := false
-            destinationBrokerCheck := false
+            // Checking if source broker Id exist
+            sourceBrokerCheck := false            
             for _, brokerId := range bs {
             	if brokerId.NodeID == sourceBrokerId && sourceBrokerCheck == false {
             		sourceBrokerCheck = true
-            	}
-            	if brokerId.NodeID == destinationBrokerId && destinationBrokerCheck == false {
-            		destinationBrokerCheck = true
+            		break
             	}
             }
-            if !(sourceBrokerCheck && destinationBrokerCheck) {
-            	out.Die("Source or Destination broker is invalid.")
+            if !(sourceBrokerCheck) {
+            	out.Die("Source broker is invalid.")
             }
+
+            /*
+            1. Get all topic-partition combinations from the source broker. DONE
+            2. Sort all topic-partitions by size first in decreasing order. DONE
+            3. Get all broker disk usage for all brokers except source broker. DONE
+            4. For each topic-partition, get the least used broker, that does not have a replica of this partition and allocate the topic-partition to it. DONE
+            5. Store all topic-partition-movement mapping in a data structure. DONE
+            6. Print all the movement information and final state of the cluster. DONE
+            7. Ask for confirmation and trigger the draining
+            */
 
 			// for storing disk usage for all brokers
-			allBrokerDiskUsageMap := getBrokerDiskUsageMap(bs)			
+			//allBrokerDiskUsageMap := getBrokerDiskUsageMap(bs)
 
-			// Get all the partitions on the source broker
-			leaderPartitions, replicaPartitions := getTopicPartitionMap(m, sourceBrokerId)
+			// 1. Get all the partitions on the source broker
+			topicPartitionMap := getTopicPartitionMap(m, kgocl, sourceBrokerId)
 
-			// For each partition, try to fix it on the destination brokers
-			for _, t := range leaderPartitions {
-				//tw.Print(t.topic, t.partition, remove(t.replicas, int32(brokerId)));
-				t.partition = t.partition + 1
-				// Verify that no leadership is present on the current broker before proceeding
-			}
+			// 2. Sort all topic-partitions by size first in decreasing order.
+			sort.Slice(topicPartitionMap, func(i, j int) bool {
+  				return topicPartitionMap[i].size > topicPartitionMap[j].size
+			})
 
-			// Fetching partition sizes
-			var req kmsg.DescribeLogDirsRequest
+			// 3. Get all broker disk usage for all brokers except source broker.
+			diskUsageMap := getBrokerDiskUsageMap(bs)
 
-			for _, t := range replicaPartitions {
-				var partitions []int32
-				partitions = append(partitions, t.partition)
-				req.Topics = append(req.Topics, kmsg.DescribeLogDirsRequestTopic{
-					Topic:      t.topic,
-					Partitions: partitions,
-				})
-			}
-
-			kresps := kgocl.RequestSharded(context.Background(), &req)
+			// 4. For each topic-partition, get the least used broker, that does not have a replica of this partition and allocate the topic-partition to it.
+			//5. Store all topic-partition-movement mapping in a data structure.
 
 			tw := out.NewTable()
 			header := func(name string) {				
@@ -187,36 +179,45 @@ func newDrainCommand(fs afero.Fs) *cobra.Command {
 				tw.Print()
 			}
 
-			header("DRAIN PLAN")			
-			
-			var totalPartitionSize int64
-			for _, kresp := range kresps {
-				resp := kresp.Resp.(*kmsg.DescribeLogDirsResponse)
-				sort.Slice(resp.Dirs, func(i, j int) bool { return resp.Dirs[i].Dir < resp.Dirs[j].Dir })
-				for _, dir := range resp.Dirs {
-					sort.Slice(dir.Topics, func(i, j int) bool { return dir.Topics[i].Topic < dir.Topics[j].Topic })
-					for _, topic := range dir.Topics {
-						sort.Slice(topic.Partitions, func(i, j int) bool { return topic.Partitions[i].Partition < topic.Partitions[j].Partition })
-						for _, partition := range topic.Partitions {							
-							totalPartitionSize = totalPartitionSize + partition.Size
-						}
-					}
-				}
-				break //TODO: REVISIT WHY DO WE NEED TO BREAK HERE
-			}
+			header("PROPOSED DRAIN PLAN")
+			header("PROPOSED DRAIN TOPICS")
 
+			tw.PrintColumn("TOPIC", "PARTITION", "DESTINATION BROKER")
+
+			drainMap := make(map[string]int)
+
+			nonDrainablePartitionCount := 0
+			for _, tp := range topicPartitionMap {
+				destinationBroker := getLeastUsedBrokerWithNoReplicas(sourceBrokerId, tp, diskUsageMap)
+				if destinationBroker != -1 {
+					uS := getUniqueTopicPartitionString(tp.topic, strconv.Itoa(int(tp.partition)))
+					drainMap[uS] = destinationBroker
+					tw.Print(tp.topic, tp.partition, destinationBroker)
+				} else {
+					nonDrainablePartitionCount = nonDrainablePartitionCount + 1
+				}
+			}
+			
+			tw.Print()
+			header("PROPOSED DRAIN SUMMARY")
+
+			tw.PrintColumn("DRAINABLE PARTITIONS", "NON DRAINABLE PARTITIONS", "TOTAL PARTITIONS")
+			tw.Print(len(topicPartitionMap) - nonDrainablePartitionCount, nonDrainablePartitionCount, len(topicPartitionMap))
+
+			//6. Print all the movement information and final state of the cluster.
+			tw.Flush()
+
+			/*
 			oldFDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100
 			newDiskUsage := ((float64(allBrokerDiskUsageMap[destinationBrokerId].total) - float64(allBrokerDiskUsageMap[destinationBrokerId].free) - float64(totalPartitionSize)) / float64(allBrokerDiskUsageMap[destinationBrokerId].total))*100			
 
-			header("DESTINATION BROKER DETAILS")
+			
 			tw.PrintColumn("BROKER ID", "CURRENT DISK USAGE %", "PROPOSED DISK USAGE %", "PARTITIONS TO DRAIN", "DATA TO DRAIN")
 			tw.Print(destinationBrokerId, math.Round(oldFDiskUsage*100)/100, math.Round(newDiskUsage*100)/100, len(req.Topics), totalPartitionSize)
 			// If the new free disk is < 10% of total usage, we terminate the move of partitions
 			if newDiskUsage < 10 {
-            	out.Die("New Free Disk Space will be less than 10% of Total Disk Space. Aborting Move.")
-            }            
-            
-            tw.Flush()
+            	out.Die("New Free Disk Space will be less than 10%% of Total Disk Space. Aborting Move.")
+            }                      
 
             fmt.Println()
             reader := bufio.NewReader(os.Stdin)            
@@ -231,6 +232,7 @@ func newDrainCommand(fs afero.Fs) *cobra.Command {
 			}
 
 			fmt.Println("Continue with the drain.")
+			*/
 /*
 			for _, t := range replicaPartitions {
 				pa, err := cl.UpdateReplicas("kafka", t.topic, int(t.partition), sourceBrokerId, destinationBrokerId)
@@ -244,59 +246,93 @@ func newDrainCommand(fs afero.Fs) *cobra.Command {
 */
 		},
 	}
-
-	cmd.Flags().IntVar(&destinationBrokerId, "destination-broker-id", -1, "Destination Broker Id")
+	
 	return cmd
 }
 
-type NodePartitionCount struct {
+/*type NodePartitionCount struct {
 	leaderCount int
 	replicaCount int
-}
+}*/
 
 type TopicPartition struct {
 	topic 		string
 	partition 	int32
 	replicas 	[]int32
-	size	 	int64
+	size 		int64
 }
 
 type DiskUsage struct {
+	broker int
 	free int64
 	total int64
 }
 
-func getTopicPartitionMap(m kadm.Metadata, brokerId int) ([]TopicPartition, []TopicPartition) {
+func getTopicPartitionMap(m kadm.Metadata, kgocl *kgo.Client, brokerId int) ([]TopicPartition) {
+	
+	var partitions []TopicPartition
+	replicaMap := make(map[string][]int32)
 
-	var leaderPartitions []TopicPartition
-	var replicaPartitions []TopicPartition
-
+	// START - Fetching partition sizes
+   
+    // Creating the fetch request to get partition sizes
+    var req kmsg.DescribeLogDirsRequest
 	for _, t := range m.Topics.Sorted() {
-	        for _, pt := range t.Partitions.Sorted() {
-                	for _, rs := range pt.Replicas {
-                        	if int(rs) == brokerId {
-                                        if int(pt.Leader) == brokerId {
-                                        	leaderPartitions = append(leaderPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
-                                        } else {
-                                        	replicaPartitions = append(replicaPartitions, TopicPartition{t.Topic, pt.Partition, pt.Replicas, 0})
-					}
-                                }
-                        }
+	    for _, pt := range t.Partitions.Sorted() {
+            for _, rs := range pt.Replicas {
+                if int(rs) == brokerId {
+                	var pts []int32
+					pts = append(pts, pt.Partition)
+					req.Topics = append(req.Topics, kmsg.DescribeLogDirsRequestTopic {
+						Topic:      t.Topic,
+						Partitions: pts,
+					})
+					uniqueTPString := getUniqueTopicPartitionString(t.Topic,strconv.Itoa(int(pt.Partition)))
+					replicaMap[uniqueTPString] = pt.Replicas
                 }
+            }
         }
+    }
 
-	return leaderPartitions,replicaPartitions
+    // Sent the request to fetch partition sizes
+	kresps := kgocl.RequestSharded(context.Background(), &req)
+
+	// Creating TopicPartition objects to return
+	tpMap := map[string]bool{}
+
+	for _, kresp := range kresps {
+		resp := kresp.Resp.(*kmsg.DescribeLogDirsResponse)
+		sort.Slice(resp.Dirs, func(i, j int) bool { return resp.Dirs[i].Dir < resp.Dirs[j].Dir })
+		for _, dir := range resp.Dirs {
+			sort.Slice(dir.Topics, func(i, j int) bool { return dir.Topics[i].Topic < dir.Topics[j].Topic })
+			for _, topic := range dir.Topics {
+				sort.Slice(topic.Partitions, func(i, j int) bool { return topic.Partitions[i].Partition < topic.Partitions[j].Partition })
+				for _, pt := range topic.Partitions {					
+					//fmt.Println("Topic: %+v\n", topic.Topic)
+					//fmt.Println("Partition:", pt.Partition)
+					//fmt.Println("Partition Size:", pt.Size)
+					uniqueTPString := getUniqueTopicPartitionString(topic.Topic,strconv.Itoa(int(pt.Partition)))
+					//fmt.Println("Partition Replicas:", replicaMap[uniqueTPString])
+					_, hasTP := tpMap[uniqueTPString]
+					if !hasTP {
+						tpMap[uniqueTPString] = true
+						partitions = append(partitions, TopicPartition{topic.Topic, pt.Partition, replicaMap[uniqueTPString], pt.Size})
+					}
+				}
+			}
+		}		
+	}
+
+	// END - Fetched partition sizes
+	return partitions
 }
 
-func getBrokerDiskUsageMap(bs []admin.Broker) (map[int]DiskUsage) {
-
-	dBrokerDiskUsage := make(map[int]DiskUsage)
-
+func getBrokerDiskUsageMap(bs []admin.Broker) []DiskUsage {
+	var diskUsageMap []DiskUsage
         for _, b := range bs {
-        	dBrokerDiskUsage[b.NodeID] = DiskUsage{b.DiskSpaceItems[0].Free, b.DiskSpaceItems[0].Total}
+        	diskUsageMap = append(diskUsageMap, DiskUsage{b.NodeID, b.DiskSpaceItems[0].Free, b.DiskSpaceItems[0].Total})
         }
-	return dBrokerDiskUsage
-
+	return diskUsageMap
 }
 
 func remove(s []int32, r int32) []int32 {
@@ -308,12 +344,46 @@ func remove(s []int32, r int32) []int32 {
     return s
 }
 
-func getLeastUsedBroker(dBrokerDiskUsageMap map[int]DiskUsage) {
-	broker := dBrokerDiskUsageMap[0]
-	for i := 1; i < len(dBrokerDiskUsageMap); i++ {
-		if dBrokerDiskUsageMap[i].free > broker.free {
-			broker = dBrokerDiskUsageMap[i]
+func removeBroker(s []DiskUsage, r int) []DiskUsage {
+	for i, v := range s {
+        if v.broker == r {
+            return append(s[:i], s[i+1:]...)
+        }
+    }
+    return s
+}
+
+func contains(s []int32, r int32) bool {
+    for _, v := range s {
+        if v == r {
+            return true
+        }
+    }    
+    return false
+}
+
+func getLeastUsedBrokerWithNoReplicas(sourceBroker int, tp TopicPartition, diskUsageMap []DiskUsage) int {
+
+	sort.Slice(diskUsageMap, func(i, j int) bool {
+		return diskUsageMap[i].free > diskUsageMap[j].free
+	})
+
+	otherReplicas := remove(tp.replicas, int32(sourceBroker))
+	otherBrokers := removeBroker(diskUsageMap, sourceBroker)
+
+	if len(otherReplicas) == 0 {
+		return otherBrokers[rand.Intn(len(otherBrokers))].broker
+	}
+
+	for _, b := range otherBrokers {
+		if !contains(otherReplicas, int32(b.broker)) {			
+			return b.broker
 		}
 	}
-	fmt.Println(broker)
+	
+	return -1
+}
+
+func getUniqueTopicPartitionString(topic string, partition string) string {
+	return topic + "-" + partition
 }


### PR DESCRIPTION
## Cover letter

This partition drain features prints out a plan for draining out partitions from a specific broker and moving the partitions to all other brokers based on the disk usage. This distributes movable partitions to other brokers efficiently by measuring their disk free space.

**How is it different from `decommission` command?**
Decommission command moves partitions based on the number of partitions to other brokers whereas drain moves partitions based on the disk free on other brokers. Drain command also makes sure that brokers does not get 80% full when the drain happens.

The command will be as follows:

```
Usage:
  rpk redpanda admin partitions drain [BROKER ID] [flags]

Aliases:
  drain, dr
```

Example:

```
redpanda admin partitions drain 114531 --hosts 10.100.101.102:9644

PROPOSED DRAIN PLAN
===================

PROPOSED DRAIN BROKER ALLOCATION
================================

TOPIC        PARTITION    DESTINATION BROKER
TOPIC_1     0                    832815
TOPIC_2    0                    832815
TOPIC_3    2                    832815
TOPIC_3    3                    832815
TOPIC_3    8                    832815
TOPIC_3    9                    832815
TOPIC_3    10                  77489
TOPIC_3    11                   832815
TOPIC_3    13                  77489
TOPIC_3    14                  832815
TOPIC_4    0                   832815
TOPIC_5    0                   832815
TOPIC_6    0                   77489

PROPOSED DRAIN SUMMARY - BROKERS
================================

BROKER  CURRENT DISK USAGE %  PROPOSED DISK USAGE %
832815  1.19                  1.19
77489   1.13                  1.13

PROPOSED DRAIN SUMMARY - PARTITIONS
===================================

DRAINABLE PARTITIONS  NON DRAINABLE PARTITIONS  TOTAL PARTITIONS
13                    206                       219

Are you sure you want to proceed with the drain?(y/n): n
Aborting the drain.
```