### PR TITLE
tests: disable topic auto creation by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -400,9 +400,6 @@ class RedpandaService(Service):
 
     CLUSTER_CONFIG_DEFAULTS = {
         'join_retry_timeout_ms': 200,
-
-        # For librdkafka
-        'auto_create_topics_enabled': True,
         'default_topic_partitions': 4,
         'enable_metrics_reporter': False,
         'superusers': [SUPERUSER_CREDENTIALS[0]],

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -28,7 +28,9 @@ class SaramaTest(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        super(SaramaTest, self).__init__(test_context=test_context)
+        super(SaramaTest, self).__init__(
+            test_context=test_context,
+            extra_rp_conf={'auto_create_topics_enabled': True})
 
         self._ctx = test_context
 


### PR DESCRIPTION

## Cover letter

This helps reduce fallout from issues with service
classes.  When auto creation is enabled, a rogue
traffic generator can end up creating topics on
nodes running unrelated tests, causing them
to fail with "Unexpected data" errors on startup.

## Release notes

* none