### PR TITLE
ducktape: add consumer group consumer to franz_go_verifiable_test

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -125,7 +125,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard e9712f5 && \
+    cd /opt/kgo-verifier && git reset --hard dd7dce41012af14e62c1db23a0aa88ec6f39a5f1 && \
     go mod tidy && go build
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -18,7 +18,12 @@ from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.redpanda import SISettings, RESTART_LOG_ALLOW_LIST
-from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
+from rptest.services.franz_go_verifiable_services import (
+    FranzGoVerifiableProducer,
+    FranzGoVerifiableSeqConsumer,
+    FranzGoVerifiableRandomConsumer,
+    FranzGoVerifiableConsumerGroupConsumer,
+)
 
 
 class FranzGoVerifiableBase(PreallocNodesTest):
@@ -31,6 +36,7 @@ class FranzGoVerifiableBase(PreallocNodesTest):
     PRODUCE_COUNT = None
     RANDOM_READ_COUNT = None
     RANDOM_READ_PARALLEL = None
+    CONSUMER_GROUP_READERS = None
 
     def __init__(self, test_context, *args, **kwargs):
         super().__init__(test_context=test_context,
@@ -49,6 +55,13 @@ class FranzGoVerifiableBase(PreallocNodesTest):
             test_context, self.redpanda, self.topic, self.MSG_SIZE,
             self.RANDOM_READ_COUNT, self.RANDOM_READ_PARALLEL,
             self.preallocated_nodes)
+        self._cg_consumer = FranzGoVerifiableConsumerGroupConsumer(
+            test_context, self.redpanda, self.topic, self.MSG_SIZE,
+            self.CONSUMER_GROUP_READERS, self.preallocated_nodes)
+
+        self._consumers = [
+            self._seq_consumer, self._rand_consumer, self._cg_consumer
+        ]
 
 
 class FranzGoVerifiableTest(FranzGoVerifiableBase):
@@ -56,6 +69,7 @@ class FranzGoVerifiableTest(FranzGoVerifiableBase):
     PRODUCE_COUNT = 100000
     RANDOM_READ_COUNT = 1000
     RANDOM_READ_PARALLEL = 20
+    CONSUMER_GROUP_READERS = 8
 
     topics = (TopicSpec(partition_count=100, replication_factor=3), )
 
@@ -76,20 +90,20 @@ class FranzGoVerifiableTest(FranzGoVerifiableBase):
                    backoff_sec=0.1)
         wrote_at_least = self._producer.produce_status.acked
 
-        self._seq_consumer.start(clean=False)
-        self._rand_consumer.start(clean=False)
+        for consumer in self._consumers:
+            consumer.start(clean=False)
 
         self._producer.wait()
         assert self._producer.produce_status.acked == self.PRODUCE_COUNT
 
-        self._seq_consumer.shutdown()
-        self._rand_consumer.shutdown()
-
-        self._seq_consumer.wait()
-        self._rand_consumer.wait()
+        for consumer in self._consumers:
+            consumer.shutdown()
+        for consumer in self._consumers:
+            consumer.wait()
 
         assert self._seq_consumer.consumer_status.valid_reads >= wrote_at_least
         assert self._rand_consumer.consumer_status.total_reads == self.RANDOM_READ_COUNT * self.RANDOM_READ_PARALLEL
+        assert self._cg_consumer.consumer_status.valid_reads >= wrote_at_least
 
 
 KGO_LOG_ALLOW_LIST = [
@@ -107,6 +121,7 @@ class FranzGoVerifiableWithSiTest(FranzGoVerifiableBase):
     PRODUCE_COUNT = 20000
     RANDOM_READ_COUNT = 1000
     RANDOM_READ_PARALLEL = 20
+    CONSUMER_GROUP_READERS = 8
 
     topics = (TopicSpec(partition_count=100, replication_factor=3), )
 
@@ -157,8 +172,8 @@ class FranzGoVerifiableWithSiTest(FranzGoVerifiableBase):
             self.logger.info(f"S3 object: {o.Key}, {o.ContentLength}")
 
         wrote_at_least = self._producer.produce_status.acked
-        self._seq_consumer.start(clean=False)
-        self._rand_consumer.start(clean=False)
+        for consumer in self._consumers:
+            consumer.start(clean=False)
 
         # Wait until we have written all the data we expected to write
         self._producer.wait()
@@ -166,13 +181,14 @@ class FranzGoVerifiableWithSiTest(FranzGoVerifiableBase):
 
         # Wait for last iteration of consumers to finish: if they are currently
         # mid-run, they'll run to completion.
-        self._seq_consumer.shutdown()
-        self._rand_consumer.shutdown()
-        self._seq_consumer.wait()
-        self._rand_consumer.wait()
+        for consumer in self._consumers:
+            consumer.shutdown()
+        for consumer in self._consumers:
+            consumer.wait()
 
         assert self._seq_consumer.consumer_status.valid_reads >= wrote_at_least
         assert self._rand_consumer.consumer_status.total_reads == self.RANDOM_READ_COUNT * self.RANDOM_READ_PARALLEL
+        assert self._cg_consumer.consumer_status.valid_reads >= wrote_at_least
 
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
     @matrix(segment_size=[100 * 2**20, 20 * 2**20])


### PR DESCRIPTION
## Cover letter

Consumer group consumer was added to kgo-verifier in
https://github.com/redpanda-data/kgo-verifier/pull/2
It launches a consumer group consisting of several fibers
that try to consume (and check) all messages in the topic.

This commit runs the consumer group consumer along with other
kgo-verifier consumers in the `franz_go_verifiable_test` tests.

## Release notes
* none