### PR TITLE
c/md_dissemination: do not capture unused variable

### DIFF
--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -100,12 +100,11 @@ make_get_leadership_reply(const partition_leaders_table& leaders) {
 }
 
 ss::future<get_leadership_reply> metadata_dissemination_handler::get_leadership(
-  get_leadership_request&& req, rpc::streaming_context&) {
-    return ss::with_scheduling_group(
-      get_scheduling_group(), [this, req = std::move(req)]() mutable {
-          return ss::make_ready_future<get_leadership_reply>(
-            make_get_leadership_reply(_leaders.local()));
-      });
+  get_leadership_request&&, rpc::streaming_context&) {
+    return ss::with_scheduling_group(get_scheduling_group(), [this]() mutable {
+        return ss::make_ready_future<get_leadership_reply>(
+          make_get_leadership_reply(_leaders.local()));
+    });
 }
 
 } // namespace cluster


### PR DESCRIPTION
req is not used in the continuation, neither is it holding a resource
which we should keep alive. so let's just drop it.

/home/kefu/dev/redpanda/src/v/cluster/metadata_dissemination_handler.cc:105:38: error: lambda capture 'req' is not used [-Werror,-Wunused-lambda-capture]
      get_scheduling_group(), [this, req = std::move(req)]() mutable {
                                   ~~^~~~~~~~~~~~~~~~~~~~
1 error generated.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
