### PR TITLE
Allow having multiple TLS kafka listeners

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -285,20 +285,8 @@ func (r *Cluster) validateKafkaListeners() field.ErrorList {
 		}
 	}
 
-	// for now only one listener can have TLS to be backward compatible with v1alpha1 API
-	foundListenerWithTLS := false
 	for i, p := range r.Spec.Configuration.KafkaAPI {
-		if p.TLS.Enabled {
-			if foundListenerWithTLS {
-				allErrs = append(allErrs,
-					field.Invalid(field.NewPath("spec").Child("configuration").Child("kafkaApi").Index(i).Child("tls"),
-						r.Spec.Configuration.KafkaAPI[i].TLS,
-						"only one listener can have TLS enabled"))
-			}
-			foundListenerWithTLS = true
-		}
-		// we need to run the validation on all listeners to also catch errors like !Enabled && RequireClientAuth
-		tlsErrs := validateTLS(
+		tlsErrs := validateListener(
 			p.TLS.Enabled,
 			p.TLS.RequireClientAuth,
 			p.TLS.IssuerRef,
@@ -441,7 +429,7 @@ func (r *Cluster) validateSchemaRegistryListener() field.ErrorList {
 		return allErrs
 	}
 	if schemaRegistry.TLS != nil {
-		tlsErrs := validateTLS(
+		tlsErrs := validateListener(
 			schemaRegistry.TLS.Enabled,
 			schemaRegistry.TLS.RequireClientAuth,
 			schemaRegistry.TLS.IssuerRef,
@@ -608,7 +596,7 @@ func validateAdminTLS(tlsConfig AdminAPITLS, path *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateTLS(
+func validateListener(
 	tlsEnabled, requireClientAuth bool,
 	issuerRef *cmmeta.ObjectReference,
 	nodeSecretRef *corev1.ObjectReference,

--- a/src/go/k8s/pkg/resources/certmanager/pki_test.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki_test.go
@@ -1,0 +1,122 @@
+package certmanager_test
+
+import (
+	"context"
+	"testing"
+
+	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/certmanager"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestKafkaAPIWithMultipleTLSListeners(t *testing.T) {
+	require.NoError(t, redpandav1alpha1.AddToScheme(scheme.Scheme))
+	require.NoError(t, cmapiv1.AddToScheme(scheme.Scheme))
+	clusterWithMultipleTLS := pandaCluster().DeepCopy()
+	clusterWithMultipleTLS.Spec.Configuration.KafkaAPI[0].TLS = redpandav1alpha1.KafkaAPITLS{Enabled: true, RequireClientAuth: true}
+	clusterWithMultipleTLS.Spec.Configuration.KafkaAPI = append(clusterWithMultipleTLS.Spec.Configuration.KafkaAPI, redpandav1alpha1.KafkaAPI{Port: 30001, External: redpandav1alpha1.ExternalConnectivityConfig{Enabled: true}, TLS: redpandav1alpha1.KafkaAPITLS{Enabled: true}})
+
+	testcases := []struct {
+		name                 string
+		cluster              redpandav1alpha1.Cluster
+		expectedCertificates []string
+	}{
+		{
+			name:                 "Two listeners with TLS",
+			cluster:              *clusterWithMultipleTLS,
+			expectedCertificates: []string{"cluster-kafka-root-certificate", "cluster-redpanda"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().Build()
+			pkiRes := certmanager.NewPki(
+				c,
+				&tc.cluster,
+				"cluster.local1",
+				"cluster.local",
+				scheme.Scheme,
+				ctrl.Log.WithName("test"))
+			require.NoError(t, pkiRes.Ensure(context.TODO()))
+
+			for _, cert := range tc.expectedCertificates {
+				actual := &cmapiv1.Certificate{}
+				err := c.Get(context.Background(), types.NamespacedName{Name: cert, Namespace: pandaCluster().Namespace}, actual)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func pandaCluster() *redpandav1alpha1.Cluster {
+	var replicas int32 = 1
+
+	resources := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	return &redpandav1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RedpandaCluster",
+			APIVersion: "core.vectorized.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "redpanda",
+			},
+			UID: "ff2770aa-c919-43f0-8b4a-30cb7cfdaf79",
+		},
+		Spec: redpandav1alpha1.ClusterSpec{
+			Image:    "image",
+			Version:  "v21.11.1",
+			Replicas: pointer.Int32Ptr(replicas),
+			CloudStorage: redpandav1alpha1.CloudStorageConfig{
+				Enabled: true,
+				CacheStorage: &redpandav1alpha1.StorageSpec{
+					Capacity:         resource.MustParse("10Gi"),
+					StorageClassName: "local",
+				},
+				SecretKeyRef: corev1.ObjectReference{
+					Namespace: "default",
+					Name:      "archival",
+				},
+			},
+			Configuration: redpandav1alpha1.RedpandaConfig{
+				AdminAPI: []redpandav1alpha1.AdminAPI{{Port: 345}},
+				KafkaAPI: []redpandav1alpha1.KafkaAPI{{Port: 123}},
+			},
+			Resources: redpandav1alpha1.RedpandaResourceRequirements{
+				ResourceRequirements: corev1.ResourceRequirements{
+					Limits:   resources,
+					Requests: resources,
+				},
+				Redpanda: nil,
+			},
+			Sidecars: redpandav1alpha1.Sidecars{
+				RpkStatus: &redpandav1alpha1.Sidecar{
+					Enabled: true,
+					Resources: &corev1.ResourceRequirements{
+						Limits:   resources,
+						Requests: resources,
+					},
+				},
+			},
+			Storage: redpandav1alpha1.StorageSpec{
+				Capacity:         resource.MustParse("10Gi"),
+				StorageClassName: "storage-class",
+			},
+		},
+	}
+}

--- a/src/go/k8s/pkg/resources/certmanager/type_helpers_test.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers_test.go
@@ -73,6 +73,28 @@ func TestClusterCertificates(t *testing.T) {
 				},
 			},
 		}, []string{"test-kafka-selfsigned-issuer", "test-kafka-root-certificate", "test-kafka-root-issuer", "test-redpanda"}, 1},
+		{"kafka tls with two tls listeners", &v1alpha1.Cluster{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: v1alpha1.ClusterSpec{
+				Configuration: v1alpha1.RedpandaConfig{
+					KafkaAPI: []v1alpha1.KafkaAPI{
+						{
+							TLS: v1alpha1.KafkaAPITLS{
+								Enabled: true,
+							},
+						},
+						{
+							External: v1alpha1.ExternalConnectivityConfig{
+								Enabled: true,
+							},
+							TLS: v1alpha1.KafkaAPITLS{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+		}, []string{"test-kafka-selfsigned-issuer", "test-kafka-root-certificate", "test-kafka-root-issuer", "test-redpanda"}, 1},
 		{"kafka tls with external node issuer", &v1alpha1.Cluster{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
@@ -91,6 +113,29 @@ func TestClusterCertificates(t *testing.T) {
 			},
 		}, []string{"test-kafka-selfsigned-issuer", "test-kafka-root-certificate", "test-kafka-root-issuer", "test-redpanda"}, 1},
 		{"kafka mutual tls", &v1alpha1.Cluster{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: v1alpha1.ClusterSpec{
+				Configuration: v1alpha1.RedpandaConfig{
+					KafkaAPI: []v1alpha1.KafkaAPI{
+						{
+							TLS: v1alpha1.KafkaAPITLS{
+								Enabled:           true,
+								RequireClientAuth: true,
+							},
+						},
+						{
+							External: v1alpha1.ExternalConnectivityConfig{
+								Enabled: true,
+							},
+							TLS: v1alpha1.KafkaAPITLS{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+		}, []string{"test-kafka-selfsigned-issuer", "test-kafka-root-certificate", "test-kafka-root-issuer", "test-redpanda", "test-operator-client", "test-user-client", "test-admin-client"}, 2},
+		{"kafka mutual tls with two tls listeners", &v1alpha1.Cluster{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{

--- a/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
@@ -20,6 +20,11 @@ spec:
     - port: 9092
       tls:
         enabled: true
+    - external:
+        enabled: true
+        subdomain: "test.subdomain.com"
+      tls:
+        enabled: true
     adminApi:
     - port: 9644
     developerMode: true


### PR DESCRIPTION
## Cover letter

Adds support for multiple listeners with TLS enabled which was for now disabled via webhook.

When both internal and external has TLS enabled, they share the same node certificate that has both internal and external domains included. Client certificates are also shared.

Multiple issuerRefs and nodeSecretRefs are disallowed for now to prevent changing having different node and client certs. If we allow that in the future, we'll have to change the way how certs are mounted as there could be multiple.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3818 

## Release notes

### Improvements

* k8s operator allows having both kafka listeners with TLS enabled
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
