### PR TITLE
cluster: check abort source in reconcile_ntp loop

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -433,6 +433,9 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
     bool stop = false;
     auto it = deltas.begin();
     while (!(stop || it == deltas.end())) {
+        // start_topics_reconcilation_loop will catch this during shutdown
+        _as.local().check();
+
         if (has_non_replicable_op_type(*it)) {
             /// This if statement has nothing to do with correctness and is only
             /// here to reduce the amount of uncessecary logging emitted by the


### PR DESCRIPTION
## Cover letter

This could otherwise loop forever if waiting for
cross-core move notifications from a partition
that already shut down.

Fixes https://github.com/redpanda-data/redpanda/issues/4719

## Release notes

### Bug Fixes

* Fix an issue where redpanda could hang during shutdown if a partition movement between cores was underway
