### PR TITLE
rpk: avoid duplicates in container port pool

### DIFF
--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -59,13 +59,17 @@ func getFreePort() (uint, error) {
 }
 
 func GetFreePortPool(n int) ([]uint, error) {
-	var ports []uint
-	for i := 0; i < n; i++ {
+	m := make(map[uint]struct{})
+	for len(m) != n {
 		p, err := getFreePort()
 		if err != nil {
 			return nil, err
 		}
-		ports = append(ports, p)
+		m[p] = struct{}{}
+	}
+	var ports []uint
+	for port := range m {
+		ports = append(ports, port)
 	}
 	return ports, nil
 }


### PR DESCRIPTION
## Cover letter

Small fix to avoid duplicates in the free port pool that we allocate during `rpk container start`

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2418

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
