### PR TITLE
pandaproxy: Invert error_code dependencies 

### DIFF
--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -202,4 +202,18 @@ std::ostream& operator<<(std::ostream& o, error_code code) {
     return o;
 }
 
+struct error_category final : std::error_category {
+    const char* name() const noexcept override { return "kafka"; }
+    std::string message(int ec) const override {
+        return std::string(
+          kafka::error_code_to_str(static_cast<kafka::error_code>(ec)));
+    }
+};
+
+const error_category error_category{};
+
+std::error_code make_error_code(kafka::error_code ec) {
+    return {static_cast<int>(ec), error_category};
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <string_view>
+#include <system_error>
 
 namespace kafka {
 
@@ -224,5 +225,13 @@ enum class error_code : int16_t {
 
 std::ostream& operator<<(std::ostream&, error_code);
 std::string_view error_code_to_str(error_code error);
+std::error_code make_error_code(error_code);
 
 } // namespace kafka
+
+namespace std {
+
+template<>
+struct is_error_code_enum<kafka::error_code> : true_type {};
+
+} // namespace std

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -15,7 +15,7 @@ v_cc_library(
     v::utils
   )
 
-
+add_subdirectory(test)
 add_subdirectory(rest)
 add_subdirectory(schema_registry)
 add_subdirectory(json)

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -78,6 +78,10 @@ struct reply_error_category final : std::error_category {
         }
         return "(unrecognized error)";
     }
+    bool
+    equivalent(const std::error_code& ec, int cond) const noexcept override {
+        return make_error_condition(ec).value() == cond;
+    }
 };
 
 const reply_error_category reply_error_category{};
@@ -196,6 +200,10 @@ struct kafka_error_category final : std::error_category {
 const kafka_error_category kafka_error_category{};
 
 }; // namespace
+
+std::error_condition make_error_condition(std::error_code ec) {
+    return ec.default_error_condition();
+}
 
 std::error_condition make_error_condition(reply_error_code ec) {
     return {static_cast<int>(ec), reply_error_category};

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -12,6 +12,7 @@
 #include "error.h"
 
 #include "kafka/protocol/errors.h"
+#include "pandaproxy/json/error.h"
 #include "pandaproxy/parsing/error.h"
 
 namespace pandaproxy {
@@ -92,6 +93,7 @@ std::error_condition make_error_condition(std::error_code ec) {
     using rec = reply_error_code;
     using kec = kafka::error_code;
     using pec = pandaproxy::parse::error_code;
+    using jec = pandaproxy::json::error_code;
 
     if (ec.category() == make_error_code(kec::none).category()) {
         switch (static_cast<kec>(ec.value())) {
@@ -200,6 +202,12 @@ std::error_condition make_error_condition(std::error_code ec) {
             return rec::not_acceptable;
         case pec::unsupported_media_type:
             return rec::unsupported_media_type;
+        }
+        return {};
+    } else if (ec.category() == make_error_code(jec::invalid_json).category()) {
+        switch (static_cast<jec>(ec.value())) {
+        case jec::invalid_json:
+            return rec::unprocessable_entity;
         }
         return {};
     }

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -91,6 +91,7 @@ const reply_error_category reply_error_category{};
 std::error_condition make_error_condition(std::error_code ec) {
     using rec = reply_error_code;
     using kec = kafka::error_code;
+    using pec = pandaproxy::parse::error_code;
 
     if (ec.category() == make_error_code(kec::none).category()) {
         switch (static_cast<kec>(ec.value())) {
@@ -190,6 +191,17 @@ std::error_condition make_error_condition(std::error_code ec) {
             return rec::kafka_authentication_error;
         }
         return {}; // keep gcc happy
+    } else if (ec.category() == make_error_code(pec::empty_param).category()) {
+        switch (static_cast<pec>(ec.value())) {
+        case pec::empty_param:
+        case pec::invalid_param:
+            return rec::kafka_bad_request;
+        case pec::not_acceptable:
+            return rec::not_acceptable;
+        case pec::unsupported_media_type:
+            return rec::unsupported_media_type;
+        }
+        return {};
     }
     return ec.default_error_condition();
 }

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -54,6 +54,7 @@ enum class reply_error_code : uint16_t {
 };
 
 std::error_condition make_error_condition(reply_error_code);
+std::error_condition make_error_condition(std::error_code ec);
 const std::error_category& reply_category() noexcept;
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -59,18 +59,9 @@ const std::error_category& reply_category() noexcept;
 
 } // namespace pandaproxy
 
-namespace kafka {
-
-std::error_code make_error_code(error_code);
-
-}
-
 namespace std {
 
 template<>
 struct is_error_condition_enum<pandaproxy::reply_error_code> : true_type {};
-
-template<>
-struct is_error_code_enum<kafka::error_code> : true_type {};
 
 } // namespace std

--- a/src/v/pandaproxy/json/CMakeLists.txt
+++ b/src/v/pandaproxy/json/CMakeLists.txt
@@ -4,7 +4,6 @@ v_cc_library(
     error.cc
   DEPS
     Seastar::seastar
-    v::pandaproxy_common
 )
 
 add_subdirectory(test)

--- a/src/v/pandaproxy/json/error.cc
+++ b/src/v/pandaproxy/json/error.cc
@@ -11,8 +11,6 @@
 
 #include "error.h"
 
-#include "pandaproxy/error.h"
-
 namespace pandaproxy::json {
 
 namespace {
@@ -25,14 +23,6 @@ struct error_category final : std::error_category {
             return "invalid json";
         }
         return "(unrecognized error)";
-    }
-    std::error_condition
-    default_error_condition(int ec) const noexcept override {
-        switch (static_cast<error_code>(ec)) {
-        case error_code::invalid_json:
-            return reply_error_code::unprocessable_entity;
-        }
-        return {};
     }
 };
 

--- a/src/v/pandaproxy/parsing/error.cc
+++ b/src/v/pandaproxy/parsing/error.cc
@@ -11,8 +11,6 @@
 
 #include "error.h"
 
-#include "pandaproxy/error.h"
-
 namespace pandaproxy::parse {
 
 namespace {
@@ -31,20 +29,6 @@ struct error_category final : std::error_category {
             return "unsupported_media_type";
         }
         return "(unrecognized error)";
-    }
-
-    std::error_condition
-    default_error_condition(int ec) const noexcept override {
-        switch (static_cast<error_code>(ec)) {
-        case error_code::empty_param:
-        case error_code::invalid_param:
-            return reply_error_code::kafka_bad_request;
-        case error_code::not_acceptable:
-            return reply_error_code::not_acceptable;
-        case error_code::unsupported_media_type:
-            return reply_error_code::unsupported_media_type;
-        }
-        return {};
     }
 };
 

--- a/src/v/pandaproxy/parsing/exceptions.h
+++ b/src/v/pandaproxy/parsing/exceptions.h
@@ -22,25 +22,25 @@
 namespace pandaproxy::parse {
 
 struct exception_base : std::exception {
-    explicit exception_base(std::error_condition err)
+    explicit exception_base(std::error_code err)
       : std::exception{}
       , error{err}
       , msg{err.message()} {}
-    exception_base(std::error_condition err, std::string_view msg)
+    exception_base(std::error_code err, std::string_view msg)
       : std::exception{}
       , error{err}
       , msg{msg} {}
     const char* what() const noexcept final { return msg.c_str(); }
-    std::error_condition error;
+    std::error_code error;
     std::string msg;
 };
 
 class error final : public exception_base {
 public:
     explicit error(error_code ec)
-      : exception_base(make_error_code(ec).default_error_condition()) {}
+      : exception_base(ec) {}
     error(error_code ec, std::string_view msg)
-      : exception_base(make_error_code(ec).default_error_condition(), msg) {}
+      : exception_base(ec, msg) {}
 };
 
 } // namespace pandaproxy::parse

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -78,7 +78,7 @@ errored_body(std::error_condition ec, ss::sstring msg) {
 
 inline std::unique_ptr<ss::httpd::reply>
 errored_body(std::error_code ec, ss::sstring msg) {
-    return errored_body(ec.default_error_condition(), std::move(msg));
+    return errored_body(make_error_condition(ec), std::move(msg));
 }
 
 inline std::unique_ptr<ss::httpd::reply> unprocessable_entity(ss::sstring msg) {

--- a/src/v/pandaproxy/test/CMakeLists.txt
+++ b/src/v/pandaproxy/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_unit
+  SOURCES
+    errors.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::pandaproxy_common v::kafka_protocol
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/test/errors.cc
+++ b/src/v/pandaproxy/test/errors.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#define BOOST_TEST_MODULE pandaproxy
+
+#include "kafka/protocol/errors.h"
+
+#include "pandaproxy/error.h"
+#include "pandaproxy/json/error.h"
+#include "pandaproxy/parsing/error.h"
+
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <ostream>
+#include <system_error>
+#include <utility>
+
+namespace bdata = boost::unit_test::data;
+namespace pp = pandaproxy;
+using rec = pp::reply_error_code;
+using kec = kafka::error_code;
+using pec = pandaproxy::parse::error_code;
+using jec = pandaproxy::json::error_code;
+
+struct ec_cond {
+    std::error_code ec;
+    rec cond;
+    friend std::ostream& operator<<(std::ostream& os, const ec_cond& p) {
+        return os << p.ec.message() << ", "
+                  << make_error_condition(p.cond).message();
+    }
+};
+
+static const std::array<ec_cond, 5> conversion_data{
+  {{kec::offset_out_of_range, rec::kafka_bad_request},
+   {kec::unknown_server_error, rec::kafka_error},
+   {kec::unknown_topic_or_partition, rec::partition_not_found},
+   {pec::not_acceptable, rec::not_acceptable},
+   {jec::invalid_json, rec::unprocessable_entity}}};
+
+BOOST_DATA_TEST_CASE(
+  test_error_condition_conversion, bdata::make(conversion_data), sample) {
+    auto ec = sample.ec;
+    auto cond = ec.default_error_condition();
+    BOOST_REQUIRE(sample.cond == cond);
+}
+
+BOOST_DATA_TEST_CASE(
+  test_error_condition_equivalence, bdata::make(conversion_data), sample) {
+    BOOST_REQUIRE(sample.cond == sample.ec);
+    BOOST_REQUIRE(sample.ec == sample.cond);
+}

--- a/src/v/pandaproxy/test/errors.cc
+++ b/src/v/pandaproxy/test/errors.cc
@@ -51,7 +51,7 @@ static const std::array<ec_cond, 5> conversion_data{
 BOOST_DATA_TEST_CASE(
   test_error_condition_conversion, bdata::make(conversion_data), sample) {
     auto ec = sample.ec;
-    auto cond = ec.default_error_condition();
+    auto cond = pp::make_error_condition(ec);
     BOOST_REQUIRE(sample.cond == cond);
 }
 


### PR DESCRIPTION
## Cover letter

Refactor pandaproxy errors, so that the conversion of `error_codes` to `reply_error_condition` becomes the responsibility of pandaproxy, not each submodule. This makes the dependencies the right way round.

There are two ways to map to an `error_condition`
1) Override `error_category::default_error_condition`
2) Override `error_category::equivalent`

However:

1) Is what's current, but it requires a global
`default_error_condition`, but `reply_error_code` is specific
to pandaproxy, so the dependency works the wrong way.
2) Could work, but only for checking equivalence of specific
`std::error_code` with a specific `reply_error_code`, not
for directly converting it.

### Solution

To break the dependency, overload `make_error_condition` that
takes a `std::error_code`, and maps from `kafka::error_code` to
`reply_error_condition` as before. Further commits will move code
to break the dependencies.

Implement `reply_error_category::equivalent` in terns of
the new `make_error_condition`.

* Move the `error_category` and `make_error_code` for kafka into kafka
* Move the `error_code` to `error_condition` code from pandaproxy::parse to pandaproxy
* Move the `error_code` to `error_condition` code from pandaproxy::json to pandaproxy

Useful resource: https://akrzemi1.wordpress.com/2017/09/04/using-error-codes-effectively/

Closes #4307 - this is a prerequisite of updating libfmt #4260

In a future PR, it will be possible to split the error_codes for Schema Registry and REST API.

### Alternative

If `reply_error_category::equivalent` were to be implemented instead, it would something like:

```c++
    bool
    equivalent(const std::error_code& ec, int cond) const noexcept override {
        using rec = reply_error_code;
        using kec = kafka::error_code;
        switch (static_cast<rec>(cond)) {
        case rec::kafka_bad_request:
            return ec == kec::offset_out_of_range || ec ==
            kec::corrupt_message
                   || ec == kec::invalid_fetch_size
                   || ec == kec::not_leader_for_partition
                   || ec == kec::message_too_large
                   || ec == kec::stale_controller_epoch
                   || ec == kec::offset_metadata_too_large
                   || ec == kec::invalid_topic_exception
                   || ec == kec::record_list_too_large
                   || ec == kec::illegal_generation
                   || ec == kec::inconsistent_group_protocol
                   || ec == kec::invalid_group_id
                   || ec == kec::invalid_session_timeout
                   || ec == kec::invalid_commit_offset_size
                   || ec == kec::invalid_timestamp
                   || ec == kec::unsupported_sasl_mechanism
                   || ec == kec::illegal_sasl_state
                   || ec == kec::unsupported_version
                   || ec == kec::topic_already_exists
                   || ec == kec::invalid_partitions
                   || ec == kec::invalid_replication_factor
                   || ec == kec::invalid_replica_assignment
                   || ec == kec::invalid_config || ec == kec::not_controller
                   || ec == kec::invalid_request
                   || ec == kec::unsupported_for_message_format
                   || ec == kec::policy_violation
                   || ec == kec::invalid_required_acks
                   || ec == kec::invalid_producer_epoch
                   || ec == kec::invalid_txn_state
                   || ec == kec::invalid_producer_id_mapping
                   || ec == kec::invalid_transaction_timeout
                   || ec == kec::concurrent_transactions
                   || ec == kec::transaction_coordinator_fenced
                   || ec == kec::security_disabled
                   || ec == kec::log_dir_not_found
                   || ec == kec::unknown_producer_id
                   || ec == kec::delegation_token_not_found
                   || ec == kec::delegation_token_owner_mismatch
                   || ec == kec::delegation_token_request_not_allowed
                   || ec == kec::delegation_token_expired
                   || ec == kec::invalid_principal_type
                   || ec == kec::non_empty_group
                   || ec == kec::group_id_not_found
                   || ec == kec::fetch_session_id_not_found
                   || ec == kec::invalid_fetch_session_epoch
                   || ec == kec::listener_not_found
                   || ec == kec::topic_deletion_disabled
                   || ec == kec::fenced_leader_epoch
                   || ec == kec::unknown_leader_epoch
                   || ec == kec::unsupported_compression_type
                   || ec == kec::stale_broker_epoch
                   || ec == kec::offset_not_available
                   || ec == kec::member_id_required
                   || ec == kec::group_max_size_reached
                   || ec == kec::fenced_instance_id
                   || ec == kec::invalid_record;
        case rec::kafka_error:
            return ec == kec::not_enough_replicas
                   || ec == kec::coordinator_not_available
                   || ec == kec::not_coordinator
                   || ec == kec::not_enough_replicas_after_append
                   || ec == kec::out_of_order_sequence_number
                   || ec == kec::duplicate_sequence_number
                   || ec == kec::operation_not_attempted
                   || ec == kec::kafka_storage_error
                   || ec == kec::unknown_server_error;
        case rec::kafka_retriable_error:
            return ec == kec::network_exception
                   || ec == kec::coordinator_load_in_progress
                   || ec == kec::request_timed_out
                   || ec == kec::rebalance_in_progress
                   || ec == kec::reassignment_in_progress;
        case rec::partition_not_found:
            return ec == kec::unknown_topic_or_partition;
        case rec::consumer_instance_not_found:
            return ec == kec::unknown_member_id;
        case rec::broker_not_available:
            return ec == kec::leader_not_available
                   || ec == kec::broker_not_available
                   || ec == kec::replica_not_available
                   || ec == kec::preferred_leader_not_available;
        case rec::kafka_authorization_error:
            return ec == kec::topic_authorization_failed
                   || ec == kec::group_authorization_failed
                   || ec == kec::transactional_id_authorization_failed
                   || ec == kec::delegation_token_authorization_failed
                   || ec == kec::cluster_authorization_failed;
        case rec::kafka_authentication_error:
            return ec == kec::sasl_authentication_failed
                   || ec == kec::delegation_token_auth_disabled;
        }
        vassert(false, "unhandled {}", ec);
    }
```
And then the other ~18 `reply_error codes` would have to be implemented for all the `error_codes` in other namespaces such as `pandaproxy::parse`, `pandaproxy::json`, etc., and there would be no way to have the compiler statically check for incomplete handling of enum cases in the distant modules. In addition, conversion to an http status code would have to exhaustive switch over each  `reply_error_code`., requiring two conversions.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none