### PR TITLE
test: speed up slow maintenance mode test

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -247,7 +247,8 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // This call in principle can be a network fetch, but in practice
     // we're only doing it immediately after cluster health has just
     // been updated, so do not expect it to go remote.
-    auto node_status_v = co_await _hm_frontend.local().get_nodes_status({});
+    auto node_status_v = co_await _hm_frontend.local().get_nodes_status(
+      model::no_timeout);
     if (node_status_v.has_error()) {
         // Raise exception to trigger backoff+retry
         throw std::runtime_error(fmt::format(

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -168,5 +168,6 @@ private:
     std::vector<std::pair<cluster::notification_id_type, health_node_cb_t>>
       _node_callbacks;
     cluster::notification_id_type _next_callback_id{0};
+    ss::condition_variable _tick_cv;
 };
 } // namespace cluster

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -86,7 +86,7 @@ class MaintenanceTest(RedpandaTest):
         node_id = self.redpanda.idx(node)
         statuses = self.rpk.cluster_maintenance_status()
         self.logger.debug(f"finding node_id {node_id} in rpk "
-                          "maintenance status: {statuses}")
+                          f"maintenance status: {statuses}")
         rpk_status = None
         for status in statuses:
             if status.node_id == node_id:
@@ -98,7 +98,7 @@ class MaintenanceTest(RedpandaTest):
         # get status for this node via admin interface
         admin_status = self.admin.maintenance_status(node)
         self.logger.debug(f"maintenance status from admin for "
-                          "{node.name}: {admin_status}")
+                          f"{node.name}: {admin_status}")
 
         # ensure that both agree on expected outcome
         return admin_status["draining"] == rpk_status.draining == draining

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -121,13 +121,13 @@ class MaintenanceTest(RedpandaTest):
             f"Checking that node {node.name} has a leadership role")
         wait_until(lambda: self._has_leadership_role(node),
                    timeout_sec=60,
-                   backoff_sec=10)
+                   backoff_sec=1)
 
         self.logger.debug(
             f"Checking that node {node.name} is not in maintenance mode")
         wait_until(lambda: self._verify_maintenance_status(node, False),
                    timeout_sec=30,
-                   backoff_sec=5)
+                   backoff_sec=1)
 
         self.logger.debug(
             f"Waiting for node {node.name} to enter maintenance mode")
@@ -142,7 +142,7 @@ class MaintenanceTest(RedpandaTest):
             self.admin.maintenance_start(node)
             wait_until(lambda: self._in_maintenance_mode(node),
                        timeout_sec=30,
-                       backoff_sec=5)
+                       backoff_sec=1)
 
         def has_drained():
             """
@@ -155,19 +155,19 @@ class MaintenanceTest(RedpandaTest):
             return not self._has_leadership_role(node),
 
         self.logger.debug(f"Waiting for node {node.name} leadership to drain")
-        wait_until(has_drained, timeout_sec=60, backoff_sec=10)
+        wait_until(has_drained, timeout_sec=60, backoff_sec=1)
 
         self.logger.debug(
             f"Waiting for node {node.name} maintenance mode to complete")
         wait_until(lambda: self._in_maintenance_mode_fully(node),
                    timeout_sec=60,
-                   backoff_sec=10)
+                   backoff_sec=1)
 
         self.logger.debug("Verifying expected broker metadata reported "
                           f"for enabled maintenance mode on node {node.name}")
         wait_until(lambda: self._verify_broker_metadata(True, node),
                    timeout_sec=60,
-                   backoff_sec=10)
+                   backoff_sec=1)
 
     def _verify_cluster(self, target, target_expect):
         for node in self.redpanda.nodes:
@@ -175,7 +175,7 @@ class MaintenanceTest(RedpandaTest):
             wait_until(
                 lambda: self._verify_maintenance_status(node, expect),
                 timeout_sec=30,
-                backoff_sec=5,
+                backoff_sec=1,
                 err_msg=f"expected {node.name} maintenance mode: {expect}")
 
     def _maintenance_disable(self, node):
@@ -186,17 +186,17 @@ class MaintenanceTest(RedpandaTest):
 
         wait_until(lambda: not self._in_maintenance_mode(node),
                    timeout_sec=30,
-                   backoff_sec=5)
+                   backoff_sec=1)
 
         wait_until(lambda: self._has_leadership_role(node),
                    timeout_sec=120,
-                   backoff_sec=10)
+                   backoff_sec=1)
 
         self.logger.debug("Verifying expected broker metadata reported "
                           f"for disabled maintenance mode on node {node.name}")
         wait_until(lambda: self._verify_broker_metadata(False, node),
                    timeout_sec=60,
-                   backoff_sec=10)
+                   backoff_sec=1)
 
     @cluster(num_nodes=3)
     @matrix(use_rpk=[True, False])


### PR DESCRIPTION
## Cover letter

1. speeds up a slow maintenance mode test by 2x. it's still too slow, but it appears to be related to propagation of metadata used in barriers. will improve this further.

2. fixes health report refresh on leader when a node is (1) freshly booted and (2) just received leadership for controller. under these conditions health reports for nodes may be missing.

## Release notes

* none