### PR TITLE
[v22.1.x] cluster: check abort source in reconcile_ntp loop

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -433,6 +433,9 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
     bool stop = false;
     auto it = deltas.begin();
     while (!(stop || it == deltas.end())) {
+        // start_topics_reconcilation_loop will catch this during shutdown
+        _as.local().check();
+
         if (has_non_replicable_op_type(*it)) {
             /// This if statement has nothing to do with correctness and is only
             /// here to reduce the amount of uncessecary logging emitted by the


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4720
  Fixes https://github.com/redpanda-data/redpanda/issues/4743
  