### PR TITLE
operator: add make task for e2e-unstable tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /dbuild
 bin
 _e2e_artifacts/
+_e2e_unstable_artifacts/
 _helm_e2e_artifacts/
 /src/go/k8s/testbin/*
 /src/go/k8s/cm-verifier

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -113,6 +113,11 @@ e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"
 	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
 
+# Execute end to end unstable tests
+e2e-unstable-tests: kuttl test docker-build docker-build-configurator
+	echo "~~~ Running kuttl unstable tests :k8s:"
+	$(KUTTL) test --config kuttl-unstable-test.yaml --kind-context=${PR_NR:-kind} $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
+
 # Execute end to end tests using helm as an installation
 helm-e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"

--- a/src/go/k8s/kuttl-unstable-test.yaml
+++ b/src/go/k8s/kuttl-unstable-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: true
+skipDelete: true
+skipClusterDelete: true
+kindContainers:
+  - vectorized/redpanda-operator:dev
+  - vectorized/configurator:dev
+  - localhost/redpanda:dev
+testDirs:
+  - ./tests/e2e-unstable
+kindConfig: ./kind.yaml
+kindNodeCache: false
+commands:
+  - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
+  - command: "./hack/install-cert-manager.sh"
+  - command: "kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml"
+  - command: "make deploy"
+  - command: "./hack/wait-for-webhook-ready.sh"
+  - command: "mkdir -p tests/_e2e_unstable_artifacts"
+artifactsDir: tests/_e2e_unstable_artifacts
+timeout: 300
+reportFormat: xml
+parallel: 1


### PR DESCRIPTION
## Cover letter

This will enable setting a soft-failing CI on unstable tests.
