### PR TITLE
s3: Improve error handling

### DIFF
--- a/src/v/bytes/iobuf_istreambuf.h
+++ b/src/v/bytes/iobuf_istreambuf.h
@@ -28,7 +28,9 @@ class iobuf_istreambuf final : public std::streambuf {
 public:
     explicit iobuf_istreambuf(iobuf& buf) noexcept
       : _curr(buf.begin())
-      , _end(buf.end()) {}
+      , _end(buf.end()) {
+        std::ignore = underflow();
+    }
     iobuf_istreambuf(iobuf_istreambuf&&) noexcept = default;
     iobuf_istreambuf& operator=(iobuf_istreambuf&&) noexcept = default;
     iobuf_istreambuf(const iobuf_istreambuf&) = delete;

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -38,6 +38,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/beast/http/field.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -142,6 +143,12 @@ void set_routes(ss::httpd::routes& r) {
           return "";
       },
       "txt");
+    auto unexpected_error_response = new function_handler(
+      []([[maybe_unused]] const_req req, reply& reply) {
+          reply.set_status(reply::status_type::internal_server_error);
+          return "unexpected!";
+      },
+      "txt");
     r.add(operation_type::PUT, url("/test"), empty_put_response);
     r.add(operation_type::PUT, url("/test-error"), erroneous_put_response);
     r.add(operation_type::GET, url("/test"), get_response);
@@ -149,6 +156,8 @@ void set_routes(ss::httpd::routes& r) {
     r.add(operation_type::DELETE, url("/test"), empty_delete_response);
     r.add(
       operation_type::DELETE, url("/test-error"), erroneous_delete_response);
+    r.add(
+      operation_type::GET, url("/test-unexpected"), unexpected_error_response);
     r.add(operation_type::GET, url("/"), list_objects_response);
 }
 
@@ -314,6 +323,26 @@ SEASTAR_TEST_CASE(test_delete_object_failure) {
             BOOST_REQUIRE_EQUAL(err.message(), "Error.Message");
             BOOST_REQUIRE_EQUAL(err.request_id(), "Error.RequestId");
             BOOST_REQUIRE_EQUAL(err.resource(), "Error.Resource");
+            error_triggered = true;
+        }
+        BOOST_REQUIRE(error_triggered);
+        server->stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_unexpected_error_message) {
+    return ss::async([] {
+        bool error_triggered = false;
+        auto conf = transport_configuration();
+        auto [server, client] = started_client_and_server(conf);
+        try {
+            auto http_response = client
+                                   ->get_object(
+                                     s3::bucket_name("test-bucket"),
+                                     s3::object_key("test-unexpected"),
+                                     100ms)
+                                   .get0();
+        } catch (...) {
             error_triggered = true;
         }
         BOOST_REQUIRE(error_triggered);


### PR DESCRIPTION

## Cover letter

Log unexpected error replies. If the reply can't be parsed (not a valid
XML) log it limiting the size (up to 256 characters) and rate limit it
to one message per second per shard. Do this on WARN level.

Log http header for every unsuccessful reply on WARN level. Reply header
doesn't have any sensitive information so it's safe to log it.

Related to #4695

## Release notes

* none


### Features

* Improve logging in case of S3 errors

### Improvements

* Improve logging in case of S3 error
