### PR TITLE
test/resourcel_limit: use less segment_fallocation

### DIFF
--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -75,6 +75,7 @@ class ResourceLimitsTest(RedpandaTest):
         self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
 
         self.redpanda.set_extra_rp_conf({
+            'segment_fallocation_step': 16384,
             # Disable memory limit: on a test node the physical memory can easily
             # be the limiting factor
             'topic_memory_per_partition': None,


### PR DESCRIPTION
## Cover letter

Using `#CORE_COUNT` XFS partitions causes ci test `rptest.tests.resource_limits_test.ResourceLimitsTest.test_cpu_limited`, because when splitting our `amd64` builder into `#CORE_COUNT` partitions the container that runs this test runs out of disk space

## Release notes

* none