### PR TITLE
tests: fix BadLogLines for "No such file" messages

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1029,8 +1029,6 @@ class RedpandaService(Service):
             ):
                 line = line.strip()
 
-                assert "No such file or directory" not in line
-
                 allowed = False
                 for a in allow_list:
                     if a.search(line) is not None:


### PR DESCRIPTION
## Cover letter

This assert originally went in when we wanted to check
we weren't grepping on a nonexistent path, but it turns
out there are certain conditions under which Redpanda
can emit matching log messages, which we should be
handling as the usual BadLogLines, not asserting on.

## Release notes

* none
