### PR TITLE
ducktape: add clustered ducktape settings to omb

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -147,7 +147,11 @@ class OpenMessagingBenchmark(Service):
             "consumer_per_subscription": 1,
             "consumer_backlog_size_GB": 0,
         }
-        if os.environ.get('CI', None) == 'true':
+        if self.redpanda.dedicated_nodes:
+            self.configuration["producer_rate"] = 0
+            self.configuration["test_duration_minutes"] = 10
+            self.configuration["warmup_duration_minutes"] = 5
+        elif os.environ.get('CI', None) == 'true':
             self.configuration["producer_rate"] = 10
             self.configuration["test_duration_minutes"] = 5
             self.configuration["warmup_duration_minutes"] = 5


### PR DESCRIPTION
## Cover letter

Add OMB setting to run in clustered mode.

0 producer rate forces OMB to produce messages as fast as it can. In that way we can measure redpanda performance

Fixes #4546
