### PR TITLE
Prepare for clang++-14

### DIFF
--- a/cmake/v_library.cmake
+++ b/cmake/v_library.cmake
@@ -3,6 +3,10 @@ include(CMakeParseArguments)
 set(V_CXX_STANDARD 20)
 set(V_DEFAULT_LINKOPTS)
 set(V_DEFAULT_COPTS -Wall -Wextra -Werror -Wno-missing-field-initializers)
+# Disable warning for clang++-14 only.
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
+  list(APPEND V_DEFAULT_COPTS -Wno-deprecated-experimental-coroutine)
+endif()
 set(V_COMMON_INCLUDE_DIRS
   "${PROJECT_SOURCE_DIR}/src/v")
 # v_cc_library()

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -14,6 +14,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/seastar.hh>
 
+#include <array>
+
 namespace net {
 ss::future<std::optional<ss::sstring>> find_ca_file() {
     // list of all possible ca-cert file locations on different linux distros


### PR DESCRIPTION
## Cover letter

* Conditionally disable a coroutine warning (e.g., this will still build with clang++12)
* Include a missing header

## Release notes

* none
