### PR TITLE
treewide: Refactor operator<< as hidden friend

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -32,9 +32,9 @@ struct upload_candidate {
     size_t final_file_offset;
     model::timestamp base_timestamp;
     model::timestamp max_timestamp;
-};
 
-std::ostream& operator<<(std::ostream& s, const upload_candidate& c);
+    friend std::ostream& operator<<(std::ostream& s, const upload_candidate& c);
+};
 
 /// Archival policy is responsible for extracting segments from
 /// log_manager in right order.

--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -138,9 +138,9 @@ public:
     iobuf share_no_consume(size_t len) {
         return ref().share(bytes_consumed(), len);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& o, const iobuf_parser& p) {
-    return o << "{bytes_left:" << p.bytes_left()
-             << ", bytes_consumed:" << p.bytes_consumed() << "}";
-}
+    friend std::ostream& operator<<(std::ostream& o, const iobuf_parser& p) {
+        return o << "{bytes_left:" << p.bytes_left()
+                 << ", bytes_consumed:" << p.bytes_consumed() << "}";
+    }
+};

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -23,10 +23,10 @@ struct partition_manifest_path_components {
     model::topic _topic;
     model::partition_id _part;
     model::initial_revision_id _rev;
-};
 
-std::ostream&
-operator<<(std::ostream& s, const partition_manifest_path_components& c);
+    friend std::ostream&
+    operator<<(std::ostream& s, const partition_manifest_path_components& c);
+};
 
 /// Parse partition manifest path and return components
 std::optional<partition_manifest_path_components>
@@ -37,6 +37,9 @@ struct segment_name_components {
     model::term_id term;
 
     auto operator<=>(const segment_name_components&) const = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const segment_name_components& k);
 };
 
 std::optional<segment_name_components>
@@ -173,5 +176,4 @@ private:
     model::offset _last_offset;
 };
 
-std::ostream& operator<<(std::ostream& o, const partition_manifest::key& k);
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -75,9 +75,9 @@ struct configuration {
     /// The bucket to use
     s3::bucket_name bucket_name;
 
+    friend std::ostream& operator<<(std::ostream& o, const configuration& cfg);
+
     static ss::future<configuration> get_config();
 };
-
-std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
 } // namespace cloud_storage

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -49,6 +49,8 @@ public:
         std::optional<size_t> eligible;
         std::optional<size_t> transferring;
         std::optional<size_t> failed;
+
+        friend std::ostream& operator<<(std::ostream&, const drain_status&);
     };
 
     explicit drain_manager(ss::sharded<cluster::partition_manager>&);
@@ -89,7 +91,5 @@ private:
     drain_status _status;
     ss::abort_source _abort;
 };
-
-std::ostream& operator<<(std::ostream&, const drain_manager::drain_status&);
 
 } // namespace cluster

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -197,12 +197,11 @@ struct replicas_to_move {
 
     model::node_id id;
     uint32_t left_to_move;
-    friend std::ostream& operator<<(std::ostream& o, const replicas_to_move& r);
-};
-
-std::ostream& operator<<(std::ostream& o, const replicas_to_move& r) {
-    fmt::print(o, "{{id: {}, left_to_move: {}}}", r.id, r.left_to_move);
-    return o;
+    friend std::ostream&
+    operator<<(std::ostream& o, const replicas_to_move& r) {
+        fmt::print(o, "{{id: {}, left_to_move: {}}}", r.id, r.left_to_move);
+        return o;
+    }
 };
 
 void members_backend::calculate_reallocations_after_node_added(

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -25,6 +25,13 @@ struct ntp_leader {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
+
+    friend std::ostream& operator<<(std::ostream& o, const ntp_leader& l) {
+        o << "{ " << l.ntp << ", term: " << l.term
+          << ", leader_id: " << (l.leader_id ? l.leader_id.value()() : -1)
+          << " }";
+        return o;
+    }
 };
 
 struct ntp_leader_revision {
@@ -63,12 +70,6 @@ struct get_leadership_request {};
 struct get_leadership_reply {
     ntp_leaders leaders;
 };
-
-inline std::ostream& operator<<(std::ostream& o, const ntp_leader& l) {
-    o << "{ " << l.ntp << ", term: " << l.term
-      << ", leader_id: " << (l.leader_id ? l.leader_id.value()() : -1) << " }";
-    return o;
-}
 
 } // namespace cluster
 

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -47,7 +47,6 @@ struct local_state {
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 
-std::ostream& operator<<(std::ostream& o, const local_state& s);
 } // namespace cluster::node
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -711,8 +711,8 @@ struct non_replicable_topic {
     static constexpr int8_t current_version = 1;
     model::topic_namespace source;
     model::topic_namespace name;
+    friend std::ostream& operator<<(std::ostream&, const non_replicable_topic&);
 };
-std::ostream& operator<<(std::ostream&, const non_replicable_topic&);
 
 using config_version = named_type<int64_t, struct config_version_type>;
 constexpr config_version config_version_unset = config_version{-1};
@@ -732,8 +732,10 @@ struct cluster_config_delta_cmd_data {
     static constexpr int8_t current_version = 0;
     std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
     std::vector<ss::sstring> remove;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const cluster_config_delta_cmd_data&);
 };
-std::ostream& operator<<(std::ostream&, const cluster_config_delta_cmd_data&);
 
 struct cluster_config_status_cmd_data {
     static constexpr int8_t current_version = 0;
@@ -756,8 +758,10 @@ struct feature_update_action {
     // meant to be stable for use on the wire, so we refer to features by name
     ss::sstring feature_name;
     action_t action;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const feature_update_action&);
 };
-std::ostream& operator<<(std::ostream&, const feature_update_action&);
 
 struct feature_update_cmd_data {
     // To avoid ambiguity on 'versions' here: `current_version`
@@ -767,8 +771,10 @@ struct feature_update_cmd_data {
 
     cluster_version logical_version;
     std::vector<feature_update_action> actions;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const feature_update_cmd_data&);
 };
-std::ostream& operator<<(std::ostream&, const feature_update_cmd_data&);
 
 enum class reconciliation_status : int8_t {
     done,

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -144,6 +144,14 @@ public:
         return result;
     }
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const config::config_store& c) {
+        o << "{ ";
+        c.for_each([&o](const auto& property) { o << property << " "; });
+        o << "}";
+        return o;
+    }
+
     virtual ~config_store() noexcept = default;
 
 private:
@@ -158,13 +166,3 @@ inline YAML::Node to_yaml(const config_store& cfg) {
     return YAML::Load(buf.GetString());
 }
 }; // namespace config
-
-namespace std {
-template<typename... Types>
-static inline ostream& operator<<(ostream& o, const config::config_store& c) {
-    o << "{ ";
-    c.for_each([&o](const auto& property) { o << property << " "; });
-    o << "}";
-    return o;
-}
-} // namespace std

--- a/src/v/config/data_directory_path.h
+++ b/src/v/config/data_directory_path.h
@@ -30,14 +30,14 @@ struct data_directory_path {
     friend bool
     operator==(const data_directory_path&, const data_directory_path&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const config::data_directory_path& p) {
+        return o << "{data_directory=" << p.path << "}";
+    }
 };
 
 } // namespace config
-
-inline std::ostream&
-operator<<(std::ostream& o, const config::data_directory_path& p) {
-    return o << "{data_directory=" << p.path << "}";
-}
 
 namespace YAML {
 template<>

--- a/src/v/config/seed_server.h
+++ b/src/v/config/seed_server.h
@@ -25,15 +25,14 @@ struct seed_server {
     net::unresolved_address addr;
 
     bool operator==(const seed_server&) const = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const config::seed_server& s) {
+        fmt::print(o, "addr: {}", s.addr);
+        return o;
+    }
 };
 } // namespace config
-
-namespace std {
-static inline ostream& operator<<(ostream& o, const config::seed_server& s) {
-    fmt::print(o, "addr: {}", s.addr);
-    return o;
-}
-} // namespace std
 
 namespace YAML {
 template<>

--- a/src/v/kafka/protocol/add_partitions_to_txn.h
+++ b/src/v/kafka/protocol/add_partitions_to_txn.h
@@ -45,12 +45,12 @@ struct add_partitions_to_txn_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const add_partitions_to_txn_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const add_partitions_to_txn_request& r) {
+        return os << r.data;
+    }
+};
 
 struct add_partitions_to_txn_response final {
     using api_type = add_partitions_to_txn_api;
@@ -64,11 +64,11 @@ struct add_partitions_to_txn_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const add_partitions_to_txn_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const add_partitions_to_txn_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/alter_configs.h
+++ b/src/v/kafka/protocol/alter_configs.h
@@ -45,12 +45,12 @@ struct alter_configs_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const alter_configs_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const alter_configs_request& r) {
+        return os << r.data;
+    }
+};
 
 struct alter_configs_response final {
     using api_type = alter_configs_api;
@@ -64,11 +64,11 @@ struct alter_configs_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const alter_configs_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const alter_configs_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/api_versions.h
+++ b/src/v/kafka/protocol/api_versions.h
@@ -40,12 +40,12 @@ struct api_versions_request final {
     void encode(response_writer& writer, api_version version) {
         data.encode(writer, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const api_versions_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const api_versions_request& r) {
+        return os << r.data;
+    }
+};
 
 struct api_versions_response final {
     using api_type = api_versions_api;
@@ -59,12 +59,12 @@ struct api_versions_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const api_versions_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const api_versions_response& r) {
+        return os << r.data;
+    }
+};
 
 inline bool operator==(
   const api_versions_response_key& a, const api_versions_response_key& b) {

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -59,14 +59,15 @@ public:
     // Release any remaining iobuf that hasn't been consumed
     iobuf release() && { return std::move(_buf); }
 
+    friend std::ostream&
+    operator<<(std::ostream& os, const batch_reader& reader) {
+        fmt::print(os, "{{size {}}}", reader.size_bytes());
+        return os;
+    }
+
 private:
     iobuf _buf;
     bool _do_load_slice_failed{false};
 };
-
-inline std::ostream& operator<<(std::ostream& os, const batch_reader& reader) {
-    fmt::print(os, "{{size {}}}", reader.size_bytes());
-    return os;
-}
 
 } // namespace kafka

--- a/src/v/kafka/protocol/create_acls.h
+++ b/src/v/kafka/protocol/create_acls.h
@@ -44,12 +44,12 @@ struct create_acls_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_acls_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_acls_request& r) {
+        return os << r.data;
+    }
+};
 
 struct create_acls_response final {
     using api_type = create_acls_api;
@@ -63,11 +63,11 @@ struct create_acls_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_acls_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_acls_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/create_partitions.h
+++ b/src/v/kafka/protocol/create_partitions.h
@@ -41,12 +41,12 @@ struct create_partitions_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_partitions_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_partitions_request& r) {
+        return os << r.data;
+    }
+};
 
 struct create_partitions_response final {
     using api_type = create_partitions_api;
@@ -60,11 +60,11 @@ struct create_partitions_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_partitions_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_partitions_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/create_topics.h
+++ b/src/v/kafka/protocol/create_topics.h
@@ -43,12 +43,12 @@ struct create_topics_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_topics_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_topics_request& r) {
+        return os << r.data;
+    }
+};
 
 struct create_topics_response final {
     using api_type = create_topics_api;
@@ -62,11 +62,11 @@ struct create_topics_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const create_topics_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const create_topics_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/delete_acls.h
+++ b/src/v/kafka/protocol/delete_acls.h
@@ -44,12 +44,12 @@ struct delete_acls_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_acls_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_acls_request& r) {
+        return os << r.data;
+    }
+};
 
 struct delete_acls_response final {
     using api_type = delete_acls_api;
@@ -63,11 +63,11 @@ struct delete_acls_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_acls_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_acls_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/delete_groups.h
+++ b/src/v/kafka/protocol/delete_groups.h
@@ -37,12 +37,12 @@ struct delete_groups_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_groups_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_groups_request& r) {
+        return os << r.data;
+    }
+};
 
 struct delete_groups_response final {
     using api_type = delete_groups_api;
@@ -61,11 +61,11 @@ struct delete_groups_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_groups_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_groups_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/delete_topics.h
+++ b/src/v/kafka/protocol/delete_topics.h
@@ -45,12 +45,12 @@ struct delete_topics_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_topics_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_topics_request& r) {
+        return os << r.data;
+    }
+};
 
 struct delete_topics_response final {
     using api_type = delete_topics_api;
@@ -64,11 +64,11 @@ struct delete_topics_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const delete_topics_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_topics_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/describe_acls.h
+++ b/src/v/kafka/protocol/describe_acls.h
@@ -44,12 +44,12 @@ struct describe_acls_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_acls_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_acls_request& r) {
+        return os << r.data;
+    }
+};
 
 struct describe_acls_response final {
     using api_type = describe_acls_api;
@@ -63,11 +63,11 @@ struct describe_acls_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_acls_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_acls_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/describe_configs.h
+++ b/src/v/kafka/protocol/describe_configs.h
@@ -45,12 +45,12 @@ struct describe_configs_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_configs_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_configs_request& r) {
+        return os << r.data;
+    }
+};
 
 struct describe_configs_response final {
     using api_type = describe_configs_api;
@@ -64,11 +64,11 @@ struct describe_configs_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_configs_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_configs_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/describe_groups.h
+++ b/src/v/kafka/protocol/describe_groups.h
@@ -42,12 +42,12 @@ struct describe_groups_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_groups_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_groups_request& r) {
+        return os << r.data;
+    }
+};
 
 struct describe_groups_response final {
     using api_type = describe_groups_api;
@@ -82,11 +82,11 @@ struct describe_groups_response final {
           .protocol_data = "",
         };
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_groups_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_groups_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/describe_log_dirs.h
+++ b/src/v/kafka/protocol/describe_log_dirs.h
@@ -44,12 +44,12 @@ struct describe_log_dirs_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_log_dirs_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_log_dirs_request& r) {
+        return os << r.data;
+    }
+};
 
 struct describe_log_dirs_response final {
     using api_type = describe_log_dirs_api;
@@ -63,11 +63,11 @@ struct describe_log_dirs_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const describe_log_dirs_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const describe_log_dirs_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/end_txn.h
+++ b/src/v/kafka/protocol/end_txn.h
@@ -45,11 +45,12 @@ struct end_txn_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const end_txn_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const end_txn_request& r) {
+        return os << r.data;
+    }
+};
 
 struct end_txn_response final {
     using api_type = end_txn_api;
@@ -63,10 +64,11 @@ struct end_txn_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const end_txn_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const end_txn_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -182,11 +182,11 @@ struct fetch_request final {
     const_iterator cend() const {
         return const_iterator(data.topics.cend(), data.topics.cend());
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const fetch_request& r) {
-    return os << r.data;
-}
+    friend std::ostream& operator<<(std::ostream& os, const fetch_request& r) {
+        return os << r.data;
+    }
+};
 
 struct fetch_response final {
     using api_type = fetch_api;
@@ -316,10 +316,10 @@ struct fetch_response final {
     }
 
     iterator end() { return iterator(data.topics.end(), data.topics.end()); }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const fetch_response& r) {
-    return os << r.data;
-}
+    friend std::ostream& operator<<(std::ostream& os, const fetch_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -51,12 +51,12 @@ struct find_coordinator_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const find_coordinator_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const find_coordinator_request& r) {
+        return os << r.data;
+    }
+};
 
 struct find_coordinator_response final {
     using api_type = find_coordinator_api;
@@ -89,11 +89,11 @@ struct find_coordinator_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const find_coordinator_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const find_coordinator_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/heartbeat.h
+++ b/src/v/kafka/protocol/heartbeat.h
@@ -45,11 +45,12 @@ struct heartbeat_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const heartbeat_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const heartbeat_request& r) {
+        return os << r.data;
+    }
+};
 
 struct heartbeat_response final {
     using api_type = heartbeat_api;
@@ -73,14 +74,15 @@ struct heartbeat_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const heartbeat_response& r) {
+        return os << r.data;
+    }
 };
 
 inline ss::future<heartbeat_response> make_heartbeat_error(error_code error) {
     return ss::make_ready_future<heartbeat_response>(error);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const heartbeat_response& r) {
-    return os << r.data;
 }
 
 } // namespace kafka

--- a/src/v/kafka/protocol/incremental_alter_configs.h
+++ b/src/v/kafka/protocol/incremental_alter_configs.h
@@ -45,12 +45,12 @@ struct incremental_alter_configs_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const incremental_alter_configs_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const incremental_alter_configs_request& r) {
+        return os << r.data;
+    }
+};
 
 struct incremental_alter_configs_response final {
     using api_type = incremental_alter_configs_api;
@@ -64,11 +64,11 @@ struct incremental_alter_configs_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const incremental_alter_configs_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const incremental_alter_configs_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/init_producer_id.h
+++ b/src/v/kafka/protocol/init_producer_id.h
@@ -45,12 +45,12 @@ struct init_producer_id_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const init_producer_id_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const init_producer_id_request& r) {
+        return os << r.data;
+    }
+};
 
 struct init_producer_id_response final {
     using api_type = init_producer_id_api;
@@ -64,11 +64,11 @@ struct init_producer_id_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const init_producer_id_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const init_producer_id_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/join_group.h
+++ b/src/v/kafka/protocol/join_group.h
@@ -76,11 +76,12 @@ struct join_group_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const join_group_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const join_group_request& r) {
+        return os << r.data;
+    }
+};
 
 static inline const kafka::member_id no_member("");
 static inline const kafka::member_id no_leader("");
@@ -127,17 +128,17 @@ struct join_group_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const join_group_response& r) {
+        return os << r.data;
+    }
 };
 
 inline join_group_response
 make_join_error(kafka::member_id member_id, error_code error) {
     return join_group_response(
       error, no_generation, no_protocol, no_leader, std::move(member_id));
-}
-
-inline std::ostream&
-operator<<(std::ostream& os, const join_group_response& r) {
-    return os << r.data;
 }
 
 // group membership helper to compare a protocol set from the wire with our

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -94,18 +94,17 @@ struct produce_request_record_data {
         adapter.batch = std::move(batch);
     }
 
+    friend std::ostream&
+    operator<<(std::ostream& os, const produce_request_record_data& data) {
+        fmt::print(
+          os,
+          "batch {} v2_format {} valid_crc {}",
+          data.adapter.batch ? data.adapter.batch->size_bytes() : -1,
+          data.adapter.v2_format,
+          data.adapter.valid_crc);
+        return os;
+    }
     kafka_batch_adapter adapter;
 };
-
-inline std::ostream&
-operator<<(std::ostream& os, const produce_request_record_data& data) {
-    fmt::print(
-      os,
-      "batch {} v2_format {} valid_crc {}",
-      data.adapter.batch ? data.adapter.batch->size_bytes() : -1,
-      data.adapter.v2_format,
-      data.adapter.valid_crc);
-    return os;
-}
 
 } // namespace kafka

--- a/src/v/kafka/protocol/leave_group.h
+++ b/src/v/kafka/protocol/leave_group.h
@@ -45,12 +45,12 @@ struct leave_group_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const leave_group_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const leave_group_request& r) {
+        return os << r.data;
+    }
+};
 
 struct leave_group_response final {
     using api_type = leave_group_api;
@@ -74,15 +74,15 @@ struct leave_group_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const leave_group_response& r) {
+        return os << r.data;
+    }
 };
 
 inline ss::future<leave_group_response> make_leave_error(error_code error) {
     return ss::make_ready_future<leave_group_response>(error);
-}
-
-inline std::ostream&
-operator<<(std::ostream& os, const leave_group_response& r) {
-    return os << r.data;
 }
 
 } // namespace kafka

--- a/src/v/kafka/protocol/legacy_message.h
+++ b/src/v/kafka/protocol/legacy_message.h
@@ -67,24 +67,25 @@ struct legacy_message {
               fmt::format("Unknown compression value: {}", value));
         }
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const legacy_message& m) {
-    fmt::print(
-      os,
-      "{{offset {} length {} crc {} magic {} attrs {}:{} ts {} key {} value "
-      "{}}}",
-      m.base_offset,
-      m.batch_length,
-      static_cast<uint32_t>(m.batch_crc),
-      m.magic,
-      m.attributes,
-      m.compression(),
-      m.timestamp,
-      m.key,
-      m.value);
-    return os;
-}
+    friend std::ostream& operator<<(std::ostream& os, const legacy_message& m) {
+        fmt::print(
+          os,
+          "{{offset {} length {} crc {} magic {} attrs {}:{} ts {} key {} "
+          "value "
+          "{}}}",
+          m.base_offset,
+          m.batch_length,
+          static_cast<uint32_t>(m.batch_crc),
+          m.magic,
+          m.attributes,
+          m.compression(),
+          m.timestamp,
+          m.key,
+          m.value);
+        return os;
+    }
+};
 
 inline std::optional<legacy_message> decode_legacy_batch(iobuf_parser& parser) {
     auto base_offset = model::offset(parser.consume_be_type<int64_t>());

--- a/src/v/kafka/protocol/list_groups.h
+++ b/src/v/kafka/protocol/list_groups.h
@@ -41,12 +41,12 @@ struct list_groups_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const list_groups_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const list_groups_request& r) {
+        return os << r.data;
+    }
+};
 
 struct list_groups_response final {
     using api_type = list_groups_api;
@@ -60,11 +60,11 @@ struct list_groups_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const list_groups_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const list_groups_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/list_offsets.h
+++ b/src/v/kafka/protocol/list_offsets.h
@@ -60,12 +60,12 @@ struct list_offsets_request final {
         model::topic_partition tp(t, id);
         return tp_dups.find(tp) != tp_dups.end();
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const list_offsets_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const list_offsets_request& r) {
+        return os << r.data;
+    }
+};
 
 struct list_offsets_response final {
     using api_type = list_offsets_api;
@@ -122,11 +122,11 @@ struct list_offsets_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const list_offsets_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const list_offsets_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/metadata.h
+++ b/src/v/kafka/protocol/metadata.h
@@ -56,11 +56,12 @@ struct metadata_request {
             list_all_topics = data.topics->empty();
         }
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const metadata_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const metadata_request& r) {
+        return os << r.data;
+    }
+};
 
 struct metadata_response {
     using api_type = metadata_api;
@@ -77,10 +78,11 @@ struct metadata_response {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const metadata_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const metadata_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/offset_commit.h
+++ b/src/v/kafka/protocol/offset_commit.h
@@ -48,12 +48,12 @@ struct offset_commit_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const offset_commit_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_commit_request& r) {
+        return os << r.data;
+    }
+};
 
 struct offset_commit_response final {
     using api_type = offset_commit_api;
@@ -83,11 +83,11 @@ struct offset_commit_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const offset_commit_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_commit_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/offset_fetch.h
+++ b/src/v/kafka/protocol/offset_fetch.h
@@ -48,9 +48,9 @@ struct offset_fetch_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-std::ostream& operator<<(std::ostream&, const offset_fetch_request&);
+    friend std::ostream& operator<<(std::ostream&, const offset_fetch_request&);
+};
 
 struct offset_fetch_response final {
     using api_type = offset_fetch_api;
@@ -95,8 +95,9 @@ struct offset_fetch_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-std::ostream& operator<<(std::ostream&, const offset_fetch_response&);
+    friend std::ostream&
+    operator<<(std::ostream&, const offset_fetch_response&);
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/offset_for_leader_epoch.h
+++ b/src/v/kafka/protocol/offset_for_leader_epoch.h
@@ -37,12 +37,12 @@ struct offset_for_leader_epoch_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const offset_for_leader_epoch_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_for_leader_epoch_request& r) {
+        return os << r.data;
+    }
+};
 
 struct offset_for_leader_epoch_response final {
     using api_type = offset_for_leader_epoch_api;
@@ -83,11 +83,11 @@ struct offset_for_leader_epoch_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const offset_for_leader_epoch_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_for_leader_epoch_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/produce.h
+++ b/src/v/kafka/protocol/produce.h
@@ -67,6 +67,11 @@ struct produce_request final {
         data.decode(reader, version);
     }
 
+    friend std::ostream&
+    operator<<(std::ostream& os, const produce_request& r) {
+        return os << r.data;
+    }
+
     /**
      * Build a generic error response for a given request.
      */
@@ -78,10 +83,6 @@ struct produce_request final {
     /// True if the request contains a batch with a producer id.
     bool has_idempotent = false;
 };
-
-inline std::ostream& operator<<(std::ostream& os, const produce_request& r) {
-    return os << r.data;
-}
 
 struct produce_response final {
     using api_type = produce_api;
@@ -107,10 +108,11 @@ struct produce_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const produce_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const produce_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/sasl_authenticate.h
+++ b/src/v/kafka/protocol/sasl_authenticate.h
@@ -43,12 +43,12 @@ struct sasl_authenticate_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const sasl_authenticate_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sasl_authenticate_request& r) {
+        return os << r.data;
+    }
+};
 
 struct sasl_authenticate_response final {
     using api_type = sasl_authenticate_api;
@@ -67,11 +67,11 @@ struct sasl_authenticate_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const sasl_authenticate_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sasl_authenticate_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/sasl_handshake.h
+++ b/src/v/kafka/protocol/sasl_handshake.h
@@ -43,12 +43,12 @@ struct sasl_handshake_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const sasl_handshake_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sasl_handshake_request& r) {
+        return os << r.data;
+    }
+};
 
 struct sasl_handshake_response final {
     using api_type = sasl_handshake_api;
@@ -70,11 +70,11 @@ struct sasl_handshake_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const sasl_handshake_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sasl_handshake_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/sync_group.h
+++ b/src/v/kafka/protocol/sync_group.h
@@ -59,11 +59,12 @@ struct sync_group_request final {
           });
         return res;
     }
-};
 
-inline std::ostream& operator<<(std::ostream& os, const sync_group_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sync_group_request& r) {
+        return os << r.data;
+    }
+};
 
 struct sync_group_response final {
     using api_type = sync_group_api;
@@ -91,11 +92,11 @@ struct sync_group_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const sync_group_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const sync_group_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/protocol/txn_offset_commit.h
+++ b/src/v/kafka/protocol/txn_offset_commit.h
@@ -48,12 +48,12 @@ struct txn_offset_commit_request final {
     void decode(request_reader& reader, api_version version) {
         data.decode(reader, version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const txn_offset_commit_request& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const txn_offset_commit_request& r) {
+        return os << r.data;
+    }
+};
 
 struct txn_offset_commit_response final {
     using api_type = txn_offset_commit_api;
@@ -83,11 +83,11 @@ struct txn_offset_commit_response final {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-};
 
-inline std::ostream&
-operator<<(std::ostream& os, const txn_offset_commit_response& r) {
-    return os << r.data;
-}
+    friend std::ostream&
+    operator<<(std::ostream& os, const txn_offset_commit_response& r) {
+        return os << r.data;
+    }
+};
 
 } // namespace kafka

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -692,8 +692,6 @@ private:
 
 using group_ptr = ss::lw_shared_ptr<group>;
 
-std::ostream& operator<<(std::ostream&, const group&);
-
 /// @}
 
 } // namespace kafka

--- a/src/v/kafka/server/member.h
+++ b/src/v/kafka/server/member.h
@@ -217,8 +217,6 @@ private:
 /// \brief Shared pointer to a group member.
 using member_ptr = ss::lw_shared_ptr<group_member>;
 
-std::ostream& operator<<(std::ostream&, const group_member&);
-
 /// @}
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -44,9 +44,9 @@ struct request_header {
     correlation_id correlation;
     ss::temporary_buffer<char> client_id_buffer;
     std::optional<std::string_view> client_id;
-};
 
-std::ostream& operator<<(std::ostream&, const request_header&);
+    friend std::ostream& operator<<(std::ostream&, const request_header&);
+};
 
 class request_context {
 public:

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -150,9 +150,9 @@ struct member_protocol {
     bool operator==(const member_protocol& o) const {
         return name == o.name && metadata == o.metadata;
     }
-};
 
-std::ostream& operator<<(std::ostream&, const member_protocol&);
+    friend std::ostream& operator<<(std::ostream&, const member_protocol&);
+};
 
 using assignments_type = std::unordered_map<member_id, bytes>;
 

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -166,8 +166,6 @@ struct topic_partition {
     }
 };
 
-std::ostream& operator<<(std::ostream&, const topic_partition&);
-
 struct ntp {
     ntp() = default;
     ntp(model::ns::type n, model::topic::type t, model::partition_id::type i)

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -81,8 +81,6 @@ struct broker_endpoint final {
     friend std::ostream& operator<<(std::ostream&, const broker_endpoint&);
 };
 
-std::ostream& operator<<(std::ostream&, const broker_endpoint&);
-
 enum class violation_recovery_policy { crash = 0, best_effort };
 
 /**
@@ -194,8 +192,6 @@ private:
     friend std::ostream& operator<<(std::ostream&, const broker&);
 };
 
-std::ostream& operator<<(std::ostream&, const broker&);
-
 /// type representing single replica assignment it contains the id of a broker
 /// and id of this broker shard.
 struct broker_shard {
@@ -280,9 +276,6 @@ struct topic_namespace {
 
     friend std::ostream& operator<<(std::ostream&, const topic_namespace&);
 };
-
-std::ostream& operator<<(std::ostream&, const topic_namespace&);
-std::ostream& operator<<(std::ostream&, const topic_namespace_view&);
 
 struct topic_namespace_hash {
     using is_transparent = void;

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -323,6 +323,5 @@ ss::future<record_batch_reader::data_t> consume_reader_to_memory(
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
 record_batch_reader make_foreign_record_batch_reader(record_batch_reader&&);
-std::ostream& operator<<(std::ostream& os, const record_batch_reader& r);
 
 } // namespace model

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -81,9 +81,9 @@ struct server_endpoint {
 
     explicit server_endpoint(ss::socket_address addr)
       : server_endpoint("", addr) {}
-};
 
-std::ostream& operator<<(std::ostream&, const server_endpoint&);
+    friend std::ostream& operator<<(std::ostream&, const server_endpoint&);
+};
 
 struct config_connection_rate_bindings {
     config::binding<std::optional<int64_t>> config_general_rate;
@@ -107,9 +107,9 @@ struct server_configuration {
 
     explicit server_configuration(ss::sstring n)
       : name(std::move(n)) {}
-};
 
-std::ostream& operator<<(std::ostream&, const server_configuration&);
+    friend std::ostream& operator<<(std::ostream&, const server_configuration&);
+};
 
 class server {
 public:

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -72,5 +72,4 @@ private:
     friend std::ostream& operator<<(std::ostream& o, const server_probe& p);
 };
 
-std::ostream& operator<<(std::ostream& o, const server_probe& p);
 }; // namespace net

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -43,17 +43,16 @@ public:
     bool operator==(const unresolved_address& other) const = default;
 
 private:
-    friend std::ostream& operator<<(std::ostream&, const unresolved_address&);
+    friend std::ostream&
+    operator<<(std::ostream& o, const unresolved_address& s) {
+        fmt::print(o, "{{host: {}, port: {}}}", s.host(), s.port());
+        return o;
+    }
 
     ss::sstring _host;
     uint16_t _port{0};
     inet_family _family;
 };
-
-inline std::ostream& operator<<(std::ostream& o, const unresolved_address& s) {
-    fmt::print(o, "{{host: {}, port: {}}}", s.host(), s.port());
-    return o;
-}
 
 } // namespace net
 

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -36,6 +36,8 @@ public:
     bool operator==(const vnode& other) const = default;
     bool operator!=(const vnode& other) const = default;
 
+    friend std::ostream& operator<<(std::ostream& o, const vnode& r);
+
     template<typename H>
     friend H AbslHashValue(H h, const vnode& node) {
         return H::combine(std::move(h), node._node_id, node._revision);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -51,6 +51,9 @@ struct protocol_metadata {
     model::offset prev_log_index;
     model::term_id prev_log_term;
     model::offset last_visible_index;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const protocol_metadata& m);
 };
 
 // The sequence used to track the order of follower append entries request
@@ -155,6 +158,9 @@ struct follower_index_metadata {
      */
     heartbeats_suppressed suppress_heartbeats = heartbeats_suppressed::no;
     follower_req_seq last_suppress_heartbeats_seq{0};
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const follower_index_metadata& i);
 };
 /**
  * class containing follower statistics, this may be helpful for debugging,
@@ -245,6 +251,9 @@ struct append_entries_reply {
     model::offset last_term_base_offset;
     /// \brief did the rpc succeed or not
     status result = status::failure;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const append_entries_reply& r);
 };
 
 struct heartbeat_metadata {
@@ -261,9 +270,12 @@ struct heartbeat_metadata {
 /// log at some offset
 struct heartbeat_request {
     std::vector<heartbeat_metadata> heartbeats;
+    friend std::ostream&
+    operator<<(std::ostream& o, const heartbeat_request& r);
 };
 struct heartbeat_reply {
     std::vector<append_entries_reply> meta;
+    friend std::ostream& operator<<(std::ostream& o, const heartbeat_reply& r);
 };
 
 struct vote_request {
@@ -281,6 +293,8 @@ struct vote_request {
     bool leadership_transfer;
     raft::group_id target_group() const { return group; }
     vnode target_node() const { return target_node_id; }
+
+    friend std::ostream& operator<<(std::ostream& o, const vote_request& r);
 };
 
 struct vote_reply {
@@ -296,6 +310,8 @@ struct vote_reply {
     /// - extension on raft. see Diego's phd dissertation, section 9.6
     /// - "Preventing disruptions when a server rejoins the cluster"
     bool log_ok = false;
+
+    friend std::ostream& operator<<(std::ostream& o, const vote_reply& r);
 };
 
 /// This structure is used by consensus to notify other systems about group
@@ -522,16 +538,8 @@ struct scheduling_config {
     ss::io_priority_class learner_recovery_iopc;
 };
 
-std::ostream& operator<<(std::ostream& o, const vnode& r);
 std::ostream& operator<<(std::ostream& o, const consistency_level& l);
-std::ostream& operator<<(std::ostream& o, const protocol_metadata& m);
-std::ostream& operator<<(std::ostream& o, const vote_reply& r);
 std::ostream& operator<<(std::ostream& o, const append_entries_reply::status&);
-std::ostream& operator<<(std::ostream& o, const append_entries_reply& r);
-std::ostream& operator<<(std::ostream& o, const vote_request& r);
-std::ostream& operator<<(std::ostream& o, const follower_index_metadata& i);
-std::ostream& operator<<(std::ostream& o, const heartbeat_request& r);
-std::ostream& operator<<(std::ostream& o, const heartbeat_reply& r);
 } // namespace raft
 
 namespace reflection {

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -88,6 +88,8 @@ struct header {
     uint32_t correlation_id{0};
     /// \brief xxhash64
     uint64_t payload_checksum{0};
+
+    friend std::ostream& operator<<(std::ostream&, const header&);
 };
 
 static constexpr size_t size_of_rpc_header
@@ -263,6 +265,5 @@ struct transport_configuration {
     net::metrics_disabled disable_metrics = net::metrics_disabled::no;
 };
 
-std::ostream& operator<<(std::ostream&, const header&);
 std::ostream& operator<<(std::ostream&, const status&);
 } // namespace rpc

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -87,9 +87,9 @@ struct configuration : net::base_transport::configuration {
       const aws_region_name& region,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes);
-};
 
-std::ostream& operator<<(std::ostream& o, const configuration& c);
+    friend std::ostream& operator<<(std::ostream& o, const configuration& c);
+};
 
 /// Request formatter for AWS S3
 class request_creator {

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -228,7 +228,11 @@ public:
         return H::combine(std::move(h), e._type, e._name);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const acl_principal&);
+    friend std::ostream&
+    operator<<(std::ostream& os, const acl_principal& principal) {
+        fmt::print(os, "{{type {} name {}}}", principal._type, principal._name);
+        return os;
+    }
 
     const ss::sstring& name() const { return _name; }
     principal_type type() const { return _type; }
@@ -238,12 +242,6 @@ private:
     principal_type _type;
     ss::sstring _name;
 };
-
-inline std::ostream&
-operator<<(std::ostream& os, const acl_principal& principal) {
-    fmt::print(os, "{{type {} name {}}}", principal._type, principal._name);
-    return os;
-}
 
 inline const acl_principal acl_wildcard_user(principal_type::user, "*");
 
@@ -268,7 +266,16 @@ public:
         return H::combine(std::move(h), e._resource, e._name, e._pattern);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const resource_pattern&);
+    friend std::ostream&
+    operator<<(std::ostream& os, const resource_pattern& r) {
+        fmt::print(
+          os,
+          "type {{{}}} name {{{}}} pattern {{{}}}",
+          r._resource,
+          r._name,
+          r._pattern);
+        return os;
+    }
 
     resource_type resource() const { return _resource; }
     const ss::sstring& name() const { return _name; }
@@ -279,16 +286,6 @@ private:
     ss::sstring _name;
     pattern_type _pattern;
 };
-
-inline std::ostream& operator<<(std::ostream& os, const resource_pattern& r) {
-    fmt::print(
-      os,
-      "type {{{}}} name {{{}}} pattern {{{}}}",
-      r._resource,
-      r._name,
-      r._pattern);
-    return os;
-}
 
 /*
  * A host (or wildcard) in an ACL rule.
@@ -314,7 +311,16 @@ public:
         }
     }
 
-    friend std::ostream& operator<<(std::ostream&, const acl_host&);
+    friend std::ostream& operator<<(std::ostream& os, const acl_host& host) {
+        if (host._addr) {
+            fmt::print(os, "{{{}}}", *host._addr);
+        } else {
+            // we can log whatever representation we want for a wildcard host,
+            // but kafka expects "*" as the wildcard representation.
+            os << "{{any_host}}";
+        }
+        return os;
+    }
 
     std::optional<ss::net::inet_address> address() const { return _addr; }
 
@@ -323,17 +329,6 @@ private:
 
     std::optional<ss::net::inet_address> _addr;
 };
-
-inline std::ostream& operator<<(std::ostream& os, const acl_host& host) {
-    if (host._addr) {
-        fmt::print(os, "{{{}}}", *host._addr);
-    } else {
-        // we can log whatever representation we want for a wildcard host, but
-        // kafka expects "*" as the wildcard representation.
-        os << "{{any_host}}";
-    }
-    return os;
-}
 
 inline const acl_host acl_wildcard_host = acl_host::wildcard_host();
 
@@ -362,7 +357,16 @@ public:
           std::move(h), e._principal, e._host, e._operation, e._permission);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const acl_entry&);
+    friend std::ostream& operator<<(std::ostream& os, const acl_entry& entry) {
+        fmt::print(
+          os,
+          "{{principal {} host {} op {} perm {}}}",
+          entry._principal,
+          entry._host,
+          entry._operation,
+          entry._permission);
+        return os;
+    }
 
     const acl_principal& principal() const { return _principal; }
     const acl_host& host() const { return _host; }
@@ -375,17 +379,6 @@ private:
     acl_operation _operation;
     acl_permission _permission;
 };
-
-inline std::ostream& operator<<(std::ostream& os, const acl_entry& entry) {
-    fmt::print(
-      os,
-      "{{principal {} host {} op {} perm {}}}",
-      entry._principal,
-      entry._host,
-      entry._operation,
-      entry._permission);
-    return os;
-}
 
 /*
  * An ACL binding is an association of resource(s) and an ACL entry. An ACL
@@ -404,7 +397,12 @@ public:
         return H::combine(std::move(h), e._pattern, e._entry);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const acl_binding&);
+    friend std::ostream&
+    operator<<(std::ostream& os, const acl_binding& binding) {
+        fmt::print(
+          os, "{{pattern {} entry {}}}", binding._pattern, binding._entry);
+        return os;
+    }
 
     const resource_pattern& pattern() const { return _pattern; }
     const acl_entry& entry() const { return _entry; }
@@ -413,11 +411,6 @@ private:
     resource_pattern _pattern;
     acl_entry _entry;
 };
-
-inline std::ostream& operator<<(std::ostream& os, const acl_binding& binding) {
-    fmt::print(os, "{{pattern {} entry {}}}", binding._pattern, binding._entry);
-    return os;
-}
 
 /*
  * A filter for matching resources.

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -190,11 +190,6 @@ private:
     bytes _signature;
 };
 
-std::ostream& operator<<(std::ostream&, const client_first_message&);
-std::ostream& operator<<(std::ostream&, const server_first_message&);
-std::ostream& operator<<(std::ostream&, const client_final_message&);
-std::ostream& operator<<(std::ostream&, const server_final_message&);
-
 template<
   typename MacType,
   typename HashType,

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -43,8 +43,6 @@ private:
     int _iterations{0};
 };
 
-std::ostream& operator<<(std::ostream&, const security::scram_credential&);
-
 } // namespace security
 
 // TODO: avoid bytes-to-iobuf conersion. either add bytes specialization to

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -46,6 +46,13 @@ struct compacted_index {
         uint32_t crc{0}; // crc32
         // version *must* be the last value
         int8_t version{0};
+
+        friend std::ostream&
+        operator<<(std::ostream& o, const compacted_index::footer& f) {
+            return o << "{size:" << f.size << ", keys:" << f.keys
+                     << ", flags:" << (uint32_t)f.flags << ", crc:" << f.crc
+                     << ", version: " << (int)f.version << "}";
+        }
     };
     enum class recovery_state {
         // happens during a crash
@@ -104,13 +111,6 @@ operator&(compacted_index::footer_flags a, compacted_index::footer_flags b) {
 [[gnu::always_inline]] inline void
 operator&=(compacted_index::footer_flags& a, compacted_index::footer_flags b) {
     a = (a & b);
-}
-
-inline std::ostream&
-operator<<(std::ostream& o, const compacted_index::footer& f) {
-    return o << "{size:" << f.size << ", keys:" << f.keys
-             << ", flags:" << (uint32_t)f.flags << ", crc:" << f.crc
-             << ", version: " << (int)f.version << "}";
 }
 
 } // namespace storage

--- a/src/v/storage/compacted_index_reader.h
+++ b/src/v/storage/compacted_index_reader.h
@@ -129,6 +129,12 @@ public:
         return _impl->consume(std::move(consumer), timeout);
     }
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const compacted_index_reader& r) {
+        r.print(o);
+        return o;
+    }
+
 private:
     ss::shared_ptr<impl> _impl;
 };
@@ -154,9 +160,5 @@ compaction_index_reader_to_memory(compacted_index_reader rdr) {
         return rdr.consume(consumer{}, model::no_timeout).finally([rdr] {});
     });
 }
-inline std::ostream&
-operator<<(std::ostream& o, const compacted_index_reader& r) {
-    r.print(o);
-    return o;
-}
+
 } // namespace storage

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -103,13 +103,13 @@ public:
     std::unique_ptr<impl> release() &&;
 
 private:
+    friend std::ostream&
+    operator<<(std::ostream& o, const compacted_index_writer& c) {
+        c.print(o);
+        return o;
+    }
     std::unique_ptr<impl> _impl;
 };
-inline std::ostream&
-operator<<(std::ostream& o, const compacted_index_writer& c) {
-    c.print(o);
-    return o;
-}
 inline void compacted_index_writer::set_flag(compacted_index::footer_flags f) {
     _impl->set_flag(f);
 }

--- a/src/v/storage/compacted_offset_list.h
+++ b/src/v/storage/compacted_offset_list.h
@@ -41,7 +41,12 @@ private:
     Roaring _to_keep;
 
     friend std::ostream&
-    operator<<(std::ostream&, const compacted_offset_list&);
+    operator<<(std::ostream& o, const compacted_offset_list& l) {
+        return o << "{base:" << l._base << ", logical_offsets_cardinality: "
+                 << l._to_keep.cardinality()
+                 << ", offset_mem_bytes: " << l._to_keep.getSizeInBytes()
+                 << "}";
+    }
 };
 
 inline void compacted_offset_list::add(model::offset o) {
@@ -55,10 +60,5 @@ inline bool compacted_offset_list::contains(model::offset o) const {
     const uint32_t x = (o - _base)();
     return _to_keep.contains(x);
 }
-inline std::ostream&
-operator<<(std::ostream& o, const compacted_offset_list& l) {
-    return o << "{base:" << l._base
-             << ", logical_offsets_cardinality: " << l._to_keep.cardinality()
-             << ", offset_mem_bytes: " << l._to_keep.getSizeInBytes() << "}";
-}
+
 } // namespace storage::internal

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -203,12 +203,10 @@ public:
 private:
     ss::shared_ptr<impl> _impl;
 
-    friend std::ostream& operator<<(std::ostream& o, const log& lg);
+    friend std::ostream& operator<<(std::ostream& o, const log& lg) {
+        return lg.print(o);
+    }
 };
-
-inline std::ostream& operator<<(std::ostream& o, const storage::log& lg) {
-    return lg.print(o);
-}
 
 class log_manager;
 class segment_set;

--- a/src/v/storage/log_replayer.h
+++ b/src/v/storage/log_replayer.h
@@ -45,6 +45,4 @@ private:
     friend std::ostream& operator<<(std::ostream&, const checkpoint&);
 };
 
-std::ostream& operator<<(std::ostream&, const log_replayer::checkpoint&);
-
 } // namespace storage

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -83,13 +83,11 @@ public:
     virtual void print(std::ostream&) const = 0;
 
 private:
-    friend std::ostream& operator<<(std::ostream&, const batch_consumer&);
+    friend std::ostream& operator<<(std::ostream& os, const batch_consumer& c) {
+        c.print(os);
+        return os;
+    }
 };
-
-inline std::ostream& operator<<(std::ostream& os, const batch_consumer& c) {
-    c.print(os);
-    return os;
-}
 
 class continuous_batch_parser {
 public:

--- a/src/v/storage/segment_appender_chunk.h
+++ b/src/v/storage/segment_appender_chunk.h
@@ -102,13 +102,10 @@ private:
     size_t _flushed_pos{0};
     std::unique_ptr<char[], ss::free_deleter> _buf;
     friend std::ostream&
-    operator<<(std::ostream&, const segment_appender_chunk&);
+    operator<<(std::ostream& o, const segment_appender_chunk& c) {
+        return o << "{_alignment:" << c._alignment << ", _pos:" << c._pos
+                 << ", _flushed_pos:" << c._flushed_pos << "}";
+    }
 };
-
-inline std::ostream&
-operator<<(std::ostream& o, const segment_appender_chunk& c) {
-    return o << "{_alignment:" << c._alignment << ", _pos:" << c._pos
-             << ", _flushed_pos:" << c._flushed_pos << "}";
-}
 
 } // namespace storage

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -80,6 +80,5 @@ private:
 
 using segment_reader_ptr = ss::lw_shared_ptr<segment_reader>;
 
-std::ostream& operator<<(std::ostream&, const segment_reader&);
 std::ostream& operator<<(std::ostream&, segment_reader_ptr);
 } // namespace storage

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -98,6 +98,4 @@ ss::future<segment_set> recover_segments(
   size_t read_buf_size,
   unsigned read_readahead_count);
 
-std::ostream& operator<<(std::ostream&, const segment_set&);
-
 } // namespace storage

--- a/src/v/utils/file_sanitizer.h
+++ b/src/v/utils/file_sanitizer.h
@@ -38,13 +38,11 @@ struct sanitizer_op
       : name_op(std::move(operation))
       , bt(ss::current_backtrace()) {}
 
-    friend std::ostream& operator<<(std::ostream& o, const sanitizer_op& s);
+    friend std::ostream& operator<<(std::ostream& o, const sanitizer_op& s) {
+        return o << "{sanitizer_op: " << s.name_op << ", backtrace:\n"
+                 << s.bt << "\n}";
+    }
 };
-
-inline std::ostream& operator<<(std::ostream& o, const sanitizer_op& s) {
-    return o << "{sanitizer_op: " << s.name_op << ", backtrace:\n"
-             << s.bt << "\n}";
-}
 
 /// Classed used to debug bad file accesses, by wrapping the file handle:
 /// auto fd = file(make_shared(file_io_sanitizer(original_fd)));

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -117,6 +117,10 @@ public:
         return base_named_type(std::numeric_limits<type>::max());
     }
 
+    friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
+        return o << "{" << t() << "}";
+    };
+
 protected:
     type _value = std::numeric_limits<T>::min();
 };
@@ -176,14 +180,12 @@ public:
     operator const type&() const& { return _value; }
     operator type() && { return std::move(_value); }
 
+    friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
+        return o << "{" << t() << "}";
+    };
+
 protected:
     type _value;
-};
-
-template<typename T, typename Tag, typename IsConstexpr>
-inline std::ostream&
-operator<<(std::ostream& o, const base_named_type<T, Tag, IsConstexpr>& t) {
-    return o << "{" << t() << "}";
 };
 
 } // namespace detail

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -56,8 +56,6 @@ private:
     operator<<(std::ostream& os, const data_policy& datapolicy);
 };
 
-std::ostream& operator<<(std::ostream& os, const data_policy& datapolicy);
-
 } // namespace v8_engine
 
 namespace reflection {


### PR DESCRIPTION
## Cover letter

With hidden friends the function lookup is found by ADL only.
I.e., it cannot be found by unqualified lookup.

There are several benefits:
* Prevents implicit conversions
* Reduces overload set
  * Reduces error message length when an overload is not found
  * Reduces compile time

See also:
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1601r0.pdf

Techniques employed:
* Inline namespace-scope definitions
* Remove namespace-scope declarations

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none
