### PR TITLE
application: fail on unexpected positional args

### DIFF
--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -114,7 +114,8 @@ private:
     // All methods are calleds from Seastar thread
     void init_env();
     ss::app_template::config setup_app_config();
-    void validate_arguments(const po::variables_map&);
+    static void validate_arguments(const po::variables_map&);
+    static void validate_positional_arguments(const po::variables_map&);
     void hydrate_config(const po::variables_map&);
 
     bool coproc_enabled() {


### PR DESCRIPTION
## Cover letter

When the redpanda application is launched it may be supplied unexpected positional args. Ideally this should be caught by seastar's cli parsing tooling but because of a possible RTTI mismatch the exception can be missed and result in program termination rather than a graceful exit because the seastar run method is noexcept.

With this change all positional args are collected in one variable and during validation we fail if these args are seen, this way we avoid termination during seastar's cli parsing.

fixes #4554 