### PR TITLE
Replace `is_leader` with `is_becoming_leader` and `is_confirmed_leader`

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -68,7 +68,7 @@ ntp_archiver::ntp_archiver(
   , _upload_sg(conf.upload_scheduling_group)
   , _io_priority(conf.upload_io_priority) {
     vassert(
-      _partition && _partition->is_leader(),
+      _partition && _partition->is_becoming_leader(),
       "must be the leader to launch ntp_archiver {}",
       _ntp);
     _start_term = _partition->term();
@@ -150,7 +150,8 @@ ss::future<> ntp_archiver::upload_loop() {
 
 bool ntp_archiver::upload_loop_can_continue() const {
     return !_as.abort_requested() && !_gate.is_closed()
-           && _partition->is_leader() && _partition->term() == _start_term;
+           && _partition->is_becoming_leader()
+           && _partition->term() == _start_term;
 }
 
 ss::future<> ntp_archiver::stop() {

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -284,7 +284,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
       std::move(to_create), concurrency, [this](const model::ntp& ntp) {
           auto log = _partition_manager.local().log(ntp);
           auto part = _partition_manager.local().get(ntp);
-          if (log.has_value() && part && part->is_leader()
+          if (log.has_value() && part && part->is_becoming_leader()
               && (part->get_ntp_config().is_archival_enabled()
                   || config::shard_local_cfg().cloud_storage_enable_remote_read())) {
               auto archiver = ss::make_lw_shared<ntp_archiver>(
@@ -335,7 +335,7 @@ ss::future<> scheduler_service_impl::reconcile_archivers() {
     for (const auto& [ntp, p] : pm.partitions()) {
         if (
           ntp.ns != model::redpanda_ns && !_archivers.contains(ntp)
-          && p->is_leader()) {
+          && p->is_becoming_leader()) {
             to_create.push_back(ntp);
         }
     }

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -244,7 +244,7 @@ void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
         auto self = app.controller->self();
         ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
         return table.wait_for_leader(ntp, deadline, {}).get0() == self
-               && app.partition_manager.local().get(ntp)->is_leader();
+               && app.partition_manager.local().get(ntp)->is_becoming_leader();
     }).get();
 }
 void archiver_fixture::delete_topic(model::ns ns, model::topic topic) {

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -109,7 +109,7 @@ public:
         vassert(
           ss::this_shard_id() == ss::shard_id(0),
           "Raft 0 API can only be called from shard 0");
-        return _raft0->is_leader();
+        return _raft0->is_becoming_leader();
     }
 
     ss::future<> wire_up();

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -116,7 +116,7 @@ std::error_code check_configuration_update(
      * if replica set is a leader it must have configuration committed i.e. it
      * was successfully replicated to majority of followers.
      */
-    if (partition->is_leader() && !configuration_committed) {
+    if (partition->is_becoming_leader() && !configuration_committed) {
         vlog(
           clusterlog.trace,
           "current node is partition {} leader, waiting for configuration to "
@@ -969,7 +969,7 @@ ss::future<std::error_code> controller_backend::update_partition_replica_set(
         return ss::make_ready_future<std::error_code>(errc::success);
     }
     // we are the leader, update configuration
-    if (partition->is_leader()) {
+    if (partition->is_becoming_leader()) {
         auto brokers = create_brokers_set(replicas, _members_table.local());
         vlog(
           clusterlog.debug,

--- a/src/v/cluster/drain_manager.cc
+++ b/src/v/cluster/drain_manager.cc
@@ -161,7 +161,7 @@ ss::future<> drain_manager::do_drain() {
         std::vector<ss::lw_shared_ptr<cluster::partition>> eligible;
         eligible.reserve(_partition_manager.local().partitions().size());
         for (const auto& p : _partition_manager.local().partitions()) {
-            if (!p.second->is_leader() || !p.second->has_followers()) {
+            if (!p.second->is_becoming_leader() || !p.second->has_followers()) {
                 continue;
             }
             eligible.push_back(p.second);

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -127,7 +127,7 @@ cluster_health_report health_monitor_backend::build_cluster_report(
     std::vector<node_state> statuses;
     // refreshing node status is not expensive on leader, we can refresh it
     // every time
-    if (_raft0->is_leader()) {
+    if (_raft0->is_becoming_leader()) {
         refresh_nodes_status();
     }
 
@@ -415,7 +415,7 @@ health_monitor_backend::maybe_refresh_cluster_health(
 
     // if current node is not the controller leader and we need a refresh we
     // refresh metadata cache
-    if (!_raft0->is_leader() && need_refresh) {
+    if (!_raft0->is_becoming_leader() && need_refresh) {
         try {
             auto f = refresh_cluster_health_cache(refresh);
             auto err = co_await ss::with_timeout(deadline, std::move(f));
@@ -451,7 +451,7 @@ void health_monitor_backend::tick() {
 }
 
 ss::future<> health_monitor_backend::tick_cluster_health() {
-    if (!_raft0->is_leader()) {
+    if (!_raft0->is_becoming_leader()) {
         vlog(clusterlog.trace, "skipping tick, not leader");
         _tick_timer.arm(tick_interval());
         co_return;

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -316,7 +316,7 @@ ss::future<> members_backend::reconcile() {
     std::erase_if(
       _updates, [](const update_meta& meta) { return meta.finished; });
 
-    if (!_raft0->is_leader() || _updates.empty()) {
+    if (!_raft0->is_becoming_leader() || _updates.empty()) {
         co_return;
     }
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -499,7 +499,7 @@ members_manager::handle_join_request(join_node_request const req) {
       req.logical_version);
 
     // curent node is a leader
-    if (_raft0->is_leader()) {
+    if (_raft0->is_becoming_leader()) {
         // if configuration contains the broker already just update its config
         // with data from join request
 

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -317,7 +317,7 @@ ss::future<> metrics_reporter::do_report_metrics() {
     // skip reporting if current node is not raft0 leader, or we need to wait
     // for next report
     if (
-      !_raft0->is_leader()
+      !_raft0->is_becoming_leader()
       || _last_success
            > ss::lowres_clock::now()
                - config::shard_local_cfg().metrics_reporter_report_interval()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -138,6 +138,7 @@ public:
       timequery(storage::timequery_config);
 
     bool is_becoming_leader() const { return _raft->is_becoming_leader(); }
+    bool is_confirmed_leader() const { return _raft->is_confirmed_leader(); }
     bool has_followers() const { return _raft->has_followers(); }
 
     void block_new_leadership() const { _raft->block_new_leadership(); }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -137,7 +137,7 @@ public:
     ss::future<std::optional<storage::timequery_result>>
       timequery(storage::timequery_config);
 
-    bool is_leader() const { return _raft->is_leader(); }
+    bool is_becoming_leader() const { return _raft->is_becoming_leader(); }
     bool has_followers() const { return _raft->has_followers(); }
 
     void block_new_leadership() const { _raft->block_new_leadership(); }

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -44,7 +44,7 @@ void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
       {
         sm::make_gauge(
           "leader",
-          [this] { return _partition.is_leader() ? 1 : 0; },
+          [this] { return _partition.is_becoming_leader() ? 1 : 0; },
           sm::description(
             "Flag indicating if this partition instance is a leader"),
           labels),

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -229,7 +229,7 @@ ss::future<bool> persisted_stm::do_sync(
 
 ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
     auto term = _c->term();
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         co_return false;
     }
     if (_insync_term == term) {

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -229,7 +229,7 @@ ss::future<bool> persisted_stm::do_sync(
 
 ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
     auto term = _c->term();
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         co_return false;
     }
     if (_insync_term == term) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -254,7 +254,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
         co_return tx_errc::request_rejected;
     }
 
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         co_return tx_errc::leader_not_found;
     }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -254,7 +254,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
         co_return tx_errc::request_rejected;
     }
 
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         co_return tx_errc::leader_not_found;
     }
 

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -78,7 +78,7 @@ ss::future<> leader_balancer::start() {
             if (group != _raft0->group()) {
                 return;
             }
-            if (_raft0->is_leader()) {
+            if (_raft0->is_becoming_leader()) {
                 if (_enabled()) {
                     vlog(
                       clusterlog.info,
@@ -202,7 +202,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         return now >= g.second.expires;
     });
 
-    if (!_raft0->is_leader()) {
+    if (!_raft0->is_becoming_leader()) {
         vlog(clusterlog.debug, "Leadership balancer tick: not leader");
         if (!_timer.armed()) {
             _timer.arm(_idle_timeout());

--- a/src/v/cluster/tests/id_allocator_stm_test.cc
+++ b/src/v/cluster/tests/id_allocator_stm_test.cc
@@ -50,7 +50,7 @@ FIXTURE_TEST(stm_monotonicity_test, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
 
     int64_t last_id = -1;
 
@@ -73,7 +73,7 @@ FIXTURE_TEST(stm_restart_test, mux_state_machine_fixture) {
 
     cluster::id_allocator_stm stm1(idstmlog, _raft.get(), cfg);
     stm1.start().get0();
-    wait_for_leader();
+    wait_for_confirmed_leader();
 
     int64_t last_id = -1;
 

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -42,7 +42,7 @@ FIXTURE_TEST(
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto count = 5;
@@ -94,7 +94,7 @@ FIXTURE_TEST(
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto count = 5;
@@ -147,7 +147,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     std::vector<model::offset> offsets;
@@ -212,7 +212,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto count = 5;
@@ -272,7 +272,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto count = 5;
@@ -325,7 +325,7 @@ FIXTURE_TEST(
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto count = 5;

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -303,7 +303,7 @@ public:
                   auto& pm = get_partition_manager(leader_id);
                   return pm.invoke_on(
                     *shard, [ntp](cluster::partition_manager& pm) {
-                        return pm.get(ntp)->is_leader();
+                        return pm.get(ntp)->is_becoming_leader();
                     });
               })
               .handle_exception([](std::exception_ptr) { return false; });

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -77,7 +77,7 @@ public:
         auto it = std::find_if(apps.begin(), apps.end(), [](auto& app) {
             auto partition = app.second->partition_manager.local().get(
               model::controller_ntp);
-            return partition && partition->is_leader();
+            return partition && partition->is_becoming_leader();
         });
 
         if (it != apps.end()) {
@@ -144,7 +144,7 @@ public:
                   auto& pm = get_partition_manager(leader_id);
                   return pm.invoke_on(
                     *shard, [ntp](cluster::partition_manager& pm) {
-                        return pm.get(ntp)->is_leader();
+                        return pm.get(ntp)->is_becoming_leader();
                     });
               })
               .handle_exception([](std::exception_ptr) { return false; });

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -73,7 +73,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto tx_seq = model::tx_seq(0);
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto min_offset = model::offset(0);
@@ -146,7 +146,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto tx_seq = model::tx_seq(0);
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto min_offset = model::offset(0);
@@ -221,7 +221,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto tx_seq = model::tx_seq(0);
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto min_offset = model::offset(0);
@@ -299,7 +299,7 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
@@ -337,7 +337,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto tx_seq = model::tx_seq(0);
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
@@ -394,7 +394,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto tx_seq = model::tx_seq(0);
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{.id = 1, .epoch = 0};

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -52,7 +52,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");
@@ -111,7 +111,7 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");
@@ -150,7 +150,7 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
-    wait_for_leader();
+    wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -69,7 +69,7 @@ std::optional<tm_transaction> tm_stm::get_tx(kafka::transactional_id tx_id) {
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::barrier() {
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         return ss::make_ready_future<
           checked<model::term_id, tm_stm::op_status>>(
           tm_stm::op_status::not_leader);
@@ -104,7 +104,7 @@ ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::barrier() {
 
 ss::future<checked<model::term_id, tm_stm::op_status>>
 tm_stm::sync(model::timeout_clock::duration timeout) {
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 
@@ -508,7 +508,7 @@ absl::btree_set<kafka::transactional_id> tm_stm::get_expired_txs() {
 }
 
 ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 
@@ -537,7 +537,7 @@ tm_stm::delete_partition_from_tx(
   model::term_id term,
   kafka::transactional_id tid,
   tm_transaction::tx_partition ntp) {
-    if (!_c->is_becoming_leader()) {
+    if (!_c->is_confirmed_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -69,7 +69,7 @@ std::optional<tm_transaction> tm_stm::get_tx(kafka::transactional_id tx_id) {
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::barrier() {
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         return ss::make_ready_future<
           checked<model::term_id, tm_stm::op_status>>(
           tm_stm::op_status::not_leader);
@@ -104,7 +104,7 @@ ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::barrier() {
 
 ss::future<checked<model::term_id, tm_stm::op_status>>
 tm_stm::sync(model::timeout_clock::duration timeout) {
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 
@@ -508,7 +508,7 @@ absl::btree_set<kafka::transactional_id> tm_stm::get_expired_txs() {
 }
 
 ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 
@@ -537,7 +537,7 @@ tm_stm::delete_partition_from_tx(
   model::term_id term,
   kafka::transactional_id tid,
   tm_transaction::tx_partition ntp) {
-    if (!_c->is_leader()) {
+    if (!_c->is_becoming_leader()) {
         co_return tm_stm::op_status::not_leader;
     }
 

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -31,7 +31,7 @@ public:
     const model::ntp& source() const { return _source->ntp(); }
     const model::ntp& ntp() const { return _log.config().ntp(); }
     const storage::ntp_config& config() const { return _log.config(); }
-    bool is_leader() const { return _source->is_leader(); }
+    bool is_becoming_leader() const { return _source->is_becoming_leader(); }
     model::term_id term() const { return _source->term(); }
     model::revision_id get_revision_id() const {
         return _log.config().get_revision();

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -32,6 +32,7 @@ public:
     const model::ntp& ntp() const { return _log.config().ntp(); }
     const storage::ntp_config& config() const { return _log.config(); }
     bool is_becoming_leader() const { return _source->is_becoming_leader(); }
+    bool is_confirmed_leader() const { return _source->is_confirmed_leader(); }
     model::term_id term() const { return _source->term(); }
     model::revision_id get_revision_id() const {
         return _log.config().get_revision();

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -199,7 +199,7 @@ static ss::future<> write_materialized_partition(
           model::topic_namespace source(input->ntp().ns, input->ntp().tp.topic);
           model::topic_namespace new_materialized(ntp.ns, ntp.tp.topic);
           return maybe_make_materialized_log(
-                   source, new_materialized, input->is_leader(), args)
+                   source, new_materialized, input->is_becoming_leader(), args)
             .then([args, ntp] { return get_partition(args.pm.local(), ntp); })
             .then([ntp, reader = std::move(reader)](
                     ss::lw_shared_ptr<partition> p) mutable {

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -177,7 +177,7 @@ ss::future<ss::lw_shared_ptr<coproc::source>> fiber_mock_fixture::make_source(
     vassert(partition, "Input must not be nullptr");
     auto batch = make_random_batch(params.records_per_input);
     co_await tests::cooperative_spin_wait_with_timeout(
-      2s, [partition]() { return partition->is_leader(); });
+      2s, [partition]() { return partition->is_becoming_leader(); });
     auto r = co_await partition->replicate(
       std::move(batch),
       raft::replicate_options(raft::consistency_level::leader_ack));

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1021,7 +1021,7 @@ error_code group_manager::validate_group_status(
     }
 
     if (const auto it = _partitions.find(ntp); it != _partitions.end()) {
-        if (!it->second->partition->is_becoming_leader()) {
+        if (!it->second->partition->is_confirmed_leader()) {
             vlog(
               klog.trace,
               "Group {} operation {} sent to non-leader coordinator {}",

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1021,7 +1021,7 @@ error_code group_manager::validate_group_status(
     }
 
     if (const auto it = _partitions.find(ntp); it != _partitions.end()) {
-        if (!it->second->partition->is_leader()) {
+        if (!it->second->partition->is_becoming_leader()) {
             vlog(
               klog.trace,
               "Group {} operation {} sent to non-leader coordinator {}",

--- a/src/v/kafka/server/group_metadata_migration.cc
+++ b/src/v/kafka/server/group_metadata_migration.cc
@@ -309,7 +309,7 @@ ss::future<std::error_code> replicate(
 }
 
 bool is_source_partition_ready(const ss::lw_shared_ptr<cluster::partition>& p) {
-    if (!p->is_leader()) {
+    if (!p->is_becoming_leader()) {
         vlog(mlog.info, "not yet leader for source partition: {}", p->ntp());
         return false;
     }
@@ -367,7 +367,7 @@ ss::future<> do_dispatch_ntp_migration(
         try {
             auto target_is_leader = co_await pm.invoke_on(
               *target_shard, [target_ntp](cluster::partition_manager& pm) {
-                  return pm.get(target_ntp)->is_leader();
+                  return pm.get(target_ntp)->is_becoming_leader();
               });
             vlog(
               mlog.info,

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -148,7 +148,7 @@ static ss::future<read_result> do_read_from_ntp(
     if (unlikely(!kafka_partition)) {
         co_return read_result(error_code::unknown_topic_or_partition);
     }
-    if (unlikely(!kafka_partition->is_leader())) {
+    if (unlikely(!kafka_partition->is_becoming_leader())) {
         co_return read_result(error_code::not_leader_for_partition);
     }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -148,7 +148,7 @@ static ss::future<read_result> do_read_from_ntp(
     if (unlikely(!kafka_partition)) {
         co_return read_result(error_code::unknown_topic_or_partition);
     }
-    if (unlikely(!kafka_partition->is_becoming_leader())) {
+    if (unlikely(!kafka_partition->is_confirmed_leader())) {
         co_return read_result(error_code::not_leader_for_partition);
     }
 

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -276,7 +276,7 @@ static partition_produce_stages produce_topic_partition(
                         .partition_index = ntp.tp.partition,
                         .error_code = error_code::unknown_topic_or_partition});
                 }
-                if (unlikely(!partition->is_leader())) {
+                if (unlikely(!partition->is_becoming_leader())) {
                     // submit back to promise source shard
                     (void)ss::smp::submit_to(
                       source_shard, [dispatch = std::move(dispatch)]() mutable {

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -276,7 +276,7 @@ static partition_produce_stages produce_topic_partition(
                         .partition_index = ntp.tp.partition,
                         .error_code = error_code::unknown_topic_or_partition});
                 }
-                if (unlikely(!partition->is_becoming_leader())) {
+                if (unlikely(!partition->is_confirmed_leader())) {
                     // submit back to promise source shard
                     (void)ss::smp::submit_to(
                       source_shard, [dispatch = std::move(dispatch)]() mutable {

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -41,7 +41,9 @@ public:
         return model::next_offset(_partition->dirty_offset());
     }
 
-    bool is_leader() const final { return _partition->is_leader(); }
+    bool is_becoming_leader() const final {
+        return _partition->is_becoming_leader();
+    }
 
     kafka::leader_epoch leader_epoch() const final {
         return leader_epoch_from_term(_partition->term());

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -45,6 +45,10 @@ public:
         return _partition->is_becoming_leader();
     }
 
+    bool is_confirmed_leader() const final {
+        return _partition->is_confirmed_leader();
+    }
+
     kafka::leader_epoch leader_epoch() const final {
         return leader_epoch_from_term(_partition->term());
     }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -37,7 +37,7 @@ public:
         virtual kafka::leader_epoch leader_epoch() const = 0;
         virtual std::optional<model::offset>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
-        virtual bool is_leader() const = 0;
+        virtual bool is_becoming_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<storage::translating_reader> make_reader(
           storage::log_reader_config,
@@ -73,7 +73,7 @@ public:
         return _impl->linearizable_barrier();
     }
 
-    bool is_leader() const { return _impl->is_leader(); }
+    bool is_becoming_leader() const { return _impl->is_becoming_leader(); }
 
     const model::ntp& ntp() const { return _impl->ntp(); }
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -38,6 +38,7 @@ public:
         virtual std::optional<model::offset>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
         virtual bool is_becoming_leader() const = 0;
+        virtual bool is_confirmed_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<storage::translating_reader> make_reader(
           storage::log_reader_config,
@@ -74,6 +75,8 @@ public:
     }
 
     bool is_becoming_leader() const { return _impl->is_becoming_leader(); }
+
+    bool is_confirmed_leader() const { return _impl->is_confirmed_leader(); }
 
     const model::ntp& ntp() const { return _impl->ntp(); }
 

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -55,7 +55,9 @@ public:
         return _translator->from_log_offset(_partition->last_stable_offset());
     }
 
-    bool is_leader() const final { return _partition->is_leader(); }
+    bool is_becoming_leader() const final {
+        return _partition->is_becoming_leader();
+    }
 
     ss::future<std::error_code> linearizable_barrier() final {
         auto r = co_await _partition->linearizable_barrier();

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -59,6 +59,10 @@ public:
         return _partition->is_becoming_leader();
     }
 
+    bool is_confirmed_leader() const final {
+        return _partition->is_confirmed_leader();
+    }
+
     ss::future<std::error_code> linearizable_barrier() final {
         auto r = co_await _partition->linearizable_barrier();
         if (r) {

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -138,7 +138,7 @@ FIXTURE_TEST(test_topic_namespaces, redpanda_thread_fixture) {
             }
             return app.partition_manager.invoke_on(
               *shard, [ntp](cluster::partition_manager& pm) {
-                  return pm.get(ntp)->is_leader();
+                  return pm.get(ntp)->is_becoming_leader();
               });
         });
     };

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -41,7 +41,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
             }
             return app.partition_manager.invoke_on(
               *shard, [ntp](cluster::partition_manager& pm) {
-                  return pm.get(ntp)->is_leader();
+                  return pm.get(ntp)->is_becoming_leader();
               });
         }).get0();
     }

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -41,7 +41,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
             }
             return app.partition_manager.invoke_on(
               *shard, [ntp](cluster::partition_manager& pm) {
-                  return pm.get(ntp)->is_becoming_leader();
+                  return pm.get(ntp)->is_confirmed_leader();
               });
         }).get0();
     }

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -249,7 +249,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
         return app.partition_manager.invoke_on(
           *shard_id, [ntp](cluster::partition_manager& pm) {
               if (pm.get(ntp)) {
-                  return pm.get(ntp)->is_leader();
+                  return pm.get(ntp)->is_becoming_leader();
               }
               return false;
           });

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2376,6 +2376,9 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
 
         return model::offset{};
     });
+    if (get_term(majority_match) == _term) {
+        _confirmed_term = _term;
+    }
     /**
      * we have to make sure that we do not advance committed_index beyond the
      * point which is readable in log. Since we are not waiting for flush to
@@ -2390,6 +2393,7 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
     majority_match = std::min(majority_match, _flushed_offset);
 
     if (majority_match > _commit_index && get_term(majority_match) == _term) {
+        _confirmed_term = _term;
         _commit_index = majority_match;
         vlog(_ctxlog.trace, "Leader commit index updated {}", _commit_index);
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -130,6 +130,9 @@ public:
     // data loss
     ss::future<std::error_code> revert_configuration_change(model::revision_id);
     bool is_becoming_leader() const { return _vstate == vote_state::leader; }
+    bool is_confirmed_leader() const {
+        return is_becoming_leader() && _term == _confirmed_term;
+    }
     bool is_candidate() const { return _vstate == vote_state::candidate; }
     std::optional<model::node_id> get_leader_id() const {
         return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;
@@ -550,6 +553,7 @@ private:
     // consensus state
     model::offset _commit_index;
     model::term_id _term;
+    model::term_id _confirmed_term;
     model::offset _flushed_offset{};
 
     // read at `ss::future<> start()`

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -129,7 +129,7 @@ public:
     // Revert current configuration change - this is safe and will never cause
     // data loss
     ss::future<std::error_code> revert_configuration_change(model::revision_id);
-    bool is_leader() const { return _vstate == vote_state::leader; }
+    bool is_becoming_leader() const { return _vstate == vote_state::leader; }
     bool is_candidate() const { return _vstate == vote_state::candidate; }
     std::optional<model::node_id> get_leader_id() const {
         return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -87,7 +87,7 @@ static heartbeat_requests requests_for_range(
 
     auto last_heartbeat = clock_type::now() - heartbeat_interval;
     for (auto& ptr : c) {
-        if (!ptr->is_leader()) {
+        if (!ptr->is_becoming_leader()) {
             continue;
         }
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -509,7 +509,7 @@ bool recovery_stm::is_recovery_finished() {
      */
     if (
       _ptr->_as.abort_requested() || _ptr->_bg.is_closed() || _stop_requested
-      || _term != _ptr->term() || !_ptr->is_leader()) {
+      || _term != _ptr->term() || !_ptr->is_becoming_leader()) {
         return true;
     }
 

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -192,7 +192,7 @@ ss::future<> replicate_batcher::flush(
         // by the followers while it is no longer a leader
         // this problem caused truncation failure.
 
-        if (!_ptr->is_leader()) {
+        if (!_ptr->is_becoming_leader()) {
             for (auto& n : item_cache) {
                 n->_promise.set_value(errc::not_leader);
             }

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -671,7 +671,7 @@ FIXTURE_TEST(test_last_visible_offset_relaxed_consistency, raft_test_fixture) {
     std::vector<model::node_id> disabled;
     model::node_id leader_id;
     for (auto& m : gr.get_members()) {
-        if (!m.second.consensus->is_leader()) {
+        if (!m.second.consensus->is_becoming_leader()) {
             disabled.push_back(m.first);
         } else {
             leader_id = m.first;

--- a/src/v/raft/tests/membership_test.cc
+++ b/src/v/raft/tests/membership_test.cc
@@ -109,7 +109,7 @@ FIXTURE_TEST(remove_non_leader, raft_test_fixture) {
                            members.begin(),
                            members.end(),
                            [](raft_group::members_t::value_type& p) {
-                               return !p.second.consensus->is_leader();
+                               return !p.second.consensus->is_becoming_leader();
                            })
                            ->first;
     res = retry_with_leader(gr, 5, 1s, [non_leader_id](raft_node& leader) {
@@ -182,7 +182,7 @@ FIXTURE_TEST(remove_multiple_members, raft_test_fixture) {
                            members.begin(),
                            members.end(),
                            [](raft_group::members_t::value_type& p) {
-                               return !p.second.consensus->is_leader();
+                               return !p.second.consensus->is_becoming_leader();
                            })
                            ->first;
     res = retry_with_leader(

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -120,10 +120,17 @@ struct mux_state_machine_fixture {
           model::broker_properties{});
     }
 
-    void wait_for_leader() {
+    void wait_for_becoming_leader() {
         using namespace std::chrono_literals;
         tests::cooperative_spin_wait_with_timeout(10s, [this] {
             return _raft->is_becoming_leader();
+        }).get0();
+    }
+
+    void wait_for_confirmed_leader() {
+        using namespace std::chrono_literals;
+        tests::cooperative_spin_wait_with_timeout(10s, [this] {
+            return _raft->is_confirmed_leader();
         }).get0();
     }
 

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -123,7 +123,7 @@ struct mux_state_machine_fixture {
     void wait_for_leader() {
         using namespace std::chrono_literals;
         tests::cooperative_spin_wait_with_timeout(10s, [this] {
-            return _raft->is_leader();
+            return _raft->is_becoming_leader();
         }).get0();
     }
 

--- a/src/v/raft/tests/mux_state_machine_test.cc
+++ b/src/v/raft/tests/mux_state_machine_test.cc
@@ -187,7 +187,7 @@ FIXTURE_TEST(
       kvlog, _raft.get(), raft::persistent_last_applied::yes, state);
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_leader();
+    wait_for_becoming_leader();
     ss::abort_source as;
 
     // success set
@@ -257,7 +257,7 @@ FIXTURE_TEST(test_concurrent_sets, mux_state_machine_fixture) {
     raft::mux_state_machine stm(
       kvlog, _raft.get(), raft::persistent_last_applied::yes, state);
     stm.start().get0();
-    wait_for_leader();
+    wait_for_becoming_leader();
     ss::abort_source as;
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
     auto range = boost::irange(0, 50);
@@ -346,7 +346,7 @@ FIXTURE_TEST(test_stm_recovery, mux_state_machine_fixture) {
       kvlog, _raft.get(), raft::persistent_last_applied::yes, state);
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_leader();
+    wait_for_becoming_leader();
     auto offset = _storage.local().log_mgr().get(_ntp)->offsets().dirty_offset;
     stm.wait(offset, model::timeout_clock::now() + 1s).get0();
     BOOST_REQUIRE_EQUAL(state.kv_map.size(), 2);
@@ -363,7 +363,7 @@ FIXTURE_TEST(test_mulitple_states, mux_state_machine_fixture) {
       kvlog, _raft.get(), raft::persistent_last_applied::yes, state_1, state_2);
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_leader();
+    wait_for_becoming_leader();
     ss::abort_source as;
 
     // set in state 1
@@ -435,7 +435,7 @@ FIXTURE_TEST(timeout_test, mux_state_machine_fixture) {
       kvlog, _raft.get(), raft::persistent_last_applied::yes, state_1);
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_leader();
+    wait_for_becoming_leader();
     ss::abort_source as;
 
     // timeout

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -439,7 +439,9 @@ struct raft_group {
     ss::future<model::node_id> wait_for_leader() {
         if (_leader_id) {
             auto it = _members.find(*_leader_id);
-            if (it != _members.end() && it->second.consensus->is_leader()) {
+            if (
+              it != _members.end()
+              && it->second.consensus->is_becoming_leader()) {
                 return ss::make_ready_future<model::node_id>(*_leader_id);
             }
             _leader_id = std::nullopt;
@@ -565,7 +567,7 @@ static void assert_at_most_one_leader(raft_group& gr) {
             leaders_per_term.try_emplace(term, 0);
         }
         auto it = leaders_per_term.find(m.consensus->term());
-        it->second += m.consensus->is_leader();
+        it->second += m.consensus->is_becoming_leader();
     }
     for (auto& [term, leaders] : leaders_per_term) {
         BOOST_REQUIRE_LE(leaders, 1);

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -258,14 +258,12 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
     return replicate_config_as_new_leader(std::move(u))
       .then([this](std::error_code ec) {
           // if we didn't replicated configuration, step down
-          if (ec) {
-              vlog(
-                _ctxlog.info,
-                "unable to replicate configuration as a leader - error code: "
-                "{} - {} ",
-                ec.value(),
-                ec.message());
-          }
+          vlog(
+            _ctxlog.info,
+            "unable to replicate configuration as a leader - error code: "
+            "{} - {} ",
+            ec.value(),
+            ec.message());
       });
 }
 


### PR DESCRIPTION
## Cover letter

`consensus::is_leader` is a misleading name it suggests that a node is a leader but according to the raft protocol a node becomes a leader after:

  1. it was voted for by the majority
  2. it successfully replicated an entry

And we set `is_leader` before we replicate the configuration batch so there may be cases then a node pretends to be a leader while it actually isn't.

The PR replaces `is_leader` with `is_becoming_leader` and `is_confirmed_leader` to clearly communicate the raft's internal state and to avoid potentials violations.

## Release notes

* none