### PR TITLE
rpk: support hostnames in config bootstrapping

### DIFF
--- a/src/go/rpk/pkg/net/hostport_test.go
+++ b/src/go/rpk/pkg/net/hostport_test.go
@@ -144,7 +144,10 @@ func TestIsDomain(t *testing.T) {
 		{"underscores and dashes can be anywhere in middle of label", "a.0-_-0.foo.com", true},
 		{"labels can be just numbers", "0.com", true},
 
-		{"relaxed restrictions allows non-alphabet tld", "foo.a0", true},
+		{"tld should be entirely alphabetical", "foo.a0", false},
+		{"tld cannot be numeric", "foo.120", false},
+		{"tld length should be > 1", "foo.a", false},
+		{"IDN tld are supported", "foo.xn--45brj9c", true},
 		{"relaxed restrictions allows just tld", "foo", true},
 		{"common docker naming test", "docker_n_1", true},
 		{"invalid duplicate dots", "foo..com", false},


### PR DESCRIPTION
## Cover letter

Change in `rpk redpanda config bootstrap`, now `--ips` flag accepts hostnames and ports.


```
$ rpk redpanda config bootstrap --id 0 --self 127.0.0.1 --ips test-host,127.0.6.1,127.0.4.1:80
 ```

will now produce:
```yaml                                                        
config_file: /etc/redpanda/redpanda.yaml
pandaproxy: {}
redpanda:
  admin:
  - address: 127.0.0.1
    port: 9644
  data_directory: /var/lib/redpanda/data
  developer_mode: true
  kafka_api:
  - address: 127.0.0.1
    port: 9092
  node_id: 0
  rpc_server:
    address: 127.0.0.1
    port: 33145
  seed_servers:
  - host:
      address: test-host
      port: 33145
  - host:
      address: 127.0.6.1
      port: 33145
  - host:
      address: 127.0.4.1
      port: 80
```
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2843 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* Change in `rpk redpanda config bootstrap`, now `--ips` flag accepts hostnames and ports.

