### PR TITLE
fix build failure with autoconf 2.70+

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -77,6 +77,10 @@ set(base_env
   CXX=@CMAKE_CXX_COMPILER@
   AR=${AR}
   PKG_CONFIG_PATH=@PKG_CONFIG_PATH@
+  # Workaround for https://savannah.gnu.org/support/?110503
+  # Starting with autoconf 2.70, it is expected that gtkdocize is installed.
+  # Since we don't build with thirdparty with docs, point gtkdocize elsewhere.
+  GTKDOCIZE=/bin/true
 )
 set(configure_env
   ${base_env}


### PR DESCRIPTION
## Cover letter
On my Ubuntu 22.04 machine with autoconf 2.71, I ran into the following
error when building gnutls:

autoreconf: running: gtkdocize --copy
Can't exec "gtkdocize": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 293.
autoreconf: error: gtkdocize failed with exit status: 2

Per [1][2], starting with Autoconf 2.70, gtkdocize is required by
default. To remedy this, rather than installing gtk-doc-tools, this
patch redirects GTKDOCIZE to /bin/true, allowing us to avoid the call to
gtkdocize altogether.

[1] https://savannah.gnu.org/support/?110503
[2] https://lwn.net/Articles/839395/

## Release notes
none

Changes in [force push](
https://github.com/redpanda-data/vtools/compare/578b9c8f2d49af09dbb4320eeda0f5c167b37e03..497e2f5130b2393aac269da7807d9d589be4822d)
- Set `GTKDOCIZE` environment variable instead of installing gtkdocize