### PR TITLE
vim: add coc-settings.json to src/v

### DIFF
--- a/src/v/.vim/coc-settings.json
+++ b/src/v/.vim/coc-settings.json
@@ -1,0 +1,3 @@
+{
+  "clangd.path": "../../vbuild/llvm/install/bin/clangd"
+}


### PR DESCRIPTION
## Cover letter
There's already a coc-settings.json file in the root directory, but it
can be convenient to have another one in src/v.

For instance, I find myself looking around primarily in the C++ portion
of the codebase and tend to reference files via their relativized paths.
As such, I open vim from within src/v so my paths don't contain src/v.
Adding another settings file allows coc.nvim to do completions when
browsing in this way.

## Release notes
none