### PR TITLE
rpc: graceful handling of unsupported methods and transport versions

### DIFF
--- a/src/v/rpc/errc.h
+++ b/src/v/rpc/errc.h
@@ -22,7 +22,8 @@ enum class errc {
     missing_node_rpc_client,
     client_request_timeout,
     service_error,
-    method_not_found
+    method_not_found,
+    version_not_supported,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "rpc::errc"; }
@@ -39,6 +40,8 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::missing_node_rpc_client";
         case errc::client_request_timeout:
             return "rpc::errc::client_request_timeout";
+        case errc::version_not_supported:
+            return "rpc::errc::version_not_supported";
         default:
             return "rpc::errc::unknown";
         }

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -110,11 +110,20 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
                     return srvc->method_from_id(method_id) != nullptr;
                 });
               if (unlikely(it == _services.end())) {
+                  vlog(
+                    rpclog.debug,
+                    "Received a request for an unknown method {} from {}",
+                    method_id,
+                    ctx->res.conn->addr);
                   rs.probe().method_not_found();
                   netbuf reply_buf;
                   reply_buf.set_status(rpc::status::method_not_found);
-                  return send_reply(ctx, std::move(reply_buf))
-                    .then([ctx]() mutable { ctx->signal_body_parse(); });
+                  return ctx->res.conn->input()
+                    .skip(ctx->get_header().payload_size)
+                    .then([ctx, reply_buf = std::move(reply_buf)]() mutable {
+                        return send_reply(ctx, std::move(reply_buf))
+                          .then([ctx]() mutable { ctx->signal_body_parse(); });
+                    });
               }
 
               method* m = it->get()->method_from_id(method_id);

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -458,3 +458,68 @@ FIXTURE_TEST(corrupted_data_at_server, rpc_integration_fixture) {
         BOOST_REQUIRE_EQUAL(echo_resp_new.value().data.str, "testing...");
     }
 }
+
+FIXTURE_TEST(version_not_supported, rpc_integration_fixture) {
+    configure_server();
+    register_services();
+    start_server();
+
+    rpc::transport t(client_config());
+    t.connect(model::no_timeout).get();
+    auto client = echo::echo_client_protocol(t);
+
+    const auto check_unsupported = [&] {
+        auto f = t.send_typed_versioned<echo::echo_req, echo::echo_resp>(
+          echo::echo_req{.str = "testing..."},
+          960598415,
+          rpc::client_opts(rpc::no_timeout),
+          rpc::transport_version::unsupported);
+        return f.then([&](auto ret) {
+            BOOST_REQUIRE(ret.has_value()); // low-level rpc succeeded
+
+            BOOST_REQUIRE(ret.value().ctx.has_error()); // payload failed
+            BOOST_REQUIRE_EQUAL(
+              ret.value().ctx.error(), rpc::errc::version_not_supported);
+
+            // returned version is server's max supported
+            BOOST_REQUIRE_EQUAL(
+              static_cast<uint8_t>(ret.value().version),
+              static_cast<uint8_t>(rpc::transport_version::max_supported));
+        });
+    };
+
+    const auto check_supported = [&] {
+        auto f = client.echo(
+          echo::echo_req{.str = "testing..."},
+          rpc::client_opts(rpc::no_timeout));
+        return f.then([&](auto ret) {
+            BOOST_REQUIRE(ret.has_value());
+            BOOST_REQUIRE_EQUAL(ret.value().data.str, "testing...");
+        });
+    };
+
+    /*
+     * randomizing the messages here is intentional: we want to ensure that
+     * unsupported version error can be handled in any situation and that the
+     * connection remains in a healthy state.
+     */
+    std::vector<std::function<ss::future<>()>> request_factory;
+    for (int i = 0; i < 200; i++) {
+        request_factory.emplace_back(check_unsupported);
+        request_factory.emplace_back(check_supported);
+    }
+    std::shuffle(
+      request_factory.begin(),
+      request_factory.end(),
+      random_generators::internal::gen);
+
+    // dispatch the requests
+    std::vector<ss::future<>> requests;
+    for (const auto& factory : request_factory) {
+        requests.emplace_back(factory());
+    }
+
+    ss::when_all_succeed(requests.begin(), requests.end()).get();
+
+    t.stop().get();
+}

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -49,7 +49,7 @@ FIXTURE_TEST(echo_round_trip, rpc_integration_fixture) {
     BOOST_REQUIRE_EQUAL(ret.value().data.str, payload);
 }
 
-FIXTURE_TEST(rpcgen_tls_integration, rpc_integration_fixture) {
+FIXTURE_TEST(echo_round_trip_tls, rpc_integration_fixture) {
     auto creds_builder = config::tls_config(
                            true,
                            config::key_cert{"redpanda.key", "redpanda.crt"},
@@ -58,22 +58,22 @@ FIXTURE_TEST(rpcgen_tls_integration, rpc_integration_fixture) {
                            std::nullopt)
                            .get_credentials_builder()
                            .get0();
+
     configure_server(creds_builder);
     register_services();
     start_server();
-    info("started");
-    auto cli = rpc::client<cycling::team_movistar_client_protocol>(
+
+    auto client = rpc::client<echo::echo_client_protocol>(
       client_config(creds_builder));
-    info("client connecting");
-    cli.connect(model::no_timeout).get();
-    auto dcli = ss::defer([&cli] { cli.stop().get(); });
-    info("client calling method");
-    auto ret = cli
-                 .ibis_hakka(
-                   cycling::san_francisco{66},
-                   rpc::client_opts(rpc::no_timeout))
-                 .get0();
-    BOOST_REQUIRE_EQUAL(ret.value().data.x, 66);
+    client.connect(model::no_timeout).get();
+    auto cleanup = ss::defer([&client] { client.stop().get(); });
+
+    const auto payload = random_generators::gen_alphanum_string(100);
+    auto f = client.echo(
+      echo::echo_req{.str = payload}, rpc::client_opts(rpc::no_timeout));
+    auto ret = f.get();
+    BOOST_REQUIRE(ret.has_value());
+    BOOST_REQUIRE_EQUAL(ret.value().data.str, payload);
 }
 
 class temporary_dir {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -61,6 +61,10 @@ public:
     ss::future<result<client_context<Output>>>
       send_typed(Input, uint32_t, rpc::client_opts);
 
+    template<typename Input, typename Output>
+    ss::future<result<result_context<Output>>> send_typed_versioned(
+      Input, uint32_t, rpc::client_opts, transport_version);
+
     void reset_state() final;
 
 private:
@@ -159,6 +163,24 @@ template<typename Input, typename Output>
 inline ss::future<result<client_context<Output>>>
 transport::send_typed(Input r, uint32_t method_id, rpc::client_opts opts) {
     using ret_t = result<client_context<Output>>;
+    return send_typed_versioned<Input, Output>(
+             std::move(r), method_id, std::move(opts), transport_version::v0)
+      .then([](result<result_context<Output>> res) {
+          if (!res) {
+              return ss::make_ready_future<ret_t>(res.error());
+          }
+          return ss::make_ready_future<ret_t>(std::move(res.value().ctx));
+      });
+}
+
+template<typename Input, typename Output>
+inline ss::future<result<result_context<Output>>>
+transport::send_typed_versioned(
+  Input r,
+  uint32_t method_id,
+  rpc::client_opts opts,
+  transport_version version) {
+    using ret_t = result<result_context<Output>>;
     _probe.request();
 
     auto b = std::make_unique<rpc::netbuf>();
@@ -166,6 +188,7 @@ transport::send_typed(Input r, uint32_t method_id, rpc::client_opts opts) {
     b->set_min_compression_bytes(opts.min_compression_bytes);
     auto raw_b = b.get();
     raw_b->set_service_method_id(method_id);
+    raw_b->set_version(version);
 
     auto& target_buffer = raw_b->buffer();
     auto seq = ++_seq;
@@ -178,7 +201,11 @@ transport::send_typed(Input r, uint32_t method_id, rpc::client_opts opts) {
           if (!sctx) {
               return ss::make_ready_future<ret_t>(sctx.error());
           }
-          return internal::parse_result<Output>(_in, std::move(sctx.value()));
+          const auto version = sctx.value()->get_header().version;
+          return internal::parse_result<Output>(_in, std::move(sctx.value()))
+            .then([version](result<client_context<Output>> r) {
+                return ret_t(result_context<Output>{version, std::move(r)});
+            });
       });
 }
 

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -112,6 +112,8 @@ inline errc map_server_error(status status) {
         return errc::service_error;
     case status::method_not_found:
         return errc::method_not_found;
+    case status::version_not_supported:
+        return errc::version_not_supported;
     };
 };
 

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -70,6 +70,8 @@ std::ostream& operator<<(std::ostream& o, transport_version v) {
     switch (v) {
     case transport_version::v0:
         return o << "rpc::transport_version::v0";
+    case transport_version::unsupported:
+        return o << "rpc::transport_version::unsupported";
     }
 }
 

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -59,8 +59,17 @@ std::ostream& operator<<(std::ostream& o, const status& s) {
         return o << "rpc::status::request_timeout";
     case status::server_error:
         return o << "rpc::status::server_error";
+    case status::version_not_supported:
+        return o << "rpc::status::version_not_supported";
     default:
         return o << "rpc::status::unknown";
+    }
+}
+
+std::ostream& operator<<(std::ostream& o, transport_version v) {
+    switch (v) {
+    case transport_version::v0:
+        return o << "rpc::transport_version::v0";
     }
 }
 

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -252,6 +252,16 @@ struct client_context {
     T data;
 };
 
+/*
+ * wrapper to hold context associated with a response that can be inspected even
+ * in cases where there is no valid response, such as recoverable errors.
+ */
+template<typename T>
+struct result_context {
+    transport_version version;
+    result<client_context<T>> ctx;
+};
+
 template<typename T>
 inline result<T> get_ctx_data(result<client_context<T>>&& ctx) {
     if (unlikely(!ctx)) {

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -74,6 +74,12 @@ enum class status : uint32_t {
 enum class transport_version : uint8_t {
     v0 = 0,
     max_supported = v0,
+
+    /*
+     * unsupported is a convenience name used in tests to construct a message
+     * with an unsupported version. the bits should not be considered reserved.
+     */
+    unsupported = max_supported + 1,
 };
 
 /// \brief core struct for communications. sent with _each_ payload

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -68,12 +68,18 @@ enum class status : uint32_t {
     method_not_found = 404,
     request_timeout = 408,
     server_error = 500,
+    version_not_supported = 505,
+};
+
+enum class transport_version : uint8_t {
+    v0 = 0,
+    max_supported = v0,
 };
 
 /// \brief core struct for communications. sent with _each_ payload
 struct header {
     /// \brief version is unused. always 0. can be used for bitflags as well
-    uint8_t version{0};
+    transport_version version{transport_version::v0};
     /// \brief everything below the checksum is hashed with crc32
     uint32_t header_checksum{0};
     /// \breif compression on the wire
@@ -186,6 +192,7 @@ public:
     void set_compression(rpc::compression_type c);
     void set_service_method_id(uint32_t);
     void set_min_compression_bytes(size_t);
+    void set_version(transport_version v) { _hdr.version = v; }
     iobuf& buffer();
 
 private:
@@ -266,4 +273,5 @@ struct transport_configuration {
 };
 
 std::ostream& operator<<(std::ostream&, const status&);
+std::ostream& operator<<(std::ostream&, transport_version);
 } // namespace rpc


### PR DESCRIPTION
## Cover letter

* Unsupported method errors were return to the client, but the payload was not skipped. This means that the connection effectively became corrupted and the client could no longer send messages following an unsupported method message.
* Servers ignored the transport version in the header and assumed v0. Now servers return an error and the max supported version when receiving a message with a version larger than what is understood by the server.

## Release notes

* None