### PR TITLE
cmake_test: catch exceptional future ignored backtraces

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -41,9 +41,9 @@ class BacktraceCapture(threading.Thread):
     """
 
     BACKTRACE_START = re.compile(
-        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$|^Direct leak.+|^Indirect leak.+|^READ of size.*|^0x.+ is located.+|^previously allocated by.+|^Thread.+created by.+)"
+        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$|^Direct leak.+|^Indirect leak.+|^READ of size.*|^0x.+ is located.+|^previously allocated by.+|^Thread.+created by.+|Exceptional future ignored)"
     )
-    BACKTRACE_BODY = re.compile("^(  |==|0x)")
+    BACKTRACE_BODY = re.compile("^(  |==|0x|.*backtrace: 0x)")
 
     def __init__(self, binary, process):
         super(BacktraceCapture, self).__init__()
@@ -100,6 +100,8 @@ class BacktraceCapture(threading.Thread):
                 # A start of backtrace line, which may also have been an end of backtrace line above
                 if accumulator is None and self.BACKTRACE_START.search(line):
                     accumulator = []
+                    if self.BACKTRACE_BODY.search(line):
+                        accumulator.append(line)
             else:
                 break
 


### PR DESCRIPTION
## Cover letter

cmake_test.py didn't catch exceptional future ignored (fixed by updating regexes) but seastar was also spitting out the backtrace on the same line that started the block collection. so this also checks that case and will save the first line if it matches body regex.

Here is an example of the backtrace reporter changes catching the exceptional future ignored backtrace:

https://buildkite.com/redpanda/redpanda/builds/10372#395201fa-248d-460d-812b-26a80ef09f98/6-5620

```
*** No errors detected
--
  | *** 1 abandoned failed future(s) detected
  | Failing the test because fail was requested by --fail-on-abandoned-failed-futures
  | Test Exit code 3
  | Decoded a Seastar backtrace:
  | addr2line: DWARF error: could not find variable specification at offset 4b
  | addr2line: DWARF error: could not find variable specification at offset c72c
  | addr2line: DWARF error: could not find variable specification at offset c7b1
  | addr2line: DWARF error: could not find variable specification at offset e9be
  | addr2line: DWARF error: could not find variable specification at offset 9b50b
  | addr2line: DWARF error: could not find variable specification at offset 9b77d
  | addr2line: DWARF error: could not find variable specification at offset 9b95f
  | addr2line: DWARF error: could not find variable specification at offset 9c5e5
  | addr2line: DWARF error: could not find variable specification at offset 9c7a8
  | addr2line: DWARF error: could not find variable specification at offset b36fc
  | addr2line: DWARF error: could not find variable specification at offset e2710
  | addr2line: DWARF error: could not find variable specification at offset 34edd
  | addr2line: DWARF error: could not find variable specification at offset 50905
  | addr2line: DWARF error: could not find variable specification at offset 55c16
  | WARN  2022-05-22 01:53:34,086 [shard 0] seastar - Exceptional future ignored: std::exception (std::exception), backtrace:
  | [Backtrace #0]
  | void seastar::backtrace<seastar::current_backtrace_tasklocal()::$_3>(seastar::current_backtrace_tasklocal()::$_3&&) at /v/build/v_deps_build/seastar-prefix/src/seastar/include/seastar/util/backtrace.hh:59
  | (inlined by) seastar::current_backtrace_tasklocal() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/util/backtrace.cc
```

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
