### PR TITLE
chore: fix warning backgrounding futures

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -183,7 +183,7 @@ ss::future<> cache::start() {
     if (ss::this_shard_id() == 0) {
         co_await clean_up_at_start();
 
-        _timer.set_callback([this] { return clean_up_cache(); });
+        _timer.set_callback([this] { ssx::background = clean_up_cache(); });
         _timer.arm_periodic(_check_period);
     }
 }

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -98,7 +98,7 @@ consumer::consumer(
   , _coordinator(std::move(coordinator))
   , _inactive_timer([me{shared_from_this()}]() {
       vlog(kclog.info, "Consumer: {}: inactive", *me);
-      return me->leave().discard_result().finally([me]() {});
+      ssx::background = me->leave().discard_result().finally([me]() {});
   })
   , _group_id(std::move(group_id))
   , _name(std::move(name))


### PR DESCRIPTION
## Cover letter

Returning the future to background will throw a warning because the
return value of the timer callback is void.

## Release notes

* none