### PR TITLE
rpk: add `registry` command to support the schema registry

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/twmb/franz-go v1.5.2
 	github.com/twmb/franz-go/pkg/kadm v0.0.0-20220106030238-d62f1bef74f9
 	github.com/twmb/franz-go/pkg/kmsg v1.0.0
+	github.com/twmb/franz-go/pkg/sr v0.0.0-20220523002247-6e9090dbbba1
 	github.com/twmb/tlscfg v1.2.0
 	github.com/twmb/types v1.1.6
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -334,6 +334,8 @@ github.com/twmb/franz-go/pkg/kadm v0.0.0-20220106030238-d62f1bef74f9/go.mod h1:f
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/franz-go/pkg/kmsg v1.0.0 h1:dQdaXLDUEb+XkSUqw2/GvMEGdw1o89X2fOiFjlhztyA=
 github.com/twmb/franz-go/pkg/kmsg v1.0.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/sr v0.0.0-20220523002247-6e9090dbbba1 h1:eG2B4K6X1QWL3703T6lzzT1Izws5LWBNPHUwXCDcE2A=
+github.com/twmb/franz-go/pkg/sr v0.0.0-20220523002247-6e9090dbbba1/go.mod h1:Js4uyv6UktPqVKzFre8+wE31N+uI5vtHzOc/Q7eYC08=
 github.com/twmb/go-rbtree v1.0.0 h1:KxN7dXJ8XaZ4cvmHV1qqXTshxX3EBvX/toG5+UR49Mg=
 github.com/twmb/go-rbtree v1.0.0/go.mod h1:UlIAI8gu3KRPkXSobZnmJfVwCJgEhD/liWzT5ppzIyc=
 github.com/twmb/tlscfg v1.2.0 h1:WCzLHtmnVJ94+veAO4TLTB1ENx7TPYLkTl4Q6WFF4Vo=

--- a/src/go/rpk/pkg/cli/cmd/registry/compatibility_level.go
+++ b/src/go/rpk/pkg/cli/cmd/registry/compatibility_level.go
@@ -1,0 +1,169 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package registry
+
+import (
+	"context"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+func compatibilityLevelCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compatibility-level",
+		Args:  cobra.ExactArgs(0),
+		Short: "Manage global or per-subject compatibility levels.",
+	}
+
+	cmd.AddCommand(
+		compatGetCommand(),
+		compatSetCommand(),
+	)
+	return cmd
+}
+
+func compatGetCommand() *cobra.Command {
+	var urls []string
+	var global bool
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the global or per-subject compatibility levels",
+		Long: `Get the global or per-subject compatibility levels.
+
+Running this command with no subject returns the global level, alternatively
+you can use the --global flag to get the global level at the same time as
+per-subject levels.
+`,
+		Run: func(_ *cobra.Command, subjects []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			if len(subjects) > 0 && global {
+				subjects = append(subjects, sr.GlobalSubject)
+			}
+			results := cl.CompatibilityLevel(context.Background(), subjects...)
+
+			tw := out.NewTable("subject", "level", "error")
+			defer tw.Flush()
+			for _, r := range results {
+				if r.Subject == "" {
+					r.Subject = "{GLOBAL}"
+				}
+				var err string
+				if r.Err != nil {
+					err = r.Err.Error()
+				}
+				tw.PrintStructFields(struct {
+					Subject string
+					Level   string
+					Err     string
+				}{
+					r.Subject,
+					r.Level.String(),
+					err,
+				})
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().BoolVar(&global, "global", false, "return the global level in addition to subject levels")
+	return cmd
+}
+
+/* DELETE /config/{subject} not implemented by Redpanda yet
+func compatResetCommand() *cobra.Command {
+	var urls []string
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset subject compatibility levels to the global level",
+		Long:  `Reset subject compatibility levels to the global level.`,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(_ *cobra.Command, subjects []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			results := cl.ResetCompatibilityLevel(context.Background(), subjects...)
+
+			tw := out.NewTable("subject", "level", "error")
+			defer tw.Flush()
+			for _, r := range results {
+				var err string
+				if r.Err != nil {
+					err = r.Err.Error()
+				}
+				tw.PrintStructFields(struct {
+					Subject string
+					Level   string
+					Err     string
+				}{
+					r.Subject,
+					r.Level.String(),
+					err,
+				})
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	return cmd
+}
+*/
+
+func compatSetCommand() *cobra.Command {
+	var urls []string
+	var global bool
+	var level string
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set the global or per-subject compatibility levels",
+		Long: `Set the global or per-subject compatibility levels.
+
+Running this command with no subject returns the global level, alternatively
+you can use the --global flag to set the global level at the same time as
+per-subject levels.
+`,
+		Run: func(_ *cobra.Command, subjects []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			if len(subjects) > 0 && global {
+				subjects = append(subjects, sr.GlobalSubject)
+			}
+			var l sr.CompatibilityLevel
+			err = l.UnmarshalText([]byte(level))
+			out.MaybeDieErr(err)
+			results := cl.SetCompatibilityLevel(context.Background(), l, subjects...)
+
+			tw := out.NewTable("subject", "level", "error")
+			defer tw.Flush()
+			for _, r := range results {
+				if r.Subject == "" {
+					r.Subject = "{GLOBAL}"
+				}
+				var err string
+				if r.Err != nil {
+					err = r.Err.Error()
+				}
+				tw.PrintStructFields(struct {
+					Subject string
+					Level   string
+					Err     string
+				}{
+					r.Subject,
+					r.Level.String(),
+					err,
+				})
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().BoolVar(&global, "global", false, "set the global level in addition to subject levels")
+	cmd.Flags().StringVar(&level, "level", "", "level to set, one of NONE, {BACKWARD,FORWARD,FULL}{,_TRANSITIVE}")
+	cmd.MarkFlagRequired("level")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/registry/registry.go
+++ b/src/go/rpk/pkg/cli/cmd/registry/registry.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package registry
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func flagURLs(cmd *cobra.Command, urls *[]string) {
+	cmd.Flags().StringSliceVar(urls, "urls", []string{"localhost:7072"}, "schema registry urls")
+}
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Args:  cobra.ExactArgs(0),
+		Short: "Commands to interact with the schema registry.",
+	}
+
+	cmd.AddCommand(
+		subjectCommand(),
+		schemaCommand(),
+		compatibilityLevelCommand(),
+	)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/registry/schema.go
+++ b/src/go/rpk/pkg/cli/cmd/registry/schema.go
@@ -1,0 +1,390 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+	"github.com/twmb/types"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+)
+
+// TODO: add references flag, `references` command
+// rpk registry schema check-compatibility {subject} --version {version} --schema {schema}
+
+func schemaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Args:  cobra.ExactArgs(0),
+		Short: "Manage your schema registry schemas.",
+	}
+
+	cmd.AddCommand(
+		schemaCreateCommand(),
+		schemaCheckCompatibilityCommand(),
+		schemaDeleteCommand(),
+		schemaGetCommand(),
+		schemaListCommand(),
+	)
+	return cmd
+}
+
+func printSubjectSchemaTable(ss ...sr.SubjectSchema) {
+	tw := out.NewTable("subject", "version", "id", "type")
+	defer tw.Flush()
+	for _, s := range ss {
+		printSubjectSchema(tw, s)
+	}
+}
+
+func printSubjectSchema(tw *out.TabWriter, s sr.SubjectSchema) {
+	tw.PrintStructFields(struct {
+		Subject string
+		Version int
+		ID      int
+		Type    string
+	}{
+		s.Subject,
+		s.Version,
+		s.ID,
+		s.Type.String(),
+	})
+}
+
+func parseVersion(version string) (int, error) {
+	if version == "latest" {
+		return -1, nil
+	}
+	i, err := strconv.Atoi(version)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse version %q", version)
+	}
+	if i < -1 {
+		return 0, fmt.Errorf("invalid version %d", i)
+	}
+	return i, nil
+}
+
+func schemaCheckCompatibilityCommand() *cobra.Command {
+	var urls []string
+	var schemaFile string
+	var sversion string
+	cmd := &cobra.Command{
+		Use:   "check-compatibility SUBJECT",
+		Short: "Check schema compatibility with existing schemas in the subject",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			version, err := parseVersion(sversion)
+			out.MaybeDieErr(err)
+
+			f, err := os.ReadFile(schemaFile)
+			out.MaybeDie(err, "unable to read %q: %v", schemaFile, err)
+
+			var t sr.SchemaType
+			switch {
+			case strings.HasSuffix(schemaFile, ".avro"):
+				t = sr.TypeAvro
+			case strings.HasSuffix(schemaFile, ".proto"):
+				t = sr.TypeProtobuf
+			default:
+				out.Die("unable to determine the schema type from %q", schemaFile)
+			}
+
+			subject := args[0]
+			schema := sr.Schema{
+				Schema: string(f),
+				Type:   t,
+			}
+			compatible, err := cl.CheckCompatibility(context.Background(), subject, version, schema)
+			out.MaybeDie(err, "unable to create schema: %v", err)
+			if compatible {
+				fmt.Println("Schema is compatible.")
+			} else {
+				fmt.Println("Schema is not compatible.")
+			}
+		},
+	}
+
+	flagURLs(cmd, &urls)
+	cmd.Flags().StringVar(&schemaFile, "schema", "", "schema filepath to upload, must be .avro or .proto")
+	cmd.Flags().StringVar(&sversion, "version", "", "version to check compatibility with")
+	cmd.MarkFlagRequired("schema")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+func schemaCreateCommand() *cobra.Command {
+	var urls []string
+	var schemaFile string
+	cmd := &cobra.Command{
+		Use:   "create SUBJECT --schema {filename}",
+		Short: "Create a schema for the given subject.",
+		Long: `Create a schema for the given subject.
+
+This uploads a schema to the registry, creating the schema if it does not
+exist. The schema type is detected by the filename extension: ".avro" for Avro
+and ".proto" for Protobuf. You can manually specify the type with the --type
+flag.
+
+`,
+
+		Args: cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			f, err := os.ReadFile(schemaFile)
+			out.MaybeDie(err, "unable to read %q: %v", schemaFile, err)
+
+			var t sr.SchemaType
+			switch {
+			case strings.HasSuffix(schemaFile, ".avro"):
+				t = sr.TypeAvro
+			case strings.HasSuffix(schemaFile, ".proto"):
+				t = sr.TypeProtobuf
+			default:
+				out.Die("unable to determine the schema type from %q", schemaFile)
+			}
+
+			subject := args[0]
+			schema := sr.Schema{
+				Schema: string(f),
+				Type:   t,
+			}
+			s, err := cl.CreateSchema(context.Background(), subject, schema)
+			out.MaybeDie(err, "unable to create schema: %v", err)
+
+			printSubjectSchemaTable(s)
+		},
+	}
+
+	flagURLs(cmd, &urls)
+	cmd.Flags().StringVar(&schemaFile, "schema", "", "schema filepath to upload, must be .avro or .proto")
+
+	cmd.MarkFlagRequired("schema")
+	return cmd
+}
+
+func schemaDeleteCommand() *cobra.Command {
+	var urls []string
+	var sversion string
+	var permanent bool
+	cmd := &cobra.Command{
+		Use:   "delete SUBJECT --version {version}",
+		Short: "Delete a specific schema for the given subject.",
+		Args:  cobra.ExactArgs(1),
+
+		Run: func(_ *cobra.Command, args []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			version, err := parseVersion(sversion)
+			out.MaybeDieErr(err)
+			subject := args[0]
+			err = cl.DeleteSchema(context.Background(), subject, version, sr.DeleteHow(permanent))
+			out.MaybeDieErr(err)
+			fmt.Println("OK")
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().StringVar(&sversion, "version", "", "version to delete, -1 or latest deletes the latest version")
+	cmd.Flags().BoolVar(&permanent, "permanent", false, "perform a hard (permanent) delete of the schema; requires a soft-delete first")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+func schemaGetCommand() *cobra.Command {
+	var (
+		urls       []string
+		sversion   string
+		id         int
+		schemaFile string
+		deleted    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a schema by version, ID, or by an existing schema",
+		Long: `Get a schema by version, ID, or by an existing schema.
+
+This returns a lookup of an existing schema or schemas in one of a few
+potential (mutually exclusive) ways:
+
+* By version, returning a schema for a required subject and version
+* By ID, returning all subjects using the schema, or filtering for one subject
+* By schema, checking if the schema has been created in the subject
+`,
+		Args: cobra.MaximumNArgs(1),
+
+		Run: func(_ *cobra.Command, args []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			var n int
+			if sversion != "" {
+				n++
+			}
+			if id != 0 {
+				n++
+			}
+			if schemaFile != "" {
+				n++
+			}
+			switch {
+			case n == 0:
+				out.Die("Must specify at least one of --version, --id, or --schema.")
+			case n == 1:
+			default:
+				out.Die("Must specify only one of --version, --id, or --schema.")
+			}
+			if len(args) == 0 && (sversion != "" || schemaFile != "") {
+				out.Die("Subject must be specified for --version or --schema.")
+			}
+
+			switch {
+			case sversion != "":
+				version, err := parseVersion(sversion)
+				out.MaybeDieErr(err)
+				s, err := cl.SchemaByVersion(context.Background(), args[0], version, sr.HideShowDeleted(deleted))
+				out.MaybeDieErr(err)
+				printSubjectSchemaTable(s)
+
+			case id != 0:
+				ss, err := cl.SchemaUsagesByID(context.Background(), id, sr.HideShowDeleted(deleted))
+				out.MaybeDieErr(err)
+				if len(args) == 0 {
+					printSubjectSchemaTable(ss...)
+					return
+				}
+				for _, s := range ss {
+					if s.Subject == args[0] {
+						printSubjectSchemaTable(s)
+						return
+					}
+				}
+
+			case schemaFile != "":
+				f, err := os.ReadFile(schemaFile)
+				out.MaybeDie(err, "unable to read %q: %v", err)
+				var t sr.SchemaType
+				switch {
+				case strings.HasSuffix(schemaFile, ".avro"):
+					t = sr.TypeAvro
+				case strings.HasSuffix(schemaFile, ".proto"):
+					t = sr.TypeProtobuf
+				default:
+					out.Die("unable to determine the schema type from %q", schemaFile)
+				}
+				s, err := cl.LookupSchema(context.Background(), args[0], sr.Schema{
+					Schema: string(f),
+					Type:   t,
+				})
+				out.MaybeDieErr(err)
+				printSubjectSchemaTable(s)
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().StringVar(&sversion, "version", "", "version to lookup, or -1 or latest for the latest version, requires subject")
+	cmd.Flags().IntVar(&id, "id", 0, "ID to lookup schemas usages of, subject optional")
+	cmd.Flags().StringVar(&schemaFile, "schema", "", "schema file to check existence of, must be .avro or .proto, requires subject")
+	cmd.Flags().BoolVar(&deleted, "deleted", false, "if true, allow getting deleted schemas")
+	return cmd
+}
+
+func schemaListCommand() *cobra.Command {
+	var urls []string
+	var deleted bool
+	cmd := &cobra.Command{
+		Use:   "list [SUBJECT...]",
+		Short: "List the schemas for the requested subjects, or list all schemas.",
+
+		Run: func(_ *cobra.Command, subjects []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			if len(subjects) == 0 {
+				subjects, err = cl.Subjects(context.Background(), sr.HideShowDeleted(deleted))
+				out.MaybeDieErr(err)
+			}
+
+			type res struct {
+				subject string
+				ss      []sr.SubjectSchema
+				err     error
+			}
+			var (
+				wg      sync.WaitGroup
+				mu      sync.Mutex
+				results []res
+			)
+
+			for i := range subjects {
+				subject := subjects[i]
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					ss, err := cl.Schemas(context.Background(), subject, sr.HideShowDeleted(deleted))
+					mu.Lock()
+					defer mu.Unlock()
+					results = append(results, res{
+						subject: subject,
+						ss:      ss,
+						err:     err,
+					})
+				}()
+			}
+			wg.Wait()
+
+			types.Sort(results)
+
+			type row struct {
+				Subject string
+				Version int
+				ID      int
+				Type    string
+				Err     string
+			}
+
+			tw := out.NewTable("subject", "version", "id", "type", "error")
+			defer tw.Flush()
+			for _, res := range results {
+				if res.err != nil {
+					tw.PrintStructFields(row{
+						Subject: res.subject,
+						Err:     res.err.Error(),
+					})
+					continue
+				}
+				for _, s := range res.ss {
+					tw.PrintStructFields(row{
+						Subject: s.Subject,
+						Version: s.Version,
+						ID:      s.ID,
+						Type:    s.Type.String(),
+					})
+				}
+			}
+		},
+	}
+
+	flagURLs(cmd, &urls)
+	cmd.Flags().BoolVar(&deleted, "deleted", false, "if true, list deleted schemas as well")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/registry/subject.go
+++ b/src/go/rpk/pkg/cli/cmd/registry/subject.go
@@ -1,0 +1,121 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+)
+
+func subjectCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "subject",
+		Args:  cobra.ExactArgs(0),
+		Short: "List or delete schema registry subjects.",
+	}
+
+	cmd.AddCommand(
+		subjectListCommand(),
+		subjectDeleteCommand(),
+	)
+	return cmd
+}
+
+func subjectListCommand() *cobra.Command {
+	var urls []string
+	var deleted bool
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "Display all subjects.",
+		Args:    cobra.ExactArgs(0),
+		Run: func(*cobra.Command, []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			subjects, err := cl.Subjects(context.Background(), sr.HideShowDeleted(deleted))
+			out.MaybeDieErr(err)
+			for _, s := range subjects {
+				fmt.Println(s)
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().BoolVar(&deleted, "deleted", false, "if true, list deleted subjects as well")
+	return cmd
+}
+
+func subjectDeleteCommand() *cobra.Command {
+	var urls []string
+	var permanent bool
+	cmd := &cobra.Command{
+		Use:   "delete [SUBJECT...]",
+		Short: "Soft or hard delete subjects.",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(_ *cobra.Command, subjects []string) {
+			cl, err := sr.NewClient(sr.URLs(urls...))
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			type res struct {
+				Subject  string
+				Versions []int
+				Err      error
+			}
+			var (
+				wg      sync.WaitGroup
+				mu      sync.Mutex
+				results []res
+			)
+
+			for i := range subjects {
+				subject := subjects[i]
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					versions, err := cl.DeleteSubject(context.Background(), subject, sr.DeleteHow(permanent))
+					mu.Lock()
+					defer mu.Unlock()
+					results = append(results, res{
+						subject,
+						versions,
+						err,
+					})
+				}()
+			}
+			wg.Wait()
+
+			tw := out.NewTable("subject", "versions-deleted", "error")
+			defer tw.Flush()
+			for _, r := range results {
+				var err string
+				if r.Err != nil {
+					err = r.Err.Error()
+				}
+				tw.PrintStructFields(struct {
+					Subject  string
+					Versions []int
+					Err      string
+				}{
+					r.Subject,
+					r.Versions,
+					err,
+				})
+			}
+		},
+	}
+	flagURLs(cmd, &urls)
+	cmd.Flags().BoolVar(&permanent, "permanent", false, "perform a hard (permanent) delete of the subject; requires a soft-delete first")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	plugincmd "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/registry"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
 	log "github.com/sirupsen/logrus"
@@ -70,6 +71,7 @@ func Execute() {
 	rootCmd.AddCommand(NewClusterCommand(fs))
 	rootCmd.AddCommand(NewACLCommand(fs))
 	rootCmd.AddCommand(group.NewCommand(fs))
+	rootCmd.AddCommand(registry.NewCommand())
 
 	rootCmd.AddCommand(plugincmd.NewCommand(fs))
 


### PR DESCRIPTION
WIP

Adds a `registry` command to rpk to interact with the schema registry.

This should probably wait until we have `-X` support so that we can just use that to configure the registry addr, rather than a new soon-to-be-deprecated urls flag.