### PR TITLE
Using `serde` in `redpanda/controller/0` partition

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -207,13 +207,22 @@ bool are_replica_sets_equal(
 template<typename Cmd>
 ss::future<std::error_code> replicate_and_wait(
   ss::sharded<controller_stm>& stm,
+  ss::sharded<feature_table>& feature_table,
   ss::sharded<ss::abort_source>& as,
   Cmd&& cmd,
   model::timeout_clock::time_point timeout) {
+    const bool use_serde_serialization = feature_table.local().is_active(
+      feature::serde_raft_0);
     return stm.invoke_on(
       controller_stm_shard,
-      [cmd = std::forward<Cmd>(cmd), &as = as, timeout](
-        controller_stm& stm) mutable {
+      [cmd = std::forward<Cmd>(cmd),
+       &as = as,
+       timeout,
+       use_serde_serialization](controller_stm& stm) mutable {
+          if (likely(use_serde_serialization)) {
+              auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
+              return stm.replicate_and_wait(std::move(b), timeout, as.local());
+          }
           return serialize_cmd(std::forward<Cmd>(cmd))
             .then([&stm, timeout, &as](model::record_batch b) {
                 return stm.replicate_and_wait(

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -41,6 +41,11 @@ using command_type = named_type<int8_t, struct command_type_tag>;
 // Generic controller command, this type is base for all commands
 template<typename K, typename V, int8_t tp, model::record_batch_type bt>
 struct controller_command {
+    static_assert(
+      tp >= 0,
+      "Command type must be greater than 0. Negative values are used to "
+      "determine serialization type");
+
     using key_t = K;
     using value_t = V;
 

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -19,6 +19,7 @@
 #include "reflection/async_adl.h"
 #include "security/credential_store.h"
 #include "security/scram_credential.h"
+#include "serde/serde.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/coroutine.hh>
@@ -271,19 +272,59 @@ serialize_cmd(Cmd cmd) {
             });
       });
 }
+// flag indicating tha the command was serialized using serde serialization
+static constexpr int8_t serde_serialized_cmd_flag = -1;
+
+template<typename Cmd>
+requires ControllerCommand<Cmd> model::record_batch
+serde_serialize_cmd(Cmd cmd) {
+    iobuf key_buf;
+    iobuf value_buf;
+    /**
+     * We leverage the fact that all reflection::adl serialized commands have
+     * command type that is >= 0. To indicate the new format we will use single
+     * byte set to -1. This will allow choosing appropriate deserializer.
+     */
+    using serde::write;
+    write<int8_t>(value_buf, serde_serialized_cmd_flag);
+    write<int8_t>(value_buf, Cmd::type);
+
+    write(value_buf, std::move(cmd.value));
+    write(key_buf, std::move(cmd.key));
+
+    simple_batch_builder builder(Cmd::batch_type, model::offset(0));
+    builder.add_raw_kv(std::move(key_buf), std::move(value_buf));
+    return std::move(builder).build();
+}
 
 namespace internal {
 template<typename Cmd>
 struct deserializer {
-    ss::future<Cmd> deserialize(iobuf_parser k_parser, iobuf_parser v_parser) {
-        using key_t = typename Cmd::key_t;
-        using value_t = typename Cmd::value_t;
+    using key_t = typename Cmd::key_t;
+    using value_t = typename Cmd::value_t;
+    ss::future<Cmd>
+    deserialize(iobuf_parser k_parser, iobuf_parser v_parser, bool use_serde) {
+        if (likely(use_serde)) {
+            co_return serde_deserialize(
+              std::move(k_parser), std::move(v_parser));
+        }
+        co_return co_await adl_deserialize(
+          std::move(k_parser), std::move(v_parser));
+    }
 
+    ss::future<Cmd>
+    adl_deserialize(iobuf_parser k_parser, iobuf_parser v_parser) {
         auto results = co_await ss::when_all_succeed(
           reflection::async_adl<key_t>{}.from(k_parser),
           reflection::async_adl<value_t>{}.from(v_parser));
 
         co_return Cmd(std::get<0>(results), std::get<1>(results));
+    }
+
+    Cmd serde_deserialize(iobuf_parser k_parser, iobuf_parser v_parser) {
+        using serde::read;
+
+        return Cmd(read<key_t>(k_parser), read<value_t>(v_parser));
     }
 };
 
@@ -306,6 +347,14 @@ deserialize(model::record_batch b, commands_type_list<Commands...>) {
     auto records = b.copy_records();
     iobuf_parser v_parser(records.begin()->release_value());
     iobuf_parser k_parser(records.begin()->release_key());
+    const bool use_serde_serialization = reflection::adl<int8_t>{}.from(
+                                           v_parser.peek(1))
+                                         == serde_serialized_cmd_flag;
+    if (likely(use_serde_serialization)) {
+        // skip over indicator field
+        v_parser.skip(1);
+    }
+
     // chose deserializer
     auto cmd_type = reflection::adl<command_type>{}.from(v_parser);
     std::optional<std::variant<internal::deserializer<Commands>...>> ret;
@@ -313,8 +362,11 @@ deserialize(model::record_batch b, commands_type_list<Commands...>) {
 
     return std::visit(
       [k_parser = std::move(k_parser),
-       v_parser = std::move(v_parser)](auto& d) mutable {
-          return d.deserialize(std::move(k_parser), std::move(v_parser))
+       v_parser = std::move(v_parser),
+       use_serde_serialization](auto& d) mutable {
+          return d
+            .deserialize(
+              std::move(k_parser), std::move(v_parser), use_serde_serialization)
             .then([](auto cmd) {
                 return std::variant<Commands...>(std::move(cmd));
             });

--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -21,10 +21,12 @@ config_frontend::config_frontend(
   ss::sharded<controller_stm>& stm,
   ss::sharded<rpc::connection_cache>& connections,
   ss::sharded<partition_leaders_table>& leaders,
+  ss::sharded<feature_table>& features,
   ss::sharded<ss::abort_source>& as)
   : _stm(stm)
   , _connections(connections)
   , _leaders(leaders)
+  , _features(features)
   , _as(as)
   , _self(config::node().node_id()) {}
 
@@ -101,7 +103,7 @@ ss::future<config_frontend::patch_result> config_frontend::do_patch(
           clusterlog.trace,
           "patch: writing delta with version {}",
           projected_version);
-        return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
+        return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
           .then([projected_version](std::error_code errc) {
               return patch_result{.errc = errc, .version = projected_version};
           });
@@ -124,7 +126,8 @@ ss::future<std::error_code> config_frontend::set_status(
     auto data = cluster_config_status_cmd_data();
     data.status = status;
     auto cmd = cluster_config_status_cmd(status.node, data);
-    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+    co_return co_await replicate_and_wait(
+      _stm, _features, _as, std::move(cmd), timeout);
 }
 
 /**

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -33,6 +33,7 @@ public:
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
+      ss::sharded<feature_table>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<patch_result>
@@ -53,6 +54,7 @@ private:
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<feature_table>& _features;
     ss::sharded<ss::abort_source>& _as;
 
     // Initially unset, frontend is not writeable until backend finishes

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -128,6 +128,7 @@ ss::future<> controller::start() {
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),
+            std::ref(_feature_table),
             std::ref(_as));
       })
       .then([this] {
@@ -165,11 +166,13 @@ ss::future<> controller::start() {
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),
+            std::ref(_feature_table),
             std::ref(_as),
             std::ref(_authorizer));
       })
       .then([this] {
-          return _data_policy_frontend.start(std::ref(_stm), std::ref(_as));
+          return _data_policy_frontend.start(
+            std::ref(_stm), std::ref(_feature_table), std::ref(_as));
       })
       .then([this] {
           return _tp_frontend.start(
@@ -181,7 +184,8 @@ ss::future<> controller::start() {
             std::ref(_tp_state),
             std::ref(_data_policy_frontend),
             std::ref(_as),
-            std::ref(_cloud_storage_api));
+            std::ref(_cloud_storage_api),
+            std::ref(_feature_table));
       })
       .then([this] {
           return _members_backend.start_single(

--- a/src/v/cluster/data_policy_frontend.cc
+++ b/src/v/cluster/data_policy_frontend.cc
@@ -12,14 +12,20 @@
 #include "cluster/data_policy_frontend.h"
 
 #include "cluster/cluster_utils.h"
+#include "cluster/fwd.h"
+
+#include <seastar/core/sharded.hh>
 
 #include <optional>
 
 namespace cluster {
 
 data_policy_frontend::data_policy_frontend(
-  ss::sharded<controller_stm>& stm, ss::sharded<ss::abort_source>& as) noexcept
+  ss::sharded<controller_stm>& stm,
+  ss::sharded<feature_table>& features,
+  ss::sharded<ss::abort_source>& as) noexcept
   : _stm(stm)
+  , _features(features)
   , _as(as) {}
 
 ss::future<std::error_code> data_policy_frontend::create_data_policy(
@@ -28,13 +34,13 @@ ss::future<std::error_code> data_policy_frontend::create_data_policy(
   model::timeout_clock::time_point tout) {
     create_data_policy_cmd_data cmd_data{.dp = std::move(dp)};
     create_data_policy_cmd cmd(std::move(topic), std::move(cmd_data));
-    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
 }
 
 ss::future<std::error_code> data_policy_frontend::clear_data_policy(
   model::topic_namespace topic, model::timeout_clock::time_point tout) {
     delete_data_policy_cmd cmd(std::move(topic), std::nullopt);
-    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
 }
 
 } // namespace cluster

--- a/src/v/cluster/data_policy_frontend.h
+++ b/src/v/cluster/data_policy_frontend.h
@@ -24,7 +24,9 @@ namespace cluster {
 class data_policy_frontend final {
 public:
     data_policy_frontend(
-      ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&) noexcept;
+      ss::sharded<controller_stm>&,
+      ss::sharded<feature_table>&,
+      ss::sharded<ss::abort_source>&) noexcept;
 
     ss::future<std::error_code> create_data_policy(
       model::topic_namespace,
@@ -36,6 +38,7 @@ public:
 
 private:
     ss::sharded<controller_stm>& _stm;
+    ss::sharded<feature_table>& _features;
     ss::sharded<ss::abort_source>& _as;
 };
 

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -347,7 +347,8 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     );
 
     auto timeout = model::timeout_clock::now() + status_retry;
-    auto err = co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+    auto err = co_await replicate_and_wait(
+      _stm, _feature_table, _as, std::move(cmd), timeout);
     if (err == errc::not_leader) {
         // Harmless, we lost leadership so the new controller
         // leader is responsible for picking up where we left off.
@@ -423,7 +424,8 @@ feature_manager::write_action(cluster::feature_update_action action) {
           std::move(data),
           0 // unused
         );
-        return replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+        return replicate_and_wait(
+          _stm, _feature_table, _as, std::move(cmd), timeout);
     }
 }
 

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -26,6 +26,8 @@ std::string_view to_string_view(feature f) {
         return "maintenance_mode";
     case feature::mtls_authentication:
         return "mtls_authentication";
+    case feature::serde_raft_0:
+        return "serde_raft_0";
     case feature::test_alpha:
         return "__test_alpha";
     }
@@ -54,7 +56,7 @@ std::string_view to_string_view(feature_state::state s) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
-static constexpr cluster_version latest_version = cluster_version{3};
+static constexpr cluster_version latest_version = cluster_version{4};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -24,6 +24,7 @@ enum class feature : std::uint64_t {
     consumer_offsets = 0x2,
     maintenance_mode = 0x4,
     mtls_authentication = 0x8,
+    serde_raft_0 = 0x10,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -99,6 +100,12 @@ constexpr static std::array feature_schema{
     "mtls_authentication",
     feature::mtls_authentication,
     feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{4},
+    "serde_raft_0",
+    feature::serde_raft_0,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{2001},

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -153,6 +153,7 @@ members_frontend::set_maintenance_mode(model::node_id id, bool enabled) {
     if (leader == _self) {
         co_return co_await replicate_and_wait(
           _stm,
+          _feature_table,
           _as,
           maintenance_mode_cmd(id, enabled),
           _node_op_timeout + model::timeout_clock::now());

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -53,7 +53,11 @@ private:
     template<typename T>
     ss::future<std::error_code> do_replicate_node_command(model::node_id id) {
         return replicate_and_wait(
-          _stm, _as, T(id, 0), _node_op_timeout + model::timeout_clock::now());
+          _stm,
+          _feature_table,
+          _as,
+          T(id, 0),
+          _node_op_timeout + model::timeout_clock::now());
     }
 
     model::node_id _self;

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -30,6 +30,7 @@ public:
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
+      ss::sharded<feature_table>&,
       ss::sharded<ss::abort_source>&,
       ss::sharded<security::authorizer>&);
 
@@ -75,6 +76,7 @@ private:
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<feature_table>& _features;
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<security::authorizer>& _authorizer;
 };

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -50,7 +50,8 @@ topics_frontend::topics_frontend(
   ss::sharded<topic_table>& topics,
   ss::sharded<data_policy_frontend>& dp_frontend,
   ss::sharded<ss::abort_source>& as,
-  ss::sharded<cloud_storage::remote>& cloud_storage_api)
+  ss::sharded<cloud_storage::remote>& cloud_storage_api,
+  ss::sharded<feature_table>& features)
   : _self(self)
   , _stm(s)
   , _allocator(pal)
@@ -59,7 +60,8 @@ topics_frontend::topics_frontend(
   , _topics(topics)
   , _dp_frontend(dp_frontend)
   , _as(as)
-  , _cloud_storage_api(cloud_storage_api) {}
+  , _cloud_storage_api(cloud_storage_api)
+  , _features(features) {}
 
 static bool
 needs_linearizable_barrier(const std::vector<topic_result>& results) {
@@ -235,7 +237,7 @@ ss::future<topic_result> topics_frontend::do_update_topic_properties(
               std::move(update.tp_ns), cluster::errc(update_dp_res.value()));
         }
         auto ec = co_await replicate_and_wait(
-          _stm, _as, std::move(cmd), timeout);
+          _stm, _features, _as, std::move(cmd), timeout);
         co_return topic_result(std::move(update.tp_ns), map_errc(ec));
     } catch (...) {
         vlog(
@@ -259,7 +261,7 @@ ss::future<topic_result> topics_frontend::do_create_non_replicable_topic(
     create_non_replicable_topic_cmd cmd(data, 0);
     try {
         auto ec = co_await replicate_and_wait(
-          _stm, _as, std::move(cmd), timeout);
+          _stm, _features, _as, std::move(cmd), timeout);
         co_return topic_result(data.name, map_errc(ec));
     } catch (const std::exception& ex) {
         vlog(
@@ -470,7 +472,7 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
           random_generators::internal::gen);
     }
 
-    return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
+    return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
       .then_wrapped([tp_ns = std::move(tp_ns), units = std::move(units)](
                       ss::future<std::error_code> f) mutable {
           try {
@@ -525,7 +527,7 @@ ss::future<topic_result> topics_frontend::do_delete_topic(
   model::topic_namespace tp_ns, model::timeout_clock::time_point timeout) {
     delete_topic_cmd cmd(tp_ns, tp_ns);
 
-    return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
+    return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
       .then_wrapped(
         [tp_ns = std::move(tp_ns)](ss::future<std::error_code> f) mutable {
             try {
@@ -614,7 +616,7 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
     }
     move_partition_replicas_cmd cmd(std::move(ntp), std::move(new_replica_set));
 
-    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
 }
 
 ss::future<std::error_code> topics_frontend::finish_moving_partition_replicas(
@@ -633,7 +635,7 @@ ss::future<std::error_code> topics_frontend::finish_moving_partition_replicas(
         finish_moving_partition_replicas_cmd cmd(
           std::move(ntp), std::move(new_replica_set));
 
-        return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+        return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
     }
 
     return _connections.local()
@@ -746,7 +748,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
 
     try {
         auto ec = co_await replicate_and_wait(
-          _stm, _as, std::move(cmd), timeout);
+          _stm, _features, _as, std::move(cmd), timeout);
         co_return topic_result(tp_ns, map_errc(ec));
     } catch (...) {
         vlog(

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -44,7 +44,8 @@ public:
       ss::sharded<topic_table>&,
       ss::sharded<data_policy_frontend>&,
       ss::sharded<ss::abort_source>&,
-      ss::sharded<cloud_storage::remote>&);
+      ss::sharded<cloud_storage::remote>&,
+      ss::sharded<feature_table>&);
 
     ss::future<std::vector<topic_result>> create_topics(
       std::vector<custom_assignable_topic_configuration>,
@@ -137,6 +138,7 @@ private:
     ss::sharded<data_policy_frontend>& _dp_frontend;
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+    ss::sharded<feature_table>& _features;
     bool _partition_movement_disabled = false;
 };
 

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -11,12 +11,14 @@
 #pragma once
 #include "bytes/bytes.h"
 #include "reflection/adl.h"
+#include "serde/envelope.h"
 
 #include <iosfwd>
 
 namespace security {
 
-class scram_credential {
+class scram_credential
+  : public serde::envelope<scram_credential, serde::version<0>> {
 public:
     scram_credential() noexcept = default;
 
@@ -33,6 +35,10 @@ public:
     int iterations() const { return _iterations; }
 
     bool operator==(const scram_credential&) const = default;
+
+    auto serde_fields() {
+        return std::tie(_salt, _server_key, _stored_key, _iterations);
+    }
 
 private:
     friend std::ostream& operator<<(std::ostream&, const scram_credential&);

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -1,0 +1,417 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from enum import Enum, auto, unique
+import random
+import re
+import string
+from threading import Event
+import threading
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from time import sleep
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+
+
+# Base class for operation
+class Operation():
+    def execute(self, redpanda) -> bool:
+        return False
+
+    def validate(self, redpanda) -> bool:
+        pass
+
+
+def random_string(length):
+    return ''.join(
+        [random.choice(string.ascii_letters) for i in range(0, length)])
+
+
+@unique
+class RedpandaAdminOperation(Enum):
+    CREATE_TOPIC = auto()
+    DELETE_TOPIC = auto()
+    UPDATE_TOPIC = auto()
+    ADD_PARTITIONS = auto()
+    CREATE_USER = auto()
+    DELETE_USER = auto()
+    CREATE_ACLS = auto()
+    UPDATE_CONFIG = auto()
+
+
+def _random_choice(prefix, collection):
+    filtered = list(filter(lambda t: t.startswith(prefix), collection))
+    if len(filtered) == 0:
+        return None
+    return random.choice(filtered)
+
+
+def _choice_random_topic(redpanda, prefix):
+    return _random_choice(prefix, RpkTool(redpanda).list_topics())
+
+
+def _choice_random_user(redpanda, prefix):
+    return _random_choice(prefix, Admin(redpanda).list_users())
+
+
+# topic operations
+class CreateTopicOperation(Operation):
+    def __init__(self, prefix, max_partitions, max_replication):
+        self.prefix = prefix
+        self.topic = f'{prefix}-{random_string(6)}'
+        self.partitions = random.randint(1, max_partitions)
+        self.rf = random.choice([x for x in range(1, max_replication + 1, 2)])
+
+    def execute(self, redpanda):
+        redpanda.logger.info(
+            f"Creating topic with name {self.topic}, replication: {self.rf} partitions: {self.partitions}"
+        )
+        rpk = RpkTool(redpanda)
+        rpk.create_topic(self.topic, self.partitions, self.rf)
+        return True
+
+    def validate(self, redpanda):
+        if self.topic is None:
+            return False
+        redpanda.logger.info(f"Validating topic {self.topic} creation")
+        rpk = RpkTool(redpanda)
+        topics = rpk.list_topics()
+        return self.topic in topics
+
+
+class DeleteTopicOperation(Operation):
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.topic = None
+
+    def execute(self, redpanda):
+        rpk = RpkTool(redpanda)
+
+        self.topic = _choice_random_topic(redpanda, prefix=self.prefix)
+        if self.topic is None:
+            return False
+        redpanda.logger.info(f"Deleting topic: {self.topic}")
+        rpk.delete_topic(self.topic)
+        return True
+
+    def validate(self, redpanda):
+        if self.topic is None:
+            return False
+        redpanda.logger.info(f"Validating topic {self.topic} deletion")
+        rpk = RpkTool(redpanda)
+        topics = rpk.list_topics()
+        return self.topic not in topics
+
+
+class UpdateTopicOperation(Operation):
+
+    properties = {
+        TopicSpec.PROPERTY_CLEANUP_POLICY:
+        lambda: random.choice(['delete', 'compact']),
+        TopicSpec.PROPERTY_TIMESTAMP_TYPE:
+        lambda: random.choice(['CreateTime', 'LogAppendTime']),
+        TopicSpec.PROPERTY_SEGMENT_SIZE:
+        lambda: random.randint(10 * 2 ^ 20, 512 * 2 ^ 20),
+        TopicSpec.PROPERTY_RETENTION_BYTES:
+        lambda: random.randint(10 * 2 ^ 20, 512 * 2 ^ 20),
+        TopicSpec.PROPERTY_RETENTION_TIME:
+        lambda: random.randint(10000, 1000000)
+    }
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.topic = None
+        self.property = None
+        self.value = None
+
+    def execute(self, redpanda):
+        rpk = RpkTool(redpanda)
+
+        self.topic = _choice_random_topic(redpanda, prefix=self.prefix)
+
+        if self.topic is None:
+            return False
+
+        self.property = random.choice(
+            list(UpdateTopicOperation.properties.keys()))
+        self.value = UpdateTopicOperation.properties[self.property]()
+
+        redpanda.logger.info(
+            f"Updating topic: {self.topic} with: {self.property}={self.value}")
+        rpk.alter_topic_config(self.topic, self.property, str(self.value))
+        return True
+
+    def validate(self, redpanda):
+        if self.topic is None:
+            return False
+        redpanda.logger.info(
+            f"Validating topic {self.topic} update, expected: {self.property}={self.value}"
+        )
+        rpk = RpkTool(redpanda)
+
+        desc = rpk.describe_topic_configs(self.topic)
+        return desc[self.property][0] == str(self.value)
+
+
+class AddPartitionsOperation(Operation):
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.topic = None
+        self.total_partitions = None
+
+    def execute(self, redpanda):
+        rpk = RpkTool(redpanda)
+
+        self.topic = _choice_random_topic(redpanda, prefix=self.prefix)
+        if self.topic is None:
+            return False
+        current = len(list(rpk.describe_topic(self.topic)))
+        to_add = random.randint(1, 5)
+        self.total = current + to_add
+        redpanda.logger.info(
+            f"Updating topic: {self.topic} partitions count, current: {current} adding: {to_add} partitions"
+        )
+        rpk.add_topic_partitions(self.topic, to_add)
+        return True
+
+    def validate(self, redpanda):
+        if self.topic is None:
+            return False
+        rpk = RpkTool(redpanda)
+        redpanda.logger.info(
+            f"Validating topic {self.topic} partitions update")
+        current = len(list(rpk.describe_topic(self.topic)))
+        return current == self.total
+
+
+class CreateUserOperation(Operation):
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.user = f'{prefix}-user-{random_string(6)}'
+        self.password = f'{prefix}-user-{random_string(6)}'
+        self.algorithm = "SCRAM-SHA-256"
+
+    def execute(self, redpanda):
+        admin = Admin(redpanda)
+        redpanda.logger.info(f"Creating user: {self.user}")
+        admin.create_user(self.user, self.password, self.algorithm)
+        return True
+
+    def validate(self, redpanda):
+        if self.user is None:
+            return False
+        admin = Admin(redpanda)
+        redpanda.logger.info(f"Validating user {self.user} is present")
+        users = admin.list_users()
+        return self.user in users
+
+
+class DeleteUserOperation(Operation):
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.user = None
+
+    def execute(self, redpanda):
+        admin = Admin(redpanda)
+        self.user = _choice_random_user(redpanda, prefix=self.prefix)
+        if self.user is None:
+            return False
+        redpanda.logger.info(f"Deleting user: {self.user}")
+        admin.delete_user(self.user)
+        return True
+
+    def validate(self, redpanda):
+        if self.user is None:
+            return False
+        admin = Admin(redpanda)
+        redpanda.logger.info(f"Validating user {self.user} is deleted")
+        users = admin.list_users()
+        return self.user not in users
+
+
+class CreateAclOperation(Operation):
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.user = None
+
+    def execute(self, redpanda):
+        self.user = _choice_random_user(redpanda, prefix=self.prefix)
+        if self.user is None:
+            return False
+
+        rpk = RpkTool(redpanda)
+
+        redpanda.logger.info(
+            f"Creating allow cluster describe ACL for user: {self.user}")
+        rpk.acl_create_allow_cluster(self.user, op="describe")
+
+        return True
+
+    def validate(self, redpanda):
+        if self.user is None:
+            return False
+        redpanda.logger.info(f"Validating user {self.user} ACL is present")
+        rpk = RpkTool(redpanda)
+        acls = rpk.acl_list()
+        lines = acls.splitlines()
+        for l in lines:
+            if self.user in l and "ALLOW" in l:
+                return True
+        return False
+
+
+class UpdateConfigOperation(Operation):
+    # property values generator
+    properties = {
+        "group_max_session_timeout_ms":
+        lambda: random.randint(300000, 600000),
+        "metadata_dissemination_retry_delay_ms":
+        lambda: random.randint(2000, 10000),
+        "log_message_timestamp_type":
+        lambda: random.choice(['CreateTime', 'LogAppendTime']),
+        "alter_topic_cfg_timeout_ms":
+        lambda: random.randint(2000, 10000),
+    }
+
+    def __init__(self):
+        p = random.choice(list(UpdateConfigOperation.properties.items()))
+        self.property = p[0]
+        self.value = p[1]()
+
+    def execute(self, redpanda):
+        rpk = RpkTool(redpanda)
+        redpanda.logger.info(
+            f"Updating {self.property} value with {self.value}")
+        rpk.cluster_config_set(self.property, str(self.value))
+        return True
+
+    def validate(self, redpanda):
+        rpk = RpkTool(redpanda)
+        redpanda.logger.info(
+            f"Validating cluster configuration is set {self.property}=={self.value}"
+        )
+        return rpk.cluster_config_get(self.property) == str(self.value)
+
+
+class AdminOperationsFuzzer():
+    def __init__(self,
+                 redpanda,
+                 initial_entities=10,
+                 retries=5,
+                 retries_interval=5,
+                 operation_timeout=30,
+                 operations_interval=1,
+                 max_partitions=10,
+                 max_replication=3):
+        self.redpanda = redpanda
+        self.initial_entities = initial_entities
+        self.retries = retries
+        self.retries_interval = retries_interval
+        self.operation_timeout = operation_timeout
+        self.operations_interval = operations_interval
+        self.max_partitions = max_partitions
+        self.max_replication = max_replication
+
+        self.prefix = f'fuzzy-operator-{random.randint(0,10000)}'
+        self._stopping = Event()
+        self.executed = 0
+
+        self.error = None
+
+    def start(self):
+        self.thread = threading.Thread(target=lambda: self.thread_loop(),
+                                       args=())
+        # pre-populate cluster with users and topics
+        for i in range(0, self.initial_entities):
+            CreateTopicOperation(self.prefix, 1,
+                                 self.max_replication).execute(self.redpanda)
+            CreateUserOperation(self.prefix).execute(self.redpanda)
+        self.thread.start()
+
+    def thread_loop(self):
+        while not self._stopping.is_set():
+            op_type, op = self.make_random_operation()
+
+            def validate_result():
+                try:
+                    op.validate(self.redpanda)
+                except Exception as e:
+                    self.redpanda.logger.debug(
+                        f"Error validating operation {op_type} - {e}")
+                    return False
+
+            try:
+                if self.execute_with_retries(op_type, op):
+                    wait_until(lambda: validate_result,
+                               timeout_sec=self.operation_timeout,
+                               backoff_sec=1)
+                    self.executed += 1
+                    sleep(self.operations_interval)
+                else:
+                    self.redpanda.logger.info(
+                        f"Skipped operation: {op_type}, current cluster state does not allow executing the operation"
+                    )
+            except Exception as e:
+                self.redpanda.logger.error(f"Operation: {op_type} error: {e}")
+                self.error = e
+                self._stopping.set()
+
+    def execute_with_retries(self, op_type, op):
+        self.redpanda.logger.info(
+            f"Executing operation: {op_type} with {self.retries} retries")
+        if self.retries == 0:
+            return op.execute(self.redpanda)
+        error = None
+        for retry in range(0, self.retries):
+            try:
+                if retry > 0:
+                    # it might happened that operation was already successful
+                    if op.validate(self.redpanda):
+                        return True
+                return op.execute(self.redpanda)
+            except Exception as e:
+                error = e
+                self.redpanda.logger.info(
+                    f"Operation: {op_type} error: {error}, retires left: {self.retries-retry}/{self.retries}"
+                )
+                sleep(1)
+        raise error
+
+    def make_random_operation(self) -> Operation:
+        op = random.choice([o for o in RedpandaAdminOperation])
+        actions = {
+            RedpandaAdminOperation.CREATE_TOPIC:
+            lambda: CreateTopicOperation(self.prefix, self.max_partitions, self
+                                         .max_replication),
+            RedpandaAdminOperation.DELETE_TOPIC:
+            lambda: DeleteTopicOperation(self.prefix),
+            RedpandaAdminOperation.UPDATE_TOPIC:
+            lambda: UpdateTopicOperation(self.prefix),
+            RedpandaAdminOperation.ADD_PARTITIONS:
+            lambda: AddPartitionsOperation(self.prefix),
+            RedpandaAdminOperation.CREATE_USER:
+            lambda: CreateUserOperation(self.prefix),
+            RedpandaAdminOperation.DELETE_USER:
+            lambda: DeleteUserOperation(self.prefix),
+            RedpandaAdminOperation.CREATE_ACLS:
+            lambda: CreateAclOperation(self.prefix),
+            RedpandaAdminOperation.UPDATE_CONFIG:
+            lambda: UpdateConfigOperation(),
+        }
+        return (op, actions[op]())
+
+    def stop(self):
+        self._stopping.set()
+        self.thread.join()
+        if self.error:
+            raise self.error
+
+    def wait(self, count, timeout):
+        wait_until(lambda: self.executed > count, timeout, 2)

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -40,7 +40,7 @@ class FeaturesTestBase(RedpandaTest):
         # This assertion will break each time we increment the value
         # of `latest_version` in the redpanda source.  Update it when
         # that happens.
-        assert features_response['cluster_version'] == 3
+        assert features_response['cluster_version'] == 4
 
         assert self._get_features_map(
             features_response)['central_config']['state'] == 'active'

--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -1,0 +1,79 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import threading
+import time
+
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.clients.default import DefaultClient
+from ducktape.utils.util import wait_until
+from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
+
+from ducktape.mark import matrix
+
+
+class ControllerUpgradeTest(EndToEndTest):
+    @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_updating_cluster_when_executing_operations(self):
+        '''
+        Validates that cluster is operational when upgrading controller log
+        '''
+
+        # set redpanda logical version to value without __consumer_offsets support
+        self.redpanda = RedpandaService(
+            self.test_context,
+            5,
+            # set redpanda logical version to v22.1 - last version without serde encoding
+            environment={"__REDPANDA_LOGICAL_VERSION": 3})
+
+        self.redpanda.start()
+        admin_fuzz = AdminOperationsFuzzer(self.redpanda)
+        self._client = DefaultClient(self.redpanda)
+
+        spec = TopicSpec(partition_count=6, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+
+        self.start_producer(1, throughput=5000)
+        self.start_consumer(1)
+        self.await_startup()
+        admin_fuzz.start()
+
+        def cluster_is_stable():
+            admin = Admin(self.redpanda)
+            brokers = admin.get_brokers()
+            if len(brokers) < 3:
+                return False
+
+            for b in brokers:
+                self.logger.debug(f"broker:  {b}")
+                if not (b['is_alive'] and 'disk_space' in b):
+                    return False
+
+            return True
+
+        # reset environment to use latest redpanda logical version
+        self.redpanda.set_environment({})
+        for n in self.redpanda.nodes:
+
+            self.redpanda.restart_nodes(n, stop_timeout=60)
+
+            # wait for leader balancer to start evening out leadership
+            wait_until(cluster_is_stable, 90, backoff_sec=2)
+
+        self.run_validation(min_records=100000,
+                            producer_timeout_sec=300,
+                            consumer_timeout_sec=180)
+        admin_fuzz.wait(20, 240)
+        admin_fuzz.stop()


### PR DESCRIPTION
## Cover letter

Changed serialization framework of all controller commands to use `serde`. 

### Compatibility with old `adl` serialized commands

In order to be able to determine if a command being read from `raft_0` log is `serde` or `adl` serialized we use a single byte flag. The flag is serialized as a first field in command record value. For all `serde` serialized commands we set a flag to `-1`. 
For all `adl` serialized commands first byte of command record value is a command type. Command type values are always positive hence we can use negative value to chose serialization format.

### Feature manager integration 

Commands serialization framework is chosen based on the `serde_raft_0` feature being enabled. Feature manager provides barrier allowing cluster to decide when it is safe to use certain feature. In the case of `serde` enabled raft0 commands serialization the feature barrier guarantees that all the nodes are able to deserialize `serde` serialized commands.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
