### PR TITLE
Attempt to avoid repeated finds during housekeeping

### DIFF
--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "storage/log.h"
+#include "utils/intrusive_list_helpers.h"
 
 namespace storage {
 struct log_housekeeping_meta {
@@ -25,6 +26,8 @@ struct log_housekeeping_meta {
     log handle;
     bitflags flags{bitflags::none};
     ss::lowres_clock::time_point last_compaction;
+
+    intrusive_list_hook link;
 };
 
 inline log_housekeeping_meta::bitflags operator|(


### PR DESCRIPTION
## Cover letter

This PR changes `log_manager::housekeeping` to attempt to iterate over `_logs` in one pass while looking for non-compacted logs. The current implementation will iterate over `_logs` twice per loop to find non-compacted logs. 

## Release notes
* none