### PR TITLE
rpc: add method_id accessors for generated code

### DIFF
--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -353,7 +353,7 @@ FIXTURE_TEST(corrupted_header_at_client_test, rpc_integration_fixture) {
     rpc::netbuf nb;
     nb.set_compression(rpc::compression_type::none);
     nb.set_correlation_id(10);
-    nb.set_service_method_id(960598415);
+    nb.set_service_method_id(echo::echo_service::echo_method_id);
     reflection::adl<echo::echo_req>{}.to(
       nb.buffer(), echo::echo_req{.str = "testing..."});
     // will fail all the futures as server close the connection
@@ -395,7 +395,7 @@ FIXTURE_TEST(corrupted_data_at_server, rpc_integration_fixture) {
     rpc::netbuf nb;
     nb.set_compression(rpc::compression_type::none);
     nb.set_correlation_id(10);
-    nb.set_service_method_id(960598415);
+    nb.set_service_method_id(echo::echo_service::echo_method_id);
     auto bytes = random_generators::get_bytes();
     nb.buffer().append(bytes.c_str(), bytes.size());
 

--- a/tools/rpcgen.py
+++ b/tools/rpcgen.py
@@ -57,6 +57,10 @@ class {{service_name}}_service : public rpc::service {
 public:
     class failure_probes;
 
+    {%- for method in methods %}
+    inline static constexpr uint32_t {{method.name}}_method_id = {{method.id}};
+    {%- endfor %}
+
     {{service_name}}_service(ss::scheduling_group sc, ss::smp_service_group ssg)
        : _sc(sc), _ssg(ssg) {}
 
@@ -101,8 +105,8 @@ public:
        return _ssg;
     }
 
-    rpc::method* method_from_id(uint32_t idx) final {
-       switch(idx) {
+    rpc::method* method_from_id(uint32_t id) final {
+       switch(id) {
        {%- for method in methods %}
          case {{method.id}}: return &_methods[{{loop.index - 1}}];
        {%- endfor %}


### PR DESCRIPTION
## Cover letter

We sometimes rely on hardcoding magic numbers in tests. This makes our
test code more confusing to read and potentially error prone. Without
knowing these numbers ahead of time and without the generated code on
hand, it's difficult to verify correctness in review.

Fixes #4892 

## Release notes
* none

[force push:](https://github.com/redpanda-data/redpanda/compare/3bb50fa2892deb1a6c7d1a691b7166ac6e721929..96d12f8a03bf7f78aecfc869e4458f15e7fbe023)
- use `constexpr` instead of `const`