### PR TITLE
rpk: introduce basic weak types for custom unmarshaling

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -192,11 +192,9 @@ func registerAdvertisedKafkaAPI(
 ) error {
 	cfg.Redpanda.AdvertisedKafkaAPI = []config.NamedSocketAddress{
 		{
-			SocketAddress: config.SocketAddress{
-				Address: c.hostName + "." + c.svcFQDN,
-				Port:    kafkaAPIPort,
-			},
-			Name: "kafka",
+			Address: c.hostName + "." + c.svcFQDN,
+			Port:    kafkaAPIPort,
+			Name:    "kafka",
 		},
 	}
 
@@ -206,11 +204,9 @@ func registerAdvertisedKafkaAPI(
 
 	if len(c.subdomain) > 0 {
 		cfg.Redpanda.AdvertisedKafkaAPI = append(cfg.Redpanda.AdvertisedKafkaAPI, config.NamedSocketAddress{
-			SocketAddress: config.SocketAddress{
-				Address: fmt.Sprintf("%d.%s", index, c.subdomain),
-				Port:    c.hostPort,
-			},
-			Name: "kafka-external",
+			Address: fmt.Sprintf("%d.%s", index, c.subdomain),
+			Port:    c.hostPort,
+			Name:    "kafka-external",
 		})
 		return nil
 	}
@@ -221,11 +217,9 @@ func registerAdvertisedKafkaAPI(
 	}
 
 	cfg.Redpanda.AdvertisedKafkaAPI = append(cfg.Redpanda.AdvertisedKafkaAPI, config.NamedSocketAddress{
-		SocketAddress: config.SocketAddress{
-			Address: networking.GetPreferredAddress(node, c.externalConnectivityAddressType),
-			Port:    c.hostPort,
-		},
-		Name: "kafka-external",
+		Address: networking.GetPreferredAddress(node, c.externalConnectivityAddressType),
+		Port:    c.hostPort,
+		Name:    "kafka-external",
 	})
 
 	return nil
@@ -236,11 +230,9 @@ func registerAdvertisedPandaproxyAPI(
 ) error {
 	cfg.Pandaproxy.AdvertisedPandaproxyAPI = []config.NamedSocketAddress{
 		{
-			SocketAddress: config.SocketAddress{
-				Address: c.hostName + "." + c.svcFQDN,
-				Port:    proxyAPIPort,
-			},
-			Name: "proxy",
+			Address: c.hostName + "." + c.svcFQDN,
+			Port:    proxyAPIPort,
+			Name:    "proxy",
 		},
 	}
 
@@ -251,11 +243,9 @@ func registerAdvertisedPandaproxyAPI(
 	// Pandaproxy uses the Kafka API subdomain.
 	if len(c.subdomain) > 0 {
 		cfg.Pandaproxy.AdvertisedPandaproxyAPI = append(cfg.Pandaproxy.AdvertisedPandaproxyAPI, config.NamedSocketAddress{
-			SocketAddress: config.SocketAddress{
-				Address: fmt.Sprintf("%d.%s", index, c.subdomain),
-				Port:    c.proxyHostPort,
-			},
-			Name: "proxy-external",
+			Address: fmt.Sprintf("%d.%s", index, c.subdomain),
+			Port:    c.proxyHostPort,
+			Name:    "proxy-external",
 		})
 		return nil
 	}
@@ -266,11 +256,9 @@ func registerAdvertisedPandaproxyAPI(
 	}
 
 	cfg.Pandaproxy.AdvertisedPandaproxyAPI = append(cfg.Pandaproxy.AdvertisedPandaproxyAPI, config.NamedSocketAddress{
-		SocketAddress: config.SocketAddress{
-			Address: getExternalIP(node),
-			Port:    c.proxyHostPort,
-		},
-		Name: "proxy-external",
+		Address: getExternalIP(node),
+		Port:    c.proxyHostPort,
+		Name:    "proxy-external",
 	})
 
 	return nil

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -224,20 +224,16 @@ func (r *ConfigMapResource) CreateConfiguration(
 	internalListener := r.pandaCluster.InternalListener()
 	cr.KafkaAPI = []config.NamedSocketAddress{} // we don't want to inherit default kafka port
 	cr.KafkaAPI = append(cr.KafkaAPI, config.NamedSocketAddress{
-		SocketAddress: config.SocketAddress{
-			Address: "0.0.0.0",
-			Port:    internalListener.Port,
-		},
-		Name: InternalListenerName,
+		Address: "0.0.0.0",
+		Port:    internalListener.Port,
+		Name:    InternalListenerName,
 	})
 
 	if r.pandaCluster.ExternalListener() != nil {
 		cr.KafkaAPI = append(cr.KafkaAPI, config.NamedSocketAddress{
-			SocketAddress: config.SocketAddress{
-				Address: "0.0.0.0",
-				Port:    calculateExternalPort(internalListener.Port, r.pandaCluster.ExternalListener().Port),
-			},
-			Name: ExternalListenerName,
+			Address: "0.0.0.0",
+			Port:    calculateExternalPort(internalListener.Port, r.pandaCluster.ExternalListener().Port),
+			Name:    ExternalListenerName,
 		})
 	}
 
@@ -251,11 +247,9 @@ func (r *ConfigMapResource) CreateConfiguration(
 	cr.AdminAPI[0].Name = AdminPortName
 	if r.pandaCluster.AdminAPIExternal() != nil {
 		externalAdminAPI := config.NamedSocketAddress{
-			SocketAddress: config.SocketAddress{
-				Address: cr.AdminAPI[0].Address,
-				Port:    cr.AdminAPI[0].Port + 1,
-			},
-			Name: AdminPortExternalName,
+			Address: cr.AdminAPI[0].Address,
+			Port:    cr.AdminAPI[0].Port + 1,
+			Name:    AdminPortExternalName,
 		}
 		cr.AdminAPI = append(cr.AdminAPI, externalAdminAPI)
 	}
@@ -357,11 +351,9 @@ func (r *ConfigMapResource) CreateConfiguration(
 	if sr := r.pandaCluster.Spec.Configuration.SchemaRegistry; sr != nil {
 		cfg.NodeConfiguration.SchemaRegistry.SchemaRegistryAPI = []config.NamedSocketAddress{
 			{
-				SocketAddress: config.SocketAddress{
-					Address: "0.0.0.0",
-					Port:    sr.Port,
-				},
-				Name: SchemaRegistryPortName,
+				Address: "0.0.0.0",
+				Port:    sr.Port,
+				Name:    SchemaRegistryPortName,
 			},
 		}
 	}
@@ -438,22 +430,18 @@ func (r *ConfigMapResource) preparePandaproxy(cfgRpk *config.Config) {
 
 	cfgRpk.Pandaproxy.PandaproxyAPI = []config.NamedSocketAddress{
 		{
-			SocketAddress: config.SocketAddress{
-				Address: "0.0.0.0",
-				Port:    internal.Port,
-			},
-			Name: PandaproxyPortInternalName,
+			Address: "0.0.0.0",
+			Port:    internal.Port,
+			Name:    PandaproxyPortInternalName,
 		},
 	}
 
 	if r.pandaCluster.PandaproxyAPIExternal() != nil {
 		cfgRpk.Pandaproxy.PandaproxyAPI = append(cfgRpk.Pandaproxy.PandaproxyAPI,
 			config.NamedSocketAddress{
-				SocketAddress: config.SocketAddress{
-					Address: "0.0.0.0",
-					Port:    calculateExternalPort(internal.Port, 0),
-				},
-				Name: PandaproxyPortExternalName,
+				Address: "0.0.0.0",
+				Port:    calculateExternalPort(internal.Port, 0),
+				Name:    PandaproxyPortExternalName,
 			})
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -120,17 +120,13 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 			conf.Redpanda.ID = id
 			conf.Redpanda.RPCServer.Address = ownIP.String()
 			conf.Redpanda.KafkaAPI = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: ownIP.String(),
-					Port:    config.DefaultKafkaPort,
-				},
+				Address: ownIP.String(),
+				Port:    config.DefaultKafkaPort,
 			}}
 
 			conf.Redpanda.AdminAPI = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: ownIP.String(),
-					Port:    config.DefaultAdminPort,
-				},
+				Address: ownIP.String(),
+				Port:    config.DefaultAdminPort,
 			}}
 			conf.Redpanda.SeedServers = []config.SeedServer{}
 			conf.Redpanda.SeedServers = seeds

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -887,7 +887,10 @@ func parseAddress(addr string, defaultPort int) (*config.SocketAddress, error) {
 	if named == nil {
 		return nil, nil
 	}
-	return &named.SocketAddress, nil
+	return &config.SocketAddress{
+		Address: named.Address,
+		Port:    named.Port,
+	}, nil
 }
 
 func parseNamedAddresses(
@@ -919,11 +922,9 @@ func parseNamedAddress(
 	host, port := net.SplitHostPortDefault(hostport, defaultPort)
 
 	return &config.NamedSocketAddress{
-		SocketAddress: config.SocketAddress{
-			Address: host,
-			Port:    port,
-		},
-		Name: scheme,
+		Address: host,
+		Port:    port,
+		Name:    scheme,
 	}, nil
 }
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -260,23 +260,17 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(path)
 			require.NoError(st, err)
 			expectedAdmin := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.54.2",
-					Port:    9643,
-				},
+				Address: "192.168.54.2",
+				Port:    9643,
 			}}
 			expectedKafkaAPI := []config.NamedSocketAddress{{
-				Name: "external",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.73.45",
-					Port:    9092,
-				},
+				Name:    "external",
+				Address: "192.168.73.45",
+				Port:    9092,
 			}, {
-				Name: "internal",
-				SocketAddress: config.SocketAddress{
-					Address: "10.21.34.58",
-					Port:    9092,
-				},
+				Name:    "internal",
+				Address: "10.21.34.58",
+				Port:    9092,
 			}}
 			require.Exactly(st, 39, conf.Redpanda.ID)
 			require.Exactly(st, expectedAdmin, conf.Redpanda.AdminAPI)
@@ -332,30 +326,22 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(path)
 			require.NoError(st, err)
 			expectedAdmin := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.54.2",
-					Port:    9643,
-				},
+				Address: "192.168.54.2",
+				Port:    9643,
 			}}
 			expectedKafkaAPI := []config.NamedSocketAddress{{
-				Name: "external",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.73.45",
-					Port:    9092,
-				},
+				Name:    "external",
+				Address: "192.168.73.45",
+				Port:    9092,
 			}, {
-				Name: "internal",
-				SocketAddress: config.SocketAddress{
-					Address: "10.21.34.58",
-					Port:    9092,
-				},
+				Name:    "internal",
+				Address: "10.21.34.58",
+				Port:    9092,
 			}}
 			expectedAdvKafkaAPI := []config.NamedSocketAddress{{
-				Name: "plaintext",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    9092,
-				},
+				Name:    "plaintext",
+				Address: "192.168.34.32",
+				Port:    9092,
 			}}
 			// The value set with --node-id should have been prioritized
 			require.Exactly(st, 42, conf.Redpanda.ID)
@@ -396,11 +382,9 @@ func TestStartCommand(t *testing.T) {
 			// The value set through the --kafka-addr flag should
 			// have been picked.
 			expectedKafkaAPI := []config.NamedSocketAddress{{
-				Name: "flag",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.3",
-					Port:    9093,
-				},
+				Name:    "flag",
+				Address: "192.168.34.3",
+				Port:    9093,
 			}}
 			// The value set with --kafka-addr should have been prioritized
 			require.Exactly(st, expectedKafkaAPI, conf.Redpanda.KafkaAPI)
@@ -857,10 +841,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    33145,
-				},
+				Address: "192.168.34.32",
+				Port:    33145,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -880,10 +862,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    9092,
-				},
+				Address: "192.168.34.32",
+				Port:    9092,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -903,11 +883,9 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				Name: "nondefaultname",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    9092,
-				},
+				Name:    "nondefaultname",
+				Address: "192.168.34.32",
+				Port:    9092,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -927,16 +905,12 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				Name: "nondefaultname",
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    9092,
-				},
+				Name:    "nondefaultname",
+				Address: "192.168.34.32",
+				Port:    9092,
 			}, {
-				SocketAddress: config.SocketAddress{
-					Address: "host",
-					Port:    9092,
-				},
+				Address: "host",
+				Port:    9092,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -969,10 +943,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "host",
-					Port:    3123,
-				},
+				Address: "host",
+				Port:    3123,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -990,10 +962,8 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf := config.Default()
 			conf.Redpanda.KafkaAPI = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.33.33",
-					Port:    9892,
-				},
+				Address: "192.168.33.33",
+				Port:    9892,
 			}}
 			return mgr.Write(conf)
 		},
@@ -1002,10 +972,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.33.33",
-					Port:    9892,
-				},
+				Address: "192.168.33.33",
+				Port:    9892,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1025,10 +993,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    33145,
-				},
+				Address: "192.168.34.32",
+				Port:    33145,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1048,10 +1014,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    9092,
-				},
+				Address: "192.168.34.32",
+				Port:    9092,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1084,10 +1048,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "host",
-					Port:    3123,
-				},
+				Address: "host",
+				Port:    3123,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1105,10 +1067,8 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf := config.Default()
 			conf.Redpanda.AdvertisedKafkaAPI = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.33.33",
-					Port:    9892,
-				},
+				Address: "192.168.33.33",
+				Port:    9892,
 			}}
 			return mgr.Write(conf)
 		},
@@ -1117,10 +1077,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.33.33",
-					Port:    9892,
-				},
+				Address: "192.168.33.33",
+				Port:    9892,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1140,10 +1098,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.34.32",
-					Port:    8083,
-				},
+				Address: "192.168.34.32",
+				Port:    8083,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -1169,10 +1125,8 @@ func TestStartCommand(t *testing.T) {
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
 			expectedAddr := []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "host",
-					Port:    3123,
-				},
+				Address: "host",
+				Port:    3123,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -309,7 +309,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 			errs = append(
 				errs,
 				checkSocketAddress(
-					addr.SocketAddress,
+					SocketAddress{addr.Address, addr.Port},
 					configPath,
 				)...,
 			)

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -188,17 +188,13 @@ func TestSet(t *testing.T) {
 `,
 			check: func(st *testing.T, c *Config, _ *manager) {
 				expected := []NamedSocketAddress{{
-					Name: "external",
-					SocketAddress: SocketAddress{
-						Address: "192.168.73.45",
-						Port:    9092,
-					},
+					Name:    "external",
+					Address: "192.168.73.45",
+					Port:    9092,
 				}, {
-					Name: "internal",
-					SocketAddress: SocketAddress{
-						Address: "10.21.34.58",
-						Port:    9092,
-					},
+					Name:    "internal",
+					Address: "10.21.34.58",
+					Port:    9092,
 				}}
 				require.Exactly(st, expected, c.Redpanda.KafkaAPI)
 			},
@@ -213,10 +209,8 @@ func TestSet(t *testing.T) {
 			format: "json",
 			check: func(st *testing.T, c *Config, _ *manager) {
 				expected := []NamedSocketAddress{{
-					SocketAddress: SocketAddress{
-						Port:    9092,
-						Address: "192.168.54.2",
-					},
+					Port:    9092,
+					Address: "192.168.54.2",
 				}}
 				require.Exactly(st, expected, c.Redpanda.KafkaAPI)
 			},
@@ -230,10 +224,8 @@ func TestSet(t *testing.T) {
 		}]`,
 			check: func(st *testing.T, c *Config, _ *manager) {
 				expected := []NamedSocketAddress{{
-					SocketAddress: SocketAddress{
-						Port:    9092,
-						Address: "192.168.54.2",
-					},
+					Port:    9092,
+					Address: "192.168.54.2",
 				}}
 				require.Exactly(st, expected, c.Redpanda.AdvertisedKafkaAPI)
 			},
@@ -300,11 +292,9 @@ func TestMerge(t *testing.T) {
 			config: Config{
 				Redpanda: RedpandaConfig{
 					KafkaAPI: []NamedSocketAddress{{
-						Name: "kafka-api-name",
-						SocketAddress: SocketAddress{
-							"1.2.3.4",
-							9123,
-						},
+						Name:    "kafka-api-name",
+						Address: "1.2.3.4",
+						Port:    9123,
 					}},
 				},
 			},
@@ -319,11 +309,9 @@ func TestMerge(t *testing.T) {
 			config: Config{
 				Pandaproxy: &Pandaproxy{
 					PandaproxyAPI: []NamedSocketAddress{{
-						Name: "proxy-api-name",
-						SocketAddress: SocketAddress{
-							"1.2.3.4",
-							8123,
-						},
+						Name:    "proxy-api-name",
+						Address: "1.2.3.4",
+						Port:    8123,
 					}},
 				},
 			},
@@ -364,16 +352,12 @@ func TestDefault(t *testing.T) {
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{"0.0.0.0", 33145},
 			KafkaAPI: []NamedSocketAddress{{
-				SocketAddress: SocketAddress{
-					"0.0.0.0",
-					9092,
-				},
+				Address: "0.0.0.0",
+				Port:    9092,
 			}},
 			AdminAPI: []NamedSocketAddress{{
-				SocketAddress: SocketAddress{
-					"0.0.0.0",
-					9644,
-				},
+				Address: "0.0.0.0",
+				Port:    9644,
 			}},
 			ID:            0,
 			SeedServers:   []SeedServer{},
@@ -600,10 +584,8 @@ schema_registry: {}
 			conf: func() *Config {
 				c := getValidConfig()
 				c.Redpanda.AdvertisedKafkaAPI = []NamedSocketAddress{{
-					SocketAddress: SocketAddress{
-						"174.32.64.2",
-						9092,
-					},
+					Address: "174.32.64.2",
+					Port:    9092,
 				}}
 				return c
 			},
@@ -1113,11 +1095,9 @@ schema_registry: {}
 				c.Pandaproxy = &Pandaproxy{
 					PandaproxyAPI: []NamedSocketAddress{
 						{
-							Name: "first",
-							SocketAddress: SocketAddress{
-								Address: "1.2.3.4",
-								Port:    1234,
-							},
+							Name:    "first",
+							Address: "1.2.3.4",
+							Port:    1234,
 						},
 					},
 					PandaproxyAPITLS: []ServerTLS{{
@@ -1129,11 +1109,9 @@ schema_registry: {}
 					}},
 					AdvertisedPandaproxyAPI: []NamedSocketAddress{
 						{
-							Name: "advertised",
-							SocketAddress: SocketAddress{
-								Address: "2.3.4.1",
-								Port:    2341,
-							},
+							Name:    "advertised",
+							Address: "2.3.4.1",
+							Port:    2341,
 						},
 					},
 				}
@@ -1205,11 +1183,9 @@ schema_registry: {}
 				c.Pandaproxy = &Pandaproxy{
 					PandaproxyAPI: []NamedSocketAddress{
 						{
-							Name: "first",
-							SocketAddress: SocketAddress{
-								Address: "1.2.3.4",
-								Port:    1234,
-							},
+							Name:    "first",
+							Address: "1.2.3.4",
+							Port:    1234,
 						},
 					},
 				}

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -240,14 +240,14 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 				Address: "0.0.0.0",
 				Port:    33145,
 			},
-			KafkaAPI: []NamedSocketAddress{{SocketAddress: SocketAddress{
+			KafkaAPI: []NamedSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9092,
-			}}},
-			AdminAPI: []NamedSocketAddress{{SocketAddress: SocketAddress{
+			}},
+			AdminAPI: []NamedSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9644,
-			}}},
+			}},
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -95,8 +95,9 @@ type SocketAddress struct {
 }
 
 type NamedSocketAddress struct {
-	SocketAddress `yaml:",inline" mapstructure:",squash"`
-	Name          string `yaml:"name,omitempty" mapstructure:"name,omitempty" json:"name,omitempty"`
+	Address string `yaml:"address" mapstructure:"address" json:"address"`
+	Port    int    `yaml:"port" mapstructure:"port" json:"port"`
+	Name    string `yaml:"name,omitempty" mapstructure:"name,omitempty" json:"name,omitempty"`
 }
 
 type TLS struct {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -1,0 +1,141 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"fmt"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// weakBool is an intermediary boolean type to be used during our transition
+// to strictly typed configuration parameters. This will allow us to support
+// weakly typed parsing:
+//
+//   - int to bool (true if value != 0)
+//   - string to bool (accepts: 1, t, T, TRUE, true, True, 0, f, F, FALSE,
+//     false, False. Anything else is an error)
+type weakBool bool
+
+func (wb *weakBool) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Tag {
+	case "!!bool":
+		bValue, err := strconv.ParseBool(n.Value)
+		if err != nil {
+			return err
+		}
+		*wb = weakBool(bValue)
+		return nil
+	case "!!int":
+		fmt.Println("deprecation warning: type conversion from integers to boolean will be deprecated")
+		ni, err := strconv.Atoi(n.Value)
+		if err != nil {
+			return fmt.Errorf("cannot parse '%s' as bool: %s", n.Value, err)
+		}
+		*wb = ni != 0
+		return nil
+	case "!!str":
+		fmt.Println("deprecation warning: type conversion from string to boolean will be deprecated")
+		// it accepts 1, t, T, TRUE, true, True, 0, f, F
+		nb, err := strconv.ParseBool(n.Value)
+		if err == nil {
+			*wb = weakBool(nb)
+			return nil
+		} else if n.Value == "" {
+			*wb = false
+			return nil
+		} else {
+			return fmt.Errorf("cannot parse '%s' as bool: %s", n.Value, err)
+		}
+	default:
+		return fmt.Errorf("type %s not supported as a boolean", n.Tag)
+	}
+}
+
+// weakInt is an intermediary integer type to be used during our transition to
+// strictly typed configuration parameters. This will allow us to support
+// weakly typed parsing:
+//
+//   - strings to int/uint (base implied by prefix)
+//   - bools to int/uint (true = 1, false = 0)
+type weakInt int
+
+func (wi *weakInt) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Tag {
+	case "!!int":
+		ni, err := strconv.Atoi(n.Value)
+		if err != nil {
+			return err
+		}
+		*wi = weakInt(ni)
+		return nil
+	case "!!str":
+		fmt.Println("deprecation warning: type conversion from string to integer will be deprecated")
+		str := n.Value
+		if str == "" {
+			str = "0"
+		}
+		ni, err := strconv.Atoi(str)
+		if err != nil {
+			return fmt.Errorf("cannot parse '%s' as an integer: %s", str, err)
+		}
+		*wi = weakInt(ni)
+		return nil
+	case "!!bool":
+		fmt.Println("deprecation warning: type conversion from boolean to integer will be deprecated")
+		nb, err := strconv.ParseBool(n.Value)
+		if err != nil {
+			return fmt.Errorf("cannot parse '%s' as an integer: %s", n.Value, err)
+		}
+		if nb {
+			*wi = 1
+			return nil
+		}
+		*wi = 0
+		return nil
+	default:
+		return fmt.Errorf("type %s not supported as an integer", n.Tag)
+	}
+}
+
+// weakInt is an intermediary string type to be used during our transition to
+// strictly typed configuration parameters. This will allow us to support
+// weakly typed parsing:
+//
+//   - bools to string (true = "1", false = "0")
+//   - numbers to string (base 10)
+type weakString string
+
+func (ws *weakString) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Tag {
+	case "!!str":
+		*ws = weakString(n.Value)
+		return nil
+	case "!!bool":
+		fmt.Println("deprecation warning: type conversion from boolean to string will be deprecated")
+		nb, err := strconv.ParseBool(n.Value)
+		if err != nil {
+			return fmt.Errorf("cannot parse '%s' as a boolean: %s", n.Value, err)
+		}
+		if nb {
+			*ws = "1"
+			return nil
+		}
+		*ws = "0"
+		return nil
+	case "!!int", "!!float":
+		fmt.Println("deprecation warning: type conversion from numbers to string will be deprecated")
+		*ws = weakString(n.Value)
+		return nil
+	default:
+		return fmt.Errorf("type %s not supported as a string", n.Tag)
+	}
+}

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -11,6 +11,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"gopkg.in/yaml.v3"
@@ -20,7 +21,7 @@ import (
 // int, and string) and one_or_many support for different types.
 //
 // The use of this file is to support our transition to a strongly typed
-// config file and our migration away from cobra and mapstructure.
+// config file and our migration away from viper and mapstructure.
 
 // weakBool is an intermediary boolean type to be used during our transition
 // to strictly typed configuration parameters. This will allow us to support
@@ -45,18 +46,18 @@ func (wb *weakBool) UnmarshalYAML(n *yaml.Node) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse '%s' as bool: %s", n.Value, err)
 		}
-		fmt.Println("deprecation warning: type conversion from integers to boolean will be deprecated in v23.2.1")
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from int to bool is deprecated and will be removed in the future")
 		*wb = ni != 0
 		return nil
 	case "!!str":
 		// it accepts 1, t, T, TRUE, true, True, 0, f, F
 		nb, err := strconv.ParseBool(n.Value)
 		if err == nil {
-			fmt.Println("deprecation warning: type conversion from string to boolean will be deprecated in v23.2.1")
+			fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from str to bool is deprecated and will be removed in the future")
 			*wb = weakBool(nb)
 			return nil
 		} else if n.Value == "" {
-			fmt.Println("deprecation warning: type conversion from string to boolean will be deprecated in v23.2.1")
+			fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from str to bool is deprecated and will be removed in the future")
 			*wb = false
 			return nil
 		} else {
@@ -93,7 +94,7 @@ func (wi *weakInt) UnmarshalYAML(n *yaml.Node) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse '%s' as an integer: %s", str, err)
 		}
-		fmt.Println("deprecation warning: type conversion from string to integer will be deprecated in v23.2.1")
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from str to int is deprecated and will be removed in the future")
 		*wi = weakInt(ni)
 		return nil
 	case "!!bool":
@@ -101,7 +102,7 @@ func (wi *weakInt) UnmarshalYAML(n *yaml.Node) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse '%s' as an integer: %s", n.Value, err)
 		}
-		fmt.Println("deprecation warning: type conversion from boolean to integer will be deprecated in v23.2.1")
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from bool to int is deprecated and will be removed in the future")
 		if nb {
 			*wi = 1
 			return nil
@@ -131,7 +132,7 @@ func (ws *weakString) UnmarshalYAML(n *yaml.Node) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse '%s' as a boolean: %s", n.Value, err)
 		}
-		fmt.Println("deprecation warning: type conversion from boolean to string will be deprecated in v23.2.1")
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from bool to str is deprecated and will be removed in the future")
 		if nb {
 			*ws = "1"
 			return nil
@@ -139,7 +140,7 @@ func (ws *weakString) UnmarshalYAML(n *yaml.Node) error {
 		*ws = "0"
 		return nil
 	case "!!int", "!!float":
-		fmt.Println("deprecation warning: type conversion from numbers to string will be deprecated in v23.2.1")
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: conversion from numbers to str is deprecated and will be removed in the future")
 		*ws = weakString(n.Value)
 		return nil
 	default:
@@ -147,18 +148,72 @@ func (ws *weakString) UnmarshalYAML(n *yaml.Node) error {
 	}
 }
 
-// NamedSocketAddresses is an intermediary one_or_many type to be used
+// weakStringArray is an intermediary one_or_many type to be used
 // during our transition to strictly typed configuration parameters.
 // This type will:
-//   - parse an array of namedSocketAddress
-//   - parse a single namedSocketAddress to an array.
-type NamedSocketAddresses []NamedSocketAddress
+//   - parse an array of strings
+//   - parse a single string to an array.
+type weakStringArray []string
 
-func (a *NamedSocketAddresses) UnmarshalYAML(n *yaml.Node) error {
+func (wsa *weakStringArray) UnmarshalYAML(n *yaml.Node) error {
+	var multi []weakString
+	err := n.Decode(&multi)
+	if err == nil {
+		s := make([]string, len(multi))
+		for i, v := range multi {
+			s[i] = string(v)
+		}
+		*wsa = s
+		return nil
+	}
+
+	var single weakString
+	err = n.Decode(&single)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "redpanda.yaml: %q must be an array; a non-array value in array fields is deprecated and will be removed in the future\n", n.Value)
+	*wsa = []string{string(single)}
+	return nil
+}
+
+// socketAddresses is an intermediary one_or_many type to be used
+// during our transition to strictly typed configuration parameters.
+// This type will:
+//   - parse an array of SocketAddress
+//   - parse a single SocketAddress to an array.
+type socketAddresses []SocketAddress
+
+func (s *socketAddresses) UnmarshalYAML(n *yaml.Node) error {
+	var multi []SocketAddress
+	err := n.Decode(&multi)
+	if err == nil {
+		*s = multi
+		return nil
+	}
+
+	var single SocketAddress
+	err = n.Decode(&single)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "redpanda.yaml: %+v must be an array; a non-array value in array fields is deprecated and will be removed in the future\n", single)
+	*s = []SocketAddress{single}
+	return nil
+}
+
+// namedSocketAddresses is an intermediary one_or_many type to be used
+// during our transition to strictly typed configuration parameters.
+// This type will:
+//   - parse an array of NamedSocketAddress
+//   - parse a single NamedSocketAddress to an array.
+type namedSocketAddresses []NamedSocketAddress
+
+func (nsa *namedSocketAddresses) UnmarshalYAML(n *yaml.Node) error {
 	var multi []NamedSocketAddress
 	err := n.Decode(&multi)
 	if err == nil {
-		*a = multi
+		*nsa = multi
 		return nil
 	}
 
@@ -167,22 +222,22 @@ func (a *NamedSocketAddresses) UnmarshalYAML(n *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("deprecation warning: single element named socket addresses will be deprecated in v23.2.1")
-	*a = []NamedSocketAddress{single}
+	fmt.Fprintf(os.Stderr, "redpanda.yaml: %+v must be an array; a non-array value in array fields is deprecated and will be removed in the future\n", single)
+	*nsa = []NamedSocketAddress{single}
 	return nil
 }
 
-// ServerTLSArray is an intermediary one_or_many type to be used during our
+// serverTLSArray is an intermediary one_or_many type to be used during our
 // transition to strictly typed configuration parameters. This type will:
 //   - parse an array of ServerTLS
 //   - parse a single ServerTLS to an array.
-type ServerTLSArray []ServerTLS
+type serverTLSArray []ServerTLS
 
-func (a *ServerTLSArray) UnmarshalYAML(n *yaml.Node) error {
+func (s *serverTLSArray) UnmarshalYAML(n *yaml.Node) error {
 	var multi []ServerTLS
 	err := n.Decode(&multi)
 	if err == nil {
-		*a = multi
+		*s = multi
 		return nil
 	}
 
@@ -191,7 +246,351 @@ func (a *ServerTLSArray) UnmarshalYAML(n *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("deprecation warning: single element server TLS will be deprecated in v23.2.1")
-	*a = []ServerTLS{single}
+	fmt.Fprintf(os.Stderr, "redpanda.yaml: %+v must be an array; a non-array value in array fields is deprecated and will be removed in the future\n", single)
+	*s = []ServerTLS{single}
+	return nil
+}
+
+// seedServers is an intermediary one_or_many type to be used during our
+// transition to strictly typed configuration parameters. This type will:
+//   - parse an array of SeedServer
+//   - parse a single SeedServer to an array.
+type seedServers []SeedServer
+
+func (ss *seedServers) UnmarshalYAML(n *yaml.Node) error {
+	var multi []SeedServer
+	err := n.Decode(&multi)
+	if err == nil {
+		*ss = multi
+		return nil
+	}
+
+	var single SeedServer
+	err = n.Decode(&single)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "redpanda.yaml: %+v must be an array; a non-array value in array fields is deprecated and will be removed in the future\n", single)
+	*ss = []SeedServer{single}
+	return nil
+}
+
+// Custom unmarshallers for all the config related types.
+
+func (c *Config) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		NodeUUID             weakString      `yaml:"node_uuid"`
+		Organization         weakString      `yaml:"organization"`
+		LicenseKey           weakString      `yaml:"license_key"`
+		ClusterID            weakString      `yaml:"cluster_id"`
+		ConfigFile           weakString      `yaml:"config_file"`
+		Redpanda             RedpandaConfig  `yaml:"redpanda"`
+		Rpk                  RpkConfig       `yaml:"rpk"`
+		Pandaproxy           *Pandaproxy     `yaml:"pandaproxy"`
+		PandaproxyClient     *KafkaClient    `yaml:"pandaproxy_client"`
+		SchemaRegistry       *SchemaRegistry `yaml:"schema_registry"`
+		SchemaRegistryClient *KafkaClient    `yaml:"schema_registry_client"`
+
+		Other map[string]interface{} `yaml:",inline"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	c.NodeUUID = string(internal.NodeUUID)
+	c.Organization = string(internal.Organization)
+	c.LicenseKey = string(internal.LicenseKey)
+	c.ClusterID = string(internal.ClusterID)
+	c.ConfigFile = string(internal.ConfigFile)
+	c.Redpanda = internal.Redpanda
+	c.Rpk = internal.Rpk
+	c.Pandaproxy = internal.Pandaproxy
+	c.PandaproxyClient = internal.PandaproxyClient
+	c.SchemaRegistry = internal.SchemaRegistry
+	c.SchemaRegistryClient = internal.SchemaRegistryClient
+	c.Other = internal.Other
+
+	return nil
+}
+
+func (rpc *RedpandaConfig) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Directory                  weakString             `yaml:"data_directory"`
+		ID                         weakInt                `yaml:"node_id" `
+		Rack                       weakString             `yaml:"rack"`
+		SeedServers                seedServers            `yaml:"seed_servers"`
+		RPCServer                  SocketAddress          `yaml:"rpc_server"`
+		RPCServerTLS               serverTLSArray         `yaml:"rpc_server_tls"`
+		KafkaAPI                   namedSocketAddresses   `yaml:"kafka_api"`
+		KafkaAPITLS                serverTLSArray         `yaml:"kafka_api_tls"`
+		AdminAPI                   namedSocketAddresses   `yaml:"admin"`
+		AdminAPITLS                serverTLSArray         `yaml:"admin_api_tls"`
+		CoprocSupervisorServer     SocketAddress          `yaml:"coproc_supervisor_server"`
+		AdminAPIDocDir             weakString             `yaml:"admin_api_doc_dir"`
+		DashboardDir               weakString             `yaml:"dashboard_dir"`
+		CloudStorageCacheDirectory weakString             `yaml:"cloud_storage_cache_directory"`
+		AdvertisedRPCAPI           *SocketAddress         `yaml:"advertised_rpc_api"`
+		AdvertisedKafkaAPI         namedSocketAddresses   `yaml:"advertised_kafka_api"`
+		DeveloperMode              weakBool               `yaml:"developer_mode"`
+		Other                      map[string]interface{} `yaml:",inline"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	rpc.Directory = string(internal.Directory)
+	rpc.ID = int(internal.ID)
+	rpc.Rack = string(internal.Rack)
+	rpc.SeedServers = internal.SeedServers
+	rpc.RPCServer = internal.RPCServer
+	rpc.RPCServerTLS = internal.RPCServerTLS
+	rpc.KafkaAPI = internal.KafkaAPI
+	rpc.KafkaAPITLS = internal.KafkaAPITLS
+	rpc.AdminAPI = internal.AdminAPI
+	rpc.AdminAPITLS = internal.AdminAPITLS
+	rpc.CoprocSupervisorServer = internal.CoprocSupervisorServer
+	rpc.AdminAPIDocDir = string(internal.AdminAPIDocDir)
+	rpc.DashboardDir = string(internal.DashboardDir)
+	rpc.CloudStorageCacheDirectory = string(internal.CloudStorageCacheDirectory)
+	rpc.AdvertisedRPCAPI = internal.AdvertisedRPCAPI
+	rpc.AdvertisedKafkaAPI = internal.AdvertisedKafkaAPI
+	rpc.DeveloperMode = bool(internal.DeveloperMode)
+	rpc.Other = internal.Other
+	return nil
+}
+
+func (rpkc *RpkConfig) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		// Deprecated 2021-07-1
+		TLS *TLS `yaml:"tls"`
+		// Deprecated 2021-07-1
+		SASL *SASL `yaml:"sasl"`
+
+		KafkaAPI                 RpkKafkaAPI     `yaml:"kafka_api"`
+		AdminAPI                 RpkAdminAPI     `yaml:"admin_api"`
+		AdditionalStartFlags     weakStringArray `yaml:"additional_start_flags"`
+		EnableUsageStats         weakBool        `yaml:"enable_usage_stats"`
+		TuneNetwork              weakBool        `yaml:"tune_network"`
+		TuneDiskScheduler        weakBool        `yaml:"tune_disk_scheduler"`
+		TuneNomerges             weakBool        `yaml:"tune_disk_nomerges"`
+		TuneDiskWriteCache       weakBool        `yaml:"tune_disk_write_cache"`
+		TuneDiskIrq              weakBool        `yaml:"tune_disk_irq"`
+		TuneFstrim               weakBool        `yaml:"tune_fstrim"`
+		TuneCPU                  weakBool        `yaml:"tune_cpu"`
+		TuneAioEvents            weakBool        `yaml:"tune_aio_events"`
+		TuneClocksource          weakBool        `yaml:"tune_clocksource"`
+		TuneSwappiness           weakBool        `yaml:"tune_swappiness"`
+		TuneTransparentHugePages weakBool        `yaml:"tune_transparent_hugepages"`
+		EnableMemoryLocking      weakBool        `yaml:"enable_memory_locking"`
+		TuneCoredump             weakBool        `yaml:"tune_coredump"`
+		CoredumpDir              weakString      `yaml:"coredump_dir"`
+		TuneBallastFile          weakBool        `yaml:"tune_ballast_file"`
+		BallastFilePath          weakString      `yaml:"ballast_file_path"`
+		BallastFileSize          weakString      `yaml:"ballast_file_size"`
+		WellKnownIo              weakString      `yaml:"well_known_io"`
+		Overprovisioned          weakBool        `yaml:"overprovisioned"`
+		SMP                      *weakInt        `yaml:"smp"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	if internal.TLS != nil {
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: rpk.tls has been replaced with rpk.kafka_api.tls and will be removed in the future")
+	}
+	if internal.SASL != nil {
+		fmt.Fprintln(os.Stderr, "redpanda.yaml: rpk.sasl has been replaced with rpk.kafka_api.sasl and will be removed in the future")
+	}
+
+	rpkc.TLS = internal.TLS
+	rpkc.SASL = internal.SASL
+	rpkc.KafkaAPI = internal.KafkaAPI
+	rpkc.AdminAPI = internal.AdminAPI
+	rpkc.AdditionalStartFlags = internal.AdditionalStartFlags
+	rpkc.EnableUsageStats = bool(internal.EnableUsageStats)
+	rpkc.TuneNetwork = bool(internal.TuneNetwork)
+	rpkc.TuneDiskScheduler = bool(internal.TuneDiskScheduler)
+	rpkc.TuneNomerges = bool(internal.TuneNomerges)
+	rpkc.TuneDiskWriteCache = bool(internal.TuneDiskWriteCache)
+	rpkc.TuneDiskIrq = bool(internal.TuneDiskIrq)
+	rpkc.TuneFstrim = bool(internal.TuneFstrim)
+	rpkc.TuneCPU = bool(internal.TuneCPU)
+	rpkc.TuneAioEvents = bool(internal.TuneAioEvents)
+	rpkc.TuneClocksource = bool(internal.TuneClocksource)
+	rpkc.TuneSwappiness = bool(internal.TuneSwappiness)
+	rpkc.TuneTransparentHugePages = bool(internal.TuneTransparentHugePages)
+	rpkc.EnableMemoryLocking = bool(internal.EnableMemoryLocking)
+	rpkc.TuneCoredump = bool(internal.TuneCoredump)
+	rpkc.CoredumpDir = string(internal.CoredumpDir)
+	rpkc.TuneBallastFile = bool(internal.TuneBallastFile)
+	rpkc.BallastFilePath = string(internal.BallastFilePath)
+	rpkc.BallastFileSize = string(internal.BallastFileSize)
+	rpkc.WellKnownIo = string(internal.WellKnownIo)
+	rpkc.Overprovisioned = bool(internal.Overprovisioned)
+	rpkc.SMP = (*int)(internal.SMP)
+	return nil
+}
+
+func (r *RpkKafkaAPI) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Brokers weakStringArray `yaml:"brokers"`
+		TLS     *TLS            `yaml:"tls"`
+		SASL    *SASL           `yaml:"sasl"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	r.Brokers = internal.Brokers
+	r.TLS = internal.TLS
+	r.SASL = internal.SASL
+	return nil
+}
+
+func (r *RpkAdminAPI) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Addresses weakStringArray `yaml:"addresses"`
+		TLS       *TLS            `yaml:"tls"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	r.Addresses = internal.Addresses
+	r.TLS = internal.TLS
+	return nil
+}
+
+func (p *Pandaproxy) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		PandaproxyAPI           namedSocketAddresses   `yaml:"pandaproxy_api"`
+		PandaproxyAPITLS        serverTLSArray         `yaml:"pandaproxy_api_tls"`
+		AdvertisedPandaproxyAPI namedSocketAddresses   `yaml:"advertised_pandaproxy_api"`
+		Other                   map[string]interface{} `yaml:",inline"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	p.PandaproxyAPI = internal.PandaproxyAPI
+	p.PandaproxyAPITLS = internal.PandaproxyAPITLS
+	p.AdvertisedPandaproxyAPI = internal.AdvertisedPandaproxyAPI
+	p.Other = internal.Other
+	return nil
+}
+
+func (k *KafkaClient) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Brokers       socketAddresses        `yaml:"brokers"`
+		BrokerTLS     ServerTLS              `yaml:"broker_tls"`
+		SASLMechanism *weakString            `yaml:"sasl_mechanism"`
+		SCRAMUsername *weakString            `yaml:"scram_username"`
+		SCRAMPassword *weakString            `yaml:"scram_password"`
+		Other         map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	k.Brokers = internal.Brokers
+	k.BrokerTLS = internal.BrokerTLS
+	k.SASLMechanism = (*string)(internal.SASLMechanism)
+	k.SCRAMUsername = (*string)(internal.SCRAMUsername)
+	k.SCRAMPassword = (*string)(internal.SCRAMPassword)
+	k.Other = internal.Other
+	return nil
+}
+
+func (s *SchemaRegistry) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		SchemaRegistryAPI               namedSocketAddresses `yaml:"schema_registry_api"`
+		SchemaRegistryAPITLS            serverTLSArray       `yaml:"schema_registry_api_tls"`
+		SchemaRegistryReplicationFactor *weakInt             `yaml:"schema_registry_replication_factor"`
+	}
+
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	s.SchemaRegistryAPI = internal.SchemaRegistryAPI
+	s.SchemaRegistryAPITLS = internal.SchemaRegistryAPITLS
+	s.SchemaRegistryReplicationFactor = (*int)(internal.SchemaRegistryReplicationFactor)
+	return nil
+}
+
+func (s *ServerTLS) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Name              weakString             `yaml:"name"`
+		KeyFile           weakString             `yaml:"key_file"`
+		CertFile          weakString             `yaml:"cert_file"`
+		TruststoreFile    weakString             `yaml:"truststore_file"`
+		Enabled           weakBool               `yaml:"enabled"`
+		RequireClientAuth weakBool               `yaml:"require_client_auth"`
+		Other             map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	s.Name = string(internal.Name)
+	s.KeyFile = string(internal.KeyFile)
+	s.CertFile = string(internal.CertFile)
+	s.TruststoreFile = string(internal.TruststoreFile)
+	s.Enabled = bool(internal.Enabled)
+	s.RequireClientAuth = bool(internal.RequireClientAuth)
+	s.Other = internal.Other
+	return nil
+}
+
+func (sa *SocketAddress) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Address weakString `yaml:"address"`
+		Port    weakInt    `yaml:"port"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	sa.Address = string(internal.Address)
+	sa.Port = int(internal.Port)
+	return nil
+}
+
+func (nsa *NamedSocketAddress) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		Name    weakString `yaml:"name"`
+		Address weakString `yaml:"address" mapstructure:"address"`
+		Port    weakInt    `yaml:"port" mapstructure:"port"`
+	}
+
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+
+	nsa.Name = string(internal.Name)
+	nsa.Address = string(internal.Address)
+	nsa.Port = int(internal.Port)
+	return nil
+}
+
+func (t *TLS) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		KeyFile        weakString `yaml:"key_file"`
+		CertFile       weakString `yaml:"cert_file"`
+		TruststoreFile weakString `yaml:"truststore_file"`
+	}
+
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	t.KeyFile = string(internal.KeyFile)
+	t.CertFile = string(internal.CertFile)
+	t.TruststoreFile = string(internal.TruststoreFile)
+	return nil
+}
+
+func (s *SASL) UnmarshalYAML(n *yaml.Node) error {
+	var internal struct {
+		User      weakString `yaml:"user"`
+		Password  weakString `yaml:"password"`
+		Mechanism weakString `yaml:"type"`
+	}
+	if err := n.Decode(&internal); err != nil {
+		return err
+	}
+	s.User = string(internal.User)
+	s.Password = string(internal.Password)
+	s.Mechanism = string(internal.Mechanism)
+
 	return nil
 }

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -1,0 +1,243 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWeakBool(t *testing.T) {
+	type testWeakBool struct {
+		Wb weakBool `yaml:"wb"`
+	}
+
+	tests := []struct {
+		name    string
+		data    string
+		expBool bool
+		expErr  bool
+	}{
+		{
+			name:    "should unmarshal boolean:true",
+			data:    "wb: true",
+			expBool: true,
+			expErr:  false,
+		},
+		{
+			name:    "should unmarshal boolean:false",
+			data:    "wb: false",
+			expBool: false,
+			expErr:  false,
+		},
+		{
+			name:    "should unmarshal int:0",
+			data:    "wb: 0",
+			expBool: false,
+			expErr:  false,
+		},
+		{
+			name:    "should unmarshal int:different from zero",
+			data:    "wb: 12",
+			expBool: true,
+			expErr:  false,
+		},
+		{
+			name:    "should unmarshal string:true",
+			data:    `wb: "true"`,
+			expBool: true,
+			expErr:  false,
+		},
+		{
+			name:    "should unmarshal string:false",
+			data:    `wb: "false"`,
+			expBool: false,
+			expErr:  false,
+		},
+		{
+			name:   "should error with unsupported string",
+			data:   `wb: "falsity"`,
+			expErr: true,
+		},
+		{
+			name:   "should error with float type",
+			data:   `wb: 123.123`,
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := testWeakBool{}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+
+			if bool(ts.Wb) != test.expBool {
+				t.Errorf("input %q: got %v, expected %v",
+					test.data, ts.Wb, test.expBool)
+				return
+			}
+		})
+	}
+}
+
+func TestWeakInt(t *testing.T) {
+	type testWeakInt struct {
+		Wi weakInt `yaml:"wi"`
+	}
+	tests := []struct {
+		name   string
+		data   string
+		expInt int
+		expErr bool
+	}{
+		{
+			name:   "should unmarshal normal int types",
+			data:   "wi: 1231",
+			expInt: 1231,
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal empty string as 0",
+			data:   `wi: ""`,
+			expInt: 0,
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal string:-23414",
+			data:   `wi: "-23414"`,
+			expInt: -23414,
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal string:231231",
+			data:   `wi: "231231"`,
+			expInt: 231231,
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal bool:true",
+			data:   `wi: true`,
+			expInt: 1,
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal bool:false",
+			data:   `wi: false`,
+			expInt: 0,
+			expErr: false,
+		},
+		{
+			name:   "should error with not-numeric strings",
+			data:   `wi: "123foo234"`,
+			expErr: true,
+		},
+		{
+			name:   "should error with float numbers",
+			data:   `wi: 123.234`,
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := testWeakInt{}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+
+			if int(ts.Wi) != test.expInt {
+				t.Errorf("input %q: got %v, expected %v",
+					test.data, ts.Wi, test.expInt)
+				return
+			}
+		})
+	}
+}
+
+func TestWeakString(t *testing.T) {
+	type testWeakString struct {
+		Ws weakString `yaml:"ws"`
+	}
+	tests := []struct {
+		name   string
+		data   string
+		expStr string
+		expErr bool
+	}{
+		{
+			name:   "should unmarshal normal string types",
+			data:   `ws: "hello world"`,
+			expStr: "hello world",
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal bool:true",
+			data:   "ws: true",
+			expStr: "1",
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal bool:false",
+			data:   "ws: false",
+			expStr: "0",
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal base10 number:231231",
+			data:   "ws: 231231",
+			expStr: "231231",
+			expErr: false,
+		},
+		{
+			name:   "should unmarshal float number:231.231",
+			data:   "ws: 231.231",
+			expStr: "231.231",
+			expErr: false,
+		},
+		{
+			name:   "should error with unsupported types",
+			data:   "ws: \n  - 231.231",
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := testWeakString{}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+
+			if string(ts.Ws) != test.expStr {
+				t.Errorf("input %q: got %v, expected %v",
+					test.data, ts.Ws, test.expStr)
+				return
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestWeakBool(t *testing.T) {
-	type testWeakBool struct {
-		Wb weakBool `yaml:"wb"`
-	}
 	for _, test := range []struct {
 		name   string
 		data   string
@@ -48,6 +45,11 @@ func TestWeakBool(t *testing.T) {
 			exp:  false,
 		},
 		{
+			name: "empty string",
+			data: `wb: ""`,
+			exp:  false,
+		},
+		{
 			name:   "error with unsupported string",
 			data:   `wb: "falsity"`,
 			expErr: true,
@@ -59,7 +61,9 @@ func TestWeakBool(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ts := testWeakBool{}
+			var ts struct {
+				Wb weakBool `yaml:"wb"`
+			}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
 
 			gotErr := err != nil
@@ -82,44 +86,41 @@ func TestWeakBool(t *testing.T) {
 }
 
 func TestWeakInt(t *testing.T) {
-	type testWeakInt struct {
-		Wi weakInt `yaml:"wi"`
-	}
 	for _, test := range []struct {
 		name   string
 		data   string
-		expInt int
+		exp    int
 		expErr bool
 	}{
 		{
-			name:   "normal int types",
-			data:   "wi: 1231",
-			expInt: 1231,
+			name: "normal int types",
+			data: "wi: 1231",
+			exp:  1231,
 		},
 		{
-			name:   "empty string as 0",
-			data:   `wi: ""`,
-			expInt: 0,
+			name: "empty string as 0",
+			data: `wi: ""`,
+			exp:  0,
 		},
 		{
-			name:   "string:-23414",
-			data:   `wi: "-23414"`,
-			expInt: -23414,
+			name: "string:-23414",
+			data: `wi: "-23414"`,
+			exp:  -23414,
 		},
 		{
-			name:   "string:231231",
-			data:   `wi: "231231"`,
-			expInt: 231231,
+			name: "string:231231",
+			data: `wi: "231231"`,
+			exp:  231231,
 		},
 		{
-			name:   "bool:true",
-			data:   `wi: true`,
-			expInt: 1,
+			name: "bool:true",
+			data: `wi: true`,
+			exp:  1,
 		},
 		{
-			name:   "bool:false",
-			data:   `wi: false`,
-			expInt: 0,
+			name: "bool:false",
+			data: `wi: false`,
+			exp:  0,
 		},
 		{
 			name:   "error with non-numeric strings",
@@ -133,7 +134,9 @@ func TestWeakInt(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ts := testWeakInt{}
+			var ts struct {
+				Wi weakInt `yaml:"wi"`
+			}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
 
 			gotErr := err != nil
@@ -146,9 +149,9 @@ func TestWeakInt(t *testing.T) {
 				return
 			}
 
-			if int(ts.Wi) != test.expInt {
+			if int(ts.Wi) != test.exp {
 				t.Errorf("input %q: got %v, expected %v",
-					test.data, ts.Wi, test.expInt)
+					test.data, ts.Wi, test.exp)
 				return
 			}
 		})
@@ -156,39 +159,36 @@ func TestWeakInt(t *testing.T) {
 }
 
 func TestWeakString(t *testing.T) {
-	type testWeakString struct {
-		Ws weakString `yaml:"ws"`
-	}
 	for _, test := range []struct {
 		name   string
 		data   string
-		expStr string
+		exp    string
 		expErr bool
 	}{
 		{
-			name:   "normal string",
-			data:   `ws: "hello world"`,
-			expStr: "hello world",
+			name: "normal string",
+			data: `ws: "hello world"`,
+			exp:  "hello world",
 		},
 		{
-			name:   "bool:true",
-			data:   "ws: true",
-			expStr: "1",
+			name: "bool:true",
+			data: "ws: true",
+			exp:  "1",
 		},
 		{
-			name:   "bool:false",
-			data:   "ws: false",
-			expStr: "0",
+			name: "bool:false",
+			data: "ws: false",
+			exp:  "0",
 		},
 		{
-			name:   "base10 number",
-			data:   "ws: 231231",
-			expStr: "231231",
+			name: "base10 number",
+			data: "ws: 231231",
+			exp:  "231231",
 		},
 		{
-			name:   "float number",
-			data:   "ws: 231.231",
-			expStr: "231.231",
+			name: "float number",
+			data: "ws: 231.231",
+			exp:  "231.231",
 		},
 		{
 			name:   "should error with unsupported types",
@@ -197,7 +197,9 @@ func TestWeakString(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ts := testWeakString{}
+			var ts struct {
+				Ws weakString `yaml:"ws"`
+			}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
 
 			gotErr := err != nil
@@ -210,42 +212,160 @@ func TestWeakString(t *testing.T) {
 				return
 			}
 
-			if string(ts.Ws) != test.expStr {
+			if string(ts.Ws) != test.exp {
 				t.Errorf("input %q: got %v, expected %v",
-					test.data, ts.Ws, test.expStr)
+					test.data, ts.Ws, test.exp)
 				return
 			}
 		})
 	}
 }
 
-func TestNamedSocketAddressArray(t *testing.T) {
-	type testNamedSocketAddressArray struct {
-		Sockets NamedSocketAddresses `yaml:"test_api"`
-	}
+func TestWeakStringArray(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		data   string
-		expArr []NamedSocketAddress
+		exp    []string
+		expErr bool
+	}{
+		{
+			name: "single weak string",
+			data: `test_array:
+  12`,
+			exp: []string{"12"},
+		},
+		{
+			name: "list of weak string",
+			data: `test_array:
+  - 12
+  - 12.3
+  - "hello"
+  - true
+`,
+			exp: []string{"12", "12.3", "hello", "1"},
+		},
+		{
+			name: "inline weak string",
+			data: `test_array: 12`,
+			exp:  []string{"12"},
+		},
+		{
+			name: "array of weak strings",
+			data: `test_array: [12, true]`,
+			exp:  []string{"12", "1"},
+		},
+		{
+			name:   "array with unsupported weak string",
+			data:   `test_array: [12, {true}]`,
+			expErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var ts struct {
+				WsArr weakStringArray `yaml:"test_array"`
+			}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+
+			require.Equal(t, weakStringArray(test.exp), ts.WsArr)
+		})
+	}
+}
+
+func TestNamedSocketAddresses(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		data   string
+		exp    []SocketAddress
+		expErr bool
+	}{
+		{
+			name: "single namedSocketAddress",
+			data: "test_api:\n  address: 0.0.0.0\n  port: 80\n",
+			exp:  []SocketAddress{{Address: "0.0.0.0", Port: 80}},
+		},
+		{
+			name: "list of 1 namedSocketAddress",
+			data: "test_api:\n  - address: 0.0.0.0\n    port: 80\n",
+			exp:  []SocketAddress{{Address: "0.0.0.0", Port: 80}},
+		},
+		{
+			name: "list of namedSocketAddress",
+			data: `test_api:
+  - address: 0.0.0.0
+    port: 80
+  - address: 0.0.0.1
+    port: 81`,
+			exp: []SocketAddress{
+				{
+					Address: "0.0.0.0", Port: 80,
+				},
+				{
+					Address: "0.0.0.1", Port: 81,
+				},
+			},
+		},
+		{
+			name:   "unsupported types",
+			data:   "test_api:\n  - address: 0.0.0.0\n    port: [80]\n",
+			expErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var ts struct {
+				Sockets socketAddresses `yaml:"test_api"`
+			}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+			require.Equal(t, socketAddresses(test.exp), ts.Sockets)
+		})
+	}
+}
+
+func TestNamedSocketAddressArray(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		data   string
+		exp    []NamedSocketAddress
 		expErr bool
 	}{
 		{
 			name: "single namedSocketAddress",
 			data: "test_api:\n  address: 0.0.0.0\n  port: 80\n  name: socket\n",
-			expArr: []NamedSocketAddress{
+			exp: []NamedSocketAddress{
 				{
-					Name:          "socket",
-					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+					Name:    "socket",
+					Address: "0.0.0.0",
+					Port:    80,
 				},
 			},
 		},
 		{
 			name: "list of 1 namedSocketAddress",
 			data: "test_api:\n  - name: socket\n    address: 0.0.0.0\n    port: 80\n",
-			expArr: []NamedSocketAddress{
+			exp: []NamedSocketAddress{
 				{
-					Name:          "socket",
-					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+					Name:    "socket",
+					Address: "0.0.0.0",
+					Port:    80,
 				},
 			},
 		},
@@ -258,20 +378,29 @@ func TestNamedSocketAddressArray(t *testing.T) {
   - name: socket2
     address: 0.0.0.1
     port: 81`,
-			expArr: []NamedSocketAddress{
+			exp: []NamedSocketAddress{
 				{
-					Name:          "socket",
-					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+					Name:    "socket",
+					Address: "0.0.0.0",
+					Port:    80,
 				},
 				{
-					Name:          "socket2",
-					SocketAddress: SocketAddress{Address: "0.0.0.1", Port: 81},
+					Name:    "socket2",
+					Address: "0.0.0.1",
+					Port:    81,
 				},
 			},
 		},
+		{
+			name:   "unsupported types",
+			data:   "test_api:\n  address: [0.0.0.0]\n  port: 80\n  name: socket\n",
+			expErr: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ts := testNamedSocketAddressArray{}
+			var ts struct {
+				Sockets namedSocketAddresses `yaml:"test_api"`
+			}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
 
 			gotErr := err != nil
@@ -283,19 +412,16 @@ func TestNamedSocketAddressArray(t *testing.T) {
 			if test.expErr {
 				return
 			}
-			require.Equal(t, NamedSocketAddresses(test.expArr), ts.Sockets)
+			require.Equal(t, namedSocketAddresses(test.exp), ts.Sockets)
 		})
 	}
 }
 
 func TestServerTLSArray(t *testing.T) {
-	type testServerTLSArray struct {
-		Servers ServerTLSArray `yaml:"test_api"`
-	}
 	for _, test := range []struct {
 		name   string
 		data   string
-		expArr []ServerTLS
+		exp    []ServerTLS
 		expErr bool
 	}{
 		{
@@ -308,7 +434,7 @@ func TestServerTLSArray(t *testing.T) {
   enabled: true
   require_client_auth: true
 `,
-			expArr: []ServerTLS{
+			exp: []ServerTLS{
 				{
 					Name:              "server",
 					KeyFile:           "/etc/certs/cert.key",
@@ -329,7 +455,7 @@ func TestServerTLSArray(t *testing.T) {
     enabled: true
     require_client_auth: true
 `,
-			expArr: []ServerTLS{
+			exp: []ServerTLS{
 				{
 					Name:              "server",
 					KeyFile:           "/etc/certs/cert.key",
@@ -356,7 +482,7 @@ func TestServerTLSArray(t *testing.T) {
     enabled: false
     require_client_auth: true
 `,
-			expArr: []ServerTLS{
+			exp: []ServerTLS{
 				{
 					Name:              "server",
 					KeyFile:           "/etc/certs/cert.key",
@@ -375,9 +501,19 @@ func TestServerTLSArray(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unsupported types",
+			data: `test_api:
+  name: server
+  enabled: [true]
+`,
+			expErr: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ts := testServerTLSArray{}
+			var ts struct {
+				Servers serverTLSArray `yaml:"test_api"`
+			}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
 
 			gotErr := err != nil
@@ -389,7 +525,555 @@ func TestServerTLSArray(t *testing.T) {
 			if test.expErr {
 				return
 			}
-			require.Equal(t, ServerTLSArray(test.expArr), ts.Servers)
+			require.Equal(t, serverTLSArray(test.exp), ts.Servers)
+		})
+	}
+}
+
+func TestSeedServers(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		data   string
+		exp    []SeedServer
+		expErr bool
+	}{
+		{
+			name: "single seed server",
+			data: `test_server:
+  host:
+    address: "0.0.0.1"
+    port: 80
+`,
+			exp: []SeedServer{
+				{Host: SocketAddress{"0.0.0.1", 80}},
+			},
+		},
+		{
+			name: "list of seed server",
+			data: `test_server:
+  - host:
+      address: "0.0.0.1"
+      port: 80
+  - host:
+      address: "0.0.0.2"
+      port: 90
+`,
+			exp: []SeedServer{
+				{Host: SocketAddress{"0.0.0.1", 80}},
+				{Host: SocketAddress{"0.0.0.2", 90}},
+			},
+		},
+		{
+			name: "unsupported types",
+			data: `test_server:
+  host:
+    address: "0.0.0.1"
+    port: [80]
+`,
+			expErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var ts struct {
+				Ss seedServers `yaml:"test_server"`
+			}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+			require.Equal(t, seedServers(test.exp), ts.Ss)
+		})
+	}
+}
+
+func TestConfig_UnmarshalYAML(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		data   string
+		exp    *Config
+		expErr bool
+	}{
+		{
+			name: "Config file with normal types",
+			data: `config_file: "/etc/redpanda/redpanda.yaml"
+organization: "my_organization"
+cluster_id: "cluster_id"
+node_uuid: "node_uuid"
+redpanda:
+  data_directory: "var/lib/redpanda/data"
+  node_id: 1
+  enable_admin_api: true
+  admin_api_doc_dir: "/usr/share/redpanda/admin-api-doc"
+  admin:
+  - address: "0.0.0.0"
+    port: 9644
+    name: admin
+  admin_api_tls:
+  - enabled: false
+    cert_file: "certs/tls-cert.pem"
+  rpc_server:
+    address: "0.0.0.0"
+    port: 33145
+  rpc_server_tls:
+  - require_client_auth: false
+    truststore_file: "certs/tls-ca.pem"
+  advertised_rpc_api:
+    address: "0.0.0.0"
+    port: 33145
+  kafka_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: 9092
+  - address: "0.0.0.0"
+    name: external
+    port: 9093
+  kafka_api_tls:
+  - name: "external"
+    key_file: "certs/tls-key.pem"
+  - name: "internal"
+    enabled: false
+  advertised_kafka_api:
+  - address: 0.0.0.0
+    name: internal
+    port: 9092
+  - address: redpanda-0.my.domain.com.
+    name: external
+    port: 9093
+  seed_servers:
+  - host:
+      address: 192.168.0.1
+      port: 33145
+  rack: "rack-id"
+pandaproxy:
+  pandaproxy_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: 8082
+  - address: "0.0.0.0"
+    name: external
+    port: 8083
+  pandaproxy_api_tls:
+  - name: external
+    enabled: false
+    truststore_file: "truststore_file"
+  - name: internal
+    enabled: false
+  advertised_pandaproxy_api:
+  - address: 0.0.0.0
+    name: internal
+    port: 8082
+  - address: "redpanda-rest-0.my.domain.com."
+    name: external
+    port: 8083
+  consumer_instance_timeout_ms: 60000
+pandaproxy_client:
+  brokers:
+  - address: "127.0.0.1"
+    port: 9092
+  broker_tls:
+    require_client_auth: false
+    cert_file: "certfile"
+  retries: 5
+  retry_base_backoff_ms: 100
+  sasl_mechanism: "mechanism"
+schema_registry:
+  schema_registry_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: 8081
+  - address: "0.0.0.0"
+    name: external
+    port: 18081
+  schema_registry_replication_factor: 3
+  schema_registry_api_tls:
+  - name: external
+    enabled: false
+  - name: internal
+    enabled: false
+rpk:
+  tls:
+    key_file: ~/certs/key.pem
+  sasl:
+    user: user
+    password: pass
+  additional_start_flags:
+    - "--overprovisioned"
+  kafka_api:
+    brokers:
+    - 192.168.72.34:9092
+    - 192.168.72.35:9092
+    tls:
+      key_file: ~/certs/key.pem
+    sasl:
+      user: user
+      password: pass
+  admin_api:
+    addresses:
+    - 192.168.72.34:9644
+    - 192.168.72.35:9644
+    tls:
+      cert_file: ~/certs/admin-cert.pem
+      truststore_file: ~/certs/admin-ca.pem
+  tune_network: false
+  tune_disk_scheduler: false
+  tune_cpu: true
+  tune_aio_events: false
+  tune_clocksource: true
+`,
+			exp: &Config{
+				ConfigFile:   "/etc/redpanda/redpanda.yaml",
+				Organization: "my_organization",
+				ClusterID:    "cluster_id",
+				NodeUUID:     "node_uuid",
+				Redpanda: RedpandaConfig{
+					Directory:      "var/lib/redpanda/data",
+					ID:             1,
+					AdminAPIDocDir: "/usr/share/redpanda/admin-api-doc",
+					Rack:           "rack-id",
+					AdminAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9644, "admin"},
+					},
+					AdminAPITLS: []ServerTLS{
+						{Enabled: false, CertFile: "certs/tls-cert.pem"},
+					},
+					RPCServer: SocketAddress{"0.0.0.0", 33145},
+					RPCServerTLS: []ServerTLS{
+						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
+					},
+					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
+					KafkaAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9092, "internal"},
+						{"0.0.0.0", 9093, "external"},
+					},
+					KafkaAPITLS: []ServerTLS{
+						{Name: "external", KeyFile: "certs/tls-key.pem"},
+						{Name: "internal", Enabled: false},
+					},
+					AdvertisedKafkaAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9092, "internal"},
+						{"redpanda-0.my.domain.com.", 9093, "external"},
+					},
+					SeedServers: []SeedServer{
+						{Host: SocketAddress{"192.168.0.1", 33145}},
+					},
+					Other: map[string]interface{}{
+						"enable_admin_api": true,
+					},
+				},
+				Pandaproxy: &Pandaproxy{
+					PandaproxyAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8082, "internal"},
+						{"0.0.0.0", 8083, "external"},
+					},
+					PandaproxyAPITLS: []ServerTLS{
+						{Name: "external", Enabled: false, TruststoreFile: "truststore_file"},
+						{Name: "internal", Enabled: false},
+					},
+					AdvertisedPandaproxyAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8082, "internal"},
+						{"redpanda-rest-0.my.domain.com.", 8083, "external"},
+					},
+					Other: map[string]interface{}{
+						"consumer_instance_timeout_ms": 60000,
+					},
+				},
+				PandaproxyClient: &KafkaClient{
+					Brokers: []SocketAddress{
+						{"127.0.0.1", 9092},
+					},
+					BrokerTLS: ServerTLS{
+						RequireClientAuth: false, CertFile: "certfile",
+					},
+					SASLMechanism: func() *string { s := "mechanism"; return &s }(),
+					Other: map[string]interface{}{
+						"retries":               5,
+						"retry_base_backoff_ms": 100,
+					},
+				},
+				SchemaRegistry: &SchemaRegistry{
+					SchemaRegistryAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8081, "internal"},
+						{"0.0.0.0", 18081, "external"},
+					},
+					SchemaRegistryAPITLS: []ServerTLS{
+						{Name: "external", Enabled: false},
+						{Name: "internal", Enabled: false},
+					},
+					SchemaRegistryReplicationFactor: func() *int { i := 3; return &i }(),
+				},
+				Rpk: RpkConfig{
+					TLS:                  &TLS{KeyFile: "~/certs/key.pem"},
+					SASL:                 &SASL{User: "user", Password: "pass"},
+					AdditionalStartFlags: []string{"--overprovisioned"},
+					KafkaAPI: RpkKafkaAPI{
+						Brokers: []string{"192.168.72.34:9092", "192.168.72.35:9092"},
+						TLS:     &TLS{KeyFile: "~/certs/key.pem"},
+						SASL:    &SASL{User: "user", Password: "pass"},
+					},
+					AdminAPI: RpkAdminAPI{
+						Addresses: []string{"192.168.72.34:9644", "192.168.72.35:9644"},
+						TLS:       &TLS{CertFile: "~/certs/admin-cert.pem", TruststoreFile: "~/certs/admin-ca.pem"},
+					},
+					TuneNetwork:       false,
+					TuneDiskScheduler: false,
+					TuneCPU:           true,
+					TuneAioEvents:     false,
+					TuneClocksource:   true,
+				},
+			},
+		},
+		{
+			name: "Config file with weak types",
+			data: `config_file: 123123
+organization: true
+cluster_id: "cluster_id"
+node_uuid: 124.42
+redpanda:
+  data_directory: "var/lib/redpanda/data"
+  node_id: 1
+  enable_admin_api: true
+  admin_api_doc_dir: "/usr/share/redpanda/admin-api-doc"
+  admin:
+    address: "0.0.0.0"
+    port: 9644
+    name: admin
+  admin_api_tls:
+    enabled: false
+    cert_file: "certs/tls-cert.pem"
+  rpc_server:
+    address: "0.0.0.0"
+    port: 33145
+  rpc_server_tls:
+    require_client_auth: false
+    truststore_file: "certs/tls-ca.pem"
+  advertised_rpc_api:
+    address: "0.0.0.0"
+    port: 33145
+  kafka_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: "9092"
+  - address: "0.0.0.0"
+    name: external
+    port: "9093"
+  kafka_api_tls:
+  - name: "external"
+    key_file: "certs/tls-key.pem"
+  - name: "internal"
+    enabled: false
+  advertised_kafka_api:
+  - address: 0.0.0.0
+    name: internal
+    port: 9092
+  - address: redpanda-0.my.domain.com.
+    name: external
+    port: 9093
+  seed_servers:
+    host:
+      address: 192.168.0.1
+      port: 33145
+  rack: "rack-id"
+pandaproxy:
+  pandaproxy_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: 8082
+  - address: "0.0.0.0"
+    name: external
+    port: 8083
+  pandaproxy_api_tls:
+  - name: external
+    enabled: 0
+    truststore_file: "truststore_file"
+  - name: internal
+    enabled: 0
+  advertised_pandaproxy_api:
+  - address: 0.0.0.0
+    name: internal
+    port: 8082
+  - address: "redpanda-rest-0.my.domain.com."
+    name: external
+    port: 8083
+  consumer_instance_timeout_ms: 60000
+pandaproxy_client:
+  brokers:
+  - address: "127.0.0.1"
+    port: 9092
+  broker_tls:
+    require_client_auth: false
+    cert_file: "certfile"
+  retries: 5
+  retry_base_backoff_ms: 100
+  sasl_mechanism: "mechanism"
+schema_registry:
+  schema_registry_api:
+  - address: "0.0.0.0"
+    name: internal
+    port: 8081
+  - address: "0.0.0.0"
+    name: external
+    port: 18081
+  schema_registry_replication_factor: 3
+  schema_registry_api_tls:
+  - name: external
+    enabled: false
+  - name: internal
+    enabled: false
+rpk:
+  tls:
+    key_file: ~/certs/key.pem
+  sasl:
+    user: user
+    password: pass
+  additional_start_flags: "--overprovisioned"
+  kafka_api:
+    brokers:
+    - 192.168.72.34:9092
+    - 192.168.72.35:9092
+    tls:
+      key_file: ~/certs/key.pem
+    sasl:
+      user: user
+      password: pass
+  admin_api:
+    addresses:
+    - 192.168.72.34:9644
+    - 192.168.72.35:9644
+    tls:
+      cert_file: ~/certs/admin-cert.pem
+      truststore_file: ~/certs/admin-ca.pem
+  tune_network: false
+  tune_disk_scheduler: false
+  tune_cpu: 1
+  tune_aio_events: false
+  tune_clocksource: 1
+`,
+			exp: &Config{
+				ConfigFile:   "123123",
+				Organization: "1",
+				ClusterID:    "cluster_id",
+				NodeUUID:     "124.42",
+				Redpanda: RedpandaConfig{
+					Directory:      "var/lib/redpanda/data",
+					ID:             1,
+					AdminAPIDocDir: "/usr/share/redpanda/admin-api-doc",
+					Rack:           "rack-id",
+					AdminAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9644, "admin"},
+					},
+					AdminAPITLS: []ServerTLS{
+						{Enabled: false, CertFile: "certs/tls-cert.pem"},
+					},
+					RPCServer: SocketAddress{"0.0.0.0", 33145},
+					RPCServerTLS: []ServerTLS{
+						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
+					},
+					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
+					KafkaAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9092, "internal"},
+						{"0.0.0.0", 9093, "external"},
+					},
+					KafkaAPITLS: []ServerTLS{
+						{Name: "external", KeyFile: "certs/tls-key.pem"},
+						{Name: "internal", Enabled: false},
+					},
+					AdvertisedKafkaAPI: []NamedSocketAddress{
+						{"0.0.0.0", 9092, "internal"},
+						{"redpanda-0.my.domain.com.", 9093, "external"},
+					},
+					SeedServers: []SeedServer{
+						{Host: SocketAddress{"192.168.0.1", 33145}},
+					},
+					Other: map[string]interface{}{
+						"enable_admin_api": true,
+					},
+				},
+				Pandaproxy: &Pandaproxy{
+					PandaproxyAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8082, "internal"},
+						{"0.0.0.0", 8083, "external"},
+					},
+					PandaproxyAPITLS: []ServerTLS{
+						{Name: "external", Enabled: false, TruststoreFile: "truststore_file"},
+						{Name: "internal", Enabled: false},
+					},
+					AdvertisedPandaproxyAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8082, "internal"},
+						{"redpanda-rest-0.my.domain.com.", 8083, "external"},
+					},
+					Other: map[string]interface{}{
+						"consumer_instance_timeout_ms": 60000,
+					},
+				},
+				PandaproxyClient: &KafkaClient{
+					Brokers: []SocketAddress{
+						{"127.0.0.1", 9092},
+					},
+					BrokerTLS: ServerTLS{
+						RequireClientAuth: false, CertFile: "certfile",
+					},
+					SASLMechanism: func() *string { s := "mechanism"; return &s }(),
+					Other: map[string]interface{}{
+						"retries":               5,
+						"retry_base_backoff_ms": 100,
+					},
+				},
+				SchemaRegistry: &SchemaRegistry{
+					SchemaRegistryAPI: []NamedSocketAddress{
+						{"0.0.0.0", 8081, "internal"},
+						{"0.0.0.0", 18081, "external"},
+					},
+					SchemaRegistryAPITLS: []ServerTLS{
+						{Name: "external", Enabled: false},
+						{Name: "internal", Enabled: false},
+					},
+					SchemaRegistryReplicationFactor: func() *int { i := 3; return &i }(),
+				},
+				Rpk: RpkConfig{
+					TLS:                  &TLS{KeyFile: "~/certs/key.pem"},
+					SASL:                 &SASL{User: "user", Password: "pass"},
+					AdditionalStartFlags: []string{"--overprovisioned"},
+					KafkaAPI: RpkKafkaAPI{
+						Brokers: []string{"192.168.72.34:9092", "192.168.72.35:9092"},
+						TLS:     &TLS{KeyFile: "~/certs/key.pem"},
+						SASL:    &SASL{User: "user", Password: "pass"},
+					},
+					AdminAPI: RpkAdminAPI{
+						Addresses: []string{"192.168.72.34:9644", "192.168.72.35:9644"},
+						TLS:       &TLS{CertFile: "~/certs/admin-cert.pem", TruststoreFile: "~/certs/admin-ca.pem"},
+					},
+					TuneNetwork:       false,
+					TuneDiskScheduler: false,
+					TuneCPU:           true,
+					TuneAioEvents:     false,
+					TuneClocksource:   true,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var ts struct {
+				Config *Config `yaml:",inline"`
+			}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+			require.Equal(t, test.exp, ts.Config)
 		})
 	}
 }

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -10,62 +11,53 @@ func TestWeakBool(t *testing.T) {
 	type testWeakBool struct {
 		Wb weakBool `yaml:"wb"`
 	}
-
-	tests := []struct {
-		name    string
-		data    string
-		expBool bool
-		expErr  bool
+	for _, test := range []struct {
+		name   string
+		data   string
+		exp    bool
+		expErr bool
 	}{
 		{
-			name:    "should unmarshal boolean:true",
-			data:    "wb: true",
-			expBool: true,
-			expErr:  false,
+			name: "boolean:true",
+			data: "wb: true",
+			exp:  true,
 		},
 		{
-			name:    "should unmarshal boolean:false",
-			data:    "wb: false",
-			expBool: false,
-			expErr:  false,
+			name: "boolean:false",
+			data: "wb: false",
+			exp:  false,
 		},
 		{
-			name:    "should unmarshal int:0",
-			data:    "wb: 0",
-			expBool: false,
-			expErr:  false,
+			name: "int:0",
+			data: "wb: 0",
+			exp:  false,
 		},
 		{
-			name:    "should unmarshal int:different from zero",
-			data:    "wb: 12",
-			expBool: true,
-			expErr:  false,
+			name: "non-zero int",
+			data: "wb: 12",
+			exp:  true,
 		},
 		{
-			name:    "should unmarshal string:true",
-			data:    `wb: "true"`,
-			expBool: true,
-			expErr:  false,
+			name: "string:true",
+			data: `wb: "true"`,
+			exp:  true,
 		},
 		{
-			name:    "should unmarshal string:false",
-			data:    `wb: "false"`,
-			expBool: false,
-			expErr:  false,
+			name: "string:false",
+			data: `wb: "false"`,
+			exp:  false,
 		},
 		{
-			name:   "should error with unsupported string",
+			name:   "error with unsupported string",
 			data:   `wb: "falsity"`,
 			expErr: true,
 		},
 		{
-			name:   "should error with float type",
+			name:   "error with float type",
 			data:   `wb: 123.123`,
 			expErr: true,
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			ts := testWeakBool{}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
@@ -80,9 +72,9 @@ func TestWeakBool(t *testing.T) {
 				return
 			}
 
-			if bool(ts.Wb) != test.expBool {
+			if bool(ts.Wb) != test.exp {
 				t.Errorf("input %q: got %v, expected %v",
-					test.data, ts.Wb, test.expBool)
+					test.data, ts.Wb, test.exp)
 				return
 			}
 		})
@@ -93,61 +85,53 @@ func TestWeakInt(t *testing.T) {
 	type testWeakInt struct {
 		Wi weakInt `yaml:"wi"`
 	}
-	tests := []struct {
+	for _, test := range []struct {
 		name   string
 		data   string
 		expInt int
 		expErr bool
 	}{
 		{
-			name:   "should unmarshal normal int types",
+			name:   "normal int types",
 			data:   "wi: 1231",
 			expInt: 1231,
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal empty string as 0",
+			name:   "empty string as 0",
 			data:   `wi: ""`,
 			expInt: 0,
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal string:-23414",
+			name:   "string:-23414",
 			data:   `wi: "-23414"`,
 			expInt: -23414,
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal string:231231",
+			name:   "string:231231",
 			data:   `wi: "231231"`,
 			expInt: 231231,
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal bool:true",
+			name:   "bool:true",
 			data:   `wi: true`,
 			expInt: 1,
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal bool:false",
+			name:   "bool:false",
 			data:   `wi: false`,
 			expInt: 0,
-			expErr: false,
 		},
 		{
-			name:   "should error with not-numeric strings",
+			name:   "error with non-numeric strings",
 			data:   `wi: "123foo234"`,
 			expErr: true,
 		},
 		{
-			name:   "should error with float numbers",
+			name:   "error with float numbers",
 			data:   `wi: 123.234`,
 			expErr: true,
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			ts := testWeakInt{}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
@@ -175,50 +159,43 @@ func TestWeakString(t *testing.T) {
 	type testWeakString struct {
 		Ws weakString `yaml:"ws"`
 	}
-	tests := []struct {
+	for _, test := range []struct {
 		name   string
 		data   string
 		expStr string
 		expErr bool
 	}{
 		{
-			name:   "should unmarshal normal string types",
+			name:   "normal string",
 			data:   `ws: "hello world"`,
 			expStr: "hello world",
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal bool:true",
+			name:   "bool:true",
 			data:   "ws: true",
 			expStr: "1",
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal bool:false",
+			name:   "bool:false",
 			data:   "ws: false",
 			expStr: "0",
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal base10 number:231231",
+			name:   "base10 number",
 			data:   "ws: 231231",
 			expStr: "231231",
-			expErr: false,
 		},
 		{
-			name:   "should unmarshal float number:231.231",
+			name:   "float number",
 			data:   "ws: 231.231",
 			expStr: "231.231",
-			expErr: false,
 		},
 		{
 			name:   "should error with unsupported types",
 			data:   "ws: \n  - 231.231",
 			expErr: true,
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			ts := testWeakString{}
 			err := yaml.Unmarshal([]byte(test.data), &ts)
@@ -238,6 +215,181 @@ func TestWeakString(t *testing.T) {
 					test.data, ts.Ws, test.expStr)
 				return
 			}
+		})
+	}
+}
+
+func TestNamedSocketAddressArray(t *testing.T) {
+	type testNamedSocketAddressArray struct {
+		Sockets NamedSocketAddresses `yaml:"test_api"`
+	}
+	for _, test := range []struct {
+		name   string
+		data   string
+		expArr []NamedSocketAddress
+		expErr bool
+	}{
+		{
+			name: "single namedSocketAddress",
+			data: "test_api:\n  address: 0.0.0.0\n  port: 80\n  name: socket\n",
+			expArr: []NamedSocketAddress{
+				{
+					Name:          "socket",
+					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+				},
+			},
+		},
+		{
+			name: "list of 1 namedSocketAddress",
+			data: "test_api:\n  - name: socket\n    address: 0.0.0.0\n    port: 80\n",
+			expArr: []NamedSocketAddress{
+				{
+					Name:          "socket",
+					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+				},
+			},
+		},
+		{
+			name: "list of namedSocketAddress",
+			data: `test_api:
+  - name: socket
+    address: 0.0.0.0
+    port: 80
+  - name: socket2
+    address: 0.0.0.1
+    port: 81`,
+			expArr: []NamedSocketAddress{
+				{
+					Name:          "socket",
+					SocketAddress: SocketAddress{Address: "0.0.0.0", Port: 80},
+				},
+				{
+					Name:          "socket2",
+					SocketAddress: SocketAddress{Address: "0.0.0.1", Port: 81},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ts := testNamedSocketAddressArray{}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+			require.Equal(t, NamedSocketAddresses(test.expArr), ts.Sockets)
+		})
+	}
+}
+
+func TestServerTLSArray(t *testing.T) {
+	type testServerTLSArray struct {
+		Servers ServerTLSArray `yaml:"test_api"`
+	}
+	for _, test := range []struct {
+		name   string
+		data   string
+		expArr []ServerTLS
+		expErr bool
+	}{
+		{
+			name: "single serverTLS",
+			data: `test_api:
+  name: server
+  key_file: "/etc/certs/cert.key"
+  truststore_file: "/etc/certs/ca.crt"
+  cert_file: "/etc/certs/cert.crt"
+  enabled: true
+  require_client_auth: true
+`,
+			expArr: []ServerTLS{
+				{
+					Name:              "server",
+					KeyFile:           "/etc/certs/cert.key",
+					TruststoreFile:    "/etc/certs/ca.crt",
+					CertFile:          "/etc/certs/cert.crt",
+					Enabled:           true,
+					RequireClientAuth: true,
+				},
+			},
+		},
+		{
+			name: "list of 1 serverTLS",
+			data: `test_api:
+  - name: server
+    key_file: "/etc/certs/cert.key"
+    truststore_file: "/etc/certs/ca.crt"
+    cert_file: "/etc/certs/cert.crt"
+    enabled: true
+    require_client_auth: true
+`,
+			expArr: []ServerTLS{
+				{
+					Name:              "server",
+					KeyFile:           "/etc/certs/cert.key",
+					TruststoreFile:    "/etc/certs/ca.crt",
+					CertFile:          "/etc/certs/cert.crt",
+					Enabled:           true,
+					RequireClientAuth: true,
+				},
+			},
+		},
+		{
+			name: "list of serverTLS",
+			data: `test_api:
+  - name: server
+    key_file: "/etc/certs/cert.key"
+    truststore_file: "/etc/certs/ca.crt"
+    cert_file: "/etc/certs/cert.crt"
+    enabled: true
+    require_client_auth: true
+  - name: server2
+    key_file: "/etc/certs/cert2.key"
+    truststore_file: "/etc/certs/ca2.crt"
+    cert_file: "/etc/certs/cert2.crt"
+    enabled: false
+    require_client_auth: true
+`,
+			expArr: []ServerTLS{
+				{
+					Name:              "server",
+					KeyFile:           "/etc/certs/cert.key",
+					TruststoreFile:    "/etc/certs/ca.crt",
+					CertFile:          "/etc/certs/cert.crt",
+					Enabled:           true,
+					RequireClientAuth: true,
+				},
+				{
+					Name:              "server2",
+					KeyFile:           "/etc/certs/cert2.key",
+					TruststoreFile:    "/etc/certs/ca2.crt",
+					CertFile:          "/etc/certs/cert2.crt",
+					Enabled:           false,
+					RequireClientAuth: true,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ts := testServerTLSArray{}
+			err := yaml.Unmarshal([]byte(test.data), &ts)
+
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("input %q: got err? %v, exp err? %v; error: %v",
+					test.data, gotErr, test.expErr, err)
+				return
+			}
+			if test.expErr {
+				return
+			}
+			require.Equal(t, ServerTLSArray(test.expArr), ts.Servers)
 		})
 	}
 }


### PR DESCRIPTION
## Cover letter
This PR introduces:

**4 new basic "weak" types:**
- weakBool
- weakInt
- weakString
- weakStringArray

Weak types allow us to control how we want to unmarshall weakly typed configuration parameters and will enable us to print deprecation warnings.

**Support for one_or_many types in:**
- socketAddress
- namedSocketAddress
- serverTLS
- seedServer

One_or_many types are being handled right now via mapstruct: rpk can handle either yaml single elements or list into the same struct type.

**Custom unmarshalling for config type:** 
Now config unmarshalls into intermediary types and preserve the original types in the Config Struct

This PR is part of our efforts to migrate away from mapstruct and viper

Part of #4531
## Release notes


*none