### PR TITLE
expiring_promise: fix loss of exception information

### DIFF
--- a/src/v/utils/expiring_promise.h
+++ b/src/v/utils/expiring_promise.h
@@ -87,30 +87,16 @@ public:
 
     bool available() const { return _available; }
 
-    void set_exception(std::exception_ptr&& ex) {
+    template<typename Exception>
+    void set_exception(Exception&& ex) {
         if (_timer.cancel()) {
             unlink_abort_source();
         }
 
         if (likely(!_available)) {
             _available = true;
-            _promise.set_exception(ex);
+            _promise.set_exception(std::forward<Exception>(ex));
         }
-    }
-
-    void set_exception(const std::exception_ptr& ex) {
-        if (_timer.cancel()) {
-            unlink_abort_source();
-        }
-
-        if (likely(!_available)) {
-            _available = true;
-            _promise.set_exception(ex);
-        }
-    }
-
-    void set_exception(const std::exception& ex) {
-        set_exception(std::make_exception_ptr(ex));
     }
 
 private:


### PR DESCRIPTION
This is an example of an exceptional future being unwrapped and logged.
It is shown as a bare std::exception, but we should not have a single
instance in the tree of throwing a bare exception.

   WARN 2022-05-24 11:09:36,133 [shard 0] cluster - config_manager.cc:134 -
   Exception during bootstrap: std::exception (std::exception)

In this case the future's exception was set by abort source via the
expiring promise utility. However, the utility's set_exception method is
overloaded. One of the overloads, `set_exception(const std::exception&)`,
appears to be the culprit, by effectively casting to the parent type
and throwing away valuable type information by the type it becomes a
std::exception_ptr.

This commit passes throw all of the type and value classes to the
underlying seastar promise and let's it do its own thing.

---

Verification attempt

* these are two `ci-repeat-10` runs. i cancelled them, but they all made it pass the unit-test phase
  * https://buildkite.com/redpanda/redpanda/builds/10506
  * https://buildkite.com/redpanda/redpanda/builds/10508

---

Fixes: https://github.com/redpanda-data/redpanda/issues/4807