### PR TITLE
Nit fixes: unused imports, stale comments, py annotations, clang tidy polish.

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -18,7 +18,6 @@
 #include "cluster/feature_manager.h"
 #include "cluster/feature_table.h"
 #include "cluster/fwd.h"
-#include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/logger.h"
 #include "cluster/members_backend.h"

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -29,12 +29,11 @@
 
 namespace cluster {
 
-/// Metadata cache provides all informationrequired to fill Kafka metadata
-/// response. metadata dissemination service. MetadataCache is the facade over
-/// cluster state distributed in separate components. The metadata cache
-/// core-affinity is independent from the actual state location as the Metadata
-/// cache facade, for simplicity, is instantiated on every core.
-/// MetadaCache itself does not hold any state
+/// Metadata cache provides all information required to fill Kafka metadata
+/// response. MetadataCache is the facade over cluster state distributed in
+/// separate components. The metadata cache core-affinity is independent from
+/// the actual state location as the Metadata cache facade, for simplicity, is
+/// instantiated on every core. MetadaCache itself does not hold any state
 ///```plain
 ///
 ///   Kafka API                  Kafka Proxy
@@ -47,11 +46,11 @@ namespace cluster {
 /// |                                          |
 /// |         Metadata Cache (facade)          |
 /// |                                          |
-/// +----+-------------+----------------+------+
-///      |             |                |
-/// +----v----+   +----v-----+    +-----v------+
-/// | Members |   |  Topics  |    |  Leaders   |
-/// +---------+   +----------+    +------------+
+/// +---+----------+------------+----------+---+
+///     |          |            |          |
+/// +---v---+  +---v----+  +----v----+  +--v---+
+/// |Members|  | Topics |  | Leaders |  |Health|
+/// +-------+  +--------+  +---------+  +------+
 class metadata_cache {
 public:
     using with_leaders = ss::bool_class<struct with_leaders_tag>;

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -28,7 +28,7 @@ inline const model::ntp controller_ntp(
  */
 inline const model::topic kvstore_topic("kvstore");
 inline model::ntp kvstore_ntp(ss::shard_id shard) {
-    return model::ntp(redpanda_ns, kvstore_topic, model::partition_id(shard));
+    return {redpanda_ns, kvstore_topic, model::partition_id(shard)};
 }
 
 inline const model::ns kafka_namespace("kafka");

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -67,7 +67,7 @@ class Admin:
         if auth is not None:
             self._session.auth = auth
 
-        self._default_node = default_node
+        self._default_node: ClusterNode = default_node
 
         # - We retry on 503s because at any time a POST to a leader-redirected
         # request will return 503 if the partition is leaderless -- this is common

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1489,15 +1489,15 @@ class RedpandaService(Service):
     def admin_endpoints(self):
         return ",".join(self.admin_endpoints_list())
 
-    def brokers(self, limit=None):
+    def brokers(self, limit=None) -> str:
         return ",".join(self.brokers_list(limit))
 
-    def brokers_list(self, limit=None):
+    def brokers_list(self, limit=None) -> list[str]:
         brokers = [self.broker_address(n) for n in self._started[:limit]]
         random.shuffle(brokers)
         return brokers
 
-    def schema_reg(self, limit=None):
+    def schema_reg(self, limit=None) -> str:
         schema_reg = [
             f"http://{n.account.hostname}:8081" for n in self._started[:limit]
         ]

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -8,12 +8,14 @@
 # by the Apache License, Version 2.0
 
 import os
+from typing import Sequence
 
 from ducktape.tests.test import Test
 from rptest.services.redpanda import RedpandaService
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.util import Scale
+from rptest.clients.types import TopicSpec
 
 
 class RedpandaTest(Test):
@@ -23,7 +25,7 @@ class RedpandaTest(Test):
 
     # List of topics to be created automatically when the cluster starts. Each
     # topic is defined by an instance of a TopicSpec.
-    topics = []
+    topics: Sequence[TopicSpec] = []
 
     def __init__(self,
                  test_context,


### PR DESCRIPTION
Pulling out some little unrelated, trivial changes from PR #4803 

- Unused import
- Comment update.
- Add some rptest type annotations.
- Clang tidy polish.