### PR TITLE
Fixed serialization of group tombstones

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2393,7 +2393,7 @@ void add_offset_tombstone_record(
       .partition = tp.partition,
     };
     auto kv = serializer.to_kv(offset_metadata_kv{.key = std::move(key)});
-    builder.add_raw_kv(reflection::to_iobuf(std::move(kv.key)), std::nullopt);
+    builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 
 void add_group_tombstone_record(
@@ -2404,7 +2404,7 @@ void add_group_tombstone_record(
       .group_id = group,
     };
     auto kv = serializer.to_kv(group_metadata_kv{.key = std::move(key)});
-    builder.add_raw_kv(reflection::to_iobuf(std::move(kv.key)), std::nullopt);
+    builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 } // namespace
 

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -12,8 +12,11 @@
 #include "kafka/server/group_metadata.h"
 
 #include "bytes/bytes.h"
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/protocol/response_writer.h"
+#include "kafka/server/logger.h"
 #include "kafka/types.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
@@ -239,13 +242,84 @@ iobuf metadata_to_iobuf(const T& t) {
     T::encode(writer, t);
     return buffer;
 }
+iobuf maybe_unwrap_from_iobuf(iobuf buffer) {
+    /*
+     * Previously in redpanda we had an error leading to wrapping
+     * tombstone record keys with an iobuf serialization envelope. In
+     * order to provide compatibility and be able to read keys wrapped
+     * with an additional iobuf we introduce a check leveraging
+     * serialization format.
+     *
+     * # New serializer format - __consumer_offset topic
+     *
+     *
+     * In Kafka the only allowed values for group metadata versions are
+     * 0, 1, and 2. Group metadata use big endian encoding hence the
+     * first two bytes of a serialized group metadata key contains
+     * information about a version. Both offset_metadata_key and
+     * group_metadata_key first serialized field is a `group_id` string
+     * which is encoded as 2 bytes of size and then array of characters.
+     * This way 4 first bytes of encoded key are:
+     *
+     * b0 - denotes LSB
+     * bN - denotes N byte indexed from LSB to MSB (LSB has index 0)
+     *
+     * Key bytes (big endian):
+     *
+     *      |version_b1|version_b0|size_b1|size_b0|...
+     *
+     * When key struct is wrapped with an iobuf serialization it is
+     * prefixed with iobuf size which is serialized as 4 bytes of a size
+     * (in a little endian encoding) and then the iobuf content
+     *
+     * iobuf size bytes (little endian):
+     *
+     *      |size_b0|size_b1|size_b2|size_b3|...
+     *
+     * To check if metadata key was wrapped with an iobuf we peek first
+     * 4 bytes to try to decode iobuf size store in little endian format
+     * if returned size is equal to size of remaining key buffer size it
+     * means that we need to unwrap key from an iobuf.
+     *
+     * # Old serializer format
+     *
+     * When serialized with previous `kafka_internal/group` serializer a key was
+     * represented by
+     *
+     * struct group_log_record_key {
+     *  enum class type : int8_t { group_metadata, offset_commit, noop };
+     *    type record_type;
+     *    iobuf key;
+     * };
+     *
+     * When serialized with ADL its binary representation is as follows
+     *
+     *      |record_tp_b0|size_b0|size_b1|size_b2|...
+     *
+     * Those 4 first bytes will be decoded as an iobuf size.
+     *
+     * TODO: remove this code in future releases
+     */
+
+    iobuf_const_parser parser(buffer);
+    // peek first 4-byte
+    auto deserialized_size = reflection::from_iobuf<int32_t>(parser.peek(4));
+
+    if (unlikely(
+          buffer.size_bytes() == static_cast<size_t>(deserialized_size) + 4)) {
+        vlog(kafka::klog.debug, "Unwrapping group metadata key from iobuf");
+        // unwrap from iobuf
+        return reflection::from_iobuf<iobuf>(std::move(buffer));
+    }
+    return buffer;
+}
 } // namespace
 
 group_metadata_serializer make_backward_compatible_serializer() {
     struct impl : group_metadata_serializer::impl {
         group_metadata_type get_metadata_type(iobuf buffer) final {
             auto key = reflection::from_iobuf<old::group_log_record_key>(
-              std::move(buffer));
+              maybe_unwrap_from_iobuf(std::move(buffer)));
             switch (key.record_type) {
             case old::group_log_record_key::type::offset_commit:
                 return group_metadata_type::offset_commit;
@@ -320,7 +394,7 @@ group_metadata_serializer make_backward_compatible_serializer() {
         group_metadata_kv decode_group_metadata(model::record record) final {
             group_metadata_kv ret;
             auto record_key = reflection::from_iobuf<old::group_log_record_key>(
-              record.release_key());
+              maybe_unwrap_from_iobuf(record.release_key()));
             auto group_id = kafka::group_id(
               reflection::from_iobuf<kafka::group_id::type>(
                 std::move(record_key.key)));
@@ -363,7 +437,7 @@ group_metadata_serializer make_backward_compatible_serializer() {
         offset_metadata_kv decode_offset_metadata(model::record r) final {
             offset_metadata_kv ret;
             auto record_key = reflection::from_iobuf<old::group_log_record_key>(
-              r.release_key());
+              maybe_unwrap_from_iobuf(r.release_key()));
             auto key = reflection::from_iobuf<old::group_log_offset_key>(
               std::move(record_key.key));
 
@@ -394,7 +468,8 @@ group_metadata_serializer make_backward_compatible_serializer() {
 group_metadata_serializer make_consumer_offsets_serializer() {
     struct impl final : group_metadata_serializer::impl {
         group_metadata_type get_metadata_type(iobuf buffer) final {
-            auto reader = request_reader(std::move(buffer));
+            auto reader = request_reader(
+              maybe_unwrap_from_iobuf(std::move(buffer)));
             return decode_metadata_type(reader);
         };
 
@@ -421,7 +496,8 @@ group_metadata_serializer make_consumer_offsets_serializer() {
 
         group_metadata_kv decode_group_metadata(model::record record) final {
             group_metadata_kv ret;
-            request_reader k_reader(record.release_key());
+            request_reader k_reader(
+              maybe_unwrap_from_iobuf(record.release_key()));
             ret.key = group_metadata_key::decode(k_reader);
             if (record.has_value()) {
                 request_reader v_reader(record.release_value());
@@ -433,7 +509,8 @@ group_metadata_serializer make_consumer_offsets_serializer() {
 
         offset_metadata_kv decode_offset_metadata(model::record record) final {
             offset_metadata_kv ret;
-            request_reader k_reader(record.release_key());
+            request_reader k_reader(
+              maybe_unwrap_from_iobuf(record.release_key()));
             ret.key = offset_metadata_key::decode(k_reader);
             if (record.has_value()) {
                 request_reader v_reader(record.release_value());

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -141,7 +141,7 @@ void group_recovery_consumer::handle_record(model::record r) {
     } catch (...) {
         vlog(
           klog.error,
-          "error handling record record - {}",
+          "error handling group metadata record - {}",
           std::current_exception());
     }
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -394,6 +394,10 @@ class RpkTool:
         cmd = ["seek", group, "--to-group", to_group]
         self._run_group(cmd)
 
+    def group_delete(self, group):
+        cmd = ["delete", group]
+        self._run_group(cmd)
+
     def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',


### PR DESCRIPTION
## Cover letter
Group metadata key serializer returns an `iobuf`. Wrapping it with another serialization layer is incorrect as it introduces additional size field in the binary format that deserializer does not expect. This leads to deserialization error and exception is being thrown. 

Fixes: #4900
Fixes: #5008 

### Proof for `iobuf` unwrapping approach

```python
import struct


# There are two tombstone types encoded for keys
#
#    offset_metadata_kv
#    group_metadata_kv
#
# Each one can be encoded with Old/New Serializer
#
# There is a bug where the key has an iobuf wrapper
#
# 1 old-serializer-key          # written by old code
# 2 wrapper(old-serializer-key) # written by new code, prior to consumer group migration
# 3 wrapper(new-serializer-key) # written by new code, after consume group migration
# 4 new-serializer-key          # will be written by new code after bug is fixed
#
# one single decoder doesn't need to handle all for cases
# we need a decode for: 1, 2 (old consumer group)
# we need a decode for: 3, 4 (new consumer group)
#
# Case 1: old serializer, group_metadata, no wrapper
#
#group_metadata_serializer::key_value ret;
#ret.key = reflection::to_iobuf(old::group_log_record_key{
#  .record_type = old::group_log_record_key::type::group_metadata,
#  .key = reflection::to_iobuf(md.key.group_id),
#});
#
# serialization is 1 byte for record type (0, 1, 2)
# followed by 4-bytes for iobuf length whose length
# is the length of md.key.group_id which is constrained
# by the kafka group_id length of int16_t with min size 1.
def group_metadata_old_key_unwrapped():
    for record_type in (0, 1, 2):
        for buffer_len in range(1, 2**15):
            data = struct.pack("<bi", record_type, buffer_len)
            assert len(data) == 5
            yield (data[:4], len(data) + buffer_len)


# Case 2: old serializer, offset_metadata, no wrapper
#
#group_metadata_serializer::key_value ret;
#ret.key = reflection::to_iobuf(old::group_log_record_key{
#  .record_type = old::group_log_record_key::type::offset_commit,
#  .key = reflection::to_iobuf(old::group_log_offset_key{
#    std::move(md.key.group_id),
#    std::move(md.key.topic),
#    md.key.partition,
#  }),
def offset_metadata_old_key_unwrapped():
    for record_type in (0, 1, 2):
        for buffer_len in range(1, 4 + 2**15 + 4 + 2**15 + 4):
            data = struct.pack("<bi", record_type, buffer_len)
            assert len(data) == 5
            yield (data[:4], len(data) + buffer_len)


# version: int16
# group_id: string (length prefix int16)
#void group_metadata_key::encode(
#  response_writer& writer, const group_metadata_key& v) {
#    writer.write(v.version);
#    writer.write(v.group_id);
#}
def group_metadata_new_key_unwrapped():
    for version in (0, 1, 2):
        for buffer_len in range(1, 2**15):
            data = struct.pack(">hh", version, buffer_len)
            assert len(data) == 4
            yield (data, len(data) + buffer_len)


# same as group_metadata_new_key_unwrapped
# except that the topic makes the remainder
# of the serialized size variable length.
#void offset_metadata_key::encode(
#  response_writer& writer, const offset_metadata_key& v) {
#    writer.write(v.version);
#    writer.write(v.group_id);
#    writer.write(v.topic);
#    writer.write(v.partition);
#}
def offset_metadata_new_key_unwrapped():
    for version in (0, 1, 2):
        for buffer_len in range(1, 2**15):
            data = struct.pack(">hh", version, buffer_len)
            assert len(data) == 4
            yield (data, len(data) + buffer_len)


generators = [
    group_metadata_old_key_unwrapped, offset_metadata_old_key_unwrapped,
    group_metadata_new_key_unwrapped, offset_metadata_new_key_unwrapped
]

for generator in generators:
    # actual_buf_length - is a length of whole encoded buffer
    for encoded_buf_length, actual_buf_len in generator():

        # first 4 bytes of encoded struct read as little endian int32_t
        read_length = struct.unpack('<i', encoded_buf_length)[0]

        print(f"encoded: {read_length}, actual: {actual_buf_len}")

        # verify that condition validating if serialized struct is wrapped in a 
        # buffer is never true when decoded buffer length comes from first 
        # 4 bytes of a serialized struct representation 
        assert read_length + 4 != actual_buf_len
```


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Fixed parsing of removed consumer groups

-->
