### PR TITLE
build: Update seastar to avoid deprecated coroutine warning in clang-14

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 5531940ecd6fa6e5a30bbce8e0573db6f721d343
+  GIT_TAG 0fd17f4cb57365c4a340fbb4435fcc903871512a
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS

--- a/cmake/v_library.cmake
+++ b/cmake/v_library.cmake
@@ -3,10 +3,6 @@ include(CMakeParseArguments)
 set(V_CXX_STANDARD 20)
 set(V_DEFAULT_LINKOPTS)
 set(V_DEFAULT_COPTS -Wall -Wextra -Werror -Wno-missing-field-initializers)
-# Disable warning for clang++-14 only.
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
-  list(APPEND V_DEFAULT_COPTS -Wno-deprecated-experimental-coroutine)
-endif()
 set(V_COMMON_INCLUDE_DIRS
   "${PROJECT_SOURCE_DIR}/src/v")
 # v_cc_library()


### PR DESCRIPTION
## Cover letter

Pulls in https://github.com/redpanda-data/seastar/pull/22

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none
