### PR TITLE
rpk: improve handling of incomplete config import

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
@@ -232,7 +232,7 @@ func (r *ClusterReconciler) retrieveClusterState(
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get centralized configuration schema")
 	}
-	clusterConfig, err := adminAPI.Config()
+	clusterConfig, err := adminAPI.Config(true)
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get current centralized configuration from cluster")
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -132,7 +132,7 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster schema to check drifts: %w", err)
 	}
-	clusterConfig, err := adminAPI.Config()
+	clusterConfig, err := adminAPI.Config(true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster configuration to check drifts: %w", err)
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -128,7 +128,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Marking the last applied configuration in the configmap")
-			baseConfig, err := testAdminAPI.Config()
+			baseConfig, err := testAdminAPI.Config(true)
 			Expect(err).To(BeNil())
 			expectedAnnotation, err := json.Marshal(baseConfig)
 			Expect(err).To(BeNil())

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -171,7 +171,7 @@ func (*unavailableError) Error() string {
 	return "unavailable"
 }
 
-func (m *mockAdminAPI) Config() (admin.Config, error) {
+func (m *mockAdminAPI) Config(_ bool) (admin.Config, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -70,7 +70,7 @@ func NewInternalAdminAPI(
 // AdminAPIClient is a sub interface of the admin API containing what we need in the operator
 // nolint:revive // usually package is called adminutils
 type AdminAPIClient interface {
-	Config() (admin.Config, error)
+	Config(bool) (admin.Config, error)
 	ClusterConfigStatus() (admin.ConfigStatusResponse, error)
 	ClusterConfigSchema() (admin.ConfigSchema, error)
 	PatchClusterConfig(upsert map[string]interface{}, remove []string) (admin.ClusterConfigWriteResult, error)

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -23,9 +23,12 @@ type Config map[string]interface{}
 
 // Config returns a single admin endpoint's configuration. This errors if
 // multiple URLs are configured.
-func (a *AdminAPI) Config() (Config, error) {
+// If include_defaults is true, all properties are returned, including those
+// that are simply reporting their defaults.  Otherwise, only properties with
+// non-default values are included (i.e. those which have been set at some point).
+func (a *AdminAPI) Config(includeDefaults bool) (Config, error) {
 	var rawResp []byte
-	err := a.sendAny(http.MethodGet, "/v1/config", nil, &rawResp)
+	err := a.sendAny(http.MethodGet, fmt.Sprintf("/v1/cluster_config?include_defaults=%t", includeDefaults), nil, &rawResp)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -55,7 +55,7 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to get current config: %v", err)
 
 			err = executeEdit(client, schema, currentConfig, all)
@@ -115,7 +115,7 @@ func executeEdit(
 	}
 
 	// Read back template & parse
-	err = importConfig(client, filename, currentConfig, schema, *all)
+	err = importConfig(client, filename, currentConfig, currentConfig, schema, *all)
 	if err != nil {
 		return fmt.Errorf("error updating config: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -159,7 +159,7 @@ to include all properties including these low level tunables.
 
 			// GET current config
 			var currentConfig admin.Config
-			currentConfig, err = client.Config()
+			currentConfig, err = client.Config(true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			// Generate a yaml template for editing

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
@@ -39,7 +39,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			val, exists := currentConfig[key]

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -38,6 +38,7 @@ func importConfig(
 	client *admin.AdminAPI,
 	filename string,
 	oldConfig admin.Config,
+	oldConfigFull admin.Config,
 	schema admin.ConfigSchema,
 	all bool,
 ) (err error) {
@@ -63,6 +64,8 @@ func importConfig(
 	remove := make([]string, 0)
 	for k, v := range readbackConfig {
 		oldVal, haveOldVal := oldConfig[k]
+		oldValMaterialized, haveOldValMaterialized := oldConfigFull[k]
+
 		if meta, ok := schema[k]; ok {
 			// For numeric types need special handling because
 			// yaml encoding will see '1' as an integer, even
@@ -75,6 +78,9 @@ func importConfig(
 
 				if oldVal != nil {
 					oldVal = int(oldVal.(float64))
+				}
+				if oldValMaterialized != nil {
+					oldValMaterialized = int(oldValMaterialized.(float64))
 				}
 			} else if meta.Type == "number" {
 				if vInt, ok := v.(int); ok {
@@ -90,6 +96,9 @@ func importConfig(
 				}
 				if oldVal != nil {
 					oldVal = loadStringArray(oldVal.([]interface{}))
+				}
+				if oldValMaterialized != nil {
+					oldValMaterialized = loadStringArray(oldValMaterialized.([]interface{}))
 				}
 			}
 
@@ -110,13 +119,16 @@ func importConfig(
 				upsert[k] = v
 			}
 		} else {
-			// Present in input but not original config, insert
-			upsert[k] = v
-			propertyDeltas = append(propertyDeltas, propertyDelta{k, "", fmt.Sprintf("%v", v)})
+			// Present in input but not original config, insert if it differs
+			// from the materialized current value (which may be a default)
+			if !haveOldValMaterialized || !reflect.DeepEqual(oldValMaterialized, v) {
+				upsert[k] = v
+				propertyDeltas = append(propertyDeltas, propertyDelta{k, "", fmt.Sprintf("%v", v)})
+			}
 		}
 	}
 
-	for k := range oldConfig {
+	for k := range oldConfigFull {
 		if _, found := readbackConfig[k]; !found {
 			if k == "cluster_id" {
 				// see above
@@ -228,11 +240,14 @@ from the YAML file, it is reset to its default value.  `,
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(false)
+			out.MaybeDie(err, "unable to query config values: %v", err)
+
+			currentFullConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to query config values: %v", err)
 
 			// Read back template & parse
-			err = importConfig(client, filename, currentConfig, schema, *all)
+			err = importConfig(client, filename, currentConfig, currentFullConfig, schema, *all)
 			if fe := (*formattedError)(nil); errors.As(err, &fe) {
 				fmt.Fprint(os.Stderr, err)
 				out.Die("No changes were made")

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -45,7 +45,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewHostClient(fs, cfg, host)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			conf, err := cl.Config()
+			conf, err := cl.Config(true)
 			out.MaybeDie(err, "unable to request configuration: %v", err)
 
 			marshaled, err := json.MarshalIndent(conf, "", "  ")


### PR DESCRIPTION
## Cover letter

Previously this would compare all the existing configuration
values against the new ones, including if the new one was
nil (reset to default), and the old one was the default.

That meant that an import of a minimal file would generate
a huge list of changes, and also a bunch of redundant 'remove'
entries in the API request.  Functional, but messy.

Fix this by only comparing with non-default existing properties
when doing an import.  The 'edit' path still compares with all
properties.

Fixes https://github.com/redpanda-data/redpanda/issues/4877

## Release notes

### Improvements

* Output from `rpk cluster config import` is made more succinct if the input file leaves out properties and those properties are already set to the default.