### PR TITLE
rpk: rename httpError for httpResponseError

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
@@ -399,7 +399,7 @@ func needsRestart(clusterStatus admin.ConfigStatusResponse) bool {
 func tryMapErrorToCondition(
 	err error,
 ) (*redpandav1alpha1.ClusterCondition, error) {
-	var httpErr *admin.HTTPError
+	var httpErr *admin.HTTPResponseError
 	if errors.As(err, &httpErr) {
 		if httpErr.Response != nil && httpErr.Response.StatusCode == http.StatusBadRequest {
 			return &redpandav1alpha1.ClusterCondition{

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -232,7 +232,7 @@ func (m *mockAdminAPI) PatchClusterConfig(
 	}
 	invalidRequest := len(newInvalid)+len(newUnknown) > 0
 	if m.directValidation && invalidRequest {
-		return admin.ClusterConfigWriteResult{}, &admin.HTTPError{
+		return admin.ClusterConfigWriteResult{}, &admin.HTTPResponseError{
 			Method: http.MethodPut,
 			URL:    "/v1/cluster_config",
 			Response: &http.Response{

--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -36,7 +36,7 @@ import (
 // ErrNoAdminAPILeader happen when there's no leader for the Admin API.
 var ErrNoAdminAPILeader = errors.New("no Admin API leader found")
 
-type HTTPError struct {
+type HTTPResponseError struct {
 	Method   string
 	URL      string
 	Response *http.Response
@@ -549,19 +549,19 @@ func (a *AdminAPI) sendAndReceive(
 		if err != nil {
 			return nil, fmt.Errorf("request %s %s failed: %s, unable to read body: %w", method, url, status, err)
 		}
-		return nil, &HTTPError{Response: res, Body: resBody}
+		return nil, &HTTPResponseError{Response: res, Body: resBody}
 	}
 
 	return res, nil
 }
 
-func (he HTTPError) DecodeGenericErrorBody() (GenericErrorBody, error) {
+func (he HTTPResponseError) DecodeGenericErrorBody() (GenericErrorBody, error) {
 	var resp GenericErrorBody
 	err := json.Unmarshal(he.Body, &resp)
 	return resp, err
 }
 
-func (he HTTPError) Error() string {
+func (he HTTPResponseError) Error() string {
 	return fmt.Sprintf("request %s %s failed: %s, body: %q",
 		he.Method, he.URL, http.StatusText(he.Response.StatusCode), he.Body)
 }

--- a/src/go/rpk/pkg/api/api.go
+++ b/src/go/rpk/pkg/api/api.go
@@ -172,7 +172,7 @@ func sendMetricsToURL(b metricsBody, url string, conf config.Config) error {
 	if err != nil {
 		return err
 	}
-	return sendRequest(bs, http.MethodPost, url, conf)
+	return sendRequest(bs, url, conf)
 }
 
 func sendEnvironmentToURL(
@@ -183,10 +183,10 @@ func sendEnvironmentToURL(
 	if err != nil {
 		return err
 	}
-	return sendRequest(bs, http.MethodPost, url, conf)
+	return sendRequest(bs, url, conf)
 }
 
-func sendRequest(body []byte, method, url string, conf config.Config) error {
+func sendRequest(body []byte, url string, conf config.Config) error {
 	if !conf.Rpk.EnableUsageStats {
 		log.Debug("Sending usage stats is disabled.")
 		return nil
@@ -200,7 +200,6 @@ func sendRequest(body []byte, method, url string, conf config.Config) error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("%s '%s' body='%s'", method, url, body)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -153,7 +153,7 @@ func importConfig(
 
 	// PUT to admin API
 	result, err := client.PatchClusterConfig(upsert, remove)
-	if he := (*admin.HTTPError)(nil); errors.As(err, &he) {
+	if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 		// Special case 400 (validation) errors with friendly output
 		// about which configuration properties were invalid.
 		if he.Response.StatusCode == 400 {
@@ -176,7 +176,7 @@ func importConfig(
 }
 
 func formatValidationError(
-	err error, httpErr *admin.HTTPError,
+	err error, httpErr *admin.HTTPResponseError,
 ) (string, error) {
 	// Output structured validation errors from server
 	var validationErrs map[string]string

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
@@ -79,7 +79,7 @@ If an empty string is given as the value, the property is reset to its default.`
 			}
 
 			result, err := client.PatchClusterConfig(upsert, remove)
-			if he := (*admin.HTTPError)(nil); errors.As(err, &he) {
+			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 				// Special case 400 (validation) errors with friendly output
 				// about which configuration properties were invalid.
 				if he.Response.StatusCode == 400 {

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
@@ -45,7 +45,7 @@ func newDisableCommand(fs afero.Fs) *cobra.Command {
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = client.DisableMaintenanceMode(nodeID)
-			if he := (*admin.HTTPError)(nil); errors.As(err, &he) {
+			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
 					body, bodyErr := he.DecodeGenericErrorBody()
 					if bodyErr == nil {

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
@@ -51,7 +51,7 @@ node exists that is already in maintenance mode then an error will be returned.
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = client.EnableMaintenanceMode(nodeID)
-			var he *admin.HTTPError
+			var he *admin.HTTPResponseError
 			if errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
 					body, bodyErr := he.DecodeGenericErrorBody()


### PR DESCRIPTION


## Cover letter
We want to make sure that we are only processing and logging a response from admin API

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none