### PR TITLE
cluster: recheck raft0 leader existence under semaphore

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -290,6 +290,15 @@ health_monitor_backend::refresh_cluster_health_cache(force_refresh force) {
     // refresh leader_id after acquiring mutex
     leader_id = _raft0->get_leader_id();
 
+    // recheck if the leader exists, since this might have changed
+    // while we were waiting
+    if (!leader_id) {
+        vlog(
+          clusterlog.info,
+          "unable to refresh health metadata, no leader controller");
+        co_return errc::no_leader_controller;
+    }
+
     if (leader_id == _raft0->self().id()) {
         co_return errc::success;
     }


### PR DESCRIPTION
While waiting for the health monitor request semaphore, the cluster may
lost its controller leader, so we need to check this condition again
after we obtain the semaphore to avoid nasal demons.

Fixes #4788.