### PR TITLE
Uniform message distribution among partitions in tests

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -488,7 +488,10 @@ class MissingPartition(BaseCase):
     def generate_baseline(self):
         """Produce enough data to trigger uploads to S3/minio"""
         for topic in self.topics:
-            self._kafka_tools.produce(topic.name, 10000, 1024)
+            self._kafka_tools.produce(topic.name,
+                                      10000,
+                                      1024,
+                                      round_robin_partition=True)
 
     def _delete(self, key):
         self.logger.info(f"deleting manifest file {key}")


### PR DESCRIPTION
## Cover letter

Provides option in KafkaCliTools to enforce round robin distribution of records among partitions. Kafka producers in new versions by default use sticky partitioning where records are sent to partition until batch size or linger.ms is reached, this may cause uneven distribution of records among partitions as seen in #4886 logs:

```
 $ awk '/handling produce request/ {tot+=$19; lc+=1} END{print tot " in " lc " requests";}' docker-rp-17/redpanda.log 
9364926 in 121 requests

 $ awk '/handling produce request/ {tot+=$19; lc+=1} END{print tot " in " lc " requests";}' docker-rp-14/redpanda.log 
981500 in 121 requests

```
the data sent to partition 0 differs from data to partition 1 by a factor of 9. It results in SI never being triggered for partition 0 because the segment is never closed.

In tests where we want a roughly equal amount of data sent to partitions (eg to trigger SI uploads) we can use the roundrobin partitioner which ensures that each partition gets a roughly equal number of messages, at the cost of performance of producer.