### PR TITLE
admin: reject maintenance mode req on 1 node cluster

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -159,6 +159,17 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
         return errc::success;
     }
 
+    if (_brokers.size() < 2) {
+        // Maintenance mode is refused on size 1 clusters in the admin API, but
+        // we might be upgrading from a version that didn't have the validation.
+        vlog(
+          clusterlog.info,
+          "Dropping maintenance mode enable operation on single node cluster");
+
+        // Return success to enable progress: this is a clean no-op.
+        return errc::success;
+    }
+
     if (
       target->second->get_maintenance_state()
       == model::maintenance_state::active) {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1798,6 +1798,13 @@ void admin_server::register_broker_routes() {
               throw ss::httpd::bad_request_exception(
                 "Maintenance mode feature not active (upgrade in progress?)");
           }
+
+          if (
+            _controller->get_members_table().local().all_brokers().size() < 2) {
+              throw ss::httpd::bad_request_exception(
+                "Maintenance mode may not be used on a single node cluster");
+          }
+
           model::node_id id = parse_broker_id(*req);
           auto ec = co_await _controller->get_members_frontend()
                       .local()


### PR DESCRIPTION
## Cover letter

    admin: reject maintenance mode req on 1 node cluster
    
    If a single node cluster puts its only node in maintenance
    mode, then there is no node elegible to become controller
    leader, and all further progress is stopped.
    
Fixes https://github.com/redpanda-data/redpanda/issues/4338

## Release notes

### Improvements

* The Admin API will now refuse to place a node in maintenance mode if it is the only node in the cluster
