### PR TITLE
cluster: drop redundant set_status config updates

### DIFF
--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -71,6 +71,14 @@ public:
 
     config_version get_version() const noexcept { return _seen_version; }
 
+    bool needs_update(const config_status& new_status) {
+        if (auto s = status.find(new_status.node); s != status.end()) {
+            return s->second != new_status;
+        } else {
+            return true;
+        }
+    }
+
 private:
     void merge_apply_result(
       config_status&,

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -34,6 +34,7 @@ class security_frontend;
 class controller_api;
 class members_frontend;
 class config_frontend;
+class config_manager;
 class members_backend;
 class data_policy_frontend;
 class tx_gateway;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -33,6 +33,7 @@ public:
       ss::sharded<controller_api>&,
       ss::sharded<members_frontend>&,
       ss::sharded<config_frontend>&,
+      ss::sharded<config_manager>&,
       ss::sharded<feature_manager>&,
       ss::sharded<feature_table>&,
       ss::sharded<health_monitor_frontend>&,
@@ -130,6 +131,7 @@ private:
     ss::sharded<controller_api>& _api;
     ss::sharded<members_frontend>& _members_frontend;
     ss::sharded<config_frontend>& _config_frontend;
+    ss::sharded<config_manager>& _config_manager;
     ss::sharded<feature_manager>& _feature_manager;
     ss::sharded<feature_table>& _feature_table;
     ss::sharded<health_monitor_frontend>& _hm_frontend;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1204,6 +1204,7 @@ void application::start_redpanda(::stop_signal& app_signal) {
             std::ref(controller->get_api()),
             std::ref(controller->get_members_frontend()),
             std::ref(controller->get_config_frontend()),
+            std::ref(controller->get_config_manager()),
             std::ref(controller->get_feature_manager()),
             std::ref(controller->get_feature_table()),
             std::ref(controller->get_health_monitor()),


### PR DESCRIPTION
## Cover letter

    cluster: drop redundant set_status config updates
    
    If a follower isn't seeing controller log updates
    promptly, it may issue many set_status RPCs while
    it's waiting.  The controller leader should not
    turn all of these into log writes: if the status
    of the node already matches what it is reporting,
    then do not write anything.


    cluster: wait between config set_status RPCs
    
    On a healthy system, we do want to send set_status
    RPCs as soon as we're ready.  However, if the controller
    log updates are not being seen promptly, this would lead
    to the follower spamming the controller leader with
    very many set_status RPCs in a tight loop.
    
    Nodes will still send their status immediately when
    a config change occurs: this change only effects the
    behaviour if _another_ config change occurs while
    it is reporting status from the first change: in this
    case the follower will wait 5 seconds before sending
    its next status RPC.

Fixes https://github.com/redpanda-data/redpanda/issues/4923

## Release notes

### Improvements

* Reduced frequency of configuration status RPCs when cluster is in a degraded state
