### PR TITLE
[v22.1.x] cluster,kafka: auto-populate cluster_id and prefix it with "redpanda."

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -315,9 +315,6 @@ ss::future<> controller::start() {
             std::ref(_as));
       })
       .then([this] {
-          if (!config::shard_local_cfg().enable_metrics_reporter()) {
-              return ss::now();
-          }
           return _metrics_reporter.invoke_on(0, &metrics_reporter::start);
       });
 }

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -312,6 +312,7 @@ ss::future<> controller::start() {
             std::ref(_members_table),
             std::ref(_tp_state),
             std::ref(_hm_frontend),
+            std::ref(_config_frontend),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -116,7 +116,13 @@ ss::future<> metrics_reporter::start() {
     _address = details::parse_url(
       config::shard_local_cfg().metrics_reporter_url());
     _tick_timer.set_callback([this] { report_metrics(); });
-    _tick_timer.arm(config::shard_local_cfg().metrics_reporter_tick_interval());
+
+    const auto initial_delay = 10s;
+
+    // A shorter initial wait than the tick interval, so that we
+    // give the cluster state a chance to stabilize, but also send
+    // a report reasonably promptly.
+    _tick_timer.arm(initial_delay);
     co_return;
 }
 

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -77,6 +77,7 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<health_monitor_frontend>&,
+      ss::sharded<config_frontend>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -90,12 +91,14 @@ private:
 
     ss::future<http::client> make_http_client();
     ss::future<> try_initialize_cluster_info();
+    ss::future<> propagate_cluster_id();
 
     ss::sstring _cluster_uuid;
     consensus_ptr _raft0;
     ss::sharded<members_table>& _members_table;
     ss::sharded<topic_table>& _topics;
     ss::sharded<health_monitor_frontend>& _health_monitor;
+    ss::sharded<config_frontend>& _config_frontend;
     ss::sharded<ss::abort_source>& _as;
     model::timestamp _creation_timestamp;
     prefix_logger _logger;

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -617,3 +617,28 @@ class RpkTool:
         ] + self._kafka_conn_settings()
         output = self._execute(cmd)
         return output
+
+    def cluster_metadata_id(self):
+        """
+        Calls 'cluster metadata' and returns the cluster ID, if set,
+        else None.  Don't return the rest of the output (brokers list)
+        because there are already other ways to get at that.
+        """
+        cmd = [
+            self._rpk_binary(), '--brokers',
+            self._redpanda.brokers(), 'cluster', 'metadata'
+        ]
+        output = self._execute(cmd)
+        lines = output.strip().split("\n")
+
+        # Output is like:
+        #
+        # CLUSTER
+        # =======
+        # foobar
+
+        # Output only has a "CLUSTER" section if cluster id is set
+        if lines[0] != "CLUSTER":
+            return None
+        else:
+            return lines[2]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -414,7 +414,6 @@ class RedpandaService(Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
 
-    CLUSTER_NAME = "my_cluster"
     READY_TIMEOUT_SEC = 10
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
@@ -446,8 +445,7 @@ class RedpandaService(Service):
         'default_topic_partitions': 4,
         'enable_metrics_reporter': False,
         'superusers': [SUPERUSER_CREDENTIALS[0]],
-        'enable_auto_rebalance_on_node_add': True,
-        'cluster_id': CLUSTER_NAME
+        'enable_auto_rebalance_on_node_add': True
     }
 
     logs = {

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -100,6 +100,16 @@ class ClusterConfigTest(RedpandaTest):
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
 
+    def setUp(self):
+        super().setUp()
+
+        # wait for the two config versions:
+        # 1. The initial bootstrap where we "import" any cluster properties
+        #    that were in bootstrap.yaml
+        # 2. The metrics reporter's first tick, where it initializes
+        #    the cluster_id property.
+        self._wait_for_version_sync(2)
+
     @cluster(num_nodes=3)
     @parametrize(legacy=False)
     @parametrize(legacy=True)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -511,7 +511,10 @@ class ClusterConfigTest(RedpandaTest):
                 else:
                     valid_value = 1000.0
             elif p['type'] == 'string':
-                valid_value = "rhubarb"
+                if name.endswith("_url"):
+                    valid_value = "http://example.com"
+                else:
+                    valid_value = "rhubarb"
             elif p['type'] == 'boolean':
                 valid_value = not initial_config[name]
             elif p['type'] == "array" and p['items']['type'] == 'string':


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4457
  
  