### PR TITLE
core: fix various warnings in tests

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -55,7 +55,7 @@ load_manifest_from_str(std::string_view v) {
     i.append(v.data(), v.size());
     auto s = make_iobuf_input_stream(std::move(i));
     m.update(std::move(s)).get();
-    return std::move(m);
+    return m;
 }
 
 static void write_batches(
@@ -464,7 +464,7 @@ cloud_storage::partition_manifest load_manifest(std::string_view v) {
     i.append(v.data(), v.size());
     auto s = make_iobuf_input_stream(std::move(i));
     m.update(std::move(s)).get();
-    return std::move(m);
+    return m;
 }
 
 archival::remote_segment_path get_segment_path(

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -67,7 +67,7 @@ static partition_manifest load_manifest_from_str(std::string_view v) {
     i.append(v.data(), v.size());
     auto s = make_iobuf_input_stream(std::move(i));
     m.update(std::move(s)).get();
-    return std::move(m);
+    return m;
 }
 
 FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -29,7 +29,7 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
     auto node_app_0 = create_node_application(node_0);
     wait_for_controller_leadership(node_0).get();
     auto node_app_1 = create_node_application(node_1);
-    auto node_app_2 = create_node_application(node_2);
+    [[maybe_unused]] auto node_app_2 = create_node_application(node_2);
 
     // wait for cluster to be stable
     tests::cooperative_spin_wait_with_timeout(
@@ -73,7 +73,7 @@ FIXTURE_TEST(test_single_node_update, cluster_test_fixture) {
     // single node
     model::node_id node_id(0);
 
-    auto node = create_node_application(node_id);
+    [[maybe_unused]] auto node = create_node_application(node_id);
     wait_for_controller_leadership(node_id).get();
 
     remove_node_application(node_id);

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -88,6 +88,7 @@ ss::future<> wait_for_all_replicas(
 }
 
 struct op {
+    virtual ~op() = default;
     virtual ss::future<bool> operator()(cluster::topics_frontend&) = 0;
     virtual ss::sstring message() const;
 };

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -76,7 +76,6 @@ ss::future<> wait_for_all_replicas(
   Predicate p) {
     return tests::cooperative_spin_wait_with_timeout(
       tout, [replica_set = std::move(replica_set), p = std::move(p)]() mutable {
-          using partition_ptr = ss::lw_shared_ptr<cluster::partition>;
           return ssx::parallel_transform(
                    replica_set.cbegin(),
                    replica_set.cend(),

--- a/src/v/coproc/tests/utils/supervisor.cc
+++ b/src/v/coproc/tests/utils/supervisor.cc
@@ -312,7 +312,7 @@ ss::future<absl::node_hash_set<script_id>> supervisor::registered_scripts() {
       absl::node_hash_set<script_id>(),
       [](absl::node_hash_set<script_id> set, absl::node_hash_set<script_id> x) {
           set.merge(std::move(x));
-          return std::move(set);
+          return set;
       });
 }
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -451,7 +451,7 @@ private:
                 ss::sstring body = parser.read_string(parser.bytes_left());
                 if (body.find(_expected_data) != ss::sstring::npos) {
                     _fin.close().get();
-                    return std::move(buffer);
+                    return buffer;
                 }
             }
             ss::sleep(1ms).get();

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -60,7 +60,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
 
         kafka::produce_request::partition partition;
         partition.partition_index = model::partition_id(0);
-        partition.records.emplace(std::move(std::move(builder).build()));
+        partition.records.emplace(std::move(builder).build());
         res.push_back(std::move(partition));
         return res;
     }

--- a/src/v/model/tests/record_batch_reader_test.cc
+++ b/src/v/model/tests/record_batch_reader_test.cc
@@ -76,9 +76,9 @@ public:
     }
 
 private:
+    size_t _depth;
     int _init_count;
     ss::circular_buffer<record_batch> _result;
-    size_t _depth;
 };
 
 template<typename... Offsets>

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -530,7 +530,8 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
     }
     auto first_ts = model::timestamp::now();
     // append some entries
-    bool res = replicate_compactible_batches(gr, first_ts).get0();
+    [[maybe_unused]] bool res
+      = replicate_compactible_batches(gr, first_ts).get0();
 
     auto second_ts = model::timestamp(first_ts() + 100);
     info("Triggerring log collection with timestamp {}", first_ts);

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -36,13 +36,13 @@ using namespace std::chrono_literals; // NOLINT
 struct config_manager_fixture {
     config_manager_fixture()
       : _storage(storage::api(
-        std::move([this]() {
+        [this] {
             return storage::kvstore_config(
               100_MiB,
               config::mock_binding(std::chrono::milliseconds(10)),
               base_dir,
               storage::debug_sanitize_files::yes);
-        }),
+        },
         [this]() {
             return storage::log_config(
               storage::log_config::storage_type::disk,

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -44,7 +44,8 @@ struct manual_deletion_fixture : public raft_test_fixture {
 
         auto first_ts = model::timestamp::now();
         // append some entries
-        bool res = replicate_compactible_batches(gr, first_ts).get0();
+        [[maybe_unused]] bool res
+          = replicate_compactible_batches(gr, first_ts).get0();
         auto second_ts = model::timestamp(first_ts() + 200000);
         // append some more entries
         res = replicate_compactible_batches(gr, second_ts).get0();

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -321,11 +321,11 @@ struct raft_node {
     ss::sharded<rpc::connection_cache> cache;
     ss::sharded<net::server> server;
     ss::sharded<test_raft_manager> raft_manager;
+    leader_clb_t leader_callback;
     raft::recovery_memory_quota recovery_mem_quota;
     std::unique_ptr<raft::heartbeat_manager> hbeats;
     consensus_ptr consensus;
     std::unique_ptr<raft::log_eviction_stm> _nop_stm;
-    leader_clb_t leader_callback;
     ss::abort_source _as;
 };
 

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -40,7 +40,8 @@ static model::record_batch make_random_batch(
     return std::move(b).build();
 }
 
-struct batch_cache_test_fixture {
+class batch_cache_test_fixture {
+public:
     batch_cache_test_fixture()
       : cache(opts) {}
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -48,7 +48,7 @@ void validate_offsets(
     BOOST_REQUIRE_EQUAL(write_headers.size(), read_batches.size());
     auto it = read_batches.begin();
     model::offset next_base = base;
-    for (auto const h : write_headers) {
+    for (auto const& h : write_headers) {
         BOOST_REQUIRE_EQUAL(it->base_offset(), next_base);
         // last offset delta is inclusive (record with this offset belongs to
         // previous batch)

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1202,7 +1202,6 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    using overrides_t = storage::ntp_config::default_overrides;
 
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
     std::vector<storage::log> logs;


### PR DESCRIPTION
## Cover letter

Silences warnings discovered while fiddling with the build system. Our tests are configured with far more forgiving set of warnings disabled.

## Release notes

* None