### PR TITLE
[v22.1.x] kafka/server: Fix operator<< for offset_metadata

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2404,7 +2404,7 @@ void group::add_pending_member(
 std::ostream& operator<<(std::ostream& o, const group::offset_metadata& md) {
     fmt::print(
       o,
-      "{log_offset:{}, offset:{}, metadata:{}, committed_leader_epoch:{}}",
+      "{{log_offset:{}, offset:{}, metadata:{}, committed_leader_epoch:{}}}",
       md.log_offset,
       md.offset,
       md.metadata,


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4927
  Fixes https://github.com/redpanda-data/redpanda/issues/4931
  