### PR TITLE
application: handle unwanted positional args

### DIFF
--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -42,6 +42,8 @@ v_cc_library(
     v::archival
   )
 
+add_subdirectory(tests)
+
 add_executable(redpanda
     main.cc)
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -25,9 +25,10 @@ endforeach()
 
 v_cc_library(
   NAME application
-  SRCS 
+  SRCS
     ${swag_files}
     admin_server.cc
+    cli_parser.cc
     request_auth.cc
     application.cc
   DEPS
@@ -42,8 +43,7 @@ v_cc_library(
   )
 
 add_executable(redpanda
-    main.cc
-  )
+    main.cc)
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -175,11 +175,14 @@ int application::run(int ac, char** av) {
       po::value<std::string>(),
       ".yaml file config for redpanda");
 
+    // Validate command line args using options registered by the app and
+    // seastar
     if (!cli_parser{
           ac,
           av,
-          app.get_options_description(),
-          app.get_conf_file_options_description()}
+          cli_parser::app_opts{app.get_options_description()},
+          cli_parser::ss_opts{app.get_conf_file_options_description()},
+          _log}
            .validate()) {
         return 1;
     }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -12,6 +12,7 @@
 #include "archival/ntp_archiver_service.h"
 #include "archival/service.h"
 #include "archival/upload_controller.h"
+#include "cli_parser.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/controller.h"
 #include "cluster/fwd.h"
@@ -173,6 +174,15 @@ int application::run(int ac, char** av) {
       "redpanda-cfg",
       po::value<std::string>(),
       ".yaml file config for redpanda");
+
+    if (!cli_parser{
+          ac,
+          av,
+          app.get_options_description(),
+          app.get_conf_file_options_description()}
+           .validate()) {
+        return 1;
+    }
 
     return app.run(ac, av, [this, &app] {
         auto& cfg = app.configuration();

--- a/src/v/redpanda/cli_parser.cc
+++ b/src/v/redpanda/cli_parser.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cli_parser.h"
+
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+
+#include <iostream>
+
+namespace po = boost::program_options;
+
+cli_parser::cli_parser(
+  int ac,
+  char** av,
+  const po::options_description& opts_desc,
+  const po::options_description& conf_file_opts_desc)
+  : _ac{ac}
+  , _av{av}
+  , _opts_desc{opts_desc}
+  , _conf_opts_desc{conf_file_opts_desc} {}
+
+bool cli_parser::validate() {
+    po::options_description desc;
+    // Copy the cli options added by redpanda, plus the seastar options added in
+    // app-template constructor
+    desc.add(_opts_desc);
+    desc.add(_conf_opts_desc);
+
+    // help-loggers is not added in app-template constructor but is handled
+    // specially in the app_template::run_deprecated method by seastar
+    desc.add_options()("help-loggers", "");
+
+    try {
+        po::variables_map vm;
+        po::store(
+          po::command_line_parser{_ac, _av}.options(desc).positional({}).run(),
+          vm);
+    } catch (const std::exception& err) {
+        std::cerr << "Error: " << err.what() << "\n";
+        return false;
+    }
+
+    return true;
+}

--- a/src/v/redpanda/cli_parser.h
+++ b/src/v/redpanda/cli_parser.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace boost::program_options {
+class options_description;
+}
+
+struct cli_parser {
+    cli_parser(
+      int ac,
+      char** av,
+      const boost::program_options::options_description& opts_desc,
+      const boost::program_options::options_description& conf_file_opts_desc);
+
+    bool validate();
+
+private:
+    int _ac;
+    char** _av;
+    const boost::program_options::options_description& _opts_desc;
+    const boost::program_options::options_description& _conf_opts_desc;
+};

--- a/src/v/redpanda/cli_parser.h
+++ b/src/v/redpanda/cli_parser.h
@@ -11,22 +11,38 @@
 
 #pragma once
 
-namespace boost::program_options {
-class options_description;
-}
+#include "seastarx.h"
+#include "utils/named_type.h"
 
+#include <seastar/util/log.hh>
+
+#include <boost/program_options/options_description.hpp>
+
+/// Parses command line options passed to the redpanda binary. Validates the
+/// options against a set of registered values. The values should include both
+/// those explicitly registered against the redpanda application as well as
+/// those that seastar adds during its startup process.
+///
+/// The parser in its current state rejects any positional arguments as these
+/// are not supported with redpanda yet.
 struct cli_parser {
+    using opts_desc = boost::program_options::options_description;
+    using app_opts = named_type<opts_desc, struct app_opts_tag>;
+    using ss_opts = named_type<opts_desc, struct ss_opts_tag>;
+
     cli_parser(
       int ac,
       char** av,
-      const boost::program_options::options_description& opts_desc,
-      const boost::program_options::options_description& conf_file_opts_desc);
+      app_opts opts_desc,
+      ss_opts seastar_opts,
+      ss::logger& log);
 
     bool validate();
 
 private:
     int _ac;
     char** _av;
-    const boost::program_options::options_description& _opts_desc;
-    const boost::program_options::options_description& _conf_opts_desc;
+    app_opts _opts_desc;
+    ss_opts _seastar_opts_desc;
+    ss::logger& _log;
 };

--- a/src/v/redpanda/tests/CMakeLists.txt
+++ b/src/v/redpanda/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+rp_test(
+        UNIT_TEST
+        BINARY_NAME test_cli_parser
+        SOURCES cli_parser_tests.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES Boost::unit_test_framework v::application
+        LABELS cli_parse
+)

--- a/src/v/redpanda/tests/cli_parser_tests.cc
+++ b/src/v/redpanda/tests/cli_parser_tests.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#define BOOST_TEST_MODULE cli_parser
+
+#include "redpanda/cli_parser.h"
+
+#include <seastar/core/smp.hh>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace po = boost::program_options;
+
+struct argv {
+    explicit argv(const std::string& cmdline) { tokenize_and_store(cmdline); }
+
+    std::pair<int, char**> args() { return {_av.size() - 1, _av.data()}; }
+
+private:
+    void tokenize_and_store(const std::string& cmdline) {
+        boost::split(_tokens, cmdline, boost::is_any_of(" "));
+        _av.resize(_tokens.size() + 1);
+        _av.back() = nullptr;
+        std::transform(
+          _tokens.begin(), _tokens.end(), _av.begin(), [](auto& s) {
+              return s.data();
+          });
+    }
+    std::vector<char*> _av;
+    std::vector<std::string> _tokens{};
+};
+
+BOOST_AUTO_TEST_CASE(test_positional_args_rejected) {
+    po::options_description unused;
+    argv a{"redpanda foo bar"};
+    auto [ac, av] = a.args();
+    cli_parser parser{ac, av, unused, unused};
+    BOOST_REQUIRE(!parser.validate());
+}
+
+BOOST_AUTO_TEST_CASE(test_help_flag) {
+    po::options_description help;
+    po::options_description ss;
+
+    help.add_options()("help", "");
+
+    argv a{"redpanda --help"};
+    auto [ac, av] = a.args();
+    cli_parser parser{ac, av, help, ss};
+    BOOST_REQUIRE(parser.validate());
+}
+
+BOOST_AUTO_TEST_CASE(test_help_mixed_with_bad_pos_arg) {
+    po::options_description help;
+    po::options_description ss;
+
+    help.add_options()("help", "");
+
+    argv a{"redpanda --help bad"};
+    auto [ac, av] = a.args();
+    cli_parser parser{ac, av, help, ss};
+    BOOST_REQUIRE(!parser.validate());
+}
+
+BOOST_AUTO_TEST_CASE(test_flag_with_arguments) {
+    po::options_description cfg;
+    po::options_description ss;
+
+    cfg.add_options()("redpanda-cfg", po::value<std::string>(), "");
+
+    {
+        argv a{"redpanda --redpanda-cfg f.yaml"};
+        auto [ac, av] = a.args();
+        cli_parser parser{ac, av, cfg, ss};
+        BOOST_REQUIRE(parser.validate());
+    }
+
+    {
+        argv a{"redpanda --redpanda-cfg=f.yaml"};
+        auto [ac, av] = a.args();
+        cli_parser parser{ac, av, cfg, ss};
+        BOOST_REQUIRE(parser.validate());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_flags_with_arguments_and_bad_pos_arg) {
+    po::options_description cfg;
+    po::options_description ss;
+
+    cfg.add_options()("redpanda-cfg", po::value<std::string>(), "");
+
+    argv a{"redpanda --redpanda-cfg f.yaml testing"};
+    auto [ac, av] = a.args();
+    cli_parser parser{ac, av, cfg, ss};
+    BOOST_REQUIRE(!parser.validate());
+}
+
+BOOST_AUTO_TEST_CASE(test_redpanda_and_ss_opts) {
+    po::options_description cfg;
+    po::options_description ss;
+
+    cfg.add_options()("redpanda-cfg", po::value<std::string>(), "");
+
+    // add seastar smp flags for testing, these are added to our application
+    // along with many other seastar flags
+    ss.add(seastar::smp::get_options_description());
+
+    argv a{"redpanda --redpanda-cfg f.yaml --smp 2 --memory 4G --mbind 1 "
+           "--max-io-requests=10"};
+    auto [ac, av] = a.args();
+    cli_parser parser{ac, av, cfg, ss};
+    BOOST_REQUIRE(parser.validate());
+}


### PR DESCRIPTION
## Cover letter

adds an extra CLI parse step using boost program_options to be able to validate unwanted positional args before the seastar CLI parsing begins.

There are a few other ways to avoid unwanted positional args but they all suffer from different drawbacks:

* Let seastar CLI parsing handle the args: ideally this should work and we should not have to do anything to manage bad args, but due to a type mismatch on the exception object, the catch clause in seastar does not recognize the exception thrown by boost, causing program termination.

* Add a catch-all positional argument field to the argument set and then fail later if the field is present in the parsed output: this works but it adds an extra help option to the usage string which looks out of place if someone types `redpanda --help`

* Explicitly instantiate the exception class template in application.cc: this causes the throw and catch to match and everything works correctly, but the code looks hard to understand without context and it looks tailored to the type mismatch issue.

Double parsing is a little extra code run at startup but allows to us exit early on bad input, before entering the seastar run function. It also allows us to control the error messages emitted on bad input.

The downside is that if seastar adds new help options in future we have to add the same options in our parser, and if we support positional args in future we also have to add those in our parser. 


Fixes #4554 