### PR TITLE
cluster: clean up config error logging

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -268,13 +268,13 @@ static void preload_local(
     result) {
     auto& cfg = config::shard_local_cfg();
     if (cfg.contains(key)) {
+        auto& property = cfg.get(key);
         try {
             // Cache values are string-ized yaml.  In many cases this
             // is the same as the underlying value (e.g. integers, bools),
             // but for strings it's not (the literal value in the cache is
             // "\"foo\"").
             auto decoded = YAML::Load(value.as<std::string>());
-            auto& property = cfg.get(key);
             property.set_value(decoded);
 
             // Because we are in preload, it doesn't matter if the property
@@ -294,7 +294,7 @@ static void preload_local(
                   clusterlog.info,
                   "Ignoring invalid property: {}={}",
                   key,
-                  YAML::Dump(value));
+                  property.format_raw(YAML::Dump(value)));
                 result.value().get().invalid.push_back(key);
             }
         }
@@ -580,7 +580,7 @@ apply_local(cluster_config_delta_cmd_data const& data, bool silent) {
                       clusterlog.warn,
                       "Invalid property value {}: {} ({})",
                       u.first,
-                      val_yaml,
+                      property.format_raw(val_yaml),
                       validation_err.value().error_message());
                 }
                 result.invalid.push_back(u.first);
@@ -657,11 +657,6 @@ void config_manager::merge_apply_result(
   config_status& status,
   cluster_config_delta_cmd_data const& data,
   apply_result const& r) {
-    vlog(
-      clusterlog.trace,
-      "merge_apply_result: data {} {}",
-      fmt::ptr(&data),
-      data.upsert.size());
     status.restart |= r.restart;
 
     std::set<ss::sstring> errored_properties;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -998,7 +998,7 @@ void admin_server::register_cluster_config_routes() {
                             logger.warn,
                             "Invalid {}: '{}' ({})",
                             i.first,
-                            yaml_value,
+                            property.format_raw(yaml_value),
                             validation_err.value().error_message());
                       } else {
                           // In case any property subclass might throw
@@ -1042,7 +1042,7 @@ void admin_server::register_cluster_config_routes() {
                         logger.warn,
                         "Invalid {}: '{}' ({})",
                         i.first,
-                        yaml_value,
+                        property.format_raw(yaml_value),
                         std::current_exception());
                   } catch (...) {
                       auto message = fmt::format(
@@ -1052,7 +1052,7 @@ void admin_server::register_cluster_config_routes() {
                         logger.warn,
                         "Invalid {}: '{}' ({})",
                         i.first,
-                        yaml_value,
+                        property.format_raw(yaml_value),
                         message);
                   }
               }


### PR DESCRIPTION

## Cover letter

There are a bunch of places we log config values on
error, which are currently safe for secrets (because
secrets are all freeform strings that cannot fail
validation), but future-proof these paths by using
format_raw to ensure that if we added validated+secret
fields in future they'd be redacted properly.


## Release notes

* none