### PR TITLE
[v21.11.x] cloud_storage: redacts fields from header

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/iobuf.h"
+#include "config/base_property.h"
 #include "http/logger.h"
 #include "rpc/backoff_policy.h"
 #include "rpc/types.h"
@@ -78,10 +79,12 @@ ss::future<client::request_response_t> client::make_request(
     auto verb = header.method();
     auto target = header.target();
     ss::sstring target_str(target.data(), target.size());
+    prefix_logger ctxlog(http_log, ssx::sformat("[{}]", target_str));
+    vlog(ctxlog.trace, "client.make_request {}", redacted_header(header));
+
     auto req = ss::make_shared<request_stream>(this, std::move(header));
     auto res = ss::make_shared<response_stream>(this, verb, target_str);
-    prefix_logger ctxlog(http_log, ssx::sformat("[{}]", target_str));
-    vlog(ctxlog.trace, "client.make_request {}", header);
+
     auto now = ss::lowres_clock::now();
     auto age = _last_response == ss::lowres_clock::time_point::min()
                  ? ss::lowres_clock::duration::max()
@@ -586,6 +589,27 @@ ss::input_stream<char> client::response_stream::as_input_stream() {
     auto ds = ss::data_source(
       std::make_unique<response_data_source>(shared_from_this()));
     return ss::input_stream<char>(std::move(ds));
+}
+
+client::request_header redacted_header(client::request_header original) {
+    using field_type = std::variant<boost::beast::http::field, std::string>;
+
+    static const std::unordered_set<field_type> redacted_fields{
+      boost::beast::http::field::authorization, "x-amz-content-sha256"};
+
+    auto h{std::move(original)};
+
+    for (const auto& field : redacted_fields) {
+        std::visit(
+          [&h](const auto& f) {
+              if (h.find(f) != h.end()) {
+                  h.set(f, std::string{config::secret_placeholder});
+              }
+          },
+          field);
+    }
+
+    return h;
 }
 
 } // namespace http

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -248,6 +248,13 @@ private:
     ss::lowres_clock::duration _max_idle_time;
 };
 
+/// Utility function for producing a copy of the request header with some
+/// fields redacted for logging.
+///
+/// \param original a request header with potentially sensitive header values
+/// \return redacted header with sensitive values removed
+client::request_header redacted_header(client::request_header original);
+
 template<class BufferSeq>
 inline ss::future<> client::forward(client* client, BufferSeq&& seq) {
     auto scattered = iobuf_as_scattered(std::forward<BufferSeq>(seq));

--- a/src/v/s3/signature.cc
+++ b/src/v/s3/signature.cc
@@ -334,11 +334,7 @@ std::error_code signature_v4::sign_header(
     auto sign_key = gen_sig_key(_private_key(), date_str, _region(), service);
     auto cred_scope = ssx::sformat(
       "{}/{}/{}/aws4_request", date_str, _region(), service);
-    vlog(
-      s3_log.trace,
-      "Credentials updated:\n[signing key]\n{}\n[scope]\n{}\n",
-      hexdigest(sign_key),
-      cred_scope);
+    vlog(s3_log.trace, "Credentials updated:\n[scope]\n{}\n", cred_scope);
     auto amz_date = _sig_time.format_datetime();
     header.set("x-amz-date", {amz_date.data(), amz_date.size()});
     header.set("x-amz-content-sha256", {sha256.data(), sha256.size()});
@@ -363,7 +359,8 @@ std::error_code signature_v4::sign_header(
       canonical_headers.value().signed_headers,
       hexdigest(digest));
     header.set(boost::beast::http::field::authorization, auth_header);
-    vlog(s3_log.trace, "\n[signed-header]\n\n{}", header);
+    vlog(
+      s3_log.trace, "\n[signed-header]\n\n{}", http::redacted_header(header));
     return {};
 }
 


### PR DESCRIPTION
## Cover letter

When logging headers, redacts two fields which may contain sensitive
information. The new function produces a copy of the original header,
so it increases memory usage by the size of the header.

(cherry picked from commit 41bafd86c6ab7e58f8e063d395d7cccf626a6c64)

 Conflicts:
	src/v/s3/client.cc

conflict resolution note:
changes to s3 client restricted to logging, other changes introduced
with commit were removed manually.

backport of #4939 