### PR TITLE
cluster: downgrade per-partition messages to DEBUG

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -505,7 +505,7 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
                 stop = true;
                 continue;
             }
-            vlog(clusterlog.info, "partition operation {} finished", *it);
+            vlog(clusterlog.debug, "partition operation {} finished", *it);
         } catch (ss::gate_closed_exception const&) {
             vlog(
               clusterlog.debug,

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -106,7 +106,7 @@ ss::future<consensus_ptr> partition_manager::manage(
     }
     storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
     vlog(
-      clusterlog.info,
+      clusterlog.debug,
       "Log created manage completed, ntp: {}, rev: {}, {} "
       "segments, {} bytes",
       log.config().ntp(),

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -480,6 +480,8 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
 ss::future<std::vector<topic_result>> topics_frontend::delete_topics(
   std::vector<model::topic_namespace> topics,
   model::timeout_clock::time_point timeout) {
+    vlog(clusterlog.info, "Delete topics {}", topics);
+
     std::vector<ss::future<topic_result>> futures;
     futures.reserve(topics.size());
 

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -26,7 +26,7 @@ state_machine::state_machine(
   , _bootstrap_last_applied(_raft->read_last_applied()) {}
 
 ss::future<> state_machine::start() {
-    vlog(_log.info, "Starting state machine for ntp={}", _raft->ntp());
+    vlog(_log.debug, "Starting state machine for ntp={}", _raft->ntp());
     ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _gate.is_closed(); }, [this] { return apply(); });


### PR DESCRIPTION
## Cover letter

This is to sequester the most verbose INFO messages
(those reporting per-partition events) in certain
subsystems: storage,cloud_storage,raft,storage-gc, and
offset-translator.

Related internal slack thread: https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1653583524478779

## Release notes

* none

### Improvements

* Higher volume log messages (those relating to individual partitions) from the cluster subsystem have been adjusted from INFO to DEBUG severity.
