### PR TITLE
security: don't log potentially sensitive messages

### DIFF
--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -54,6 +54,7 @@ public:
     ss::future<storage_t> do_load_slice(model::timeout_clock::time_point) final;
 
     // Implements model::record_batch_reader::impl
+    // NOTE: this stream is intentially devoid of user data.
     void print(std::ostream& os) final { os << "{kafka::consumer_records}"; }
 
     // Release any remaining iobuf that hasn't been consumed
@@ -61,6 +62,7 @@ public:
 
     friend std::ostream&
     operator<<(std::ostream& os, const batch_reader& reader) {
+        // NOTE: this stream is intentially devoid of user data.
         fmt::print(os, "{{size {}}}", reader.size_bytes());
         return os;
     }

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -96,6 +96,7 @@ struct produce_request_record_data {
 
     friend std::ostream&
     operator<<(std::ostream& os, const produce_request_record_data& data) {
+        // NOTE: this stream is intentially devoid of user data.
         fmt::print(
           os,
           "batch {} v2_format {} valid_crc {}",

--- a/src/v/kafka/protocol/tests/security_test.cc
+++ b/src/v/kafka/protocol/tests/security_test.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 #include "security/acl.h"
 #define BOOST_TEST_MODULE example
+#include "kafka/protocol/schemata/sasl_authenticate_request.h"
+#include "kafka/protocol/schemata/sasl_authenticate_response.h"
 #include "kafka/server/handlers/details/security.h"
 #include "random/generators.h"
 #include "security/authorizer.h"
@@ -125,6 +127,17 @@ BOOST_AUTO_TEST_CASE(to_acl_permission) {
       details::to_acl_permission(3), security::acl_permission::allow);
     BOOST_REQUIRE_THROW(
       details::to_acl_permission(4), details::acl_conversion_error);
+}
+
+BOOST_AUTO_TEST_CASE(redact_sensitive_messages) {
+    BOOST_REQUIRE_EQUAL(
+      "{auth_bytes=****}", fmt::to_string(sasl_authenticate_request_data{}));
+
+    BOOST_REQUIRE_EQUAL(
+      "{error_code={ error_code: none [0] } error_message={nullopt} "
+      "auth_bytes=**** "
+      "session_lifetime_ms=0}",
+      fmt::to_string(sasl_authenticate_response_data{}));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/sasl_authenticate.cc
+++ b/src/v/kafka/server/handlers/sasl_authenticate.cc
@@ -12,6 +12,7 @@
 #include "bytes/bytes.h"
 #include "kafka/protocol/errors.h"
 #include "security/scram_algorithm.h"
+#include "vlog.h"
 
 namespace kafka {
 

--- a/src/v/security/scram_algorithm.cc
+++ b/src/v/security/scram_algorithm.cc
@@ -329,17 +329,6 @@ parse_server_final(std::string_view message) {
 
 namespace security {
 
-std::ostream& operator<<(std::ostream& os, const scram_credential& cred) {
-    fmt::print(
-      os,
-      "salt {} server_key {} stored_key {} iterations {}",
-      cred._salt,
-      cred._server_key,
-      cred._stored_key,
-      cred._iterations);
-    return os;
-}
-
 client_first_message::client_first_message(bytes_view data) {
     auto view = std::string_view(
       reinterpret_cast<const char*>(data.data()), data.size()); // NOLINT
@@ -395,14 +384,10 @@ bool client_first_message::token_authenticated() const {
     return false;
 }
 
-std::ostream& operator<<(std::ostream& os, const client_first_message& msg) {
-    fmt::print(
-      os,
-      "authzid {} username {} nonce {}",
-      msg._authzid,
-      msg._username,
-      msg._nonce);
-    return os;
+std::ostream& operator<<(std::ostream& os, const client_first_message&) {
+    // NOTE: this stream is intentially left minimal to err away from exposing
+    // anything that may be useful for an attacker to use.
+    return os << "{client_first_message}";
 }
 
 ss::sstring server_first_message::sasl_message() const {
@@ -410,14 +395,10 @@ ss::sstring server_first_message::sasl_message() const {
       "r={},s={},i={}", _nonce, bytes_to_base64(_salt), _iterations);
 }
 
-std::ostream& operator<<(std::ostream& os, const server_first_message& msg) {
-    fmt::print(
-      os,
-      "nonce {} salt {} iterations {}",
-      msg._nonce,
-      msg._salt,
-      msg._iterations);
-    return os;
+std::ostream& operator<<(std::ostream& os, const server_first_message&) {
+    // NOTE: this stream is intentially left minimal to err away from exposing
+    // anything that may be useful for an attacker to use.
+    return os << "{server_first_message}";
 }
 
 client_final_message::client_final_message(bytes_view data) {
@@ -441,15 +422,10 @@ ss::sstring client_final_message::msg_no_proof() const {
     return ssx::sformat("c={},r={}", bytes_to_base64(_channel_binding), _nonce);
 }
 
-std::ostream& operator<<(std::ostream& os, const client_final_message& msg) {
-    fmt::print(
-      os,
-      "channel {} nonce {} extensions {} proof {}",
-      msg._channel_binding,
-      msg._nonce,
-      msg._extensions,
-      msg._proof);
-    return os;
+std::ostream& operator<<(std::ostream& os, const client_final_message&) {
+    // NOTE: this stream is intentially left minimal to err away from exposing
+    // anything that may be useful for an attacker to use.
+    return os << "{client_final_message}";
 }
 
 ss::sstring server_final_message::sasl_message() const {
@@ -459,9 +435,10 @@ ss::sstring server_final_message::sasl_message() const {
     return ssx::sformat("v={}", bytes_to_base64(_signature));
 }
 
-std::ostream& operator<<(std::ostream& os, const server_final_message& msg) {
-    fmt::print(os, "error {} signature {}", msg._error, msg._signature);
-    return os;
+std::ostream& operator<<(std::ostream& os, const server_final_message&) {
+    // NOTE: this stream is intentially left minimal to err away from exposing
+    // anything that may be useful for an attacker to use.
+    return os << "{server_final_message}";
 }
 
 server_first_message::server_first_message(bytes_view data) {

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -42,8 +42,7 @@ scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
     if (_credential->iterations() < scram::min_iterations) {
         vlog(
           seclog.info,
-          "Requested iterations {} less than minimum {}",
-          _credential->iterations(),
+          "Requested iterations less than minimum {}",
           scram::min_iterations);
         return errc::invalid_credentials;
     }

--- a/src/v/security/scram_credential.cc
+++ b/src/v/security/scram_credential.cc
@@ -15,6 +15,8 @@
 namespace security {
 
 std::ostream& operator<<(std::ostream& os, const scram_credential&) {
+    // NOTE: this stream is intentially left minimal to err away from exposing
+    // anything that may be useful for an attacker to use.
     return os << "{scram_credential}";
 }
 


### PR DESCRIPTION
## Cover letter
We were logging information about potentially sensitive messages in a few places. It's not immediately clear when the bytes would be useful to typical users, so this patch removes them outright.

One of the culprits is that we define stream operators in generated code, and the code generator doesn't take into account the sensitivity of the structs being generator. Since it's tough to be absolutely sure a given generated type is never logged, certain message types are now redacted entirely when their stream operator is used.

Note that a redacted operator<< is already defined for scram_credential& so I've removed the more detailed operator entirely.

## Release notes
* none
