### PR TITLE
Backport Slash Command Refactor

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -2,37 +2,55 @@ name: backport-command
 on:
   repository_dispatch:
     types: [backport-command]
+env:
+  SCRIPT_DIR: "${{ github.workspace }}/.github/workflows/scripts/backport-command"
+  PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+  ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.issue.html_url }}
+  TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
+  TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
+  ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
+  MILESTONE_ARG: ${{ github.event.client_payload.slash_command.args.named.milestone }}
+  TARGET_FULL_REPO: ${{ github.event.client_payload.slash_command.args.named.org }}/${{ github.event.client_payload.slash_command.args.named.repo }}
+
 jobs:
   # assumptions:
   #   label "kind/backport" exists
   #   the TARGET_REPO has been already forked into the bots account
-  # outputs the source of the comment (PR or issue)
+  #   outputs the source of the comment (PR or issue)
   backport-type:
     outputs:
-      commented_on: ${{ steps.type.outputs.commented_on }}
+      commented_on: ${{ steps.get_backport_type.outputs.commented_on }}
+      backport_branch: ${{ steps.get_backport_type.outputs.backport_branch }}
+      target_milestone: ${{ steps.get_backport_type.outputs.target_milestone }}
     runs-on: ubuntu-latest
-    env:
-      TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
-      TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
       - name: Get type of backport (issue or PR)
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
-        id: type
-        run: |
-          branches=$(gh api "/repos/${TARGET_ORG}/${TARGET_REPO}/branches" --jq '.[] | select(.name=='\"$ARG1\"')')
-          if [[ $branches == "" ]]; then
-            echo "Branch name not found"
-            exit 1
-          fi
-          if [[ $(echo $CLIENT_PAYLOAD | jq 'has("pull_request")') == true ]]; then
-            commented_on=pr
-          else
-            commented_on=issue
-          fi
-          echo "::set-output name=commented_on::$commented_on"
+        id: get_backport_type
+        run: $SCRIPT_DIR/get_backport_type.sh
+        shell: bash
+
+      - name: Failed reaction
+        uses: peter-evans/create-or-update-comment@v1
+        if: failure()
+        with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: "-1"
+
+      - name: Post Error
+        if: failure()
+        env:
+          COMMENTED_ON: ${{ steps.get_backport_type.outputs.commented_on }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        run: $SCRIPT_DIR/post_error.sh
+        shell: bash
 
   # creates backport issue if commented on issue, or
   # creates backport PR if commented on PR
@@ -41,9 +59,11 @@ jobs:
     needs: backport-type
     runs-on: ubuntu-latest
     env:
-      TARGET_ORG: ${{ github.event.client_payload.slash_command.args.named.org }}
-      TARGET_REPO: ${{ github.event.client_payload.slash_command.args.named.repo }}
+      BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
       - name: Get user
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -60,82 +80,26 @@ jobs:
         id: assignees
         run: echo ::set-output name=assignees::$(echo "$ASSIGNEES" | jq -r '.[].login' | paste -s -d ',' -)
 
-      - name: Get branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          BRANCH: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
-        id: branch
-        run: |
-          branches=$(gh api "/repos/${TARGET_ORG}/${TARGET_REPO}/branches" --jq .[].name | grep "$BRANCH")
-          if [[ $branches == "" ]]; then
-            exit 2
-          fi
-          echo ::set-output name=branch::"$BRANCH"
-
       - name: Discover and create milestone
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
-          TARGET_MILESTONE: ${{ github.event.client_payload.slash_command.args.named.milestone }}
-        id: milestone
-        run: |
-          if [[ "${TARGET_MILESTONE}" == "auto" ]]; then
-            major=$(echo "$BACKPORT_BRANCH" | grep -Eo '^v[0-9]{2}\.[0-9]{1,2}\.')
-            list_released=$(gh api "repos/${TARGET_ORG}/${TARGET_REPO}/releases" --jq '.[] | select(.draft==false).name')
-            latest_released=$(echo "$list_released" | grep -m1 -F "${major}" || true)
-            if [[ -z $latest_released ]]; then
-              echo "INFO no previous releases found with major prefix $major"
-              assigne_milestone="${major}1"
-            else
-              echo "INFO found previous releases with major prefix $major"
-              assigne_milestone=$(echo ${latest_released} | awk -F. -v OFS=. '{$NF += 1; print; exit}')
-            fi
-          else
-            assigne_milestone="${TARGET_MILESTONE}"
-          fi
-          if [[ $(gh api "repos/${TARGET_ORG}/${TARGET_REPO}/milestones" --jq .[].title | grep "${assigne_milestone}") == "" ]]; then
-            # the below fails of something goes wrong
-            gh api "repos/${TARGET_ORG}/${TARGET_REPO}/milestones" --silent --method POST -f title="${assigne_milestone}"
-            sleep 20 # wait for milestone creation to be propagated
-          fi
-          echo ::set-output name=milestone::${assigne_milestone}
+          TARGET_MILESTONE: ${{ needs.backport-type.outputs.target_milestone }}
+        id: create_milestone
+        run: $SCRIPT_DIR/create_milestone.sh
+        shell: bash
 
       - name: Create issue
         if: needs.backport-type.outputs.commented_on == 'issue'
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          TARGET_MILESTONE: ${{ steps.milestone.outputs.milestone }}
-          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
+          ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
           ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
-          ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.issue.html_url }}
-        run: |
-          orig_is_backport=$(echo "$ORIG_TITLE" | grep -Eo '\[v[0-9]{2}\.[0-9]{1,2}\.x\]' || true)
-          if [[ "$orig_is_backport" != "" ]]; then
-            msg="Seems that the issue is already a backport."
-            echo "$msg"
-            gh issue comment "$ORIG_ISSUE_URL" \
-              --body "$msg" \
-              --repo "$TARGET_ORG/$TARGET_REPO"
-            exit 1
-          fi
-          backport_issue_url=$(gh issue list --repo "${TARGET_ORG}/${TARGET_REPO}" \
-              --state open \
-              --search "[${BACKPORT_BRANCH}] ${ORIG_TITLE} in:title" \
-              --json url \
-              --milestone "${TARGET_MILESTONE}" \
-              --jq '.[0].url')
-          if [[ "$backport_issue_url" == "" ]]; then
-            gh issue create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
-              --label "kind/backport" \
-              --repo "${TARGET_ORG}/${TARGET_REPO}" \
-              --assignee "${ORIG_ASSIGNEES}" \
-              --milestone "${TARGET_MILESTONE}" \
-              --body "Backport ${ORIG_ISSUE_URL} to branch ${BACKPORT_BRANCH}"
-          else
-            gh issue comment "$ORIG_ISSUE_URL" --body "Backport issue already exists: $backport_issue_url"
-          fi
-
+        id: create_issue
+        run: $SCRIPT_DIR/create_issue.sh 
+        shell: bash
+          
       - name: Get reviewers of PR
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
@@ -150,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
         id: backport_commits
         run: |
-          backport_commits=$(gh api "repos/$TARGET_ORG/$TARGET_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
+          backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
           echo ::set-output name=backport_commits::$backport_commits
 
       - uses: actions/checkout@v3
@@ -158,148 +122,38 @@ jobs:
         with:
           repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          path: ./fork
 
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
-          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
           BACKPORT_COMMITS: ${{ steps.backport_commits.outputs.backport_commits }}
           IS_MERGED: ${{ github.event.client_payload.pull_request.merged }}
           PR_BASE_BRANCH: ${{ github.event.client_payload.pull_request.base.ref }}
           REPO_DEFAULT_BRANCH: ${{ github.event.client_payload.pull_request.base.repo.default_branch }}
+          GIT_USER: ${{ steps.user.outputs.username }}
+          GIT_EMAIL: ${{ steps.user.outputs.email }}
         id: pr_details
-        run: |
-          if [[ "$IS_MERGED" != true ]]; then
-            msg="The pull request is not merged yet. Cancelling backport..."
-            echo "$msg"
-            gh pr comment "$PR_NUMBER" \
-              --body "$msg" \
-              --repo "$TARGET_ORG/$TARGET_REPO"
-            exit 1
-          elif [[ "$PR_BASE_BRANCH" != "$REPO_DEFAULT_BRANCH" ]]; then
-            msg="The pull request's base branch is not the default one. Cancelling backport..."
-            echo "$msg"
-            gh pr comment "$PR_NUMBER" \
-              --body "$msg" \
-              --repo "$TARGET_ORG/$TARGET_REPO"
-            exit 1
-          fi
-          fixing_issue_urls=$(gh api graphql -f query='{
-              resource(url: "https://github.com/'${TARGET_ORG}'/'${TARGET_REPO}'/pull/'${PR_NUMBER}'") {
-                ... on PullRequest {
-                  closingIssuesReferences(first: 20) {
-                    nodes {
-                      url
-                    }
-                  }
-                }
-              }
-            }' --jq .data.resource.closingIssuesReferences.nodes.[].url)
-          # ensure unique branch
-          suffix=$(echo $(($RANDOM % 1000)))
-          git config --global user.email "${{ steps.user.outputs.email }}"
-          git config --global user.name "${{ steps.user.outputs.username }}"
-          git remote add upstream "https://github.com/$TARGET_ORG/$TARGET_REPO.git"
-          git fetch --all
-          git remote set-url origin "https://${{ steps.user.outputs.username }}:$GITHUB_TOKEN@github.com/${{ steps.user.outputs.username }}/$TARGET_REPO.git"
-          backport_issues_numbers=""
-          for issue_url in $fixing_issue_urls; do
-            backport_issues_numbers+=$(echo $issue_url | awk -F/ '{print $NF"-"}')
-          done
-          if [[ "$backport_issues_numbers" == "" ]]; then
-            backport_issues_numbers="fixes-to-"
-          fi
-          head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
-          git checkout -b $head_branch remotes/upstream/$BACKPORT_BRANCH
-          set +e
-          git cherry-pick -x $BACKPORT_COMMITS
-          if [[ "$?" != "0" ]]; then
-            msg="""Failed to run cherry-pick command. see [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            I executed the below command:
-            \`\`\`
-            git cherry-pick -x $BACKPORT_COMMITS
-            \`\`\`
-            """
-            gh pr comment "$PR_NUMBER" \
-              --body "$msg" \
-              --repo "$TARGET_ORG/$TARGET_REPO"
-            exit 1
-          fi
-          set -e
-          git push --set-upstream origin $head_branch
-          git remote rm upstream
-          echo ::set-output name=head_branch::$head_branch
-          echo ::set-output name=fixing_issue_urls::$fixing_issue_urls
+        run: $SCRIPT_DIR/pr_details.sh
+        shell: bash
 
       - name: Create pull request
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          TARGET_MILESTONE: ${{ steps.milestone.outputs.milestone }}
-          BACKPORT_BRANCH: ${{ steps.branch.outputs.branch }}
+          TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
           ORIG_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
-          ORIG_ISSUE_URL: ${{ github.event.client_payload.github.payload.issue.html_url }}
           HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
-          FIXING_ISSUE_URLs: ${{ steps.pr_details.outputs.fixing_issue_urls }}
+          FIXING_ISSUE_URLS: ${{ steps.pr_details.outputs.fixing_issue_urls }}
           ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
-        run: |
-          backport_issue_urls=""
-          if [[ "$FIXING_ISSUE_URLs" != "" ]]; then
-            for FIXING_ISSUE_URL in $FIXING_ISSUE_URLs; do
-              orig_issue_number=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $NF}')
-              orig_org=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $4}')
-              orig_repo=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $5}')
-
-              if [[ "$orig_repo" != "${TARGET_REPO}" || "$orig_org" != "${TARGET_ORG}" ]]; then
-                break
-              fi
-
-              orig_issue_title=$(gh issue view "$orig_issue_number" \
-                --repo "${orig_org}/${orig_repo}" \
-                --json title --jq .title)
-
-              backport_issue_url=$(gh issue list --repo "${orig_org}/${orig_repo}" \
-                --state open \
-                --search "[${BACKPORT_BRANCH}] ${orig_issue_title} in:title" \
-                --json url \
-                --milestone "${TARGET_MILESTONE}" \
-                --jq '.[0].url')
-
-              if [[ "$backport_issue_url" == "" ]]; then
-                # backport issue does not exist and will be created
-                # get orig issue assignees
-                orig_issue_assingees=$(gh issue view "$orig_issue_number" \
-                  --repo "${orig_org}/${orig_repo}" \
-                  --json assignees --jq .assignees.[].login | paste -s -d ',' -)
-                # create issue
-                backport_issue_url=$(gh issue create --title "[${BACKPORT_BRANCH}] ${orig_issue_title}" \
-                  --label "kind/backport" \
-                  --repo "${orig_org}/${orig_repo}" \
-                  --assignee "${orig_issue_assingees}" \
-                  --milestone "${TARGET_MILESTONE}" \
-                  --body "Backport ${FIXING_ISSUE_URL} to branch ${BACKPORT_BRANCH}. Requested by PR $ORIG_PR_URL")
-              fi
-              backport_issue_urls+=$(echo "Fixes $backport_issue_url, ")
-            done
-            backport_issue_urls=$(echo $backport_issue_urls | sed 's/.$//')
-          fi
-
-          gh pr create --title "[${BACKPORT_BRANCH}] ${ORIG_TITLE}" \
-            --base "${BACKPORT_BRANCH}" \
-            --label "kind/backport" \
-            --head "${{ steps.user.outputs.username }}:${HEAD_BRANCH}" \
-            --draft \
-            --repo "${TARGET_ORG}/${TARGET_REPO}" \
-            --reviewer "${ORIG_REVIEWERS}" \
-            --milestone "${TARGET_MILESTONE}" \
-            --body """Backport from pull request: ${ORIG_ISSUE_URL}
-            $backport_issue_urls
-            """
+          GIT_USER: ${{ steps.user.outputs.username }}
+        id: create_pr
+        run: $SCRIPT_DIR/create_pr.sh 
+        shell: bash
 
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1
@@ -308,3 +162,20 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray
+
+      - name: Failed reaction
+        uses: peter-evans/create-or-update-comment@v1
+        if: failure()
+        with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: "-1"
+
+      - name: Post Error
+        if: failure()
+        env:
+          COMMENTED_ON: ${{ needs.backport-type.outputs.commented_on }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        run: $SCRIPT_DIR/post_error.sh
+        shell: bash

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -5,6 +5,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
 if [[ -n $(echo "$ORIG_LABELS" | jq '.[] | select(.name == "kind/backport")') ]]; then

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# type-branch job
+# Create issue step
+
+set -e
+
+source "$SCRIPT_DIR/gh_wrapper.sh"
+
+if [[ -n $(echo "$ORIG_LABELS" | jq '.[] | select(.name == "kind/backport")') ]]; then
+  msg="The issue is already a backport."
+  echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
+  backport_failure "$msg"
+fi
+
+backport_issue_url=$(gh_issue_url)
+if [[ -z $backport_issue_url ]]; then
+  gh issue create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
+    --label "kind/backport" \
+    --repo "$TARGET_ORG/$TARGET_REPO" \
+    --assignee "$ORIG_ASSIGNEES" \
+    --milestone "$TARGET_MILESTONE" \
+    --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH"
+else
+  msg="Backport issue already exists: $backport_issue_url"
+  echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
+fi

--- a/.github/workflows/scripts/backport-command/create_milestone.sh
+++ b/.github/workflows/scripts/backport-command/create_milestone.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# type-branch job
+# Discover and create milestone step
+
+set -e
+
+if [[ $TARGET_MILESTONE == "auto" ]]; then
+  assignee_milestone="$BACKPORT_BRANCH-next"
+else
+  assignee_milestone=$TARGET_MILESTONE
+fi
+if [[ $(gh api "repos/$TARGET_ORG/$TARGET_REPO/milestones" --jq .[].title | grep "$assignee_milestone") == "" ]]; then
+  # The below fails if something goes wrong
+  gh api "repos/$TARGET_ORG/$TARGET_REPO/milestones" --silent --method POST -f title="$assignee_milestone"
+  sleep 20 # wait for milestone creation to be propagated
+fi
+echo "::set-output name=milestone::$assignee_milestone"

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -5,6 +5,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
 cd "$GITHUB_WORKSPACE/fork" || exit 1

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# type-branch job
+# Create pull request step
+
+set -e
+
+source "$SCRIPT_DIR/gh_wrapper.sh"
+
+cd "$GITHUB_WORKSPACE/fork" || exit 1
+
+backport_issue_urls=""
+# shellcheck disable=SC2153
+if [[ $FIXING_ISSUE_URLS != "" ]]; then
+  for FIXING_ISSUE_URL in $FIXING_ISSUE_URLS; do
+    orig_issue_number=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $NF}')
+    orig_org=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $4}')
+    orig_repo=$(echo "$FIXING_ISSUE_URL" | awk -F/ '{print $5}')
+
+    if [[ $orig_repo != "$TARGET_REPO" || $orig_org != "$TARGET_ORG" ]]; then
+      break
+    fi
+
+    orig_issue_title=$(gh issue view "$orig_issue_number" \
+      --repo "$orig_org/$orig_repo" \
+      --json title --jq .title)
+
+    backport_issue_url=$(gh_issue_url -r "$orig_org/$orig_repo" \
+      -s "[$BACKPORT_BRANCH] $orig_issue_title in:title")
+
+    # backport issue does not exist and will be created
+    if [[ $backport_issue_url == "" ]]; then
+      # get orig issue assignees
+      orig_issue_assignees=$(gh issue view "$orig_issue_number" \
+        --repo "$orig_org/$orig_repo" \
+        --json assignees --jq .assignees.[].login | paste -s -d ',' -)
+
+      # create issue
+      backport_issue_url=$(gh issue create --title "[$BACKPORT_BRANCH] $orig_issue_title" \
+        --label "kind/backport" \
+        --repo "$orig_org/$orig_repo" \
+        --assignee "$orig_issue_assignees" \
+        --milestone "$TARGET_MILESTONE" \
+        --body "Backport $FIXING_ISSUE_URL to branch $BACKPORT_BRANCH. Requested by PR $ORIG_PR_URL")
+    fi
+    backport_issue_urls+="Fixes $backport_issue_url, "
+  done
+  # shellcheck disable=SC2001
+  backport_issue_urls=$(echo "$backport_issue_urls" | sed 's/.$//')
+fi
+
+gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
+  --base "$BACKPORT_BRANCH" \
+  --label "kind/backport" \
+  --head "$GIT_USER:$HEAD_BRANCH" \
+  --draft \
+  --repo "$TARGET_ORG/$TARGET_REPO" \
+  --reviewer "$ORIG_REVIEWERS" \
+  --milestone "$TARGET_MILESTONE" \
+  --body "Backport from pull request: $ORIG_ISSUE_URL.
+$backport_issue_urls"

--- a/.github/workflows/scripts/backport-command/get_backport_type.sh
+++ b/.github/workflows/scripts/backport-command/get_backport_type.sh
@@ -5,6 +5,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
 gh_branch_exists() {

--- a/.github/workflows/scripts/backport-command/get_backport_type.sh
+++ b/.github/workflows/scripts/backport-command/get_backport_type.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# backport-type job
+# "Get type of backport (issue or pr)" step
+
+set -e
+
+source "$SCRIPT_DIR/gh_wrapper.sh"
+
+gh_branch_exists() {
+  [[ -n $(gh api "/repos/$TARGET_FULL_REPO/branches" --jq \
+    '.[] | select(.name == '\""$1"\"')') ]] && return 0
+  return 1
+}
+
+if [[ $(echo "$CLIENT_PAYLOAD" | jq 'has("pull_request")') == true ]]; then
+  commented_on="pr"
+else
+  commented_on="issue"
+fi
+echo "::set-output name=commented_on::$commented_on"
+
+if ! gh_branch_exists "$ARG1"; then
+  new_arg=$ARG1
+  if [[ ${new_arg:0:1} != "v" ]]; then new_arg="v$ARG1"; fi
+  major=$(echo "$new_arg" | grep -Eo '^v[0-9]{2}\.[0-9]{1,2}\.')
+
+  if gh_branch_exists "$new_arg"; then
+    backport_branch=$new_arg
+  elif [[ $MILESTONE_ARG == "auto" || $MILESTONE_ARG == "$ARG1" ]] && gh_branch_exists "${major}x"; then
+    echo "Milestone given instead of branch. Using \"${major}x\" branch."
+    backport_branch="${major}x"
+    target_milestone="$new_arg"
+  else
+    msg="Branch name \"$ARG1\" not found."
+
+    echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
+    backport_failure "$msg"
+  fi
+fi
+
+echo "::set-output name=backport_branch::${backport_branch-$ARG1}"
+echo "::set-output name=target_milestone::${target_milestone-$MILESTONE_ARG}"

--- a/.github/workflows/scripts/backport-command/gh_wrapper.sh
+++ b/.github/workflows/scripts/backport-command/gh_wrapper.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Wrapper functions for gh and git to make them reusable.
+
+# Many functions take optional parameters. When these are not provided,
+# the script attempts to get necessary details from env variables. Most of the convenience
+# of these functions is the default env variables it uses.
+# If the env variable is also not set, `set -u` should throw an unbound variable error.
+set -u
+
+backport_failure() {
+  echo "$1" >&2
+  exit 1
+}
+
+gh_issue_url() {
+  while getopts :s:m:r: opt; do
+    case $opt in
+      s)
+        search=$OPTARG
+        ;;
+      m)
+        milestone=$OPTARG
+        ;;
+      r)
+        repo=$OPTARG
+        ;;
+      \?)
+        backport_failure "Invalid option: -$OPTARG"
+        ;;
+      :)
+        backport_failure "-$OPTARG option requires an argument"
+        ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  search=${search-"[$BACKPORT_BRANCH] $ORIG_TITLE in:title"}
+  milestone=${milestone-$TARGET_MILESTONE}
+  repo=${repo-$TARGET_ORG/$TARGET_REPO}
+
+  gh issue list \
+    --state open \
+    --search "$search" \
+    --json url \
+    --milestone "$milestone" \
+    --repo "$repo" \
+    --jq '.[0].url'
+}
+
+# Do nothing if being imported in another script via `source`.
+if [[ ${BASH_SOURCE[0]} != "${0}" ]]; then
+  :
+
+# Allows functions to be called directly from github actions yaml.
+elif declare -f "$1" >/dev/null; then
+  "$@"
+
+else
+  backport_failure "No function named '$1'"
+fi

--- a/.github/workflows/scripts/backport-command/post_error.sh
+++ b/.github/workflows/scripts/backport-command/post_error.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# post error message to issue or pr
+
+set -e
+
+default_error="Oops! Something went wrong."
+
+msg="${BACKPORT_ERROR-$default_error}
+
+[Workflow run logs]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+
+case $COMMENTED_ON in
+  issue)
+    link=$ORIG_ISSUE_URL
+    ;;
+  pr)
+    link=$PR_NUMBER
+    ;;
+esac
+
+gh "$COMMENTED_ON" comment "$link" \
+  --repo "$TARGET_FULL_REPO" \
+  --body "$msg"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# type-branch job
+# Backport commits and get details step
+
+set -e
+
+source "$SCRIPT_DIR/gh_wrapper.sh"
+
+cd "$GITHUB_WORKSPACE/fork"
+
+if [[ $IS_MERGED != true ]]; then
+  msg="The pull request is not merged yet. Cancelling backport..."
+  echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
+  backport_failure "$msg"
+
+elif [[ $PR_BASE_BRANCH != "$REPO_DEFAULT_BRANCH" ]]; then
+  msg="The pull request's base branch is not the default one. Cancelling backport..."
+  echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
+  backport_failure "$msg"
+fi
+
+fixing_issue_urls=$(gh api graphql -f query='{
+  resource(url: "https://github.com/'"$TARGET_FULL_REPO"'/pull/'"$PR_NUMBER"'") {
+    ... on PullRequest {
+      closingIssuesReferences(first: 20) {
+        nodes {
+          url
+        }
+      }
+    }
+  }
+}' --jq .data.resource.closingIssuesReferences.nodes.[].url)
+
+suffix=$((RANDOM % 1000))
+git config --global user.email "$GIT_EMAIL"
+git config --global user.name "$GIT_USER"
+git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
+git fetch --all
+git remote set-url origin "https://$GIT_USER:$GITHUB_TOKEN@github.com/$GIT_USER/$TARGET_REPO.git"
+
+backport_issues_numbers=""
+for issue_url in $fixing_issue_urls; do
+  backport_issues_numbers+=$(echo "$issue_url" | awk -F/ '{print $NF"-"}')
+done
+if [[ $backport_issues_numbers == "" ]]; then
+  backport_issues_numbers="fixes-to-"
+fi
+head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
+git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
+
+if ! git cherry-pick -x "$BACKPORT_COMMITS"; then
+  msg="Failed to run cherry-pick command. I executed the below command:\n
+\`\`\`\r
+git cherry-pick -x $BACKPORT_COMMITS
+\`\`\`"
+
+  # Multiline workaround for GitHub Actions.
+  {
+    echo 'BACKPORT_ERROR<<EOF'
+    echo -e "$msg"
+    echo 'EOF'
+  } >>"$GITHUB_ENV"
+
+  backport_failure "$msg"
+fi
+
+git push --set-upstream origin "$head_branch"
+git remote rm upstream
+echo "::set-output name=head_branch::$head_branch"
+echo "::set-output name=fixing_issue_urls::$fixing_issue_urls"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -5,6 +5,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
 cd "$GITHUB_WORKSPACE/fork"


### PR DESCRIPTION
## Cover letter

Refactor of the backport slash command. 

Besides clean up and organization, includes additional features:

* `-1` (thumbs down) emoji reaction on failure.
* Posts error message with link to workflow logs. 
* Defaults to adding backport to `<version>-next` milestone to prevent clutter on release milestones.
* Auto corrects when the `v` is forgotten in branch/milestone name (example: `22.1.x` vs `v22.1.x`). 
* Accepts milestones as well as branches. 

## Release Notes

none
