### PR TITLE
rpc: adaptive rpc message encoding

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -136,7 +136,6 @@ private:
     ss::sharded<topics_frontend> _tp_frontend;       // instance per core
     ss::sharded<controller_backend> _backend;        // instance per core
     ss::sharded<controller_stm> _stm;                // single instance
-    ss::sharded<controller_service> _service;        // instance per core
     ss::sharded<controller_api> _api;                // instance per core
     ss::sharded<members_frontend> _members_frontend; // instance per core
     ss::sharded<members_backend> _members_backend;   // single instance

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -15,7 +15,6 @@ namespace cluster {
 
 class controller;
 class controller_backend;
-class controller_service;
 class controller_stm_shard;
 class id_allocator_frontend;
 class rm_partition_frontend;

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -49,6 +49,7 @@ struct partition_balancer_violations
         model::node_id id;
         model::timestamp unavailable_since;
 
+        unavailable_node() noexcept = default;
         unavailable_node(model::node_id id, model::timestamp unavailable_since)
           : id(id)
           , unavailable_since(unavailable_since) {}
@@ -65,6 +66,7 @@ struct partition_balancer_violations
         model::node_id id;
         uint32_t disk_used_percent;
 
+        full_node() noexcept = default;
         full_node(model::node_id id, uint32_t disk_used_percent)
           : id(id)
           , disk_used_percent(disk_used_percent) {}

--- a/src/v/coproc/types.h
+++ b/src/v/coproc/types.h
@@ -47,6 +47,7 @@ enum class topic_ingestion_policy : int8_t { earliest = 0, stored, latest };
 
 /// \brief type to use for registration/deregistration of a topic
 struct enable_copros_request {
+    using rpc_serde_exempt = std::true_type;
     struct data {
         script_id id;
         iobuf source_code;
@@ -57,6 +58,7 @@ struct enable_copros_request {
 /// \brief registration acks per copro, responses are organized in the
 /// same order as the list of topics in the 'topics' array
 struct enable_copros_reply {
+    using rpc_serde_exempt = std::true_type;
     using topic_policy = std::pair<model::topic, topic_ingestion_policy>;
     struct script_metadata {
         script_id id;
@@ -76,12 +78,14 @@ using state_size_t = named_type<int64_t, struct state_size_tag>;
 /// \brief deregistration request, remove all topics registered to a coprocessor
 /// with id 'script_id'.
 struct disable_copros_request {
+    using rpc_serde_exempt = std::true_type;
     std::vector<script_id> ids;
 };
 
 /// \brief deregistration acks per topic, responses are organized in the
 /// same order as the list of topics in the 'ids' array
 struct disable_copros_reply {
+    using rpc_serde_exempt = std::true_type;
     using ack = std::pair<script_id, disable_response_code>;
     std::vector<ack> acks;
 };
@@ -89,6 +93,7 @@ struct disable_copros_reply {
 /// \brief Request that co-processors with the given script ids, process batches
 /// from the reader whose source topic is the given ntp
 struct process_batch_request {
+    using rpc_serde_exempt = std::true_type;
     struct data {
         std::vector<script_id> ids;
         model::ntp ntp;
@@ -100,6 +105,7 @@ struct process_batch_request {
 /// \brief Response from the above request, acks from script ids that have
 /// processed the record and produce new batches on a new materialized ntp
 struct process_batch_reply {
+    using rpc_serde_exempt = std::true_type;
     struct data {
         script_id id;
         model::ntp source;

--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -156,6 +156,39 @@ encode_for_version(iobuf& out, T msg, transport_version version) {
     }
 }
 
+/*
+ * Decode a client request at the given transport version.
+ */
+template<typename T>
+ss::future<T>
+decode_for_version(iobuf_parser& parser, transport_version version) {
+    static_assert(!is_rpc_adl_exempt<T> || !is_rpc_serde_exempt<T>);
+
+    if constexpr (is_rpc_serde_exempt<T>) {
+        if (version != transport_version::v0) {
+            return ss::make_exception_future<T>(std::runtime_error(fmt::format(
+              "Unexpected adl-only message {} at {} != v0",
+              typeid(T).name(),
+              version)));
+        }
+        return reflection::async_adl<T>{}.from(parser);
+    } else if constexpr (is_rpc_adl_exempt<T>) {
+        if (version < transport_version::v2) {
+            return ss::make_exception_future<T>(std::runtime_error(fmt::format(
+              "Unexpected serde-only message {} at {} < v2",
+              typeid(T).name(),
+              version)));
+        }
+        return serde::read_async<T>(parser);
+    } else {
+        if (version < transport_version::v2) {
+            return reflection::async_adl<T>{}.from(parser);
+        } else {
+            return serde::read_async<T>(parser);
+        }
+    }
+}
+
 template<typename T>
 ss::future<T> parse_type(ss::input_stream<char>& in, const header& h) {
     return read_iobuf_exactly(in, h.payload_size).then([h](iobuf io) {
@@ -178,8 +211,8 @@ ss::future<T> parse_type(ss::input_stream<char>& in, const header& h) {
 
         auto p = std::make_unique<iobuf_parser>(std::move(io));
         auto raw = p.get();
-        return reflection::async_adl<T>{}.from(*raw).finally(
-          [p = std::move(p)] {});
+        return decode_for_version<T>(*raw, h.version)
+          .finally([p = std::move(p)] {});
     });
 }
 

--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -224,6 +224,33 @@ struct default_message_codec {
     }
 };
 
+/*
+ * service specialization mixin to create a v0 compliant service. a v0 service
+ * encodes and decodes using adl, ignores versions on requests, and sends
+ * replies with v0 in the header.
+ *
+ * example:
+ *   using echo_service_v0 = echo_service_base<v0_message_codec>;
+ */
+struct v0_message_codec {
+    template<typename T>
+    static ss::future<T> decode(iobuf_parser& parser, transport_version) {
+        return reflection::async_adl<T>{}.from(parser);
+    }
+
+    static transport_version response_version(const header&) {
+        return transport_version::v0;
+    }
+
+    template<typename T>
+    static ss::future<transport_version>
+    encode(iobuf& out, T msg, transport_version) {
+        return reflection::async_adl<T>{}.to(out, std::move(msg)).then([] {
+            return transport_version::v0;
+        });
+    }
+};
+
 template<typename T, typename Codec>
 ss::future<T> parse_type(ss::input_stream<char>& in, const header& h) {
     return read_iobuf_exactly(in, h.payload_size).then([h](iobuf io) {

--- a/src/v/rpc/test/echo_service.json
+++ b/src/v/rpc/test/echo_service.json
@@ -34,6 +34,21 @@
             "name": "throw_exception",
             "input_type": "throw_req",
             "output_type": "throw_resp"
+        },
+        {
+            "name": "echo_adl_only",
+            "input_type": "echo_req_adl_only",
+            "output_type": "echo_resp_adl_only"
+        },
+        {
+            "name": "echo_adl_serde",
+            "input_type": "echo_req_adl_serde",
+            "output_type": "echo_resp_adl_serde"
+        },
+        {
+            "name": "echo_serde_only",
+            "input_type": "echo_req_serde_only",
+            "output_type": "echo_resp_serde_only"
         }
     ]
 }

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -21,8 +21,9 @@ namespace rpc {
 /// \brief expects the inputstream to be prefixed by an rpc::header
 template<typename T>
 ss::future<T> parse_framed(ss::input_stream<char>& in) {
-    return parse_header(in).then(
-      [&in](std::optional<header> o) { return parse_type<T>(in, o.value()); });
+    return parse_header(in).then([&in](std::optional<header> o) {
+        return parse_type<T, default_message_codec>(in, o.value());
+    });
 }
 } // namespace rpc
 

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -396,6 +396,7 @@ FIXTURE_TEST(missing_method_test, rpc_integration_fixture) {
 
     rpc::transport t(client_config());
     t.connect(model::no_timeout).get();
+    auto stop = ss::defer([&t] { t.stop().get(); });
     auto client = echo::echo_client_protocol(t);
 
     const auto check_missing = [&] {
@@ -441,8 +442,6 @@ FIXTURE_TEST(missing_method_test, rpc_integration_fixture) {
     }
 
     ss::when_all_succeed(requests.begin(), requests.end()).get();
-
-    t.stop().get();
 }
 
 FIXTURE_TEST(corrupted_header_at_client_test, rpc_integration_fixture) {
@@ -538,6 +537,7 @@ FIXTURE_TEST(version_not_supported, rpc_integration_fixture) {
 
     rpc::transport t(client_config());
     t.connect(model::no_timeout).get();
+    auto stop = ss::defer([&t] { t.stop().get(); });
     auto client = echo::echo_client_protocol(t);
 
     const auto check_unsupported = [&] {
@@ -592,8 +592,6 @@ FIXTURE_TEST(version_not_supported, rpc_integration_fixture) {
     }
 
     ss::when_all_succeed(requests.begin(), requests.end()).get();
-
-    t.stop().get();
 }
 
 class erroneous_protocol_exception : public std::exception {};

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -11,8 +11,11 @@
 
 #pragma once
 
+#include "reflection/adl.h"
 #include "rpc/parse_utils.h"
 #include "seastarx.h"
+#include "serde/envelope.h"
+#include "serde/serde.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -64,7 +67,177 @@ enum class failure_type { throw_exception, exceptional_future, none };
 using throw_req = failure_type;
 
 struct throw_resp {
+    using rpc_serde_exempt = std::true_type;
     ss::sstring reply;
 };
 
+/*
+ * echo methods with req/resp that support encodings:
+ * - adl only
+ * - serde only
+ * - serde and adl
+ */
+struct echo_req_adl_only {
+    using rpc_serde_exempt = std::true_type;
+    ss::sstring str;
+};
+
+struct echo_resp_adl_only {
+    using rpc_serde_exempt = std::true_type;
+    ss::sstring str;
+};
+
+// an adl-only type should not have serde support
+static_assert(!serde::is_serde_compatible_v<echo_req_adl_only>);
+static_assert(!serde::is_serde_compatible_v<echo_resp_adl_only>);
+
+// an adl-only type should not be exempt from adl support
+static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_only>);
+static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_only>);
+
+struct echo_req_adl_serde
+  : serde::envelope<echo_req_adl_serde, serde::version<1>> {
+    ss::sstring str;
+
+    void serde_write(iobuf& out) const {
+        // serialize with serde an adl-serde type
+        using serde::write;
+        write(out, str + "_to_sas");
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        // deserialize with serde an adl-serde type
+        using serde::read_nested;
+        str = read_nested<ss::sstring>(in, h._bytes_left_limit);
+        str += "_from_sas";
+    }
+};
+
+struct echo_resp_adl_serde
+  : serde::envelope<echo_resp_adl_serde, serde::version<1>> {
+    ss::sstring str;
+
+    void serde_write(iobuf& out) const {
+        // serialize with serde an adl-serde type
+        using serde::write;
+        write(out, str + "_to_sas");
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        // deserialize with serde an adl-serde type
+        using serde::read_nested;
+        str = read_nested<ss::sstring>(in, h._bytes_left_limit);
+        str += "_from_sas";
+    }
+};
+
+static_assert(serde::is_serde_compatible_v<echo_req_adl_serde>);
+static_assert(serde::is_serde_compatible_v<echo_resp_adl_serde>);
+static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_serde>);
+static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_serde>);
+
+struct echo_req_serde_only
+  : serde::envelope<echo_req_serde_only, serde::version<1>> {
+    using rpc_adl_exempt = std::true_type;
+    ss::sstring str;
+
+    void serde_write(iobuf& out) const {
+        // serialize with serde a serde-only type
+        using serde::write;
+        write(out, str + "_to_sso");
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        // deserialize with serde a serde-only type
+        using serde::read_nested;
+        str = read_nested<ss::sstring>(in, h._bytes_left_limit);
+        str += "_from_sso";
+    }
+};
+
+struct echo_resp_serde_only
+  : serde::envelope<echo_resp_serde_only, serde::version<1>> {
+    using rpc_adl_exempt = std::true_type;
+    ss::sstring str;
+
+    void serde_write(iobuf& out) const {
+        // serialize with serde a serde-only type
+        using serde::write;
+        write(out, str + "_to_sso");
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        // deserialize with serde a serde-only type
+        using serde::read_nested;
+        str = read_nested<ss::sstring>(in, h._bytes_left_limit);
+        str += "_from_sso";
+    }
+};
+
+// serde-only type needs to have serde support
+static_assert(serde::is_serde_compatible_v<echo_req_serde_only>);
+static_assert(serde::is_serde_compatible_v<echo_resp_serde_only>);
+
+// serde-only type needs to be example from adl
+static_assert(rpc::is_rpc_adl_exempt<echo_req_serde_only>);
+static_assert(rpc::is_rpc_adl_exempt<echo_resp_serde_only>);
+
 } // namespace echo
+
+namespace reflection {
+template<>
+struct adl<echo::echo_req_adl_only> {
+    void to(iobuf& out, echo::echo_req_adl_only&& r) {
+        // serialize with adl an adl-only type
+        reflection::serialize(out, r.str + "_to_aao");
+    }
+    echo::echo_req_adl_only from(iobuf_parser& in) {
+        // deserialize with adl an adl-only type
+        return echo::echo_req_adl_only{
+          .str = adl<ss::sstring>{}.from(in) + "_from_aao",
+        };
+    }
+};
+
+template<>
+struct adl<echo::echo_resp_adl_only> {
+    void to(iobuf& out, echo::echo_resp_adl_only&& r) {
+        // serialize with adl an adl-only type
+        reflection::serialize(out, r.str + "_to_aao");
+    }
+    echo::echo_resp_adl_only from(iobuf_parser& in) {
+        // deserialize with adl an adl-only type
+        return echo::echo_resp_adl_only{
+          .str = adl<ss::sstring>{}.from(in) + "_from_aao",
+        };
+    }
+};
+
+template<>
+struct adl<echo::echo_req_adl_serde> {
+    void to(iobuf& out, echo::echo_req_adl_serde&& r) {
+        // serialize with adl an adl-serde type
+        reflection::serialize(out, r.str + "_to_aas");
+    }
+    echo::echo_req_adl_serde from(iobuf_parser& in) {
+        // deserialize with adl an adl-serde type
+        return echo::echo_req_adl_serde{
+          .str = adl<ss::sstring>{}.from(in) + "_from_aas",
+        };
+    }
+};
+
+template<>
+struct adl<echo::echo_resp_adl_serde> {
+    void to(iobuf& out, echo::echo_resp_adl_serde&& r) {
+        // serialize with adl an adl-serde type
+        reflection::serialize(out, r.str + "_to_aas");
+    }
+    echo::echo_resp_adl_serde from(iobuf_parser& in) {
+        // deserialize with adl an adl-serde type
+        return echo::echo_resp_adl_serde{
+          .str = adl<ss::sstring>{}.from(in) + "_from_aas",
+        };
+    }
+};
+} // namespace reflection

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "rpc/parse_utils.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -19,33 +20,41 @@
 
 namespace cycling {
 struct ultimate_cf_slx {
+    using rpc_serde_exempt = std::true_type;
     int x = 42;
 };
 struct nairo_quintana {
+    using rpc_serde_exempt = std::true_type;
     int x = 43;
 };
 struct san_francisco {
+    using rpc_serde_exempt = std::true_type;
     int x = 44;
 };
 struct mount_tamalpais {
+    using rpc_serde_exempt = std::true_type;
     int x = 45;
 };
 } // namespace cycling
 
 namespace echo {
 struct echo_req {
+    using rpc_serde_exempt = std::true_type;
     ss::sstring str;
 };
 
 struct echo_resp {
+    using rpc_serde_exempt = std::true_type;
     ss::sstring str;
 };
 
 struct cnt_req {
+    using rpc_serde_exempt = std::true_type;
     uint64_t expected;
 };
 
 struct cnt_resp {
+    using rpc_serde_exempt = std::true_type;
     uint64_t expected;
     uint64_t current;
 };

--- a/src/v/rpc/test/test_types.h
+++ b/src/v/rpc/test/test_types.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 struct pod {
+    using rpc_serde_exempt = std::true_type;
     int16_t x = 1;
     int32_t y = 2;
     int64_t z = 3;

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -137,32 +137,32 @@ ss::future<result<rpc::client_context<T>>> parse_result(
     // check status first
     auto st = static_cast<status>(sctx->get_header().meta);
     if (st != status::success) {
-    /**
-     * signal that request body is parsed since it is empty when status
-     * indicates server error.
-     */
-    sctx->signal_body_parse();
+        /**
+         * signal that request body is parsed since it is empty when status
+         * indicates server error.
+         */
+        sctx->signal_body_parse();
 
-    return ss::make_ready_future<ret_t>(map_server_error(st));
+        return ss::make_ready_future<ret_t>(map_server_error(st));
     }
 
     // success case
-        return parse_type<T>(in, sctx->get_header())
-          .then_wrapped([sctx = std::move(sctx)](ss::future<T> data_fut) {
-              if (data_fut.failed()) {
-                  const auto ex = data_fut.get_exception();
-                  sctx->body_parse_exception(ex);
-                  /**
-                   * we want to throw an exception when body parsing failed.
-                   * this will invalidate the connection since it may not be
-                   * valid any more.
-                   */
-                  std::rethrow_exception(ex);
-              }
-              sctx->signal_body_parse();
-              return ret_t(rpc::client_context<T>(
-                sctx->get_header(), std::move(data_fut.get())));
-          });
+    return parse_type<T>(in, sctx->get_header())
+      .then_wrapped([sctx = std::move(sctx)](ss::future<T> data_fut) {
+          if (data_fut.failed()) {
+              const auto ex = data_fut.get_exception();
+              sctx->body_parse_exception(ex);
+              /**
+               * we want to throw an exception when body parsing failed.
+               * this will invalidate the connection since it may not be
+               * valid any more.
+               */
+              std::rethrow_exception(ex);
+          }
+          sctx->signal_body_parse();
+          return ret_t(rpc::client_context<T>(
+            sctx->get_header(), std::move(data_fut.get())));
+      });
 }
 
 } // namespace internal

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -68,6 +68,8 @@ public:
 
     void reset_state() final;
 
+    transport_version version() const { return _version; }
+
 private:
     using sequence_t = named_type<uint64_t, struct sequence_tag>;
     struct entry {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -38,6 +38,9 @@
 #include <optional>
 #include <utility>
 
+class rpc_integration_fixture_oc_ns_adl_serde_no_upgrade;
+class rpc_integration_fixture_oc_ns_adl_only_no_upgrade;
+
 namespace rpc {
 struct client_context_impl;
 
@@ -111,6 +114,10 @@ private:
      * upgraded if it is discovered that a server supports a newer version.
      */
     transport_version _version{transport_version::v1};
+
+    friend class ::rpc_integration_fixture_oc_ns_adl_serde_no_upgrade;
+    friend class ::rpc_integration_fixture_oc_ns_adl_only_no_upgrade;
+    void set_version(transport_version v) { _version = v; }
 
     friend std::ostream& operator<<(std::ostream&, const transport&);
 };

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -102,6 +102,14 @@ private:
     requests_queue_t _requests_queue;
     sequence_t _seq;
     sequence_t _last_seq;
+
+    /*
+     * version level used when dispatching requests. this value may change
+     * during the lifetime of the transport. for example the version may be
+     * upgraded if it is discovered that a server supports a newer version.
+     */
+    transport_version _version{transport_version::v0};
+
     friend std::ostream& operator<<(std::ostream&, const transport&);
 };
 
@@ -165,7 +173,7 @@ inline ss::future<result<client_context<Output>>>
 transport::send_typed(Input r, uint32_t method_id, rpc::client_opts opts) {
     using ret_t = result<client_context<Output>>;
     return send_typed_versioned<Input, Output>(
-             std::move(r), method_id, std::move(opts), transport_version::v0)
+             std::move(r), method_id, std::move(opts), _version)
       .then([](result<result_context<Output>> res) {
           if (!res) {
               return ss::make_ready_future<ret_t>(res.error());

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -110,7 +110,7 @@ private:
      * during the lifetime of the transport. for example the version may be
      * upgraded if it is discovered that a server supports a newer version.
      */
-    transport_version _version{transport_version::v0};
+    transport_version _version{transport_version::v1};
 
     friend std::ostream& operator<<(std::ostream&, const transport&);
 };

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -173,7 +173,7 @@ ss::future<result<rpc::client_context<T>>> parse_result(
         return ss::make_ready_future<ret_t>(map_server_error(st));
     }
 
-    return parse_type<T>(in, sctx->get_header())
+    return parse_type<T, default_message_codec>(in, sctx->get_header())
       .then_wrapped([sctx = std::move(sctx)](ss::future<T> data_fut) {
           if (data_fut.failed()) {
               const auto ex = data_fut.get_exception();

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -67,12 +67,11 @@ std::ostream& operator<<(std::ostream& o, const status& s) {
 }
 
 std::ostream& operator<<(std::ostream& o, transport_version v) {
-    switch (v) {
-    case transport_version::v0:
-        return o << "rpc::transport_version::v0";
-    case transport_version::unsupported:
-        return o << "rpc::transport_version::unsupported";
-    }
+    fmt::print(
+      o,
+      "rpc::transport_version::v{}",
+      static_cast<std::underlying_type_t<transport_version>>(v));
+    return o;
 }
 
 } // namespace rpc

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -87,7 +87,7 @@ enum class transport_version : uint8_t {
     v1 = 1,
     v2 = 2,
 
-    max_supported = v0,
+    max_supported = v2,
 
     /*
      * unsupported is a convenience name used in tests to construct a message

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
 #include <type_traits>
 #include <vector>
 
@@ -79,7 +80,7 @@ enum class transport_version : uint8_t {
      * unsupported is a convenience name used in tests to construct a message
      * with an unsupported version. the bits should not be considered reserved.
      */
-    unsupported = max_supported + 1,
+    unsupported = std::numeric_limits<uint8_t>::max()
 };
 
 /// \brief core struct for communications. sent with _each_ payload

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -73,7 +73,20 @@ enum class status : uint32_t {
 };
 
 enum class transport_version : uint8_t {
+    /*
+     * the first version used by rpc simple protocol. at this version level
+     * clients and servers (1) assume adl encoding, (2) ignore the version when
+     * handling a request, and (3) always respond with version 0.
+     */
     v0 = 0,
+
+    /*
+     * starting with version v1 clients and servers no longer ignore the
+     * version. v1 indicates adl encoding and v2 indicates serde encoding.
+     */
+    v1 = 1,
+    v2 = 2,
+
     max_supported = v0,
 
     /*


### PR DESCRIPTION
## Coverletter

Adds ability for RPC protocol to upgrade from adl<> to serde<>. See design document linked in epic #4730 for details.

The primary deviation from the changes described int he design document is the allowance at the type-system level for adl<> only types. This exception to the rule is clearly marked and will be removed once all types gain serde support.

Fixes: #4730 

## Release notes

* None