### PR TITLE
Do not restart cluster when scaling up

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -12,7 +12,6 @@ package resources
 import (
 	"bytes"
 	"context"
-	"crypto/md5" // nolint:gosec // this is not encrypting secure info
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -645,24 +644,16 @@ func generatePassword(length int) (string, error) {
 func (r *ConfigMapResource) GetNodeConfigHash(
 	ctx context.Context,
 ) (string, error) {
-	var configString string
+	cfg, err := r.CreateConfiguration(ctx)
+	if err != nil {
+		return "", err
+	}
 	if featuregates.CentralizedConfiguration(r.pandaCluster.Spec.Version) {
-		cfg, err := r.CreateConfiguration(ctx)
-		if err != nil {
-			return "", err
-		}
 		return cfg.GetNodeConfigurationHash()
 	}
 
 	// Previous behavior for v21.x
-	obj, err := r.obj(ctx)
-	if err != nil {
-		return "", err
-	}
-	configMap := obj.(*corev1.ConfigMap)
-	configString = configMap.Data[configKey]
-	md5Hash := md5.Sum([]byte(configString)) // nolint:gosec // this is not encrypting secure info
-	return fmt.Sprintf("%x", md5Hash), nil
+	return cfg.GetAllConfigurationHash()
 }
 
 // globalConfigurationChanged verifies if the new global configuration

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "0cb36f0be0d64032a61eb51a5d2985ea",
+			expectedHash:            "66339723e4a05fd6ddf0c69a1c21ef50",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "4697714fe9b8f8bcaebb814b93f2b8f6",
+			expectedHash: "13f15bd68fe224846f532c29a10eb3b0",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "2f51e71fa4b673fb105f98cb09cb7a00",
+			expectedHash: "27a43c846e6c990e60307fb3b88f91c4",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/k8s/pkg/resources/configuration/configuration.go
+++ b/src/go/k8s/pkg/resources/configuration/configuration.go
@@ -135,6 +135,18 @@ func (c *GlobalConfiguration) GetNodeConfigurationHash() (string, error) {
 	return fmt.Sprintf("%x", md5Hash), nil
 }
 
+// GetAllConfigurationHash computes a hash of the whole serialized config. This
+// is default behavior prior to centralized configuration feature was developed
+func (c *GlobalConfiguration) GetAllConfigurationHash() (string, error) {
+	clone := *c
+	serialized, err := clone.Serialize()
+	if err != nil {
+		return "", err
+	}
+	md5Hash := md5.Sum(serialized.RedpandaFile) // nolint:gosec // this is not encrypting secure info
+	return fmt.Sprintf("%x", md5Hash), nil
+}
+
 // GetAdditionalRedpandaProperty retrieves a configuration option
 func (c *GlobalConfiguration) GetAdditionalRedpandaProperty(
 	prop string,


### PR DESCRIPTION
## Cover letter

Currently when scaling up, we always update seed servers and that update triggered restart of the whole cluster. That's unnecessary, it's only important that there's at least one node up from all seeds, there does not have to be all listed. 

This PR changes the current behavior so the algorithm computing hashes to not include seeds - so change in seeds will never trigger restart. Considering the way how clusters are scaled up and down right now, this is correct behavior.

We cannot backport this as it triggers restart of the whole cluster because it changes the existing hashes.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
### Improvements

* Increasing number of replicas won't trigger restart of the whole cluster. Updating to this version will trigger restart as the algorithm for computation of hash triggering restart changed.