### PR TITLE
Track persistent volume in k8s environement

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -42,6 +42,7 @@ const (
 	externalConnectivityAddressTypeEnvVar = "EXTERNAL_CONNECTIVITY_ADDRESS_TYPE"
 	hostPortEnvVar                        = "HOST_PORT"
 	proxyHostPortEnvVar                   = "PROXY_HOST_PORT"
+	dataDirPath                           = "DATA_DIR_PATH"
 )
 
 type brokerID int
@@ -58,6 +59,7 @@ type configuratorConfig struct {
 	redpandaRPCPort                 int
 	hostPort                        int
 	proxyHostPort                   int
+	dataDirPath                     string
 }
 
 func (c *configuratorConfig) String() string {
@@ -72,7 +74,8 @@ func (c *configuratorConfig) String() string {
 		"externalConnectivityAddressType: %s\n"+
 		"redpandaRPCPort: %d\n"+
 		"hostPort: %d\n"+
-		"proxyHostPort: %d\n",
+		"proxyHostPort: %d\n"+
+		"dataDirPath: %s\n",
 		c.hostName,
 		c.svcFQDN,
 		c.configSourceDir,
@@ -83,7 +86,8 @@ func (c *configuratorConfig) String() string {
 		c.externalConnectivityAddressType,
 		c.redpandaRPCPort,
 		c.hostPort,
-		c.proxyHostPort)
+		c.proxyHostPort,
+		c.dataDirPath)
 }
 
 var errorMissingEnvironmentVariable = errors.New("missing environment variable")
@@ -335,6 +339,10 @@ func checkEnvVars() (configuratorConfig, error) {
 		{
 			value: &hostPort,
 			name:  hostPortEnvVar,
+		},
+		{
+			value: &c.dataDirPath,
+			name:  dataDirPath,
 		},
 	}
 	for _, envVar := range envVarList {

--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -116,32 +116,32 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	hostIndex, err := hostIndex(c.hostName)
+	podOrdinal, err := hostIndex(c.hostName)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to extract host index: %w", err))
 	}
 
-	log.Printf("Host index calculated %d", hostIndex)
+	log.Printf("Host index calculated %d", podOrdinal)
 
-	err = registerAdvertisedKafkaAPI(&c, cfg, hostIndex, kafkaAPIPort)
+	err = registerAdvertisedKafkaAPI(&c, cfg, podOrdinal, kafkaAPIPort)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to register advertised Kafka API: %w", err))
 	}
 
 	if cfg.Pandaproxy != nil && len(cfg.Pandaproxy.PandaproxyAPI) > 0 {
 		proxyAPIPort := getInternalProxyAPIPort(cfg)
-		err = registerAdvertisedPandaproxyAPI(&c, cfg, hostIndex, proxyAPIPort)
+		err = registerAdvertisedPandaproxyAPI(&c, cfg, podOrdinal, proxyAPIPort)
 		if err != nil {
 			log.Fatalf("%s", fmt.Errorf("unable to register advertised Pandaproxy API: %w", err))
 		}
 	}
 
-	err = calculateRedpandaID(cfg, c, hostIndex)
+	err = calculateRedpandaID(cfg, c, podOrdinal)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to register node Redpanda ID: %w", err))
 	}
 
-	err = initializeSeedSeverList(cfg, c, hostIndex)
+	err = initializeSeedSeverList(cfg, c, podOrdinal)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to determine seed server list: %w", err))
 	}

--- a/src/go/k8s/cmd/configurator/main_test.go
+++ b/src/go/k8s/cmd/configurator/main_test.go
@@ -1,14 +1,24 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/labels"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCalculateRedpandaID(t *testing.T) {
@@ -90,37 +100,281 @@ func TestCalculateRedpandaID(t *testing.T) {
 }
 
 func TestInitSeedServerList(t *testing.T) {
+	err := redpandav1alpha1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+
 	t.Run("empty Redpanda data folder", func(t *testing.T) {
 		t.Run("first POD", func(t *testing.T) {
-			tmp := t.TempDir()
-
 			statefulsetOrdinal := 0
+			t.Run("with more than 1 pod", func(t *testing.T) {
+				replicas := int32(3)
+				t.Run("without other pods running from Redpanda cluster", func(t *testing.T) {
+					tmp := t.TempDir()
 
-			cfg := config.Config{
-				Redpanda: config.RedpandaConfig{
-					SeedServers: []config.SeedServer{
-						{
-							Host: config.SocketAddress{
-								Address: "testAddress",
-								Port:    768,
+					cfg := config.Config{
+						Redpanda: config.RedpandaConfig{
+							SeedServers: []config.SeedServer{
+								{
+									Host: config.SocketAddress{
+										Address: "testAddress",
+										Port:    768,
+									},
+								},
 							},
 						},
-					},
-				},
-			}
-			err := initializeSeedSeverList(&cfg,
-				configuratorConfig{
-					dataDirPath: tmp,
-				},
-				brokerID(statefulsetOrdinal))
-			assert.NoError(t, err)
+					}
 
-			assert.Len(t, cfg.Redpanda.SeedServers, 0)
+					c := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testHostName",
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Replicas: &replicas,
+						},
+					}).Build()
+
+					err = initializeSeedSeverList(&cfg,
+						configuratorConfig{
+							dataDirPath: tmp,
+							hostName:    "testHostName-1",
+						},
+						brokerID(statefulsetOrdinal), c)
+					assert.NoError(t, err)
+
+					assert.Len(t, cfg.Redpanda.SeedServers, 0)
+				})
+
+				t.Run("with one running pod from Redpanda cluster without TLS", func(t *testing.T) {
+					tmp := t.TempDir()
+
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Write([]byte(`[
+  {
+    "node_id": 0,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": false,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1103825203200,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  },
+  {
+    "node_id": 1,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": true,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1103853776896,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  },
+  {
+    "node_id": 2,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": true,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1117177769984,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  }
+]`))
+					}))
+					defer srv.Close()
+
+					add := strings.Split(srv.Listener.Addr().String(), ":")
+					port, err := strconv.Atoi(add[1])
+					assert.NoError(t, err)
+
+					cfg := config.Config{
+						Redpanda: config.RedpandaConfig{
+							SeedServers: []config.SeedServer{
+								{
+									Host: config.SocketAddress{
+										Address: add[0],
+										Port:    port,
+									},
+								},
+							},
+						},
+					}
+
+					c := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testHostName",
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Replicas: &replicas,
+						},
+					}, &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								labels.InstanceKey: "testHostName",
+							},
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
+						},
+					}, &redpandav1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testHostName",
+						},
+						Spec: redpandav1alpha1.ClusterSpec{
+							Configuration: redpandav1alpha1.RedpandaConfig{
+								AdminAPI: []redpandav1alpha1.AdminAPI{
+									{
+										Port: 9644,
+										TLS: redpandav1alpha1.AdminAPITLS{
+											Enabled: false,
+										},
+									},
+								},
+							},
+						},
+						Status: redpandav1alpha1.ClusterStatus{},
+					}).Build()
+
+					err = initializeSeedSeverList(&cfg,
+						configuratorConfig{
+							dataDirPath: tmp,
+							hostName:    "testHostName-1",
+						},
+						brokerID(statefulsetOrdinal), c)
+					assert.NoError(t, err)
+
+					assert.Len(t, cfg.Redpanda.SeedServers, 1)
+				})
+
+				t.Run("with one running pod from Redpanda cluster with TLS", func(t *testing.T) {
+					tmp := t.TempDir()
+
+					srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Write([]byte(`[
+  {
+    "node_id": 0,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": false,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1103825203200,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  },
+  {
+    "node_id": 1,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": true,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1103853776896,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  },
+  {
+    "node_id": 2,
+    "num_cores": 2,
+    "membership_status": "active",
+    "is_alive": true,
+    "disk_space": [
+      {
+        "path": "/var/lib/redpanda/data",
+        "free": 1117177769984,
+        "total": 1249389649920
+      }
+    ],
+    "version": "v21.11.15 - 7325762b6f9e1586efc60ab97b8596f08510b31a-dirty"
+  }
+]`))
+					}))
+					defer srv.Close()
+
+					add := strings.Split(srv.Listener.Addr().String(), ":")
+					port, err := strconv.Atoi(add[1])
+					assert.NoError(t, err)
+
+					cfg := config.Config{
+						Redpanda: config.RedpandaConfig{
+							SeedServers: []config.SeedServer{
+								{
+									Host: config.SocketAddress{
+										Address: add[0],
+										Port:    port,
+									},
+								},
+							},
+						},
+					}
+
+					c := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testHostName",
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Replicas: &replicas,
+						},
+					}, &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								labels.InstanceKey: "testHostName",
+							},
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
+						},
+					}, &redpandav1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testHostName",
+						},
+						Spec: redpandav1alpha1.ClusterSpec{
+							Configuration: redpandav1alpha1.RedpandaConfig{
+								AdminAPI: []redpandav1alpha1.AdminAPI{
+									{
+										Port: 9644,
+										TLS: redpandav1alpha1.AdminAPITLS{
+											Enabled: true,
+										},
+									},
+								},
+							},
+						},
+						Status: redpandav1alpha1.ClusterStatus{},
+					}).Build()
+
+					err = initializeSeedSeverList(&cfg,
+						configuratorConfig{
+							dataDirPath: tmp,
+							hostName:    "testHostName-1",
+						},
+						brokerID(statefulsetOrdinal), c)
+					assert.NoError(t, err)
+
+					assert.Len(t, cfg.Redpanda.SeedServers, 1)
+				})
+			})
 		})
 
 		t.Run("not first POD", func(t *testing.T) {
-			tmp := t.TempDir()
-
 			statefulsetOrdinal := 2
 
 			cfg := config.Config{
@@ -135,11 +389,10 @@ func TestInitSeedServerList(t *testing.T) {
 					},
 				},
 			}
+			c := fake.NewClientBuilder().Build()
 			err := initializeSeedSeverList(&cfg,
-				configuratorConfig{
-					dataDirPath: tmp,
-				},
-				brokerID(statefulsetOrdinal))
+				configuratorConfig{},
+				brokerID(statefulsetOrdinal), c)
 			assert.NoError(t, err)
 
 			assert.Len(t, cfg.Redpanda.SeedServers, 1)
@@ -166,21 +419,19 @@ func TestInitSeedServerList(t *testing.T) {
 					},
 				},
 			}
+			c := fake.NewClientBuilder().Build()
 			err = initializeSeedSeverList(&cfg,
 				configuratorConfig{
 					dataDirPath: tmp,
+					hostName:    "testHostName-1",
 				},
-				brokerID(statefulsetOrdinal))
+				brokerID(statefulsetOrdinal), c)
 			assert.NoError(t, err)
 
 			assert.Len(t, cfg.Redpanda.SeedServers, 1)
 		})
 
 		t.Run("not first POD", func(t *testing.T) {
-			tmp := t.TempDir()
-			err := os.WriteFile(filepath.Join(tmp, "test"), []byte("test"), 0o666)
-			require.NoError(t, err)
-
 			statefulsetOrdinal := 2
 
 			cfg := config.Config{
@@ -195,14 +446,18 @@ func TestInitSeedServerList(t *testing.T) {
 					},
 				},
 			}
-			err = initializeSeedSeverList(&cfg,
-				configuratorConfig{
-					dataDirPath: tmp,
-				},
-				brokerID(statefulsetOrdinal))
+			c := fake.NewClientBuilder().Build()
+			err := initializeSeedSeverList(&cfg,
+				configuratorConfig{},
+				brokerID(statefulsetOrdinal), c)
 			assert.NoError(t, err)
 
 			assert.Len(t, cfg.Redpanda.SeedServers, 1)
 		})
 	})
+}
+
+func TestRenderStsName(t *testing.T) {
+	podName := "node-1"
+	assert.Equal(t, "node", renderStsName(podName, 1))
 }

--- a/src/go/k8s/cmd/configurator/main_test.go
+++ b/src/go/k8s/cmd/configurator/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateRedpandaID(t *testing.T) {
+	redpandaIDFile := ".redpanda_id"
+	t.Run("Clean state - empty Redpanda data folder", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfg := config.Config{}
+
+		statefulsetOrdinal := 2
+
+		err := calculateRedpandaID(&cfg,
+			configuratorConfig{
+				dataDirPath: tmp,
+			},
+			brokerID(statefulsetOrdinal))
+		assert.NoError(t, err)
+
+		redpandaID, err := os.ReadFile(filepath.Join(tmp, redpandaIDFile))
+		require.NoError(t, err)
+
+		rpID, err := strconv.Atoi(string(redpandaID))
+		require.NoError(t, err)
+
+		assert.Equal(t, rpID, cfg.Redpanda.ID)
+		assert.NotEqual(t, statefulsetOrdinal, cfg.Redpanda.ID)
+	})
+
+	t.Run("Fake not empty data Redpanda", func(t *testing.T) {
+		tmp := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmp, "test"), []byte("test"), 0o666)
+		require.NoError(t, err)
+
+		statefulsetOrdinal := 2
+
+		cfg := config.Config{}
+		err = calculateRedpandaID(&cfg,
+			configuratorConfig{
+				dataDirPath: tmp,
+			},
+			brokerID(statefulsetOrdinal))
+		assert.NoError(t, err)
+
+		redpandaID, err := os.ReadFile(filepath.Join(tmp, redpandaIDFile))
+		require.NoError(t, err)
+
+		rpID, err := strconv.Atoi(string(redpandaID))
+		require.NoError(t, err)
+
+		assert.Equal(t, rpID, cfg.Redpanda.ID)
+		assert.Equal(t, statefulsetOrdinal, cfg.Redpanda.ID)
+	})
+
+	t.Run(".redpanda_id file exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		storedRedpandaID := 0
+		err := os.WriteFile(filepath.Join(tmp, ".redpanda_id"), []byte(strconv.Itoa(storedRedpandaID)), 0o666)
+		require.NoError(t, err)
+
+		statefulsetOrdinal := 2
+
+		cfg := config.Config{}
+		err = calculateRedpandaID(&cfg,
+			configuratorConfig{
+				dataDirPath: tmp,
+			},
+			brokerID(statefulsetOrdinal))
+		assert.NoError(t, err)
+
+		redpandaID, err := os.ReadFile(filepath.Join(tmp, redpandaIDFile))
+		require.NoError(t, err)
+
+		rpID, err := strconv.Atoi(string(redpandaID))
+		require.NoError(t, err)
+
+		assert.Equal(t, storedRedpandaID, cfg.Redpanda.ID)
+		assert.Equal(t, rpID, cfg.Redpanda.ID)
+		assert.NotEqual(t, statefulsetOrdinal, cfg.Redpanda.ID)
+	})
+}

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -94,6 +94,11 @@ func (r *ClusterRoleResource) obj() k8sclient.Object {
 				APIGroups: []string{redpandav1alpha1.SchemeBuilder.GroupVersion.String()},
 				Resources: []string{"clusters"},
 			},
+			{
+				Verbs:     []string{"get", "create", "update"},
+				APIGroups: []string{corev1.GroupName},
+				Resources: []string{"configmaps"},
+			},
 		},
 	}
 }

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,21 @@ func (r *ClusterRoleResource) obj() k8sclient.Object {
 				Verbs:     []string{"get"},
 				APIGroups: []string{corev1.GroupName},
 				Resources: []string{"nodes"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{appsv1.SchemeGroupVersion.String()},
+				Resources: []string{"statefulsets"},
+			},
+			{
+				Verbs:     []string{"list"},
+				APIGroups: []string{corev1.GroupName},
+				Resources: []string{"pods"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{redpandav1alpha1.SchemeBuilder.GroupVersion.String()},
+				Resources: []string{"clusters"},
 			},
 		},
 	}

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -503,7 +503,7 @@ func (r *StatefulSetResource) obj(
 		})
 	}
 
-	setCloudStorage(ss, r.pandaCluster)
+	setVolumes(ss, r.pandaCluster)
 
 	rpkStatusContainer := r.rpkStatusContainer(tlsVolumeMounts)
 	if rpkStatusContainer != nil {
@@ -586,11 +586,9 @@ func (r *StatefulSetResource) composeCURLMaintenanceCommand(
 	return cmd
 }
 
-// setCloudStorage manipulates v1.StatefulSet object in order to add cloud storage specific
-// properties to Redpanda pod.
-func setCloudStorage(
-	ss *appsv1.StatefulSet, cluster *redpandav1alpha1.Cluster,
-) {
+// setVolumes manipulates v1.StatefulSet object in order to add cloud storage and
+// Redpanda data volume
+func setVolumes(ss *appsv1.StatefulSet, cluster *redpandav1alpha1.Cluster) {
 	pvcDataDir := preparePVCResource(datadirName, cluster.Namespace, cluster.Spec.Storage, ss.Labels)
 	ss.Spec.VolumeClaimTemplates = append(ss.Spec.VolumeClaimTemplates, pvcDataDir)
 	vol := corev1.Volume{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -365,6 +365,10 @@ func (r *StatefulSetResource) obj(
 									Name:  "HOST_PORT",
 									Value: r.getNodePort(ExternalListenerName),
 								},
+								{
+									Name:  "DATA_DIR_PATH",
+									Value: dataDirectory,
+								},
 							}, r.pandaproxyEnvVars()...),
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  pointer.Int64Ptr(userID),

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -612,6 +612,17 @@ func setVolumes(ss *appsv1.StatefulSet, cluster *redpandav1alpha1.Cluster) {
 		}
 	}
 
+	initContainers := ss.Spec.Template.Spec.InitContainers
+	for i := range initContainers {
+		if initContainers[i].Name == configuratorContainerName {
+			volMount := corev1.VolumeMount{
+				Name:      datadirName,
+				MountPath: dataDirectory,
+			}
+			initContainers[i].VolumeMounts = append(initContainers[i].VolumeMounts, volMount)
+		}
+	}
+
 	if cluster.Spec.CloudStorage.Enabled && featuregates.ShadowIndex(cluster.Spec.Version) && cluster.Spec.CloudStorage.CacheStorage != nil {
 		pvcArchivalDir := preparePVCResource(archivalCacheIndexAnchorName, cluster.Namespace, *cluster.Spec.CloudStorage.CacheStorage, ss.Labels)
 		ss.Spec.VolumeClaimTemplates = append(ss.Spec.VolumeClaimTemplates, pvcArchivalDir)


### PR DESCRIPTION
## Cover letter

Change Redpanda ID calculation based on the Redpanda data
folder mounted to the POD. If user would like to choose faster
local storage, every time local disk is wiped out due to node
change the Redpanda ID will be regenerated.

This PR changes seed server list calculation where seed server
list will be clean only when there will be no data and no running
other seed server nodes.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

-->
* Init container in kubernetes deployment will track Redpanda ID using
  persistent volumes
<!--
Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.
-->
### Improvements

* Seed server list will be removed only in POD with ordinal 0 when cluster
  has more than 1 replicas and none other Replicas is running.


## First FP

Fix linter issues with file permission.

REF:
https://github.com/redpanda-data/redpanda/issues/333