### PR TITLE
rpk: Add a way to specify ports for nodes to start on

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -18,9 +18,9 @@ const (
 	ModeDev  = "dev"
 	ModeProd = "prod"
 
-	DefaultKafkaPort     = 9092
 	DefaultSchemaRegPort = 8081
 	DefaultProxyPort     = 8082
+	DefaultKafkaPort     = 9092
 	DefaultAdminPort     = 9644
 	DefaultRPCPort       = 33145
 	DefaultListenAddress = "0.0.0.0"

--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -58,9 +58,12 @@ func getFreePort() (uint, error) {
 	return uint(l.Addr().(*net.TCPAddr).Port), nil
 }
 
-func GetFreePortPool(n int) ([]uint, error) {
+func GetFreePortPool(n int, takenPorts map[uint]struct{}) ([]uint, error) {
 	m := make(map[uint]struct{})
-	for len(m) != n {
+	for p := range takenPorts {
+		m[p] = struct{}{}
+	}
+	for len(m) < n {
 		p, err := getFreePort()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Cover letter

Currently, rpk randomly chooses open tcp ports to start its containers. This might not be ideal for testing environment where we specify the addresses of the brokers. In order to enhance the developer experience, we want to be able to spin up containers in specific ports

### Features

* Add a new flag to rpk for specifying ports

