### PR TITLE
Break ties randomly in partition allocator

### DIFF
--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -533,9 +533,15 @@ FIXTURE_TEST(rack_aware_assignment_1, partition_allocator_fixture) {
         nodes.insert(node_id);
     }
     BOOST_REQUIRE(nodes.size() == 3);
-    BOOST_REQUIRE(nodes.contains(model::node_id(0))); // rack-a
-    BOOST_REQUIRE(nodes.contains(model::node_id(2))); // rack-b
-    BOOST_REQUIRE(nodes.contains(model::node_id(4))); // rack-c
+    BOOST_REQUIRE(
+      nodes.contains(model::node_id(0))
+      || nodes.contains(model::node_id(1))); // rack-a
+    BOOST_REQUIRE(
+      nodes.contains(model::node_id(2))
+      || nodes.contains(model::node_id(3))); // rack-b
+    BOOST_REQUIRE(
+      nodes.contains(model::node_id(4))
+      || nodes.contains(model::node_id(5))); // rack-c
 }
 FIXTURE_TEST(rack_aware_assignment_2, partition_allocator_fixture) {
     std::vector<std::tuple<int, model::rack_id, int>> id_rack_ncpu = {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -23,6 +23,7 @@
 #include <bits/stdint-intn.h>
 #include <boost/functional/hash.hpp>
 
+#include <compare>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -203,6 +204,7 @@ struct broker_shard {
     uint32_t shard;
     friend std::ostream& operator<<(std::ostream&, const broker_shard&);
     bool operator==(const broker_shard&) const = default;
+    auto operator<=>(const model::broker_shard&) const = default;
 
     template<typename H>
     friend H AbslHashValue(H h, const broker_shard& s) {


### PR DESCRIPTION
## Cover letter

Currently we always select the node with the lowest ID out of nodes
with equal scores when allocating new partitions. This is largely a
side effect of the scan for the lowest score, but it means that
replica sets chosen tend to be highly concentrated: only a few replica
sets are chosen in practice even if many are available.

For example, in a cluster with 6 nodes, when the partition is balanced,
new partitions will be assigned only to replica sets [0 1 2] or [3 4 5]
despite there being 18 other valid replica sets to choose from.

This change breaks ties randomly, resulting in (probabilistically) a
relatively even spread of chosen replica sets.

Fixes #4809.

## Release notes

* none

### Improvements

The entire set of possible replica sets is available for allocation,
respecting, of course, any specified constraints.

This means that during node failure, the existing load will be 
more evenly balanced among the remaining nodes.