### PR TITLE
cluster, kafka, raft: Logging refinement

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -141,6 +141,7 @@ ss::future<> members_manager::maybe_update_current_node_configuration() {
       .then([] {
           vlog(clusterlog.info, "Node configuration updated successfully");
       })
+      .handle_exception_type([](const ss::sleep_aborted&) {})
       .handle_exception([](const std::exception_ptr& e) {
           vlog(clusterlog.error, "Unable to update node configuration - {}", e);
       });

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -194,6 +194,12 @@ ss::future<bool> persisted_stm::do_sync(
     if (offset > committed) {
         try {
             co_await wait_offset_committed(timeout, offset, term);
+        } catch (const ss::broken_condition_variable&) {
+            co_return false;
+        } catch (const ss::gate_closed_exception&) {
+            co_return false;
+        } catch (const ss::abort_requested_exception&) {
+            co_return false;
         } catch (...) {
             vlog(
               clusterlog.error,

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -95,7 +95,7 @@ ss::future<> leader_balancer::start() {
                 if (_enabled()) {
                     vlog(
                       clusterlog.info,
-                      "Leader balancer: controller leadership lost");
+                      "Leader balancer: node is not controller leader");
                 }
                 _need_controller_refresh = true;
                 _timer.cancel();

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -64,7 +64,9 @@ ss::future<bool> try_create_consumer_group_topic(
            * kindly ask client to retry on error
            */
           vassert(res.size() == 1, "expected exactly one result");
-          if (res[0].ec != cluster::errc::success) {
+          if (
+            res[0].ec != cluster::errc::success
+            && res[0].ec != cluster::errc::topic_already_exists) {
               vlog(
                 klog.warn,
                 "can not create {}/{} topic - error: {}",

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -134,6 +134,8 @@ ss::future<> state_machine::apply() {
                 }
             });
       })
+      .handle_exception_type([](const raft::offset_monitor::wait_aborted&) {})
+      .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
           vlog(
             _log.info, "State machine for ntp={} handles {}", _raft->ntp(), e);

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -62,10 +62,6 @@ RESTART_LOG_ALLOW_LIST = [
     re.compile(
         "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)"
     ),
-    # cluster - members_manager.cc:118 - Unable to update node configuration - seastar::sleep_aborted (Sleep is aborted)
-    re.compile("members_manager.*sleep_aborted"),
-    # cluster - members_backend.cc:91 - error waiting for members updates - seastar::abort_requested_exception (abort requested)
-    re.compile("members_backend.*abort_requested_exception"),
     re.compile(
         "raft - .*recovery append entries error.*client_request_timeout"),
     # cluster - rm_stm.cc:550 - Error "raft::errc:19" on replicating pid:{producer_identity: id=1, epoch=0} commit batch

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -67,9 +67,6 @@ RESTART_LOG_ALLOW_LIST = [
     # cluster - rm_stm.cc:550 - Error "raft::errc:19" on replicating pid:{producer_identity: id=1, epoch=0} commit batch
     # raft::errc:19 is the shutdown error code, the transaction subsystem encounters this and logs at error level
     re.compile("Error \"raft::errc:19\" on replicating"),
-
-    # cluster - persisted_stm.cc:199 - sync error: wait_offset_committed failed with seastar::broken_condition_variable (Condition variable is broken); offsets: dirty=692, committed=689; ntp={kafka/topic7/0
-    re.compile("cluster - .*broken_condition_variable"),
 ]
 
 # Log errors that are expected in chaos-style tests that e.g.
@@ -79,9 +76,6 @@ CHAOS_LOG_ALLOW_LIST = [
     re.compile(
         "(raft|rpc) - .*(client_request_timeout|disconnected_endpoint|Broken pipe|Connection reset by peer)"
     ),
-
-    # cluster - persisted_stm.cc:199 - sync error: wait_offset_committed failed with seastar::broken_condition_variable (Condition variable is broken); offsets: dirty=692, committed=689; ntp={kafka/topic7/0
-    re.compile("cluster - .*broken_condition_variable"),
 
     # Torn disk writes
     re.compile("storage - Could not parse header"),

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -96,11 +96,6 @@ CHAOS_LOG_ALLOW_LIST = [
 
     # rpc - Service handler threw an exception: seastar::broken_promise (broken promise)"
     re.compile("rpc - Service handler threw an exception: seastar"),
-
-    # rpc - server.cc:91 - vectorized internal rpc protocol - Error[applying protocol] remote address: 172.18.0.10:60503 - rpc::rpc_internal_body_parsing_exception (Unable to parse received RPC request payload - std::out_of_range (parse_utils out of range. got:9726 bytes and expected:46927 bytes
-    re.compile(
-        "rpc - .*Unable to parse received RPC request payload - std::out_of_range"
-    ),
     re.compile(
         "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
     ),

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -96,9 +96,7 @@ class TopicDeleteStressTest(RedpandaTest):
                              num_brokers=3,
                              extra_rp_conf=extra_rp_conf)
 
-    # log_allow_list should not be needed here: it is a workaround pending
-    # investigation of https://github.com/redpanda-data/redpanda/issues/4326
-    @cluster(num_nodes=4, log_allow_list=["rpc - .* - std::out_of_range"])
+    @cluster(num_nodes=4)
     def stress_test(self):
         for i in range(10):
             spec = TopicSpec(partition_count=2,


### PR DESCRIPTION
## Cover letter

These are messages which are either misleading, too high severity, or too numerous at info level.  Includes several items from the allow lists in tests.

In practice, these are the things that were noticeably interfering with observability when testing high partition counts under heavy load and inspecting logs, to the extent that it was worth fixing them while I was there.

## Release notes

### Improvements

* Several noisy log messages during restarts or client disconnects are reduced in severity and/or frequency