### PR TITLE
Update external connectivity docs to get a valid VERSION environment variable

### DIFF
--- a/src/go/k8s/docs/external-connectivity-localhost.md
+++ b/src/go/k8s/docs/external-connectivity-localhost.md
@@ -21,7 +21,7 @@ helm install \
 ```
 3. Get Latest version of the operator
 ```
-export VERSION=$(curl -s https://api.github.com/repos/vectorizedio/redpanda/releases/latest | jq -r .tag_name)
+export VERSION=$(curl -s https://api.github.com/repos/redpanda-data/redpanda/releases/latest | jq -r .tag_name)
 ```
 4. Install CRDs
 ```


### PR DESCRIPTION
## Cover letter

While going through these instructions the process failed silently on the CRD install step. The previous step required finding the latest Redpanda release version, but the URL pointed to the previous org name (vectorized).

It would be great to not have to first set an environment variable at all, and have a single step for CRD install.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
## Release notes

* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
