### PR TITLE
/backport on PR: remove quotes when cherry-picking

### DIFF
--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -50,7 +50,7 @@ fi
 head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 
-if ! git cherry-pick -x "$BACKPORT_COMMITS"; then
+if ! git cherry-pick -x $BACKPORT_COMMITS; then
   msg="Failed to run cherry-pick command. I executed the below command:\n
 \`\`\`\r
 git cherry-pick -x $BACKPORT_COMMITS


### PR DESCRIPTION
### Bugfix

having quotes when cherry-picking commits, treats the sha1s
as a single object and causes /backport command to fail when
there are more than one commits


## Release notes

* none