### PR TITLE
cluster: remember initial logical version & expose in API

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -178,6 +178,12 @@ void feature_state::notify_version(cluster_version v) {
 void feature_table::set_active_version(cluster_version v) {
     _active_version = v;
 
+    if (_original_version == invalid_version) {
+        // Rely on controller log replay to call us first with
+        // the first version the cluster ever agreed upon.
+        _original_version = v;
+    }
+
     for (auto& fs : _feature_state) {
         fs.notify_version(v);
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -217,7 +217,7 @@ public:
         return _active_version;
     }
 
-    cluster_version get_original_version() const noexcept {
+    cluster::cluster_version get_original_version() const noexcept {
         return _original_version;
     }
 
@@ -307,7 +307,7 @@ private:
     // The earliest version this cluster ever saw: guaranteed that no
     // on-disk structures were written with an encoding that predates
     // this.
-    cluster_version _original_version{invalid_version};
+    cluster::cluster_version _original_version{cluster::invalid_version};
 
     std::vector<feature_state> _feature_state;
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -299,6 +299,9 @@ private:
 
     // The controller log offset of last batch applied to this state machine
     void set_applied_offset(model::offset o) { _applied_offset = o; }
+    void set_original_version(cluster::cluster_version v) {
+        _original_version = v;
+    }
 
     void on_update();
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -217,6 +217,10 @@ public:
         return _active_version;
     }
 
+    cluster_version get_original_version() const noexcept {
+        return _original_version;
+    }
+
     const std::vector<feature_state>& get_feature_state() const {
         return _feature_state;
     }
@@ -299,6 +303,11 @@ private:
     void on_update();
 
     cluster::cluster_version _active_version{cluster::invalid_version};
+
+    // The earliest version this cluster ever saw: guaranteed that no
+    // on-disk structures were written with an encoding that predates
+    // this.
+    cluster_version _original_version{invalid_version};
 
     std::vector<feature_state> _feature_state;
 

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -30,6 +30,7 @@ feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
           .name = ss::sstring(name), .state = state._state});
     }
     fts.applied_offset = ft.get_applied_offset();
+    fts.original_version = ft.get_original_version();
 
     return fts;
 }
@@ -59,6 +60,7 @@ void feature_table_snapshot::apply(feature_table& ft) const {
     }
 
     ft.set_applied_offset(applied_offset);
+    ft.set_original_version(original_version);
 
     ft.on_update();
 }

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/types.h"
 #include "feature_state.h"
 #include "model/fundamental.h"
 #include "security/license.h"
@@ -30,7 +31,7 @@ class feature_table;
 struct feature_state_snapshot
   : serde::envelope<
       feature_state_snapshot,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     ss::sstring name;
     feature_state::state state;
@@ -52,9 +53,11 @@ struct feature_table_snapshot
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;
     std::vector<feature_state_snapshot> states;
+    cluster::cluster_version original_version;
 
     auto serde_fields() {
-        return std::tie(applied_offset, version, states, license);
+        return std::tie(
+          applied_offset, version, states, license, original_version);
     }
 
     /// Create a snapshot from a live feature table

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -118,6 +118,10 @@
                     "type": "long",
                     "description": "Logical version of cluster"
                 },
+                "original_cluster_version": {
+                    "type": "long",
+                    "description": "Logical version at time of cluster creation"
+                },
                 "features": {
                     "type": "array",
                     "description": "list of feature_state for each feature",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1790,6 +1790,7 @@ void admin_server::register_features_routes() {
           auto version = ft.get_active_version();
 
           res.cluster_version = version;
+          res.original_cluster_version = ft.get_original_version();
           for (const auto& fs : ft.get_feature_state()) {
               ss::httpd::features_json::feature_state item;
               vlog(


### PR DESCRIPTION
## Cover letter

This is useful if you'd like to know whether the cluster
has ever run code before a certain logical version.  It
can be used to know whether on-disk structures might
include data encoded with code from before a certain
logical version.

## Release notes

### Improvements

* The `/v1/features` Admin API endpoint now includes an `original_cluster_version` reflecting the logical version at which the cluster was created.

