### PR TITLE
tests: make test_si_cache_speak_leak work on symlinked data dir

### DIFF
--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -121,9 +121,11 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
                 # and deleted files. The deleted files are likely cache
                 # files that were deleted by retention previously but
                 # still kept open because they're used by the consumer.
-                return fname.startswith(
-                    "/var/lib/redpanda/data/cloud_storage_cache"
-                ) or fname == "(deleted)"
+                #
+                # Do not use an absolute path, because the redpanda data
+                # directory may have been a symlink & the path in lsof
+                # will be the underlying storage.
+                return "data/cloud_storage_cache" in fname or fname == "(deleted)"
 
             files_count = 0
             for node in self.redpanda.nodes:


### PR DESCRIPTION
## Cover letter

Anything that uses lsof will see the underlying
path (e.g. /mnt/vectorized) rather than the symlink
/var/lib/redpanda.

This makes the test work on clustered ducktape.

## Release notes

* none
