### PR TITLE
treewide: Don't depend on ss::condition_variable being assignable

### DIFF
--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -161,7 +161,8 @@ feature_barrier_response feature_barrier_state_base::update_barrier(
       entered);
     auto i = _barrier_state.find(tag);
     if (i == _barrier_state.end()) {
-        _barrier_state[tag] = feature_barrier_tag_state({{peer, entered}});
+        _barrier_state.erase(tag);
+        _barrier_state.emplace(tag, std::make_pair(peer, entered));
         return {false, false};
     } else {
         i->second.node_enter(peer, entered);

--- a/src/v/cluster/feature_barrier.h
+++ b/src/v/cluster/feature_barrier.h
@@ -29,10 +29,10 @@ class feature_barrier_tag_state {
 public:
     feature_barrier_tag_state() {}
 
-    feature_barrier_tag_state(bool e)
+    explicit feature_barrier_tag_state(bool e)
       : _exited(e) {}
 
-    feature_barrier_tag_state(std::pair<model::node_id, bool> p)
+    explicit feature_barrier_tag_state(std::pair<model::node_id, bool> p)
       : _exited(false) {
         _nodes_entered.insert(p);
     }

--- a/src/v/cluster/feature_barrier.h
+++ b/src/v/cluster/feature_barrier.h
@@ -110,7 +110,8 @@ public:
     ss::future<> barrier(feature_barrier_tag tag);
 
     void exit_barrier(feature_barrier_tag tag) {
-        _barrier_state[tag] = feature_barrier_tag_state(true);
+        _barrier_state.erase(tag);
+        _barrier_state.emplace(tag, true);
     }
 
     struct update_barrier_result {

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -54,7 +54,8 @@ public:
     }
 
     iterator emplace(vnode n, follower_index_metadata m) {
-        auto [it, success] = _followers.insert_or_assign(n, std::move(m));
+        _followers.erase(n);
+        auto [it, success] = _followers.emplace(n, std::move(m));
         vassert(success, "could not insert node:{}", n);
         return it;
     }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -66,7 +66,7 @@ struct follower_index_metadata {
     follower_index_metadata(const follower_index_metadata&) = delete;
     follower_index_metadata& operator=(const follower_index_metadata&) = delete;
     follower_index_metadata(follower_index_metadata&&) = default;
-    follower_index_metadata& operator=(follower_index_metadata&&) = default;
+    follower_index_metadata& operator=(follower_index_metadata&&) = delete;
 
     vnode node_id;
     // index of last known log for this follower


### PR DESCRIPTION
## Cover letter

A future version of seastar makes `ss::condition_variable` no longer move assignable.

The commit(s):
https://github.com/scylladb/seastar/commit/79dfb83cc93f147eb34f4ca4aa5519a3a55e309d
https://github.com/scylladb/seastar/commit/e74a93c3934b2c8d360468bcdc03e2651dc1020d

This commit is preparation for updating seastar.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/d9b91f852ff2d954e80cd843f31081ccf5b7ad09..eb8213730ca6bcd49b66139df9be72b74178d814)
* Split the commit into two
* Make `feature_barrier_tag_state` constructors explicit.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none