### PR TITLE
tests/TopicRecovery: mark ok to fail

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1313,6 +1313,7 @@ class TopicRecoveryTest(RedpandaTest):
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4972
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
     def test_fast3(self):
         """Basic recovery test. This test stresses successful recovery


### PR DESCRIPTION
## Cover letter

This test has failed five times in the last 2 days. Let's mark it ok_to_fail for now.