### PR TITLE
Add partition size to health monitor

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -18,6 +18,7 @@
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/node/local_monitor.h"
+#include "cluster/partition_probe.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "config/property.h"
@@ -38,6 +39,7 @@
 #include <seastar/util/log.hh>
 
 #include <absl/container/node_hash_set.h>
+#include <fmt/format.h>
 
 #include <iterator>
 
@@ -619,81 +621,95 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
     co_return ret;
 }
 namespace {
+
 struct ntp_leader {
-    model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
     model::revision_id revision_id;
 };
 
-partition_status to_partition_leader(const ntp_leader& ntpl) {
+struct ntp_report {
+    model::ntp ntp;
+    ntp_leader leader;
+    size_t size_bytes;
+};
+
+partition_status to_partition_status(const ntp_report& ntpr) {
     return partition_status{
-      .id = ntpl.ntp.tp.partition,
-      .term = ntpl.term,
-      .leader_id = ntpl.leader_id,
-      .revision_id = ntpl.revision_id,
+      .id = ntpr.ntp.tp.partition,
+      .term = ntpr.leader.term,
+      .leader_id = ntpr.leader.leader_id,
+      .revision_id = ntpr.leader.revision_id,
+      .size_bytes = ntpr.size_bytes,
     };
 }
 
-std::vector<ntp_leader> collect_shard_local_leaders(
+std::vector<ntp_report> collect_shard_local_reports(
   partition_manager& pm, const partitions_filter& filters) {
-    std::vector<ntp_leader> leaders;
+    std::vector<ntp_report> reports;
     // empty filter, collect all
     if (filters.namespaces.empty()) {
-        leaders.reserve(pm.partitions().size());
+        reports.reserve(pm.partitions().size());
         std::transform(
           pm.partitions().begin(),
           pm.partitions().end(),
-          std::back_inserter(leaders),
+          std::back_inserter(reports),
           [](auto& p) {
-              return ntp_leader{
+              return ntp_report{
                 .ntp = p.first,
-                .term = p.second->term(),
-                .leader_id = p.second->get_leader_id(),
-                .revision_id = p.second->get_revision_id(),
+                .leader = ntp_leader{
+                  .term = p.second->term(),
+                  .leader_id = p.second->get_leader_id(),
+                  .revision_id = p.second->get_revision_id(),
+                },
+                .size_bytes = p.second->size_bytes(),
               };
           });
     } else {
         for (const auto& [ntp, partition] : pm.partitions()) {
             if (filters.matches(ntp)) {
-                leaders.push_back(ntp_leader{
-                  .ntp = ntp,
+                reports.push_back(ntp_report{
+                .ntp = ntp,
+                .leader = ntp_leader{
                   .term = partition->term(),
                   .leader_id = partition->get_leader_id(),
                   .revision_id = partition->get_revision_id(),
+                },
+                .size_bytes = partition->size_bytes(),
                 });
             }
         }
     }
 
-    return leaders;
+    return reports;
 }
-using leaders_acc_t
+
+using reports_acc_t
   = absl::node_hash_map<model::topic_namespace, std::vector<partition_status>>;
 
-leaders_acc_t
-reduce_leaders_map(leaders_acc_t acc, std::vector<ntp_leader> current_leaders) {
-    for (auto& ntpl : current_leaders) {
+reports_acc_t
+reduce_reports_map(reports_acc_t acc, std::vector<ntp_report> current_reports) {
+    for (auto& ntpr : current_reports) {
         model::topic_namespace tp_ns(
-          std::move(ntpl.ntp.ns), std::move(ntpl.ntp.tp.topic));
+          std::move(ntpr.ntp.ns), std::move(ntpr.ntp.tp.topic));
 
-        acc[tp_ns].push_back(to_partition_leader(ntpl));
+        acc[tp_ns].push_back(to_partition_status(ntpr));
     }
     return acc;
 }
 } // namespace
 ss::future<std::vector<topic_status>>
 health_monitor_backend::collect_topic_status(partitions_filter filters) {
-    auto leaders_map = co_await _partition_manager.map_reduce0(
+    auto reports_map = co_await _partition_manager.map_reduce0(
       [&filters](partition_manager& pm) {
-          return collect_shard_local_leaders(pm, filters);
+          return collect_shard_local_reports(pm, filters);
       },
-      leaders_acc_t{},
-      &reduce_leaders_map);
+      reports_acc_t{},
+      &reduce_reports_map);
 
     std::vector<topic_status> topics;
-    topics.reserve(leaders_map.size());
-    for (auto& [tp_ns, partitions] : leaders_map) {
+    topics.reserve(reports_map.size());
+    for (auto& [tp_ns, partitions] : reports_map) {
         topics.push_back(
           topic_status{.tp_ns = tp_ns, .partitions = std::move(partitions)});
     }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -54,13 +54,24 @@ struct partition_status {
      * cause older redpanda versions to crash.
      *
      * Version: -1: added revision_id field
+     * Version: -2: added size_bytes field
+     *
+     * Same versioning should also be supported in get_node_health_request
      */
-    static constexpr int8_t current_version = -1;
+
+    static constexpr int8_t initial_version = 0;
+    static constexpr int8_t revision_id_version = -1;
+    static constexpr int8_t size_bytes_version = -2;
+
+    static constexpr int8_t current_version = size_bytes_version;
+
+    static constexpr size_t invalid_size_bytes = size_t(-1);
 
     model::partition_id id;
     model::term_id term;
     std::optional<model::node_id> leader_id;
     model::revision_id revision_id;
+    size_t size_bytes;
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);
     friend bool operator==(const partition_status&, const partition_status&)
@@ -194,8 +205,13 @@ using force_refresh = ss::bool_class<struct hm_force_refresh_tag>;
  */
 
 struct get_node_health_request {
+    static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
-    static constexpr int8_t current_version = -1;
+    static constexpr int8_t revision_id_version = -1;
+    // version -2: included size_bytes in partition status
+    static constexpr int8_t size_bytes_version = -2;
+
+    static constexpr int8_t current_version = size_bytes_version;
 
     node_report_filter filter;
     // this field is not serialized
@@ -210,8 +226,14 @@ struct get_node_health_reply {
 };
 
 struct get_cluster_health_request {
+    static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
-    static constexpr int8_t current_version = -1;
+    static constexpr int8_t revision_id_version = -1;
+    // version -2: included size_bytes in partition status
+    static constexpr int8_t size_bytes_version = -2;
+
+    static constexpr int8_t current_version = size_bytes_version;
+
     cluster_report_filter filter;
     // if set to true will force node health metadata refresh
     force_refresh refresh = force_refresh::no;

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -115,7 +115,7 @@ FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
                  .get_cluster_health(
                    get_all, cluster::force_refresh::yes, model::no_timeout)
                  .get0();
-    auto r_3 = n2->controller->get_health_monitor()
+    auto r_3 = n3->controller->get_health_monitor()
                  .local()
                  .get_cluster_health(
                    get_all, cluster::force_refresh::yes, model::no_timeout)

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -373,6 +373,7 @@ SEASTAR_THREAD_TEST_CASE(partition_status_serialiaztion_test) {
       .term = model::term_id(256),
       .leader_id = model::node_id(123),
       .revision_id = model::revision_id(1024),
+      .size_bytes = 4096,
     };
     auto original = status;
 
@@ -388,23 +389,50 @@ struct partition_status_v0 {
     std::optional<model::node_id> leader_id;
 };
 
+struct partition_status_v1 {
+    int8_t version = 0;
+    model::partition_id id;
+    model::term_id term;
+    std::optional<model::node_id> leader_id;
+    model::revision_id revision_id;
+};
+
 SEASTAR_THREAD_TEST_CASE(partition_status_serialization_backward_compat_test) {
-    partition_status_v0 status{
+    partition_status_v0 status_v0{
       .id = model::partition_id(10),
       .term = model::term_id(256),
       .leader_id = model::node_id(123),
     };
 
-    auto original = status;
-    auto buf = reflection::to_iobuf(std::move(status));
+    auto original_v0 = status_v0;
+    auto buf = reflection::to_iobuf(std::move(status_v0));
     auto result = reflection::from_iobuf<cluster::partition_status>(
       std::move(buf));
 
-    BOOST_REQUIRE_EQUAL(result.id, original.id);
-    BOOST_REQUIRE_EQUAL(result.term, original.term);
-    BOOST_REQUIRE_EQUAL(result.leader_id, original.leader_id);
+    BOOST_REQUIRE_EQUAL(result.id, original_v0.id);
+    BOOST_REQUIRE_EQUAL(result.term, original_v0.term);
+    BOOST_REQUIRE_EQUAL(result.leader_id, original_v0.leader_id);
     BOOST_REQUIRE_EQUAL(result.revision_id, model::revision_id{});
+    BOOST_REQUIRE_EQUAL(result.size_bytes, 0);
+
+    partition_status_v1 status_v1{
+      .id = model::partition_id(10),
+      .term = model::term_id(256),
+      .leader_id = model::node_id(123),
+      .revision_id = model::revision_id(1024),
+    };
+
+    auto original_v1 = status_v1;
+    buf = reflection::to_iobuf(std::move(status_v1));
+    result = reflection::from_iobuf<cluster::partition_status>(std::move(buf));
+
+    BOOST_REQUIRE_EQUAL(result.id, original_v1.id);
+    BOOST_REQUIRE_EQUAL(result.term, original_v1.term);
+    BOOST_REQUIRE_EQUAL(result.leader_id, original_v1.leader_id);
+    BOOST_REQUIRE_EQUAL(result.revision_id, model::revision_id{1024});
+    BOOST_REQUIRE_EQUAL(result.size_bytes, 0);
 }
+
 namespace reflection {
 template<>
 struct adl<partition_status_v0> {
@@ -425,6 +453,34 @@ struct adl<partition_status_v0> {
         };
     }
 };
+
+template<>
+struct adl<partition_status_v1> {
+    void to(iobuf& out, partition_status_v1&& s) {
+        if (s.revision_id == model::revision_id{}) {
+            serialize(out, int8_t(0), s.id, s.term, s.leader_id);
+        } else {
+            serialize(
+              out, int8_t(-1), s.id, s.term, s.leader_id, s.revision_id);
+        }
+    }
+
+    partition_status_v1 from(iobuf_parser& p) {
+        auto version = adl<int8_t>{}.from(p);
+        auto id = adl<model::partition_id>{}.from(p);
+        auto term = adl<model::term_id>{}.from(p);
+        auto leader = adl<std::optional<model::node_id>>{}.from(p);
+        partition_status_v1 ret{
+          .id = id,
+          .term = term,
+          .leader_id = leader,
+        };
+        if (version < 0) {
+            ret.revision_id = adl<model::revision_id>{}.from(p);
+        }
+        return ret;
+    }
+};
 } // namespace reflection
 
 SEASTAR_THREAD_TEST_CASE(partition_status_serialization_old_version) {
@@ -434,21 +490,32 @@ SEASTAR_THREAD_TEST_CASE(partition_status_serialization_old_version) {
       .term = model::term_id(256),
       .leader_id = model::node_id(123),
       .revision_id = model::revision_id{},
+      .size_bytes = 0,
     });
     statuses.push_back(cluster::partition_status{
       .id = model::partition_id(1),
       .term = model::term_id(256),
       .leader_id = model::node_id(123),
       .revision_id = model::revision_id{},
+      .size_bytes = 0,
     });
 
     auto original = statuses;
     auto buf = reflection::to_iobuf(std::move(statuses));
-    auto result = reflection::from_iobuf<std::vector<partition_status_v0>>(
+    auto result_v0 = reflection::from_iobuf<std::vector<partition_status_v0>>(
       std::move(buf));
     for (auto i = 0; i < statuses.size(); ++i) {
-        BOOST_CHECK(result[i].id == original[i].id);
-        BOOST_CHECK(result[i].term == original[i].term);
-        BOOST_CHECK(result[i].leader_id == original[i].leader_id);
+        BOOST_CHECK(result_v0[i].id == original[i].id);
+        BOOST_CHECK(result_v0[i].term == original[i].term);
+        BOOST_CHECK(result_v0[i].leader_id == original[i].leader_id);
+    }
+
+    buf = reflection::to_iobuf(std::move(statuses));
+    auto result_v1 = reflection::from_iobuf<std::vector<partition_status_v1>>(
+      std::move(buf));
+    for (auto i = 0; i < statuses.size(); ++i) {
+        BOOST_CHECK(result_v1[i].id == original[i].id);
+        BOOST_CHECK(result_v1[i].term == original[i].term);
+        BOOST_CHECK(result_v1[i].leader_id == original[i].leader_id);
     }
 }


### PR DESCRIPTION
## Cover letter

Partition autobalancer will perform partition movements according to current nodes disk free space.
To know if we can move partition to a node, we need to understand whether this partition will overflow free disk space.
That is why we need to know partition size inside ring0.

#4814