### PR TITLE
admin_server: redact configs in admin API

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -103,8 +103,15 @@ func importConfig(
 		}
 
 		if haveOldVal {
-			// If value changed, add it to list of updates
-			// DeepEqual because values can be slices
+			// Since the admin endpoint will redact secret fields, ignore any
+			// such sentinel strings we've been given, to avoid accidentally
+			// setting configs to this value.
+			// TODO: why doesn't this work with DeepEqual?
+			if fmt.Sprintf("%v", oldVal) == "[secret]" && fmt.Sprintf("%v", v) == "[secret]" {
+				continue
+			}
+			// If value changed, add it to list of updates.
+			// DeepEqual because values can be slices.
 			if !reflect.DeepEqual(oldVal, v) {
 				propertyDeltas = append(propertyDeltas, propertyDelta{k, fmt.Sprintf("%v", oldVal), fmt.Sprintf("%v", v)})
 				upsert[k] = v

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -150,7 +150,7 @@ ss::future<> config_manager::do_bootstrap() {
           if (!p.is_default()) {
               json::StringBuffer buf;
               json::Writer<json::StringBuffer> writer(buf);
-              p.to_json(writer);
+              p.to_json(writer, config::redact_secrets::no);
               ss::sstring key_str(p.name());
               ss::sstring val_str = buf.GetString();
               vlog(clusterlog.info, "Importing property {}", p);

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -33,6 +33,10 @@ using required = ss::bool_class<struct required_tag>;
 using needs_restart = ss::bool_class<struct needs_restart_tag>;
 using is_secret = ss::bool_class<struct is_secret_tag>;
 
+// Whether to redact secrets. If true, `secret_placeholder` should be used
+// instead of the config value.
+using redact_secrets = ss::bool_class<struct redact_secrets_tag>;
+
 enum class visibility {
     // Tunables can be set by the user, but they control implementation
     // details like (e.g. buffer sizes, queue lengths)
@@ -75,7 +79,8 @@ public:
     // this serializes the property value. a full configuration serialization is
     // performed in config_store::to_json where the json object key is taken
     // from the property name.
-    virtual void to_json(json::Writer<json::StringBuffer>& w) const = 0;
+    virtual void to_json(
+      json::Writer<json::StringBuffer>& w, redact_secrets redact) const = 0;
 
     virtual void print(std::ostream&) const = 0;
     virtual bool set_value(YAML::Node) = 0;

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -115,6 +115,7 @@ public:
      */
     void to_json(
       json::Writer<json::StringBuffer>& w,
+      redact_secrets redact,
       std::optional<std::function<bool(base_property&)>> filter
       = std::nullopt) const {
         w.StartObject();
@@ -129,7 +130,7 @@ public:
             }
 
             w.Key(name.data(), name.size());
-            property->to_json(w);
+            property->to_json(w, redact);
         }
 
         w.EndObject();
@@ -159,10 +160,10 @@ private:
     std::unordered_map<std::string_view, base_property*> _properties;
 };
 
-inline YAML::Node to_yaml(const config_store& cfg) {
+inline YAML::Node to_yaml(const config_store& cfg, redact_secrets redact) {
     json::StringBuffer buf;
     json::Writer<json::StringBuffer> writer(buf);
-    cfg.to_json(writer);
+    cfg.to_json(writer, redact);
     return YAML::Load(buf.GetString());
 }
 }; // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -113,7 +113,8 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(json::Writer<json::StringBuffer>& w) const override {
+    void to_json(json::Writer<json::StringBuffer>& w, redact_secrets)
+      const override {
         json::rjson_serialize(w, _value);
     }
 
@@ -624,7 +625,8 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(json::Writer<json::StringBuffer>& w) const final {
+    void to_json(
+      json::Writer<json::StringBuffer>& w, redact_secrets) const final {
         json::rjson_serialize(w, _value.value_or(-1ms));
     }
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -37,6 +37,8 @@ struct test_config : public config::config_store {
     config::property<std::chrono::seconds> seconds;
     config::property<std::optional<std::chrono::seconds>> optional_seconds;
     config::property<std::chrono::milliseconds> milliseconds;
+    config::property<ss::sstring> secret_string;
+    config::property<ss::sstring> default_secret_string;
 
     test_config()
       : optional_int(
@@ -84,7 +86,17 @@ struct test_config : public config::config_store {
           false)
       , seconds(*this, "seconds", "Plain seconds")
       , optional_seconds(*this, "optional_seconds", "Optional seconds")
-      , milliseconds(*this, "milliseconds", "Plain milliseconds") {}
+      , milliseconds(*this, "milliseconds", "Plain milliseconds")
+      , default_secret_string(
+          *this,
+          "default_secret_string",
+          "Secret string value set to the default",
+          {.secret = config::is_secret::yes})
+      , secret_string(
+          *this,
+          "secret_string",
+          "Secret string value",
+          {.secret = config::is_secret::yes}) {}
 };
 
 YAML::Node minimal_valid_configuration() {
@@ -106,7 +118,8 @@ YAML::Node valid_configuration() {
                       " - one\n"
                       " - two\n"
                       " - three\n"
-                      "nullable_int: 111\n");
+                      "nullable_int: 111\n"
+                      "secret_string: actual_secret\n");
 }
 
 } // namespace
@@ -183,6 +196,7 @@ SEASTAR_THREAD_TEST_CASE(read_valid_configuration) {
     BOOST_TEST(cfg.strings().at(1) == "two");
     BOOST_TEST(cfg.strings().at(2) == "three");
     BOOST_TEST(cfg.nullable_int() == std::make_optional(111));
+    BOOST_TEST(cfg.secret_string() == "actual_secret");
 };
 
 SEASTAR_THREAD_TEST_CASE(update_property_value) {
@@ -208,68 +222,92 @@ SEASTAR_THREAD_TEST_CASE(validate_invalid_configuration) {
 }
 
 SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
-    auto cfg = test_config();
-    auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
-    lg.info("Config: {}", cfg);
-    // json data
-    const char* expected_result = "{"
-                                  "\"strings\": [\"one\", \"two\", \"three\"],"
-                                  "\"an_int64_t\": 55,"
-                                  "\"optional_int\": 3,"
-                                  "\"an_aggregate\": {"
-                                  "\"string_value\": \"some_value\","
-                                  "\"int_value\": 88"
-                                  "},"
-                                  "\"required_string\": \"test_value_2\","
-                                  "\"nullable_int\": 111"
-                                  "}";
+    const auto test_with_redaction = [](config::redact_secrets redact) {
+        auto cfg = test_config();
+        auto errors = cfg.read_yaml(valid_configuration());
+        BOOST_TEST(errors.size() == 0);
+        lg.info("Config: {}", cfg);
+        // json data
+        // TODO: get this to work with fmt.
+        auto expected_result = redact == config::redact_secrets::yes
+                                 ? "{"
+                                   "\"strings\": [\"one\", \"two\", \"three\"],"
+                                   "\"an_int64_t\": 55,"
+                                   "\"optional_int\": 3,"
+                                   "\"an_aggregate\": {"
+                                   "\"string_value\": \"some_value\","
+                                   "\"int_value\": 88"
+                                   "},"
+                                   "\"required_string\": \"test_value_2\","
+                                   "\"nullable_int\": 111,"
+                                   "\"default_secret_string\": \"\","
+                                   "\"secret_string\": \"[secret]\""
+                                   "}"
+                                 : "{"
+                                   "\"strings\": [\"one\", \"two\", \"three\"],"
+                                   "\"an_int64_t\": 55,"
+                                   "\"optional_int\": 3,"
+                                   "\"an_aggregate\": {"
+                                   "\"string_value\": \"some_value\","
+                                   "\"int_value\": 88"
+                                   "},"
+                                   "\"required_string\": \"test_value_2\","
+                                   "\"nullable_int\": 111,"
+                                   "\"default_secret_string\": \"\","
+                                   "\"secret_string\": \"actual_secret\""
+                                   "}";
 
-    // cfg -> json string
-    json::StringBuffer cfg_sb;
-    json::Writer<json::StringBuffer> cfg_writer(cfg_sb);
-    cfg.to_json(cfg_writer, config::redact_secrets::no);
-    auto jstr = cfg_sb.GetString();
+        // cfg -> json string
+        json::StringBuffer cfg_sb;
+        json::Writer<json::StringBuffer> cfg_writer(cfg_sb);
+        cfg.to_json(cfg_writer, redact);
+        auto jstr = cfg_sb.GetString();
 
-    // json string -> rapidjson doc
-    json::Document res_doc;
-    res_doc.Parse(jstr);
+        // json string -> rapidjson doc
+        json::Document res_doc;
+        res_doc.Parse(jstr);
 
-    // json string -> rapidjson doc
-    json::Document exp_doc;
-    exp_doc.Parse(expected_result);
+        // json string -> rapidjson doc
+        json::Document exp_doc;
+        exp_doc.Parse(expected_result);
 
-    // test equivalence
-    BOOST_TEST(res_doc["required_string"].IsString());
-    BOOST_TEST(
-      res_doc["required_string"].GetString()
-      == exp_doc["required_string"].GetString());
+        // test equivalence
+        BOOST_TEST(res_doc["required_string"].IsString());
+        BOOST_TEST(
+          res_doc["required_string"].GetString()
+          == exp_doc["required_string"].GetString());
 
-    BOOST_TEST(res_doc["optional_int"].IsInt());
-    BOOST_TEST(
-      res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
+        BOOST_TEST(res_doc["optional_int"].IsInt());
+        BOOST_TEST(
+          res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
 
-    BOOST_TEST(res_doc["an_int64_t"].IsInt64());
-    BOOST_TEST(
-      res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
+        BOOST_TEST(res_doc["an_int64_t"].IsInt64());
+        BOOST_TEST(
+          res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
 
-    BOOST_TEST(res_doc["an_aggregate"].IsObject());
+        BOOST_TEST(res_doc["an_aggregate"].IsObject());
 
-    BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
-    BOOST_TEST(
-      res_doc["an_aggregate"]["int_value"].GetInt()
-      == exp_doc["an_aggregate"]["int_value"].GetInt());
+        BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
+        BOOST_TEST(
+          res_doc["an_aggregate"]["int_value"].GetInt()
+          == exp_doc["an_aggregate"]["int_value"].GetInt());
 
-    BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
-    BOOST_TEST(
-      res_doc["an_aggregate"]["string_value"].GetString()
-      == exp_doc["an_aggregate"]["string_value"].GetString());
+        BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
+        BOOST_TEST(
+          res_doc["an_aggregate"]["string_value"].GetString()
+          == exp_doc["an_aggregate"]["string_value"].GetString());
 
-    BOOST_TEST(res_doc["strings"].IsArray());
+        BOOST_TEST(res_doc["strings"].IsArray());
 
-    BOOST_TEST(res_doc["nullable_int"].IsInt());
-    BOOST_TEST(
-      res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
+        BOOST_TEST(res_doc["nullable_int"].IsInt());
+        BOOST_TEST(
+          res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
+        BOOST_TEST(
+          res_doc["secret_string"].GetString()
+          == exp_doc["secret_string"].GetString());
+    };
+    test_with_redaction(config::redact_secrets::yes);
+    test_with_redaction(config::redact_secrets::no);
 }
 
 /// Test that unset std::optional options are decoded correctly

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -228,7 +228,7 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
     // cfg -> json string
     json::StringBuffer cfg_sb;
     json::Writer<json::StringBuffer> cfg_writer(cfg_sb);
-    cfg.to_json(cfg_writer);
+    cfg.to_json(cfg_writer, config::redact_secrets::no);
     auto jstr = cfg_sb.GetString();
 
     // json string -> rapidjson doc

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -40,7 +40,7 @@ kafka::client::client make_client() {
     cfg.brokers.set_value(std::vector<net::unresolved_address>{
       config::node().kafka_api()[0].address});
     cfg.retries.set_value(size_t(1));
-    return kafka::client::client{to_yaml(cfg)};
+    return kafka::client::client{to_yaml(cfg, config::redact_secrets::no)};
 }
 
 } // namespace

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -42,7 +42,8 @@ std::unique_ptr<kafka::client::client> make_client() {
     cfg.retries.set_value(size_t(5));
     cfg.retry_base_backoff.set_value(10ms);
     cfg.produce_batch_delay.set_value(0ms);
-    return std::make_unique<kafka::client::client>(to_yaml(cfg));
+    return std::make_unique<kafka::client::client>(
+      to_yaml(cfg, config::redact_secrets::no));
 }
 
 } // namespace

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -40,11 +40,12 @@ api::~api() noexcept = default;
 ss::future<> api::start() {
     _store = std::make_unique<sharded_store>();
     co_await _store->start(_sg);
-    co_await _client.start(config::to_yaml(_client_cfg));
+    co_await _client.start(
+      config::to_yaml(_client_cfg, config::redact_secrets::no));
     co_await _sequencer.start(
       _node_id, _sg, std::ref(_client), std::ref(*_store));
     co_await _service.start(
-      config::to_yaml(_cfg),
+      config::to_yaml(_cfg, config::redact_secrets::no),
       _sg,
       _max_memory,
       std::ref(_client),

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -68,7 +68,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     // (which itself is only instantiated to receive consume_to_store's
     //  offset updates), is just needed for constructor;
     ss::sharded<kafka::client::client> dummy_kafka_client;
-    dummy_kafka_client.start(to_yaml(kafka::client::configuration{})).get();
+    dummy_kafka_client
+      .start(
+        to_yaml(kafka::client::configuration{}, config::redact_secrets::no))
+      .get();
     auto stop_kafka_client = ss::defer(
       [&dummy_kafka_client]() { dummy_kafka_client.stop().get(); });
 

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -87,7 +87,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     // (which itself is only instantiated to receive consume_to_store's
     //  offset updates), is just needed for constructor;
     ss::sharded<kafka::client::client> dummy_kafka_client;
-    dummy_kafka_client.start(to_yaml(kafka::client::configuration{})).get();
+    dummy_kafka_client
+      .start(
+        to_yaml(kafka::client::configuration{}, config::redact_secrets::no))
+      .get();
     auto stop_kafka_client = ss::defer(
       [&dummy_kafka_client]() { dummy_kafka_client.stop().get(); });
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -607,7 +607,8 @@ void admin_server::register_config_routes() {
       ss::httpd::config_json::get_config, [](ss::const_req, ss::reply& reply) {
           json::StringBuffer buf;
           json::Writer<json::StringBuffer> writer(buf);
-          config::shard_local_cfg().to_json(writer, config::redact_secrets::no);
+          config::shard_local_cfg().to_json(
+            writer, config::redact_secrets::yes);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
@@ -627,7 +628,7 @@ void admin_server::register_config_routes() {
 
           config::shard_local_cfg().to_json(
             writer,
-            config::redact_secrets::no,
+            config::redact_secrets::yes,
             [include_defaults](config::base_property& p) {
                 return include_defaults || !p.is_default();
             });
@@ -641,7 +642,7 @@ void admin_server::register_config_routes() {
       [](ss::const_req, ss::reply& reply) {
           json::StringBuffer buf;
           json::Writer<json::StringBuffer> writer(buf);
-          config::node().to_json(writer, config::redact_secrets::no);
+          config::node().to_json(writer, config::redact_secrets::yes);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -979,29 +979,28 @@ void admin_server::register_cluster_config_routes() {
               // properties.
 
               std::map<ss::sstring, ss::sstring> errors;
-              for (const auto& i : update.upsert) {
+              for (const auto& [yaml_name, yaml_value] : update.upsert) {
                   // Decode to a YAML object because that's what the property
                   // interface expects.
                   // Don't both catching ParserException: this was encoded
                   // just a few lines above.
-                  const auto& yaml_value = i.second;
                   auto val = YAML::Load(yaml_value);
 
-                  if (!cfg.contains(i.first)) {
-                      errors[i.first] = "Unknown property";
+                  if (!cfg.contains(yaml_name)) {
+                      errors[yaml_name] = "Unknown property";
                       continue;
                   }
-                  auto& property = cfg.get(i.first);
+                  auto& property = cfg.get(yaml_name);
 
                   try {
                       auto validation_err = property.validate(val);
                       if (validation_err.has_value()) {
-                          errors[i.first]
+                          errors[yaml_name]
                             = validation_err.value().error_message();
                           vlog(
                             logger.warn,
                             "Invalid {}: '{}' ({})",
-                            i.first,
+                            yaml_name,
                             property.format_raw(yaml_value),
                             validation_err.value().error_message());
                       } else {
@@ -1044,21 +1043,21 @@ void admin_server::register_cluster_config_routes() {
                           }
                       }
 
-                      errors[i.first] = message;
+                      errors[yaml_name] = message;
                       vlog(
                         logger.warn,
                         "Invalid {}: '{}' ({})",
-                        i.first,
+                        yaml_name,
                         property.format_raw(yaml_value),
                         std::current_exception());
                   } catch (...) {
                       auto message = fmt::format(
                         "{}", std::current_exception());
-                      errors[i.first] = message;
+                      errors[yaml_name] = message;
                       vlog(
                         logger.warn,
                         "Invalid {}: '{}' ({})",
-                        i.first,
+                        yaml_name,
                         property.format_raw(yaml_value),
                         message);
                   }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -959,6 +959,7 @@ void admin_server::register_cluster_config_routes() {
           // but we also do an early validation pass here to avoid writing
           // clearly wrong things into the log & give better feedback
           // to the API consumer.
+          absl::flat_hash_set<ss::sstring> upsert_no_op_names;
           if (!get_boolean_query_param(*req, "force")) {
               // A scratch copy of configuration: we must not touch
               // the real live configuration object, that will be updated
@@ -1008,7 +1009,10 @@ void admin_server::register_cluster_config_routes() {
                           // from it's value setter even after a non-throwing
                           // call to validate (if this happens validate() was
                           // implemented wrongly, but let's be safe)
-                          property.set_value(val);
+                          auto changed = property.set_value(val);
+                          if (!changed) {
+                              upsert_no_op_names.insert(yaml_name);
+                          }
                       }
                   } catch (YAML::BadConversion const& e) {
                       // Be helpful, and give the user an example of what
@@ -1100,6 +1104,24 @@ void admin_server::register_cluster_config_routes() {
               // A dry run doesn't really need a result, but it's simpler for
               // the API definition if we return the same structure as a
               // normal write.
+              ss::httpd::cluster_config_json::cluster_config_write_result
+                result;
+              result.config_version = current_version;
+              co_return ss::json::json_return_type(std::move(result));
+          }
+
+          if (
+            update.upsert.size() == upsert_no_op_names.size()
+            && update.remove.empty()) {
+              vlog(
+                logger.trace,
+                "patch_cluster_config: ignoring request, {} upserts resulted "
+                "in no-ops",
+                update.upsert.size());
+              auto current_version
+                = co_await _controller->get_config_manager().invoke_on(
+                  cluster::config_manager::shard,
+                  [](cluster::config_manager& cm) { return cm.get_version(); });
               ss::httpd::cluster_config_json::cluster_config_write_result
                 result;
               result.config_version = current_version;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -607,7 +607,7 @@ void admin_server::register_config_routes() {
       ss::httpd::config_json::get_config, [](ss::const_req, ss::reply& reply) {
           json::StringBuffer buf;
           json::Writer<json::StringBuffer> writer(buf);
-          config::shard_local_cfg().to_json(writer);
+          config::shard_local_cfg().to_json(writer, config::redact_secrets::no);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
@@ -626,7 +626,9 @@ void admin_server::register_config_routes() {
           }
 
           config::shard_local_cfg().to_json(
-            writer, [include_defaults](config::base_property& p) {
+            writer,
+            config::redact_secrets::no,
+            [include_defaults](config::base_property& p) {
                 return include_defaults || !p.is_default();
             });
 
@@ -639,7 +641,7 @@ void admin_server::register_config_routes() {
       [](ss::const_req, ss::reply& reply) {
           json::StringBuffer buf;
           json::Writer<json::StringBuffer> writer(buf);
-          config::node().to_json(writer);
+          config::node().to_json(writer, config::redact_secrets::no);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -565,10 +565,13 @@ void application::wire_up_services() {
         wire_up_redpanda_services();
     }
     if (_proxy_config) {
-        construct_service(_proxy_client, to_yaml(*_proxy_client_config)).get();
+        construct_service(
+          _proxy_client,
+          to_yaml(*_proxy_client_config, config::redact_secrets::no))
+          .get();
         construct_service(
           _proxy,
-          to_yaml(*_proxy_config),
+          to_yaml(*_proxy_config, config::redact_secrets::no),
           smp_service_groups.proxy_smp_sg(),
           // TODO: Improve memory budget for services
           // https://github.com/redpanda-data/redpanda/issues/1392

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -198,7 +198,7 @@ public:
         cfg.get("pandaproxy_api")
           .set_value(std::vector<model::broker_endpoint>{model::broker_endpoint(
             net::unresolved_address("127.0.0.1", proxy_port))});
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     YAML::Node proxy_client_config(
@@ -208,7 +208,7 @@ public:
           config::node().kafka_api()[0].address.host(), kafka_api_port};
         cfg.brokers.set_value(
           std::vector<net::unresolved_address>({kafka_api}));
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     YAML::Node schema_reg_config(uint16_t listen_port = 8081) {
@@ -218,7 +218,7 @@ public:
             net::unresolved_address("127.0.0.1", listen_port))});
         cfg.get("schema_registry_replication_factor")
           .set_value(std::make_optional<int16_t>(1));
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     ss::future<> wait_for_controller_leadership() {


### PR DESCRIPTION
## Cover letter                                                                                      
                                                                                                     
Previously the admin API would send over unredacted configs.  While the endpoint is only authorized to superusers, this is not a good practice.
                                                                                                     
This PR adds the option to redact property::to_json(), and by extension, its callers like to_yaml(). All config requests in the admin API now redact their JSON, replacing the contents with a "[secret]" hardcoded string. 
                                                                                                     
An important side effect of this redaction: rpk no longer knows about the existing values of sensitive properties. This means that it can no longer, e.g. tell the difference between an old secret property and a new one. To maintain existing behavior, Importing same exact configs that already exist will now be deduplicated by the admin server, and will return the current config version upon no-op, rather than replicating a new version.
                                                                                                     
NOTE: While currently this option is not used for existing calls to to_yaml(), I opted to force users to explicitly declare whether they want to redact, if anything, to force us to re-examine where it's being used today.

[force push](https://github.com/redpanda-data/redpanda/compare/5586f54e8a94f9bc992a6cd4bd95f1df793fc8c0..83b6c4fe30f773679bf20a119da91aede137690b):
- lints cpp

[force push](https://github.com/redpanda-data/redpanda/compare/e4c17d6a6dcecd80a010a87451d7f93254cdeb75..5586f54e8a94f9bc992a6cd4bd95f1df793fc8c0):
- no longer redacts default value
- deduplicates on the RP side upon request
- replaced redaction in retention_duration_property with vassert

[force push](https://github.com/redpanda-data/redpanda/compare/7de7b7c1a40daf8b7790a38ccb307b3dfc06e283..e4c17d6a6dcecd80a010a87451d7f93254cdeb75):
- removes some surprise python changes

[force push](https://github.com/redpanda-data/redpanda/compare/ee74e2aa9caa1a93c2ef15f0e4e0e180efadcc82..7de7b7c1a40daf8b7790a38ccb307b3dfc06e283):
- lints cpp

[force push](https://github.com/redpanda-data/redpanda/compare/eafd0e7970e0cb7e6bcf98813c506bf043628949..ee74e2aa9caa1a93c2ef15f0e4e0e180efadcc82):
- fixes rpk
- uses ss::bool
