### PR TITLE
Fix lost update consistency error

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -262,6 +262,7 @@ private:
     bool check_seq(model::batch_identity);
     std::optional<model::offset> known_seq(model::batch_identity) const;
     void set_seq(model::batch_identity, model::offset);
+    void reset_seq(model::batch_identity);
 
     ss::future<result<raft::replicate_result>>
       replicate_tx(model::batch_identity, model::record_batch_reader);
@@ -364,6 +365,7 @@ private:
         absl::flat_hash_map<model::producer_identity, expiration_info>
           expiration;
         model::offset last_end_tx{-1};
+        absl::flat_hash_map<model::producer_identity, int64_t> inflight;
 
         void forget(model::producer_identity pid) {
             expected.erase(pid);


### PR DESCRIPTION
## Cover letter

Sometimes Kafka java client reuses seq id. Without special handling on the server side this behavior may lead to a consistency violation. The PR fixes it.

A sequence of actions leading to the violation:
1. client starts a transaction
2. client replicates a batch with say seq_id=42
3. the replication passes but the response is erroneous (timeout, unknown server error, etc)
4. client successfully aborts the transaction
5. client starts new transaction
6. it replicates a new batch BUT reuses the same seq_id=42
7. Redpanda dedupes seq_id=42 using the original record and returns old offset

## Release notes

* none