### PR TITLE
rm_stm: make recovery from memory reset faster

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -182,8 +182,13 @@ public:
     struct expiration_info {
         duration_type timeout;
         time_point_type last_update;
+        bool is_expiration_requested;
 
         time_point_type deadline() const { return last_update + timeout; }
+
+        bool is_expired(time_point_type now) const {
+            return is_expiration_requested || deadline() <= now;
+        }
     };
 
     struct transaction_info {


### PR DESCRIPTION
## Cover letter

Prevent tx coordinator from falling into a retry loop until a tx is expired by premature tx abort. As the result in case of a cold restart tx coordinator recovers instantly instead of being stuck for a minute.

## Release notes

* none