### PR TITLE
Use explicit adl<> encoding for RPC types

### DIFF
--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -33,11 +33,12 @@ from_ntp_leaders(std::vector<cluster::ntp_leader> old_leaders) {
       old_leaders.end(),
       std::back_inserter(leaders),
       [](cluster::ntp_leader& leader) {
-          return cluster::ntp_leader_revision{
-            .ntp = std::move(leader.ntp),
-            .term = leader.term,
-            .leader_id = leader.leader_id,
-          };
+          return cluster::ntp_leader_revision(
+            std::move(leader.ntp),
+            leader.term,
+            leader.leader_id,
+            model::revision_id{} /* explicitly default */
+          );
       });
     return leaders;
 }

--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -85,7 +85,7 @@ metadata_dissemination_handler::do_update_leadership(
 
 static get_leadership_reply
 make_get_leadership_reply(const partition_leaders_table& leaders) {
-    ntp_leaders ret;
+    std::vector<ntp_leader> ret;
     leaders.for_each_leader([&ret](
                               model::topic_namespace_view tp_ns,
                               model::partition_id pid,

--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -90,10 +90,7 @@ make_get_leadership_reply(const partition_leaders_table& leaders) {
                               model::partition_id pid,
                               std::optional<model::node_id> leader,
                               model::term_id term) mutable {
-        ret.emplace_back(ntp_leader{
-          .ntp = model::ntp(tp_ns.ns, tp_ns.tp, pid),
-          .term = term,
-          .leader_id = leader});
+        ret.emplace_back(model::ntp(tp_ns.ns, tp_ns.tp, pid), term, leader);
     });
 
     return get_leadership_reply{std::move(ret)};

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -409,11 +409,8 @@ std::vector<cluster::ntp_leader> from_ntp_leader_revision_vector(
       leaders.end(),
       std::back_inserter(old_leaders),
       [](cluster::ntp_leader_revision& leader) {
-          return cluster::ntp_leader{
-            .ntp = std::move(leader.ntp),
-            .term = leader.term,
-            .leader_id = leader.leader_id,
-          };
+          return cluster::ntp_leader(
+            std::move(leader.ntp), leader.term, leader.leader_id);
       });
     return old_leaders;
 }

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -429,7 +429,7 @@ ss::future<> metadata_dissemination_service::dispatch_one_update(
               target_id);
             return proto
               .update_leadership_v2(
-                update_leadership_request_v2{std::move(updates)},
+                update_leadership_request_v2(std::move(updates)),
                 rpc::client_opts(
                   _dissemination_interval + rpc::clock_type::now()))
               .then(&rpc::get_ctx_data<update_leadership_reply>);

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -87,11 +87,7 @@ void metadata_dissemination_service::disseminate_leadership(
       ntp,
       leader_id.value());
 
-    _requests.push_back(ntp_leader_revision{
-      .ntp = std::move(ntp),
-      .term = term,
-      .leader_id = leader_id,
-      .revision = revision});
+    _requests.emplace_back(std::move(ntp), term, leader_id, revision);
 }
 
 ss::future<> metadata_dissemination_service::start() {

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -453,8 +453,8 @@ ss::future<> metadata_dissemination_service::dispatch_one_update(
                         updates,
                         target_id);
                       return proto.update_leadership(
-                        update_leadership_request{
-                          from_ntp_leader_revision_vector(std::move(updates))},
+                        update_leadership_request(
+                          from_ntp_leader_revision_vector(std::move(updates))),
                         rpc::client_opts(
                           _dissemination_interval + rpc::clock_type::now()));
                   })

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -101,11 +101,25 @@ struct get_leadership_request {
 
 struct get_leadership_reply {
     std::vector<ntp_leader> leaders;
+
+    explicit get_leadership_reply(std::vector<ntp_leader> leaders)
+      : leaders(std::move(leaders)) {}
 };
 
 } // namespace cluster
 
 namespace reflection {
+template<>
+struct adl<cluster::get_leadership_reply> {
+    void to(iobuf& out, cluster::get_leadership_reply&& r) {
+        serialize(out, r.leaders);
+    }
+    cluster::get_leadership_reply from(iobuf_parser& in) {
+        auto leaders = adl<std::vector<cluster::ntp_leader>>{}.from(in);
+        return cluster::get_leadership_reply(std::move(leaders));
+    }
+};
+
 template<>
 struct adl<cluster::get_leadership_request> {
     void to(iobuf&, cluster::get_leadership_request&&) {}

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -77,6 +77,9 @@ struct ntp_leader_revision {
 
 struct update_leadership_request {
     std::vector<ntp_leader> leaders;
+
+    explicit update_leadership_request(std::vector<ntp_leader> leaders)
+      : leaders(std::move(leaders)) {}
 };
 
 struct update_leadership_request_v2 {
@@ -95,6 +98,17 @@ struct get_leadership_reply {
 } // namespace cluster
 
 namespace reflection {
+template<>
+struct adl<cluster::update_leadership_request> {
+    void to(iobuf& out, cluster::update_leadership_request&& r) {
+        serialize(out, std::move(r.leaders));
+    }
+    cluster::update_leadership_request from(iobuf_parser& in) {
+        auto leaders = adl<std::vector<cluster::ntp_leader>>{}.from(in);
+        return cluster::update_leadership_request(std::move(leaders));
+    }
+};
+
 template<>
 struct adl<cluster::ntp_leader_revision> {
     void to(iobuf& out, cluster::ntp_leader_revision&& l) {

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -75,10 +75,8 @@ struct ntp_leader_revision {
     }
 };
 
-using ntp_leaders = std::vector<ntp_leader>;
-
 struct update_leadership_request {
-    ntp_leaders leaders;
+    std::vector<ntp_leader> leaders;
 };
 
 struct update_leadership_request_v2 {
@@ -91,7 +89,7 @@ struct update_leadership_reply {};
 struct get_leadership_request {};
 
 struct get_leadership_reply {
-    ntp_leaders leaders;
+    std::vector<ntp_leader> leaders;
 };
 
 } // namespace cluster

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -85,6 +85,10 @@ struct update_leadership_request {
 struct update_leadership_request_v2 {
     static constexpr int8_t version = 0;
     std::vector<ntp_leader_revision> leaders;
+
+    explicit update_leadership_request_v2(
+      std::vector<ntp_leader_revision> leaders)
+      : leaders(std::move(leaders)) {}
 };
 
 struct update_leadership_reply {};
@@ -146,8 +150,7 @@ struct adl<cluster::update_leadership_request_v2> {
         adl<int8_t>{}.from(in);
         auto leaders = adl<std::vector<cluster::ntp_leader_revision>>{}.from(
           in);
-        return cluster::update_leadership_request_v2{
-          .leaders = std::move(leaders)};
+        return cluster::update_leadership_request_v2(std::move(leaders));
     }
 };
 } // namespace reflection

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -91,7 +91,9 @@ struct update_leadership_request_v2 {
       : leaders(std::move(leaders)) {}
 };
 
-struct update_leadership_reply {};
+struct update_leadership_reply {
+    update_leadership_reply() = default;
+};
 
 struct get_leadership_request {};
 
@@ -102,6 +104,12 @@ struct get_leadership_reply {
 } // namespace cluster
 
 namespace reflection {
+template<>
+struct adl<cluster::update_leadership_reply> {
+    void to(iobuf&, cluster::update_leadership_reply&&) {}
+    cluster::update_leadership_reply from(iobuf_parser&) { return {}; }
+};
+
 template<>
 struct adl<cluster::update_leadership_request> {
     void to(iobuf& out, cluster::update_leadership_request&& r) {

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -27,9 +27,12 @@ struct ntp_leader {
     std::optional<model::node_id> leader_id;
 
     friend std::ostream& operator<<(std::ostream& o, const ntp_leader& l) {
-        o << "{ " << l.ntp << ", term: " << l.term
-          << ", leader_id: " << (l.leader_id ? l.leader_id.value()() : -1)
-          << " }";
+        fmt::print(
+          o,
+          "{{ntp: {}, term: {}, leader: {}}}",
+          l.ntp,
+          l.term,
+          l.leader_id ? l.leader_id.value()() : -1);
         return o;
     }
 };

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -95,7 +95,9 @@ struct update_leadership_reply {
     update_leadership_reply() = default;
 };
 
-struct get_leadership_request {};
+struct get_leadership_request {
+    get_leadership_request() = default;
+};
 
 struct get_leadership_reply {
     std::vector<ntp_leader> leaders;
@@ -104,6 +106,12 @@ struct get_leadership_reply {
 } // namespace cluster
 
 namespace reflection {
+template<>
+struct adl<cluster::get_leadership_request> {
+    void to(iobuf&, cluster::get_leadership_request&&) {}
+    cluster::get_leadership_request from(iobuf_parser&) { return {}; }
+};
+
 template<>
 struct adl<cluster::update_leadership_reply> {
     void to(iobuf&, cluster::update_leadership_reply&&) {}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -51,6 +51,10 @@ struct allocate_id_request {
 struct allocate_id_reply {
     int64_t id;
     errc ec;
+
+    allocate_id_reply(int64_t id, errc ec)
+      : id(id)
+      , ec(ec) {}
 };
 
 enum class tx_errc {
@@ -1200,6 +1204,18 @@ struct adl<cluster::allocate_id_request> {
     cluster::allocate_id_request from(iobuf_parser& in) {
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return cluster::allocate_id_request(timeout);
+    }
+};
+
+template<>
+struct adl<cluster::allocate_id_reply> {
+    void to(iobuf& out, cluster::allocate_id_reply&& r) {
+        serialize(out, r.id, r.ec);
+    }
+    cluster::allocate_id_reply from(iobuf_parser& in) {
+        auto id = adl<int64_t>{}.from(in);
+        auto ec = adl<cluster::errc>{}.from(in);
+        return {id, ec};
     }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -43,6 +43,9 @@ constexpr cluster_version invalid_version = cluster_version{-1};
 
 struct allocate_id_request {
     model::timeout_clock::duration timeout;
+
+    explicit allocate_id_request(model::timeout_clock::duration timeout)
+      : timeout(timeout) {}
 };
 
 struct allocate_id_reply {
@@ -1187,6 +1190,17 @@ template<>
 struct adl<cluster::set_maintenance_mode_reply> {
     void to(iobuf&, cluster::set_maintenance_mode_reply&&);
     cluster::set_maintenance_mode_reply from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::allocate_id_request> {
+    void to(iobuf& out, cluster::allocate_id_request&& r) {
+        serialize(out, r.timeout);
+    }
+    cluster::allocate_id_request from(iobuf_parser& in) {
+        auto timeout = adl<model::timeout_clock::duration>{}.from(in);
+        return cluster::allocate_id_request(timeout);
+    }
 };
 
 } // namespace reflection


### PR DESCRIPTION
## Cover letter

* Adds explicit adl<> specialization for types used in RPC
* This is preparation PR for adding serde<> support to all RPC types.

Adding explicit adl<> specialization accomplishes two things:

1. Allows the types to later inherit from serde::envelope. Without this change automatic adl<> reflection would be disabled by inheritance and heavier weight serde integration would be required.
2. Helps avoid accidental deviation between adl<> and serde<> by making it clear that both encoding need to be updated during the transition period when we support both.

## Release notes

* None