### PR TITLE
[POC] tests: Provide pandas.DataFrame abstraction over metrics (#2068)

### DIFF
--- a/tests/rptest/services/metrics_check.py
+++ b/tests/rptest/services/metrics_check.py
@@ -7,130 +7,71 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import re
+from cmath import exp
+from pandasql import PandaSQL
 
-
-class MetricCheckFailed(Exception):
-    def __init__(self, metric, old_value, new_value):
-        self.metric = metric
-        self.old_value = old_value
-        self.new_value = new_value
-
-    def __str__(self):
-        return f"MetricCheckFailed<{self.metric} old={self.old_value} new={self.new_value}>"
-
+import pandas as pd
 
 class MetricCheck(object):
     """
     A MetricCheck spans a region of code: instantiate at the start, then
-    call `expect` or `evaluate` later to measure how your metrics of
-    interest have changed over that region.
+    call `evaluate` later to measure how your metrics of interest have changed
+    over that region.
     """
-    def __init__(self, logger, redpanda, node, metrics, labels, reduce=None):
+    def __init__(self, logger, redpanda, node, sql_template, names):
         """
         :param redpanda: a RedpandaService
         :param logger: a Logger
         :param node: a ducktape Node
-        :param metrics: a list of metric names, or a single compiled regex (use re.compile())
-        :param labels: dict, to filter metrics as we capture and check.
-        :param reduce: reduction function (e.g. sum) if multiple samples match metrics+labels
+        :param sql_template: SQL query to evaluate over the metrics snapshot templated by {name}
+        :param names: list of metric names to capture
         """
         self.redpanda = redpanda
         self.node = node
-        self.labels = labels
         self.logger = logger
+        # Query should evaluate to single row per name and should be aliased as value
+        # for evaluate() to work.
+        self._sql_template = sql_template
+        self._names = names
+        # Initial samples in the order of names
+        self._initial_samples = self._capture()
 
-        self._reduce = reduce
-        self._initial_samples = self._capture(metrics)
 
-    def _capture(self, check_metrics):
+    def _capture(self):
         metrics = self.redpanda.metrics(self.node)
-
-        samples = {}
-        for family in metrics:
-            for sample in family.samples:
-                if isinstance(check_metrics, re.Pattern):
-                    include = bool(check_metrics.match(sample.name))
-                else:
-                    include = sample.name in check_metrics
-
-                if not include:
-                    continue
-
-                label_mismatch = False
-                for k, v in self.labels.items():
-                    if sample.labels.get(k, None) != v:
-                        label_mismatch = True
-                        continue
-
-                if label_mismatch:
-                    continue
-
-                self.logger.info(
-                    f"  Read {sample.name}={sample.value} {sample.labels}")
-                if sample.name in samples:
-                    if self._reduce is None:
-                        raise RuntimeError(
-                            f"Labels {self.labels} on {sample.name} not specific enough"
-                        )
-                    else:
-                        samples[sample.name] = self._reduce(
-                            [samples[sample.name], sample.value])
-
-                else:
-                    samples[sample.name] = sample.value
-
-        for k, v in samples.items():
-            self.logger.info(f"  Captured {k}={v}")
+        samples = []
+        for name in self._names:
+            samples.append(PandaSQL()(self._sql_template.substitute(name=name)))
 
         if len(samples) == 0:
-            url = f"http://{self.node.account.hostname}:9644/metrics"
-            import requests
-            dump = requests.get(url).text
-            self.logger.warn(f"Metrics dump: {dump}")
-            raise RuntimeError("Failed to capture metrics!")
-
+            with pd.option_context('display.max_rows', None, 'display.max_columns', None):
+                self.logger.warn(f"=== metrics dump for {self.node} ====")
+                self.logger.warn(metrics)
+                raise RuntimeError("Failed to capture metrics!")
         return samples
-
-    def expect(self, expectations):
-        # Gather current values for all the metrics we are going to
-        # apply expectations to (this may be a subset of the metrics
-        # we originally gathered at construction time).
-        samples = self._capture([e[0] for e in expectations])
-
-        error = None
-        for (metric, comparator) in expectations:
-            try:
-                old_value = self._initial_samples[metric]
-            except KeyError:
-                self.logger.error(
-                    f"Missing metrics {metric} on {self.node.account.hostname}.  Have metrics: {list(self._initial_samples.keys())}"
-                )
-                raise
-
-            new_value = samples[metric]
-            ok = comparator(old_value, new_value)
-            if not ok:
-                error = MetricCheckFailed(metric, old_value, new_value)
-                # Log each bad metric, raise the last one as our actual exception below
-                self.logger.error(str(error))
-
-        if error:
-            raise error
 
     def evaluate(self, expectations):
         """
-        Similar to `expect`, but instead of asserting the expections are
-        true, just evaluate whether they are and return a boolean.
+        Evaluates expectations by comparing the initial and current snapshot of metrics.
+
+        :param expectations: a list of comparators, one for each name evaluated on it's values
+        :return True if the expectations are met, False otherwise
         """
-        samples = self._capture([e[0] for e in expectations])
-        for (metric, comparator) in expectations:
-            old_value = self._initial_samples.get(metric, None)
-            if old_value is None:
-                return False
+        assert len(self._names) == len(expectations)
+        # Capture a newer snapshot with the same metrics SQL query.
+        current_samples = self._capture()
+        result = True
 
-            new_value = samples[metric]
-            if not comparator(old_value, new_value):
+        for comparator, samples in zip(expectations, zip(self._initial_samples, current_samples)):
+            assert len(samples[0].index) == 1
+            assert len(samples[1].index) == 1
+            before = samples[0].at[0, "value"]
+            after = samples[1].at[0, "value"]
+            try:
+              result = comparator(before, after)
+              if not result:
+                  self.logger.warn(f"Result mismatch before: {before}, after: {after}, node: {self.node.account.hostname}")
+            except (TypeError, ValueError):
+                self.logger.exception("Encountered error evaluating comparator. This may be legit if one of the operands is NoneType.")
                 return False
-
-        return True
+        return result

--- a/tests/rptest/tests/bytes_sent_test.py
+++ b/tests/rptest/tests/bytes_sent_test.py
@@ -34,20 +34,11 @@ class BytesSentTest(RedpandaTest):
 
     def _bytes_sent(self):
         bytes_sent = 0
+        bytes_sent_query = "select sum(value) as total_bytes from metrics where family='vectorized_kafka_rpc_sent_bytes'"
 
         for node in self.redpanda.nodes:
-            # Convert the metrics generator to a list
-            metrics = list(self.redpanda.metrics(node))
-
-            # Find the metric family that tracks bytes sent from kafka subsystem
-            family_filter = filter(
-                lambda fam: fam.name == "vectorized_kafka_rpc_sent_bytes",
-                metrics)
-            family = next(family_filter)
-
-            # Sum bytes sent
-            for sample in family.samples:
-                bytes_sent += sample.value
+            result = self.redpanda.query_metrics(node, bytes_sent_query)
+            bytes_sent += result.at[0, "total_bytes"]
 
         return bytes_sent
 

--- a/tests/rptest/tests/node_metrics_test.py
+++ b/tests/rptest/tests/node_metrics_test.py
@@ -38,9 +38,9 @@ class NodeMetricsTest(RedpandaTest):
         super().__init__(test_context=test_ctx)
 
     def _get_metrics_vals(self, name_substr: str) -> list[float]:
-        family = self.redpanda.metrics_sample(name_substr)
-        assert family
-        return list(map(lambda s: floor(s.value), family.samples))
+        samples = self.redpanda.metrics_sample(name_substr)
+        assert samples is not None
+        return [floor(val) for val in samples['value'].values.tolist()]
 
     def _node_disk_total_bytes(self) -> list[float]:
         return self._get_metrics_vals("storage_disk_total_bytes")

--- a/tests/rptest/tests/partition_metrics_test.py
+++ b/tests/rptest/tests/partition_metrics_test.py
@@ -10,6 +10,7 @@
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
+from pandasql import PandaSQL
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.services.rpk_consumer import RpkConsumer
@@ -44,15 +45,10 @@ class PartitionMetricsTest(RedpandaTest):
 
     def _sum_metrics(self, metric_name):
 
-        family = self.redpanda.metrics_sample(metric_name,
+        samples = self.redpanda.metrics_sample(metric_name,
                                               nodes=self.redpanda.nodes)
-        total = 0
-        for sample in family.samples:
-            self.redpanda.logger.info(
-                f"value: {sample.family} - {sample.value}")
-            total += sample.value
-
-        return total
+        assert samples is not None
+        return PandaSQL()("select sum(value) as s from samples").at[0, 's']
 
     @cluster(num_nodes=3)
     def test_partition_metrics(self):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -18,6 +18,7 @@ setup(
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3',
+        'pandas==1.4.2', 'pandasql==0.7.3',
         'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests'
     ],
     scripts=[],


### PR DESCRIPTION
## Cover letter

This patch provides pandas DataFrame abstaction for redpanda
metrics. This makes it easy to filter and aggregate them over various
dimensions.  Additionally there are packages like pandasql that lets us
run SQL queries over these DataFrames.

Summary of changes:

- RedPanda service metrics() call now returns a pandas.DataFrame
- Added utility function query_metrics() that lets callers run SQL
queries on the metrics DataFrame.
- Fixed all the existing callsites for the metrics to SQL based
querying
- Cleaned up MetricsCheck implementation

TODO:
- Make sure there is a clean ducktape test run with the changes to avoid
any flakes or regressions (ran all the affected tests locally)
- Performance implications of using pandasql in terms of overall test
suite time.
- Better refactoring of code to further simplify the service API.
- Better bounds checking for queries returning empty result sets
(which may manifest as index out of bounds errors)

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2068 

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
