### PR TITLE
Added `serde` serialization support to cluster types

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -117,7 +117,7 @@ using update_topic_properties_cmd = controller_command<
 
 using create_partition_cmd = controller_command<
   model::topic_namespace,
-  create_partititions_configuration_assignment,
+  create_partitions_configuration_assignment,
   create_partition_cmd_type,
   model::record_batch_type::topic_management_cmd>;
 

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -284,11 +284,8 @@ partition_allocator::allocate(allocation_request request) {
         if (!replicas) {
             return replicas.error();
         }
-        assignments.push_back(partition_assignment{
-          .group = _state->next_group_id(),
-          .id = partition_id,
-          .replicas = std::move(replicas.value()),
-        });
+        assignments.emplace_back(
+          _state->next_group_id(), partition_id, std::move(replicas.value()));
     }
 
     return allocation_units(std::move(assignments).finish(), _state.get());
@@ -337,9 +334,9 @@ result<allocation_units> partition_allocator::reallocate_partition(
     }
 
     partition_assignment assignment{
-      .group = current_assignment.group,
-      .id = current_assignment.id,
-      .replicas = std::move(replicas.value()),
+      current_assignment.group,
+      current_assignment.id,
+      std::move(replicas.value()),
     };
 
     return allocation_units(
@@ -370,9 +367,9 @@ result<allocation_units> partition_allocator::reassign_decommissioned_replicas(
     }
 
     partition_assignment assignment{
-      .group = current_assignment.group,
-      .id = current_assignment.id,
-      .replicas = std::move(replicas.value()),
+      current_assignment.group,
+      current_assignment.id,
+      std::move(replicas.value()),
     };
 
     return allocation_units(

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -84,6 +84,11 @@ private:
         }
         void push_back(T t) { _partial.push_back(std::move(t)); }
 
+        template<typename... Args>
+        void emplace_back(Args&&... args) {
+            _partial.emplace_back(std::forward<Args>(args)...);
+        }
+
         const std::vector<T>& get() const { return _partial; }
         std::vector<T> finish() && { return std::exchange(_partial, {}); }
         intermediate_allocation(intermediate_allocation&&) noexcept = default;

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -29,6 +29,8 @@
 #include <bits/stdint-intn.h>
 #include <boost/test/tools/old/interface.hpp>
 
+#include <vector>
+
 using namespace std::chrono_literals;
 
 struct cmd_test_fixture {
@@ -73,8 +75,10 @@ struct cmd_test_fixture {
         std::vector<cluster::partition_assignment> ret;
         ret.reserve(cfg.partition_count);
         for (int i = 0; i < cfg.partition_count; i++) {
-            ret.push_back(cluster::partition_assignment{
-              raft::group_id(0), model::partition_id(i), {}});
+            ret.emplace_back(
+              raft::group_id(0),
+              model::partition_id(i),
+              std::vector<model::broker_shard>{});
         }
         return {};
     }

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -25,9 +25,7 @@ model::broker_shard make_bs(uint32_t node, uint32_t shard) {
 cluster::partition_assignment
 make_assignment(std::vector<model::broker_shard> replicas) {
     return cluster::partition_assignment{
-      .group = raft::group_id(1),
-      .id = model::partition_id(1),
-      .replicas = std::move(replicas)};
+      raft::group_id(1), model::partition_id(1), std::move(replicas)};
 }
 
 using op_t = cluster::topic_table::delta::op_type;

--- a/src/v/cluster/tests/create_partitions_test.cc
+++ b/src/v/cluster/tests/create_partitions_test.cc
@@ -24,10 +24,10 @@ FIXTURE_TEST(test_creating_partitions, rebalancing_tests_fixture) {
     create_topic(create_topic_cfg("test-2", 4, 3));
 
     // topic test-1, increase partition count to 6
-    cluster::create_partititions_configuration cfg_test_1(
+    cluster::create_partitions_configuration cfg_test_1(
       make_tp_ns("test-1"), 6);
     // topic test-2, increase partition count to 9
-    cluster::create_partititions_configuration cfg_test_2(
+    cluster::create_partitions_configuration cfg_test_2(
       make_tp_ns("test-2"), 9);
 
     auto res = (*get_leader_node_application())
@@ -68,7 +68,7 @@ FIXTURE_TEST(test_error_handling, rebalancing_tests_fixture) {
     create_topic(create_topic_cfg("test-1", 3, 1));
 
     // topic test-1, try decreasing partition count
-    cluster::create_partititions_configuration cfg_test_1(
+    cluster::create_partitions_configuration cfg_test_1(
       make_tp_ns("test-1"), 2);
 
     auto res = (*get_leader_node_application())

--- a/src/v/cluster/tests/metadata_dissemination_utils_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_utils_test.cc
@@ -21,8 +21,9 @@
 
 cluster::partition_assignment
 make_assignment(const std::vector<model::node_id>& nodes) {
-    cluster::partition_assignment p_as{
-      .group = raft::group_id(1), .id = model::partition_id(1)};
+    cluster::partition_assignment p_as;
+    p_as.group = raft::group_id(1);
+    p_as.id = model::partition_id(1);
     p_as.replicas.reserve(nodes.size());
     for (auto n : nodes) {
         p_as.replicas.push_back(model::broker_shard{

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -828,6 +828,14 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(status);
     }
     { roundtrip_test(random_property_kv()); }
+    {
+        cluster::cluster_config_delta_cmd_data data;
+        data.upsert = {
+          random_property_kv(), random_property_kv(), random_property_kv()};
+        data.remove = random_strings();
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -580,6 +580,10 @@ security::acl_principal random_acl_principal() {
       security::principal_type::user,
       random_generators::gen_alphanum_string(12)};
 }
+security::acl_host create_acl_host() {
+    return security::acl_host(ss::net::inet_address("127.0.0.1"));
+}
+
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
       model::ntp(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -582,4 +582,26 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(random_property_update(tests::random_tristate(
           [] { return random_generators::get_int<size_t>(0, 100000); })));
     }
+    {
+        cluster::incremental_topic_updates updates{
+          .compression = random_property_update(
+            tests::random_optional([] { return model::random_compression(); })),
+          .cleanup_policy_bitflags = random_property_update(
+            tests::random_optional(
+              [] { return model::random_cleanup_policy(); })),
+          .compaction_strategy = random_property_update(tests::random_optional(
+            [] { return model::random_compaction_strategy(); })),
+          .timestamp_type = random_property_update(tests::random_optional(
+            [] { return model::random_timestamp_type(); })),
+          .segment_size = random_property_update(tests::random_optional(
+            [] { return random_generators::get_int(100_MiB, 1_GiB); })),
+          .retention_bytes = random_property_update(tests::random_tristate(
+            [] { return random_generators::get_int(100_MiB, 1_GiB); })),
+          .retention_duration = random_property_update(
+            tests::random_tristate([] { return tests::random_duration_ms(); })),
+          .shadow_indexing = random_property_update(tests::random_optional(
+            [] { return model::random_shadow_indexing_mode(); })),
+        };
+        roundtrip_test(updates);
+    }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -784,4 +784,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         }
         roundtrip_test(data);
     }
+    {
+        cluster::create_data_policy_cmd_data data;
+        data.dp = v8_engine::data_policy(
+          random_generators::gen_alphanum_string(20),
+          random_generators::gen_alphanum_string(20));
+
+        roundtrip_test(data);
+    }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -836,6 +836,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::cluster_config_status_cmd_data data;
+        data.status.node = tests::random_named_int<model::node_id>();
+        data.status.restart = tests::random_bool();
+        data.status.version
+          = tests::random_named_int<cluster::config_version>();
+        data.status.invalid = random_strings();
+        data.status.unknown = random_strings();
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -14,6 +14,7 @@
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/tests/randoms.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
@@ -539,5 +540,28 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         }
 
         roundtrip_test(p_as);
+    }
+    {
+        cluster::topic_properties properties;
+        properties.cleanup_policy_bitflags = tests::random_optional(
+          [] { return model::random_cleanup_policy(); });
+        properties.compaction_strategy = tests::random_optional(
+          [] { return model::random_compaction_strategy(); });
+        properties.compression = tests::random_optional(
+          [] { return model::random_compression(); });
+        properties.timestamp_type = tests::random_optional(
+          [] { return model::random_timestamp_type(); });
+        properties.segment_size = tests::random_optional(
+          [] { return random_generators::get_int(100_MiB, 1_GiB); });
+        properties.retention_bytes = tests::random_tristate(
+          [] { return random_generators::get_int(100_MiB, 1_GiB); });
+        properties.retention_duration = tests::random_tristate(
+          [] { return tests::random_duration_ms(); });
+        properties.recovery = tests::random_optional(
+          [] { return tests::random_bool(); });
+        properties.shadow_indexing = tests::random_optional(
+          [] { return model::random_shadow_indexing_mode(); });
+
+        roundtrip_test(properties);
     }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -859,6 +859,18 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     { roundtrip_test(random_feature_update_action()); }
+    {
+        cluster::feature_update_cmd_data data;
+        data.actions = {
+          random_feature_update_action(),
+          random_feature_update_action(),
+          random_feature_update_action(),
+          random_feature_update_action()};
+        data.logical_version
+          = tests::random_named_int<cluster::cluster_version>();
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -670,6 +670,17 @@ cluster::cluster_property_kv random_property_kv() {
       random_generators::gen_alphanum_string(
         random_generators::get_int(1, 64))};
 }
+cluster::feature_update_action random_feature_update_action() {
+    cluster::feature_update_action action;
+    action.action = random_generators::random_choice(
+      std::vector<cluster::feature_update_action::action_t>{
+        cluster::feature_update_action::action_t::activate,
+        cluster::feature_update_action::action_t::deactivate,
+        cluster::feature_update_action::action_t::complete_preparing,
+      });
+    action.feature_name = random_generators::gen_alphanum_string(32);
+    return action;
+}
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
@@ -847,6 +858,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    { roundtrip_test(random_feature_update_action()); }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -97,9 +97,9 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
 
 SEASTAR_THREAD_TEST_CASE(partition_assignment_rt_test) {
     cluster::partition_assignment p_as{
-      .group = raft::group_id(2),
-      .id = model::partition_id(3),
-      .replicas = {{.node_id = model::node_id(0), .shard = 1}}};
+      raft::group_id(2),
+      model::partition_id(3),
+      {{.node_id = model::node_id(0), .shard = 1}}};
 
     auto d = serialize_roundtrip_rpc(std::move(p_as));
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -547,6 +547,33 @@ random_create_partitions_configuration() {
     }
     return cpc;
 }
+security::scram_credential random_credential() {
+    return security::scram_credential(
+      random_generators::get_bytes(256),
+      random_generators::get_bytes(256),
+      random_generators::get_bytes(256),
+      random_generators::get_int(1, 10));
+}
+
+security::resource_type random_resource_type() {
+    return random_generators::random_choice<security::resource_type>(
+      {security::resource_type::cluster,
+       security::resource_type::group,
+       security::resource_type::topic,
+       security::resource_type::transactional_id});
+}
+
+security::pattern_type random_pattern_type() {
+    return random_generators::random_choice<security::pattern_type>(
+      {security::pattern_type::literal, security::pattern_type::prefixed});
+}
+
+security::resource_pattern random_resource_pattern() {
+    return {
+      random_resource_type(),
+      random_generators::gen_alphanum_string(10),
+      random_pattern_type()};
+}
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -792,4 +792,11 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::non_replicable_topic tp;
+        tp.name = model::random_topic_namespace();
+        tp.source = model::random_topic_namespace();
+
+        roundtrip_test(tp);
+    }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/commands.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/metadata_dissemination_types.h"
 #include "cluster/tests/utils.h"
@@ -729,5 +730,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cfg.assignments = random_partition_assignments();
 
         roundtrip_test(cfg);
+    }
+    {
+        cluster::create_acls_cmd_data data;
+        for (auto i = 0; i < random_generators::get_int(5, 25); ++i) {
+            data.bindings.push_back(random_acl_binding());
+        }
+        roundtrip_test(data);
     }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -609,6 +609,9 @@ security::acl_entry random_acl_entry() {
       random_acl_operation(),
       random_acl_permission()};
 }
+security::acl_binding random_acl_binding() {
+    return {random_resource_pattern(), random_acl_entry()};
+}
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -470,6 +470,17 @@ void roundtrip_test(const T original) {
     BOOST_REQUIRE(original == from_adl);
 }
 
+template<typename T>
+cluster::property_update<T> random_property_update(T value) {
+    return {
+      value,
+      random_generators::random_choice(
+        std::vector<cluster::incremental_update_operation>{
+          cluster::incremental_update_operation::set,
+          cluster::incremental_update_operation::remove}),
+    };
+}
+
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
       model::ntp(
@@ -563,5 +574,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           [] { return model::random_shadow_indexing_mode(); });
 
         roundtrip_test(properties);
+    }
+    {
+        roundtrip_test(
+          random_property_update(random_generators::gen_alphanum_string(10)));
+
+        roundtrip_test(random_property_update(tests::random_tristate(
+          [] { return random_generators::get_int<size_t>(0, 100000); })));
     }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -527,4 +527,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
     roundtrip_test(
       cluster::allocate_id_reply(23433, cluster::errc::invalid_node_operation));
+    {
+        cluster::partition_assignment p_as;
+        p_as.group = tests::random_named_int<raft::group_id>();
+        p_as.id = tests::random_named_int<model::partition_id>();
+        for (int i = 0; i < 5; ++i) {
+            p_as.replicas.push_back(model::broker_shard{
+              .node_id = tests::random_named_int<model::node_id>(),
+              .shard = random_generators::get_int<uint16_t>(1, 20),
+            });
+        }
+
+        roundtrip_test(p_as);
+    }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -613,4 +613,19 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         tp_cfg.partition_count = random_generators::get_int(0, 100);
         roundtrip_test(tp_cfg);
     }
+    {
+        cluster::create_partitions_configuration cpc;
+        cpc.tp_ns = model::random_topic_namespace();
+        cpc.new_total_partition_count = random_generators::get_int<int16_t>(
+          10, 100);
+
+        for (int i = 0; i < 3; ++i) {
+            cpc.custom_assignments.push_back(
+              {tests::random_named_int<model::node_id>(),
+               tests::random_named_int<model::node_id>(),
+               tests::random_named_int<model::node_id>()});
+        }
+
+        roundtrip_test(cpc);
+    }
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -575,6 +575,11 @@ security::resource_pattern random_resource_pattern() {
       random_pattern_type()};
 }
 
+security::acl_principal random_acl_principal() {
+    return {
+      security::principal_type::user,
+      random_generators::gen_alphanum_string(12)};
+}
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
       model::ntp(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -583,6 +583,32 @@ security::acl_principal random_acl_principal() {
 security::acl_host create_acl_host() {
     return security::acl_host(ss::net::inet_address("127.0.0.1"));
 }
+security::acl_operation random_acl_operation() {
+    return random_generators::random_choice<security::acl_operation>(
+      {security::acl_operation::all,
+       security::acl_operation::alter,
+       security::acl_operation::alter_configs,
+       security::acl_operation::describe_configs,
+       security::acl_operation::cluster_action,
+       security::acl_operation::create,
+       security::acl_operation::remove,
+       security::acl_operation::read,
+       security::acl_operation::idempotent_write,
+       security::acl_operation::describe});
+}
+
+security::acl_permission random_acl_permission() {
+    return random_generators::random_choice<security::acl_permission>(
+      {security::acl_permission::allow, security::acl_permission::deny});
+}
+
+security::acl_entry random_acl_entry() {
+    return {
+      random_acl_principal(),
+      create_acl_host(),
+      random_acl_operation(),
+      random_acl_permission()};
+}
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -664,6 +664,12 @@ std::vector<ss::sstring> random_strings() {
     }
     return ret;
 }
+cluster::cluster_property_kv random_property_kv() {
+    return {
+      random_generators::gen_alphanum_string(random_generators::get_int(1, 64)),
+      random_generators::gen_alphanum_string(
+        random_generators::get_int(1, 64))};
+}
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
@@ -821,6 +827,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(status);
     }
+    { roundtrip_test(random_property_kv()); }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/simple_batch_builder_test.cc
+++ b/src/v/cluster/tests/simple_batch_builder_test.cc
@@ -36,9 +36,7 @@ cluster::partition_assignment create_test_assignment(uint32_t p, uint16_t rf) {
     }
 
     return cluster::partition_assignment{
-      .group = raft::group_id(p),
-      .id = model::partition_id(p),
-      .replicas = std::move(replicas)};
+      raft::group_id(p), model::partition_id(p), std::move(replicas)};
 }
 
 SEASTAR_THREAD_TEST_CASE(simple_batch_builder_batch_test) {

--- a/src/v/cluster/tests/topic_configuration_compat_test.cc
+++ b/src/v/cluster/tests/topic_configuration_compat_test.cc
@@ -675,20 +675,20 @@ void topic_configuration_assignment_roundtrip() {
         tc.properties.shadow_indexing = model::shadow_indexing_mode::archival;
     }
     auto p1 = cluster::partition_assignment{
-      .group = raft::group_id{42},
-      .id = model::partition_id{34},
-      .replicas = {
-          model::broker_shard{.node_id = model::node_id{1}, .shard = 2},
-          model::broker_shard{.node_id = model::node_id{3}, .shard = 4},
-        },
+      raft::group_id{42},
+      model::partition_id{34},
+      {
+        model::broker_shard{.node_id = model::node_id{1}, .shard = 2},
+        model::broker_shard{.node_id = model::node_id{3}, .shard = 4},
+      },
     };
     auto p2 = cluster::partition_assignment{
-      .group = raft::group_id{51},
-      .id = model::partition_id{15},
-      .replicas = {
-          model::broker_shard{.node_id = model::node_id{4}, .shard = 1},
-          model::broker_shard{.node_id = model::node_id{5}, .shard = 2},
-        },
+      raft::group_id{51},
+      model::partition_id{15},
+      {
+        model::broker_shard{.node_id = model::node_id{4}, .shard = 1},
+        model::broker_shard{.node_id = model::node_id{5}, .shard = 2},
+      },
     };
 
     ReqIn assign_cfg(tc, {p1, p2});

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -123,7 +123,7 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     // discard create delta
     create_topics();
     table.local().wait_for_changes(as).get0();
-    cluster::create_partititions_configuration cfg(make_tp_ns("test_tp_2"), 3);
+    cluster::create_partitions_configuration cfg(make_tp_ns("test_tp_2"), 3);
     std::vector<cluster::partition_assignment> p_as{
       cluster::partition_assignment{
         .group = raft::group_id(10),
@@ -143,7 +143,7 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
         .replicas
         = {model::broker_shard{model::node_id(0), 0}, model::broker_shard{model::node_id(1), 1}, model::broker_shard{model::node_id(2), 2}},
       }};
-    cluster::create_partititions_configuration_assignment pca(
+    cluster::create_partitions_configuration_assignment pca(
       std::move(cfg), std::move(p_as));
 
     auto res_1 = table.local()

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -126,22 +126,25 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     cluster::create_partitions_configuration cfg(make_tp_ns("test_tp_2"), 3);
     std::vector<cluster::partition_assignment> p_as{
       cluster::partition_assignment{
-        .group = raft::group_id(10),
-        .id = model::partition_id(0),
-        .replicas
-        = {model::broker_shard{model::node_id(0), 0}, model::broker_shard{model::node_id(1), 1}, model::broker_shard{model::node_id(2), 2}},
+        raft::group_id(10),
+        model::partition_id(0),
+        {model::broker_shard{model::node_id(0), 0},
+         model::broker_shard{model::node_id(1), 1},
+         model::broker_shard{model::node_id(2), 2}},
       },
       cluster::partition_assignment{
-        .group = raft::group_id(11),
-        .id = model::partition_id(1),
-        .replicas
-        = {model::broker_shard{model::node_id(0), 0}, model::broker_shard{model::node_id(1), 1}, model::broker_shard{model::node_id(2), 2}},
+        raft::group_id(11),
+        model::partition_id(1),
+        {model::broker_shard{model::node_id(0), 0},
+         model::broker_shard{model::node_id(1), 1},
+         model::broker_shard{model::node_id(2), 2}},
       },
       cluster::partition_assignment{
-        .group = raft::group_id(12),
-        .id = model::partition_id(2),
-        .replicas
-        = {model::broker_shard{model::node_id(0), 0}, model::broker_shard{model::node_id(1), 1}, model::broker_shard{model::node_id(2), 2}},
+        raft::group_id(12),
+        model::partition_id(2),
+        {model::broker_shard{model::node_id(0), 0},
+         model::broker_shard{model::node_id(1), 1},
+         model::broker_shard{model::node_id(2), 2}},
       }};
     cluster::create_partitions_configuration_assignment pca(
       std::move(cfg), std::move(p_as));

--- a/src/v/cluster/tests/utils.h
+++ b/src/v/cluster/tests/utils.h
@@ -23,9 +23,10 @@ static cluster::partition_assignment create_test_assignment(
   int partition_id,
   std::vector<std::pair<uint32_t, uint32_t>> shards_assignment,
   int group_id) {
-    cluster::partition_assignment p_as{
-      .group = raft::group_id(group_id),
-      .id = model::partition_id(partition_id)};
+    cluster::partition_assignment p_as;
+    p_as.group = raft::group_id(group_id);
+    p_as.id = model::partition_id(partition_id);
+
     std::transform(
       shards_assignment.begin(),
       shards_assignment.end(),

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -240,9 +240,9 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     _update_in_progress.erase(cmd.key);
 
     partition_assignment delta_assignment{
-      .group = current_assignment_it->group,
-      .id = current_assignment_it->id,
-      .replicas = std::move(cmd.value),
+      current_assignment_it->group,
+      current_assignment_it->id,
+      std::move(cmd.value),
     };
 
     /// Remove child non_replicable topics out of the 'update_in_progress' set

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -650,7 +650,7 @@ ss::future<result<model::offset>> topics_frontend::stm_linearizable_barrier(
 }
 
 ss::future<std::vector<topic_result>> topics_frontend::create_partitions(
-  std::vector<create_partititions_configuration> partitions,
+  std::vector<create_partitions_configuration> partitions,
   model::timeout_clock::time_point timeout) {
     auto r = co_await stm_linearizable_barrier(timeout);
     if (!r) {
@@ -660,7 +660,7 @@ ss::future<std::vector<topic_result>> topics_frontend::create_partitions(
           partitions.begin(),
           partitions.end(),
           std::back_inserter(results),
-          [err = r.error()](const create_partititions_configuration& cfg) {
+          [err = r.error()](const create_partitions_configuration& cfg) {
               return make_error_result(cfg.tp_ns, err);
           });
         co_return results;
@@ -669,7 +669,7 @@ ss::future<std::vector<topic_result>> topics_frontend::create_partitions(
     auto result = co_await ssx::parallel_transform(
       partitions.begin(),
       partitions.end(),
-      [this, timeout](create_partititions_configuration cfg) {
+      [this, timeout](create_partitions_configuration cfg) {
           return do_create_partition(std::move(cfg), timeout);
       });
 
@@ -687,7 +687,7 @@ topics_frontend::validate_shard(model::node_id node, uint32_t shard) const {
 allocation_request make_allocation_request(
   int16_t replication_factor,
   const int32_t current_partitions_count,
-  const create_partititions_configuration& cfg) {
+  const create_partitions_configuration& cfg) {
     const auto new_partitions_cnt = cfg.new_total_partition_count
                                     - current_partitions_count;
     allocation_request req;
@@ -699,7 +699,7 @@ allocation_request make_allocation_request(
 }
 
 ss::future<topic_result> topics_frontend::do_create_partition(
-  create_partititions_configuration p_cfg,
+  create_partitions_configuration p_cfg,
   model::timeout_clock::time_point timeout) {
     auto tp_cfg = _topics.local().get_topic_cfg(p_cfg.tp_ns);
     if (!tp_cfg) {
@@ -725,7 +725,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
     }
 
     auto tp_ns = p_cfg.tp_ns;
-    create_partititions_configuration_assignment payload(
+    create_partitions_configuration_assignment payload(
       std::move(p_cfg), units.value().get_assignments());
     create_partition_cmd cmd = create_partition_cmd(tp_ns, std::move(payload));
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -67,7 +67,7 @@ public:
       std::vector<topic_properties_update>, model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> create_partitions(
-      std::vector<create_partititions_configuration>,
+      std::vector<create_partitions_configuration>,
       model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> create_non_replicable_topics(
@@ -123,7 +123,7 @@ private:
     validate_topic_configuration(const custom_assignable_topic_configuration&);
 
     ss::future<topic_result> do_create_partition(
-      create_partititions_configuration, model::timeout_clock::time_point);
+      create_partitions_configuration, model::timeout_clock::time_point);
 
     model::node_id _self;
     ss::sharded<controller_stm>& _stm;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1370,4 +1370,19 @@ adl<cluster::set_maintenance_mode_reply>::from(iobuf_parser& parser) {
     return cluster::set_maintenance_mode_reply{.error = error};
 }
 
+void adl<cluster::partition_assignment>::to(
+  iobuf& out, cluster::partition_assignment&& p_as) {
+    reflection::serialize(out, p_as.group, p_as.id, std::move(p_as.replicas));
+}
+
+cluster::partition_assignment
+adl<cluster::partition_assignment>::from(iobuf_parser& parser) {
+    auto group = reflection::adl<raft::group_id>{}.from(parser);
+    auto id = reflection::adl<model::partition_id>{}.from(parser);
+    auto replicas = reflection::adl<std::vector<model::broker_shard>>{}.from(
+      parser);
+
+    return {group, id, std::move(replicas)};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1202,8 +1202,7 @@ adl<cluster::cluster_config_delta_cmd_data>::from(iobuf_parser& in) {
       "Unexpected version: {} (expected {})",
       version,
       cluster::cluster_config_delta_cmd_data::current_version);
-    auto upsert = adl<std::vector<std::pair<ss::sstring, ss::sstring>>>().from(
-      in);
+    auto upsert = adl<std::vector<cluster::cluster_property_kv>>().from(in);
     auto remove = adl<std::vector<ss::sstring>>().from(in);
 
     return cluster::cluster_config_delta_cmd_data{
@@ -1431,6 +1430,20 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       retention_duration,
       recovery,
       shadow_indexing};
+}
+
+void adl<cluster::cluster_property_kv>::to(
+  iobuf& out, cluster::cluster_property_kv&& kv) {
+    reflection::serialize(out, std::move(kv.key), std::move(kv.value));
+}
+
+cluster::cluster_property_kv
+adl<cluster::cluster_property_kv>::from(iobuf_parser& p) {
+    cluster::cluster_property_kv kv;
+
+    kv.key = adl<ss::sstring>{}.from(p);
+    kv.value = adl<ss::sstring>{}.from(p);
+    return kv;
 }
 
 } // namespace reflection

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1385,4 +1385,52 @@ adl<cluster::partition_assignment>::from(iobuf_parser& parser) {
     return {group, id, std::move(replicas)};
 }
 
+void adl<cluster::topic_properties>::to(
+  iobuf& out, cluster::topic_properties&& p) {
+    reflection::serialize(
+      out,
+      p.compression,
+      p.cleanup_policy_bitflags,
+      p.compaction_strategy,
+      p.timestamp_type,
+      p.segment_size,
+      p.retention_bytes,
+      p.retention_duration,
+      p.recovery,
+      p.shadow_indexing);
+}
+
+cluster::topic_properties
+adl<cluster::topic_properties>::from(iobuf_parser& parser) {
+    auto compression
+      = reflection::adl<std::optional<model::compression>>{}.from(parser);
+    auto cleanup_policy_bitflags
+      = reflection::adl<std::optional<model::cleanup_policy_bitflags>>{}.from(
+        parser);
+    auto compaction_strategy
+      = reflection::adl<std::optional<model::compaction_strategy>>{}.from(
+        parser);
+    auto timestamp_type
+      = reflection::adl<std::optional<model::timestamp_type>>{}.from(parser);
+    auto segment_size = reflection::adl<std::optional<size_t>>{}.from(parser);
+    auto retention_bytes = reflection::adl<tristate<size_t>>{}.from(parser);
+    auto retention_duration
+      = reflection::adl<tristate<std::chrono::milliseconds>>{}.from(parser);
+    auto recovery = reflection::adl<std::optional<bool>>{}.from(parser);
+    auto shadow_indexing
+      = reflection::adl<std::optional<model::shadow_indexing_mode>>{}.from(
+        parser);
+
+    return {
+      compression,
+      cleanup_policy_bitflags,
+      compaction_strategy,
+      timestamp_type,
+      segment_size,
+      retention_bytes,
+      retention_duration,
+      recovery,
+      shadow_indexing};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -146,7 +146,7 @@ ntp_reconciliation_state::ntp_reconciliation_state(
   : ntp_reconciliation_state(
     std::move(ntp), {}, reconciliation_status::error, ec) {}
 
-create_partititions_configuration::create_partititions_configuration(
+create_partitions_configuration::create_partitions_configuration(
   model::topic_namespace tp_ns, int32_t cnt)
   : tp_ns(std::move(tp_ns))
   , new_total_partition_count(cnt) {}
@@ -374,7 +374,7 @@ operator<<(std::ostream& o, const ntp_reconciliation_state& state) {
 }
 
 std::ostream&
-operator<<(std::ostream& o, const create_partititions_configuration& cfg) {
+operator<<(std::ostream& o, const create_partitions_configuration& cfg) {
     fmt::print(
       o,
       "{{topic: {}, new total partition count: {}, custom assignments: {}}}",
@@ -385,7 +385,7 @@ operator<<(std::ostream& o, const create_partititions_configuration& cfg) {
 }
 
 std::ostream& operator<<(
-  std::ostream& o, const create_partititions_configuration_assignment& cpca) {
+  std::ostream& o, const create_partitions_configuration_assignment& cpca) {
     fmt::print(
       o, "{{configuration: {}, assignments: {}}}", cpca.cfg, cpca.assignments);
     return o;
@@ -1014,38 +1014,38 @@ adl<cluster::ntp_reconciliation_state>::from(iobuf_parser& in) {
       std::move(ntp), std::move(ops), status, error);
 }
 
-void adl<cluster::create_partititions_configuration>::to(
-  iobuf& out, cluster::create_partititions_configuration&& pc) {
+void adl<cluster::create_partitions_configuration>::to(
+  iobuf& out, cluster::create_partitions_configuration&& pc) {
     return serialize(
       out, pc.tp_ns, pc.new_total_partition_count, pc.custom_assignments);
 }
 
-cluster::create_partititions_configuration
-adl<cluster::create_partititions_configuration>::from(iobuf_parser& in) {
+cluster::create_partitions_configuration
+adl<cluster::create_partitions_configuration>::from(iobuf_parser& in) {
     auto tp_ns = adl<model::topic_namespace>{}.from(in);
     auto partition_count = adl<int32_t>{}.from(in);
     auto custom_assignment = adl<std::vector<
-      cluster::create_partititions_configuration::custom_assignment>>{}
+      cluster::create_partitions_configuration::custom_assignment>>{}
                                .from(in);
 
-    cluster::create_partititions_configuration ret(
+    cluster::create_partitions_configuration ret(
       std::move(tp_ns), partition_count);
     ret.custom_assignments = std::move(custom_assignment);
     return ret;
 }
 
-void adl<cluster::create_partititions_configuration_assignment>::to(
-  iobuf& out, cluster::create_partititions_configuration_assignment&& ca) {
+void adl<cluster::create_partitions_configuration_assignment>::to(
+  iobuf& out, cluster::create_partitions_configuration_assignment&& ca) {
     return serialize(out, std::move(ca.cfg), std::move(ca.assignments));
 }
 
-cluster::create_partititions_configuration_assignment
-adl<cluster::create_partititions_configuration_assignment>::from(
+cluster::create_partitions_configuration_assignment
+adl<cluster::create_partitions_configuration_assignment>::from(
   iobuf_parser& in) {
-    auto cfg = adl<cluster::create_partititions_configuration>{}.from(in);
+    auto cfg = adl<cluster::create_partitions_configuration>{}.from(in);
     auto p_as = adl<std::vector<cluster::partition_assignment>>{}.from(in);
 
-    return cluster::create_partititions_configuration_assignment(
+    return cluster::create_partitions_configuration_assignment(
       std::move(cfg), std::move(p_as));
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -920,7 +920,8 @@ struct cluster_config_status_cmd_data
     config_status status;
 };
 
-struct feature_update_action {
+struct feature_update_action
+  : serde::envelope<feature_update_action, serde::version<0>> {
     static constexpr int8_t current_version = 1;
     enum class action_t : std::uint16_t {
         // Notify when a feature is done with preparing phase
@@ -936,6 +937,8 @@ struct feature_update_action {
     // meant to be stable for use on the wire, so we refer to features by name
     ss::sstring feature_name;
     action_t action;
+
+    auto serde_fields() { return std::tie(feature_name, action); }
 
     friend std::ostream&
     operator<<(std::ostream&, const feature_update_action&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -548,12 +548,15 @@ struct topic_properties_update {
 
 // Structure holding topic configuration, optionals will be replaced by broker
 // defaults
-struct topic_configuration {
+struct topic_configuration
+  : serde::envelope<topic_configuration, serde::version<0>> {
     topic_configuration(
       model::ns ns,
       model::topic topic,
       int32_t partition_count,
       int16_t replication_factor);
+
+    topic_configuration() = default;
 
     storage::ntp_config make_ntp_config(
       const ss::sstring&,
@@ -573,6 +576,10 @@ struct topic_configuration {
     int16_t replication_factor;
 
     topic_properties properties;
+
+    auto serde_fields() {
+        return std::tie(tp_ns, partition_count, replication_factor, properties);
+    }
 
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -814,9 +814,12 @@ struct create_acls_reply {
     std::vector<errc> results;
 };
 
-struct delete_acls_cmd_data {
+struct delete_acls_cmd_data
+  : serde::envelope<delete_acls_cmd_data, serde::version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<security::acl_binding_filter> filters;
+
+    auto serde_fields() { return std::tie(filters); }
 };
 
 // result for a single filter

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -355,7 +355,8 @@ struct configuration_update_reply {
 
 /// Partition assignment describes an assignment of all replicas for single NTP.
 /// The replicas are hold in vector of broker_shard.
-struct partition_assignment {
+struct partition_assignment
+  : serde::envelope<partition_assignment, serde::version<0>> {
     partition_assignment() noexcept = default;
     partition_assignment(
       raft::group_id group,
@@ -375,6 +376,7 @@ struct partition_assignment {
         return p_md;
     }
 
+    auto serde_fields() { return std::tie(group, id, replicas); }
     friend std::ostream& operator<<(std::ostream&, const partition_assignment&);
 
     friend bool

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -647,6 +647,11 @@ struct topic_configuration_assignment {
     std::vector<partition_assignment> assignments;
 
     model::topic_metadata get_metadata() const;
+
+    friend bool operator==(
+      const topic_configuration_assignment&,
+      const topic_configuration_assignment&)
+      = default;
 };
 
 struct create_partitions_configuration_assignment {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -28,6 +28,8 @@
 #include "utils/to_string.h"
 #include "v8_engine/data_policy.h"
 
+#include <seastar/core/sstring.hh>
+
 #include <absl/container/btree_set.h>
 #include <fmt/format.h>
 
@@ -944,7 +946,8 @@ struct feature_update_action
     operator<<(std::ostream&, const feature_update_action&);
 };
 
-struct feature_update_cmd_data {
+struct feature_update_cmd_data
+  : serde::envelope<feature_update_cmd_data, serde::version<0>> {
     // To avoid ambiguity on 'versions' here: `current_version`
     // is the encoding version of the struct, subsequent version
     // fields are the payload.
@@ -952,6 +955,8 @@ struct feature_update_cmd_data {
 
     cluster_version logical_version;
     std::vector<feature_update_action> actions;
+
+    auto serde_fields() { return std::tie(logical_version, actions); }
 
     friend std::ostream&
     operator<<(std::ostream&, const feature_update_cmd_data&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -356,6 +356,15 @@ struct configuration_update_reply {
 /// Partition assignment describes an assignment of all replicas for single NTP.
 /// The replicas are hold in vector of broker_shard.
 struct partition_assignment {
+    partition_assignment() noexcept = default;
+    partition_assignment(
+      raft::group_id group,
+      model::partition_id id,
+      std::vector<model::broker_shard> replicas)
+      : group(group)
+      , id(id)
+      , replicas(std::move(replicas)) {}
+
     raft::group_id group;
     model::partition_id id;
     std::vector<model::broker_shard> replicas;
@@ -1229,5 +1238,9 @@ struct adl<cluster::allocate_id_reply> {
         return {id, ec};
     }
 };
-
+template<>
+struct adl<cluster::partition_assignment> {
+    void to(iobuf&, cluster::partition_assignment&&);
+    cluster::partition_assignment from(iobuf_parser&);
+};
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -445,7 +445,9 @@ struct topic_properties : serde::envelope<topic_properties, serde::version<0>> {
 
 enum incremental_update_operation : int8_t { none, set, remove };
 template<typename T>
-struct property_update {
+
+struct property_update
+  : serde::envelope<property_update<T>, serde::version<0>> {
     property_update() = default;
     property_update(T v, incremental_update_operation op)
       : value(std::move(v))
@@ -454,21 +456,25 @@ struct property_update {
     T value;
     incremental_update_operation op = incremental_update_operation::none;
 
+    auto serde_fields() { return std::tie(value, op); }
+
     friend bool operator==(const property_update<T>&, const property_update<T>&)
       = default;
 };
 
 template<typename T>
-struct property_update<tristate<T>> {
+struct property_update<tristate<T>>
+  : serde::envelope<property_update<tristate<T>>, serde::version<0>> {
     property_update()
       : value(std::nullopt){};
 
     property_update(tristate<T> v, incremental_update_operation op)
       : value(std::move(v))
       , op(op) {}
-
     tristate<T> value;
     incremental_update_operation op = incremental_update_operation::none;
+
+    auto serde_fields() { return std::tie(value, op); }
 
     friend bool operator==(
       const property_update<tristate<T>>&, const property_update<tristate<T>>&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -405,6 +405,9 @@ struct topic_properties {
     storage::ntp_config::default_overrides get_ntp_cfg_overrides() const;
 
     friend std::ostream& operator<<(std::ostream&, const topic_properties&);
+
+    friend bool operator==(const topic_properties&, const topic_properties&)
+      = default;
 };
 
 enum incremental_update_operation : int8_t { none, set, remove };

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -657,7 +657,10 @@ struct topic_configuration_assignment
       = default;
 };
 
-struct create_partitions_configuration_assignment {
+struct create_partitions_configuration_assignment
+  : serde::
+      envelope<create_partitions_configuration_assignment, serde::version<0>> {
+    create_partitions_configuration_assignment() = default;
     create_partitions_configuration_assignment(
       create_partitions_configuration cfg,
       std::vector<partition_assignment> pas)
@@ -666,6 +669,8 @@ struct create_partitions_configuration_assignment {
 
     create_partitions_configuration cfg;
     std::vector<partition_assignment> assignments;
+
+    auto serde_fields() { return std::tie(cfg, assignments); }
 
     friend std::ostream& operator<<(
       std::ostream&, const create_partitions_configuration_assignment&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -575,6 +575,10 @@ struct topic_configuration {
     topic_properties properties;
 
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
+
+    friend bool
+    operator==(const topic_configuration&, const topic_configuration&)
+      = default;
 };
 
 struct custom_partition_assignment {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -881,13 +881,19 @@ struct config_status : serde::envelope<config_status, serde::version<0>> {
     bool operator==(const config_status&) const;
     friend std::ostream& operator<<(std::ostream&, const config_status&);
 };
-struct cluster_property_kv {
+
+struct cluster_property_kv
+  : serde::envelope<cluster_property_kv, serde::version<0>> {
     cluster_property_kv() = default;
     cluster_property_kv(ss::sstring k, ss::sstring v)
       : key(std::move(k))
       , value(std::move(v)) {}
+
     ss::sstring key;
     ss::sstring value;
+
+    auto serde_fields() { return std::tie(key, value); }
+
     friend bool
     operator==(const cluster_property_kv&, const cluster_property_kv&)
       = default;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -881,10 +881,21 @@ struct config_status : serde::envelope<config_status, serde::version<0>> {
     bool operator==(const config_status&) const;
     friend std::ostream& operator<<(std::ostream&, const config_status&);
 };
+struct cluster_property_kv {
+    cluster_property_kv() = default;
+    cluster_property_kv(ss::sstring k, ss::sstring v)
+      : key(std::move(k))
+      , value(std::move(v)) {}
+    ss::sstring key;
+    ss::sstring value;
+    friend bool
+    operator==(const cluster_property_kv&, const cluster_property_kv&)
+      = default;
+};
 
 struct cluster_config_delta_cmd_data {
     static constexpr int8_t current_version = 0;
-    std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
+    std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
 
     friend std::ostream&
@@ -1057,7 +1068,7 @@ struct create_non_replicable_topics_reply {
 };
 
 struct config_update_request final {
-    std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
+    std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
 };
 
@@ -1389,5 +1400,10 @@ struct adl<cluster::property_update<T>> {
           parser);
         return {std::move(value), op};
     }
+};
+template<>
+struct adl<cluster::cluster_property_kv> {
+    void to(iobuf&, cluster::cluster_property_kv&&);
+    cluster::cluster_property_kv from(iobuf_parser&);
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -853,10 +853,14 @@ struct create_data_policy_cmd_data
     v8_engine::data_policy dp;
 };
 
-struct non_replicable_topic {
+struct non_replicable_topic
+  : serde::envelope<non_replicable_topic, serde::version<0>> {
     static constexpr int8_t current_version = 1;
     model::topic_namespace source;
     model::topic_namespace name;
+
+    auto serde_fields() { return std::tie(source, name); }
+
     friend std::ostream& operator<<(std::ostream&, const non_replicable_topic&);
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -669,6 +669,11 @@ struct create_partitions_configuration_assignment {
 
     friend std::ostream& operator<<(
       std::ostream&, const create_partitions_configuration_assignment&);
+
+    friend bool operator==(
+      const create_partitions_configuration_assignment&,
+      const create_partitions_configuration_assignment&)
+      = default;
 };
 
 struct topic_result {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -797,9 +797,12 @@ struct topic_table_delta {
     friend std::ostream& operator<<(std::ostream&, const op_type&);
 };
 
-struct create_acls_cmd_data {
+struct create_acls_cmd_data
+  : serde::envelope<create_acls_cmd_data, serde::version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<security::acl_binding> bindings;
+
+    auto serde_fields() { return std::tie(bindings); }
 };
 
 struct create_acls_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -899,10 +899,13 @@ struct cluster_property_kv
       = default;
 };
 
-struct cluster_config_delta_cmd_data {
+struct cluster_config_delta_cmd_data
+  : serde::envelope<cluster_config_delta_cmd_data, serde::version<0>> {
     static constexpr int8_t current_version = 0;
     std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
+
+    auto serde_fields() { return std::tie(upsert, remove); }
 
     friend std::ostream&
     operator<<(std::ostream&, const cluster_config_delta_cmd_data&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -612,8 +612,11 @@ struct custom_assignable_topic_configuration {
     operator<<(std::ostream&, const custom_assignable_topic_configuration&);
 };
 
-struct create_partitions_configuration {
+struct create_partitions_configuration
+  : serde::envelope<create_partitions_configuration, serde::version<0>> {
     using custom_assignment = std::vector<model::node_id>;
+
+    create_partitions_configuration() = default;
     create_partitions_configuration(model::topic_namespace, int32_t);
 
     model::topic_namespace tp_ns;
@@ -623,6 +626,10 @@ struct create_partitions_configuration {
 
     // TODO: use when we will start supporting custom partitions assignment
     std::vector<custom_assignment> custom_assignments;
+
+    auto serde_fields() {
+        return std::tie(tp_ns, new_total_partition_count, custom_assignments);
+    }
 
     friend std::ostream&
     operator<<(std::ostream&, const create_partitions_configuration&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -519,9 +519,9 @@ struct custom_assignable_topic_configuration {
     operator<<(std::ostream&, const custom_assignable_topic_configuration&);
 };
 
-struct create_partititions_configuration {
+struct create_partitions_configuration {
     using custom_assignment = std::vector<model::node_id>;
-    create_partititions_configuration(model::topic_namespace, int32_t);
+    create_partitions_configuration(model::topic_namespace, int32_t);
 
     model::topic_namespace tp_ns;
 
@@ -532,7 +532,7 @@ struct create_partititions_configuration {
     std::vector<custom_assignment> custom_assignments;
 
     friend std::ostream&
-    operator<<(std::ostream&, const create_partititions_configuration&);
+    operator<<(std::ostream&, const create_partitions_configuration&);
 };
 
 struct topic_configuration_assignment {
@@ -549,18 +549,18 @@ struct topic_configuration_assignment {
     model::topic_metadata get_metadata() const;
 };
 
-struct create_partititions_configuration_assignment {
-    create_partititions_configuration_assignment(
-      create_partititions_configuration cfg,
+struct create_partitions_configuration_assignment {
+    create_partitions_configuration_assignment(
+      create_partitions_configuration cfg,
       std::vector<partition_assignment> pas)
       : cfg(std::move(cfg))
       , assignments(std::move(pas)) {}
 
-    create_partititions_configuration cfg;
+    create_partitions_configuration cfg;
     std::vector<partition_assignment> assignments;
 
     friend std::ostream& operator<<(
-      std::ostream&, const create_partititions_configuration_assignment&);
+      std::ostream&, const create_partitions_configuration_assignment&);
 };
 
 struct topic_result {
@@ -1118,15 +1118,15 @@ struct adl<cluster::delete_acls_result> {
 };
 
 template<>
-struct adl<cluster::create_partititions_configuration> {
-    void to(iobuf&, cluster::create_partititions_configuration&&);
-    cluster::create_partititions_configuration from(iobuf_parser&);
+struct adl<cluster::create_partitions_configuration> {
+    void to(iobuf&, cluster::create_partitions_configuration&&);
+    cluster::create_partitions_configuration from(iobuf_parser&);
 };
 
 template<>
-struct adl<cluster::create_partititions_configuration_assignment> {
-    void to(iobuf&, cluster::create_partititions_configuration_assignment&&);
-    cluster::create_partititions_configuration_assignment from(iobuf_parser&);
+struct adl<cluster::create_partitions_configuration_assignment> {
+    void to(iobuf&, cluster::create_partitions_configuration_assignment&&);
+    cluster::create_partitions_configuration_assignment from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -911,8 +911,12 @@ struct cluster_config_delta_cmd_data
     operator<<(std::ostream&, const cluster_config_delta_cmd_data&);
 };
 
-struct cluster_config_status_cmd_data {
+struct cluster_config_status_cmd_data
+  : serde::envelope<cluster_config_status_cmd_data, serde::version<0>> {
     static constexpr int8_t current_version = 0;
+
+    auto serde_fields() { return std::tie(status); }
+
     config_status status;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -481,7 +481,8 @@ struct property_update<tristate<T>>
       = default;
 };
 
-struct incremental_topic_updates {
+struct incremental_topic_updates
+  : serde::envelope<incremental_topic_updates, serde::version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
     // negative version indicating different format:
@@ -499,6 +500,18 @@ struct incremental_topic_updates {
     property_update<tristate<size_t>> retention_bytes;
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
     property_update<std::optional<model::shadow_indexing_mode>> shadow_indexing;
+
+    auto serde_fields() {
+        return std::tie(
+          compression,
+          cleanup_policy_bitflags,
+          compaction_strategy,
+          timestamp_type,
+          segment_size,
+          retention_bytes,
+          retention_duration,
+          shadow_indexing);
+    }
 
     friend bool operator==(
       const incremental_topic_updates&, const incremental_topic_updates&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -388,7 +388,7 @@ struct partition_assignment
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults
  */
-struct topic_properties {
+struct topic_properties : serde::envelope<topic_properties, serde::version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -426,6 +426,18 @@ struct topic_properties {
     storage::ntp_config::default_overrides get_ntp_cfg_overrides() const;
 
     friend std::ostream& operator<<(std::ostream&, const topic_properties&);
+    auto serde_fields() {
+        return std::tie(
+          compression,
+          cleanup_policy_bitflags,
+          compaction_strategy,
+          timestamp_type,
+          segment_size,
+          retention_bytes,
+          retention_duration,
+          recovery,
+          shadow_indexing);
+    }
 
     friend bool operator==(const topic_properties&, const topic_properties&)
       = default;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -844,8 +844,12 @@ struct backend_operation {
     friend std::ostream& operator<<(std::ostream&, const backend_operation&);
 };
 
-struct create_data_policy_cmd_data {
+struct create_data_policy_cmd_data
+  : serde::envelope<create_data_policy_cmd_data, serde::version<0>> {
     static constexpr int8_t current_version = 1; // In future dp will be vector
+
+    auto serde_fields() { return std::tie(dp); }
+
     v8_engine::data_policy dp;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -867,12 +867,16 @@ struct non_replicable_topic
 using config_version = named_type<int64_t, struct config_version_type>;
 constexpr config_version config_version_unset = config_version{-1};
 
-struct config_status {
+struct config_status : serde::envelope<config_status, serde::version<0>> {
     model::node_id node;
     config_version version{config_version_unset};
     bool restart{false};
     std::vector<ss::sstring> unknown;
     std::vector<ss::sstring> invalid;
+
+    auto serde_fields() {
+        return std::tie(node, version, restart, unknown, invalid);
+    }
 
     bool operator==(const config_status&) const;
     friend std::ostream& operator<<(std::ostream&, const config_status&);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -376,6 +376,10 @@ struct partition_assignment {
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_assignment&);
+
+    friend bool
+    operator==(const partition_assignment&, const partition_assignment&)
+      = default;
 };
 
 /**

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -389,6 +389,27 @@ struct partition_assignment
  * with defaults
  */
 struct topic_properties {
+    topic_properties() noexcept = default;
+    topic_properties(
+      std::optional<model::compression> compression,
+      std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags,
+      std::optional<model::compaction_strategy> compaction_strategy,
+      std::optional<model::timestamp_type> timestamp_type,
+      std::optional<size_t> segment_size,
+      tristate<size_t> retention_bytes,
+      tristate<std::chrono::milliseconds> retention_duration,
+      std::optional<bool> recovery,
+      std::optional<model::shadow_indexing_mode> shadow_indexing)
+      : compression(compression)
+      , cleanup_policy_bitflags(cleanup_policy_bitflags)
+      , compaction_strategy(compaction_strategy)
+      , timestamp_type(timestamp_type)
+      , segment_size(segment_size)
+      , retention_bytes(retention_bytes)
+      , retention_duration(retention_duration)
+      , recovery(recovery)
+      , shadow_indexing(shadow_indexing) {}
+
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
     std::optional<model::compaction_strategy> compaction_strategy;
@@ -1251,5 +1272,11 @@ template<>
 struct adl<cluster::partition_assignment> {
     void to(iobuf&, cluster::partition_assignment&&);
     cluster::partition_assignment from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::topic_properties> {
+    void to(iobuf&, cluster::topic_properties&&);
+    cluster::topic_properties from(iobuf_parser&);
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -635,8 +635,9 @@ struct create_partitions_configuration
     operator<<(std::ostream&, const create_partitions_configuration&);
 };
 
-struct topic_configuration_assignment {
-    topic_configuration_assignment() = delete;
+struct topic_configuration_assignment
+  : serde::envelope<topic_configuration_assignment, serde::version<0>> {
+    topic_configuration_assignment() = default;
 
     topic_configuration_assignment(
       topic_configuration cfg, std::vector<partition_assignment> pas)
@@ -647,6 +648,8 @@ struct topic_configuration_assignment {
     std::vector<partition_assignment> assignments;
 
     model::topic_metadata get_metadata() const;
+
+    auto serde_fields() { return std::tie(cfg, assignments); }
 
     friend bool operator==(
       const topic_configuration_assignment&,

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -100,7 +100,7 @@ ss::future<std::vector<cluster::topic_result>> do_create_partitions(
     if (sz == 0) {
         co_return std::vector<cluster::topic_result>{};
     }
-    std::vector<cluster::create_partititions_configuration> partitions;
+    std::vector<cluster::create_partitions_configuration> partitions;
     partitions.reserve(sz);
 
     std::transform(
@@ -108,7 +108,7 @@ ss::future<std::vector<cluster::topic_result>> do_create_partitions(
       end,
       std::back_inserter(partitions),
       [](create_partitions_topic& tp) {
-          return cluster::create_partititions_configuration(
+          return cluster::create_partitions_configuration(
             model::topic_namespace(model::kafka_namespace, std::move(tp.name)),
             tp.count);
       });

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -397,19 +397,19 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
             // interface expects.
             // Don't both catching ParserException: this was encoded
             // just a few lines above.
-            const auto& yaml_value = i.second;
+            const auto& yaml_value = i.value;
             auto val = YAML::Load(yaml_value);
 
-            if (!cfg.contains(i.first)) {
+            if (!cfg.contains(i.key)) {
                 responses.push_back(
                   make_error_alter_config_resource_response<resp_resource_t>(
                     resource,
                     error_code::invalid_config,
-                    fmt::format("Unknown property '{}'", i.first)));
+                    fmt::format("Unknown property '{}'", i.key)));
                 errored = true;
                 continue;
             }
-            auto& property = cfg.get(i.first);
+            auto& property = cfg.get(i.key);
             try {
                 property.set_value(val);
             } catch (...) {
@@ -418,7 +418,7 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
                     resource,
                     error_code::invalid_config,
                     fmt::format(
-                      "bad property value for '{}': '{}'", i.first, i.second)));
+                      "bad property value for '{}': '{}'", i.key, i.value)));
                 errored = true;
                 continue;
             }

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -1,0 +1,73 @@
+
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "model/compression.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+#include "test_utils/randoms.h"
+
+namespace model {
+inline model::topic_namespace random_topic_namespace() {
+    return {
+      tests::random_named_string<model::ns>(),
+      tests::random_named_string<model::topic>()};
+}
+
+inline model::ntp random_ntp() {
+    return {
+      tests::random_named_string<model::ns>(),
+      tests::random_named_string<model::topic>(),
+      tests::random_named_int<model::partition_id>()};
+}
+
+inline model::cleanup_policy_bitflags random_cleanup_policy() {
+    return random_generators::random_choice(
+      std::vector<model::cleanup_policy_bitflags>{
+        model::cleanup_policy_bitflags::none,
+        model::cleanup_policy_bitflags::compaction,
+        model::cleanup_policy_bitflags::deletion});
+}
+
+inline model::compaction_strategy random_compaction_strategy() {
+    return random_generators::random_choice(
+      std::vector<model::compaction_strategy>{
+        model::compaction_strategy::header,
+        model::compaction_strategy::offset,
+        model::compaction_strategy::timestamp});
+}
+
+inline model::compression random_compression() {
+    return random_generators::random_choice(std::vector<model::compression>{
+      model::compression::gzip,
+      model::compression::zstd,
+      model::compression::none,
+      model::compression::producer,
+      model::compression::snappy});
+}
+
+inline model::shadow_indexing_mode random_shadow_indexing_mode() {
+    return random_generators::random_choice(
+      std::vector<model::shadow_indexing_mode>{
+        model::shadow_indexing_mode::archival,
+        model::shadow_indexing_mode::drop_archival,
+        model::shadow_indexing_mode::drop_fetch,
+        model::shadow_indexing_mode::drop_full,
+        model::shadow_indexing_mode::disabled,
+        model::shadow_indexing_mode::full,
+      });
+}
+
+inline model::timestamp_type random_timestamp_type() {
+    return random_generators::random_choice(std::vector<model::timestamp_type>{
+      model::timestamp_type::append_time, model::timestamp_type::create_time});
+}
+} // namespace model

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -67,4 +67,10 @@ inline ss::sstring gen_alphanum_string(size_t n) {
     return s;
 }
 
+template<typename T>
+const T& random_choice(const std::vector<T>& elements) {
+    auto idx = get_int<size_t>(0, elements.size() - 1);
+    return elements[idx];
+}
+
 } // namespace random_generators

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -760,7 +760,7 @@ void config_multi_property_validation(
   std::map<ss::sstring, ss::sstring>& errors) {
     absl::flat_hash_set<ss::sstring> modified_keys;
     for (const auto& i : req.upsert) {
-        modified_keys.insert(i.first);
+        modified_keys.insert(i.key);
     }
 
     if (

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -396,8 +396,9 @@ private:
  * An ACL binding is an association of resource(s) and an ACL entry. An ACL
  * binding describes if a principal may access resources.
  */
-class acl_binding {
+class acl_binding : public serde::envelope<acl_binding, serde::version<0>> {
 public:
+    acl_binding() = default;
     acl_binding(resource_pattern pattern, acl_entry entry)
       : _pattern(std::move(pattern))
       , _entry(std::move(entry)) {}
@@ -418,6 +419,8 @@ public:
 
     const resource_pattern& pattern() const { return _pattern; }
     const acl_entry& entry() const { return _entry; }
+
+    auto serde_fields() { return std::tie(_pattern, _entry); }
 
 private:
     resource_pattern _pattern;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -249,10 +249,11 @@ inline const acl_principal acl_wildcard_user(principal_type::user, "*");
  * Resource pattern matches resources using a (type, name, pattern) tuple. The
  * pattern type changes how matching occurs (e.g. literal, name prefix).
  */
-class resource_pattern {
+class resource_pattern
+  : public serde::envelope<resource_pattern, serde::version<0>> {
 public:
     static constexpr const char* wildcard = "*";
-
+    resource_pattern() = default;
     resource_pattern(resource_type type, ss::sstring name, pattern_type pattern)
       : _resource(type)
       , _name(std::move(name))
@@ -280,6 +281,8 @@ public:
     resource_type resource() const { return _resource; }
     const ss::sstring& name() const { return _name; }
     pattern_type pattern() const { return _pattern; }
+
+    auto serde_fields() { return std::tie(_resource, _name, _pattern); }
 
 private:
     resource_type _resource;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -676,8 +676,10 @@ inline bool acl_entry_filter::matches(const acl_entry& other) const {
 /*
  * A filter for matching ACL bindings.
  */
-class acl_binding_filter {
+class acl_binding_filter
+  : public serde::envelope<acl_binding_filter, serde::version<0>> {
 public:
+    acl_binding_filter() = default;
     acl_binding_filter(resource_pattern_filter pattern, acl_entry_filter acl)
       : _pattern(std::move(pattern))
       , _acl(std::move(acl)) {}
@@ -698,6 +700,8 @@ public:
 
     const resource_pattern_filter& pattern() const { return _pattern; }
     const acl_entry_filter& entry() const { return _acl; }
+
+    auto serde_fields() { return std::tie(_pattern, _acl); }
 
 private:
     resource_pattern_filter _pattern;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -608,8 +608,10 @@ resource_pattern_filter::to_resource_patterns() const {
 /*
  * A filter for matching ACL entries.
  */
-class acl_entry_filter {
+class acl_entry_filter
+  : public serde::envelope<acl_entry_filter, serde::version<0>> {
 public:
+    acl_entry_filter() = default;
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     acl_entry_filter(const acl_entry& entry)
       : acl_entry_filter(
@@ -643,6 +645,10 @@ public:
     std::optional<acl_host> host() const { return _host; }
     std::optional<acl_operation> operation() const { return _operation; }
     std::optional<acl_permission> permission() const { return _permission; }
+
+    auto serde_fields() {
+        return std::tie(_principal, _host, _operation, _permission);
+    }
 
 private:
     std::optional<acl_principal> _principal;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -296,8 +296,9 @@ private:
 /*
  * A host (or wildcard) in an ACL rule.
  */
-class acl_host {
+class acl_host : public serde::envelope<acl_host, serde::version<0>> {
 public:
+    acl_host() = default;
     explicit acl_host(const ss::sstring& host)
       : _addr(host) {}
 
@@ -330,9 +331,9 @@ public:
 
     std::optional<ss::net::inet_address> address() const { return _addr; }
 
-private:
-    acl_host() = default;
+    auto serde_fields() { return std::tie(_addr); }
 
+private:
     std::optional<ss::net::inet_address> _addr;
 };
 

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -344,8 +344,9 @@ inline const acl_host acl_wildcard_host = acl_host::wildcard_host();
  * permitted to execute an operation on. When associated with a resource, it
  * describes if the principal can execute the operation on that resource.
  */
-class acl_entry {
+class acl_entry : public serde::envelope<acl_entry, serde::version<0>> {
 public:
+    acl_entry() = default;
     acl_entry(
       acl_principal principal,
       acl_host host,
@@ -379,6 +380,10 @@ public:
     const acl_host& host() const { return _host; }
     acl_operation operation() const { return _operation; }
     acl_permission permission() const { return _permission; }
+
+    auto serde_fields() {
+        return std::tie(_principal, _host, _operation, _permission);
+    }
 
 private:
     acl_principal _principal;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -214,8 +214,9 @@ inline std::ostream& operator<<(std::ostream& os, principal_type type) {
 /*
  * Kafka principal is (principal-type, principal)
  */
-class acl_principal {
+class acl_principal : public serde::envelope<acl_principal, serde::version<0>> {
 public:
+    acl_principal() = default;
     acl_principal(principal_type type, ss::sstring name)
       : _type(type)
       , _name(std::move(name)) {}
@@ -237,6 +238,8 @@ public:
     const ss::sstring& name() const { return _name; }
     principal_type type() const { return _type; }
     bool wildcard() const { return _name == "*"; }
+
+    auto serde_fields() { return std::tie(_type, _name); }
 
 private:
     principal_type _type;

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_parser.h"
 #include "hashing/crc32c.h"
+#include "likely.h"
 #include "reflection/type_traits.h"
 #include "serde/envelope_for_each_field.h"
 #include "serde/logger.h"
@@ -23,6 +24,8 @@
 #include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
 #include "vlog.h"
+
+#include <seastar/net/inet_address.hh>
 
 #include <iosfwd>
 #include <numeric>
@@ -145,7 +148,7 @@ inline constexpr auto const is_serde_compatible_v
     || std::is_same_v<T, iobuf>
     || std::is_same_v<T, ss::sstring>
     || std::is_same_v<T, bytes>
-    || is_fragmented_vector_v<T> || reflection::is_tristate_v<T>;
+    || is_fragmented_vector_v<T> || reflection::is_tristate_v<T> || std::is_same_v<T, ss::net::inet_address>;
 
 template<typename T>
 inline constexpr auto const are_bytes_and_string_different = !(
@@ -287,6 +290,14 @@ void write(iobuf& out, T t) {
             write<int8_t>(out, 1);
             write(out, std::move(t.value()));
         }
+    } else if constexpr (std::is_same_v<T, ss::net::inet_address>) {
+        iobuf address_bytes;
+
+        // NOLINTNEXTLINE
+        address_bytes.append((const char*)t.data(), t.size());
+
+        write(out, t.is_ipv4());
+        write(out, std::move(address_bytes));
     }
 }
 
@@ -510,6 +521,42 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
               sizeof(Type),
               in.bytes_left(),
               flag));
+        }
+    } else if constexpr (std::is_same_v<T, ss::net::inet_address>) {
+        bool is_ipv4 = read_nested<bool>(in, bytes_left_limit);
+        auto address_buf = read_nested<iobuf>(in, bytes_left_limit);
+        auto address_bytes = iobuf_to_bytes(address_buf);
+        if (is_ipv4) {
+            ::in_addr addr{};
+            if (unlikely(address_bytes.size() != sizeof(addr))) {
+                throw serde_exception(fmt_with_ctx(
+                  ssx::sformat,
+                  "reading type {} of size {}: {} bytes left - unexpected ipv4 "
+                  "address size, read: {}, expected: {}",
+                  type_str<Type>(),
+                  sizeof(Type),
+                  in.bytes_left(),
+                  address_bytes.size(),
+                  sizeof(addr)));
+            }
+
+            std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+            t = ss::net::inet_address(addr);
+        } else {
+            ::in6_addr addr{};
+            if (unlikely(address_bytes.size() != sizeof(addr))) {
+                throw serde_exception(fmt_with_ctx(
+                  ssx::sformat,
+                  "reading type {} of size {}: {} bytes left - unexpected ipv6 "
+                  "address size, read: {}, expected: {}",
+                  type_str<Type>(),
+                  sizeof(Type),
+                  in.bytes_left(),
+                  address_bytes.size(),
+                  sizeof(addr)));
+            }
+            std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+            t = ss::net::inet_address(addr);
         }
     }
 }

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -18,6 +18,7 @@
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/net/inet_address.hh>
 #include <seastar/testing/thread_test_case.hh>
 
 #include <boost/test/unit_test.hpp>
@@ -739,4 +740,15 @@ SEASTAR_THREAD_TEST_CASE(serde_tristate_test) {
       empty, serde::from_iobuf<tristate<ss::sstring>>(std::move(empty_buf)));
     BOOST_CHECK_EQUAL(
       set, serde::from_iobuf<tristate<ss::sstring>>(std::move(set_buf)));
+}
+
+SEASTAR_THREAD_TEST_CASE(seastar_inet_address_test) {
+    ss::net::inet_address ipv4("192.168.1.0");
+    ss::net::inet_address ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+    iobuf ipv4_buf = serde::to_iobuf(ipv4);
+    iobuf ipv6_buf = serde::to_iobuf(ipv6);
+    BOOST_CHECK_EQUAL(
+      ipv4, serde::from_iobuf<ss::net::inet_address>(std::move(ipv4_buf)));
+    BOOST_CHECK_EQUAL(
+      ipv6, serde::from_iobuf<ss::net::inet_address>(std::move(ipv6_buf)));
 }

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -19,6 +19,10 @@
 
 #include <bits/stdint-uintn.h>
 
+#include <limits>
+#include <optional>
+#include <vector>
+
 namespace tests {
 
 inline net::unresolved_address random_net_address() {
@@ -37,6 +41,42 @@ random_broker(int32_t id_low_bound, int32_t id_upper_bound) {
       std::nullopt,
       model::broker_properties{
         .cores = random_generators::get_int<uint32_t>(96)});
+}
+
+inline bool random_bool() { return random_generators::get_int(0, 100) > 50; }
+
+template<typename T>
+T random_named_string(size_t size = 20) {
+    return T{random_generators::gen_alphanum_string(size)};
+}
+
+template<typename T>
+T random_named_int() {
+    return T{random_generators::get_int<typename T::type>(
+      0, std::numeric_limits<T>::max())};
+}
+
+template<typename Func>
+auto random_optional(Func f) {
+    using T = decltype(f());
+    if (random_bool()) {
+        return std::optional<T>(f());
+    }
+    return std::optional<T>();
+}
+
+template<typename Func>
+auto random_tristate(Func f) {
+    using T = decltype(f());
+    if (random_bool()) {
+        return tristate<T>{};
+    }
+    return tristate<T>(random_optional(f));
+}
+
+inline std::chrono::milliseconds random_duration_ms() {
+    return std::chrono::milliseconds(random_generators::get_int<uint64_t>(
+      0, std::chrono::milliseconds::max().count()));
 }
 
 } // namespace tests

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -12,6 +12,7 @@
 
 #include "reflection/adl.h"
 #include "seastarx.h"
+#include "serde/envelope.h"
 #include "vlog.h"
 
 #include <seastar/core/sstring.hh>
@@ -35,10 +36,11 @@ private:
 // Datapolicy property for v8_engine. In first version it contains only
 // function_name and script_name, in the future it will contain ACLs, geo,
 // e.t.c.
-class data_policy {
+class data_policy : public serde::envelope<data_policy, serde::version<0>> {
 public:
     static constexpr int8_t version{1};
 
+    data_policy() = default;
     data_policy(ss::sstring fn, ss::sstring sn) noexcept
       : _function_name(std::move(fn))
       , _script_name(std::move(sn)) {}
@@ -47,6 +49,7 @@ public:
     const ss::sstring& script_name() const { return _script_name; }
 
     friend bool operator==(const data_policy&, const data_policy&) = default;
+    auto serde_fields() { return std::tie(_function_name, _script_name); }
 
 private:
     ss::sstring _function_name;


### PR DESCRIPTION
## Cover letter

As we are moving to use serde in multiple redpanda subsystems we need to add `serde` serialization format to most of the types. This PR adds support for serializing types in `cluster` namespace.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

Prerequisite to: 4889
force push: 
- split commits
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->

Depends on #5049 