### PR TITLE
Change alter-config help text to use --delete

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/config.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/config.go
@@ -32,7 +32,7 @@ func NewAlterConfigCommand(fs afero.Fs) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "alter-config [TOPICS...] --set key=value --del key2,key3",
+		Use:   "alter-config [TOPICS...] --set key=value --delete key2,key3",
 		Short: `Set, delete, add, and remove key/value configs for a topic.`,
 		Long: `Set, delete, add, and remove key/value configs for a topic.
 


### PR DESCRIPTION
We used the invalid flag --del in the help text,
it should be --delete instead.

Fixes #5041.