### PR TITLE
cloud_storage: Improve SI cache

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   NAME cloud_storage
   SRCS
     cache_service.cc
+    access_time_tracker.cc
     cache_probe.cc
     topic_manifest.cc
     partition_manifest.cc

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -78,6 +78,16 @@ void access_time_tracker::remove_timestamp(std::string_view key) noexcept {
     }
 }
 
+void access_time_tracker::remove_others(const access_time_tracker& t) {
+    table_t tmp;
+    for (auto it : _table.data) {
+        if (t._table.data.contains(it.first)) {
+            tmp.data.insert(it);
+        }
+    }
+    _table = std::move(tmp);
+}
+
 std::optional<std::chrono::system_clock::time_point>
 access_time_tracker::estimate_timestamp(std::string_view key) const {
     uint32_t hash = xxhash_32(key.data(), key.size());

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/access_time_tracker.h"
+
+#include "serde/serde.h"
+#include "units.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/smp.hh>
+
+#include <absl/container/btree_map.h>
+
+#include <exception>
+#include <variant>
+
+namespace absl {
+
+template<class Key, class Value>
+void write(iobuf& out, const btree_map<Key, Value>& btree) {
+    using serde::write;
+    write(out, static_cast<uint64_t>(btree.size()));
+    for (auto it : btree) {
+        write(out, it.first);
+        write(out, it.second);
+    }
+}
+
+template<class Key, class Value>
+void read_nested(
+  iobuf_parser& in,
+  btree_map<Key, Value>& btree,
+  size_t const bytes_left_limit) {
+    using serde::read_nested;
+    uint64_t sz;
+    read_nested(in, sz, bytes_left_limit);
+    for (auto i = 0UL; i < sz; i++) {
+        Key key;
+        Value value;
+        read_nested(in, key, bytes_left_limit);
+        read_nested(in, value, bytes_left_limit);
+        btree.insert({key, value});
+    }
+}
+
+} // namespace absl
+
+namespace cloud_storage {
+
+void access_time_tracker::add_timestamp(
+  std::string_view key, std::chrono::system_clock::time_point ts) {
+    uint32_t seconds = std::chrono::time_point_cast<std::chrono::seconds>(ts)
+                         .time_since_epoch()
+                         .count();
+    uint32_t hash = xxhash_32(key.data(), key.size());
+    _table.data[hash] = seconds;
+    _dirty = true;
+}
+
+void access_time_tracker::remove_timestamp(std::string_view key) noexcept {
+    try {
+        uint32_t hash = xxhash_32(key.data(), key.size());
+        _table.data.erase(hash);
+        _dirty = true;
+    } catch (...) {
+        vassert(
+          false,
+          "Can't remove key {} from access_time_tracker, exception: {}",
+          key,
+          std::current_exception());
+    }
+}
+
+std::optional<std::chrono::system_clock::time_point>
+access_time_tracker::estimate_timestamp(std::string_view key) const {
+    uint32_t hash = xxhash_32(key.data(), key.size());
+    auto it = _table.data.find(hash);
+    if (it == _table.data.end()) {
+        return std::nullopt;
+    }
+    auto seconds = std::chrono::seconds(it->second);
+    std::chrono::system_clock::time_point ts(seconds);
+    return ts;
+}
+
+iobuf access_time_tracker::to_iobuf() {
+    _dirty = false;
+    return serde::to_iobuf(_table);
+}
+
+void access_time_tracker::from_iobuf(iobuf b) {
+    iobuf_parser parser(std::move(b));
+    _table = serde::read<table_t>(parser);
+    _dirty = false;
+}
+
+bool access_time_tracker::is_dirty() const { return _dirty; }
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/access_time_tracker.h
+++ b/src/v/cloud_storage/access_time_tracker.h
@@ -61,6 +61,9 @@ public:
     /// to disk.
     bool is_dirty() const;
 
+    /// Remove every key which isn't present in 't'
+    void remove_others(const access_time_tracker& t);
+
 private:
     table_t _table;
     bool _dirty{false};

--- a/src/v/cloud_storage/access_time_tracker.h
+++ b/src/v/cloud_storage/access_time_tracker.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "hashing/xx.h"
+#include "seastarx.h"
+#include "serde/envelope.h"
+
+#include <seastar/core/future.hh>
+
+#include <absl/container/btree_map.h>
+
+#include <chrono>
+#include <string_view>
+
+namespace cloud_storage {
+
+/// Access time tracker maintains map from filename hash to
+/// the timestamp that represents the time when the file was
+/// accessed last.
+///
+/// It is possible to have conflicts. In case of conflict
+/// 'add_timestamp' method will overwrite another key. For that
+/// key we will observe larger access time. When one of the
+/// conflicted entries will be deleted another will be deleted
+/// as well. This is OK because the code in the
+/// 'cloud_storage/cache_service' is ready for that.
+class access_time_tracker {
+    using timestamp_t = uint32_t;
+    struct table_t
+      : serde::envelope<table_t, serde::version<0>, serde::compat_version<0>> {
+        absl::btree_map<uint32_t, timestamp_t> data;
+    };
+
+public:
+    /// Add access time to the container.
+    void add_timestamp(
+      std::string_view key, std::chrono::system_clock::time_point ts);
+
+    /// Remove key from the container.
+    void remove_timestamp(std::string_view) noexcept;
+
+    /// Return access time estimate (it can differ if there is a conflict
+    /// on file name hash).
+    std::optional<std::chrono::system_clock::time_point>
+    estimate_timestamp(std::string_view key) const;
+
+    iobuf to_iobuf();
+    void from_iobuf(iobuf b);
+
+    /// Returns true if tracker has new data which wasn't serialized
+    /// to disk.
+    bool is_dirty() const;
+
+private:
+    table_t _table;
+    bool _dirty{false};
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage/access_time_tracker.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -30,7 +31,7 @@ public:
     // recursively walks start_dir, returns the total size of files in this
     // directory and a list of files sorted by access time from oldest to newest
     ss::future<std::pair<uint64_t, std::vector<file_list_item>>>
-    walk(ss::sstring start_dir);
+    walk(ss::sstring start_dir, const access_time_tracker& tracker);
 
 private:
     ss::gate _gate;

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -17,3 +17,12 @@ rp_test(
   ARGS "-- -c 1"
   LABELS cloud_storage
 )
+
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME cloud_storage_bench
+  SOURCES cache_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::cloud_storage
+  LABELS cloud_storage
+)

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -7,7 +7,6 @@ rp_test(
     topic_manifest_test.cc
     s3_imposter.cc
     remote_test.cc
-    cache_test.cc
     offset_translation_layer_test.cc
     remote_segment_test.cc
     remote_partition_test.cc
@@ -18,6 +17,15 @@ rp_test(
   LABELS cloud_storage
 )
 
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_cloud_storage_smp
+  SOURCES
+    cache_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils
+  LABELS cloud_storage
+)
 
 rp_test(
   BENCHMARK_TEST

--- a/src/v/cloud_storage/tests/cache_bench.cc
+++ b/src/v/cloud_storage/tests/cache_bench.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/access_time_tracker.h"
+#include "seastarx.h"
+#include "ssx/sformat.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+static std::chrono::system_clock::time_point make_ts(int64_t val) {
+    auto seconds = std::chrono::seconds(val);
+    return std::chrono::system_clock::time_point(seconds);
+}
+
+static void run_test(int test_scale) {
+    cloud_storage::access_time_tracker tracker;
+    std::vector<ss::sstring> names;
+    for (int i = 0; i < test_scale; i++) {
+        names.push_back(ssx::sformat("name-{}", i));
+    }
+
+    for (int i = 0; i < test_scale; i++) {
+        perf_tests::start_measuring_time();
+        tracker.add_timestamp(names[i % test_scale], make_ts(i));
+        perf_tests::stop_measuring_time();
+    }
+}
+
+PERF_TEST(cache_utils, cm_sketch_1000) { run_test(1000); }
+
+PERF_TEST(cache_utils, cm_sketch_10000) { run_test(10000); }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -47,9 +47,7 @@ public:
     cache_test_fixture()
       : test_dir("test_cache_dir")
       , CACHE_DIR(get_cache_dir(test_dir.get_path())) {
-        sharded_cache
-          .start(CACHE_DIR, 1_MiB + 500_KiB, ss::lowres_clock::duration(1s))
-          .get();
+        sharded_cache.start(CACHE_DIR, 1_MiB + 500_KiB).get();
         sharded_cache
           .invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
           .get();

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 
 #include <boost/filesystem/operations.hpp>
@@ -41,18 +42,21 @@ public:
 
     temporary_dir test_dir;
     const std::filesystem::path CACHE_DIR;
-    cloud_storage::cache cache_service;
+    ss::sharded<cloud_storage::cache> sharded_cache;
 
     cache_test_fixture()
       : test_dir("test_cache_dir")
-      , CACHE_DIR(get_cache_dir(test_dir.get_path()))
-      , cache_service(
-          CACHE_DIR, 1_MiB + 500_KiB, ss::lowres_clock::duration(1s)) {
-        cache_service.start().get();
+      , CACHE_DIR(get_cache_dir(test_dir.get_path())) {
+        sharded_cache
+          .start(CACHE_DIR, 1_MiB + 500_KiB, ss::lowres_clock::duration(1s))
+          .get();
+        sharded_cache
+          .invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
+          .get();
     }
 
     ~cache_test_fixture() {
-        cache_service.stop().get();
+        sharded_cache.stop().get();
         test_dir.remove().get();
     }
 
@@ -68,6 +72,6 @@ public:
         buf.append(data_string.data(), data_string.length());
 
         auto input = make_iobuf_input_stream(std::move(buf));
-        cache_service.put(key, input).get();
+        sharded_cache.local().put(key, input).get();
     }
 };

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -29,9 +29,8 @@ struct cloud_storage_fixture : s3_imposter_fixture {
     cloud_storage_fixture() {
         tmp_directory.create().get();
         constexpr size_t cache_size = 1024 * 1024 * 1024;
-        const ss::lowres_clock::duration cache_duration = 1000s;
 
-        cache.start(tmp_directory.get_path(), cache_size, cache_duration).get();
+        cache.start(tmp_directory.get_path(), cache_size).get();
 
         cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
           .get();

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -30,13 +30,15 @@ struct cloud_storage_fixture : s3_imposter_fixture {
         tmp_directory.create().get();
         constexpr size_t cache_size = 1024 * 1024 * 1024;
         const ss::lowres_clock::duration cache_duration = 1000s;
-        cache = ss::make_shared<cloud_storage::cache>(
-          tmp_directory.get_path(), cache_size, cache_duration);
-        cache->start().get();
+
+        cache.start(tmp_directory.get_path(), cache_size, cache_duration).get();
+
+        cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
+          .get();
     }
 
     ~cloud_storage_fixture() {
-        cache->stop().get();
+        cache.stop().get();
         tmp_directory.remove().get();
     }
 
@@ -46,5 +48,5 @@ struct cloud_storage_fixture : s3_imposter_fixture {
     cloud_storage_fixture operator=(cloud_storage_fixture&&) = delete;
 
     ss::tmp_dir tmp_directory;
-    ss::shared_ptr<cloud_storage::cache> cache;
+    ss::sharded<cloud_storage::cache> cache;
 };

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -328,7 +328,7 @@ static model::record_batch_header read_single_batch_from_remote_partition(
     auto manifest = hydrate_manifest(api, bucket);
 
     auto partition = ss::make_lw_shared<remote_partition>(
-      manifest, api, *fixture.cache, bucket);
+      manifest, api, fixture.cache.local(), bucket);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     auto reader = partition->make_reader(reader_config).get().reader;
@@ -358,7 +358,7 @@ static std::vector<model::record_batch_header> scan_remote_partition(
     auto manifest = hydrate_manifest(api, bucket);
 
     auto partition = ss::make_lw_shared<remote_partition>(
-      manifest, api, *imposter.cache, bucket);
+      manifest, api, imposter.cache.local(), bucket);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     partition->start().get();
@@ -891,7 +891,7 @@ scan_remote_partition_incrementally(
 
     auto manifest = hydrate_manifest(api, bucket);
     auto partition = ss::make_lw_shared<remote_partition>(
-      manifest, api, *imposter.cache, bucket);
+      manifest, api, imposter.cache.local(), bucket);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     partition->start().get();
@@ -1021,7 +1021,7 @@ FIXTURE_TEST(test_remote_partition_read_cached_index, cloud_storage_fixture) {
     // After this block finishes the segment will be hydrated.
     {
         auto partition = ss::make_lw_shared<remote_partition>(
-          manifest, api, *cache, bucket);
+          manifest, api, cache.local(), bucket);
         auto partition_stop = ss::defer(
           [&partition] { partition->stop().get(); });
         partition->start().get();
@@ -1042,7 +1042,7 @@ FIXTURE_TEST(test_remote_partition_read_cached_index, cloud_storage_fixture) {
     // This will trigger offset_index materialization from cache.
     {
         auto partition = ss::make_lw_shared<remote_partition>(
-          manifest, api, *cache, bucket);
+          manifest, api, cache.local(), bucket);
         auto partition_stop = ss::defer(
           [&partition] { partition->stop().get(); });
         partition->start().get();

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -97,7 +97,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(upl_res == upload_result::success);
     m.add(key, meta);
 
-    remote_segment segment(remote, *cache, bucket, m, key, fib);
+    remote_segment segment(remote, cache.local(), bucket, m, key, fib);
     auto reader_handle
       = segment.data_stream(0, ss::default_priority_class()).get();
 
@@ -132,7 +132,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
         .ntp_revision = manifest_revision});
 
     retry_chain_node fib(100ms, 20ms);
-    remote_segment segment(remote, *cache, bucket, m, key, fib);
+    remote_segment segment(remote, cache.local(), bucket, m, key, fib);
     BOOST_REQUIRE_THROW(
       segment.data_stream(0, ss::default_priority_class()).get(),
       download_exception);
@@ -172,7 +172,7 @@ FIXTURE_TEST(
     storage::log_reader_config reader_config(
       model::offset(1), model::offset(1), ss::default_priority_class());
     auto segment = ss::make_lw_shared<remote_segment>(
-      remote, *cache, bucket, m, key, fib);
+      remote, cache.local(), bucket, m, key, fib);
     partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(segment, reader_config, probe);
     storage::offset_translator_state ot_state(m.get_ntp());
@@ -261,7 +261,7 @@ void test_remote_segment_batch_reader(
       begin, end, ss::default_priority_class());
     reader_config.max_bytes = std::numeric_limits<size_t>::max();
     auto segment = ss::make_lw_shared<remote_segment>(
-      remote, *fixture.cache, bucket, m, key, fib);
+      remote, fixture.cache.local(), bucket, m, key, fib);
     partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(segment, reader_config, probe);
     storage::offset_translator_state ot_state(m.get_ntp());
@@ -364,7 +364,7 @@ FIXTURE_TEST(
     m.add(key, meta);
 
     auto segment = ss::make_lw_shared<remote_segment>(
-      remote, *cache, bucket, m, key, fib);
+      remote, cache.local(), bucket, m, key, fib);
 
     partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -782,11 +782,7 @@ void application::wire_up_redpanda_services() {
         }
         auto cache_size
           = config::shard_local_cfg().cloud_storage_cache_size.value();
-        auto cache_interval = config::shard_local_cfg()
-                                .cloud_storage_cache_check_interval_ms.value();
-        construct_service(
-          shadow_index_cache, cache_dir, cache_size, cache_interval)
-          .get();
+        construct_service(shadow_index_cache, cache_dir, cache_size).get();
 
         shadow_index_cache
           .invoke_on_all(


### PR DESCRIPTION
## Cover letter

Implement access time tracking and precise size calculation in SI cache.

There are two parts:
- access time maintenance
- size maintenance

Access times are stored on shard 0 in a compact data structure which is flushed to disk periodically. It's stored in cache directory and hydrated on startup. The cache size maintenance is done cooperatively by all shards but eviction is performed on core 0.

On every file access every shard calls back to shard 0 to update access time.
On every put operation every shard calls back to shard 0 to update occupied disk space.

Shard 0 makes decision to run eviction loop and also maintains the access times.

#### Access time tracker

This is a data structure that holds the state needed to track access times. Access times might not be supported by the FS (depends on mount options). The common practice is to disable access time handling for performance reasons. So we need to maintains that ourselves. 

The tracker stores hashes of names instead of the actual file names. This is done to save space. The tracker can also be serialized and saved to disk.

#### Manual intervention

Currently, the SI cache survives the manual deletion of files. This is an important feature that allows support engineers to quickly solve disk space issues by nuking the SI cache dir. The updated version also allows this. The tracker creates a problem in this case. If files were deleted from cache manually, the information about them will still be kept in tracker. To avoid this the tracker is cleaned from stale entries on every scan (during first startup and when cache eviction runs).

#### Size tracking

Previously, the size tracking were performed by periodic scans. In this PR this logic is replaced with size tracking. Every time when redpanda downloads something to SI cache dir it updates an internal size estimate. When this estimate goes above the threshold the eviction starts.

This alg. has the same problem as the access time tracking. If the user removes files manually the size estimate becomes incorrect. To avoid this the estimate gets updated on every dir scan (eviction or startup).

## Release notes


* Improve shadow-indexing cache

### Features

* Shadow indexing cache can no longer grow larger than configured size.
