### PR TITLE
read_replica: Download manifest for read replica

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -92,6 +92,7 @@ v_cc_library(
     feature_barrier.cc
     feature_table.cc
     drain_manager.cc
+    read_replica_manager.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -180,7 +180,8 @@ ss::future<> controller::start() {
             std::ref(_partition_leaders),
             std::ref(_tp_state),
             std::ref(_data_policy_frontend),
-            std::ref(_as));
+            std::ref(_as),
+            std::ref(_cloud_storage_api));
       })
       .then([this] {
           return _members_backend.start_single(

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -57,7 +57,8 @@ controller::controller(
   ss::sharded<storage::api>& storage,
   ss::sharded<storage::node_api>& storage_node,
   ss::sharded<raft::group_manager>& raft_manager,
-  ss::sharded<v8_engine::data_policy_table>& data_policy_table)
+  ss::sharded<v8_engine::data_policy_table>& data_policy_table,
+  ss::sharded<cloud_storage::remote>& cloud_storage_api)
   : _config_preload(std::move(config_preload))
   , _connections(ccache)
   , _partition_manager(pm)
@@ -67,7 +68,8 @@ controller::controller(
   , _tp_updates_dispatcher(_partition_allocator, _tp_state, _partition_leaders)
   , _security_manager(_credentials, _authorizer)
   , _data_policy_manager(data_policy_table)
-  , _raft_manager(raft_manager) {}
+  , _raft_manager(raft_manager)
+  , _cloud_storage_api(cloud_storage_api) {}
 
 ss::future<> controller::wire_up() {
     return _as.start()

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -37,7 +37,8 @@ public:
       ss::sharded<storage::api>& storage,
       ss::sharded<storage::node_api>& storage_node,
       ss::sharded<raft::group_manager>&,
-      ss::sharded<v8_engine::data_policy_table>&);
+      ss::sharded<v8_engine::data_policy_table>&,
+      ss::sharded<cloud_storage::remote>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
@@ -154,6 +155,7 @@ private:
     ss::sharded<feature_table> _feature_table;     // instance per core
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
+    ss::sharded<cloud_storage::remote>& _cloud_storage_api;
 };
 
 } // namespace cluster

--- a/src/v/cluster/read_replica_manager.cc
+++ b/src/v/cluster/read_replica_manager.cc
@@ -1,0 +1,55 @@
+#include "cluster/read_replica_manager.h"
+
+#include "cloud_storage/topic_manifest.h"
+#include "cluster/logger.h"
+#include "config/configuration.h"
+#include "s3/client.h"
+
+namespace cluster {
+
+read_replica_manager::read_replica_manager(cloud_storage::remote& remote)
+  : _remote(remote) {}
+
+ss::future<errc> read_replica_manager::set_remote_properties_in_config(
+  custom_assignable_topic_configuration& cfg,
+  const s3::bucket_name& bucket,
+  ss::abort_source& as) {
+    cloud_storage::topic_manifest manifest;
+
+    auto timeout
+      = config::shard_local_cfg().cloud_storage_manifest_upload_timeout_ms();
+    auto backoff = config::shard_local_cfg().cloud_storage_initial_backoff_ms();
+    retry_chain_node rc_node(as, timeout, backoff);
+
+    model::ns ns = cfg.cfg.tp_ns.ns;
+    model::topic topic = cfg.cfg.tp_ns.tp;
+    cloud_storage::remote_manifest_path key
+      = cloud_storage::topic_manifest::get_topic_manifest_path(ns, topic);
+
+    auto res = co_await _remote.download_manifest(
+      bucket, key, manifest, rc_node);
+
+    if (res != cloud_storage::download_result::success) {
+        vlog(
+          clusterlog.warn,
+          "Could not download topic manifest {} from bucket {}: {}",
+          key,
+          bucket,
+          res);
+        co_return errc::topic_operation_error;
+    }
+
+    if (!manifest.get_topic_config()) {
+        vlog(
+          clusterlog.warn,
+          "Topic manifest {} doesn't contain topic config",
+          key);
+        co_return errc::topic_operation_error;
+    } else {
+        cfg.cfg.properties.remote_topic_properties = remote_topic_properties(
+          manifest.get_revision(),
+          manifest.get_topic_config()->partition_count);
+    }
+    co_return errc::success;
+}
+} // namespace cluster

--- a/src/v/cluster/read_replica_manager.h
+++ b/src/v/cluster/read_replica_manager.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cloud_storage/remote.h"
+#include "s3/client.h"
+
+#include <seastar/core/abort_source.hh>
+
+namespace cluster {
+
+class read_replica_manager {
+public:
+    read_replica_manager(cloud_storage::remote&);
+
+    /**
+     * Download remote topic manifest and set remote_properties to cfg.
+     *
+     * @param cfg custom_assignable_topic_configuration that will be changed
+     * @param bucket s3 bucket where the topic manifeset will be downloaded from
+     * @param as abourt source that caller can use request abort
+     */
+    ss::future<errc> set_remote_properties_in_config(
+      custom_assignable_topic_configuration& cfg,
+      const s3::bucket_name& bucket,
+      ss::abort_source& as);
+
+private:
+    cloud_storage::remote& _remote;
+};
+
+} // namespace cluster

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -11,10 +11,12 @@
 
 #pragma once
 
+#include "cloud_storage/remote.h"
 #include "cluster/controller_stm.h"
 #include "cluster/data_policy_frontend.h"
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
+#include "cluster/read_replica_manager.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/topic_table.h"
 #include "model/metadata.h"
@@ -41,7 +43,8 @@ public:
       ss::sharded<partition_leaders_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<data_policy_frontend>&,
-      ss::sharded<ss::abort_source>&);
+      ss::sharded<ss::abort_source>&,
+      ss::sharded<cloud_storage::remote>&);
 
     ss::future<std::vector<topic_result>> create_topics(
       std::vector<custom_assignable_topic_configuration>,
@@ -133,6 +136,7 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<data_policy_frontend>& _dp_frontend;
     ss::sharded<ss::abort_source>& _as;
+    ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     bool _partition_movement_disabled = false;
 };
 

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -302,28 +302,6 @@ FIXTURE_TEST(create_non_replicable_topics, create_topic_fixture) {
     BOOST_CHECK(resp[1].tp_ns.tp() == "topic2");
 }
 
-// read replica creation is not implemented yet, see
-// https://github.com/redpanda-data/redpanda/issues/4736
-FIXTURE_TEST(create_read_replica_topics, create_topic_fixture) {
-    auto topic = make_topic(
-      "topic1",
-      std::nullopt,
-      std::nullopt,
-      std::map<ss::sstring, ss::sstring>{
-        {"redpanda.remote.readreplica", "true"},
-        {"redpanda.remote.readreplica.bucket", "panda-bucket"}});
-
-    auto req = make_req({topic});
-
-    auto client = make_kafka_client().get0();
-    client.connect().get();
-    auto resp = client.dispatch(req, kafka::api_version(2)).get0();
-
-    BOOST_CHECK(
-      resp.data.topics[0].error_code == kafka::error_code::invalid_config);
-    BOOST_CHECK(resp.data.topics[0].name == "topic1");
-}
-
 FIXTURE_TEST(s3bucket_is_missing, create_topic_fixture) {
     auto topic = make_topic(
       "topic1",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -707,7 +707,8 @@ void application::wire_up_redpanda_services() {
       storage,
       storage_node,
       std::ref(raft_group_manager),
-      data_policies);
+      data_policies,
+      std::ref(cloud_storage_api));
 
     controller->wire_up().get0();
     syschecks::systemd_message("Creating kafka metadata cache").get();


### PR DESCRIPTION
## Cover letter

This PR adds read replica manager that is responsible for downloading topic manifest for
read replica topic, adding remote revision id and remote partition count
to topic configuration before topic is created.

Context: https://github.com/redpanda-data/redpanda/issues/4993

## Release notes

* none
