### PR TITLE
model: Refactor adl<timeout_clock>

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -641,23 +641,6 @@ adl<cluster::create_topics_reply>::from(iobuf_parser& in) {
       std::move(results), std::move(md), std::move(cfg)};
 }
 
-void adl<model::timeout_clock::duration>::to(iobuf& out, duration dur) {
-    // This is a clang bug that cause ss::cpu_to_le to become ambiguous
-    // because rep has type of long long
-    // adl<rep>{}.to(out, dur.count());
-    adl<uint64_t>{}.to(
-      out, std::chrono::duration_cast<std::chrono::milliseconds>(dur).count());
-}
-
-model::timeout_clock::duration
-adl<model::timeout_clock::duration>::from(iobuf_parser& in) {
-    // This is a clang bug that cause ss::cpu_to_le to become ambiguous
-    // because rep has type of long long
-    // auto rp = adl<rep>{}.from(in);
-    auto rp = adl<uint64_t>{}.from(in);
-    return std::chrono::duration_cast<duration>(std::chrono::milliseconds{rp});
-}
-
 void adl<cluster::topic_configuration_assignment>::to(
   iobuf& b, cluster::topic_configuration_assignment&& assigned_cfg) {
     reflection::serialize(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -993,15 +993,6 @@ struct is_error_code_enum<cluster::tx_errc> : true_type {};
 namespace reflection {
 
 template<>
-struct adl<model::timeout_clock::duration> {
-    using rep = model::timeout_clock::rep;
-    using duration = model::timeout_clock::duration;
-
-    void to(iobuf& out, duration dur);
-    duration from(iobuf_parser& in);
-};
-
-template<>
 struct adl<cluster::topic_configuration> {
     void to(iobuf&, cluster::topic_configuration&&);
     cluster::topic_configuration from(iobuf_parser&);

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -15,6 +15,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "model/timeout_clock.h"
 #include "reflection/adl.h"
 #include "tristate.h"
 
@@ -23,6 +24,21 @@
 #include <seastar/net/socket_defs.hh>
 
 namespace reflection {
+
+template<>
+struct adl<model::timeout_clock::duration> {
+    using duration = model::timeout_clock::duration;
+
+    void to(iobuf& out, duration dur) {
+        adl<std::chrono::milliseconds>{}.to(
+          out, std::chrono::duration_cast<std::chrono::milliseconds>(dur));
+    }
+
+    model::timeout_clock::duration from(iobuf_parser& in) {
+        return std::chrono::duration_cast<duration>(
+          adl<std::chrono::milliseconds>{}.from(in));
+    }
+};
 
 template<>
 struct adl<model::topic> {

--- a/src/v/model/tests/CMakeLists.txt
+++ b/src/v/model/tests/CMakeLists.txt
@@ -18,8 +18,9 @@ rp_test(
     lexical_cast_tests.cc
     ntp_path_test.cc
     topic_view_tests.cc
+    timeout_adl.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::model
+  LIBRARIES Boost::unit_test_framework v::model v::cluster
   LABELS model
 )
 

--- a/src/v/model/tests/CMakeLists.txt
+++ b/src/v/model/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ rp_test(
     topic_view_tests.cc
     timeout_adl.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::model v::cluster
+  LIBRARIES Boost::unit_test_framework v::model
   LABELS model
 )
 

--- a/src/v/model/tests/timeout_adl.cc
+++ b/src/v/model/tests/timeout_adl.cc
@@ -1,0 +1,36 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf_parser.h"
+#include "cluster/types.h"
+#include "model/timeout_clock.h"
+#include "reflection/adl.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+BOOST_AUTO_TEST_CASE(test_timeout_clock_is_ms_1) {
+    const model::timeout_clock::duration d{std::chrono::milliseconds{-16}};
+    iobuf buf;
+    reflection::adl<model::timeout_clock::duration>{}.to(buf, d);
+    iobuf_parser p{buf.share(0, buf.size_bytes())};
+    auto res = reflection::adl<std::chrono::milliseconds>{}.from(p);
+    BOOST_REQUIRE_EQUAL(res, d);
+};
+
+BOOST_AUTO_TEST_CASE(test_timeout_clock_is_ms_2) {
+    model::timeout_clock::duration d{std::chrono::milliseconds{16}};
+    iobuf buf;
+    reflection::adl<std::chrono::milliseconds>{}.to(
+      buf, std::chrono::duration_cast<std::chrono::milliseconds>(d));
+    iobuf_parser p{buf.share(0, buf.size_bytes())};
+    auto res = reflection::adl<model::timeout_clock::duration>{}.from(p);
+    BOOST_REQUIRE_EQUAL(res, d);
+};

--- a/src/v/model/tests/timeout_adl.cc
+++ b/src/v/model/tests/timeout_adl.cc
@@ -8,9 +8,10 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/iobuf_parser.h"
-#include "cluster/types.h"
+#include "model/adl_serde.h"
 #include "model/timeout_clock.h"
 #include "reflection/adl.h"
+#include "utils/to_string.h"
 
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
## Cover letter

* Move the implementation to where other adl types are implemented for `namespace model`.
* Refactor the implementation over `adl<std::chrono::milliseconds>`

## Release notes

* none