### PR TITLE
[v21.11.x] admin_server: redact configs in admin API

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -142,7 +142,7 @@ ss::future<> config_manager::do_bootstrap() {
           if (!p.is_default()) {
               rapidjson::StringBuffer buf;
               rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-              p.to_json(writer);
+              p.to_json(writer, config::redact_secrets::no);
               ss::sstring key_str(p.name());
               ss::sstring val_str = buf.GetString();
               vlog(clusterlog.info, "Importing property {}", p);

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -32,6 +32,10 @@ using required = ss::bool_class<struct required_tag>;
 using needs_restart = ss::bool_class<struct needs_restart_tag>;
 using is_secret = ss::bool_class<struct is_secret_tag>;
 
+// Whether to redact secrets. If true, `secret_placeholder` should be used
+// instead of the config value.
+using redact_secrets = ss::bool_class<struct redact_secrets_tag>;
+
 enum class visibility {
     // Tunables can be set by the user, but they control implementation
     // details like (e.g. buffer sizes, queue lengths)
@@ -75,7 +79,7 @@ public:
     // performed in config_store::to_json where the json object key is taken
     // from the property name.
     virtual void
-    to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const = 0;
+    to_json(rapidjson::Writer<rapidjson::StringBuffer>& w, redact_secrets redact) const = 0;
 
     virtual void print(std::ostream&) const = 0;
     virtual bool set_value(YAML::Node) = 0;

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -73,12 +73,12 @@ public:
         return errors;
     }
 
-    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const {
+    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w, redact_secrets redact) const {
         w.StartObject();
 
         for (const auto& [name, property] : _properties) {
             w.Key(name.data(), name.size());
-            property->to_json(w);
+            property->to_json(w, redact);
         }
 
         w.EndObject();
@@ -100,10 +100,10 @@ private:
     std::unordered_map<std::string_view, base_property*> _properties;
 };
 
-inline YAML::Node to_yaml(const config_store& cfg) {
+inline YAML::Node to_yaml(const config_store& cfg, redact_secrets redact) {
     rapidjson::StringBuffer buf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-    cfg.to_json(writer);
+    cfg.to_json(writer, redact);
     return YAML::Load(buf.GetString());
 }
 }; // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -94,7 +94,7 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const override {
+    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w, redact_secrets) const override {
         json::rjson_serialize(w, _value);
     }
 
@@ -360,7 +360,7 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const final {
+    void to_json(rapidjson::Writer<rapidjson::StringBuffer>& w, redact_secrets) const final {
         json::rjson_serialize(w, _value.value_or(-1ms));
     }
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -234,7 +234,7 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
     // cfg -> json string
     rapidjson::StringBuffer cfg_sb;
     rapidjson::Writer<rapidjson::StringBuffer> cfg_writer(cfg_sb);
-    cfg.to_json(cfg_writer);
+    cfg.to_json(cfg_writer, config::redact_secrets::no);
     auto jstr = cfg_sb.GetString();
 
     // json string -> rapidjson doc

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -36,6 +36,8 @@ struct test_config : public config::config_store {
     config::property<std::chrono::seconds> seconds;
     config::property<std::optional<std::chrono::seconds>> optional_seconds;
     config::property<std::chrono::milliseconds> milliseconds;
+    config::property<ss::sstring> secret_string;
+    config::property<ss::sstring> default_secret_string;
 
     test_config()
       : optional_int(
@@ -92,7 +94,17 @@ struct test_config : public config::config_store {
           "milliseconds",
           "Plain milliseconds",
           config::required::no,
-          {}) {}
+          {})
+      , default_secret_string(
+          *this,
+          "default_secret_string",
+          "Secret string value set to the default",
+          {.secret = config::is_secret::yes})
+      , secret_string(
+          *this,
+          "secret_string",
+          "Secret string value",
+          {.secret = config::is_secret::yes}) {}
 };
 
 YAML::Node minimal_valid_configuration() {
@@ -114,7 +126,8 @@ YAML::Node valid_configuration() {
                       " - one\n"
                       " - two\n"
                       " - three\n"
-                      "nullable_int: 111\n");
+                      "nullable_int: 111\n"
+                      "secret_string: actual_secret\n");
 }
 
 } // namespace
@@ -189,6 +202,7 @@ SEASTAR_THREAD_TEST_CASE(read_valid_configuration) {
     BOOST_TEST(cfg.strings().at(1) == "two");
     BOOST_TEST(cfg.strings().at(2) == "three");
     BOOST_TEST(cfg.nullable_int() == std::make_optional(111));
+    BOOST_TEST(cfg.secret_string() == "actual_secret");
 };
 
 SEASTAR_THREAD_TEST_CASE(update_property_value) {
@@ -215,67 +229,91 @@ SEASTAR_THREAD_TEST_CASE(validate_invalid_configuration) {
 }
 
 SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
-    auto cfg = test_config();
-    cfg.read_yaml(valid_configuration());
-    lg.info("Config: {}", cfg);
-    // json data
-    const char* expected_result = "{"
-                                  "\"strings\": [\"one\", \"two\", \"three\"],"
-                                  "\"an_int64_t\": 55,"
-                                  "\"optional_int\": 3,"
-                                  "\"an_aggregate\": {"
-                                  "\"string_value\": \"some_value\","
-                                  "\"int_value\": 88"
-                                  "},"
-                                  "\"required_string\": \"test_value_2\","
-                                  "\"nullable_int\": 111"
-                                  "}";
+    const auto test_with_redaction = [](config::redact_secrets redact) {
+        auto cfg = test_config();
+        cfg.read_yaml(valid_configuration());
+        lg.info("Config: {}", cfg);
+        // json data
+        // TODO: get this to work with fmt.
+        auto expected_result = redact == config::redact_secrets::yes
+                                 ? "{"
+                                   "\"strings\": [\"one\", \"two\", \"three\"],"
+                                   "\"an_int64_t\": 55,"
+                                   "\"optional_int\": 3,"
+                                   "\"an_aggregate\": {"
+                                   "\"string_value\": \"some_value\","
+                                   "\"int_value\": 88"
+                                   "},"
+                                   "\"required_string\": \"test_value_2\","
+                                   "\"nullable_int\": 111,"
+                                   "\"default_secret_string\": \"\","
+                                   "\"secret_string\": \"[secret]\""
+                                   "}"
+                                 : "{"
+                                   "\"strings\": [\"one\", \"two\", \"three\"],"
+                                   "\"an_int64_t\": 55,"
+                                   "\"optional_int\": 3,"
+                                   "\"an_aggregate\": {"
+                                   "\"string_value\": \"some_value\","
+                                   "\"int_value\": 88"
+                                   "},"
+                                   "\"required_string\": \"test_value_2\","
+                                   "\"nullable_int\": 111,"
+                                   "\"default_secret_string\": \"\","
+                                   "\"secret_string\": \"actual_secret\""
+                                   "}";
 
-    // cfg -> json string
-    rapidjson::StringBuffer cfg_sb;
-    rapidjson::Writer<rapidjson::StringBuffer> cfg_writer(cfg_sb);
-    cfg.to_json(cfg_writer, config::redact_secrets::no);
-    auto jstr = cfg_sb.GetString();
+        // cfg -> json string
+        rapidjson::StringBuffer cfg_sb;
+        rapidjson::Writer<rapidjson::StringBuffer> cfg_writer(cfg_sb);
+        cfg.to_json(cfg_writer, redact);
+        auto jstr = cfg_sb.GetString();
 
-    // json string -> rapidjson doc
-    rapidjson::Document res_doc;
-    res_doc.Parse(jstr);
+        // json string -> rapidjson doc
+        rapidjson::Document res_doc;
+        res_doc.Parse(jstr);
 
-    // json string -> rapidjson doc
-    rapidjson::Document exp_doc;
-    exp_doc.Parse(expected_result);
+        // json string -> rapidjson doc
+        rapidjson::Document exp_doc;
+        exp_doc.Parse(expected_result);
 
-    // test equivalence
-    BOOST_TEST(res_doc["required_string"].IsString());
-    BOOST_TEST(
-      res_doc["required_string"].GetString()
-      == exp_doc["required_string"].GetString());
+        // test equivalence
+        BOOST_TEST(res_doc["required_string"].IsString());
+        BOOST_TEST(
+          res_doc["required_string"].GetString()
+          == exp_doc["required_string"].GetString());
 
-    BOOST_TEST(res_doc["optional_int"].IsInt());
-    BOOST_TEST(
-      res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
+        BOOST_TEST(res_doc["optional_int"].IsInt());
+        BOOST_TEST(
+          res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
 
-    BOOST_TEST(res_doc["an_int64_t"].IsInt64());
-    BOOST_TEST(
-      res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
+        BOOST_TEST(res_doc["an_int64_t"].IsInt64());
+        BOOST_TEST(
+          res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
 
-    BOOST_TEST(res_doc["an_aggregate"].IsObject());
+        BOOST_TEST(res_doc["an_aggregate"].IsObject());
 
-    BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
-    BOOST_TEST(
-      res_doc["an_aggregate"]["int_value"].GetInt()
-      == exp_doc["an_aggregate"]["int_value"].GetInt());
+        BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
+        BOOST_TEST(
+          res_doc["an_aggregate"]["int_value"].GetInt()
+          == exp_doc["an_aggregate"]["int_value"].GetInt());
 
-    BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
-    BOOST_TEST(
-      res_doc["an_aggregate"]["string_value"].GetString()
-      == exp_doc["an_aggregate"]["string_value"].GetString());
+        BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
+        BOOST_TEST(
+          res_doc["an_aggregate"]["string_value"].GetString()
+          == exp_doc["an_aggregate"]["string_value"].GetString());
 
-    BOOST_TEST(res_doc["strings"].IsArray());
+        BOOST_TEST(res_doc["strings"].IsArray());
 
-    BOOST_TEST(res_doc["nullable_int"].IsInt());
-    BOOST_TEST(
-      res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
+        BOOST_TEST(res_doc["nullable_int"].IsInt());
+        BOOST_TEST(
+          res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
+        BOOST_TEST(
+          res_doc["secret_string"].GetString()
+          == exp_doc["secret_string"].GetString());
+    };
+    test_with_redaction(config::redact_secrets::yes);
+    test_with_redaction(config::redact_secrets::no);
 }
 
 /// Test that unset std::optional options are decoded correctly

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -40,7 +40,7 @@ kafka::client::client make_client() {
     cfg.brokers.set_value(
       std::vector<unresolved_address>{config::node().kafka_api()[0].address});
     cfg.retries.set_value(size_t(1));
-    return kafka::client::client{to_yaml(cfg)};
+    return kafka::client::client{to_yaml(cfg, config::redact_secrets::no)};
 }
 
 } // namespace

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -41,7 +41,8 @@ std::unique_ptr<kafka::client::client> make_client() {
     cfg.retries.set_value(size_t(5));
     cfg.retry_base_backoff.set_value(10ms);
     cfg.produce_batch_delay.set_value(0ms);
-    return std::make_unique<kafka::client::client>(to_yaml(cfg));
+    return std::make_unique<kafka::client::client>(
+      to_yaml(cfg, config::redact_secrets::no));
 }
 
 } // namespace

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -40,11 +40,12 @@ api::~api() noexcept = default;
 ss::future<> api::start() {
     _store = std::make_unique<sharded_store>();
     co_await _store->start(_sg);
-    co_await _client.start(config::to_yaml(_client_cfg));
+    co_await _client.start(
+      config::to_yaml(_client_cfg, config::redact_secrets::no));
     co_await _sequencer.start(
       _node_id, _sg, std::ref(_client), std::ref(*_store));
     co_await _service.start(
-      config::to_yaml(_cfg),
+      config::to_yaml(_cfg, config::redact_secrets::no),
       _sg,
       _max_memory,
       std::ref(_client),

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -68,7 +68,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     // (which itself is only instantiated to receive consume_to_store's
     //  offset updates), is just needed for constructor;
     ss::sharded<kafka::client::client> dummy_kafka_client;
-    dummy_kafka_client.start(to_yaml(kafka::client::configuration{})).get();
+    dummy_kafka_client
+      .start(
+        to_yaml(kafka::client::configuration{}, config::redact_secrets::no))
+      .get();
     auto stop_kafka_client = ss::defer(
       [&dummy_kafka_client]() { dummy_kafka_client.stop().get(); });
 

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -85,7 +85,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     // (which itself is only instantiated to receive consume_to_store's
     //  offset updates), is just needed for constructor;
     ss::sharded<kafka::client::client> dummy_kafka_client;
-    dummy_kafka_client.start(to_yaml(kafka::client::configuration{})).get();
+    dummy_kafka_client
+      .start(
+        to_yaml(kafka::client::configuration{}, config::redact_secrets::no))
+      .get();
     auto stop_kafka_client = ss::defer(
       [&dummy_kafka_client]() { dummy_kafka_client.stop().get(); });
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -423,7 +423,7 @@ void admin_server::register_config_routes() {
       []([[maybe_unused]] ss::const_req req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-          config::shard_local_cfg().to_json(writer, config::redact_secrets::no);
+          config::shard_local_cfg().to_json(writer, config::redact_secrets::yes);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
@@ -439,7 +439,7 @@ void admin_server::register_config_routes() {
       []([[maybe_unused]] ss::const_req req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-          config::node().to_json(writer, config::redact_secrets::no);
+          config::node().to_json(writer, config::redact_secrets::yes);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -423,7 +423,7 @@ void admin_server::register_config_routes() {
       []([[maybe_unused]] ss::const_req req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-          config::shard_local_cfg().to_json(writer);
+          config::shard_local_cfg().to_json(writer, config::redact_secrets::no);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";
@@ -439,7 +439,7 @@ void admin_server::register_config_routes() {
       []([[maybe_unused]] ss::const_req req, ss::reply& reply) {
           rapidjson::StringBuffer buf;
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-          config::node().to_json(writer);
+          config::node().to_json(writer, config::redact_secrets::no);
 
           reply.set_status(ss::httpd::reply::status_type::ok, buf.GetString());
           return "";

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -551,10 +551,13 @@ void application::wire_up_services() {
         wire_up_redpanda_services();
     }
     if (_proxy_config) {
-        construct_service(_proxy_client, to_yaml(*_proxy_client_config)).get();
+        construct_service(
+          _proxy_client,
+          to_yaml(*_proxy_client_config, config::redact_secrets::no))
+          .get();
         construct_service(
           _proxy,
-          to_yaml(*_proxy_config),
+          to_yaml(*_proxy_config, config::redact_secrets::no),
           smp_service_groups.proxy_smp_sg(),
           // TODO: Improve memory budget for services
           // https://github.com/vectorizedio/redpanda/issues/1392

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -186,7 +186,7 @@ public:
         cfg.get("pandaproxy_api")
           .set_value(std::vector<model::broker_endpoint>{model::broker_endpoint(
             unresolved_address("127.0.0.1", proxy_port))});
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     YAML::Node proxy_client_config(
@@ -195,7 +195,7 @@ public:
         unresolved_address kafka_api{
           config::node().kafka_api()[0].address.host(), kafka_api_port};
         cfg.brokers.set_value(std::vector<unresolved_address>({kafka_api}));
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     YAML::Node schema_reg_config(uint16_t listen_port = 8081) {
@@ -205,7 +205,7 @@ public:
             unresolved_address("127.0.0.1", listen_port))});
         cfg.get("schema_registry_replication_factor")
           .set_value(std::make_optional<int16_t>(1));
-        return to_yaml(cfg);
+        return to_yaml(cfg, config::redact_secrets::no);
     }
 
     ss::future<> wait_for_controller_leadership() {


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5024.

### Cover letter

Previously the admin API would send over unredacted configs. While the endpoint is only authorized to superusers, this is not a good practice.

This PR adds the option to redact property::to_json(), and by extension, its callers like to_yaml(). All config requests in the admin API now redact their JSON, replacing the contents with a "[secret]" hardcoded string.

An important side effect of this redaction: rpk no longer knows about the existing values of sensitive properties. This means that it can no longer, e.g. tell the difference between an old secret property and a new one. To maintain existing behavior, Importing same exact configs that already exist will now be deduplicated by the admin server, and will return the current config version upon no-op, rather than replicating a new version.

NOTE: While currently this option is not used for existing calls to to_yaml(), I opted to force users to explicitly declare whether they want to redact, if anything, to force us to re-examine where it's being used today.

### Conflicts
- `rpk edit,export,import` don't exist on this branch, so the changes focused around `rpk` usage (e.g. catching `[secret]` values) are no longer needed.
- `patch_cluster_config` is only enabled if `enable_central_config=True`, so any concerns around patching aren't relevant (e.g. no-oping when patching a duplicate value).