### PR TITLE
Log startup failure message at ERROR level

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -213,7 +213,7 @@ int application::run(int ac, char** av) {
                 vlog(_log.info, "Stopping...");
             } catch (...) {
                 vlog(
-                  _log.info,
+                  _log.error,
                   "Failure during startup: {}",
                   std::current_exception());
                 return 1;

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -243,6 +243,13 @@ class FeaturesSingleNodeTest(FeaturesTestBase):
                    backoff_sec=1)
 
 
+OLD_NODE_JOIN_LOG_ALLOW_LIST = [
+    # We expect startup failure when an old node joins, so we allow the corresponding
+    # error message.
+    r'Failure during startup: seastar::abort_requested_exception \(abort requested\)'
+]
+
+
 class FeaturesNodeJoinTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, num_brokers=4, **kwargs)
@@ -253,7 +260,7 @@ class FeaturesNodeJoinTest(RedpandaTest):
         # We will start nodes by hand during test.
         pass
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4, log_allow_list=OLD_NODE_JOIN_LOG_ALLOW_LIST)
     def test_old_node_join(self):
         """
         Verify that when an old-versioned node tries to join a newer-versioned cluster,

--- a/tests/rptest/tests/node_resize_test.py
+++ b/tests/rptest/tests/node_resize_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
+
 from ducktape.cluster.cluster import ClusterNode
 
 from rptest.clients.types import TopicSpec
@@ -14,6 +16,12 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
+
+RESIZE_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
+    re.compile("Decreasing redpanda core count is not allowed"),
+    re.compile(
+        "Failure during startup: cluster::configuration_invariants_changed")
+]
 
 
 class NodeResizeTest(RedpandaTest):
@@ -51,9 +59,7 @@ class NodeResizeTest(RedpandaTest):
             self.redpanda.start_node(node)
             self.logger.info("As expected, redpanda started successfully")
 
-    @cluster(num_nodes=4,
-             log_allow_list=RESTART_LOG_ALLOW_LIST +
-             ["Decreasing redpanda core count is not allowed"])
+    @cluster(num_nodes=4, log_allow_list=RESIZE_LOG_ALLOW_LIST)
     def test_node_resize(self):
         # Create a topic and write some data to make sure the cluster
         # is all up & initialized, and that subsequent checks are happening


### PR DESCRIPTION
Currently startup failures are logged at INFO level, but there doesn't
seem to be any reason to not log this critical failure message at error,
as it only occurs at most once per run.

Fixes #5058.