### PR TITLE
k/replicated_partition: do not validate fetch offset when stopping

### DIFF
--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "cluster/partition_probe.h"
 #include "coproc/partition.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
@@ -84,9 +85,11 @@ public:
 
     cluster::partition_probe& probe() final { return _probe; }
 
-    ss::future<bool> is_fetch_offset_valid(
+    ss::future<error_code> validate_fetch_offset(
       model::offset fetch_offset, model::timeout_clock::time_point) final {
-        co_return fetch_offset >= start_offset();
+        co_return fetch_offset >= start_offset()
+          ? error_code::none
+          : error_code::offset_out_of_range;
     }
 
 private:

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -13,6 +13,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "coproc/fwd.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "storage/translating_reader.h"
@@ -51,8 +52,8 @@ public:
             model::offset,
             ss::lw_shared_ptr<const storage::offset_translator_state>)
           = 0;
-        virtual ss::future<bool>
-          is_fetch_offset_valid(model::offset, model::timeout_clock::time_point)
+        virtual ss::future<error_code>
+          validate_fetch_offset(model::offset, model::timeout_clock::time_point)
           = 0;
         virtual cluster::partition_probe& probe() = 0;
         virtual ~impl() noexcept = default;
@@ -104,9 +105,9 @@ public:
         return _impl->get_leader_epoch_last_offset(epoch);
     }
 
-    ss::future<bool> is_fetch_offset_valid(
+    ss::future<error_code> validate_fetch_offset(
       model::offset o, model::timeout_clock::time_point deadline) {
-        return _impl->is_fetch_offset_valid(o, deadline);
+        return _impl->validate_fetch_offset(o, deadline);
     }
 
 private:

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -12,6 +12,7 @@
 
 #include "cluster/partition.h"
 #include "cluster/partition_probe.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
@@ -94,7 +95,7 @@ public:
         return leader_epoch_from_term(_partition->term());
     }
 
-    ss::future<bool> is_fetch_offset_valid(
+    ss::future<error_code> validate_fetch_offset(
       model::offset, model::timeout_clock::time_point) final;
 
 private:


### PR DESCRIPTION
## Cover letter

The issues was caused by out of range error returned to the consumer
when redpanda was shutting down - to simulate cluster update. When
validating consumer offset is reset it asserts:
```
AssertionError: Consumed from an unexpected offset
```
this assertion stops consumer thread and it is not longer able to
consume messages. Tests results with failure as consumer is not able to
consume requested number of messages. This may happen in real life
scenarios when Redpanda is being shutdown gracefully. We need to prevent
shutdown sequence from resetting consumer offsets.

When partition is shutting down we may not be able to correctly
validate consumer requested offset. We claim that the offset is
valid not return `OUT_OF_RANGE_ERROR` and reset consumer offsets.

We instead return NOT_LEADER_FOR_PARTITION error to force client retry.

Fixes: #4976




## Release notes
### Improvements
- fixed possible reset of consumer offset during shutdown

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.


-->
