### PR TITLE
rpk-operator refactor: allow cancelling admin API calls by propagating context

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -518,7 +518,7 @@ func (r *ClusterReconciler) setInitialSuperUserPassword(
 		username := string(secret.Data[corev1.BasicAuthUsernameKey])
 		password := string(secret.Data[corev1.BasicAuthPasswordKey])
 
-		err = adminAPI.CreateUser(username, password, admin.ScramSha256)
+		err = adminAPI.CreateUser(ctx, username, password, admin.ScramSha256)
 		// {"message": "Creating user: User already exists", "code": 400}
 		if err != nil && !strings.Contains(err.Error(), "already exists") { // TODO if user already exists, we only receive "400". Check for specific error code when available.
 			return &resources.RequeueAfterError{

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -128,11 +128,11 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("could not get admin API to check drifts on the cluster: %w", err)
 	}
 
-	schema, err := adminAPI.ClusterConfigSchema()
+	schema, err := adminAPI.ClusterConfigSchema(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster schema to check drifts: %w", err)
 	}
-	clusterConfig, err := adminAPI.Config()
+	clusterConfig, err := adminAPI.Config(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster configuration to check drifts: %w", err)
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -128,7 +128,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Marking the last applied configuration in the configmap")
-			baseConfig, err := testAdminAPI.Config()
+			baseConfig, err := testAdminAPI.Config(context.Background())
 			Expect(err).To(BeNil())
 			expectedAnnotation, err := json.Marshal(baseConfig)
 			Expect(err).To(BeNil())
@@ -672,7 +672,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		It("Should report configuration errors present in the .bootstrap.yaml file", func() {
 			// Inject property before creating the cluster, simulating .bootstrap.yaml
 			const val = "nown"
-			_, err := testAdminAPI.PatchClusterConfig(map[string]interface{}{
+			_, err := testAdminAPI.PatchClusterConfig(context.Background(), map[string]interface{}{
 				"unk": val,
 			}, nil)
 			Expect(err).To(BeNil())

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -171,7 +171,7 @@ func (*unavailableError) Error() string {
 	return "unavailable"
 }
 
-func (m *mockAdminAPI) Config() (admin.Config, error) {
+func (m *mockAdminAPI) Config(_ context.Context) (admin.Config, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {
@@ -182,10 +182,9 @@ func (m *mockAdminAPI) Config() (admin.Config, error) {
 	return res, nil
 }
 
-func (m *mockAdminAPI) ClusterConfigStatus() (
-	admin.ConfigStatusResponse,
-	error,
-) {
+func (m *mockAdminAPI) ClusterConfigStatus(
+	_ context.Context,
+) (admin.ConfigStatusResponse, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {
@@ -198,7 +197,9 @@ func (m *mockAdminAPI) ClusterConfigStatus() (
 	return []admin.ConfigStatus{node}, nil
 }
 
-func (m *mockAdminAPI) ClusterConfigSchema() (admin.ConfigSchema, error) {
+func (m *mockAdminAPI) ClusterConfigSchema(
+	_ context.Context,
+) (admin.ConfigSchema, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {
@@ -210,7 +211,7 @@ func (m *mockAdminAPI) ClusterConfigSchema() (admin.ConfigSchema, error) {
 }
 
 func (m *mockAdminAPI) PatchClusterConfig(
-	upsert map[string]interface{}, remove []string,
+	_ context.Context, upsert map[string]interface{}, remove []string,
 ) (admin.ClusterConfigWriteResult, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
@@ -269,7 +270,7 @@ func (m *mockAdminAPI) PatchClusterConfig(
 	return admin.ClusterConfigWriteResult{}, nil
 }
 
-func (m *mockAdminAPI) CreateUser(_, _, _ string) error {
+func (m *mockAdminAPI) CreateUser(_ context.Context, _, _, _ string) error {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {
@@ -288,7 +289,9 @@ func (m *mockAdminAPI) Clear() {
 	m.directValidation = false
 }
 
-func (m *mockAdminAPI) GetFeatures() (admin.FeaturesResponse, error) {
+func (m *mockAdminAPI) GetFeatures(
+	_ context.Context,
+) (admin.FeaturesResponse, error) {
 	return admin.FeaturesResponse{
 		ClusterVersion: 0,
 		Features: []admin.Feature{

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -70,14 +70,14 @@ func NewInternalAdminAPI(
 // AdminAPIClient is a sub interface of the admin API containing what we need in the operator
 // nolint:revive // usually package is called adminutils
 type AdminAPIClient interface {
-	Config() (admin.Config, error)
-	ClusterConfigStatus() (admin.ConfigStatusResponse, error)
-	ClusterConfigSchema() (admin.ConfigSchema, error)
-	PatchClusterConfig(upsert map[string]interface{}, remove []string) (admin.ClusterConfigWriteResult, error)
+	Config(ctx context.Context) (admin.Config, error)
+	ClusterConfigStatus(ctx context.Context) (admin.ConfigStatusResponse, error)
+	ClusterConfigSchema(ctx context.Context) (admin.ConfigSchema, error)
+	PatchClusterConfig(ctx context.Context, upsert map[string]interface{}, remove []string) (admin.ClusterConfigWriteResult, error)
 
-	CreateUser(username, password, mechanism string) error
+	CreateUser(ctx context.Context, username, password, mechanism string) error
 
-	GetFeatures() (admin.FeaturesResponse, error)
+	GetFeatures(ctx context.Context) (admin.FeaturesResponse, error)
 }
 
 var _ AdminAPIClient = &admin.AdminAPI{}

--- a/src/go/k8s/pkg/admin/utils.go
+++ b/src/go/k8s/pkg/admin/utils.go
@@ -9,14 +9,20 @@
 
 package admin
 
-import "github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+import (
+	"context"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+)
 
 // CentralConfigFeatureName is the name of the centralized configuration feature in Redpanda
 const CentralConfigFeatureName = "central_config"
 
 // IsFeatureActive is a helper function that checks if a given feature is active in the cluster
-func IsFeatureActive(c AdminAPIClient, name string) (bool, error) {
-	res, err := c.GetFeatures()
+func IsFeatureActive(
+	ctx context.Context, c AdminAPIClient, name string,
+) (bool, error) {
+	res, err := c.GetFeatures(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestAdminAPI(t *testing.T) {
 			name:     "delete user in 1 node cluster",
 			nNodes:   1,
 			leaderID: 0,
-			action:   func(t *testing.T, a *AdminAPI) error { return a.DeleteUser("Milo") },
+			action:   func(t *testing.T, a *AdminAPI) error { return a.DeleteUser(context.Background(), "Milo") },
 			leader:   []string{"/v1/security/users/Milo"},
 			none:     []string{"/v1/partitions/redpanda/controller/0", "/v1/node_config"},
 		},
@@ -53,7 +54,7 @@ func TestAdminAPI(t *testing.T) {
 			name:     "delete user in 3 node cluster",
 			nNodes:   3,
 			leaderID: 1,
-			action:   func(t *testing.T, a *AdminAPI) error { return a.DeleteUser("Lola") },
+			action:   func(t *testing.T, a *AdminAPI) error { return a.DeleteUser(context.Background(), "Lola") },
 			all:      []string{"/v1/node_config"},
 			any:      []string{"/v1/partitions/redpanda/controller/0"},
 			leader:   []string{"/v1/security/users/Lola"},
@@ -62,10 +63,12 @@ func TestAdminAPI(t *testing.T) {
 			name:     "create user in 3 node cluster",
 			nNodes:   3,
 			leaderID: 1,
-			action:   func(t *testing.T, a *AdminAPI) error { return a.CreateUser("Joss", "momorocks", ScramSha256) },
-			all:      []string{"/v1/node_config"},
-			any:      []string{"/v1/partitions/redpanda/controller/0"},
-			leader:   []string{"/v1/security/users"},
+			action: func(t *testing.T, a *AdminAPI) error {
+				return a.CreateUser(context.Background(), "Joss", "momorocks", ScramSha256)
+			},
+			all:    []string{"/v1/node_config"},
+			any:    []string{"/v1/partitions/redpanda/controller/0"},
+			leader: []string{"/v1/security/users"},
 		},
 		{
 			name:     "list users in 3 node cluster",
@@ -78,7 +81,7 @@ func TestAdminAPI(t *testing.T) {
 				},
 			},
 			action: func(t *testing.T, a *AdminAPI) error {
-				users, err := a.ListUsers()
+				users, err := a.ListUsers(context.Background())
 				require.NoError(t, err)
 				require.Len(t, users, 4)
 				return nil

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -41,26 +42,28 @@ type Broker struct {
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.
-func (a *AdminAPI) Brokers() ([]Broker, error) {
+func (a *AdminAPI) Brokers(ctx context.Context) ([]Broker, error) {
 	var bs []Broker
 	defer func() {
 		sort.Slice(bs, func(i, j int) bool { return bs[i].NodeID < bs[j].NodeID }) //nolint:revive // return inside this deferred function is for the sort's less function
 	}()
-	return bs, a.sendAny(http.MethodGet, brokersEndpoint, nil, &bs)
+	return bs, a.sendAny(ctx, http.MethodGet, brokersEndpoint, nil, &bs)
 }
 
 // Broker queries one of the client's hosts and returns broker information.
-func (a *AdminAPI) Broker(node int) (Broker, error) {
+func (a *AdminAPI) Broker(ctx context.Context, node int) (Broker, error) {
 	var b Broker
 	err := a.sendAny(
+		ctx,
 		http.MethodGet,
 		fmt.Sprintf(brokerEndpoint, node), nil, &b)
 	return b, err
 }
 
 // DecommissionBroker issues a decommission request for the given broker.
-func (a *AdminAPI) DecommissionBroker(node int) error {
+func (a *AdminAPI) DecommissionBroker(ctx context.Context, node int) error {
 	return a.sendToLeader(
+		ctx,
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/decommission", brokersEndpoint, node),
 		nil,
@@ -69,8 +72,9 @@ func (a *AdminAPI) DecommissionBroker(node int) error {
 }
 
 // RecommissionBroker issues a recommission request for the given broker.
-func (a *AdminAPI) RecommissionBroker(node int) error {
+func (a *AdminAPI) RecommissionBroker(ctx context.Context, node int) error {
 	return a.sendToLeader(
+		ctx,
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/recommission", brokersEndpoint, node),
 		nil,
@@ -79,8 +83,9 @@ func (a *AdminAPI) RecommissionBroker(node int) error {
 }
 
 // EnableMaintenanceMode enables maintenance mode for a node.
-func (a *AdminAPI) EnableMaintenanceMode(nodeID int) error {
+func (a *AdminAPI) EnableMaintenanceMode(ctx context.Context, nodeID int) error {
 	return a.sendAny(
+		ctx,
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeID),
 		nil,
@@ -89,8 +94,9 @@ func (a *AdminAPI) EnableMaintenanceMode(nodeID int) error {
 }
 
 // DisableMaintenanceMode disables maintenance mode for a node.
-func (a *AdminAPI) DisableMaintenanceMode(nodeID int) error {
+func (a *AdminAPI) DisableMaintenanceMode(ctx context.Context, nodeID int) error {
 	return a.sendAny(
+		ctx,
 		http.MethodDelete,
 		fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeID),
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -9,7 +9,10 @@
 
 package admin
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // Health overview data structure.
 type ClusterHealthOverview struct {
@@ -20,7 +23,7 @@ type ClusterHealthOverview struct {
 	LeaderlessPartitions []string `json:"leaderless_partition"`
 }
 
-func (a *AdminAPI) GetHealthOverview() (ClusterHealthOverview, error) {
+func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview, error) {
 	var response ClusterHealthOverview
-	return response, a.sendAny(http.MethodGet, "/v1/cluster/health_overview", nil, &response)
+	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/health_overview", nil, &response)
 }

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,9 +24,9 @@ type Config map[string]interface{}
 
 // Config returns a single admin endpoint's configuration. This errors if
 // multiple URLs are configured.
-func (a *AdminAPI) Config() (Config, error) {
+func (a *AdminAPI) Config(ctx context.Context) (Config, error) {
 	var rawResp []byte
-	err := a.sendAny(http.MethodGet, "/v1/config", nil, &rawResp)
+	err := a.sendAny(ctx, http.MethodGet, "/v1/config", nil, &rawResp)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +43,7 @@ func (a *AdminAPI) Config() (Config, error) {
 //
 // Expiry configures how long the log level override will persist. If zero,
 // Redpanda will persist the override until it shuts down.
-func (a *AdminAPI) SetLogLevel(name, level string, expirySeconds int) error {
+func (a *AdminAPI) SetLogLevel(ctx context.Context, name, level string, expirySeconds int) error {
 	if expirySeconds < 0 {
 		return fmt.Errorf("invalid negative expiry of %ds", expirySeconds)
 	}
@@ -57,7 +58,7 @@ func (a *AdminAPI) SetLogLevel(name, level string, expirySeconds int) error {
 	}
 
 	path := fmt.Sprintf("/v1/config/log_level/%s?level=%s&expires=%d", url.PathEscape(name), level, expirySeconds)
-	return a.sendOne(http.MethodPut, path, nil, nil, false)
+	return a.sendOne(ctx, http.MethodPut, path, nil, nil, false)
 }
 
 type ConfigPropertyItems struct {
@@ -82,9 +83,9 @@ type ConfigSchemaResponse struct {
 	Properties ConfigSchema `json:"properties"`
 }
 
-func (a *AdminAPI) ClusterConfigSchema() (ConfigSchema, error) {
+func (a *AdminAPI) ClusterConfigSchema(ctx context.Context) (ConfigSchema, error) {
 	var response ConfigSchemaResponse
-	err := a.sendAny(http.MethodGet, "/v1/cluster_config/schema", nil, &response)
+	err := a.sendAny(ctx, http.MethodGet, "/v1/cluster_config/schema", nil, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ type ClusterConfigWriteResult struct {
 }
 
 func (a *AdminAPI) PatchClusterConfig(
-	upsert map[string]interface{}, remove []string,
+	ctx context.Context, upsert map[string]interface{}, remove []string,
 ) (ClusterConfigWriteResult, error) {
 	body := map[string]interface{}{
 		"upsert": upsert,
@@ -105,7 +106,7 @@ func (a *AdminAPI) PatchClusterConfig(
 	}
 
 	var result ClusterConfigWriteResult
-	err := a.sendAny(http.MethodPut, "/v1/cluster_config", body, &result)
+	err := a.sendAny(ctx, http.MethodPut, "/v1/cluster_config", body, &result)
 	if err != nil {
 		return result, err
 	}
@@ -123,9 +124,9 @@ type ConfigStatus struct {
 
 type ConfigStatusResponse []ConfigStatus
 
-func (a *AdminAPI) ClusterConfigStatus() (ConfigStatusResponse, error) {
+func (a *AdminAPI) ClusterConfigStatus(ctx context.Context) (ConfigStatusResponse, error) {
 	var result ConfigStatusResponse
-	err := a.sendAny(http.MethodGet, "/v1/cluster_config/status", nil, &result)
+	err := a.sendAny(ctx, http.MethodGet, "/v1/cluster_config/status", nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/api/admin/api_features.go
+++ b/src/go/rpk/pkg/api/admin/api_features.go
@@ -9,7 +9,10 @@
 
 package admin
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // FeatureState enumerates the possible states of a feature.
 type FeatureState string
@@ -36,9 +39,10 @@ type FeaturesResponse struct {
 }
 
 // GetFeatures returns information about the available features.
-func (a *AdminAPI) GetFeatures() (FeaturesResponse, error) {
+func (a *AdminAPI) GetFeatures(ctx context.Context) (FeaturesResponse, error) {
 	var features FeaturesResponse
 	return features, a.sendAny(
+		ctx,
 		http.MethodGet,
 		"/v1/features",
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_metrics.go
+++ b/src/go/rpk/pkg/api/admin/api_metrics.go
@@ -9,10 +9,13 @@
 
 package admin
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
-func (a *AdminAPI) PrometheusMetrics() ([]byte, error) {
+func (a *AdminAPI) PrometheusMetrics(ctx context.Context) ([]byte, error) {
 	var res []byte
-	err := a.sendOne(http.MethodGet, "/metrics", nil, &res, false)
+	err := a.sendOne(ctx, http.MethodGet, "/metrics", nil, &res, false)
 	return res, err
 }

--- a/src/go/rpk/pkg/api/admin/api_node_config.go
+++ b/src/go/rpk/pkg/api/admin/api_node_config.go
@@ -9,7 +9,10 @@
 
 package admin
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 type NodeConfig struct {
 	NodeID int `json:"node_id"`
@@ -19,8 +22,8 @@ type NodeConfig struct {
 // NodeConfig returns a single node configuration.
 // It's expected to be called from an AdminAPI with a single broker URL,
 // otherwise the method will return an error.
-func (a *AdminAPI) GetNodeConfig() (NodeConfig, error) {
+func (a *AdminAPI) GetNodeConfig(ctx context.Context) (NodeConfig, error) {
 	var nodeconfig NodeConfig
 
-	return nodeconfig, a.sendOne(http.MethodGet, "/v1/node_config", nil, &nodeconfig, false)
+	return nodeconfig, a.sendOne(ctx, http.MethodGet, "/v1/node_config", nil, &nodeconfig, false)
 }

--- a/src/go/rpk/pkg/api/admin/api_partition.go
+++ b/src/go/rpk/pkg/api/admin/api_partition.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -33,10 +34,11 @@ type Partition struct {
 
 // GetPartition returns detailed partition information.
 func (a *AdminAPI) GetPartition(
-	namespace, topic string, partition int,
+	ctx context.Context, namespace, topic string, partition int,
 ) (Partition, error) {
 	var pa Partition
 	return pa, a.sendAny(
+		ctx,
 		http.MethodGet,
 		fmt.Sprintf("/v1/partitions/%s/%s/%d", namespace, topic, partition),
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_user.go
+++ b/src/go/rpk/pkg/api/admin/api_user.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -35,7 +36,7 @@ const (
 
 // CreateUser creates a user with the given username and password using the
 // given mechanism (SCRAM-SHA-256, SCRAM-SHA-512).
-func (a *AdminAPI) CreateUser(username, password, mechanism string) error {
+func (a *AdminAPI) CreateUser(ctx context.Context, username, password, mechanism string) error {
 	if username == "" {
 		return errors.New("invalid empty username")
 	}
@@ -47,20 +48,20 @@ func (a *AdminAPI) CreateUser(username, password, mechanism string) error {
 		Password:  password,
 		Algorithm: mechanism,
 	}
-	return a.sendToLeader(http.MethodPost, usersEndpoint, u, nil)
+	return a.sendToLeader(ctx, http.MethodPost, usersEndpoint, u, nil)
 }
 
 // DeleteUser deletes the given username, if it exists.
-func (a *AdminAPI) DeleteUser(username string) error {
+func (a *AdminAPI) DeleteUser(ctx context.Context, username string) error {
 	if username == "" {
 		return errors.New("invalid empty username")
 	}
 	path := usersEndpoint + "/" + url.PathEscape(username)
-	return a.sendToLeader(http.MethodDelete, path, nil, nil)
+	return a.sendToLeader(ctx, http.MethodDelete, path, nil, nil)
 }
 
 // ListUsers returns the current users.
-func (a *AdminAPI) ListUsers() ([]string, error) {
+func (a *AdminAPI) ListUsers(ctx context.Context) ([]string, error) {
 	var users []string
-	return users, a.sendAny(http.MethodGet, usersEndpoint, nil, &users)
+	return users, a.sendAny(ctx, http.MethodGet, usersEndpoint, nil, &users)
 }

--- a/src/go/rpk/pkg/cli/cmd/acl/user.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user.go
@@ -113,7 +113,7 @@ acl help text for more info.
 				out.Die("unsupported mechanism %q", mechanism)
 			}
 
-			err = cl.CreateUser(user, pass, mechanism)
+			err = cl.CreateUser(cmd.Context(), user, pass, mechanism)
 			out.MaybeDie(err, "unable to create user %q: %v", user, err)
 			fmt.Printf("Created user %q.\n", user)
 		},
@@ -167,7 +167,7 @@ delete any ACLs that may exist for this user.
 				out.Die("missing required username argument")
 			}
 
-			err = cl.DeleteUser(user)
+			err = cl.DeleteUser(cmd.Context(), user)
 			out.MaybeDie(err, "unable to delete user %q: %s", user, err)
 			fmt.Printf("Deleted user %q.\n", user)
 		},
@@ -192,7 +192,7 @@ func NewListUsersCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			users, err := cl.ListUsers()
+			users, err := cl.ListUsers(cmd.Context())
 			out.MaybeDie(err, "unable to list users: %v", err)
 
 			tw := out.NewTable("Username")

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -10,6 +10,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -51,14 +52,14 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema
-			schema, err := client.ClusterConfigSchema()
+			schema, err := client.ClusterConfigSchema(cmd.Context())
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(cmd.Context())
 			out.MaybeDie(err, "unable to get current config: %v", err)
 
-			err = executeEdit(client, schema, currentConfig, all)
+			err = executeEdit(cmd.Context(), client, schema, currentConfig, all)
 			out.MaybeDie(err, "unable to edit: %v", err)
 		},
 	}
@@ -66,6 +67,7 @@ to edit all properties including these tunables.
 }
 
 func executeEdit(
+	ctx context.Context,
 	client *admin.AdminAPI,
 	schema admin.ConfigSchema,
 	currentConfig admin.Config,
@@ -115,7 +117,7 @@ func executeEdit(
 	}
 
 	// Read back template & parse
-	err = importConfig(client, filename, currentConfig, schema, *all)
+	err = importConfig(ctx, client, filename, currentConfig, schema, *all)
 	if err != nil {
 		return fmt.Errorf("error updating config: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -154,12 +154,12 @@ to include all properties including these low level tunables.
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema
-			schema, err := client.ClusterConfigSchema()
+			schema, err := client.ClusterConfigSchema(cmd.Context())
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
 			var currentConfig admin.Config
-			currentConfig, err = client.Config()
+			currentConfig, err = client.Config(cmd.Context())
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			// Generate a yaml template for editing

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
@@ -39,7 +39,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(cmd.Context())
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			val, exists := currentConfig[key]

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
@@ -39,7 +39,7 @@ central configuration store (and via 'rpk cluster config edit').
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			schema, err := client.ClusterConfigSchema()
+			schema, err := client.ClusterConfigSchema(cmd.Context())
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			configFile, err := p.LocateConfig(fs)

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
@@ -43,7 +43,7 @@ If an empty string is given as the value, the property is reset to its default.`
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			schema, err := client.ClusterConfigSchema()
+			schema, err := client.ClusterConfigSchema(cmd.Context())
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			meta, ok := schema[key]
@@ -78,7 +78,7 @@ If an empty string is given as the value, the property is reset to its default.`
 				upsert[key] = value
 			}
 
-			result, err := client.PatchClusterConfig(upsert, remove)
+			result, err := client.PatchClusterConfig(cmd.Context(), upsert, remove)
 			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 				// Special case 400 (validation) errors with friendly output
 				// about which configuration properties were invalid.

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/status.go
@@ -40,7 +40,7 @@ is offline.`,
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the status endpoint
-			resp, err := client.ClusterConfigStatus()
+			resp, err := client.ClusterConfigStatus(cmd.Context())
 			out.MaybeDie(err, "error fetching status: %v", err)
 
 			tw := out.NewTable("NODE", "CONFIG-VERSION", "NEEDS-RESTART", "INVALID", "UNKNOWN")

--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -57,7 +57,7 @@ following conditions are met:
 
 			var lastOverview admin.ClusterHealthOverview
 			for {
-				ret, err := cl.GetHealthOverview()
+				ret, err := cl.GetHealthOverview(cmd.Context())
 				out.MaybeDie(err, "unable to request cluster health: %v", err)
 				if !reflect.DeepEqual(ret, lastOverview) {
 					printHealthOverview(&ret)

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
@@ -44,7 +44,7 @@ func newDisableCommand(fs afero.Fs) *cobra.Command {
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			err = client.DisableMaintenanceMode(nodeID)
+			err = client.DisableMaintenanceMode(cmd.Context(), nodeID)
 			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
 					body, bodyErr := he.DecodeGenericErrorBody()

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
@@ -50,7 +50,7 @@ node exists that is already in maintenance mode then an error will be returned.
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			err = client.EnableMaintenanceMode(nodeID)
+			err = client.EnableMaintenanceMode(cmd.Context(), nodeID)
 			var he *admin.HTTPResponseError
 			if errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
@@ -78,7 +78,7 @@ node exists that is already in maintenance mode then an error will be returned.
 			var table *out.TabWriter
 			retries := 3
 			for {
-				b, err := client.Broker(nodeID)
+				b, err := client.Broker(cmd.Context(), nodeID)
 				if err == nil && b.Maintenance == nil {
 					err = fmt.Errorf("maintenance mode not supported. upgrade in progress?")
 					// since admin api client uses `sendAny` it is possible that

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
@@ -78,7 +78,7 @@ Notes:
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			brokers, err := client.Brokers()
+			brokers, err := client.Brokers(cmd.Context())
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
 			if len(brokers) == 0 {

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -70,7 +70,7 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 			logsLimit, err := units.FromHumanSize(logsSizeLimit)
 			out.MaybeDie(err, "unable to parse --logs-size-limit: %v", err)
 
-			err = executeBundle(fs, cfg, cl, admin, logsSince, logsUntil, int(logsLimit), timeout)
+			err = executeBundle(cmd.Context(), fs, cfg, cl, admin, logsSince, logsUntil, int(logsLimit), timeout)
 			out.MaybeDie(err, "unable to create bundle: %v", err)
 		},
 	}

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_all.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_all.go
@@ -12,6 +12,7 @@
 package debug
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 )
 
 func executeBundle(
+	context.Context,
 	afero.Fs,
 	*config.Config,
 	*kgo.Client,

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
@@ -47,6 +47,7 @@ import (
 )
 
 func executeBundle(
+	ctx context.Context,
 	fs afero.Fs,
 	conf *config.Config,
 	cl *kgo.Client,
@@ -88,7 +89,7 @@ func executeBundle(
 		saveResourceUsageData(ps, conf),
 		saveNTPDrift(ps),
 		saveSyslog(ps),
-		savePrometheusMetrics(ps, admin),
+		savePrometheusMetrics(ctx, ps, admin),
 		saveDNSData(ps),
 		saveDiskUsage(ps, conf),
 		saveLogs(ps, logsSince, logsUntil, logsLimitBytes),
@@ -546,9 +547,9 @@ func saveSyslog(ps *stepParams) step {
 }
 
 // Queries the given admin API address for prometheus metrics.
-func savePrometheusMetrics(ps *stepParams, admin *admin.AdminAPI) step {
+func savePrometheusMetrics(ctx context.Context, ps *stepParams, admin *admin.AdminAPI) step {
 	return func() error {
-		raw, err := admin.PrometheusMetrics()
+		raw, err := admin.PrometheusMetrics(ctx)
 		if err != nil {
 			return fmt.Errorf("unable to fetch metrics from the admin API: %w", err)
 		}

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
@@ -81,7 +81,7 @@ func executeBundle(
 	}
 
 	steps := []step{
-		saveKafkaMetadata(ps, cl),
+		saveKafkaMetadata(ctx, ps, cl),
 		saveDataDirStructure(ps, conf),
 		saveConfig(ps, conf),
 		saveCPUInfo(ps),
@@ -90,15 +90,15 @@ func executeBundle(
 		saveNTPDrift(ps),
 		saveSyslog(ps),
 		savePrometheusMetrics(ctx, ps, admin),
-		saveDNSData(ps),
-		saveDiskUsage(ps, conf),
-		saveLogs(ps, logsSince, logsUntil, logsLimitBytes),
-		saveSocketData(ps),
-		saveTopOutput(ps),
-		saveVmstat(ps),
-		saveIP(ps),
-		saveLspci(ps),
-		saveDmidecode(ps),
+		saveDNSData(ctx, ps),
+		saveDiskUsage(ctx, ps, conf),
+		saveLogs(ctx, ps, logsSince, logsUntil, logsLimitBytes),
+		saveSocketData(ctx, ps),
+		saveTopOutput(ctx, ps),
+		saveVmstat(ctx, ps),
+		saveIP(ctx, ps),
+		saveLspci(ctx, ps),
+		saveDmidecode(ctx, ps),
 	}
 
 	for _, s := range steps {
@@ -181,6 +181,7 @@ func writeFileToZip(ps *stepParams, filename string, contents []byte) error {
 
 // Runs a command and pipes its output to a new file in the zip writer.
 func writeCommandOutputToZipLimit(
+	rootCtx context.Context,
 	ps *stepParams,
 	filename string,
 	outputLimitBytes int,
@@ -190,7 +191,7 @@ func writeCommandOutputToZipLimit(
 	ps.m.Lock()
 	defer ps.m.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), ps.timeout)
+	ctx, cancel := context.WithTimeout(rootCtx, ps.timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, command, args...)
 
@@ -234,9 +235,9 @@ func writeCommandOutputToZipLimit(
 
 // Runs a command and pipes its output to a new file in the zip writer.
 func writeCommandOutputToZip(
-	ps *stepParams, filename, command string, args ...string,
+	ctx context.Context, ps *stepParams, filename, command string, args ...string,
 ) error {
-	return writeCommandOutputToZipLimit(ps, filename, -1, command, args...)
+	return writeCommandOutputToZipLimit(ctx, ps, filename, -1, command, args...)
 }
 
 // Parses an error return from kadm, and if the return is a shard errors,
@@ -268,11 +269,11 @@ func stringifyKadmErr(err error) []string {
 	}
 }
 
-func saveKafkaMetadata(ps *stepParams, cl *kgo.Client) step {
+func saveKafkaMetadata(rootCtx context.Context, ps *stepParams, cl *kgo.Client) step {
 	return func() error {
 		log.Debug("Reading Kafka information")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(rootCtx, 10*time.Second)
 		defer cancel()
 
 		type resp struct {
@@ -558,16 +559,17 @@ func savePrometheusMetrics(ctx context.Context, ps *stepParams, admin *admin.Adm
 }
 
 // Saves the output of `dig`.
-func saveDNSData(ps *stepParams) step {
+func saveDNSData(ctx context.Context, ps *stepParams) step {
 	return func() error {
-		return writeCommandOutputToZip(ps, "dig.txt", "dig")
+		return writeCommandOutputToZip(ctx, ps, "dig.txt", "dig")
 	}
 }
 
 // Saves the disk usage total within redpanda's data directory.
-func saveDiskUsage(ps *stepParams, conf *config.Config) step {
+func saveDiskUsage(ctx context.Context, ps *stepParams, conf *config.Config) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"du.txt",
 			"du", "-h", conf.Redpanda.Directory,
@@ -577,7 +579,7 @@ func saveDiskUsage(ps *stepParams, conf *config.Config) step {
 
 // TODO: What if running inside a container/ k8s?
 // Writes the journald redpanda logs, if available, to the bundle.
-func saveLogs(ps *stepParams, since, until string, logsLimitBytes int) step {
+func saveLogs(ctx context.Context, ps *stepParams, since, until string, logsLimitBytes int) step {
 	return func() error {
 		args := []string{"--no-pager", "-u", "redpanda"}
 		if since != "" {
@@ -587,6 +589,7 @@ func saveLogs(ps *stepParams, since, until string, logsLimitBytes int) step {
 			args = append(args, "--until", until)
 		}
 		return writeCommandOutputToZipLimit(
+			ctx,
 			ps,
 			"redpanda.log",
 			logsLimitBytes,
@@ -597,16 +600,17 @@ func saveLogs(ps *stepParams, since, until string, logsLimitBytes int) step {
 }
 
 // Saves the output of `ss`.
-func saveSocketData(ps *stepParams) step {
+func saveSocketData(ctx context.Context, ps *stepParams) step {
 	return func() error {
-		return writeCommandOutputToZip(ps, "ss.txt", "ss")
+		return writeCommandOutputToZip(ctx, ps, "ss.txt", "ss")
 	}
 }
 
 // Saves the output of `top`.
-func saveTopOutput(ps *stepParams) step {
+func saveTopOutput(ctx context.Context, ps *stepParams) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"top.txt",
 			"top", "-b", "-n", "10", "-H", "-d", "1",
@@ -615,9 +619,10 @@ func saveTopOutput(ps *stepParams) step {
 }
 
 // Saves the output of `vmstat`.
-func saveVmstat(ps *stepParams) step {
+func saveVmstat(ctx context.Context, ps *stepParams) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"vmstat.txt",
 			"vmstat", "-w", "1", "10",
@@ -626,9 +631,10 @@ func saveVmstat(ps *stepParams) step {
 }
 
 // Saves the output of `ip addr`.
-func saveIP(ps *stepParams) step {
+func saveIP(ctx context.Context, ps *stepParams) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"ip.txt",
 			"ip", "addr",
@@ -637,9 +643,10 @@ func saveIP(ps *stepParams) step {
 }
 
 // Saves the output of `lspci`.
-func saveLspci(ps *stepParams) step {
+func saveLspci(ctx context.Context, ps *stepParams) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"lspci.txt",
 			"lspci",
@@ -648,9 +655,10 @@ func saveLspci(ps *stepParams) step {
 }
 
 // Saves the output of `dmidecode`.
-func saveDmidecode(ps *stepParams) step {
+func saveDmidecode(ctx context.Context, ps *stepParams) step {
 	return func() error {
 		return writeCommandOutputToZip(
+			ctx,
 			ps,
 			"dmidecode.txt",
 			"dmidecode",

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -51,7 +51,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			bs, err := cl.Brokers()
+			bs, err := cl.Brokers(cmd.Context())
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
 			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
@@ -105,7 +105,7 @@ leader handles the request.
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			err = cl.DecommissionBroker(broker)
+			err = cl.DecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to decommission broker: %v", err)
 
 			fmt.Printf("Success, broker %d has been decommissioned!\n", broker)
@@ -143,7 +143,7 @@ the cluster leader handles the request.
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			err = cl.RecommissionBroker(broker)
+			err = cl.RecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to recommission broker: %v", err)
 
 			fmt.Printf("Success, broker %d has been recommissioned!\n", broker)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -45,7 +45,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewHostClient(fs, cfg, host)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			conf, err := cl.Config()
+			conf, err := cl.Config(cmd.Context())
 			out.MaybeDie(err, "unable to request configuration: %v", err)
 
 			marshaled, err := json.MarshalIndent(conf, "", "  ")
@@ -135,7 +135,7 @@ failure of enabling each logger is individually printed.
 			var successes []string
 
 			for _, logger := range loggers {
-				err := cl.SetLogLevel(logger, level, expirySeconds)
+				err := cl.SetLogLevel(cmd.Context(), logger, level, expirySeconds)
 				if err != nil {
 					failures = append(failures, failure{logger, err})
 				} else {


### PR DESCRIPTION
## Cover letter

This adds a `context.Context` argument to all admin API calls, to allow setting up timeouts or cancelling ongoing calls and avoid them block indefinitely.

It's useful in rpk since it binds the context to the cobra command context, but I need it particularly in the operator, where I plan to add timeouts when doing certain API calls.

## Release notes

* none
