### PR TITLE
[V22.1.x] backport of #4901

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2159,7 +2159,7 @@ void add_offset_tombstone_record(
       .partition = tp.partition,
     };
     auto kv = serializer.to_kv(offset_metadata_kv{.key = std::move(key)});
-    builder.add_raw_kv(reflection::to_iobuf(std::move(kv.key)), std::nullopt);
+    builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 
 void add_group_tombstone_record(
@@ -2170,7 +2170,7 @@ void add_group_tombstone_record(
       .group_id = group,
     };
     auto kv = serializer.to_kv(group_metadata_kv{.key = std::move(key)});
-    builder.add_raw_kv(reflection::to_iobuf(std::move(kv.key)), std::nullopt);
+    builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 } // namespace
 

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -141,7 +141,7 @@ void group_recovery_consumer::handle_record(model::record r) {
     } catch (...) {
         vlog(
           klog.error,
-          "error handling record record - {}",
+          "error handling group metadata record - {}",
           std::current_exception());
     }
 }


### PR DESCRIPTION
## Cover letter
Group metadata key serializer returns an iobuf. Wrapping it with another serialization layer is incorrect as it introduces additional size field in the binary format that deserializer does not expect. This leads to deserialization error and exception is being thrown.

Fixes: https://github.com/redpanda-data/redpanda/issues/4900
Fixes: https://github.com/redpanda-data/redpanda/issues/5008

Proof for iobuf unwrapping approach
```python
import struct

# Case 1: old serializer, group_metadata, no wrapper
#group_metadata_serializer::key_value ret;
#ret.key = reflection::to_iobuf(old::group_log_record_key{
#  .record_type = old::group_log_record_key::type::group_metadata,
#  .key = reflection::to_iobuf(md.key.group_id),
#});
def group_metadata_old_key_unwrapped():
    for record_type in (0, 1, 2):
        for group_id_len in range(2**15):
            # the group id is serialized inside an iobuf
            # so the length after the record type is the
            # group id bytes length plus the string length
            # prefix which is an extra 4 bytes
            iobuf_len = group_id_len + 4
            data = struct.pack("<bi", record_type, iobuf_len)
            assert len(data) == 5
            # content plus 4 bytes for length plus 1 byte for type
            yield data[:4], iobuf_len + 4 + 1, group_id_len, 1


# Case 2: old serializer, offset_metadata, no wrapper
#group_metadata_serializer::key_value ret;
#ret.key = reflection::to_iobuf(old::group_log_record_key{
#  .record_type = old::group_log_record_key::type::offset_commit,
#  .key = reflection::to_iobuf(old::group_log_offset_key{
#    std::move(md.key.group_id),
#    std::move(md.key.topic),
#    md.key.partition,
#  }),
def offset_metadata_old_key_unwrapped():
    for record_type in (0, 1, 2):
        for strings_len in range(2 * 2**15):
            # partition id (4) two 4 byte string lengths plus string bytes
            iobuf_len = strings_len + 4 + 4 + 4
            data = struct.pack("<bi", record_type, iobuf_len)
            assert len(data) == 5
            # content plus 4 bytes for length plus 1 byte for type
            yield data[:4], iobuf_len + 4 + 1, strings_len, 1

# version: int16
# group_id: string (length prefix int16)
#void group_metadata_key::encode(
#  response_writer& writer, const group_metadata_key& v) {
#    writer.write(v.version);
#    writer.write(v.group_id);
#}
def group_metadata_new_key_unwrapped():
    for version in (0, 1, 2):
        for group_id_len in range(2**15):
            data = struct.pack(">hh", version, group_id_len)
            assert len(data) == 4
            # group id bytes plus (2) version and (2) group id len
            yield data, group_id_len + 2 + 2, group_id_len, 1

# same as group_metadata_new_key_unwrapped
# except that the topic makes the remainder
# of the serialized size variable length.
#void offset_metadata_key::encode(
#  response_writer& writer, const offset_metadata_key& v) {
#    writer.write(v.version);
#    writer.write(v.group_id);
#    writer.write(v.topic);
#    writer.write(v.partition);
#}
def offset_metadata_new_key_unwrapped():
    for version in (0, 1, 2):
        for group_id_len in range(2**15):
            for topic_len in range(2**15):
                data = struct.pack(">hh", version, group_id_len)
                assert len(data) == 4
                # group/topic bytes, 2ver, 2group len, 2topic len, partition id
                yield data, group_id_len + topic_len + 2 + 2 + 2 + 4, group_id_len, topic_len

unwrapped = [group_metadata_old_key_unwrapped,
        offset_metadata_old_key_unwrapped,
        group_metadata_new_key_unwrapped,
        offset_metadata_new_key_unwrapped]

# unwrapped cases
# data that was written as unwrapped should never be unwrapped
for f in unwrapped:
    for prefix, size, invariant1, invariant2 in f():
        length = struct.unpack("<i", prefix)[0]
        # invariant == 0 would be like a zero-length group-id or topic-id
        # so we might trigger the condition in which we incorrect unwrap
        # but as long as the invariant says it won't happen in practice
        # then ok. so this would be like a group-id length == 0
        if size == (length + 4):
            if invariant1 == 0 or invariant2 == 0:
                print("{}, {}, i={}, i={}, s={}, l={}".format(
                        f.__name__, prefix, invariant1, invariant2, size,
                        length))
                continue
            assert False
```
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
