### PR TITLE
rptest: Disable two flaky topic recovery tests

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1296,6 +1296,7 @@ class TopicRecoveryTest(RedpandaTest):
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4960
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
     def test_fast2(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1334,6 +1335,7 @@ class TopicRecoveryTest(RedpandaTest):
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4887
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
     def test_size_based_retention(self):
         """Test topic recovery with size based retention policy.


### PR DESCRIPTION
## Cover letter

Disable two tests  cases in `TopicRecoveryTest`. 
First one triggered CI issue #4960
Second one is #4887

## Release notes


* none

