### PR TITLE
cluster: add serde support for transaction gateway service rpc types

### DIFF
--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -633,14 +633,14 @@ ss::future<abort_tx_reply> rm_partition_frontend::abort_tx(
 
     if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
         return ss::make_ready_future<abort_tx_reply>(
-          abort_tx_reply{.ec = tx_errc::partition_not_exists});
+          abort_tx_reply{tx_errc::partition_not_exists});
     }
 
     auto leader = _leaders.local().get_leader(ntp);
     if (!leader) {
         vlog(txlog.warn, "can't find a leader for {}", ntp);
         return ss::make_ready_future<abort_tx_reply>(
-          abort_tx_reply{.ec = tx_errc::leader_not_found});
+          abort_tx_reply{tx_errc::leader_not_found});
     }
 
     auto _self = _controller->self();
@@ -692,7 +692,7 @@ ss::future<abort_tx_reply> rm_partition_frontend::dispatch_abort_tx(
       .then([](result<abort_tx_reply> r) {
           if (r.has_error()) {
               vlog(txlog.warn, "got error {} on remote abort tx", r.error());
-              return abort_tx_reply{.ec = tx_errc::timeout};
+              return abort_tx_reply{tx_errc::timeout};
           }
 
           return r.value();
@@ -728,14 +728,14 @@ ss::future<abort_tx_reply> rm_partition_frontend::do_abort_tx(
   model::timeout_clock::duration timeout) {
     if (!is_leader_of(ntp)) {
         return ss::make_ready_future<abort_tx_reply>(
-          abort_tx_reply{.ec = tx_errc::leader_not_found});
+          abort_tx_reply{tx_errc::leader_not_found});
     }
 
     auto shard = _shard_table.local().shard_for(ntp);
 
     if (!shard) {
         return ss::make_ready_future<abort_tx_reply>(
-          abort_tx_reply{.ec = tx_errc::shard_not_found});
+          abort_tx_reply{tx_errc::shard_not_found});
     }
 
     return _partition_manager.invoke_on(
@@ -745,7 +745,7 @@ ss::future<abort_tx_reply> rm_partition_frontend::do_abort_tx(
           auto partition = mgr.get(ntp);
           if (!partition) {
               return ss::make_ready_future<abort_tx_reply>(
-                abort_tx_reply{.ec = tx_errc::partition_not_found});
+                abort_tx_reply{tx_errc::partition_not_found});
           }
 
           auto stm = partition->rm_stm();
@@ -753,11 +753,11 @@ ss::future<abort_tx_reply> rm_partition_frontend::do_abort_tx(
           if (!stm) {
               vlog(txlog.warn, "can't get tx stm of the {}' partition", ntp);
               return ss::make_ready_future<abort_tx_reply>(
-                abort_tx_reply{.ec = tx_errc::stm_not_found});
+                abort_tx_reply{tx_errc::stm_not_found});
           }
 
           return stm->abort_tx(pid, tx_seq, timeout).then([](tx_errc ec) {
-              return cluster::abort_tx_reply{.ec = ec};
+              return cluster::abort_tx_reply{ec};
           });
       });
 }

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -685,8 +685,7 @@ ss::future<abort_tx_reply> rm_partition_frontend::dispatch_abort_tx(
         timeout,
         [ntp, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
             return cp.abort_tx(
-              abort_tx_request{
-                .ntp = ntp, .pid = pid, .tx_seq = tx_seq, .timeout = timeout},
+              abort_tx_request{ntp, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<abort_tx_reply>)

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -221,11 +221,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::dispatch_begin_tx(
         [ntp, pid, tx_seq, transaction_timeout_ms, timeout](
           tx_gateway_client_protocol cp) {
             return cp.begin_tx(
-              begin_tx_request{
-                .ntp = ntp,
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .transaction_timeout_ms = transaction_timeout_ms},
+              begin_tx_request{ntp, pid, tx_seq, transaction_timeout_ms},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<begin_tx_reply>)

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -546,8 +546,7 @@ ss::future<commit_tx_reply> rm_partition_frontend::dispatch_commit_tx(
         timeout,
         [ntp, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
             return cp.commit_tx(
-              commit_tx_request{
-                .ntp = ntp, .pid = pid, .tx_seq = tx_seq, .timeout = timeout},
+              commit_tx_request{ntp, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<commit_tx_reply>)

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -392,13 +392,7 @@ ss::future<prepare_tx_reply> rm_partition_frontend::dispatch_prepare_tx(
         timeout,
         [ntp, etag, tm, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
             return cp.prepare_tx(
-              prepare_tx_request{
-                .ntp = ntp,
-                .etag = etag,
-                .tm = tm,
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .timeout = timeout},
+              prepare_tx_request{ntp, etag, tm, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<prepare_tx_reply>)

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -331,14 +331,14 @@ ss::future<prepare_tx_reply> rm_partition_frontend::prepare_tx(
 
     if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
         return ss::make_ready_future<prepare_tx_reply>(
-          prepare_tx_reply{.ec = tx_errc::partition_not_exists});
+          prepare_tx_reply{tx_errc::partition_not_exists});
     }
 
     auto leader = _leaders.local().get_leader(ntp);
     if (!leader) {
         vlog(txlog.warn, "can't find a leader for {}", ntp);
         return ss::make_ready_future<prepare_tx_reply>(
-          prepare_tx_reply{.ec = tx_errc::leader_not_found});
+          prepare_tx_reply{tx_errc::leader_not_found});
     }
 
     auto _self = _controller->self();
@@ -399,7 +399,7 @@ ss::future<prepare_tx_reply> rm_partition_frontend::dispatch_prepare_tx(
       .then([](result<prepare_tx_reply> r) {
           if (r.has_error()) {
               vlog(txlog.warn, "got error {} on remote prepare tx", r.error());
-              return prepare_tx_reply{.ec = tx_errc::timeout};
+              return prepare_tx_reply{tx_errc::timeout};
           }
 
           return r.value();
@@ -445,14 +445,14 @@ ss::future<prepare_tx_reply> rm_partition_frontend::do_prepare_tx(
   model::timeout_clock::duration timeout) {
     if (!is_leader_of(ntp)) {
         return ss::make_ready_future<prepare_tx_reply>(
-          prepare_tx_reply{.ec = tx_errc::leader_not_found});
+          prepare_tx_reply{tx_errc::leader_not_found});
     }
 
     auto shard = _shard_table.local().shard_for(ntp);
 
     if (!shard) {
         return ss::make_ready_future<prepare_tx_reply>(
-          prepare_tx_reply{.ec = tx_errc::shard_not_found});
+          prepare_tx_reply{tx_errc::shard_not_found});
     }
 
     return _partition_manager.invoke_on(
@@ -463,7 +463,7 @@ ss::future<prepare_tx_reply> rm_partition_frontend::do_prepare_tx(
           auto partition = mgr.get(ntp);
           if (!partition) {
               return ss::make_ready_future<prepare_tx_reply>(
-                prepare_tx_reply{.ec = tx_errc::partition_not_found});
+                prepare_tx_reply{tx_errc::partition_not_found});
           }
 
           auto stm = partition->rm_stm();
@@ -471,11 +471,11 @@ ss::future<prepare_tx_reply> rm_partition_frontend::do_prepare_tx(
           if (!stm) {
               vlog(txlog.warn, "can't get tx stm of the {}' partition", ntp);
               return ss::make_ready_future<prepare_tx_reply>(
-                prepare_tx_reply{.ec = tx_errc::stm_not_found});
+                prepare_tx_reply{tx_errc::stm_not_found});
           }
 
           return stm->prepare_tx(etag, tm, pid, tx_seq, timeout)
-            .then([](tx_errc ec) { return prepare_tx_reply{.ec = ec}; });
+            .then([](tx_errc ec) { return prepare_tx_reply{ec}; });
       });
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -269,7 +269,7 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
     if (is_new_pid || pid.get_epoch() > fence_it->second) {
         if (!is_new_pid) {
             auto old_pid = model::producer_identity{
-              .id = pid.get_id(), .epoch = fence_it->second};
+              pid.get_id(), fence_it->second};
             // there is a fence, it might be that tm_stm failed, forget about
             // an ongoing transaction, assigned next pid for the same tx.id and
             // started a new transaction without aborting the previous one.
@@ -1631,8 +1631,7 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     tx_snapshot tx_ss;
 
     for (auto const& [k, v] : _log_state.fence_pid_epoch) {
-        tx_ss.fenced.push_back(
-          model::producer_identity{.id = k(), .epoch = v()});
+        tx_ss.fenced.push_back(model::producer_identity{k(), v()});
     }
     for (auto& entry : _log_state.ongoing_map) {
         tx_ss.ongoing.push_back(entry.second);

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -53,7 +53,7 @@ FIXTURE_TEST(
       .producer_id = -1,
       .base_sequence = 0});
     auto bid1 = model::batch_identity{
-      .pid = model::producer_identity{.id = -1, .epoch = 0},
+      .pid = model::producer_identity{-1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
     auto r1 = stm
@@ -71,7 +71,7 @@ FIXTURE_TEST(
       .producer_id = -1,
       .base_sequence = 0});
     auto bid2 = model::batch_identity{
-      .pid = model::producer_identity{.id = -1, .epoch = 0},
+      .pid = model::producer_identity{-1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
     auto r2 = stm
@@ -105,7 +105,7 @@ FIXTURE_TEST(
       .producer_id = 1,
       .base_sequence = 0});
     auto bid1 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
     auto r1 = stm
@@ -123,7 +123,7 @@ FIXTURE_TEST(
       .producer_id = 1,
       .base_sequence = count});
     auto bid2 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = count,
       .last_seq = count + (count - 1)};
     auto r2 = stm
@@ -162,7 +162,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, mux_state_machine_fixture) {
           .producer_id = 1,
           .base_sequence = i * count});
         auto bid = model::batch_identity{
-          .pid = model::producer_identity{.id = 1, .epoch = 0},
+          .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
           .last_seq = i * count + (count - 1)};
         auto r1 = stm
@@ -187,7 +187,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, mux_state_machine_fixture) {
           .producer_id = 1,
           .base_sequence = i * count});
         auto bid = model::batch_identity{
-          .pid = model::producer_identity{.id = 1, .epoch = 0},
+          .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
           .last_seq = i * count + (count - 1)};
         auto r1 = stm
@@ -225,7 +225,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, mux_state_machine_fixture) {
           .producer_id = 1,
           .base_sequence = i * count});
         auto bid = model::batch_identity{
-          .pid = model::producer_identity{.id = 1, .epoch = 0},
+          .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
           .last_seq = i * count + (count - 1)};
         auto r1 = stm
@@ -246,7 +246,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, mux_state_machine_fixture) {
           .producer_id = 1,
           .base_sequence = 0});
         auto bid = model::batch_identity{
-          .pid = model::producer_identity{.id = 1, .epoch = 0},
+          .pid = model::producer_identity{1, 0},
           .first_seq = 0,
           .last_seq = count - 1};
         auto r1 = stm
@@ -283,7 +283,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
       .producer_id = 1,
       .base_sequence = 0});
     auto bid1 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
     auto r1 = stm
@@ -301,7 +301,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
       .producer_id = 1,
       .base_sequence = count + 1});
     auto bid2 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = count + 1,
       .last_seq = count + 1 + (count - 1)};
     auto r2 = stm
@@ -337,7 +337,7 @@ FIXTURE_TEST(
       .base_sequence = 1});
 
     auto bid = model::batch_identity{
-      .pid = model::producer_identity{.id = 0, .epoch = 0},
+      .pid = model::producer_identity{0, 0},
       .first_seq = 1,
       .last_seq = 1 + (count - 1)};
 
@@ -372,7 +372,7 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, mux_state_machine_fixture) {
       .producer_id = 1,
       .base_sequence = 0});
     auto bid1 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
 
@@ -386,7 +386,7 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, mux_state_machine_fixture) {
       .producer_id = 1,
       .base_sequence = 0});
     auto bid2 = model::batch_identity{
-      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .pid = model::producer_identity{1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
 

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -79,7 +79,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     auto min_offset = model::offset(0);
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -94,7 +94,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     auto first_offset = offset_r.value().last_offset();
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
-    auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
                      .begin_tx(
                        pid2,
@@ -152,7 +152,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     auto min_offset = model::offset(0);
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -167,7 +167,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     auto first_offset = offset_r.value().last_offset();
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
-    auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
                      .begin_tx(
                        pid2,
@@ -227,7 +227,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     auto min_offset = model::offset(0);
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -242,7 +242,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     auto first_offset = offset_r.value().last_offset();
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
-    auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
                      .begin_tx(
                        pid2,
@@ -302,7 +302,7 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -313,7 +313,7 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
                       .get0();
     BOOST_REQUIRE((bool)offset_r);
 
-    auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid2 = model::producer_identity{2, 0};
     rreader = make_rreader(pid2, 0, 5, true);
     offset_r = stm
                  .replicate(
@@ -340,7 +340,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -351,7 +351,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
                       .get0();
     BOOST_REQUIRE((bool)offset_r);
 
-    auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid20 = model::producer_identity{2, 0};
     auto term_op = stm
                      .begin_tx(
                        pid20,
@@ -361,7 +361,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
                      .get0();
     BOOST_REQUIRE((bool)term_op);
 
-    auto pid21 = model::producer_identity{.id = 2, .epoch = 1};
+    auto pid21 = model::producer_identity{2, 1};
     term_op = stm
                 .begin_tx(
                   pid21,
@@ -397,7 +397,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_rreader(pid1, 0, 5, false);
     auto offset_r = stm
                       .replicate(
@@ -408,7 +408,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
                       .get0();
     BOOST_REQUIRE((bool)offset_r);
 
-    auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
+    auto pid20 = model::producer_identity{2, 0};
     auto term_op = stm
                      .begin_tx(
                        pid20,

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -960,6 +960,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::prepare_tx_request data{
+          model::random_ntp(),
+          tests::random_named_int<model::term_id>(),
+          tests::random_named_int<model::partition_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -723,41 +723,29 @@ cluster::tx_errc random_tx_errc() {
 
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
-      model::ntp(
-        model::ns("a namespace"),
-        model::topic("a topic"),
-        model::partition_id(287)),
-      model::term_id(1234),
-      model::node_id(2)));
+      model::random_ntp(),
+      tests::random_named_int<model::term_id>(),
+      tests::random_named_int<model::node_id>()));
 
     roundtrip_test(cluster::ntp_leader_revision(
-      model::ntp(
-        model::ns("a namespace"),
-        model::topic("a topic"),
-        model::partition_id(287)),
-      model::term_id(1234),
-      model::node_id(2),
-      model::revision_id(888)));
+      model::random_ntp(),
+      tests::random_named_int<model::term_id>(),
+      tests::random_named_int<model::node_id>(),
+      tests::random_named_int<model::revision_id>()));
 
     roundtrip_test(cluster::update_leadership_request({
       cluster::ntp_leader(
-        model::ntp(
-          model::ns("a namespace"),
-          model::topic("a topic"),
-          model::partition_id(287)),
-        model::term_id(1234),
-        model::node_id(2)),
+        model::random_ntp(),
+        tests::random_named_int<model::term_id>(),
+        tests::random_named_int<model::node_id>()),
     }));
 
     roundtrip_test(cluster::update_leadership_request_v2({
       cluster::ntp_leader_revision(
-        model::ntp(
-          model::ns("a namespace"),
-          model::topic("a topic"),
-          model::partition_id(287)),
-        model::term_id(1234),
-        model::node_id(2),
-        model::revision_id(8888)),
+        model::random_ntp(),
+        tests::random_named_int<model::term_id>(),
+        tests::random_named_int<model::node_id>(),
+        tests::random_named_int<model::revision_id>()),
     }));
 
     roundtrip_test(cluster::update_leadership_reply());
@@ -766,12 +754,9 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
     roundtrip_test(cluster::get_leadership_reply({
       cluster::ntp_leader(
-        model::ntp(
-          model::ns("a namespace"),
-          model::topic("a topic"),
-          model::partition_id(287)),
-        model::term_id(1234),
-        model::node_id(2)),
+        model::random_ntp(),
+        tests::random_named_int<model::term_id>(),
+        tests::random_named_int<model::node_id>()),
     }));
 
     roundtrip_test(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -927,6 +927,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::init_tm_tx_request data{
+          tests::random_named_string<kafka::transactional_id>(),
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            random_timeout_clock_duration()),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -971,6 +971,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::prepare_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1077,6 +1077,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::commit_group_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -997,6 +997,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::abort_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -975,6 +975,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::prepare_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::commit_tx_request data{
+          model::random_ntp(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -952,6 +952,14 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::begin_tx_reply data{
+          model::random_ntp(),
+          tests::random_named_int<model::term_id>(),
+          random_tx_errc()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -697,6 +697,30 @@ model::timeout_clock::duration random_timeout_clock_duration() {
       random_generators::get_int(-100000, 100000));
 }
 
+cluster::tx_errc random_tx_errc() {
+    return random_generators::random_choice(std::vector<cluster::tx_errc>{
+      cluster::tx_errc::none,
+      cluster::tx_errc::leader_not_found,
+      cluster::tx_errc::shard_not_found,
+      cluster::tx_errc::partition_not_found,
+      cluster::tx_errc::stm_not_found,
+      cluster::tx_errc::partition_not_exists,
+      cluster::tx_errc::pid_not_found,
+      cluster::tx_errc::timeout,
+      cluster::tx_errc::conflict,
+      cluster::tx_errc::fenced,
+      cluster::tx_errc::stale,
+      cluster::tx_errc::not_coordinator,
+      cluster::tx_errc::coordinator_not_available,
+      cluster::tx_errc::preparing_rebalance,
+      cluster::tx_errc::rebalance_in_progress,
+      cluster::tx_errc::coordinator_load_in_progress,
+      cluster::tx_errc::unknown_server_error,
+      cluster::tx_errc::request_rejected,
+      cluster::tx_errc::invalid_producer_id_mapping,
+      cluster::tx_errc::invalid_txn_state});
+}
+
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
       model::ntp(
@@ -892,6 +916,14 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           random_producer_identity(),
           tests::random_named_int<model::tx_seq>(),
           random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
+    {
+        cluster::try_abort_reply data{
+          cluster::try_abort_reply::committed_type(tests::random_bool()),
+          cluster::try_abort_reply::aborted_type(tests::random_bool()),
+          random_tx_errc()};
 
         roundtrip_test(data);
     }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1021,6 +1021,16 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::begin_group_tx_reply data{
+          tests::random_named_int<model::term_id>(), random_tx_errc()};
+        roundtrip_test(data);
+    }
+    {
+        // error only ctor
+        cluster::begin_group_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -984,6 +984,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::commit_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1057,6 +1057,26 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::prepare_group_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::commit_group_tx_request data{
+          model::random_ntp(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_named_string<kafka::group_id>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
+    {
+        // with default ntp ctor
+        cluster::commit_group_tx_request data{
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_named_string<kafka::group_id>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1101,6 +1101,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::abort_group_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -988,6 +988,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::commit_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::abort_tx_request data{
+          model::random_ntp(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1081,6 +1081,26 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::commit_group_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::abort_group_tx_request data{
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
+    {
+        // with default ntp ctor
+        cluster::abort_group_tx_request data{
+          tests::random_named_string<kafka::group_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1031,6 +1031,28 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::begin_group_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::prepare_group_tx_request data{
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          tests::random_named_int<model::term_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
+    {
+        // with default ntp ctor
+        cluster::prepare_group_tx_request data{
+          tests::random_named_string<kafka::group_id>(),
+          tests::random_named_int<model::term_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -936,6 +936,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::init_tm_tx_reply data{
+          random_producer_identity(), random_tx_errc()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1053,6 +1053,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::prepare_group_tx_reply data{random_tx_errc()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1001,6 +1001,26 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::abort_tx_reply data{random_tx_errc()};
         roundtrip_test(data);
     }
+    {
+        cluster::begin_group_tx_request data{
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
+    {
+        // with default ntp ctor
+        cluster::begin_group_tx_request data{
+          tests::random_named_string<kafka::group_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -682,6 +682,21 @@ cluster::feature_update_action random_feature_update_action() {
     return action;
 }
 
+model::producer_identity random_producer_identity() {
+    return {
+      random_generators::get_int(
+        std::numeric_limits<int64_t>::min(),
+        std::numeric_limits<int64_t>::max()),
+      random_generators::get_int(
+        std::numeric_limits<int16_t>::min(),
+        std::numeric_limits<int16_t>::max())};
+}
+
+model::timeout_clock::duration random_timeout_clock_duration() {
+    return model::timeout_clock::duration(
+      random_generators::get_int(-100000, 100000));
+}
+
 SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     roundtrip_test(cluster::ntp_leader(
       model::ntp(
@@ -868,6 +883,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           random_feature_update_action()};
         data.logical_version
           = tests::random_named_int<cluster::cluster_version>();
+
+        roundtrip_test(data);
+    }
+    {
+        cluster::try_abort_request data{
+          tests::random_named_int<model::partition_id>(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          random_timeout_clock_duration()};
 
         roundtrip_test(data);
     }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -942,6 +942,16 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         roundtrip_test(data);
     }
+    {
+        cluster::begin_tx_request data{
+          model::random_ntp(),
+          random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            random_timeout_clock_duration())};
+
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -55,7 +55,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid = model::producer_identity{1, 0};
 
     auto op_code = stm
                      .register_new_producer(
@@ -114,7 +114,7 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid = model::producer_identity{1, 0};
 
     auto op_code = stm
                      .register_new_producer(
@@ -153,7 +153,7 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     wait_for_meta_initialized();
 
     auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
+    auto pid1 = model::producer_identity{1, 0};
 
     auto op_code = stm
                      .register_new_producer(
@@ -173,7 +173,7 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
     auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
 
-    auto pid2 = model::producer_identity{.id = 1, .epoch = 1};
+    auto pid2 = model::producer_identity{1, 1};
     op_code = stm
                 .re_register_producer(
                   c->term(), tx_id, std::chrono::milliseconds(0), pid2)

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -600,10 +600,7 @@ ss::future<init_tm_tx_reply> tx_gateway_frontend::dispatch_init_tm_tx(
         [tx_id, transaction_timeout_ms, timeout](
           tx_gateway_client_protocol cp) {
             return cp.init_tm_tx(
-              init_tm_tx_request{
-                .tx_id = tx_id,
-                .transaction_timeout_ms = transaction_timeout_ms,
-                .timeout = timeout},
+              init_tm_tx_request{tx_id, transaction_timeout_ms, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<init_tm_tx_reply>)

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -294,8 +294,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::dispatch_try_abort(
         timeout,
         [tm, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
             return cp.try_abort(
-              try_abort_request{
-                .tm = tm, .pid = pid, .tx_seq = tx_seq, .timeout = timeout},
+              try_abort_request{tm, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<try_abort_reply>)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -263,7 +263,13 @@ struct abort_tx_request {
 
 struct abort_tx_reply {
     tx_errc ec;
+
+    abort_tx_reply() noexcept = default;
+
+    explicit abort_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
+
 struct begin_group_tx_request {
     model::ntp ntp;
     kafka::group_id group_id;
@@ -1712,6 +1718,15 @@ struct adl<cluster::abort_tx_request> {
         auto tx_seq = adl<model::tx_seq>{}.from(in);
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {std::move(ntp), pid, tx_seq, timeout};
+    }
+};
+
+template<>
+struct adl<cluster::abort_tx_reply> {
+    void to(iobuf& out, cluster::abort_tx_reply&& r) { serialize(out, r.ec); }
+    cluster::abort_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::abort_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -591,12 +591,15 @@ struct commit_group_tx_reply
     auto serde_fields() { return std::tie(ec); }
 };
 
-struct abort_group_tx_request {
+struct abort_group_tx_request
+  : serde::envelope<abort_group_tx_request, serde::version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    abort_group_tx_request() noexcept = default;
 
     abort_group_tx_request(
       model::ntp ntp,
@@ -621,6 +624,10 @@ struct abort_group_tx_request {
       model::timeout_clock::duration timeout)
       : abort_group_tx_request(
         model::ntp(), std::move(group_id), pid, tx_seq, timeout) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, group_id, pid, tx_seq, timeout);
+    }
 };
 
 struct abort_group_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -319,6 +319,11 @@ struct abort_group_tx_request {
 
 struct abort_group_tx_reply {
     tx_errc ec;
+
+    abort_group_tx_reply() noexcept = default;
+
+    explicit abort_group_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
 
 /// Old-style request sent by node to join raft-0
@@ -1471,6 +1476,17 @@ struct adl<cluster::abort_group_tx_request> {
         auto tx_seq = adl<model::tx_seq>{}.from(in);
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {std::move(ntp), std::move(group_id), pid, tx_seq, timeout};
+    }
+};
+
+template<>
+struct adl<cluster::abort_group_tx_reply> {
+    void to(iobuf& out, cluster::abort_group_tx_reply&& r) {
+        serialize(out, r.ec);
+    }
+    cluster::abort_group_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::abort_group_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -397,11 +397,13 @@ struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
     auto serde_fields() { return std::tie(ec); }
 };
 
-struct abort_tx_request {
+struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    abort_tx_request() noexcept = default;
 
     abort_tx_request(
       model::ntp ntp,
@@ -412,6 +414,8 @@ struct abort_tx_request {
       , pid(pid)
       , tx_seq(tx_seq)
       , timeout(timeout) {}
+
+    auto serde_fields() { return std::tie(ntp, pid, tx_seq, timeout); }
 };
 
 struct abort_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -304,7 +304,7 @@ struct begin_tx_request : serde::envelope<begin_tx_request, serde::version<0>> {
     }
 };
 
-struct begin_tx_reply {
+struct begin_tx_reply : serde::envelope<begin_tx_reply, serde::version<0>> {
     model::ntp ntp;
     model::term_id etag;
     tx_errc ec;
@@ -319,6 +319,8 @@ struct begin_tx_reply {
     begin_tx_reply(model::ntp ntp, tx_errc ec)
       : ntp(std::move(ntp))
       , ec(ec) {}
+
+    auto serde_fields() { return std::tie(ntp, etag, ec); }
 };
 
 struct prepare_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -429,12 +429,15 @@ struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
     auto serde_fields() { return std::tie(ec); }
 };
 
-struct begin_group_tx_request {
+struct begin_group_tx_request
+  : serde::envelope<begin_group_tx_request, serde::version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    begin_group_tx_request() noexcept = default;
 
     begin_group_tx_request(
       model::ntp ntp,
@@ -459,6 +462,10 @@ struct begin_group_tx_request {
       model::timeout_clock::duration timeout)
       : begin_group_tx_request(
         model::ntp(), std::move(group_id), pid, tx_seq, timeout) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, group_id, pid, tx_seq, timeout);
+    }
 };
 
 struct begin_group_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -528,13 +528,16 @@ struct prepare_group_tx_request
     }
 };
 
-struct prepare_group_tx_reply {
+struct prepare_group_tx_reply
+  : serde::envelope<prepare_group_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     prepare_group_tx_reply() noexcept = default;
 
     explicit prepare_group_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 struct commit_group_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -281,11 +281,13 @@ struct end_tx_request {
 struct end_tx_reply {
     tx_errc error_code{};
 };
-struct begin_tx_request {
+struct begin_tx_request : serde::envelope<begin_tx_request, serde::version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     std::chrono::milliseconds transaction_timeout_ms;
+
+    begin_tx_request() noexcept = default;
 
     begin_tx_request(
       model::ntp ntp,
@@ -296,6 +298,10 @@ struct begin_tx_request {
       , pid(pid)
       , tx_seq(tx_seq)
       , transaction_timeout_ms(transaction_timeout_ms) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, pid, tx_seq, transaction_timeout_ms);
+    }
 };
 
 struct begin_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -175,13 +175,15 @@ struct try_abort_request
     auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
 };
 
-struct try_abort_reply {
+struct try_abort_reply : serde::envelope<try_abort_reply, serde::version<0>> {
     using committed_type = ss::bool_class<struct committed_type_tag>;
     using aborted_type = ss::bool_class<struct aborted_type_tag>;
 
     committed_type commited;
     aborted_type aborted;
     tx_errc ec;
+
+    try_abort_reply() noexcept = default;
 
     try_abort_reply(committed_type committed, aborted_type aborted, tx_errc ec)
       : commited(committed)
@@ -198,6 +200,8 @@ struct try_abort_reply {
     static try_abort_reply make_committed() {
         return {committed_type::yes, aborted_type::no, tx_errc::none};
     }
+
+    auto serde_fields() { return std::tie(commited, aborted, ec); }
 };
 
 struct init_tm_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -353,13 +353,15 @@ struct prepare_tx_request
     }
 };
 
-struct prepare_tx_reply {
+struct prepare_tx_reply : serde::envelope<prepare_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     prepare_tx_reply() noexcept = default;
 
     explicit prepare_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 struct commit_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -309,7 +309,13 @@ struct commit_group_tx_request {
 
 struct commit_group_tx_reply {
     tx_errc ec;
+
+    commit_group_tx_reply() noexcept = default;
+
+    explicit commit_group_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
+
 struct abort_group_tx_request {
     model::ntp ntp;
     kafka::group_id group_id;
@@ -1533,6 +1539,17 @@ struct adl<cluster::commit_group_tx_request> {
         auto group_id = adl<kafka::group_id>{}.from(in);
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {std::move(ntp), pid, tx_seq, std::move(group_id), timeout};
+    }
+};
+
+template<>
+struct adl<cluster::commit_group_tx_reply> {
+    void to(iobuf& out, cluster::commit_group_tx_reply&& r) {
+        serialize(out, r.ec);
+    }
+    cluster::commit_group_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::commit_group_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -323,13 +323,16 @@ struct begin_tx_reply : serde::envelope<begin_tx_reply, serde::version<0>> {
     auto serde_fields() { return std::tie(ntp, etag, ec); }
 };
 
-struct prepare_tx_request {
+struct prepare_tx_request
+  : serde::envelope<prepare_tx_request, serde::version<0>> {
     model::ntp ntp;
     model::term_id etag;
     model::partition_id tm;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    prepare_tx_request() noexcept = default;
 
     prepare_tx_request(
       model::ntp ntp,
@@ -344,6 +347,10 @@ struct prepare_tx_request {
       , pid(pid)
       , tx_seq(tx_seq)
       , timeout(timeout) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, etag, tm, pid, tx_seq, timeout);
+    }
 };
 
 struct prepare_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -249,7 +249,13 @@ struct prepare_tx_request {
 
 struct prepare_tx_reply {
     tx_errc ec;
+
+    prepare_tx_reply() noexcept = default;
+
+    explicit prepare_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
+
 struct commit_tx_request {
     model::ntp ntp;
     model::producer_identity pid;
@@ -1799,6 +1805,15 @@ struct adl<cluster::prepare_tx_request> {
         auto tx_seq = adl<model::tx_seq>{}.from(in);
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {std::move(ntp), etag, tm, pid, tx_seq, timeout};
+    }
+};
+
+template<>
+struct adl<cluster::prepare_tx_reply> {
+    void to(iobuf& out, cluster::prepare_tx_reply&& r) { serialize(out, r.ec); }
+    cluster::prepare_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::prepare_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -418,13 +418,15 @@ struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {
     auto serde_fields() { return std::tie(ntp, pid, tx_seq, timeout); }
 };
 
-struct abort_tx_reply {
+struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     abort_tx_reply() noexcept = default;
 
     explicit abort_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 struct begin_group_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -153,11 +153,14 @@ inline std::error_code make_error_code(tx_errc e) noexcept {
     return std::error_code(static_cast<int>(e), tx_error_category());
 }
 
-struct try_abort_request {
+struct try_abort_request
+  : serde::envelope<try_abort_request, serde::version<0>> {
     model::partition_id tm;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    try_abort_request() noexcept = default;
 
     try_abort_request(
       model::partition_id tm,
@@ -168,6 +171,8 @@ struct try_abort_request {
       , pid(pid)
       , tx_seq(tx_seq)
       , timeout(timeout) {}
+
+    auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
 };
 
 struct try_abort_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -630,13 +630,16 @@ struct abort_group_tx_request
     }
 };
 
-struct abort_group_tx_reply {
+struct abort_group_tx_reply
+  : serde::envelope<abort_group_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     abort_group_tx_reply() noexcept = default;
 
     explicit abort_group_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 /// Old-style request sent by node to join raft-0

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -540,12 +540,15 @@ struct prepare_group_tx_reply
     auto serde_fields() { return std::tie(ec); }
 };
 
-struct commit_group_tx_request {
+struct commit_group_tx_request
+  : serde::envelope<commit_group_tx_request, serde::version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     kafka::group_id group_id;
     model::timeout_clock::duration timeout;
+
+    commit_group_tx_request() noexcept = default;
 
     commit_group_tx_request(
       model::ntp ntp,
@@ -570,6 +573,10 @@ struct commit_group_tx_request {
       model::timeout_clock::duration timeout)
       : commit_group_tx_request(
         model::ntp(), pid, tx_seq, std::move(group_id), timeout) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, pid, tx_seq, group_id, timeout);
+    }
 };
 
 struct commit_group_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -302,7 +302,13 @@ struct prepare_group_tx_request {
 
 struct prepare_group_tx_reply {
     tx_errc ec;
+
+    prepare_group_tx_reply() noexcept = default;
+
+    explicit prepare_group_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
+
 struct commit_group_tx_request {
     model::ntp ntp;
     model::producer_identity pid;
@@ -1602,6 +1608,17 @@ struct adl<cluster::prepare_group_tx_request> {
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {
           std::move(ntp), std::move(group_id), etag, pid, tx_seq, timeout};
+    }
+};
+
+template<>
+struct adl<cluster::prepare_group_tx_reply> {
+    void to(iobuf& out, cluster::prepare_group_tx_reply&& r) {
+        serialize(out, r.ec);
+    }
+    cluster::prepare_group_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::prepare_group_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -225,7 +225,7 @@ struct init_tm_tx_request
     }
 };
 
-struct init_tm_tx_reply {
+struct init_tm_tx_reply : serde::envelope<init_tm_tx_reply, serde::version<0>> {
     // partition_not_exists, not_leader, topic_not_exists
     model::producer_identity pid;
     tx_errc ec;
@@ -238,6 +238,8 @@ struct init_tm_tx_reply {
 
     explicit init_tm_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(pid, ec); }
 };
 
 struct add_paritions_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -579,13 +579,16 @@ struct commit_group_tx_request
     }
 };
 
-struct commit_group_tx_reply {
+struct commit_group_tx_reply
+  : serde::envelope<commit_group_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     commit_group_tx_reply() noexcept = default;
 
     explicit commit_group_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 struct abort_group_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -468,7 +468,8 @@ struct begin_group_tx_request
     }
 };
 
-struct begin_group_tx_reply {
+struct begin_group_tx_reply
+  : serde::envelope<begin_group_tx_reply, serde::version<0>> {
     model::term_id etag;
     tx_errc ec;
 
@@ -480,6 +481,8 @@ struct begin_group_tx_reply {
     begin_group_tx_reply(model::term_id etag, tx_errc ec)
       : etag(etag)
       , ec(ec) {}
+
+    auto serde_fields() { return std::tie(etag, ec); }
 };
 
 struct prepare_group_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -364,11 +364,14 @@ struct prepare_tx_reply : serde::envelope<prepare_tx_reply, serde::version<0>> {
     auto serde_fields() { return std::tie(ec); }
 };
 
-struct commit_tx_request {
+struct commit_tx_request
+  : serde::envelope<commit_tx_request, serde::version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    commit_tx_request() noexcept = default;
 
     commit_tx_request(
       model::ntp ntp,
@@ -379,6 +382,8 @@ struct commit_tx_request {
       , pid(pid)
       , tx_seq(tx_seq)
       , timeout(timeout) {}
+
+    auto serde_fields() { return std::tie(ntp, pid, tx_seq, timeout); }
 };
 
 struct commit_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -254,7 +254,13 @@ struct commit_tx_request {
 
 struct commit_tx_reply {
     tx_errc ec;
+
+    commit_tx_reply() noexcept = default;
+
+    explicit commit_tx_reply(tx_errc ec)
+      : ec(ec) {}
 };
+
 struct abort_tx_request {
     model::ntp ntp;
     model::producer_identity pid;
@@ -1752,6 +1758,15 @@ struct adl<cluster::commit_tx_request> {
         auto tx_seq = adl<model::tx_seq>{}.from(in);
         auto timeout = adl<model::timeout_clock::duration>{}.from(in);
         return {std::move(ntp), pid, tx_seq, timeout};
+    }
+};
+
+template<>
+struct adl<cluster::commit_tx_reply> {
+    void to(iobuf& out, cluster::commit_tx_reply&& r) { serialize(out, r.ec); }
+    cluster::commit_tx_reply from(iobuf_parser& in) {
+        auto ec = adl<cluster::tx_errc>{}.from(in);
+        return cluster::commit_tx_reply{ec};
     }
 };
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -386,13 +386,15 @@ struct commit_tx_request
     auto serde_fields() { return std::tie(ntp, pid, tx_seq, timeout); }
 };
 
-struct commit_tx_reply {
+struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
     tx_errc ec;
 
     commit_tx_reply() noexcept = default;
 
     explicit commit_tx_reply(tx_errc ec)
       : ec(ec) {}
+
+    auto serde_fields() { return std::tie(ec); }
 };
 
 struct abort_tx_request {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -485,13 +485,16 @@ struct begin_group_tx_reply
     auto serde_fields() { return std::tie(etag, ec); }
 };
 
-struct prepare_group_tx_request {
+struct prepare_group_tx_request
+  : serde::envelope<prepare_group_tx_request, serde::version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::term_id etag;
     model::producer_identity pid;
     model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
+
+    prepare_group_tx_request() noexcept = default;
 
     prepare_group_tx_request(
       model::ntp ntp,
@@ -519,6 +522,10 @@ struct prepare_group_tx_request {
       model::timeout_clock::duration timeout)
       : prepare_group_tx_request(
         model::ntp(), std::move(group_id), etag, pid, tx_seq, timeout) {}
+
+    auto serde_fields() {
+        return std::tie(ntp, group_id, etag, pid, tx_seq, timeout);
+    }
 };
 
 struct prepare_group_tx_reply {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -204,10 +204,13 @@ struct try_abort_reply : serde::envelope<try_abort_reply, serde::version<0>> {
     auto serde_fields() { return std::tie(commited, aborted, ec); }
 };
 
-struct init_tm_tx_request {
+struct init_tm_tx_request
+  : serde::envelope<init_tm_tx_request, serde::version<0>> {
     kafka::transactional_id tx_id;
     std::chrono::milliseconds transaction_timeout_ms;
     model::timeout_clock::duration timeout;
+
+    init_tm_tx_request() noexcept = default;
 
     init_tm_tx_request(
       kafka::transactional_id tx_id,
@@ -216,6 +219,10 @@ struct init_tm_tx_request {
       : tx_id(std::move(tx_id))
       , transaction_timeout_ms(tx_timeout)
       , timeout(timeout) {}
+
+    auto serde_fields() {
+        return std::tie(tx_id, transaction_timeout_ms, timeout);
+    }
 };
 
 struct init_tm_tx_reply {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1989,8 +1989,7 @@ group::store_txn_offsets(txn_offset_commit_request r) {
           r, error_code::unknown_server_error);
     }
 
-    model::producer_identity pid{
-      .id = r.data.producer_id, .epoch = r.data.producer_epoch};
+    model::producer_identity pid{r.data.producer_id, r.data.producer_epoch};
 
     auto tx_it = _volatile_txs.find(pid);
 

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -535,7 +535,7 @@ ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
     if (!ntp_opt) {
         vlog(cluster::txlog.warn, "can't find ntp for {} ", group_id);
         co_return cluster::abort_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
     auto ntp = std::move(ntp_opt.value());
 
@@ -543,14 +543,14 @@ ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
     if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
         vlog(cluster::txlog.warn, "can't find meta info for {}", ntp);
         co_return cluster::abort_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
 
     auto leader_opt = _leaders.local().get_leader(ntp);
     if (!leader_opt) {
         vlog(cluster::txlog.warn, "can't find a leader for {}", ntp);
         co_return cluster::abort_group_tx_reply{
-          .ec = cluster::tx_errc::leader_not_found};
+          cluster::tx_errc::leader_not_found};
     }
     auto leader = leader_opt.value();
     auto _self = _controller->self();
@@ -615,8 +615,7 @@ rm_group_frontend::dispatch_abort_group_tx(
                 cluster::txlog.warn,
                 "got error {} on remote abort group tx",
                 r.error());
-              return cluster::abort_group_tx_reply{
-                .ec = cluster::tx_errc::timeout};
+              return cluster::abort_group_tx_reply{cluster::tx_errc::timeout};
           }
 
           return r.value();

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -132,7 +132,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
               "can't create consumer group topic",
               group_id);
             co_return cluster::begin_group_tx_reply{
-              .ec = cluster::tx_errc::partition_not_exists};
+              cluster::tx_errc::partition_not_exists};
         }
     }
 
@@ -174,7 +174,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
     }
 
     if (!leader_opt) {
-        co_return cluster::begin_group_tx_reply{.ec = ec};
+        co_return cluster::begin_group_tx_reply{ec};
     }
 
     auto leader = leader_opt.value();
@@ -234,8 +234,7 @@ rm_group_frontend::dispatch_begin_group_tx(
                 cluster::txlog.warn,
                 "got error {} on remote begin group tx",
                 r.error());
-              return cluster::begin_group_tx_reply{
-                .ec = cluster::tx_errc::timeout};
+              return cluster::begin_group_tx_reply{cluster::tx_errc::timeout};
           }
 
           return r.value();

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -181,11 +181,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        cluster::begin_group_tx_request req;
-        req.group_id = group_id;
-        req.pid = pid;
-        req.tx_seq = tx_seq;
-        req.timeout = timeout;
+        cluster::begin_group_tx_request req{group_id, pid, tx_seq, timeout};
         co_return co_await begin_group_tx_locally(std::move(req));
     }
 
@@ -228,11 +224,7 @@ rm_group_frontend::dispatch_begin_group_tx(
         [group_id, pid, tx_seq, timeout](
           cluster::tx_gateway_client_protocol cp) {
             return cp.begin_group_tx(
-              cluster::begin_group_tx_request{
-                .group_id = group_id,
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .timeout = timeout},
+              cluster::begin_group_tx_request{group_id, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<cluster::begin_group_tx_reply>)

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -413,7 +413,7 @@ ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
     if (!ntp_opt) {
         vlog(cluster::txlog.warn, "can't find ntp for {}", group_id);
         co_return cluster::commit_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
 
     auto ntp = std::move(ntp_opt.value());
@@ -422,14 +422,14 @@ ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
     if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
         vlog(cluster::txlog.warn, "can' find meta info for {}", ntp);
         co_return cluster::commit_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
 
     auto leader_opt = _leaders.local().get_leader(ntp);
     if (!leader_opt) {
         vlog(cluster::txlog.warn, "can't find a leader for {}", ntp);
         co_return cluster::commit_group_tx_reply{
-          .ec = cluster::tx_errc::leader_not_found};
+          cluster::tx_errc::leader_not_found};
     }
     auto leader = leader_opt.value();
     auto _self = _controller->self();
@@ -489,8 +489,7 @@ rm_group_frontend::dispatch_commit_group_tx(
                 cluster::txlog.warn,
                 "got error {} on remote commit tx",
                 r.error());
-              return cluster::commit_group_tx_reply{
-                .ec = cluster::tx_errc::timeout};
+              return cluster::commit_group_tx_reply{cluster::tx_errc::timeout};
           }
 
           return r.value();

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -556,11 +556,12 @@ ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        cluster::abort_group_tx_request req;
-        req.group_id = group_id;
-        req.pid = pid;
-        req.tx_seq = tx_seq;
-        req.timeout = timeout;
+        cluster::abort_group_tx_request req{
+          group_id,
+          pid,
+          tx_seq,
+          timeout,
+        };
         co_return co_await abort_group_tx_locally(std::move(req));
     }
 
@@ -604,11 +605,7 @@ rm_group_frontend::dispatch_abort_group_tx(
         [group_id, pid, tx_seq, timeout](
           cluster::tx_gateway_client_protocol cp) {
             return cp.abort_group_tx(
-              cluster::abort_group_tx_request{
-                .group_id = group_id,
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .timeout = timeout},
+              cluster::abort_group_tx_request{group_id, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<cluster::abort_group_tx_reply>)

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -282,7 +282,7 @@ ss::future<cluster::prepare_group_tx_reply> rm_group_frontend::prepare_group_tx(
     if (!ntp_opt) {
         vlog(cluster::txlog.warn, "can't find ntp for {} ", group_id);
         co_return cluster::prepare_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
     auto ntp = std::move(ntp_opt.value());
 
@@ -290,14 +290,14 @@ ss::future<cluster::prepare_group_tx_reply> rm_group_frontend::prepare_group_tx(
     if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
         vlog(cluster::txlog.warn, "can't find meta info for {}", ntp);
         co_return cluster::prepare_group_tx_reply{
-          .ec = cluster::tx_errc::partition_not_exists};
+          cluster::tx_errc::partition_not_exists};
     }
 
     auto leader_opt = _leaders.local().get_leader(ntp);
     if (!leader_opt) {
         vlog(cluster::txlog.warn, "can't find a leader for {}", ntp);
         co_return cluster::prepare_group_tx_reply{
-          .ec = cluster::tx_errc::leader_not_found};
+          cluster::tx_errc::leader_not_found};
     }
     auto leader = leader_opt.value();
     auto _self = _controller->self();
@@ -363,8 +363,7 @@ rm_group_frontend::dispatch_prepare_group_tx(
                 cluster::txlog.warn,
                 "got error {} on remote prepare group tx",
                 r.error());
-              return cluster::prepare_group_tx_reply{
-                .ec = cluster::tx_errc::timeout};
+              return cluster::prepare_group_tx_reply{cluster::tx_errc::timeout};
           }
 
           return r.value();

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -435,11 +435,7 @@ ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        cluster::commit_group_tx_request req;
-        req.group_id = group_id;
-        req.pid = pid;
-        req.tx_seq = tx_seq;
-        req.timeout = timeout;
+        cluster::commit_group_tx_request req{pid, tx_seq, group_id, timeout};
         co_return co_await commit_group_tx_locally(std::move(req));
     }
 
@@ -483,11 +479,7 @@ rm_group_frontend::dispatch_commit_group_tx(
         [group_id, pid, tx_seq, timeout](
           cluster::tx_gateway_client_protocol cp) {
             return cp.commit_group_tx(
-              cluster::commit_group_tx_request{
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .group_id = group_id,
-                .timeout = timeout},
+              cluster::commit_group_tx_request{pid, tx_seq, group_id, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<cluster::commit_group_tx_reply>)

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -303,12 +303,8 @@ ss::future<cluster::prepare_group_tx_reply> rm_group_frontend::prepare_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        cluster::prepare_group_tx_request req;
-        req.group_id = group_id;
-        req.etag = etag;
-        req.pid = pid;
-        req.tx_seq = tx_seq;
-        req.timeout = timeout;
+        cluster::prepare_group_tx_request req{
+          group_id, etag, pid, tx_seq, timeout};
         co_return co_await prepare_group_tx_locally(std::move(req));
     }
 
@@ -357,11 +353,7 @@ rm_group_frontend::dispatch_prepare_group_tx(
           cluster::tx_gateway_client_protocol cp) {
             return cp.prepare_group_tx(
               cluster::prepare_group_tx_request{
-                .group_id = group_id,
-                .etag = etag,
-                .pid = pid,
-                .tx_seq = tx_seq,
-                .timeout = timeout},
+                group_id, etag, pid, tx_seq, timeout},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<cluster::prepare_group_tx_reply>)

--- a/src/v/model/adl_serde.cc
+++ b/src/v/model/adl_serde.cc
@@ -288,4 +288,15 @@ model::topic_metadata adl<model::topic_metadata>::from(iobuf_parser& in) {
       = reflection::adl<std::vector<model::partition_metadata>>{}.from(in);
     return md;
 }
+
+model::producer_identity adl<model::producer_identity>::from(iobuf_parser& in) {
+    auto id = reflection::adl<int64_t>{}.from(in);
+    auto epoch = reflection::adl<int16_t>{}.from(in);
+    return {id, epoch};
+}
+
+void adl<model::producer_identity>::to(
+  iobuf& out, model::producer_identity&& p) {
+    reflection::serialize(out, p.id, p.epoch);
+}
 } // namespace reflection

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -164,6 +164,12 @@ struct adl<tristate<T>> {
     }
 };
 
+template<>
+struct adl<model::producer_identity> {
+    void to(iobuf& out, model::producer_identity&& md);
+    model::producer_identity from(iobuf_parser& in);
+};
+
 template<typename Parser>
 model::record_batch_header
 adl<model::record_batch_header>::parse_from(Parser& in) {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -440,9 +440,16 @@ struct record_batch_header {
 using tx_seq = named_type<int64_t, struct tm_tx_seq>;
 using producer_id = named_type<int64_t, struct producer_identity_id>;
 using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
+
 struct producer_identity {
     int64_t id{-1};
     int16_t epoch{0};
+
+    producer_identity() noexcept = default;
+
+    producer_identity(int64_t id, int16_t epoch)
+      : id(id)
+      , epoch(epoch) {}
 
     model::producer_id get_id() const { return model::producer_id(id); }
 
@@ -471,8 +478,7 @@ struct batch_identity {
 
     static batch_identity from(const record_batch_header& hdr) {
         return batch_identity{
-          .pid = model::
-            producer_identity{.id = hdr.producer_id, .epoch = hdr.producer_epoch},
+          .pid = model::producer_identity{hdr.producer_id, hdr.producer_epoch},
           .first_seq = hdr.base_sequence,
           .last_seq = increment_sequence(
             hdr.base_sequence, hdr.last_offset_delta),

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -441,7 +441,8 @@ using tx_seq = named_type<int64_t, struct tm_tx_seq>;
 using producer_id = named_type<int64_t, struct producer_identity_id>;
 using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
 
-struct producer_identity {
+struct producer_identity
+  : serde::envelope<producer_identity, serde::version<0>> {
     int64_t id{-1};
     int16_t epoch{0};
 
@@ -465,6 +466,8 @@ struct producer_identity {
     }
 
     friend std::ostream& operator<<(std::ostream&, const producer_identity&);
+
+    auto serde_fields() { return std::tie(id, epoch); }
 };
 
 struct batch_identity {

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -40,6 +40,7 @@ template<
   typename CompatVersion = compat_version<Version::v>>
 struct envelope {
     bool operator==(envelope const&) const = default;
+    auto operator<=>(envelope const&) const = default;
     using value_t = T;
     static constexpr auto redpanda_serde_version = Version::v;
     static constexpr auto redpanda_serde_compat_version = CompatVersion::v;


### PR DESCRIPTION
## Cover letter

* Adds ADL specializations for request/reply types in the transaction gateway service
* ADL specialization is needed because serde disables adl reflection
* Removed designated initializers since types will no longer be aggregates after serde is added
* Adds serde support to the rpc types used in tx gateway service

For reviewers:
* When switching from reflection to explicit adl specialization, the order of the fields in the structure needs to match the order and type of the fields in the adl specialization to/from methods.

## Release notes

* None