### PR TITLE
tests: update internal topic replication factor

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -107,7 +107,8 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
     def __init__(self, test_context):
         super().__init__(test_context,
                          extra_rp_conf={
-                             'default_topic_replications': self.num_brokers,
+                             'internal_topic_replication_factor':
+                             self.num_brokers,
                          })
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)


### PR DESCRIPTION
## Cover letter

fixes #4639 

During disruptive test, the cluster does not appear to be able to elect a new leader when the current leader is killed. looking at controller logs it seems to be stuck on the old leader for the duration of the test.

Updating the internal topic replication factor to be in sync with the number of brokers. this factor is three by default which is the same as number of brokers in the test, but here we set it explicitly.

message from consumer logs:

```
[2022-06-09 07:24:35,493] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] Discovered group coordinator docker-rp-12:9092 (id: 2147483646 rack: null) (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2022-06-09 07:24:35,493] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] Group coordinator docker-rp-12:9092 (id: 2147483646 rack: null) is unavailable or invalid due to cause: coordinator unavailable.isDisconnected: false. Rediscovery will be attempted. (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2022-06-09 07:24:35,599] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] Discovered group coordinator docker-rp-12:9092 (id: 2147483646 rack: null) (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2022-06-09 07:24:35,599] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] (Re-)joining group (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2022-06-09 07:24:35,600] WARN [Consumer clientId=consumer-test_group-1, groupId=test_group] Connection to node 2147483646 (docker-rp-12/172.16.16.12:9092) could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient)
[2022-06-09 07:24:35,600] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] Group coordinator docker-rp-12:9092 (id: 2147483646 rack: null) is unavailable or invalid due to cause: null.isDisconnected: true. Rediscovery will be attempted. (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2022-06-09 07:24:35,600] INFO [Consumer clientId=consumer-test_group-1, groupId=test_group] Rebalance failed. (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
```