### PR TITLE
rpk: update feedback URL

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -17,7 +17,7 @@ import (
 )
 
 const FeedbackMsg = `We'd love to hear about your experience with redpanda:
-https://vectorized.io/feedback`
+https://redpanda.com/feedback`
 
 func Deprecated(newCmd *cobra.Command, newUse string) *cobra.Command {
 	newCmd.Deprecated = fmt.Sprintf("use %q instead", newUse)


### PR DESCRIPTION
Signed-off-by: Stano Bocinec <stano@redpanda.com>

## Cover letter

This tiny PR just updates the feedback URL used in `rpk` - running `rpk tune` today I noticed we use the old domain in the command output.

## Release notes

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

### Features

* none

### Improvements

* update the feedback URL domain used in `rpk` to `redpanda.com`
