### PR TITLE
cluster: add configs for read_replica to topic properties

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1394,6 +1394,20 @@ adl<cluster::partition_assignment>::from(iobuf_parser& parser) {
     return {group, id, std::move(replicas)};
 }
 
+void adl<cluster::remote_topic_properties>::to(
+  iobuf& out, cluster::remote_topic_properties&& p) {
+    reflection::serialize(out, p.remote_revision, p.remote_partition_count);
+}
+
+cluster::remote_topic_properties
+adl<cluster::remote_topic_properties>::from(iobuf_parser& parser) {
+    auto remote_revision = reflection::adl<model::initial_revision_id>{}.from(
+      parser);
+    auto remote_partition_count = reflection::adl<int32_t>{}.from(parser);
+
+    return {remote_revision, remote_partition_count};
+}
+
 void adl<cluster::topic_properties>::to(
   iobuf& out, cluster::topic_properties&& p) {
     reflection::serialize(
@@ -1408,7 +1422,8 @@ void adl<cluster::topic_properties>::to(
       p.recovery,
       p.shadow_indexing,
       p.read_replica,
-      p.read_replica_bucket);
+      p.read_replica_bucket,
+      p.remote_topic_properties);
 }
 
 cluster::topic_properties
@@ -1434,6 +1449,9 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
     auto read_replica = reflection::adl<std::optional<bool>>{}.from(parser);
     auto read_replica_bucket
       = reflection::adl<std::optional<ss::sstring>>{}.from(parser);
+    auto remote_topic_properties
+      = reflection::adl<std::optional<cluster::remote_topic_properties>>{}.from(
+        parser);
 
     return {
       compression,
@@ -1446,7 +1464,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       recovery,
       shadow_indexing,
       read_replica,
-      read_replica_bucket};
+      read_replica_bucket,
+      remote_topic_properties};
 }
 
 void adl<cluster::cluster_property_kv>::to(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -19,6 +19,8 @@
 #include "tristate.h"
 #include "utils/to_string.h"
 
+#include <seastar/core/sstring.hh>
+
 #include <fmt/ostream.h>
 
 #include <chrono>
@@ -174,7 +176,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "{}, retention_bytes: {}, retention_duration_ms: {}, segment_size: "
       "{}, "
       "timestamp_type: {}, recovery_enabled: {}, shadow_indexing: {}, "
-      "read_replica: {} }}",
+      "read_replica: {}, read_replica_bucket: {} }}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -184,7 +186,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.timestamp_type,
       properties.recovery,
       properties.shadow_indexing,
-      properties.read_replica);
+      properties.read_replica,
+      properties.read_replica_bucket);
 
     return o;
 }
@@ -1404,7 +1407,8 @@ void adl<cluster::topic_properties>::to(
       p.retention_duration,
       p.recovery,
       p.shadow_indexing,
-      p.read_replica);
+      p.read_replica,
+      p.read_replica_bucket);
 }
 
 cluster::topic_properties
@@ -1428,6 +1432,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       = reflection::adl<std::optional<model::shadow_indexing_mode>>{}.from(
         parser);
     auto read_replica = reflection::adl<std::optional<bool>>{}.from(parser);
+    auto read_replica_bucket
+      = reflection::adl<std::optional<ss::sstring>>{}.from(parser);
 
     return {
       compression,
@@ -1439,7 +1445,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       retention_duration,
       recovery,
       shadow_indexing,
-      read_replica};
+      read_replica,
+      read_replica_bucket};
 }
 
 void adl<cluster::cluster_property_kv>::to(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -753,7 +753,8 @@ struct topic_properties
       tristate<std::chrono::milliseconds> retention_duration,
       std::optional<bool> recovery,
       std::optional<model::shadow_indexing_mode> shadow_indexing,
-      std::optional<bool> read_replica)
+      std::optional<bool> read_replica,
+      std::optional<ss::sstring> read_replica_bucket)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -763,7 +764,8 @@ struct topic_properties
       , retention_duration(retention_duration)
       , recovery(recovery)
       , shadow_indexing(shadow_indexing)
-      , read_replica(read_replica) {}
+      , read_replica(read_replica)
+      , read_replica_bucket(read_replica_bucket) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -775,6 +777,7 @@ struct topic_properties
     std::optional<bool> recovery;
     std::optional<model::shadow_indexing_mode> shadow_indexing;
     std::optional<bool> read_replica;
+    std::optional<ss::sstring> read_replica_bucket;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -793,7 +796,8 @@ struct topic_properties
           retention_duration,
           recovery,
           shadow_indexing,
-          read_replica);
+          read_replica,
+          read_replica_bucket);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -34,6 +34,7 @@
 #include <absl/container/btree_set.h>
 #include <fmt/format.h>
 
+#include <cstdint>
 #include <optional>
 
 namespace cluster {
@@ -735,6 +736,30 @@ struct partition_assignment
       = default;
 };
 
+struct remote_topic_properties
+  : serde::envelope<remote_topic_properties, serde::version<0>> {
+    remote_topic_properties() = default;
+    remote_topic_properties(
+      model::initial_revision_id remote_revision,
+      int32_t remote_partition_count)
+      : remote_revision(remote_revision)
+      , remote_partition_count(remote_partition_count) {}
+
+    model::initial_revision_id remote_revision;
+    int32_t remote_partition_count;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const remote_topic_properties&);
+
+    auto serde_fields() {
+        return std::tie(remote_revision, remote_partition_count);
+    }
+
+    friend bool
+    operator==(const remote_topic_properties&, const remote_topic_properties&)
+      = default;
+};
+
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults
@@ -754,7 +779,8 @@ struct topic_properties
       std::optional<bool> recovery,
       std::optional<model::shadow_indexing_mode> shadow_indexing,
       std::optional<bool> read_replica,
-      std::optional<ss::sstring> read_replica_bucket)
+      std::optional<ss::sstring> read_replica_bucket,
+      std::optional<remote_topic_properties> remote_topic_properties)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -765,7 +791,8 @@ struct topic_properties
       , recovery(recovery)
       , shadow_indexing(shadow_indexing)
       , read_replica(read_replica)
-      , read_replica_bucket(read_replica_bucket) {}
+      , read_replica_bucket(read_replica_bucket)
+      , remote_topic_properties(remote_topic_properties) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -778,6 +805,7 @@ struct topic_properties
     std::optional<model::shadow_indexing_mode> shadow_indexing;
     std::optional<bool> read_replica;
     std::optional<ss::sstring> read_replica_bucket;
+    std::optional<remote_topic_properties> remote_topic_properties;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -797,7 +825,8 @@ struct topic_properties
           recovery,
           shadow_indexing,
           read_replica,
-          read_replica_bucket);
+          read_replica_bucket,
+          remote_topic_properties);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)
@@ -1764,6 +1793,12 @@ template<>
 struct adl<cluster::partition_assignment> {
     void to(iobuf&, cluster::partition_assignment&&);
     cluster::partition_assignment from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::remote_topic_properties> {
+    void to(iobuf&, cluster::remote_topic_properties&&);
+    cluster::remote_topic_properties from(iobuf_parser&);
 };
 
 template<>


### PR DESCRIPTION
## Cover letter

Add read_replica and read_replica_bucket to topic_properties. Also add remote_topic_properties.
remote_topic_properties contain information that is fetched from remote
topic manifest: remote initial revision id and remote partition count.
This data should be stored in controller log in order to not download
manifest every time redpanda restarts.

Fixes: https://github.com/redpanda-data/redpanda/issues/4987

## Release notes
 - none
