### PR TITLE
cluster: use consistent chrono::duration type

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1988,7 +1988,7 @@ struct adl<cluster::begin_tx_request> {
         auto ntp = adl<model::ntp>{}.from(in);
         auto pid = adl<model::producer_identity>{}.from(in);
         auto tx_seq = adl<model::tx_seq>{}.from(in);
-        auto timeout = adl<model::timeout_clock::duration>{}.from(in);
+        auto timeout = adl<std::chrono::milliseconds>{}.from(in);
         return {std::move(ntp), pid, tx_seq, timeout};
     }
 };


### PR DESCRIPTION
The type in the structure is explicitly milliseconds, but was being
serialized as a model::timeout_clock::duration.

## Release notes

* None
