### PR TITLE
net/kafka/rpc/cluster: Improved logging

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -206,7 +206,7 @@ ss::future<allocate_id_reply> id_allocator_frontend::do_allocate_id(
                     vlog(
                       clusterlog.warn,
                       "allocate id stm call failed with {}",
-                      r.raft_status);
+                      raft::make_error_code(r.raft_status).message());
                     return allocate_id_reply{r.id, errc::replication_error};
                 }
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -905,9 +905,9 @@ members_manager::initialize_broker_connection(const model::broker& broker) {
 
           vlog(
             clusterlog.info,
-            "Hello response from {} failed: {}",
+            "Node {} did not respond to Hello message ({})",
             broker_id,
-            r.error());
+            r.error().message());
       });
 }
 

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -200,6 +200,8 @@ ss::future<bool> persisted_stm::do_sync(
             co_return false;
         } catch (const ss::abort_requested_exception&) {
             co_return false;
+        } catch (const ss::condition_variable_timed_out&) {
+            co_return false;
         } catch (...) {
             vlog(
               clusterlog.error,
@@ -218,6 +220,14 @@ ss::future<bool> persisted_stm::do_sync(
     if (_c->term() == term) {
         try {
             co_await wait(offset, model::timeout_clock::now() + timeout);
+        } catch (const ss::broken_condition_variable&) {
+            co_return false;
+        } catch (const ss::gate_closed_exception&) {
+            co_return false;
+        } catch (const ss::abort_requested_exception&) {
+            co_return false;
+        } catch (const ss::condition_variable_timed_out&) {
+            co_return false;
         } catch (...) {
             vlog(
               clusterlog.error,

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -172,6 +172,7 @@ void leader_balancer::trigger_balance() {
                    return balance();
                })
           .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([this](const std::exception& e) {
               vlog(
                 clusterlog.info,

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -368,10 +368,22 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                               // on any future reader to check the abort
                               // source before considering reading the
                               // connection.
-                              vlog(
-                                klog.info,
-                                "Detected error processing request: {}",
+
+                              auto disconnected = net::is_disconnect_exception(
                                 e);
+                              if (disconnected) {
+                                  vlog(
+                                    klog.info,
+                                    "Disconnected {} ({})",
+                                    self->_rs.conn->addr,
+                                    disconnected.value());
+                              } else {
+                                  vlog(
+                                    klog.warn,
+                                    "Error processing request: {}",
+                                    e);
+                              }
+
                               self->_rs.probe().service_error();
                               self->_rs.conn->shutdown_input();
                           })

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -68,9 +68,20 @@ ss::future<> connection_context::process_one_request() {
                       _rs.probe().header_corrupted();
                       return ss::make_ready_future<>();
                   }
-                  return handle_mtls_auth().then(
-                    [this, h = std::move(h.value()), s]() mutable {
+                  return handle_mtls_auth()
+                    .then([this, h = std::move(h.value()), s]() mutable {
                         return dispatch_method_once(std::move(h), s);
+                    })
+                    .handle_exception_type([this](const std::bad_alloc&) {
+                        // In general, dispatch_method_once does not throw,
+                        // but bad_allocs are an exception.  Log it cleanly
+                        // to avoid this bubbling up as an unhandled
+                        // exceptional future.
+                        vlog(
+                          klog.error,
+                          "Request from {} failed on memory exhaustion "
+                          "(std::bad_alloc)",
+                          _rs.conn->addr);
                     });
               });
       });

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -76,7 +76,7 @@ fetch_session_cache::maybe_get_session(const fetch_request& req) {
         // Any session specified in a FULL fetch request will be closed.
         if (session_id != invalid_fetch_session_id) {
             if (auto it = _sessions.find(session_id); it != _sessions.end()) {
-                vlog(klog.info, "removing fetch session {}", session_id);
+                vlog(klog.debug, "removing fetch session {}", session_id);
                 _sessions_mem_usage -= it->second->mem_usage();
                 _sessions.erase(it);
             }
@@ -104,7 +104,7 @@ fetch_session_cache::maybe_get_session(const fetch_request& req) {
           "fetch session {} already exists, can not insert the session",
           *new_id);
 
-        vlog(klog.info, "fetch session created: {}", *new_id);
+        vlog(klog.debug, "fetch session created: {}", *new_id);
         _sessions_mem_usage += it->second->mem_usage();
         return fetch_session_ctx(it->second, true);
     }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -406,6 +406,13 @@ ss::future<> group_manager::recover_partition(
               "Recovering {} - {}",
               group_id,
               group_stm.get_metadata());
+            for (const auto& member : group_stm.get_metadata().members) {
+                vlog(
+                  klog.debug,
+                  "Recovering group {} member {}",
+                  group_id,
+                  member);
+            }
             if (!group) {
                 group = ss::make_lw_shared<kafka::group>(
                   group_id,

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -547,13 +547,13 @@ std::ostream& operator<<(std::ostream& o, const group_metadata_value& v) {
     fmt::print(
       o,
       "{{protocol_type: {}, generation: {}, protocol: {}, leader: {}, "
-      "state_timestamp: {}, members: {}}}",
+      "state_timestamp: {}, member count: {}}}",
       v.protocol_type,
       v.generation,
       v.protocol,
       v.leader,
       v.state_timestamp,
-      v.members);
+      v.members.size());
     return o;
 }
 std::ostream& operator<<(std::ostream& o, const offset_metadata_key& v) {

--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -31,9 +31,8 @@ batched_output_stream::batched_output_stream(
 
 [[gnu::cold]] static ss::future<>
 already_closed_error(ss::scattered_message<char>& msg) {
-    return ss::make_exception_future<>(std::runtime_error(fmt::format(
-      "batched_output_stream is already closed. Ignoring: {} bytes",
-      msg.size())));
+    return ss::make_exception_future<>(
+      batched_output_stream_closed(msg.size()));
 }
 
 ss::future<> batched_output_stream::write(ss::scattered_message<char> msg) {

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -21,6 +21,18 @@
 
 namespace net {
 
+class batched_output_stream_closed : std::exception {
+public:
+    batched_output_stream_closed(size_t ignored_bytes)
+      : msg(fmt::format(
+        "Output stream closed (dropped {} bytes)", ignored_bytes)) {}
+
+    const char* what() const noexcept final { return msg.c_str(); }
+
+private:
+    std::string msg;
+};
+
 /// \brief batch operations for zero copy interface of an output_stream<char>
 class batched_output_stream {
 public:

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -28,6 +28,8 @@
  */
 namespace net {
 
+std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr);
+
 class connection : public boost::intrusive::list_base_hook<> {
 public:
     connection(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -836,6 +836,8 @@ void consensus::dispatch_vote(bool leadership_transfer) {
                                     ss::future<> vote_f) mutable {
                         try {
                             vote_f.get();
+                        } catch (const ss::gate_closed_exception&) {
+                            // Shutting down, don't log.
                         } catch (...) {
                             vlog(
                               _ctxlog.warn,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -515,6 +515,16 @@ void consensus::dispatch_recovery(follower_index_metadata& idx) {
               this, node_id, _scheduling, _recovery_mem_quota);
             auto ptr = recovery.get();
             return ptr->apply()
+              .handle_exception_type(
+                [this, node_id](const std::system_error& syserr) {
+                    // Likely to contain an rpc::errc such as
+                    // client_request_timeout
+                    vlog(
+                      _ctxlog.info,
+                      "Node {} recovery cancelled ({})",
+                      node_id,
+                      syserr.code().message());
+                })
               .handle_exception([this, node_id](const std::exception_ptr& e) {
                   vlog(
                     _ctxlog.warn, "Node {} recovery failed - {}", node_id, e);

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -135,7 +135,12 @@ transport::make_response_handler(netbuf& b, const rpc::client_opts& opts) {
     item_raw_ptr->with_timeout(opts.timeout, [this, idx] {
         auto it = _correlations.find(idx);
         if (likely(it != _correlations.end())) {
-            vlog(rpclog.info, "Request timeout, correlation id: {}", idx);
+            vlog(
+              rpclog.info,
+              "Request timeout to {}, correlation id: {} ({} in flight)",
+              server_address(),
+              idx,
+              _correlations.size());
             _probe.request_timeout();
             _correlations.erase(it);
         }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -263,6 +263,14 @@ ss::future<> remove_compacted_index(const ss::sstring& reader_path) {
     auto path = internal::compacted_index_path(reader_path.c_str());
     return ss::remove_file(path.c_str())
       .handle_exception([path](const std::exception_ptr& e) {
+          try {
+              rethrow_exception(e);
+          } catch (const std::filesystem::filesystem_error& e) {
+              if (e.code() == std::errc::no_such_file_or_directory) {
+                  // Do not log: ENOENT on removal is success
+                  return;
+              }
+          }
           vlog(stlog.warn, "error removing compacted index {} - {}", path, e);
       });
 }


### PR DESCRIPTION
## Cover letter

This PR contains further incremental improvements to logging, driven by experience testing redpanda with large numbers of partitions through node restarts + failures.

Highlights:
- net/rpc/kafka: consolidate handling of exceptions that occur on client disconnects via `is_disconnect` exception, and log them in a more consistent way, with messages like "Disconnected {client ip} ({reason})".  Gets rid of long C++ class names in log messages and avoids making regular disconnects sound like scary errors.
- RPC request timeout messages previously logged no context, now they say which peer they were with and how many requests were in flight at the time.
- Catch a few more safe shutdown type errors in various places.  These could still use some kind of general purpose solution but for the moment they're easy to handle when we notice them.
- Avoid abandoned exceptional futures
- Scale: do not log all fetch session messages at INFO level (this is very spammy with many clients)
- Scale: avoid logging entire list of consumer group members on a single line (this produces impractically long lines with many clients), and tune down the per-client info to DEBUG (otherwise this is very spammy with many clients)

Fixes https://github.com/redpanda-data/redpanda/issues/5078

## Release notes

### Improvements

* Verbosity of certain per-partition log messages has been reduced to improve the monitoring experience at sca