### PR TITLE
schema_registry: Support GET /mode

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -161,6 +161,38 @@
         }
       }
     },
+    "/mode": {
+      "get": {
+        "summary": "Get the global mode.",
+        "operationId": "get_mode",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/schemas/types": {
       "get": {
         "summary": "Get the supported schema types.",

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -176,6 +176,16 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     co_return rp;
 }
 
+ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
+    parse_accept_header(rq, rp);
+    rq.req.reset();
+
+    rp.rep->write_body("json", ss::sstring{R"({
+  "mode": "READWRITE"
+})"});
+    co_return rp;
+}
+
 ss::future<server::reply_t>
 get_schemas_types(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -31,6 +31,9 @@ ss::future<ctx_server<service>::reply_t> get_config_subject(
 ss::future<ctx_server<service>::reply_t> put_config_subject(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t>
+get_mode(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -64,6 +64,9 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, put_config_subject)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_mode, wrap(gate, es, get_mode)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_schemas_types,
       wrap(gate, es, get_schemas_types)});
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -173,6 +173,9 @@ class SchemaRegistryTest(RedpandaTest):
                              headers=headers,
                              data=data)
 
+    def _get_mode(self, headers=HTTP_GET_HEADERS):
+        return self._request("GET", "mode", headers=headers)
+
     def _get_schemas_types(self, headers=HTTP_GET_HEADERS):
         return self._request("GET", f"schemas/types", headers=headers)
 
@@ -621,6 +624,15 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.debug("Get subject config - should be overriden")
         result_raw = self._get_config_subject(subject=f"{topic}-key")
         assert result_raw.json()["compatibilityLevel"] == "BACKWARD_TRANSITIVE"
+
+    @cluster(num_nodes=3)
+    def test_mode(self):
+        """
+        Smoketest get_mode endpoint
+        """
+        self.logger.debug("Get initial global mode")
+        result_raw = self._get_mode()
+        assert result_raw.json()["mode"] == "READWRITE"
 
     @cluster(num_nodes=3)
     def test_post_compatibility_subject_version(self):


### PR DESCRIPTION
## Cover letter

There's a lot more work to do to support /mode properly, but the Schema Registry will now report the global mode.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

### Improvements

* Schema Registry: Support `GET /mode`