### PR TITLE
kafka: introduce separate TCP buffer sizes for kafka vs. internal RPC

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -81,14 +81,14 @@ configuration::configuration()
   , rpc_server_tcp_recv_buf(
       *this,
       "rpc_server_tcp_recv_buf",
-      "TCP receive buffer size in bytes.",
+      "Internal RPC TCP receive buffer size in bytes.",
       {.example = "65536"},
       std::nullopt,
       {.min = 32_KiB, .align = 4_KiB})
   , rpc_server_tcp_send_buf(
       *this,
       "rpc_server_tcp_send_buf",
-      "TCP transmit buffer size in bytes.",
+      "Internal RPC TCP transmit buffer size in bytes.",
       {.example = "65536"},
       std::nullopt,
       {.min = 32_KiB, .align = 4_KiB})
@@ -402,6 +402,7 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
+
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",
@@ -825,6 +826,20 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
+  , kafka_rpc_server_tcp_recv_buf(
+      *this,
+      "kafka_rpc_server_tcp_recv_buf",
+      "Kafka server TCP receive buffer size in bytes.",
+      {.example = "65536"},
+      std::nullopt,
+      {.min = 32_KiB, .align = 4_KiB})
+  , kafka_rpc_server_tcp_send_buf(
+      *this,
+      "kafka_rpc_server_tcp_send_buf",
+      "Kafka server TCP transmit buffer size in bytes.",
+      {.example = "65536"},
+      std::nullopt,
+      {.min = 32_KiB, .align = 4_KiB})
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -180,6 +180,8 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>> kafka_connections_max;
     property<std::optional<uint32_t>> kafka_connections_max_per_ip;
     property<std::vector<ss::sstring>> kafka_connections_max_overrides;
+    bounded_property<std::optional<int>> kafka_rpc_server_tcp_recv_buf;
+    bounded_property<std::optional<int>> kafka_rpc_server_tcp_send_buf;
 
     // Archival storage
     property<bool> cloud_storage_enabled;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1006,10 +1006,24 @@ void application::wire_up_redpanda_services() {
                 = memory_groups::kafka_total_memory();
               c.listen_backlog
                 = config::shard_local_cfg().rpc_server_listen_backlog;
-              c.tcp_recv_buf
-                = config::shard_local_cfg().rpc_server_tcp_recv_buf;
-              c.tcp_send_buf
-                = config::shard_local_cfg().rpc_server_tcp_send_buf;
+              if (config::shard_local_cfg().kafka_rpc_server_tcp_recv_buf()) {
+                  c.tcp_recv_buf
+                    = config::shard_local_cfg().kafka_rpc_server_tcp_recv_buf;
+              } else {
+                  // Backward compat: prior to Redpanda 22.2, rpc_server_*
+                  // settings applied to both Kafka and Internal RPC listeners.
+                  c.tcp_recv_buf
+                    = config::shard_local_cfg().rpc_server_tcp_recv_buf;
+              };
+              if (config::shard_local_cfg().kafka_rpc_server_tcp_send_buf()) {
+                  c.tcp_send_buf
+                    = config::shard_local_cfg().kafka_rpc_server_tcp_send_buf;
+              } else {
+                  // Backward compat: prior to Redpanda 22.2, rpc_server_*
+                  // settings applied to both Kafka and Internal RPC listeners.
+                  c.tcp_send_buf
+                    = config::shard_local_cfg().rpc_server_tcp_send_buf;
+              }
               auto& tls_config = config::node().kafka_api_tls.value();
               for (const auto& ep : config::node().kafka_api()) {
                   ss::shared_ptr<ss::tls::server_credentials> credentails;


### PR DESCRIPTION
## Cover letter
    
For systems with many clients, we may want smaller
buffers for Kafka traffic (many sockets), and larger
buffers for Internal RPC (fewer sockets with higher
bandwidth).

## Release notes

### Improvements

* The `kafka_rpc_server_tcp_recv_buf` and `kafka_rpc_server_tcp_send_buf` configuration properties are added, to control TCP buffer sizes on network connections from Redpanda servers to Kafka clients.  Previously, these connections' buffer sizes were controllled by `rpc_server_tcp_recv_buf` and `rpc_server_tcp_send_buf`, those properties are now intended for setting the internal RPC socket buffer sizes only.  The `rpc_server_tcp_recv_buf` and `rpc_server_tcp_send_buf` properties are still used for Kafka API sockets if the new kafka-specific properties are not set, to provide backward compatibility for clusters that were already using those properties.