### PR TITLE
tests: fix rare failure in test_old_node_join

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -265,13 +265,19 @@ class FeaturesNodeJoinTest(RedpandaTest):
         self.redpanda.set_environment(
             {'__REDPANDA_LOGICAL_VERSION': f"{initial_version}"})
 
+        # Pick a node to roleplay an old version of redpanda
+        old_node = self.redpanda.nodes[-1]
+
         # Start first three nodes
         self.redpanda.start(self.redpanda.nodes[0:-1])
+
+        # Explicit clean because it's not included in the default
+        # one during start()
+        self.redpanda.clean_node(old_node)
 
         assert initial_version == self.admin.get_features()['cluster_version']
 
         # Bring up the fourth node reporting an old logical version
-        old_node = self.redpanda.nodes[-1]
         old_version = initial_version - 1
         self.redpanda.set_environment(
             {'__REDPANDA_LOGICAL_VERSION': f"{old_version}"})


### PR DESCRIPTION
## Cover letter

If this test ran after a test that did not clear
out the node's storage properly, then it could
fail to start with "configuration invariants changed".

Fix it by explicitly cleaning the node at test start:
usually we do this in RedpandaService.start(), but this
test doesn't start that one node as part of its main
call to start().

Fixes #5088 

## Release notes

* none