### PR TITLE
rptest: use ducktape with rebase on top of v0.9.0 upstream

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@a60d8e93ac5f13554dae036465a28ece6e407df1',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@8b230e421309280131e10cc07aab899144c96185',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',


### PR DESCRIPTION
## Cover letter

Use https://github.com/redpanda-data/ducktape/tree/8b230e421309280131e10cc07aab899144c96185 which is rebased on top of https://github.com/confluentinc/ducktape/releases/tag/v0.9.0

## Release notes

* none