### PR TITLE
Extend lifetime of group for background tasks

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -623,6 +623,9 @@ group::join_group_stages group::update_static_member_and_rebalance(
                         new_member_id,
                         std::move(md));
                       try_finish_joining_member(member, std::move(reply));
+                  })
+                  .finally([group = shared_from_this()] {
+                      // keep the group alive while the background task runs
                   });
             return join_group_stages(std::move(f));
         } else {
@@ -1063,7 +1066,8 @@ void group::complete_join() {
             ssx::background
               = store_group(checkpoint(assignments_type{}))
                   .then(
-                    []([[maybe_unused]] result<raft::replicate_result> r) {});
+                    []([[maybe_unused]] result<raft::replicate_result> r) {})
+                  .finally([this_group = shared_from_this()] {});
         } else {
             std::for_each(
               std::cbegin(_members),

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -112,7 +112,7 @@ kafka::error_code map_store_offset_error_code(std::error_code);
 /// \brief A Kafka group.
 ///
 /// Container of members.
-class group {
+class group final : public ss::enable_lw_shared_from_this<group> {
 public:
     using clock_type = ss::lowres_clock;
     using duration_type = clock_type::duration;


### PR DESCRIPTION
In general the lifetime of the kafka::group objects are a bit
fraught: groups may be destroyed at any time, e.g., because
leadership of the associated group partition was moved to
another node. This means that operations dispatched on the
group object must be careful to extend the life of the group
for the duratoin of the operation.

Much of this is handled in the group_router, which usually
attaches a final continuation to futures returned by group
method which holds on to a group_ptr: this ensures that even
if the group is erased() from the main group map, it will live on
until the futures resolve.

However, in a couple of places we launch background tasks
during a group operation. These tasks don't hold to any group
pointer, so they may race with group destruction. Losing the
race manifests as segfaults or other weird behavior.

We fix this by enabling group for shared_from_this and using
that when we launch background tasks, attaching a future in
the "usual" way.

Fixes #5118.