### PR TITLE
redpanda: add --version argument

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -220,6 +220,9 @@ int application::run(int ac, char** av) {
     return app.run(ac, av, [this, &app] {
         auto& cfg = app.configuration();
         log_system_resources(_log, cfg);
+        // NOTE: we validate required args here instead of above because run()
+        // catches some Seastar-specific args like --help that may result in
+        // valid omissions of required args.
         validate_arguments(cfg);
         return ss::async([this, &cfg] {
             try {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -159,8 +159,54 @@ static void log_system_resources(
     }
 }
 
+namespace {
+
+static constexpr std::string_view community_msg = R"banner(
+
+Welcome to the Redpanda community!
+
+Documentation: https://docs.redpanda.com - Product documentation site
+GitHub Discussion: https://github.com/redpanda-data/redpanda/discussions - Longer, more involved discussions
+GitHub Issues: https://github.com/redpanda-data/redpanda/issues - Report and track issues with the codebase
+Support: https://support.redpanda.com - Contact the support team privately
+Product Feedback: https://redpanda.com/feedback - Let us know how we can improve your experience
+Slack: https://redpanda.com/slack - Chat about all things Redpanda. Join the conversation!
+Twitter: https://twitter.com/redpandadata - All the latest Redpanda news!
+
+)banner";
+
+} // anonymous namespace
+
 int application::run(int ac, char** av) {
-    init_env();
+    std::setvbuf(stdout, nullptr, _IOLBF, 1024);
+    ss::app_template app(setup_app_config());
+    app.add_options()("version", po::bool_switch(), "print version and exit");
+    app.add_options()(
+      "redpanda-cfg",
+      po::value<std::string>(),
+      ".yaml file config for redpanda");
+
+    // Validate command line args using options registered by the app and
+    // seastar. Keep the resulting variables in a temporary map so they don't
+    // live for the lifetime of the application.
+    {
+        po::variables_map vm;
+        if (!cli_parser{
+              ac,
+              av,
+              cli_parser::app_opts{app.get_options_description()},
+              cli_parser::ss_opts{app.get_conf_file_options_description()},
+              _log}
+               .validate_into(vm)) {
+            return 1;
+        }
+        if (vm["version"].as<bool>()) {
+            std::cout << redpanda_version() << std::endl;
+            return 0;
+        }
+    }
+    // use endl for explicit flushing
+    std::cout << community_msg << std::endl;
     vlog(_log.info, "Redpanda {}", redpanda_version());
     struct ::utsname buf;
     ::uname(&buf);
@@ -170,23 +216,6 @@ int application::run(int ac, char** av) {
       buf.release,
       buf.nodename,
       buf.machine);
-    ss::app_template app(setup_app_config());
-    app.add_options()(
-      "redpanda-cfg",
-      po::value<std::string>(),
-      ".yaml file config for redpanda");
-
-    // Validate command line args using options registered by the app and
-    // seastar
-    if (!cli_parser{
-          ac,
-          av,
-          cli_parser::app_opts{app.get_options_description()},
-          cli_parser::ss_opts{app.get_conf_file_options_description()},
-          _log}
-           .validate()) {
-        return 1;
-    }
 
     return app.run(ac, av, [this, &app] {
         auto& cfg = app.configuration();
@@ -316,8 +345,6 @@ void application::validate_arguments(const po::variables_map& cfg) {
         throw std::invalid_argument("Missing redpanda-cfg flag");
     }
 }
-
-void application::init_env() { std::setvbuf(stdout, nullptr, _IOLBF, 1024); }
 
 ss::app_template::config application::setup_app_config() {
     ss::app_template::config app_cfg;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -112,7 +112,6 @@ private:
       = std::vector<ss::deferred_action<std::function<void()>>>;
 
     // All methods are calleds from Seastar thread
-    void init_env();
     ss::app_template::config setup_app_config();
     void validate_arguments(const po::variables_map&);
     void hydrate_config(const po::variables_map&);

--- a/src/v/redpanda/cli_parser.cc
+++ b/src/v/redpanda/cli_parser.cc
@@ -30,7 +30,7 @@ cli_parser::cli_parser(
   , _seastar_opts_desc{std::move(seastar_opts)}
   , _log{log} {}
 
-bool cli_parser::validate() {
+bool cli_parser::validate_into(po::variables_map& vm) {
     po::options_description desc;
     // Copy the cli options added by redpanda, plus
     desc.add(_opts_desc);
@@ -39,7 +39,6 @@ bool cli_parser::validate() {
     desc.add(_seastar_opts_desc);
 
     try {
-        po::variables_map vm;
         po::store(
           po::command_line_parser{_ac, _av}.options(desc).positional({}).run(),
           vm);

--- a/src/v/redpanda/cli_parser.h
+++ b/src/v/redpanda/cli_parser.h
@@ -17,6 +17,7 @@
 #include <seastar/util/log.hh>
 
 #include <boost/program_options/options_description.hpp>
+#include <boost/program_options/variables_map.hpp>
 
 /// Parses command line options passed to the redpanda binary. Validates the
 /// options against a set of registered values. The values should include both
@@ -37,7 +38,10 @@ struct cli_parser {
       ss_opts seastar_opts,
       ss::logger& log);
 
-    bool validate();
+    // Validates the arguments, returning true if the input arguments match
+    // those expected by the configured options. Upon success, the resulting
+    // variables are placed into 'vm'.
+    bool validate_into(boost::program_options::variables_map& vm);
 
 private:
     int _ac;

--- a/src/v/redpanda/main.cc
+++ b/src/v/redpanda/main.cc
@@ -14,23 +14,7 @@ namespace debug {
 application* app;
 }
 
-static constexpr std::string_view community_msg = R"banner(
-
-Welcome to the Redpanda community!
-
-Documentation: https://docs.redpanda.com - Product documentation site
-GitHub Discussion: https://github.com/redpanda-data/redpanda/discussions - Longer, more involved discussions
-GitHub Issues: https://github.com/redpanda-data/redpanda/issues - Report and track issues with the codebase
-Support: https://support.redpanda.com - Contact the support team privately
-Product Feedback: https://redpanda.com/feedback - Let us know how we can improve your experience
-Slack: https://redpanda.com/slack - Chat about all things Redpanda. Join the conversation!
-Twitter: https://twitter.com/redpandadata - All the latest Redpanda news!
-
-)banner";
-
 int main(int argc, char** argv, char** /*env*/) {
-    // using endl explicitly for flushing
-    std::cout << community_msg << std::endl;
     // must be the first thing called
     syschecks::initialize_intrinsics();
     application app;

--- a/src/v/redpanda/tests/cli_parser_tests.cc
+++ b/src/v/redpanda/tests/cli_parser_tests.cc
@@ -52,7 +52,9 @@ BOOST_AUTO_TEST_CASE(test_positional_args_rejected) {
       cli_parser::app_opts{unused},
       cli_parser::ss_opts{unused},
       test_log};
-    BOOST_REQUIRE(!parser.validate());
+    po::variables_map vm;
+    BOOST_REQUIRE(!parser.validate_into(vm));
+    BOOST_REQUIRE(vm.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_help_flag) {
@@ -66,7 +68,9 @@ BOOST_AUTO_TEST_CASE(test_help_flag) {
 
     cli_parser parser{
       ac, av, cli_parser::app_opts{help}, cli_parser::ss_opts{ss}, test_log};
-    BOOST_REQUIRE(parser.validate());
+    po::variables_map vm;
+    BOOST_REQUIRE(parser.validate_into(vm));
+    BOOST_REQUIRE(!vm.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_help_mixed_with_bad_pos_arg) {
@@ -79,7 +83,9 @@ BOOST_AUTO_TEST_CASE(test_help_mixed_with_bad_pos_arg) {
     auto [ac, av] = a.args();
     cli_parser parser{
       ac, av, cli_parser::app_opts{help}, cli_parser::ss_opts{ss}, test_log};
-    BOOST_REQUIRE(!parser.validate());
+    po::variables_map vm;
+    BOOST_REQUIRE(!parser.validate_into(vm));
+    BOOST_REQUIRE(vm.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_flag_with_arguments) {
@@ -93,7 +99,9 @@ BOOST_AUTO_TEST_CASE(test_flag_with_arguments) {
         auto [ac, av] = a.args();
         cli_parser parser{
           ac, av, cli_parser::app_opts{cfg}, cli_parser::ss_opts{ss}, test_log};
-        BOOST_REQUIRE(parser.validate());
+        po::variables_map vm;
+        BOOST_REQUIRE(parser.validate_into(vm));
+        BOOST_REQUIRE(!vm.empty());
     }
 
     {
@@ -101,7 +109,9 @@ BOOST_AUTO_TEST_CASE(test_flag_with_arguments) {
         auto [ac, av] = a.args();
         cli_parser parser{
           ac, av, cli_parser::app_opts{cfg}, cli_parser::ss_opts{ss}, test_log};
-        BOOST_REQUIRE(parser.validate());
+        po::variables_map vm;
+        BOOST_REQUIRE(parser.validate_into(vm));
+        BOOST_REQUIRE(!vm.empty());
     }
 }
 
@@ -115,7 +125,9 @@ BOOST_AUTO_TEST_CASE(test_flags_with_arguments_and_bad_pos_arg) {
     auto [ac, av] = a.args();
     cli_parser parser{
       ac, av, cli_parser::app_opts{cfg}, cli_parser::ss_opts{ss}, test_log};
-    BOOST_REQUIRE(!parser.validate());
+    po::variables_map vm;
+    BOOST_REQUIRE(!parser.validate_into(vm));
+    BOOST_REQUIRE(vm.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_redpanda_and_ss_opts) {
@@ -131,7 +143,9 @@ BOOST_AUTO_TEST_CASE(test_redpanda_and_ss_opts) {
         auto [ac, av] = a.args();
         cli_parser parser{
           ac, av, cli_parser::app_opts{cfg}, cli_parser::ss_opts{ss}, test_log};
-        BOOST_REQUIRE(parser.validate());
+        po::variables_map vm;
+        BOOST_REQUIRE(parser.validate_into(vm));
+        BOOST_REQUIRE(!vm.empty());
     }
 
     {
@@ -139,6 +153,8 @@ BOOST_AUTO_TEST_CASE(test_redpanda_and_ss_opts) {
         auto [ac, av] = a.args();
         cli_parser parser{
           ac, av, cli_parser::app_opts{cfg}, cli_parser::ss_opts{ss}, test_log};
-        BOOST_REQUIRE(parser.validate());
+        po::variables_map vm;
+        BOOST_REQUIRE(parser.validate_into(vm));
+        BOOST_REQUIRE(!vm.empty());
     }
 }

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -13,7 +13,7 @@ from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
 
 
-def cluster(log_allow_list=None, **kwargs):
+def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
     """
     Drop-in replacement for Ducktape `cluster` that imposes additional
     redpanda-specific checks and defaults.
@@ -38,16 +38,18 @@ def cluster(log_allow_list=None, **kwargs):
                 self.redpanda.raise_on_crash()
                 raise
             else:
-                # Only do log inspections on tests that are otherwise
-                # successful.  This executes *before* the end-of-test shutdown,
-                # thereby avoiding having to add the various gate_closed etc
-                # errors to our allow list.
-                # TODO: extend this to cover shutdown logging too, and clean up
-                # redpanda to not log so many errors on shutdown.
-                self.redpanda.raise_on_bad_logs(allow_list=log_allow_list)
-                return r
+                if check_allowed_error_logs:
+                    # Only do log inspections on tests that are otherwise
+                    # successful.  This executes *before* the end-of-test
+                    # shutdown, thereby avoiding having to add the various
+                    # gate_closed etc errors to our allow list.
+                    # TODO: extend this to cover shutdown logging too, and
+                    # clean up redpanda to not log so many errors on shutdown.
+                    self.redpanda.raise_on_bad_logs(allow_list=log_allow_list)
+                    return r
 
-        # Propagate ducktape markers (e.g. parametrize) to our function wrapper
+        # Propagate ducktape markers (e.g. parameterize) to our function
+        # wrapper
         wrapped.marks = f.marks
         wrapped.mark_names = f.mark_names
 

--- a/tests/rptest/tests/redpanda_binary_test.py
+++ b/tests/rptest/tests/redpanda_binary_test.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+
+from ducktape.tests.test import Test
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaService
+
+
+class RedpandaBinaryTest(Test):
+    """
+    Test class for testing the redpanda binary without necessarily running the
+    redpanda service.
+    """
+    def __init__(self, test_context):
+        super(RedpandaBinaryTest, self).__init__(test_context=test_context)
+        self.redpanda = RedpandaService(self.test_context, 1)
+
+    @cluster(num_nodes=1, check_allowed_error_logs=False)
+    def test_version(self):
+        version_cmd = f"{self.redpanda.find_binary('redpanda')} --version"
+        version_lines = [
+            l for l in self.redpanda.nodes[0].account.ssh_capture(version_cmd)
+        ]
+        assert len(version_lines) == 1, version_lines
+        version_regex_str = "v\\d+\\.\\d+\\.\\d+.*"  # E.g. "v22.1.1-rc1-1373-g77f868..."
+        version_re = re.compile(version_regex_str)
+        assert version_re.search(
+            version_lines[0]
+        ), f"Expected '{version_lines[0]}' to match '{version_regex_str}'"


### PR DESCRIPTION
## Cover letter

This commit adds a `--version` argument to the `redpanda` binary. Upon supplying
this argument, the program prints the version and exits immediately.

The startup sequence is reordered so that we parse CLI arguments before doing
any kind of printing (e.g. the community banner).

Before:
```
~/Repos/redpanda/vbuild/debug/clang$ ./bin/redpanda --version

Welcome to the Redpanda community!

Documentation: https://docs.redpanda.com - Product documentation site
GitHub Discussion: https://github.com/redpanda-data/redpanda/discussions - Longer, more involved discussions
GitHub Issues: https://github.com/redpanda-data/redpanda/issues - Report and track issues with the codebase
Support: https://support.redpanda.com - Contact the support team privately
Product Feedback: https://redpanda.com/feedback - Let us know how we can improve your experience
Slack: https://redpanda.com/slack - Chat about all things Redpanda. Join the conversation!
Twitter: https://twitter.com/redpandadata - All the latest Redpanda news!

INFO   redpanda::main - application.cc:162 - Redpanda v22.1.1-rc1-1026-gc627dbe7e - c627dbe7e0954600692f947d02764dde4a8ab698-dirty
INFO   redpanda::main - application.cc:170 - kernel=5.15.0-33-generic, nodename=thonkpad, machine=x86_64
libc++abi: terminating with uncaught exception of type boost::wrapexcept<boost::program_options::unknown_option>: unrecognised option '--version'
```

After:

```
~/Repos/redpanda/vbuild/debug/clang$ ./bin/redpanda --version
v22.1.1-rc1-1372-g2db200948 - 2db200948e1ce3b0688511e15681f900a80c270a-dirty
```

## Release notes

* A new `--version` flag is added to the `redpanda` binary. When supplied, the program will print the version and exit immediately.