### PR TITLE
vassert: prevent assert condition from influencing formatting

### DIFF
--- a/src/v/vassert.h
+++ b/src/v/vassert.h
@@ -39,9 +39,10 @@ static dummyassert g_assert_log;
         /*The !(x) is not an error. see description above*/                    \
         if (unlikely(!(x))) {                                                  \
             ::detail::g_assert_log.l.error(                                    \
-              "Assert failure: ({}:{}) '" #x "' " msg,                         \
+              "Assert failure: ({}:{}) '{}' " msg,                             \
               __FILE__,                                                        \
               __LINE__,                                                        \
+              #x,                                                              \
               ##args);                                                         \
             ::detail::g_assert_log.l.error(                                    \
               "Backtrace below:\n{}", ss::current_backtrace());                \


### PR DESCRIPTION
Rendering condition string using logger string interpolation.

Previously when assert condition contained curly braces it lead to a
situation in which assert message could not be logged correctly.
Example:

```c++
    vassert(
      _allocated_partitions > allocation_capacity{0} && _weights[core] >
      0,
      "unable to deallocate partition from core {} at node {}",
      core,
      *this);
```

lead to `fmt` throwing an error as `{0}` indicates numbered formatting
placeholder.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
