### PR TITLE
redpanda: permit running with no Kafka listeners

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -539,6 +539,7 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
               "redirect: {} did not match any kafka listeners, redirecting to "
               "peer's internal RPC address",
               req_hostname);
+            target_host = leader.broker.rpc_address().host();
         }
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -104,7 +104,11 @@ static void set_local_kafka_client_config(
   const config::node_config& config) {
     client_config.emplace();
     const auto& kafka_api = config.kafka_api.value();
-    vassert(!kafka_api.empty(), "There are no kafka_api listeners");
+    if (kafka_api.empty()) {
+        // No Kafka listeners configured, cannot configure
+        // a client.
+        return;
+    }
     client_config->brokers.set_value(
       std::vector<net::unresolved_address>{kafka_api[0].address});
     const auto& kafka_api_tls = config::node().kafka_api_tls.value();

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1303,7 +1303,10 @@ class RedpandaService(Service):
         return self.s3_client.list_objects(
             self._si_settings.cloud_storage_bucket)
 
-    def set_cluster_config(self, values: dict, expect_restart: bool = False):
+    def set_cluster_config(self,
+                           values: dict,
+                           expect_restart: bool = False,
+                           admin_client: Admin = None):
         """
         Update cluster configuration and wait for all nodes to report that they
         have seen the new config.
@@ -1312,11 +1315,14 @@ class RedpandaService(Service):
         :param expect_restart: set to true if you wish to permit a node restart for needs_restart=yes properties.
                                If you set such a property without this flag, an assertion error will be raised.
         """
-        patch_result = self._admin.patch_cluster_config(upsert=values)
+        if admin_client is None:
+            admin_client = self._admin
+
+        patch_result = admin_client.patch_cluster_config(upsert=values)
         new_version = patch_result['config_version']
 
         def is_ready():
-            status = self._admin.get_cluster_config_status(
+            status = admin_client.get_cluster_config_status(
                 node=self.controller())
             ready = all([n['config_version'] >= new_version for n in status])
 
@@ -1974,26 +1980,29 @@ class RedpandaService(Service):
                     f"registered: node {node.name} now visible in peer {peer.name}'s broker list ({admin_brokers})"
                 )
 
-        auth_args = {}
-        if self.sasl_enabled():
-            auth_args = {
-                'username': self._superuser.username,
-                'password': self._superuser.password,
-                'algorithm': self._superuser.algorithm
-            }
+        if self.brokers():  # Conditional in case Kafka API turned off
+            auth_args = {}
+            if self.sasl_enabled():
+                auth_args = {
+                    'username': self._superuser.username,
+                    'password': self._superuser.password,
+                    'algorithm': self._superuser.algorithm
+                }
+            client = PythonLibrdkafka(self,
+                                      tls_cert=self._tls_cert,
+                                      **auth_args)
+            brokers = client.brokers()
+            broker = brokers.get(node_id, None)
+            if broker is None:
+                # This should never happen, because we already checked via the admin API
+                # that the node of interest had become visible to all peers.
+                self.logger.error(
+                    f"registered: node {node.name} not found in kafka metadata!"
+                )
+                assert broker is not None
 
-        client = PythonLibrdkafka(self, tls_cert=self._tls_cert, **auth_args)
+            self.logger.debug(f"registered: found broker info: {broker}")
 
-        brokers = client.brokers()
-        broker = brokers.get(node_id, None)
-        if broker is None:
-            # This should never happen, because we already checked via the admin API
-            # that the node of interest had become visible to all peers.
-            self.logger.error(
-                f"registered: node {node.name} not found in kafka metadata!")
-            assert broker is not None
-
-        self.logger.debug(f"registered: found broker info: {broker}")
         return True
 
     def controller(self):
@@ -2133,8 +2142,12 @@ class RedpandaService(Service):
 
     def broker_address(self, node):
         assert node in self.nodes, f"where node is {node.name}"
+        assert node in self._started
         cfg = self._node_configs[node]
-        return f"{node.account.hostname}:{one_or_many(cfg['redpanda']['kafka_api'])['port']}"
+        if cfg['redpanda']['kafka_api']:
+            return f"{node.account.hostname}:{one_or_many(cfg['redpanda']['kafka_api'])['port']}"
+        else:
+            return None
 
     def admin_endpoint(self, node):
         assert node in self.nodes, f"where node is {node.name}"
@@ -2153,6 +2166,7 @@ class RedpandaService(Service):
 
     def brokers_list(self, limit=None) -> list[str]:
         brokers = [self.broker_address(n) for n in self._started[:limit]]
+        brokers = [b for b in brokers if b is not None]
         random.shuffle(brokers)
         return brokers
 


### PR DESCRIPTION
## Cover letter

Running with zero Kafka listeners is a legitimate configuration: we might want to start up a cluster in a state where it exposes admin API and internal RPC, but is not accessible to Kafka clients.

## Release notes

### Improvements

* Redpanda may now be run with an empty list for the `kafka_api` node configuration property, enabling starting a cluster without client connectivity during initial configuration/bootstrap.