### PR TITLE
storage: explicitly mark clean segments in kvstore on clean shutdown

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -106,6 +106,11 @@ ss::future<> disk_log_impl::remove() {
                 return _kvstore.remove(
                   kvstore::key_space::storage,
                   internal::start_offset_key(config().ntp()));
+            })
+            .then([this] {
+                return _kvstore.remove(
+                  kvstore::key_space::storage,
+                  internal::clean_segment_key(config().ntp()));
             });
       });
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -128,15 +128,26 @@ ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
     vlog(stlog.trace, "waiting for {} compaction to finish", config().ntp());
     co_await _compaction_gate.close();
     vlog(stlog.trace, "stopping {} readers cache", config().ntp());
-    co_await _readers_cache->stop().then([this] {
-        return ss::parallel_for_each(_segs, [](ss::lw_shared_ptr<segment>& h) {
-            return h->close().handle_exception([h](std::exception_ptr e) {
-                vlog(stlog.error, "Error closing segment:{} - {}", e, h);
-            });
-        });
+
+    // close() on the segments is not expected to fail, but it might
+    // encounter I/O errors (e.g. ENOSPC, EIO, out of file handles)
+    // when trying to flush.  If that happens, all bets are off and
+    // we will not mark our latest segment as clean (even if that
+    // particular segment didn't report an I/O error)
+    bool errors = false;
+
+    co_await _readers_cache->stop().then([this, &errors] {
+        return ss::parallel_for_each(
+          _segs, [&errors](ss::lw_shared_ptr<segment>& h) {
+              return h->close().handle_exception(
+                [&errors, h](std::exception_ptr e) {
+                    vlog(stlog.error, "Error closing segment:{} - {}", e, h);
+                    errors = true;
+                });
+          });
     });
 
-    if (_segs.size()) {
+    if (_segs.size() && !errors) {
         auto clean_seg = _segs.back()->filename();
         vlog(
           stlog.debug,

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -60,7 +60,7 @@ public:
     disk_log_impl(const disk_log_impl&) = delete;
     disk_log_impl& operator=(const disk_log_impl&) = delete;
 
-    ss::future<> close() final;
+    ss::future<std::optional<ss::sstring>> close() final;
     ss::future<> remove() final;
     ss::future<> flush() final;
     ss::future<> truncate(truncate_config) final;

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -385,7 +385,8 @@ ss::future<> kvstore::recover() {
               [] { return std::nullopt; },
               _as,
               config::shard_local_cfg().storage_read_buffer_size(),
-              config::shard_local_cfg().storage_read_readahead_count())
+              config::shard_local_cfg().storage_read_readahead_count(),
+              std::nullopt)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -57,7 +57,7 @@ public:
         virtual log_appender make_appender(log_append_config) = 0;
 
         // final operation. Invalid filesystem state after
-        virtual ss::future<> close() = 0;
+        virtual ss::future<std::optional<ss::sstring>> close() = 0;
         // final operation. Invalid state after
         virtual ss::future<> remove() = 0;
 
@@ -99,7 +99,7 @@ public:
 public:
     explicit log(ss::shared_ptr<impl> i)
       : _impl(std::move(i)) {}
-    ss::future<> close() { return _impl->close(); }
+    ss::future<std::optional<ss::sstring>> close() { return _impl->close(); }
     ss::future<> remove() { return _impl->remove(); }
     ss::future<> flush() { return _impl->flush(); }
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -267,7 +267,8 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       [this, cache_enabled] { return create_cache(cache_enabled); },
       _abort_source,
       config::shard_local_cfg().storage_read_buffer_size(),
-      config::shard_local_cfg().storage_read_readahead_count());
+      config::shard_local_cfg().storage_read_readahead_count(),
+      last_clean_segment);
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -189,9 +189,9 @@ log_manager::create_cache(with_cache ntp_cache_enabled) {
 }
 
 ss::future<log> log_manager::manage(ntp_config cfg) {
-    return ss::with_gate(_open_gate, [this, cfg = std::move(cfg)]() mutable {
-        return do_manage(std::move(cfg));
-    });
+    auto gate = _open_gate.hold();
+
+    co_return co_await do_manage(std::move(cfg));
 }
 
 ss::future<> log_manager::recover_log_state(const ntp_config& cfg) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -85,13 +85,33 @@ void log_manager::trigger_housekeeping() {
     });
 }
 
+ss::future<> log_manager::clean_close(storage::log& log) {
+    auto clean_segment = co_await log.close();
+
+    if (clean_segment) {
+        vlog(
+          stlog.debug,
+          "writing clean record for: {} {}",
+          log.config().ntp(),
+          clean_segment.value());
+        co_await _kvstore.put(
+          kvstore::key_space::storage,
+          internal::clean_segment_key(log.config().ntp()),
+          serde::to_iobuf(internal::clean_segment_value{
+            .segment_name = std::filesystem::path(clean_segment.value())
+                              .filename()
+                              .string()}));
+    }
+}
+
 ss::future<> log_manager::stop() {
     _compaction_timer.cancel();
     _abort_source.request_abort();
+
     co_await _open_gate.close();
     co_await ss::coroutine::parallel_for_each(
-      _logs, [](logs_type::value_type& entry) {
-          return entry.second->handle.close().discard_result();
+      _logs, [this](logs_type::value_type& entry) {
+          return clean_close(entry.second->handle);
       });
     co_await _batch_cache.stop();
     co_await ssx::async_clear(_logs)();
@@ -227,6 +247,15 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
         co_return l;
     }
 
+    std::optional<ss::sstring> last_clean_segment;
+    auto clean_iobuf = _kvstore.get(
+      kvstore::key_space::storage, internal::clean_segment_key(cfg.ntp()));
+    if (clean_iobuf) {
+        last_clean_segment = serde::from_iobuf<internal::clean_segment_value>(
+                               std::move(clean_iobuf.value()))
+                               .segment_name;
+    }
+
     co_await recover_log_state(cfg);
 
     ss::sstring path = cfg.work_directory();
@@ -239,6 +268,7 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       _abort_source,
       config::shard_local_cfg().storage_read_buffer_size(),
       config::shard_local_cfg().storage_read_readahead_count());
+
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);
     auto [it, success] = _logs.emplace(
@@ -255,8 +285,7 @@ ss::future<> log_manager::shutdown(model::ntp ntp) {
     if (handle.empty()) {
         co_return;
     }
-    storage::log lg = handle.mapped()->handle;
-    co_await lg.close();
+    co_await clean_close(handle.mapped()->handle);
 }
 
 ss::future<> log_manager::remove(model::ntp ntp) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -91,7 +91,7 @@ ss::future<> log_manager::stop() {
     co_await _open_gate.close();
     co_await ss::coroutine::parallel_for_each(
       _logs, [](logs_type::value_type& entry) {
-          return entry.second->handle.close();
+          return entry.second->handle.close().discard_result();
       });
     co_await _batch_cache.stop();
     co_await ssx::async_clear(_logs)();

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -234,6 +234,7 @@ private:
       = intrusive_list<log_housekeeping_meta, &log_housekeeping_meta::link>;
 
     ss::future<log> do_manage(ntp_config);
+    ss::future<> clean_close(storage::log&);
 
     /**
      * \brief delete old segments and trigger compacted segments

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -150,12 +150,12 @@ struct mem_log_impl final : log::impl {
     mem_log_impl& operator=(const mem_log_impl&) = delete;
     mem_log_impl(mem_log_impl&&) noexcept = default;
     mem_log_impl& operator=(mem_log_impl&&) noexcept = delete;
-    ss::future<> close() final {
+    ss::future<std::optional<ss::sstring>> close() final {
         if (_eviction_monitor) {
             _eviction_monitor->promise.set_exception(
               std::runtime_error("log closed"));
         }
-        return ss::make_ready_future<>();
+        return ss::make_ready_future<std::optional<ss ::sstring>>(std::nullopt);
     }
     ss::future<> remove() final { return ss::make_ready_future<>(); }
     ss::future<> flush() final { return ss::make_ready_future<>(); }

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -171,9 +171,13 @@ std::ostream& operator<<(std::ostream& o, const segment_set& s) {
 // Recover the last segment. Whenever we close a segment, we will likely
 // open a new one to which we will direct new writes. That new segment
 // might be empty. To optimize log replay, implement #140.
-static ss::future<segment_set>
-unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
-    return ss::async([segments = std::move(segments), &as]() mutable {
+static ss::future<segment_set> unsafe_do_recover(
+  segment_set&& segments,
+  std::optional<ss::sstring> last_clean_segment,
+  ss::abort_source& as) {
+    return ss::async([segments = std::move(segments),
+                      last_clean_segment = std::move(last_clean_segment),
+                      &as]() mutable {
         if (segments.empty() || as.abort_requested()) {
             return std::move(segments);
         }
@@ -197,35 +201,29 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
                 }
             }
 
-            if (i + 1 < good.size()) {
-                try {
-                    // use the segment materialize instead of going through
-                    // the index directly to hydrate the max_offset state
-                    if (s.materialize_index().get()) {
-                        vassert(
-                          s.offsets().dirty_offset == s.index().max_offset(),
-                          "dirty_offset and index max_offset must be equal for "
-                          "segment {}",
-                          s);
-                    } else {
-                        to_recover_set.insert(&s);
-                    }
-                } catch (...) {
-                    vlog(
-                      stlog.info,
-                      "Error materializing index:{}. Recovering parent "
-                      "segment:{}. Details:{}",
-                      s.index().filename(),
-                      s.filename(),
-                      std::current_exception());
+            try {
+                // use the segment materialize instead of going through
+                // the index directly to hydrate the max_offset state
+                if (s.materialize_index().get()) {
+                    vassert(
+                      s.offsets().dirty_offset == s.index().max_offset(),
+                      "dirty_offset and index max_offset must be equal for "
+                      "segment {}",
+                      s);
+                } else {
                     to_recover_set.insert(&s);
                 }
-            } else {
-                // always recover the last segment
+            } catch (...) {
+                vlog(
+                  stlog.info,
+                  "Error materializing index:{}. Recovering parent "
+                  "segment:{}. Details:{}",
+                  s.index().filename(),
+                  s.filename(),
+                  std::current_exception());
                 to_recover_set.insert(&s);
             }
         }
-
         segment_set::underlying_t to_recover;
         // keep segments sorted
         auto good_end = std::stable_partition(
@@ -280,6 +278,20 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
             if (unlikely(as.abort_requested())) {
                 return segment_set(std::move(good));
             }
+
+            if (
+              last_clean_segment
+              && std::filesystem::path(s->filename()).filename().string()
+                   == last_clean_segment.value()) {
+                vlog(
+                  stlog.debug,
+                  "Skipping recovery of {}, it is marked clean",
+                  s);
+                good.emplace_back(std::move(s));
+                continue;
+            }
+
+            // Check if the segment was marked clean on shutdown
             auto replayer = log_replayer(*s);
             auto recovered = replayer.recover_in_thread(
               ss::default_priority_class());
@@ -305,8 +317,10 @@ unsafe_do_recover(segment_set&& segments, ss::abort_source& as) {
     });
 }
 
-static ss::future<segment_set>
-do_recover(segment_set&& segments, ss::abort_source& as) {
+static ss::future<segment_set> do_recover(
+  segment_set&& segments,
+  std::optional<ss::sstring> last_clean_segment,
+  ss::abort_source& as) {
     // light-weight copy used for clean-up if recovery fails
     segment_set::underlying_t copy;
     copy.reserve(segments.size());
@@ -318,7 +332,7 @@ do_recover(segment_set&& segments, ss::abort_source& as) {
     // are any pending io operations on a file associated with the segment
     // at the time of destruction seastar will complain about the file handle
     // being destroyed with pending ops.
-    return unsafe_do_recover(std::move(segments), as)
+    return unsafe_do_recover(std::move(segments), last_clean_segment, as)
       .handle_exception(
         [copy = std::move(copy)](const std::exception_ptr& ex) mutable {
             return ss::do_with(
@@ -420,7 +434,8 @@ ss::future<segment_set> recover_segments(
   std::function<std::optional<batch_cache_index>()> cache_factory,
   ss::abort_source& as,
   size_t read_buf_size,
-  unsigned read_readahead_count) {
+  unsigned read_readahead_count,
+  std::optional<ss::sstring> last_clean_segment) {
     return ss::recursive_touch_directory(path.string())
       .then([&as,
              cache_factory,
@@ -436,7 +451,10 @@ ss::future<segment_set> recover_segments(
             read_buf_size,
             read_readahead_count);
       })
-      .then([&as, is_compaction_enabled](segment_set::underlying_t segs) {
+      .then([&as,
+             is_compaction_enabled,
+             last_clean_segment = std::move(last_clean_segment)](
+              segment_set::underlying_t segs) {
           auto segments = segment_set(std::move(segs));
           // we have to mark compacted segments before recovery to allow reading
           // gaps introduced by compaction
@@ -445,7 +463,7 @@ ss::future<segment_set> recover_segments(
                   s->mark_as_compacted_segment();
               }
           }
-          return do_recover(std::move(segments), as);
+          return do_recover(std::move(segments), last_clean_segment, as);
       });
 }
 

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -96,6 +96,7 @@ ss::future<segment_set> recover_segments(
   std::function<std::optional<batch_cache_index>()> batch_cache_factory,
   ss::abort_source& as,
   size_t read_buf_size,
-  unsigned read_readahead_count);
+  unsigned read_readahead_count,
+  std::optional<ss::sstring> last_clean_segment);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -854,4 +854,10 @@ bytes start_offset_key(model::ntp ntp) {
     return iobuf_to_bytes(buf);
 }
 
+bytes clean_segment_key(model::ntp ntp) {
+    iobuf buf;
+    reflection::serialize(buf, kvstore_key_type::clean_segment, std::move(ntp));
+    return iobuf_to_bytes(buf);
+}
+
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -170,8 +170,18 @@ size_t
 // key types used to store data in key-value store
 enum class kvstore_key_type : int8_t {
     start_offset = 0,
+    clean_segment = 1,
 };
 
 bytes start_offset_key(model::ntp ntp);
+bytes clean_segment_key(model::ntp ntp);
+
+struct clean_segment_value
+  : serde::envelope<
+      clean_segment_value,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ss::sstring segment_name;
+};
 
 } // namespace storage::internal


### PR DESCRIPTION
## Cover letter

Previously, we could shut down in an ambiguous state, where an index file exists but may not be completely written, and/or a log segment is complete but may not have been properly truncated.

To address these cases in a general way, we used to unconditionally replay the most recent segment in each log on startup.  That full replay is prohibitively expensive when the number of logs (partitions) in the system is large.  e.g. with 20,000 partitions, even with small 16MB segments, a full replay of all the latest segments is 320GB of disk reads, taking Redpanda's startup time from seconds to minutes.

Startup time is important: it impacts the overall time to execute a rolling restart (upgrade), and most importantly the amount of time data is at-risk (under-replicated) while the restarting node is unavailable.

To enable faster restarts, this PR introduces a new KVStore key for each partition, that stores the filename of the segment most recently safely flushed on shutdown.  During recovery, if the most recent segment's name is equal to that recorded in kvstore, then we can know that it is complete and does not require replay.

## Release notes

### Improvements

* Redpanda now starts more quickly if it was previously shutdown cleanly.