### PR TITLE
rp_service: bypass fsync by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -150,7 +150,7 @@ class ResourceSettings:
         self._memory_mb = memory_mb
 
         if bypass_fsync is None:
-            self._bypass_fsync = False
+            self._bypass_fsync = True
         else:
             self._bypass_fsync = bypass_fsync
 


### PR DESCRIPTION
## Cover letter

Bypassing fsync by default might help reducing the CI
runtime

## Release notes

* none