### PR TITLE
expiring_promise, r/mux_state_machine: make expiring_promise moveable

### DIFF
--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -30,7 +30,7 @@
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/log.hh>
 
-#include <absl/container/node_hash_map.h>
+#include <absl/container/flat_hash_map.h>
 
 #include <optional>
 #include <system_error>
@@ -167,7 +167,7 @@ private:
     replicate_units get_units() { return replicate_units(this); }
 
     consensus* _c;
-    absl::node_hash_map<model::offset, std::error_code> _results;
+    absl::flat_hash_map<model::offset, std::error_code> _results;
     model::offset _last_applied;
     int64_t _pending = 0;
     const persistent_last_applied _persist_last_applied;

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -35,7 +35,7 @@ namespace storage {
  * Manages a mapping between string and blob values. All mutating operates are
  * written to a write-ahead log and flushed before being applied in-memory.
  * Flushing is controlled by a commit interval configuration setting that allows
- * operations to be batched, amatorizing the cost of flushing to disk.
+ * operations to be batched, amortizing the cost of flushing to disk.
  *
  * Operation
  * =========


### PR DESCRIPTION
## Cover letter

- make `expiring_promise` moveable, so we don't need to use a node hash map for holding `expiring_promise` instances
- s/node_hash_map/flat_hash_map/: should be more readable / straightforward this way.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

fixes #487

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
