### PR TITLE
KIP-525 - Return topic configs in create topics responses

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -254,4 +254,20 @@ metadata_cache::get_default_shadow_indexing_mode() const {
     }
     return m;
 }
+
+topic_properties metadata_cache::get_default_properties() const {
+    topic_properties tp;
+    tp.compression = {get_default_compression()};
+    tp.cleanup_policy_bitflags = {get_default_cleanup_policy_bitflags()};
+    tp.compaction_strategy = {get_default_compaction_strategy()};
+    tp.timestamp_type = {get_default_timestamp_type()};
+    tp.segment_size = {get_default_segment_size()};
+    tp.retention_bytes = tristate<size_t>({get_default_retention_bytes()});
+    tp.retention_duration = tristate<std::chrono::milliseconds>(
+      {get_default_retention_duration()});
+    tp.recovery = {false};
+    tp.shadow_indexing = {get_default_shadow_indexing_mode()};
+    return tp;
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -166,6 +166,7 @@ public:
     std::optional<std::chrono::milliseconds>
     get_default_retention_duration() const;
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
+    topic_properties get_default_properties() const;
 
 private:
     ss::sharded<topic_table>& _topics_state;

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -70,6 +70,7 @@ v_cc_library(
     v::cluster
     v::kafka_protocol
     v::security
+    v::coproc
     absl::flat_hash_map
     absl::flat_hash_set
 )

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -159,6 +159,14 @@ path_type_map = {
             },
         },
     },
+    "CreateTopicsResponseData": {
+        "Topics": {
+            "Configs": {
+                "ConfigSource": ("kafka::describe_configs_source", "int8"),
+            },
+            "TopicConfigErrorCode": ("kafka::error_code", "int16"),
+        },
+    },
     "FindCoordinatorRequestData": {
         "KeyType": ("kafka::coordinator_type", "int8"),
     },

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1138,6 +1138,8 @@ if (!{{ tdef.name }}.empty()) {
 if ({{ tdef.name }} != {{ tdef.default_value() }}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
+{%- else %}
+{{ vec }}.push_back({{ tdef.tag() }});
 {%- endif %}
 {%- endmacro %}
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1126,24 +1126,18 @@ while(num_tags-- > 0) {
 {% macro conditional_tag_encode(tdef, vec) %}
 {%- if tdef.is_array %}
 {%- if tdef.nullable() %}
-{%- call tag_version_guard(tdef) %}
 if ({{ tdef.name }}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
-{%- endcall %}
 {%- else %}
-{%- call tag_version_guard(tdef) %}
 if (!{{ tdef.name }}.empty()) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
-{%- endcall %}
 {%- endif %}
 {%- elif tdef.default_value() != "" %}
-{%- call tag_version_guard(tdef) %}
 if ({{ tdef.name }} != {{ tdef.default_value() }}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
-{%- endcall %}
 {%- endif %}
 {%- endmacro %}
 
@@ -1151,7 +1145,9 @@ if ({{ tdef.name }} != {{ tdef.default_value() }}) {
 /// Tags encoding section
 std::vector<uint32_t> to_encode;
 {%- for tdef in tag_definitions -%}
+{%- call tag_version_guard(tdef) %}
 {{- conditional_tag_encode(tdef, "to_encode") }}
+{%- endcall %}
 {%- endfor %}
 writer.write_unsigned_varint(to_encode.size());
 for(size_t tag : to_encode) {

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1124,16 +1124,14 @@ while(num_tags-- > 0) {
 {%- endmacro %}
 
 {% macro conditional_tag_encode(tdef, vec) %}
-{%- if tdef.is_array %}
 {%- if tdef.nullable() %}
 if ({{ tdef.name }}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
-{%- else %}
+{%- elif tdef.is_array %}
 if (!{{ tdef.name }}.empty()) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
-{%- endif %}
 {%- elif tdef.default_value() != "" %}
 if ({{ tdef.name }} != {{ tdef.default_value() }}) {
     {{ vec }}.push_back({{ tdef.tag() }});

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -34,16 +34,16 @@
 namespace kafka {
 
 static constexpr std::array<std::string_view, 10> supported_configs{
-  {"compression.type",
-   "cleanup.policy",
-   "message.timestamp.type",
-   "segment.bytes",
-   "compaction.strategy",
-   "retention.bytes",
-   "retention.ms",
-   "redpanda.remote.recovery",
-   "redpanda.remote.write",
-   "redpanda.remote.read"}};
+  topic_property_compression,
+  topic_property_cleanup_policy,
+  topic_property_timestamp_type,
+  topic_property_segment_size,
+  topic_property_compaction_strategy,
+  topic_property_retention_bytes,
+  topic_property_retention_duration,
+  topic_property_recovery,
+  topic_property_remote_write,
+  topic_property_remote_read};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/create_topics.h
+++ b/src/v/kafka/server/handlers/create_topics.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using create_topics_handler = handler<create_topics_api, 0, 4>;
+using create_topics_handler = handler<create_topics_api, 0, 5>;
 
 }

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -45,7 +45,10 @@ template<typename T>
 requires TopicRequestItem<T> creatable_topic_result
 generate_error(T item, error_code code, const ss::sstring& msg) {
     return creatable_topic_result{
-      .name = item.name, .error_code = code, .error_message = msg};
+      .name = item.name,
+      .error_code = code,
+      .error_message = msg,
+      .topic_config_error_code = code};
 }
 
 /// Generates successfull creatable_topic_result for single topic request item

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -31,7 +31,12 @@
 
 namespace kafka {
 
-config_map_t config_map(const std::vector<createable_topic_config>& config) {
+template<typename T>
+concept CreatableTopicCfg = std::is_same_v<T, creatable_topic_configs> || std::
+  is_same_v<T, createable_topic_config>;
+
+template<CreatableTopicCfg T>
+config_map_t make_config_map(const std::vector<T>& config) {
     config_map_t ret;
     ret.reserve(config.size());
     for (const auto& c : config) {
@@ -40,6 +45,14 @@ config_map_t config_map(const std::vector<createable_topic_config>& config) {
         }
     }
     return ret;
+}
+
+config_map_t config_map(const std::vector<createable_topic_config>& config) {
+    return make_config_map(config);
+}
+
+config_map_t config_map(const std::vector<creatable_topic_configs>& config) {
+    return make_config_map(config);
 }
 
 // Either parse configuration or return nullopt

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -150,4 +150,74 @@ to_cluster_type(const creatable_topic& t) {
     return ret;
 }
 
+template<typename T>
+static ss::sstring from_config_type(const T& v) {
+    if constexpr (std::is_enum_v<T>) {
+        return ss::to_sstring(static_cast<std::underlying_type_t<T>>(v));
+    } else if constexpr (std::is_same_v<bool, T>) {
+        return v ? "true" : "false";
+    } else if constexpr (std::is_same_v<T, std::chrono::milliseconds>) {
+        return ss::to_sstring(
+          std::chrono::duration_cast<std::chrono::milliseconds>(v).count());
+    } else {
+        return ss::to_sstring(v);
+    }
+}
+
+config_map_t from_cluster_type(const cluster::topic_properties& properties) {
+    config_map_t config_entries;
+    if (properties.compression) {
+        config_entries[topic_property_compression] = from_config_type(
+          *properties.compression);
+    }
+    if (properties.cleanup_policy_bitflags) {
+        config_entries[topic_property_cleanup_policy] = from_config_type(
+          *properties.cleanup_policy_bitflags);
+    }
+    if (properties.timestamp_type) {
+        config_entries[topic_property_timestamp_type] = from_config_type(
+          *properties.timestamp_type);
+    }
+    if (properties.segment_size) {
+        config_entries[topic_property_segment_size] = from_config_type(
+          *properties.segment_size);
+    }
+    if (properties.compaction_strategy) {
+        config_entries[topic_property_compaction_strategy] = from_config_type(
+          *properties.compaction_strategy);
+    }
+    if (properties.recovery) {
+        config_entries[topic_property_recovery] = from_config_type(
+          *properties.recovery);
+    }
+    if (properties.shadow_indexing) {
+        config_entries[topic_property_remote_write] = "false";
+        config_entries[topic_property_remote_read] = "false";
+
+        switch (*properties.shadow_indexing) {
+        case model::shadow_indexing_mode::archival:
+            config_entries[topic_property_remote_write] = "true";
+            break;
+        case model::shadow_indexing_mode::fetch:
+            config_entries[topic_property_remote_read] = "true";
+            break;
+        case model::shadow_indexing_mode::full:
+            config_entries[topic_property_remote_write] = "true";
+            config_entries[topic_property_remote_read] = "true";
+            break;
+        default:
+            break;
+        }
+    }
+    if (properties.segment_size.has_value()) {
+        config_entries[topic_property_segment_size] = from_config_type(
+          properties.segment_size.value());
+    }
+    if (properties.retention_duration.has_value()) {
+        config_entries[topic_property_retention_duration] = from_config_type(
+          *properties.retention_duration);
+    }
+    return config_entries;
+}
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -105,6 +105,7 @@ from_cluster_topic_result(const cluster::topic_result& err) {
 }
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);
+config_map_t config_map(const std::vector<creatable_topic_configs>& config);
 
 cluster::custom_assignable_topic_configuration
 to_cluster_type(const creatable_topic& t);

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -109,4 +109,5 @@ config_map_t config_map(const std::vector<createable_topic_config>& config);
 cluster::custom_assignable_topic_configuration
 to_cluster_type(const creatable_topic& t);
 
+config_map_t from_cluster_type(const cluster::topic_properties&);
 } // namespace kafka

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/metadata.h"
+#include "kafka/server/handlers/topics/types.h"
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/io_priority.h"
 
@@ -86,12 +87,14 @@ public:
         return topic;
     }
 
-    void test_create_topic(kafka::create_topics_request req) {
+    kafka::create_topics_response test_create_topic(
+      kafka::create_topics_request req,
+      kafka::api_version version = kafka::api_version(2)) {
         auto client = make_kafka_client().get0();
         client.connect().get();
-        auto resp = client.dispatch(req, kafka::api_version(2)).get0();
+        auto resp = client.dispatch(req, version).get0();
 
-        BOOST_TEST(
+        BOOST_REQUIRE_MESSAGE(
           std::all_of(
             std::cbegin(resp.data.topics),
             std::cend(resp.data.topics),
@@ -102,6 +105,15 @@ public:
 
         for (auto& topic : req.data.topics) {
             verify_metadata(client, req, topic);
+
+            auto it = std::find_if(
+              resp.data.topics.begin(),
+              resp.data.topics.end(),
+              [name = topic.name](const auto& t) { return t.name == name; });
+
+            BOOST_CHECK(it != resp.data.topics.end());
+            verify_response(topic, *it, version, req.data.validate_only);
+
             // TODO: one we combine the cluster fixture with the redpanda
             // fixture and enable multiple RP instances to run at the same time
             // in the test, then we should create two clients in this test where
@@ -111,6 +123,45 @@ public:
         }
 
         client.stop().then([&client] { client.shutdown(); }).get();
+        return resp;
+    }
+
+    void verify_response(
+      const kafka::creatable_topic& req,
+      const kafka::creatable_topic_result& topic_res,
+      kafka::api_version version,
+      bool validate_only) {
+        if (version < kafka::api_version(5)) {
+            /// currently this method only verifies configurations in v5
+            /// responses
+            return;
+        }
+        if (validate_only) {
+            /// Server should return default configs
+            BOOST_TEST(topic_res.configs, "empty config response");
+            auto cfg_map = config_map(*topic_res.configs);
+            const auto default_topic_properties = kafka::from_cluster_type(
+              app.metadata_cache.local().get_default_properties());
+            BOOST_TEST(
+              cfg_map == default_topic_properties,
+              "incorrect default properties");
+            BOOST_CHECK_EQUAL(
+              topic_res.topic_config_error_code, kafka::error_code::none);
+            return;
+        }
+        if (req.configs.empty()) {
+            /// no custom configs were passed
+            return;
+        }
+        BOOST_TEST(topic_res.configs, "Expecting configs");
+        auto resp_cfgs = kafka::config_map(*topic_res.configs);
+        auto cfg = app.metadata_cache.local().get_topic_cfg(
+          model::topic_namespace_view{model::kafka_namespace, topic_res.name});
+        BOOST_TEST(cfg, "missing topic config");
+        auto config_map = kafka::from_cluster_type(cfg->properties);
+        BOOST_TEST(config_map == resp_cfgs, "configs didn't match");
+        BOOST_CHECK_EQUAL(
+          topic_res.topic_config_error_code, kafka::error_code::none);
     }
 
     void test_create_non_replicable_topic(
@@ -299,4 +350,26 @@ FIXTURE_TEST(create_non_replicable_topics, create_topic_fixture) {
     BOOST_CHECK(resp[0].tp_ns.tp() == "def");
     BOOST_CHECK(resp[1].ec == cluster::errc::topic_already_exists);
     BOOST_CHECK(resp[1].tp_ns.tp() == "topic2");
+}
+
+FIXTURE_TEST(test_v5_validate_configs_resp, create_topic_fixture) {
+    wait_for_controller_leadership().get();
+
+    /// Test conditions in create_topic_fixture::verify_metadata will run
+    test_create_topic(
+      make_req({make_topic("topicA"), make_topic("topicB")}, true),
+      kafka::api_version(5));
+
+    /// Test create topic with custom configs, verify that they have been set
+    /// and correctly returned in response
+    std::map<ss::sstring, ss::sstring> config_map{
+      {ss::sstring(kafka::topic_property_retention_bytes), "1234567"},
+      {ss::sstring(kafka::topic_property_segment_size), "7654321"}};
+
+    test_create_topic(
+      make_req(
+        {make_topic("topicC", 3, 1, config_map),
+         make_topic("topicD", 3, 1, config_map)},
+        false),
+      kafka::api_version(5));
 }

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -36,7 +36,6 @@ v_cc_library(
     v::cluster
     v::syschecks
     v::kafka
-    v::coproc
     v::pandaproxy_rest
     v::pandaproxy_schema_registry
     v::archival


### PR DESCRIPTION
More then supporting the described feature, implementing KIP-525 has other benefits. By bumping the version of `create_topics` to 5 (to support the kip) we can:

1. Test another API at the flexible level. The min flex version for `create_topics` is also 5, so doing this work will expose our new parser logic to real flex workloads. (Feature introduced by #4513)
2. `create_topics_response` also has a `tag` at version 5. Bumping to 5 allows us to observe and ensure all tag parsing/encoding logic is working fine. (Feature expanded on by #5017)
3. Implementing what exists at version 5 also means we can then move to v6 which is needed for throttle quota work, [performed here in draft state](https://github.com/redpanda-data/redpanda/pull/4316)
