### PR TITLE
kafka/protocol: use default generated operator==()

### DIFF
--- a/src/v/kafka/protocol/api_versions.h
+++ b/src/v/kafka/protocol/api_versions.h
@@ -58,36 +58,8 @@ struct api_versions_response final {
 
 private:
     friend bool operator==(
-      const kafka::api_versions_response& a,
-      const kafka::api_versions_response& b) {
-        return a.data.error_code == b.data.error_code
-               && a.data.throttle_time_ms == b.data.throttle_time_ms
-               && a.data.finalized_features_epoch
-                    == b.data.finalized_features_epoch
-               && a.data.api_keys == b.data.api_keys
-               && a.data.supported_features == b.data.supported_features
-               && a.data.finalized_features == b.data.finalized_features;
-    }
+      const kafka::api_versions_response&, const kafka::api_versions_response&)
+      = default;
 };
-
-inline bool operator==(
-  const api_versions_response_key& a, const api_versions_response_key& b) {
-    return a.api_key == b.api_key && a.min_version == b.min_version
-           && a.max_version == b.max_version;
-}
-
-inline bool operator==(
-  const kafka::supported_feature_key& a,
-  const kafka::supported_feature_key& b) {
-    return a.name == b.name && a.min_version == b.min_version
-           && a.max_version == b.max_version;
-}
-
-inline bool operator==(
-  const kafka::finalized_feature_key& a,
-  const kafka::finalized_feature_key& b) {
-    return a.name == b.name && a.max_version_level == b.max_version_level
-           && a.min_version_level == b.min_version_level;
-}
 
 } // namespace kafka

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -33,7 +33,6 @@
 #   make it easier to audit where sensitive information is used.
 import io
 import json
-import functools
 import pathlib
 import re
 import sys


### PR DESCRIPTION
## Cover letter

simpler this way. also, this helps the compiler to find the comparison
operators before they are used.

this change helps to address the FTBFS with clang++-15 + libstd++-12:

/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algobase.h:1161:22: error: invalid operands to binary expression ('const kafka::api_versions_response_key' and 'const kafka::api_versions_response_key')
            if (!(*__first1 == *__first2))
                  ~~~~~~~~~ ^  ~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algobase.h:1210:38: note: in instantiation of function template specialization 'std::__equal<false>::equal<const kafka::api_versions_response_key *, const kafka::api_versions_response_key *>' requested here
      return std::__equal<__simple>::equal(__first1, __last1, __first2);
                                     ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algobase.h:1218:19: note: in instantiation of function template specialization 'std::__equal_aux1<const kafka::api_versions_response_key *, const kafka::api_versions_response_key *>' requested here
      return std::__equal_aux1(std::__niter_base(__first1),
                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algobase.h:1555:19: note: in instantiation of function template specialization 'std::__equal_aux<__gnu_cxx::__normal_iterator<const kafka::api_versions_response_key *, std::vector<kafka::api_versions_response_key>>, __gnu_cxx::__normal_iterator<const kafka::api_versions_response_key *, std::vector<kafka::api_versions_response_key>>>' requested here
      return std::__equal_aux(__first1, __last1, __first2);
                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_vector.h:2037:16: note: in instantiation of function template specialization 'std::equal<__gnu_cxx::__normal_iterator<const kafka::api_versions_response_key *, std::vector<kafka::api_versions_response_key>>, __gnu_cxx::__normal_iterator<const kafka::api_versions_response_key *, std::vector<kafka::api_versions_response_key>>>' requested here
              && std::equal(__x.begin(), __x.end(), __y.begin())); }
                      ^
/home/kefu/dev/redpanda/src/v/kafka/protocol/api_versions.h:67:35: note: in instantiation of function template specialization 'std::operator==<kafka::api_versions_response_key, std::allocator<kafka::api_versions_response_key>>' requested here
               && a.data.api_keys == b.data.api_keys
                                  ^
/home/kefu/dev/redpanda/src/v/kafka/protocol/join_group.h:137:13: note: candidate function not viable: no known conversion from 'const kafka::api_versions_response_key' to 'const std::vector<join_group_request_protocol>' for 1st argument
inline bool operator==(
            ^

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


## Release notes

* none
