### PR TITLE
k/protocol: move kafka_request_schemata into v::kafka_protocol

### DIFF
--- a/src/v/kafka/protocol/CMakeLists.txt
+++ b/src/v/kafka/protocol/CMakeLists.txt
@@ -1,10 +1,39 @@
 add_subdirectory(schemata)
 
+set(message_gen ${CMAKE_CURRENT_SOURCE_DIR}/schemata/generator.py)
+set(message_srcs)
+
+foreach(schema ${schemata})
+  get_filename_component(msg_name ${schema} NAME_WE)
+  set(schema_src ${CMAKE_CURRENT_SOURCE_DIR}/schemata/${schema})
+  set(msg_dir "${CMAKE_CURRENT_BINARY_DIR}/schemata")
+  set(msg_srcs
+    "${msg_dir}/${msg_name}.h"
+    "${msg_dir}/${msg_name}.cc")
+  list(APPEND message_srcs ${msg_srcs})
+  add_custom_command(
+    OUTPUT ${msg_srcs}
+    COMMAND ${KAFKA_CODEGEN_VENV} ${message_gen}
+    ARGS ${msg_dir} ${schema_src}
+    DEPENDS ${schema_src} ${message_gen} ${KAFKA_CODEGEN_VENV}
+    COMMENT "Running kafka request codegen on ${schema_src}"
+    VERBATIM)
+endforeach()
+
+
 v_cc_library(
   NAME kafka_protocol
   SRCS
     errors.cc
+    ${message_srcs}
+  COPTS
+    "-Wno-unused-lambda-capture"
   DEPS
-    v::kafka_request_schemata)
+    Seastar::seastar
+    v::bytes
+    v::rpc
+    absl::flat_hash_map
+    absl::flat_hash_set
+)
 
 add_subdirectory(tests)

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -68,32 +68,4 @@ set(schemata
   offset_for_leader_epoch_request.json
   offset_for_leader_epoch_response.json)
 
-set(srcs)
-foreach(schema ${schemata})
-  get_filename_component(msg_name ${schema} NAME_WE)
-  set(hdr "${CMAKE_CURRENT_BINARY_DIR}/${msg_name}.h")
-  set(src "${CMAKE_CURRENT_BINARY_DIR}/${msg_name}.cc")
-  list(APPEND srcs ${hdr})
-  list(APPEND srcs ${src})
-  add_custom_command(
-    OUTPUT ${hdr} ${src}
-    COMMAND ${KAFKA_CODEGEN_VENV} ${CMAKE_CURRENT_SOURCE_DIR}/generator.py
-    ARGS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${schema}
-    DEPENDS ${schema} ${CMAKE_CURRENT_SOURCE_DIR}/generator.py ${KAFKA_CODEGEN_VENV}
-    COMMENT "Running kafka request codegen on ${schema}"
-    VERBATIM)
-endforeach()
-
-v_cc_library(
-  NAME kafka_request_schemata
-  SRCS
-    ${srcs}
-  COPTS
-    "-Wno-unused-lambda-capture"
-  DEPS
-    Seastar::seastar
-    v::bytes
-    v::rpc
-    absl::flat_hash_map
-    absl::flat_hash_set
-)
+set(schemata ${schemata} PARENT_SCOPE)


### PR DESCRIPTION
in sasl_authenticate_response.cc,
operator<<(.., const sasl_authenticate_response_data&) references
operator<<(.., kafka::error_code). the former is compiled as a part of
v::kafka_request_schemata. while the latter is defined by
kafka/protocol/errors.cc. which is in turn compiled as a part of
v::kafka_protocol. so we need to help v::kafka_request_schemata
to link against v::kafka_protocol to avoid following link failure:
```
lib/libv_v_kafka_request_schemata.a(sasl_authenticate_response.cc.o): in function `void fmt::v8::detail::format_value<char, kafka::error_code>(fmt::v8::detail::buffer<char>&, kafka::error_code const&, fmt::v8::detail::locale_ref)':
sasl_authenticate_response.cc:(.text._ZN3fmt2v86detail12format_valueIcN5kafka10error_codeEEEvRNS1_6bufferIT_EERKT0_NS1_10locale_refE[_ZN3fmt2v86detail12format_valueIcN5kafka10error_codeEEEvRNS1_6bufferIT_EERKT0_NS1_10locale_refE]+0x551): undefined reference to `kafka::operator<<(std::ostream&, kafka::error_code)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
