### PR TITLE
storage: introduce `storage_resources` for controlling resource use at scale

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -84,7 +84,6 @@ ss::future<> controller::wire_up() {
             config::shard_local_cfg().topic_fds_per_partition.bind(),
             config::shard_local_cfg().topic_partitions_per_shard.bind(),
             config::shard_local_cfg().topic_partitions_reserve_shard0.bind(),
-            config::shard_local_cfg().segment_fallocation_step.bind(),
             config::shard_local_cfg().enable_rack_awareness.bind());
       })
       .then([this] { return _credentials.start(); })

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -305,6 +305,7 @@ ss::future<> controller::start() {
             std::ref(_raft_manager),
             std::ref(_as),
             std::ref(_storage_node),
+            std::ref(_storage),
             std::ref(_drain_manager),
             std::ref(_feature_table),
             config::shard_local_cfg()

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -54,7 +54,8 @@ health_monitor_backend::health_monitor_backend(
   ss::sharded<partition_manager>& partition_manager,
   ss::sharded<raft::group_manager>& raft_manager,
   ss::sharded<ss::abort_source>& as,
-  ss::sharded<storage::node_api>& storage_api,
+  ss::sharded<storage::node_api>& storage_node_api,
+  ss::sharded<storage::api>& storage_api,
   ss::sharded<drain_manager>& drain_manager,
   ss::sharded<feature_table>& feature_table,
   config::binding<size_t> storage_min_bytes_alert,
@@ -72,6 +73,7 @@ health_monitor_backend::health_monitor_backend(
       std::move(storage_min_bytes_alert),
       std::move(storage_min_percent_alert),
       std::move(storage_min_bytes),
+      storage_node_api,
       storage_api) {
     _tick_timer.set_callback([this] { tick(); });
     _tick_timer.arm(tick_interval());

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -53,6 +53,7 @@ public:
       ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
       ss::sharded<storage::node_api>&,
+      ss::sharded<storage::api>&,
       ss::sharded<drain_manager>&,
       ss::sharded<feature_table>&,
       config::binding<size_t> min_bytes_alert,

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -31,7 +31,8 @@ public:
       config::binding<size_t> min_bytes_alert,
       config::binding<unsigned> min_percent_alert,
       config::binding<size_t> min_bytes,
-      ss::sharded<storage::node_api>& api);
+      ss::sharded<storage::node_api>&,
+      ss::sharded<storage::api>&);
     local_monitor(const local_monitor&) = delete;
     local_monitor(local_monitor&&) = default;
     ~local_monitor() = default;
@@ -76,7 +77,8 @@ private:
     config::binding<unsigned> _free_percent_alert_threshold;
     config::binding<size_t> _min_free_bytes;
 
-    ss::sharded<storage::node_api>& _storage_api; // single instance
+    ss::sharded<storage::node_api>& _storage_node_api; // single instance
+    ss::sharded<storage::api>& _storage_api;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -38,7 +38,6 @@ partition_allocator::partition_allocator(
   config::binding<std::optional<int32_t>> fds_per_partition,
   config::binding<uint32_t> partitions_per_shard,
   config::binding<uint32_t> partitions_reserve_shard0,
-  config::binding<size_t> fallocation_step,
   config::binding<bool> enable_rack_awareness)
   : _state(std::make_unique<allocation_state>(
     partitions_per_shard, partitions_reserve_shard0))
@@ -48,7 +47,6 @@ partition_allocator::partition_allocator(
   , _fds_per_partition(fds_per_partition)
   , _partitions_per_shard(partitions_per_shard)
   , _partitions_reserve_shard0(partitions_reserve_shard0)
-  , _fallocation_step(fallocation_step)
   , _enable_rack_awareness(enable_rack_awareness) {}
 
 allocation_constraints default_constraints() {

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -250,20 +250,6 @@ std::error_code partition_allocator::check_cluster_limits(
         }
     }
 
-    // Refuse to create partitions if there isn't enough space to at least
-    // falloc the first part of a segment for each partition
-    if (_fallocation_step() > 0) {
-        uint64_t disk_limit = effective_cluster_disk / _fallocation_step();
-        if (disk_limit > 0 && (proposed_total_partitions > disk_limit)) {
-            vlog(
-              clusterlog.warn,
-              "Refusing to create {} partitions, exceeds disk limit {}",
-              create_count,
-              disk_limit);
-            return errc::topic_invalid_partitions;
-        }
-    }
-
     return errc::success;
 }
 

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -30,7 +30,6 @@ public:
       config::binding<std::optional<int32_t>>,
       config::binding<uint32_t>,
       config::binding<uint32_t>,
-      config::binding<size_t>,
       config::binding<bool>);
 
     void register_node(allocation_state::node_ptr n) {
@@ -123,7 +122,6 @@ private:
     config::binding<std::optional<int32_t>> _fds_per_partition;
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
-    config::binding<size_t> _fallocation_step;
     config::binding<bool> _enable_rack_awareness;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -23,7 +23,8 @@ struct local_monitor_fixture {
     ~local_monitor_fixture();
 
     std::filesystem::path _test_path;
-    ss::sharded<storage::node_api> _storage_api;
+    ss::sharded<storage::api> _storage_api;
+    ss::sharded<storage::node_api> _storage_node_api;
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -32,7 +32,6 @@ struct partition_allocator_fixture {
         config::mock_binding<std::optional<int32_t>>(std::nullopt),
         config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
         config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-        config::mock_binding<size_t>(32_MiB),
         config::mock_binding<bool>(true)) {
         members.start().get0();
         ss::smp::invoke_on_all([] {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -57,7 +57,6 @@ public:
             config::mock_binding<std::optional<int32_t>>(std::nullopt),
             config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-            config::mock_binding<size_t>(16_KiB),
             config::mock_binding<bool>(false))
           .get();
     }

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -50,7 +50,6 @@ struct topic_table_fixture {
             config::mock_binding<std::optional<int32_t>>(std::nullopt),
             config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-            config::mock_binding<size_t>(32_MiB),
             config::mock_binding<bool>(false))
           .get0();
         allocator.local().register_node(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -734,6 +734,26 @@ configuration::configuration()
        .visibility = visibility::tunable},
       32_MiB,
       storage::segment_appender::validate_fallocation_step)
+  , storage_target_replay_bytes(
+      *this,
+      "storage_target_replay_bytes",
+      "Target bytes to replay from disk on startup after clean shutdown: "
+      "controls frequency of snapshots and checkpoints",
+      {.needs_restart = needs_restart::no,
+       .example = "2147483648",
+       .visibility = visibility::tunable},
+      10_GiB,
+      {.min = 128_MiB, .max = 1_TiB})
+  , storage_max_concurrent_replay(
+      *this,
+      "storage_max_concurrent_replay",
+      "Maximum number of partitions' logs that will be replayed concurrently "
+      "at startup, or flushed concurrently on shutdown.",
+      {.needs_restart = needs_restart::no,
+       .example = "2048",
+       .visibility = visibility::tunable},
+      1024,
+      {.min = 128})
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -165,6 +165,8 @@ struct configuration final : public config_store {
     property<size_t> storage_read_buffer_size;
     property<int16_t> storage_read_readahead_count;
     property<size_t> segment_fallocation_step;
+    bounded_property<uint64_t> storage_target_replay_bytes;
+    bounded_property<uint64_t> storage_max_concurrent_replay;
     property<size_t> max_compacted_log_segment_size;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -205,6 +205,10 @@ private:
      */
     size_t _bytes_since_last_offset_update = 0;
 
+    // Units issued by the storage resource manager to track how many bytes
+    // of data is currently pending checkpoint.
+    ss::semaphore_units<> _bytes_since_last_offset_update_units;
+
     model::revision_id _initial_revision{};
     ctx_log& _ctxlog;
     configuration_idx _next_index{0};

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -128,6 +128,15 @@ private:
     model::offset _highest_known_offset;
 
     size_t _bytes_processed = 0;
+
+    // Units issued by the storage resource manager to track how many bytes
+    // of data is currently pending checkpoint.
+    ss::semaphore_units<> _bytes_processed_units;
+
+    // If true, the storage resource manager has asked us to checkpoint at the
+    // next opportunity.
+    bool _checkpoint_hint{false};
+
     size_t _map_version = 0;
 
     mutex _checkpoint_lock;

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -321,6 +321,7 @@ FIXTURE_TEST(test_recovery_of_crashed_leader_truncation, raft_test_fixture) {
     auto leader_raft = gr.get_member(first_leader_id).consensus;
     auto f = leader_raft->replicate(
       random_batches_reader(2), default_replicate_opts);
+    leader_raft.release();
     // since replicate doesn't accept timeout client have to deal with it.
     auto v = ss::with_timeout(model::timeout_clock::now() + 1s, std::move(f))
                .handle_exception_type([](const ss::timed_out_error&) {

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -99,6 +99,7 @@ struct mux_state_machine_fixture {
         if (_started) {
             _recovery_throttle.stop().get();
             _group_mgr.stop().get0();
+            _raft.release();
             _connections.stop().get0();
             _storage.stop().get0();
         }

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -240,6 +240,11 @@ struct raft_node {
               return ss::make_ready_future<>();
           })
           .then([this] {
+              if (hbeats) {
+                  hbeats.reset();
+              }
+          })
+          .then([this] {
               tstlog.info("Stopping raft at {}", broker.id());
               return consensus->stop();
           })
@@ -250,8 +255,19 @@ struct raft_node {
               return ss::now();
           })
           .then([this] {
-              tstlog.info("Raft stopped at node {}", broker.id());
+              tstlog.info(
+                "Raft stopped at node {} {}",
+                broker.id(),
+                consensus.use_count());
               return raft_manager.stop();
+          })
+          .then([this] {
+              tstlog.info(
+                "consensus destroyed at node {} {}",
+                broker.id(),
+                consensus.use_count());
+              consensus = nullptr;
+              return ss::now();
           })
           .then([this] {
               tstlog.info("Stopping cache at node {}", broker.id());

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -275,6 +275,7 @@ struct raft_node {
           })
           .then([this] {
               tstlog.info("Stopping storage at node {}", broker.id());
+              log.reset();
               return storage.stop();
           })
           .then([this] {

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -55,6 +55,11 @@ bool snapshot_exists(raft_node& n) {
     return snapshot_exists;
 }
 
+/**
+ * Specialized vs. raft_node::stop_node because in the below
+ * tests we explicitly stop consensus early, so need to avoid
+ * double-stopping it during stop_node.
+ */
 void stop_node(raft_node& node) {
     node.recovery_throttle.stop().get();
     node.server.stop().get0();
@@ -63,7 +68,9 @@ void stop_node(raft_node& node) {
         node._nop_stm->stop().get0();
     }
     node.raft_manager.stop().get0();
+    node.consensus = nullptr;
     node.hbeats->stop().get0();
+    node.hbeats.reset();
     node.cache.stop().get0();
     node.storage.stop().get0();
 

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -72,6 +72,7 @@ void stop_node(raft_node& node) {
     node.hbeats->stop().get0();
     node.hbeats.reset();
     node.cache.stop().get0();
+    node.log.reset();
     node.storage.stop().get0();
 
     node.started = false;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1211,8 +1211,26 @@ void application::start_redpanda(::stop_signal& app_signal) {
       config::shard_local_cfg()
         .storage_space_alert_free_threshold_percent.bind(),
       config::shard_local_cfg().storage_min_free_bytes.bind(),
-      storage_node);
+      storage_node,
+      storage);
     tmp_lm.update_state().get();
+
+    auto disk_stats
+      = storage_node
+          .invoke_on(
+            ss::shard_id{0},
+            [](const storage::node_api& na) -> storage::disk_metrics {
+                return na.get_disk_metrics();
+            })
+          .get();
+
+    storage
+      .invoke_on_all([disk_stats](storage::api& sa) -> ss::future<> {
+          sa.resources().update_allowance(
+            disk_stats.total_bytes, disk_stats.free_bytes);
+          return ss::now();
+      })
+      .get();
 
     storage.invoke_on_all(&storage::api::start).get();
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -133,7 +133,10 @@ private:
     template<typename Service, typename... Args>
     void construct_single_service(std::unique_ptr<Service>& s, Args&&... args) {
         s = std::make_unique<Service>(std::forward<Args>(args)...);
-        _deferred.emplace_back([&s] { s->stop().get(); });
+        _deferred.emplace_back([&s] {
+            s->stop().get();
+            s.reset();
+        });
     }
 
     template<typename Service, typename... Args>

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -19,6 +19,7 @@ v_cc_library(
     segment.cc
     segment_index.cc
     segment_appender_utils.cc
+    storage_resources.cc
     batch_cache.cc
     index_state.cc
     lock_manager.cc

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -57,7 +57,7 @@ public:
       , _log_conf_cb(std::move(log_conf_cb)) {}
 
     ss::future<> start() {
-        _kvstore = std::make_unique<kvstore>(_kv_conf_cb());
+        _kvstore = std::make_unique<kvstore>(_kv_conf_cb(), _resources);
         return _kvstore->start().then([this] {
             _log_mgr = std::make_unique<log_manager>(
               _log_conf_cb(), kvs(), _resources);

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -59,7 +59,8 @@ public:
     ss::future<> start() {
         _kvstore = std::make_unique<kvstore>(_kv_conf_cb());
         return _kvstore->start().then([this] {
-            _log_mgr = std::make_unique<log_manager>(_log_conf_cb(), kvs());
+            _log_mgr = std::make_unique<log_manager>(
+              _log_conf_cb(), kvs(), _resources);
         });
     }
 

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -24,6 +24,8 @@
 
 namespace storage {
 
+class storage_resources;
+
 /** format on file is:
     INT16 PAYLOAD
     INT16 PAYLOAD
@@ -149,6 +151,6 @@ compacted_index_writer make_file_backed_compacted_index(
   ss::io_priority_class p,
   debug_sanitize_files debug,
   bool truncate,
-  size_t max_memory);
+  storage_resources& resources);
 
 } // namespace storage

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -123,6 +123,10 @@ disk_log_appender::append_batch_to_segment(const model::record_batch& batch) {
         auto& p = _log.get_probe();
         p.add_bytes_written(r.byte_size);
         p.batch_written();
+
+        // Register increase in dirty bytes since last STM snapshot
+        _log.wrote_stm_bytes(r.byte_size);
+
         // substract the bytes from the append
         // take the min because _bytes_left_in_segment is optimistic
         _bytes_left_in_segment -= std::min(_bytes_left_in_segment, r.byte_size);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -345,7 +345,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
         }
 
         auto result = co_await storage::internal::self_compact_segment(
-          seg, cfg, _probe, *_readers_cache);
+          seg, cfg, _probe, *_readers_cache, _manager.resources());
         vlog(
           gclog.debug,
           "[{}] segment {} compaction result: {}",
@@ -471,7 +471,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
     auto staging_path = std::filesystem::path(
       fmt::format("{}.compaction.staging", target->reader().filename()));
     auto replacement = co_await storage::internal::make_concatenated_segment(
-      staging_path, segments, cfg);
+      staging_path, segments, cfg, _manager.resources());
 
     // compact the combined data in the replacement segment. the partition size
     // tracking needs to be adjusted as compaction routines assume the segment
@@ -479,7 +479,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
     replacement->mark_as_compacted_segment();
     _probe.add_initial_segment(*replacement.get());
     auto ret = co_await storage::internal::self_compact_segment(
-      replacement, cfg, _probe, *_readers_cache);
+      replacement, cfg, _probe, *_readers_cache, _manager.resources());
     _probe.delete_segment(*replacement.get());
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 
@@ -1348,6 +1348,8 @@ int64_t disk_log_impl::compaction_backlog() const {
 
     return backlog;
 }
+
+storage_resources& disk_log_impl::resources() { return _manager.resources(); }
 
 std::ostream& disk_log_impl::print(std::ostream& o) const {
     return o << "{offsets:" << offsets()

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -157,6 +157,8 @@ private:
 
     compaction_config apply_overrides(compaction_config) const;
 
+    storage_resources& resources();
+
 private:
     size_t max_segment_size() const;
     struct eviction_monitor {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -159,6 +159,8 @@ private:
 
     storage_resources& resources();
 
+    void wrote_stm_bytes(size_t);
+
 private:
     size_t max_segment_size() const;
     struct eviction_monitor {
@@ -183,6 +185,9 @@ private:
     std::unique_ptr<readers_cache> _readers_cache;
     // average ratio of segment sizes after segment size before compaction
     moving_average<double, 5> _compaction_ratio{1.0};
+
+    // Bytes written since last time we requested stm snapshot
+    ss::semaphore_units<> _stm_dirty_bytes_units;
 };
 
 } // namespace storage

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -30,8 +30,9 @@ static ss::logger lg("kvstore");
 
 namespace storage {
 
-kvstore::kvstore(kvstore_config kv_conf)
+kvstore::kvstore(kvstore_config kv_conf, storage_resources& resources)
   : _conf(kv_conf)
+  , _resources(resources)
   , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),
@@ -259,7 +260,8 @@ ss::future<> kvstore::roll() {
                  config::shard_local_cfg().storage_read_buffer_size(),
                  config::shard_local_cfg().storage_read_readahead_count(),
                  _conf.sanitize_fileops,
-                 std::nullopt)
+                 std::nullopt,
+                 _resources)
           .then([this](ss::lw_shared_ptr<segment> seg) {
               _segment = std::move(seg);
           });
@@ -300,7 +302,8 @@ ss::future<> kvstore::roll() {
                        config::shard_local_cfg().storage_read_buffer_size(),
                        config::shard_local_cfg().storage_read_readahead_count(),
                        _conf.sanitize_fileops,
-                       std::nullopt)
+                       std::nullopt,
+                       _resources)
                 .then([this](ss::lw_shared_ptr<segment> seg) {
                     _segment = std::move(seg);
                 });
@@ -386,7 +389,8 @@ ss::future<> kvstore::recover() {
               _as,
               config::shard_local_cfg().storage_read_buffer_size(),
               config::shard_local_cfg().storage_read_readahead_count(),
-              std::nullopt)
+              std::nullopt,
+              _resources)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -16,6 +16,7 @@
 #include "storage/parser.h"
 #include "storage/segment_set.h"
 #include "storage/snapshot.h"
+#include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "utils/mutex.h"
 
@@ -99,7 +100,7 @@ public:
         /* your sub-system here */
     };
 
-    explicit kvstore(kvstore_config kv_conf);
+    explicit kvstore(kvstore_config kv_conf, storage_resources&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -115,6 +116,7 @@ public:
 
 private:
     kvstore_config _conf;
+    storage_resources& _resources;
     ntp_config _ntpc;
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -215,6 +215,7 @@ log_manager::create_cache(with_cache ntp_cache_enabled) {
 ss::future<log> log_manager::manage(ntp_config cfg) {
     auto gate = _open_gate.hold();
 
+    auto units = co_await _resources.get_recovery_units();
     co_return co_await do_manage(std::move(cfg));
 }
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -196,7 +196,8 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
             read_buf_size,
             read_ahead,
             _config.sanitize_fileops,
-            create_cache(ntp.cache_enabled()));
+            create_cache(ntp.cache_enabled()),
+            _resources);
       });
 }
 
@@ -277,7 +278,8 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       _abort_source,
       config::shard_local_cfg().storage_read_buffer_size(),
       config::shard_local_cfg().storage_read_readahead_count(),
-      last_clean_segment);
+      last_clean_segment,
+      _resources);
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -229,6 +229,8 @@ public:
 
     int64_t compaction_backlog() const;
 
+    storage_resources& resources() { return _resources; }
+
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -20,6 +20,7 @@
 #include "storage/log_housekeeping_meta.h"
 #include "storage/ntp_config.h"
 #include "storage/segment.h"
+#include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "storage/version.h"
 #include "units.h"
@@ -181,7 +182,8 @@ struct log_config {
  */
 class log_manager {
 public:
-    explicit log_manager(log_config, kvstore& kvstore) noexcept;
+    explicit log_manager(
+      log_config, kvstore& kvstore, storage_resources&) noexcept;
 
     ss::future<log> manage(ntp_config);
 
@@ -253,6 +255,7 @@ private:
 
     log_config _config;
     kvstore& _kvstore;
+    storage_resources& _resources;
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _compaction_timer;
     logs_type _logs;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -34,6 +34,8 @@ public:
     void set_disk_metrics(
       uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
 
+    const disk_metrics& get_disk_metrics() const { return _disk; }
+
 private:
     disk_metrics _disk;
     ss::metrics::metric_groups _metrics;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -87,6 +87,8 @@ ss::future<> segment::close() {
     co_await _gate.close();
     auto locked = co_await write_lock();
 
+    auto units = co_await _resources.get_close_flush_units();
+
     co_await do_flush();
     co_await do_close();
     co_await remove_tombstones();

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -614,6 +614,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                          path,
                          sanitize_fileops,
                          internal::number_of_chunks_from_config(ntpc),
+                         internal::segment_size_from_config(ntpc),
                          pc,
                          config::shard_local_cfg()
                            .segment_fallocation_step.bind())

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -48,8 +48,10 @@ segment::segment(
   segment_index i,
   segment_appender_ptr a,
   std::optional<compacted_index_writer> ci,
-  std::optional<batch_cache_index> c) noexcept
-  : _appender_callbacks(this)
+  std::optional<batch_cache_index> c,
+  storage_resources& resources) noexcept
+  : _resources(resources)
+  , _appender_callbacks(this)
   , _tracker(tkr)
   , _reader(std::move(r))
   , _idx(std::move(i))
@@ -551,7 +553,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
-  unsigned read_ahead) {
+  unsigned read_ahead,
+  storage_resources& resources) {
     auto const meta = segment_path::parse_segment_filename(
       path.filename().string());
     if (!meta || meta->version != record_version_type::v1) {
@@ -582,7 +585,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
       std::move(idx),
       nullptr,
       std::nullopt,
-      std::move(batch_cache));
+      std::move(batch_cache),
+      resources);
 }
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
@@ -594,7 +598,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   size_t buf_size,
   unsigned read_ahead,
   debug_sanitize_files sanitize_fileops,
-  std::optional<batch_cache_index> batch_cache) {
+  std::optional<batch_cache_index> batch_cache,
+  storage_resources& resources) {
     auto path = segment_path::make_segment_path(
       ntpc, base_offset, term, version);
     vlog(stlog.info, "Creating new segment {}", path.string());
@@ -603,12 +608,13 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
              sanitize_fileops,
              std::move(batch_cache),
              buf_size,
-             read_ahead)
-      .then([path, &ntpc, sanitize_fileops, pc](
+             read_ahead,
+             resources)
+      .then([path, &ntpc, sanitize_fileops, pc, &resources](
               ss::lw_shared_ptr<segment> seg) {
           return with_segment(
             std::move(seg),
-            [path, &ntpc, sanitize_fileops, pc](
+            [path, &ntpc, sanitize_fileops, pc, &resources](
               const ss::lw_shared_ptr<segment>& seg) {
                 return internal::make_segment_appender(
                          path,
@@ -616,9 +622,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                          internal::number_of_chunks_from_config(ntpc),
                          internal::segment_size_from_config(ntpc),
                          pc,
-                         config::shard_local_cfg()
-                           .segment_fallocation_step.bind())
-                  .then([seg](segment_appender_ptr a) {
+                         resources)
+                  .then([seg, &resources](segment_appender_ptr a) {
                       return ss::make_ready_future<ss::lw_shared_ptr<segment>>(
                         ss::make_lw_shared<segment>(
                           seg->offsets(),
@@ -628,23 +633,24 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           std::nullopt,
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
-                            : std::nullopt));
+                            : std::nullopt,
+                          resources));
                   });
             });
       })
-      .then([path, &ntpc, sanitize_fileops, pc](
+      .then([path, &ntpc, sanitize_fileops, pc, &resources](
               ss::lw_shared_ptr<segment> seg) {
           if (!ntpc.is_compacted()) {
               return ss::make_ready_future<ss::lw_shared_ptr<segment>>(seg);
           }
           return with_segment(
             seg,
-            [path, sanitize_fileops, pc](
+            [path, sanitize_fileops, pc, &resources](
               const ss::lw_shared_ptr<segment>& seg) {
                 auto compacted_path = internal::compacted_index_path(path);
                 return internal::make_compacted_index_writer(
-                         compacted_path, sanitize_fileops, pc)
-                  .then([seg](compacted_index_writer compact) {
+                         compacted_path, sanitize_fileops, pc, resources)
+                  .then([seg, &resources](compacted_index_writer compact) {
                       return ss::make_ready_future<ss::lw_shared_ptr<segment>>(
                         ss::make_lw_shared<segment>(
                           seg->offsets(),
@@ -654,7 +660,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           std::move(compact),
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
-                            : std::nullopt));
+                            : std::nullopt,
+                          resources));
                   });
             });
       });

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -17,6 +17,7 @@
 #include "storage/segment_appender.h"
 #include "storage/segment_index.h"
 #include "storage/segment_reader.h"
+#include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "storage/version.h"
 
@@ -69,7 +70,8 @@ public:
       segment_index,
       segment_appender_ptr,
       std::optional<compacted_index_writer>,
-      std::optional<batch_cache_index>) noexcept;
+      std::optional<batch_cache_index>,
+      storage_resources&) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -173,6 +175,8 @@ private:
         segment* _segment;
     };
 
+    storage_resources& _resources;
+
     appender_callbacks _appender_callbacks;
 
     void advance_stable_offset(size_t offset);
@@ -212,7 +216,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
-  unsigned read_ahead);
+  unsigned read_ahead,
+  storage_resources&);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,
@@ -223,7 +228,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   size_t buf_size,
   unsigned read_ahead,
   debug_sanitize_files sanitize_fileops,
-  std::optional<batch_cache_index> batch_cache);
+  std::optional<batch_cache_index> batch_cache,
+  storage_resources&);
 
 // bitflags operators
 [[gnu::always_inline]] inline segment::bitflags

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -42,13 +42,20 @@ public:
         options(
           ss::io_priority_class p,
           size_t chunks_no,
+          std::optional<uint64_t> s,
           config::binding<size_t> falloc_step)
           : priority(p)
           , number_of_chunks(chunks_no)
+          , segment_size(s)
           , falloc_step(falloc_step) {}
 
         ss::io_priority_class priority;
         size_t number_of_chunks;
+        // Generally a segment appender doesn't need to know the target size
+        // of the segment it's appending to, but this is used as an input
+        // to the dynamic fallocation size algorithm, to avoid falloc'ing
+        // more space than a segment would ever need.
+        std::optional<uint64_t> segment_size;
         config::binding<size_t> falloc_step;
     };
 

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -16,6 +16,7 @@
 #include "likely.h"
 #include "seastarx.h"
 #include "storage/segment_appender_chunk.h"
+#include "storage/storage_resources.h"
 #include "utils/intrusive_list_helpers.h"
 
 #include <seastar/core/file.hh>
@@ -43,11 +44,11 @@ public:
           ss::io_priority_class p,
           size_t chunks_no,
           std::optional<uint64_t> s,
-          config::binding<size_t> falloc_step)
+          storage_resources& r)
           : priority(p)
           , number_of_chunks(chunks_no)
           , segment_size(s)
-          , falloc_step(falloc_step) {}
+          , resources(r) {}
 
         ss::io_priority_class priority;
         size_t number_of_chunks;
@@ -56,7 +57,7 @@ public:
         // to the dynamic fallocation size algorithm, to avoid falloc'ing
         // more space than a segment would ever need.
         std::optional<uint64_t> segment_size;
-        config::binding<size_t> falloc_step;
+        storage_resources& resources;
     };
 
     segment_appender(ss::file f, options opts);

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -364,7 +364,8 @@ static ss::future<segment_set::underlying_t> open_segments(
   std::function<std::optional<batch_cache_index>()> cache_factory,
   ss::abort_source& as,
   size_t buf_size,
-  unsigned read_ahead) {
+  unsigned read_ahead,
+  storage_resources& resources) {
     using segs_type = segment_set::underlying_t;
     return ss::do_with(
       segs_type{},
@@ -373,7 +374,8 @@ static ss::future<segment_set::underlying_t> open_segments(
        sanitize_fileops,
        dir = std::move(dir),
        buf_size,
-       read_ahead](segs_type& segs) {
+       read_ahead,
+       &resources](segs_type& segs) {
           auto f = directory_walker::walk(
             dir,
             [&as,
@@ -382,7 +384,8 @@ static ss::future<segment_set::underlying_t> open_segments(
              sanitize_fileops,
              &segs,
              buf_size,
-             read_ahead](ss::directory_entry seg) {
+             read_ahead,
+             &resources](ss::directory_entry seg) {
                 // abort if requested
                 if (as.abort_requested()) {
                     return ss::now();
@@ -411,7 +414,8 @@ static ss::future<segment_set::underlying_t> open_segments(
                          sanitize_fileops,
                          cache_factory(),
                          buf_size,
-                         read_ahead)
+                         read_ahead,
+                         resources)
                   .then([&segs](ss::lw_shared_ptr<segment> p) {
                       segs.push_back(std::move(p));
                   });
@@ -435,21 +439,24 @@ ss::future<segment_set> recover_segments(
   ss::abort_source& as,
   size_t read_buf_size,
   unsigned read_readahead_count,
-  std::optional<ss::sstring> last_clean_segment) {
+  std::optional<ss::sstring> last_clean_segment,
+  storage_resources& resources) {
     return ss::recursive_touch_directory(path.string())
       .then([&as,
              cache_factory,
              sanitize_fileops,
              path = std::move(path),
              read_buf_size,
-             read_readahead_count] {
+             read_readahead_count,
+             &resources] {
           return open_segments(
             path.string(),
             sanitize_fileops,
             cache_factory,
             as,
             read_buf_size,
-            read_readahead_count);
+            read_readahead_count,
+            resources);
       })
       .then([&as,
              is_compaction_enabled,

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -97,6 +97,7 @@ ss::future<segment_set> recover_segments(
   ss::abort_source& as,
   size_t read_buf_size,
   unsigned read_readahead_count,
-  std::optional<ss::sstring> last_clean_segment);
+  std::optional<ss::sstring> last_clean_segment,
+  storage_resources&);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -167,16 +167,11 @@ ss::future<ss::file> make_reader_handle(
 ss::future<compacted_index_writer> make_compacted_index_writer(
   const std::filesystem::path& path,
   debug_sanitize_files debug,
-  ss::io_priority_class iopc) {
+  ss::io_priority_class iopc,
+  storage_resources& resources) {
     return ss::make_ready_future<compacted_index_writer>(
       make_file_backed_compacted_index(
-        path.string(),
-        iopc,
-        debug,
-        false,
-        // TODO: replace hardcoded max_mem
-        // https://github.com/redpanda-data/redpanda/issues/4645
-        segment_appender::write_behind_memory / 2));
+        path.string(), iopc, debug, false, resources));
 }
 
 ss::future<segment_appender_ptr> make_segment_appender(
@@ -185,9 +180,9 @@ ss::future<segment_appender_ptr> make_segment_appender(
   size_t number_of_chunks,
   std::optional<uint64_t> segment_size,
   ss::io_priority_class iopc,
-  config::binding<size_t> fallocate_size) {
+  storage_resources& resources) {
     return internal::make_writer_handle(path, debug)
-      .then([number_of_chunks, iopc, path, segment_size, fallocate_size](
+      .then([number_of_chunks, iopc, path, segment_size, &resources](
               ss::file writer) {
           try {
               // NOTE: This try-catch is needed to not uncover the real
@@ -197,7 +192,7 @@ ss::future<segment_appender_ptr> make_segment_appender(
                 std::make_unique<segment_appender>(
                   writer,
                   segment_appender::options(
-                    iopc, number_of_chunks, segment_size, fallocate_size)));
+                    iopc, number_of_chunks, segment_size, resources)));
           } catch (...) {
               auto e = std::current_exception();
               vlog(stlog.error, "could not allocate appender: {}", e);
@@ -265,17 +260,15 @@ ss::future<> copy_filtered_entries(
 }
 
 static ss::future<> do_write_clean_compacted_index(
-  compacted_index_reader reader, compaction_config cfg) {
+  compacted_index_reader reader,
+  compaction_config cfg,
+  storage_resources& resources) {
     const auto tmpname = std::filesystem::path(
       fmt::format("{}.staging", reader.filename()));
     return natural_index_of_entries_to_keep(reader)
-      .then([reader, cfg, tmpname](Roaring bitmap) -> ss::future<> {
+      .then([reader, cfg, tmpname, &resources](Roaring bitmap) -> ss::future<> {
           auto truncating_writer = make_file_backed_compacted_index(
-            tmpname.string(),
-            cfg.iopc,
-            cfg.sanitize,
-            true,
-            segment_appender::write_behind_memory / 2);
+            tmpname.string(), cfg.iopc, cfg.sanitize, true, resources);
 
           return copy_filtered_entries(
             reader, std::move(bitmap), std::move(truncating_writer));
@@ -290,9 +283,11 @@ static ss::future<> do_write_clean_compacted_index(
 };
 
 ss::future<> write_clean_compacted_index(
-  compacted_index_reader reader, compaction_config cfg) {
+  compacted_index_reader reader,
+  compaction_config cfg,
+  storage_resources& resources) {
     // integrity verified in `do_detect_compaction_index_state`
-    return do_write_clean_compacted_index(reader, cfg)
+    return do_write_clean_compacted_index(reader, cfg, resources)
       .finally([reader]() mutable {
           return reader.close().then_wrapped(
             [reader](ss::future<>) { /*ignore*/ });
@@ -345,23 +340,26 @@ generate_compacted_list(model::offset o, compacted_index_reader reader) {
       .finally([reader] {});
 }
 
-ss::future<>
-do_compact_segment_index(ss::lw_shared_ptr<segment> s, compaction_config cfg) {
+ss::future<> do_compact_segment_index(
+  ss::lw_shared_ptr<segment> s,
+  compaction_config cfg,
+  storage_resources& resources) {
     auto compacted_path = std::filesystem::path(s->reader().filename());
     compacted_path.replace_extension(".compaction_index");
     vlog(gclog.trace, "compacting segment compaction index:{}", compacted_path);
     return make_reader_handle(compacted_path, cfg.sanitize)
-      .then([cfg, compacted_path, s](ss::file f) {
+      .then([cfg, compacted_path, s, &resources](ss::file f) {
           auto reader = make_file_backed_compacted_reader(
             compacted_path.string(), std::move(f), cfg.iopc, 64_KiB);
-          return write_clean_compacted_index(reader, cfg);
+          return write_clean_compacted_index(reader, cfg, resources);
       });
 }
 ss::future<storage::index_state> do_copy_segment_data(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
-  ss::rwlock::holder h) {
+  ss::rwlock::holder h,
+  storage_resources& resources) {
     auto idx_path = std::filesystem::path(s->reader().filename());
     idx_path.replace_extension(".compaction_index");
     return make_reader_handle(idx_path, cfg.sanitize)
@@ -373,7 +371,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                 return reader.close().then_wrapped([](ss::future<>) {});
             });
       })
-      .then([cfg, s, &pb, h = std::move(h)](
+      .then([cfg, s, &pb, h = std::move(h), &resources](
               compacted_offset_list list) mutable {
           const auto tmpname = data_segment_staging_name(s);
           return make_segment_appender(
@@ -383,7 +381,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                      / config::shard_local_cfg().append_chunk_size(),
                    std::nullopt,
                    cfg.iopc,
-                   config::shard_local_cfg().segment_fallocation_step.bind())
+                   resources)
             .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
                     segment_appender_ptr w) mutable {
                 auto raw = w.get();
@@ -464,20 +462,22 @@ ss::future<size_t> do_self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
-  storage::readers_cache& readers_cache) {
+  storage::readers_cache& readers_cache,
+  storage_resources& resources) {
     vlog(gclog.trace, "self compacting segment {}", s->reader().filename());
     return s->read_lock()
-      .then([cfg, s, &pb](ss::rwlock::holder h) {
+      .then([cfg, s, &pb, &resources](ss::rwlock::holder h) {
           if (s->is_closed()) {
               return ss::make_exception_future<index_state>(
                 segment_closed_exception());
           }
 
-          return do_compact_segment_index(s, cfg)
+          return do_compact_segment_index(s, cfg, resources)
             // copy the bytes after segment is good - note that we
             // need to do it with the READ-lock, not the write lock
-            .then([cfg, s, h = std::move(h), &pb]() mutable {
-                return do_copy_segment_data(s, cfg, pb, std::move(h));
+            .then([cfg, s, h = std::move(h), &pb, &resources]() mutable {
+                return do_copy_segment_data(
+                  s, cfg, pb, std::move(h), resources);
             });
       })
       .then([s, &readers_cache](storage::index_state idx) {
@@ -519,8 +519,9 @@ ss::future<size_t> do_self_compact_segment(
 ss::future<> rebuild_compaction_index(
   model::record_batch_reader rdr,
   std::filesystem::path p,
-  compaction_config cfg) {
-    return make_compacted_index_writer(p, cfg.sanitize, cfg.iopc)
+  compaction_config cfg,
+  storage_resources& resources) {
+    return make_compacted_index_writer(p, cfg.sanitize, cfg.iopc, resources)
       .then([r = std::move(rdr)](compacted_index_writer w) mutable {
           auto u = std::make_unique<compacted_index_writer>(std::move(w));
           auto ptr = u.get();
@@ -542,7 +543,8 @@ ss::future<compaction_result> self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
-  storage::readers_cache& readers_cache) {
+  storage::readers_cache& readers_cache,
+  storage_resources& resources) {
     if (s->has_appender()) {
         return ss::make_exception_future<compaction_result>(
           std::runtime_error(fmt::format(
@@ -554,7 +556,7 @@ ss::future<compaction_result> self_compact_segment(
     auto idx_path = std::filesystem::path(s->reader().filename());
     idx_path.replace_extension(".compaction_index");
     return detect_compaction_index_state(idx_path, cfg)
-      .then([idx_path, s, cfg, &pb, &readers_cache](
+      .then([idx_path, s, cfg, &pb, &readers_cache, &resources](
               compacted_index::recovery_state state) mutable {
           vlog(gclog.trace, "segment {} compaction state: {}", idx_path, state);
           switch (state) {
@@ -563,7 +565,8 @@ ss::future<compaction_result> self_compact_segment(
               return ss::make_ready_future<compaction_result>(s->size_bytes());
           }
           case compacted_index::recovery_state::nonrecovered:
-              return do_self_compact_segment(s, cfg, pb, readers_cache)
+              return do_self_compact_segment(
+                       s, cfg, pb, readers_cache, resources)
                 .then([before = s->size_bytes(), &pb](size_t sz_after) {
                     pb.segment_compacted();
                     return compaction_result(before, sz_after);
@@ -574,18 +577,21 @@ ss::future<compaction_result> self_compact_segment(
               vlog(gclog.info, "Rebuilding index file... ({})", idx_path);
               pb.corrupted_compaction_index();
               return s->read_lock()
-                .then([s, cfg, &pb, idx_path](ss::rwlock::holder h) {
-                    return rebuild_compaction_index(
-                      create_segment_full_reader(s, cfg, pb, std::move(h)),
-                      idx_path,
-                      cfg);
-                })
-                .then([s, cfg, &pb, idx_path, &readers_cache] {
+                .then(
+                  [s, cfg, &pb, idx_path, &resources](ss::rwlock::holder h) {
+                      return rebuild_compaction_index(
+                        create_segment_full_reader(s, cfg, pb, std::move(h)),
+                        idx_path,
+                        cfg,
+                        resources);
+                  })
+                .then([s, cfg, &pb, idx_path, &readers_cache, &resources] {
                     vlog(
                       gclog.info,
                       "rebuilt index: {}, attempting compaction again",
                       idx_path);
-                    return self_compact_segment(s, cfg, pb, readers_cache);
+                    return self_compact_segment(
+                      s, cfg, pb, readers_cache, resources);
                 });
           }
           }
@@ -600,7 +606,8 @@ ss::future<compaction_result> self_compact_segment(
 ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
   std::filesystem::path path,
   std::vector<ss::lw_shared_ptr<segment>> segments,
-  compaction_config cfg) {
+  compaction_config cfg,
+  storage_resources& resources) {
     // read locks on source segments
     std::vector<ss::rwlock::holder> locks;
     locks.reserve(segments.size());
@@ -622,7 +629,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
         co_await ss::remove_file(compacted_idx_path.string());
     }
     co_await write_concatenated_compacted_index(
-      compacted_idx_path, segments, cfg);
+      compacted_idx_path, segments, cfg, resources);
 
     // concatenation process
     if (co_await ss::file_exists(path.string())) {
@@ -672,7 +679,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       std::move(index),
       nullptr,
       std::nullopt,
-      std::nullopt);
+      std::nullopt,
+      resources);
 }
 
 ss::future<std::vector<compacted_index_reader>> make_indices_readers(
@@ -724,14 +732,15 @@ ss::future<> rewrite_concatenated_indicies(
 ss::future<> do_write_concatenated_compacted_index(
   std::filesystem::path target_path,
   std::vector<ss::lw_shared_ptr<segment>>& segments,
-  compaction_config cfg) {
+  compaction_config cfg,
+  storage_resources& resources) {
     return make_indices_readers(segments, cfg.iopc, cfg.sanitize)
-      .then([cfg, target_path = std::move(target_path)](
+      .then([cfg, target_path = std::move(target_path), &resources](
               std::vector<compacted_index_reader> readers) mutable {
           vlog(gclog.debug, "concatenating {} indicies", readers.size());
           return ss::do_with(
             std::move(readers),
-            [cfg, target_path = std::move(target_path)](
+            [cfg, target_path = std::move(target_path), &resources](
               std::vector<compacted_index_reader>& readers) mutable {
                 return ss::parallel_for_each(
                          readers.begin(),
@@ -748,14 +757,16 @@ ss::future<> do_write_concatenated_compacted_index(
                         e);
                       return false;
                   })
-                  .then([cfg, target_path = std::move(target_path), &readers](
-                          bool verified_successfully) {
+                  .then([cfg,
+                         target_path = std::move(target_path),
+                         &readers,
+                         &resources](bool verified_successfully) {
                       if (!verified_successfully) {
                           return ss::now();
                       }
 
                       return make_compacted_index_writer(
-                               target_path, cfg.sanitize, cfg.iopc)
+                               target_path, cfg.sanitize, cfg.iopc, resources)
                         .then([&readers](compacted_index_writer writer) {
                             return rewrite_concatenated_indicies(
                               std::move(writer), readers);
@@ -773,7 +784,8 @@ ss::future<> do_write_concatenated_compacted_index(
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path target_path,
   std::vector<ss::lw_shared_ptr<segment>> segments,
-  compaction_config cfg) {
+  compaction_config cfg,
+  storage_resources& resources) {
     if (segments.empty()) {
         return ss::now();
     }
@@ -781,10 +793,10 @@ ss::future<> write_concatenated_compacted_index(
     readers.reserve(segments.size());
     return ss::do_with(
       std::move(segments),
-      [cfg, target_path = std::move(target_path)](
+      [cfg, target_path = std::move(target_path), &resources](
         std::vector<ss::lw_shared_ptr<segment>>& segments) mutable {
           return do_write_concatenated_compacted_index(
-            std::move(target_path), segments, cfg);
+            std::move(target_path), segments, cfg, resources);
       });
 }
 

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -35,7 +35,8 @@ ss::future<compaction_result> self_compact_segment(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
   storage::probe&,
-  storage::readers_cache&);
+  storage::readers_cache&,
+  storage::storage_resources&);
 
 /*
  * Concatentate segments into a minimal new segment.
@@ -57,12 +58,14 @@ ss::future<compaction_result> self_compact_segment(
 ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
   std::filesystem::path,
   std::vector<ss::lw_shared_ptr<segment>>,
-  compaction_config);
+  compaction_config,
+  storage_resources& resources);
 
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path,
   std::vector<ss::lw_shared_ptr<segment>>,
-  compaction_config);
+  compaction_config,
+  storage_resources& resources);
 
 ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> to,
@@ -100,7 +103,8 @@ ss::future<ss::file> make_handle(
 ss::future<compacted_index_writer> make_compacted_index_writer(
   const std::filesystem::path& path,
   storage::debug_sanitize_files debug,
-  ss::io_priority_class iopc);
+  ss::io_priority_class iopc,
+  storage_resources& resources);
 
 ss::future<segment_appender_ptr> make_segment_appender(
   const std::filesystem::path& path,
@@ -108,7 +112,7 @@ ss::future<segment_appender_ptr> make_segment_appender(
   size_t number_of_chunks,
   std::optional<uint64_t> segment_size,
   ss::io_priority_class iopc,
-  config::binding<size_t> fallocate_size);
+  storage_resources& resources);
 
 size_t number_of_chunks_from_config(const storage::ntp_config&);
 uint64_t segment_size_from_config(const storage::ntp_config&);
@@ -133,7 +137,9 @@ ss::future<> copy_filtered_entries(
 /// \brief writes a new `*.compacted_index` file and *closes* the
 /// input compacted_index_reader file
 ss::future<> write_clean_compacted_index(
-  storage::compacted_index_reader, storage::compaction_config);
+  storage::compacted_index_reader,
+  storage::compaction_config,
+  storage_resources& resources);
 
 ss::future<compacted_offset_list>
   generate_compacted_list(model::offset, storage::compacted_index_reader);
@@ -153,7 +159,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
   storage::probe&,
-  ss::rwlock::holder);
+  ss::rwlock::holder,
+  storage_resources&);
 
 ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -106,10 +106,12 @@ ss::future<segment_appender_ptr> make_segment_appender(
   const std::filesystem::path& path,
   storage::debug_sanitize_files debug,
   size_t number_of_chunks,
+  std::optional<uint64_t> segment_size,
   ss::io_priority_class iopc,
   config::binding<size_t> fallocate_size);
 
 size_t number_of_chunks_from_config(const storage::ntp_config&);
+uint64_t segment_size_from_config(const storage::ntp_config&);
 
 /*
 1. if footer.flags == truncate write new .compacted_index file

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -55,7 +55,10 @@ spill_key_index::spill_key_index(
   , _appender(storage::segment_appender(
       std::move(dummy_file),
       segment_appender::options(
-        _pc, 1, config::shard_local_cfg().segment_fallocation_step.bind())))
+        _pc,
+        1,
+        std::nullopt,
+        config::shard_local_cfg().segment_fallocation_step.bind())))
   , _max_mem(max_memory) {}
 
 spill_key_index::~spill_key_index() {
@@ -246,7 +249,10 @@ ss::future<> spill_key_index::open() {
     _appender.emplace(storage::segment_appender(
       std::move(index_file),
       segment_appender::options(
-        _pc, 1, config::shard_local_cfg().segment_fallocation_step.bind())));
+        _pc,
+        1,
+        std::nullopt,
+        config::shard_local_cfg().segment_fallocation_step.bind())));
 }
 
 ss::future<> spill_key_index::close() {

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -35,31 +35,31 @@ using namespace storage; // NOLINT
 spill_key_index::spill_key_index(
   ss::sstring name,
   ss::io_priority_class p,
-  size_t max_memory,
   bool truncate,
-  storage::debug_sanitize_files debug)
+  storage::debug_sanitize_files debug,
+  storage_resources& resources)
   : compacted_index_writer::impl(std::move(name))
   , _debug(debug)
+  , _resources(resources)
   , _pc(p)
-  , _truncate(truncate)
-  , _max_mem(max_memory) {}
+  , _truncate(truncate) {}
 
 /**
  * This constructor is only for unit tests, which pre-construct a ss::file
  * rather than relying on spill_key_index to open it on-demand.
  */
 spill_key_index::spill_key_index(
-  ss::sstring name, ss::file dummy_file, size_t max_memory)
+  ss::sstring name,
+  ss::file dummy_file,
+  size_t max_mem,
+  storage_resources& resources)
   : compacted_index_writer::impl(std::move(name))
+  , _resources(resources)
   , _pc(ss::default_priority_class())
   , _appender(storage::segment_appender(
       std::move(dummy_file),
-      segment_appender::options(
-        _pc,
-        1,
-        std::nullopt,
-        config::shard_local_cfg().segment_fallocation_step.bind())))
-  , _max_mem(max_memory) {}
+      segment_appender::options(_pc, 1, std::nullopt, _resources)))
+  , _max_mem(max_mem) {}
 
 spill_key_index::~spill_key_index() {
     vassert(
@@ -86,6 +86,8 @@ ss::future<> spill_key_index::add_key(bytes b, value_type v) {
     auto f = ss::now();
     auto const key_size = b.size();
     auto const expected_size = idx_mem_usage() + _keys_mem_usage + key_size;
+
+    // TODO call into storage_resources
 
     if (expected_size >= _max_mem) {
         f = ss::do_until(
@@ -248,11 +250,7 @@ ss::future<> spill_key_index::open() {
 
     _appender.emplace(storage::segment_appender(
       std::move(index_file),
-      segment_appender::options(
-        _pc,
-        1,
-        std::nullopt,
-        config::shard_local_cfg().segment_fallocation_step.bind())));
+      segment_appender::options(_pc, 1, std::nullopt, _resources)));
 }
 
 ss::future<> spill_key_index::close() {
@@ -303,10 +301,9 @@ void spill_key_index::print(std::ostream& o) const { o << *this; }
 std::ostream& operator<<(std::ostream& o, const spill_key_index& k) {
     fmt::print(
       o,
-      "{{name:{}, max_mem:{}, key_mem_usage:{}, persisted_entries:{}, "
+      "{{name:{}, key_mem_usage:{}, persisted_entries:{}, "
       "in_memory_entries:{}, file_appender:{}}}",
       k.filename(),
-      k._max_mem,
       k._keys_mem_usage,
       k._footer.keys,
       k._midx.size(),
@@ -322,8 +319,8 @@ compacted_index_writer make_file_backed_compacted_index(
   ss::io_priority_class p,
   debug_sanitize_files debug,
   bool truncate,
-  size_t max_memory) {
+  storage_resources& resources) {
     return compacted_index_writer(std::make_unique<internal::spill_key_index>(
-      std::move(name), p, max_memory, truncate, debug));
+      std::move(name), p, truncate, debug, resources));
 }
 } // namespace storage

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -17,6 +17,7 @@
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/segment_appender.h"
+#include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "utils/vint.h"
 
@@ -45,11 +46,15 @@ public:
     spill_key_index(
       ss::sstring filename,
       ss::io_priority_class,
-      size_t max_memory,
       bool truncate,
-      storage::debug_sanitize_files debug);
+      storage::debug_sanitize_files debug,
+      storage_resources&);
 
-    spill_key_index(ss::sstring name, ss::file dummy_file, size_t max_memory);
+    spill_key_index(
+      ss::sstring name,
+      ss::file dummy_file,
+      size_t max_mem,
+      storage_resources&);
 
     spill_key_index(const spill_key_index&) = delete;
     spill_key_index& operator=(const spill_key_index&) = delete;
@@ -87,11 +92,12 @@ private:
     ss::future<> spill(compacted_index::entry_type, bytes_view, value_type);
 
     storage::debug_sanitize_files _debug;
+    storage_resources& _resources;
     ss::io_priority_class _pc;
     bool _truncate;
     std::optional<segment_appender> _appender;
     underlying_t _midx;
-    size_t _max_mem;
+    size_t _max_mem{512_KiB};
     size_t _keys_mem_usage{0};
     compacted_index::footer _footer;
     crc::crc32c _crc;

--- a/src/v/storage/storage_resources.cc
+++ b/src/v/storage/storage_resources.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "storage_resources.h"
+
+#include "config/configuration.h"
+#include "storage/logger.h"
+#include "vlog.h"
+
+namespace storage {
+
+storage_resources::storage_resources(
+  config::binding<size_t> falloc_step,
+  config::binding<uint64_t> target_replay_bytes,
+  config::binding<uint64_t> max_concurrent_replay)
+  : _segment_fallocation_step(falloc_step)
+  , _target_replay_bytes(target_replay_bytes)
+  , _max_concurrent_replay(max_concurrent_replay)
+  , _append_chunk_size(config::shard_local_cfg().append_chunk_size())
+  , _offset_translator_dirty_bytes(_target_replay_bytes() / ss::smp::count)
+  , _configuration_manager_dirty_bytes(_target_replay_bytes() / ss::smp::count)
+  , _stm_dirty_bytes(_target_replay_bytes() / ss::smp::count)
+  , _inflight_recovery(
+      std::max(_max_concurrent_replay() / ss::smp::count, uint64_t{1}))
+  , _inflight_close_flush(
+      std::max(_max_concurrent_replay() / ss::smp::count, uint64_t{1})) {
+    // Register notifications on configuration changes
+    _target_replay_bytes.watch([this]() {
+        auto v = _target_replay_bytes() / ss::smp::count;
+
+        _offset_translator_dirty_bytes.set_capacity(v);
+        _stm_dirty_bytes.set_capacity(v);
+        _configuration_manager_dirty_bytes.set_capacity(v);
+    });
+
+    _max_concurrent_replay.watch([this]() {
+        auto v = _max_concurrent_replay() / ss::smp::count;
+
+        // Guard against case where core count is higher than
+        // total concurrent replay count.
+        v = std::max(v, uint64_t{1});
+
+        _inflight_recovery.set_capacity(v);
+        _inflight_close_flush.set_capacity(v);
+    });
+}
+
+// Unit test convenience for tests that want to control the falloc step
+// but otherwise do not want to override anything.
+storage_resources::storage_resources(config::binding<size_t> falloc_step)
+  : storage_resources(
+    std::move(falloc_step),
+    config::shard_local_cfg().storage_target_replay_bytes.bind(),
+    config::shard_local_cfg().storage_max_concurrent_replay.bind()
+
+  ) {}
+
+storage_resources::storage_resources()
+  : storage_resources(
+    config::shard_local_cfg().segment_fallocation_step.bind(),
+    config::shard_local_cfg().storage_target_replay_bytes.bind(),
+    config::shard_local_cfg().storage_max_concurrent_replay.bind()
+
+  ) {}
+
+void storage_resources::update_allowance(uint64_t total, uint64_t free) {
+    // TODO: also take as an input the disk consumption of the SI cache:
+    // it knows this because it calculates it when doing periodic trimming.
+    if (
+      config::shard_local_cfg().cloud_storage_enabled
+      && total > config::shard_local_cfg().cloud_storage_cache_size()) {
+        total -= config::shard_local_cfg().cloud_storage_cache_size();
+    }
+
+    _space_allowance = total;
+    _space_allowance_free = std::min(free, total);
+
+    _falloc_step = calc_falloc_step();
+}
+
+size_t storage_resources::calc_falloc_step() {
+    // Heuristic: use at most half the available disk space for per-allocating
+    // space to write into.
+
+    // At most, use the configured fallocation step.
+    size_t step = _segment_fallocation_step();
+
+    if (_partition_count == 0) {
+        // Called before log_manager, this is an internal kvstore, give it a
+        // full falloc step.
+        return step;
+    }
+
+    // Initial disk stats read happens very early in startup, we should
+    // never be called before that.
+    vassert(_space_allowance > 0, "Called before disk stats init");
+
+    // Pessimistic assumption that each shard may use _at most_ the
+    // disk space divided by the shard count.  If allocation of partitions
+    // is uneven, this may lead to us underestimasting how much space
+    // is available, which is safe.
+
+    uint64_t space_free_this_shard = _space_allowance_free / ss::smp::count;
+
+    // Only use up to half the available space for fallocs.
+    uint64_t space_per_partition = (space_free_this_shard / 2)
+                                   / (_partition_count);
+
+    step = std::min(space_per_partition, step);
+
+    // Round down to nearest append chunk size
+    auto remainder = step % _append_chunk_size;
+    step = step - remainder;
+
+    // At the minimum, falloc one chunk's worth of space.
+    if (step < min_falloc_step) {
+        // If we have less than the minimum step, don't both falloc'ing at all.
+        step = _append_chunk_size;
+    }
+
+    vlog(
+      stlog.debug,
+      "calc_falloc_step: step {} (max {})",
+      step,
+      _segment_fallocation_step());
+    return step;
+}
+
+size_t
+storage_resources::get_falloc_step(std::optional<uint64_t> segment_size_hint) {
+    if (_falloc_step_dirty) {
+        _falloc_step = calc_falloc_step();
+        _falloc_step_dirty = false;
+    }
+
+    auto step = _falloc_step;
+
+    if (step == 0) {
+        // Disk stats not initialized, give them the full sized step.
+        step = _segment_fallocation_step();
+    }
+
+    if (segment_size_hint) {
+        // Don't falloc more than the segment size, plus a little extra because
+        // we don't roll segments until they overshoot the size.
+        step = std::min(step, segment_size_hint.value() + _append_chunk_size);
+    }
+    return step;
+}
+
+adjustable_allowance::take_result
+storage_resources::offset_translator_take_bytes(int32_t bytes) {
+    vlog(
+      stlog.trace,
+      "offset_translator_take_bytes {} (current {})",
+      bytes,
+      _offset_translator_dirty_bytes.current());
+
+    return _offset_translator_dirty_bytes.take(bytes);
+}
+
+adjustable_allowance::take_result
+storage_resources::configuration_manager_take_bytes(size_t bytes) {
+    vlog(
+      stlog.trace,
+      "configuration_manager_take_bytes {} (current {})",
+      bytes,
+      _configuration_manager_dirty_bytes.current());
+
+    return _configuration_manager_dirty_bytes.take(bytes);
+}
+
+adjustable_allowance::take_result
+storage_resources::stm_take_bytes(size_t bytes) {
+    vlog(
+      stlog.trace,
+      "stm_take_bytes {} (current {})",
+      bytes,
+      _stm_dirty_bytes.current());
+
+    return _stm_dirty_bytes.take(bytes);
+}
+
+} // namespace storage

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "units.h"
+
+#include <seastar/core/semaphore.hh>
+
+#include <cstdint>
+
+namespace storage {
+
+/**
+ * This class is extension of ss::semaphore to fit the needs
+ * of the storage_resources class's tracking of byte/concurrency
+ * allowances.
+ *
+ * Callers may use this class as either a soft or hard quota.  In
+ * the hard case, regular async-waiting semaphore calls (ss::get_units)
+ * may be used.  In the soft case, the take() function will allow the
+ * semaphore count to go negative, but return a `checkpoint_hint` field
+ * that prompts the holder of the units to release some.
+ *
+ * This is 'adjustable' in that:
+ * - Regular sempahores are just a counter: they have no
+ *   memory of their intended capacity.  In order to enable runtime
+ *   changes to the max units in a semaphore, we must keep an extra
+ *   record of the capacity.
+ * - This enables runtime configuration changes to parameters that
+ *   control the capacity of a semaphore.
+ */
+class adjustable_allowance {
+public:
+    adjustable_allowance(uint64_t capacity)
+      : _sem(capacity)
+      , _capacity(capacity) {}
+
+    void set_capacity(uint64_t capacity) noexcept {
+        if (capacity > _capacity) {
+            _sem.signal(capacity - _capacity);
+        } else if (capacity < _capacity) {
+            _sem.consume(_capacity - capacity);
+        }
+
+        _capacity = capacity;
+    }
+
+    /**
+     * When a consumer wants some units, it gets them unconditionally, but
+     * gets a hint as to whether it exceeded the capacity.  That is the hint
+     * to e.g. the offset translator that now is the time to checkpoint
+     * because there are too many dirty bytes.
+     */
+    struct take_result {
+        ss::semaphore_units<> units;
+        bool checkpoint_hint{false};
+    };
+
+    /**
+     * Non-blocking consume of units, may send the semaphore negative.
+     *
+     * Includes a hint in the response if the semaphore has gone negative,
+     * to induce the caller to release some units when they can.
+     */
+    take_result take(size_t units) {
+        take_result result = {
+          .units = ss::consume_units(_sem, units),
+          .checkpoint_hint = _sem.current() <= 0};
+
+        return result;
+    }
+
+    /**
+     * Blocking get units: will block until units are available.
+     */
+    ss::future<ss::semaphore_units<>> get_units(size_t units) {
+        return ss::get_units(_sem, units);
+    }
+
+    size_t current() const noexcept { return _sem.current(); }
+
+private:
+    ss::semaphore _sem;
+
+    uint64_t _capacity;
+};
+
+/**
+ * This class is used by various storage components to control consumption
+ * of shared system resources.  It broadly does this in two ways:
+ * - Limiting concurrency of certain types of operation
+ * - Controlling buffer sizes depending on available resources
+ */
+class storage_resources {
+public:
+    // If we don't have this much disk space available per partition,
+    // don't both falloc'ing at all.
+    static constexpr size_t min_falloc_step = 128_KiB;
+
+    storage_resources();
+    storage_resources(config::binding<size_t>);
+    storage_resources(
+      config::binding<size_t>,
+      config::binding<uint64_t>,
+      config::binding<uint64_t>);
+    storage_resources(const storage_resources&) = delete;
+
+    /**
+     * Call this when the storage::node_api state is updated
+     */
+    void update_allowance(uint64_t total, uint64_t free);
+
+    /**
+     * Call this when topics_table gets updated
+     */
+    void update_partition_count(size_t partition_count) {
+        _partition_count = partition_count;
+        _falloc_step_dirty = true;
+    }
+
+    uint64_t get_space_allowance() { return _space_allowance; }
+
+    size_t get_falloc_step(std::optional<uint64_t>);
+    size_t calc_falloc_step();
+
+    adjustable_allowance::take_result
+    offset_translator_take_bytes(int32_t bytes);
+
+    adjustable_allowance::take_result
+    configuration_manager_take_bytes(size_t bytes);
+
+    adjustable_allowance::take_result stm_take_bytes(size_t bytes);
+
+    ss::future<ss::semaphore_units<>> get_recovery_units() {
+        return _inflight_recovery.get_units(1);
+    }
+
+    ss::future<ss::semaphore_units<>> get_close_flush_units() {
+        return _inflight_close_flush.get_units(1);
+    }
+
+private:
+    uint64_t _space_allowance{9};
+    uint64_t _space_allowance_free{0};
+
+    size_t _partition_count{9};
+    config::binding<size_t> _segment_fallocation_step;
+    config::binding<uint64_t> _target_replay_bytes;
+    config::binding<uint64_t> _max_concurrent_replay;
+    size_t _append_chunk_size;
+
+    size_t _falloc_step{0};
+    bool _falloc_step_dirty{false};
+
+    // These 'dirty_bytes' semaphores control how many bytes
+    // may be written to logs in between checkpoints/snapshots, in
+    // order to limit the quantity of data that must be replayed after
+    // a restart.
+
+    // How many bytes may all logs on this shard advance before
+    // the offset translator must checkpoint to the kvstore?
+    adjustable_allowance _offset_translator_dirty_bytes{0};
+
+    // How many bytes may logs write between checkpoints of the
+    // configuration_manager?
+    adjustable_allowance _configuration_manager_dirty_bytes{0};
+
+    // How many bytes may all consensus instances write before
+    // we ask them to start snapshotting their state machines?
+    adjustable_allowance _stm_dirty_bytes{0};
+
+    // How many logs may be recovered (via log_manager::manage)
+    // concurrently?
+    adjustable_allowance _inflight_recovery{0};
+
+    // How many logs may be flushed during segment close concurrently?
+    // (e.g. when we shut down and ask everyone to flush)
+    adjustable_allowance _inflight_close_flush{0};
+};
+
+} // namespace storage

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -57,7 +57,8 @@ SEASTAR_THREAD_TEST_CASE(key_space) {
     auto conf = prepare_store(dir).get();
 
     // empty started then stopped
-    auto kvs = std::make_unique<storage::kvstore>(conf);
+    storage::storage_resources resources;
+    auto kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
 
     const auto value_a = bytes_to_iobuf(random_generators::get_bytes(100));
@@ -90,7 +91,7 @@ SEASTAR_THREAD_TEST_CASE(key_space) {
     kvs->stop().get();
 
     // still all true after recovery
-    kvs = std::make_unique<storage::kvstore>(conf);
+    kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
 
     BOOST_REQUIRE(
@@ -118,19 +119,20 @@ SEASTAR_THREAD_TEST_CASE(kvstore_empty) {
     auto conf = prepare_store(dir).get();
 
     // empty started then stopped
-    auto kvs = std::make_unique<storage::kvstore>(conf);
+    storage::storage_resources resources;
+    auto kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
     kvs->stop().get();
 
     // and can restart from empty
-    kvs = std::make_unique<storage::kvstore>(conf);
+    kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
     kvs->stop().get();
 
     std::unordered_map<bytes, iobuf> truth;
 
     // now fill it up with some key value pairs
-    kvs = std::make_unique<storage::kvstore>(conf);
+    kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
 
     std::vector<ss::future<>> batch;
@@ -170,7 +172,7 @@ SEASTAR_THREAD_TEST_CASE(kvstore_empty) {
     kvs->stop().get();
 
     // now restart the db and ensure still empty
-    kvs = std::make_unique<storage::kvstore>(conf);
+    kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
     BOOST_REQUIRE(kvs->empty());
     kvs->stop().get();
@@ -188,7 +190,8 @@ SEASTAR_THREAD_TEST_CASE(kvstore) {
 
     std::unordered_map<bytes, iobuf> truth;
 
-    auto kvs = std::make_unique<storage::kvstore>(conf);
+    storage::storage_resources resources;
+    auto kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
     for (int i = 0; i < 500; i++) {
         auto key = random_generators::get_bytes(2);
@@ -219,7 +222,7 @@ SEASTAR_THREAD_TEST_CASE(kvstore) {
     kvs.reset(nullptr);
 
     // shutdown, restart, and verify all the original key-value pairs
-    kvs = std::make_unique<storage::kvstore>(conf);
+    kvs = std::make_unique<storage::kvstore>(conf, resources);
     kvs->start().get();
     for (auto& e : truth) {
         BOOST_REQUIRE(

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -33,6 +33,7 @@ class log_replayer_fixture {
 public:
     ss::lw_shared_ptr<segment> _seg;
     std::optional<log_replayer> replayer_opt;
+    storage::storage_resources resources;
     ss::sstring base_name = "test."
                             + random_generators::gen_alphanum_string(20);
 
@@ -50,7 +51,7 @@ public:
         auto appender = std::make_unique<segment_appender>(
           fd,
           segment_appender::options(
-            ss::default_priority_class(), 1, config::mock_binding(16_KiB)));
+            ss::default_priority_class(), 1, std::nullopt, resources));
         auto indexer = segment_index(
           base_name + ".index", std::move(fidx), base, 4096);
         auto reader = segment_reader(
@@ -62,7 +63,8 @@ public:
           std::move(indexer),
           std::move(appender),
           std::nullopt,
-          std::nullopt);
+          std::nullopt,
+          resources);
         replayer_opt = log_replayer(*_seg);
     }
 

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -35,13 +35,12 @@ ss::file open_file(std::string_view filename) {
       .get0();
 }
 
-segment_appender make_segment_appender(ss::file file, size_t fallocate_size) {
+segment_appender
+make_segment_appender(ss::file file, storage::storage_resources& resources) {
     return segment_appender(
       std::move(file),
       segment_appender::options(
-        ss::default_priority_class(),
-        1,
-        config::mock_binding(std::move(fallocate_size))));
+        ss::default_priority_class(), 1, std::nullopt, resources));
 }
 
 iobuf make_random_data(size_t len) {
@@ -53,7 +52,9 @@ iobuf make_random_data(size_t len) {
 static void run_test_can_append_multiple_flushes(size_t fallocate_size) {
     std::cout.setf(std::ios::unitbuf);
     auto f = open_file("test.segment_appender_random.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
 
     iobuf expected;
     ss::sstring data = "123456789\n";
@@ -88,7 +89,9 @@ SEASTAR_THREAD_TEST_CASE(test_can_append_multiple_flushes) {
 
 static void run_test_can_append_mixed(size_t fallocate_size) {
     auto f = open_file("test_log_segment_mixed.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
     auto alignment = f.disk_write_dma_alignment();
     for (size_t i = 0, acc = 0; i < 100; ++i) {
         iobuf original;
@@ -149,7 +152,9 @@ SEASTAR_THREAD_TEST_CASE(test_can_append_mixed) {
 
 static void run_test_can_append_10MB(size_t fallocate_size) {
     auto f = open_file("test_segment_appender.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
 
     for (size_t i = 0; i < 10; ++i) {
         constexpr size_t one_meg = 1024 * 1024;
@@ -173,7 +178,9 @@ SEASTAR_THREAD_TEST_CASE(test_can_append_10MB) {
 static void run_test_can_append_10MB_sequential_write_sequential_read(
   size_t fallocate_size) {
     auto f = open_file("test_segment_appender_sequential.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
 
     // write sequential. then read all
     constexpr size_t one_meg = 1024 * 1024;
@@ -203,7 +210,9 @@ SEASTAR_THREAD_TEST_CASE(
 
 static void run_test_can_append_little_data(size_t fallocate_size) {
     auto f = open_file("test_segment_appender_little.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
     auto alignment = f.disk_write_dma_alignment();
     // at least 1 page and some 20 bytes to test boundary conditions
     const auto data = random_generators::gen_alphanum_string(alignment + 20);
@@ -242,7 +251,9 @@ SEASTAR_THREAD_TEST_CASE(test_can_append_little_data) {
 
 static void run_test_fallocate_size(size_t fallocate_size) {
     auto f = open_file("test_segment_appender.log");
-    auto appender = make_segment_appender(f, fallocate_size);
+    storage::storage_resources resources(
+      config::mock_binding<size_t>(std::move(fallocate_size)));
+    auto appender = make_segment_appender(f, resources);
 
     for (size_t i = 0; i < 10; ++i) {
         iobuf original;

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -50,11 +50,13 @@ public:
 
     storage_test_fixture()
       : test_dir("test.data." + random_generators::gen_alphanum_string(10))
-      , kvstore(storage::kvstore_config(
-          1_MiB,
-          config::mock_binding(10ms),
-          test_dir,
-          storage::debug_sanitize_files::yes)) {
+      , kvstore(
+          storage::kvstore_config(
+            1_MiB,
+            config::mock_binding(10ms),
+            test_dir,
+            storage::debug_sanitize_files::yes),
+          resources) {
         configure_unit_test_logging();
         // avoid double metric registrations
         ss::smp::invoke_on_all([] {

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -46,6 +46,7 @@ class storage_test_fixture {
 public:
     ss::sstring test_dir;
     storage::kvstore kvstore;
+    storage::storage_resources resources;
 
     storage_test_fixture()
       : test_dir("test.data." + random_generators::gen_alphanum_string(10))
@@ -68,12 +69,13 @@ public:
 
     /// Creates a log manager in test directory
     storage::log_manager make_log_manager(storage::log_config cfg) {
-        return storage::log_manager(std::move(cfg), kvstore);
+        return storage::log_manager(std::move(cfg), kvstore, resources);
     }
 
     /// Creates a log manager in test directory with default config
     storage::log_manager make_log_manager() {
-        return storage::log_manager(default_log_config(test_dir), kvstore);
+        return storage::log_manager(
+          default_log_config(test_dir), kvstore, resources);
     }
 
     /// \brief randomizes the configuration options

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -286,7 +286,9 @@ class RpkTool:
                 group=None,
                 regex=False,
                 offset=None,
-                fetch_max_bytes=None):
+                partition=None,
+                fetch_max_bytes=None,
+                quiet=False):
         cmd = ["consume", topic]
         if group is not None:
             cmd += ["-g", group]
@@ -298,6 +300,11 @@ class RpkTool:
             cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
         if offset is not None:
             cmd += ["-o", f"{n}"]
+        if partition is not None:
+            cmd += ["-p", f"{partition}"]
+        if quiet:
+            cmd += ["-f", "_\\n"]
+
         return self._run_topic(cmd)
 
     def group_seek_to(self, group, to):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1461,9 +1461,15 @@ class RedpandaService(Service):
                     partition.add_files(listdir(partition.path))
         return store
 
-    def storage(self):
+    def storage(self, all_nodes: bool = False):
+        """
+        :param all_nodes: if true, report on all nodes, otherwise only report
+                          on started nodes.
+
+        :returns: instances of ClusterStorage
+        """
         store = ClusterStorage()
-        for node in self._started:
+        for node in (self.nodes if all_nodes else self._started):
             s = self.node_storage(node)
             store.add_node(s)
         return store

--- a/tests/rptest/tests/storage_resources_test.py
+++ b/tests/rptest/tests/storage_resources_test.py
@@ -7,10 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import signal
+
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.rpk_producer import RpkProducer
+from rptest.services.rpk_consumer import RpkConsumer
+from rptest.clients.rpk import RpkTool
+from ducktape.utils.util import wait_until
+from ducktape.mark import parametrize
+from ducktape.cluster.cluster_spec import ClusterSpec
 
 
 class StorageResourceTest(RedpandaTest):
@@ -103,3 +110,190 @@ class StorageResourceTest(RedpandaTest):
         # be open.
         assert self._topic_fd_count() == 1
         assert live_seg.compaction_index is None
+
+
+class StorageResourceRestartTest(RedpandaTest):
+    PARTITION_COUNT = 64
+    TARGET_REPLAY_BYTES = 1024 * 1024 * 1024
+
+    topics = (TopicSpec(
+        partition_count=PARTITION_COUNT,
+        replication_factor=1,
+    ), )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            extra_rp_conf={
+                # Decrease from the default 10GB so that we can run the test
+                # without having to write >10GB of data on slow docker environments
+                'storage_target_replay_bytes': self.TARGET_REPLAY_BYTES
+            },
+            **kwargs)
+
+    def _await_replay(self):
+        """
+        Block until all partitions are available
+        """
+        rpk = RpkTool(self.redpanda)
+
+        def ready():
+            partitions = list(rpk.describe_topic(self.topic))
+            if len(partitions) < self.PARTITION_COUNT:
+                return False
+            else:
+                return all(p.leader >= 0 for p in partitions)
+
+        wait_until(ready, timeout_sec=30, backoff_sec=5)
+
+    def _write(self, msg_size, msg_count):
+        producer = RpkProducer(self.test_context,
+                               self.redpanda,
+                               self.topic,
+                               msg_size,
+                               msg_count=msg_count,
+                               acks=-1)
+        producer.start()
+        producer.wait()
+        producer.free()
+
+    def _read_all(self, msg_count):
+        consumer = RpkConsumer(self.test_context,
+                               self.redpanda,
+                               self.topic,
+                               offset='oldest',
+                               save_msgs=False,
+                               num_msgs=msg_count)
+        consumer.start()
+        consumer.wait()
+        consumer.free()
+
+    def _read_tips(self):
+        rpk = RpkTool(self.redpanda)
+        partition_meta = list(rpk.describe_topic(self.topic))
+        assert len(partition_meta) == self.PARTITION_COUNT
+        for p in partition_meta:
+            rpk.consume(self.topic,
+                        partition=p.id,
+                        n=1,
+                        offset=p.high_watermark,
+                        quiet=True)
+
+    def _sum_metrics(self, metric_name):
+        samples = self.redpanda.metrics_sample(metric_name).samples
+        self.logger.info(f"{metric_name} samples:")
+        for s in samples:
+            self.logger.info(f"{s.value} {s.labels}")
+        return sum(s.value for s in samples)
+
+    def _get_partition_segments(self, partition_idx):
+        storage = self.redpanda.storage(all_nodes=True)
+        partitions = list(storage.partitions("kafka", self.topic))
+        p = partitions[partition_idx]
+        segments = list(p.segments.values())
+
+        # Sort by offset, so that earliest-written segments are first
+        segments = sorted(segments, key=lambda s: int(s.name.split("-")[0]))
+
+        for s in segments:
+            self.logger.info(f"Got segment: {s}")
+        return segments
+
+    @cluster(num_nodes=2)
+    @parametrize(clean_shutdown=False)
+    @parametrize(clean_shutdown=True)
+    def test_recovery_reads(self, clean_shutdown):
+        """
+        Verify the amount of disk IO that occurs on both clean and
+        unclean restarts.
+        """
+
+        if self.debug_mode:
+            self.logger.info("Skipping in debug mode")
+            # Satisfy checks for test using all its nodes
+            nodes = self.test_context.cluster.alloc(
+                ClusterSpec.simple_linux(1))
+            self.test_context.cluster.free_single(nodes[0])
+            return
+
+        # Enough writes to exceed threshold for checkpointing
+        # a single partition.  The equivalent for testing with
+        # large numbers of partitions is ManyPartitionsTest, which
+        # we do not run here because docker test environments can't
+        # handle it.
+        msg_size = 128 * 1024
+        msg_count = 8 * self.PARTITION_COUNT * 32
+
+        # We should be playing in enough traffic to trip checkpoints/snapshots
+        # for meeting the target replay threshold.
+        assert msg_count * msg_size > self.TARGET_REPLAY_BYTES
+
+        # This value is hardcoded in Redpanda, the threshold for checkpointing
+        # offset translator and/or state machines on each partition.
+        per_partition_checkpoint_threshold = 64 * 1024 * 1024
+
+        # We should not be playing in enough data per-partition to trip the
+        # naive per-partition checkpoint limits
+        assert (msg_count * msg_size /
+                self.PARTITION_COUNT) < per_partition_checkpoint_threshold
+
+        self._write(msg_size, msg_count)
+        total_bytes = msg_size * msg_count
+
+        # Use low level seastar metrics, because storage log metrics do
+        # not reflect I/O during replay
+        write_bytes_metric = "vectorized_io_queue_total_write_bytes_total"
+        read_bytes_metric = "vectorized_io_queue_total_read_bytes_total"
+
+        assert self._sum_metrics(write_bytes_metric) >= total_bytes
+
+        # Stop node
+        # =========
+        if clean_shutdown:
+            # Clean shutdown: stop with SIGTERM
+            self.redpanda.stop_node(self.redpanda.nodes[0])
+        else:
+            # Unclean shutdown: stop with SIGKILL
+            self.redpanda.signal_redpanda(self.redpanda.nodes[0],
+                                          signal=signal.SIGKILL)
+
+        # Inspect disk
+        # ============
+        # Just look at one partition as an example
+        segments = self._get_partition_segments(0)
+
+        assert len(segments) == 1
+        if clean_shutdown:
+            assert segments[0].base_index is not None
+        else:
+            assert segments[0].base_index is None
+
+        # Start node
+        # ==========
+        self.redpanda.start_node(self.redpanda.nodes[0])
+        self._await_replay()
+
+        if clean_shutdown:
+            # Clean shutdown
+            # ==============
+            assert self._sum_metrics(read_bytes_metric) < total_bytes
+
+            # Reading the tip of the log should not prompt reading all history
+            self._read_tips()
+            assert self._sum_metrics(read_bytes_metric) < total_bytes
+
+            # Validate metrics work as expected by explicitly reading all data
+            self._read_all(msg_count)
+            assert self._sum_metrics(read_bytes_metric) >= total_bytes
+        else:
+            # Unclean shutdown
+            # ================
+            # We expect the entire latest segment for all partitions to
+            # be read during replay after unsafe shutdown, to rebuild the index.
+            assert self._sum_metrics(read_bytes_metric) >= total_bytes
+
+            # Check that reads still work, although we aren't interested in
+            # the byte count: we have already read >= the total size of data
+            # on disk.
+            self._read_tips()
+            self._read_all(msg_count)


### PR DESCRIPTION
## Cover letter

(Part of RFC https://docs.google.com/document/d/1I1h7v5OyslRu4QGI4rKo9rklYsLTS5Y_Iz27QM_J7xQ/edit)

There are broadly three parts to the code change:
- Defining the `storage_resources` class which tracks the state we need to handle large partition counts more smoothly.  This is a mixture of centralizing some allowances (especially un-checkpointed allowances which were previously 64MiB per log, resulting in too much un-checkpointed data when partition count is high), and adding some new central concurrency limits (in this PR, on log recovery and log flush on close)
- Carry references to the shared `storage_resources` instance to everywhere it is needed.
- Add calls into `storage_resources` in the locations that we need to limit concurrency or receive hints to checkpoint more frequently.

`storage_resources` depends on `local_monitor` to tip it off about the disk free status: currently that's done by initially spinning up a local_monitor to populate disk state, and then later passing a reference to `storage::api` all the way into the controller's local_monitor object.  We might want to rearrange this to move local_monitor out of controller and have it start very early alongside the storage system.

There's a new test `StorageResourceRestartTest` that validates the checkpointing stuff is doing its job and avoiding oversized re-reads of whole logs/segments on startup.

## Release notes

### Improvements

* A new tunable configuration property for controlling how much data Redpanda will write to disk between checkpoints, to provide more deterministic replay times on startup.  `storage_target_replay_bytes` is 10GiB by default, to provide approximately 10 second startup times on systems with typical NVMe SSD performance.  This will not affect systems with <100 partitions, but on larger systems it will improve startup time at the expense of more frequent checkpoints during writes.
* A new tunable configuration property is added for controlling how many log replays or flush-on-close operations Redpanda will do in parallel.  `storage_max_concurrent_replay` is 1024 by default.  This makes Redpanda more reliable on systems with high partition counts.
