### PR TITLE
test infrastructure to support upgrade testing

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -541,7 +541,12 @@ class RpkTool:
         return output
 
     def _rpk_binary(self):
-        return self._redpanda.find_binary("rpk")
+        # NOTE: since this runs on separate nodes from the service, the binary
+        # path used by each node may differ from that returned by
+        # redpanda.find_binary(), e.g. if using a RedpandaInstaller.
+        rp_install_path_root = self._redpanda._context.globals.get(
+            "rp_install_path_root", None)
+        return f"{rp_install_path_root}/bin/rpk"
 
     def cluster_maintenance_enable(self, node, wait=False):
         node_id = self._redpanda.idx(node) if isinstance(node,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1659,10 +1659,16 @@ class RedpandaService(Service):
             f"Saving executable as {os.path.basename(self.EXECUTABLE_SAVE_PATH)}"
         )
 
-        # Any node will do, they all run the same binary.  May cease to be true
-        # for future mixed-version rolling upgrade testing.
+        # Any node will do. Even in a mixed-version upgrade test, we should
+        # still have the original binaries available.
         node = self.nodes[0]
-        binary = self.find_raw_binary('redpanda')
+        if self._installer and self._installer._started:
+            head_root_path = self._installer.path_for_version(
+                RedpandaInstaller.HEAD)
+            binary = f"{head_root_path}/libexec/redpanda"
+        else:
+            binary = self.find_raw_binary('redpanda')
+
         save_to = self.EXECUTABLE_SAVE_PATH
         try:
             node.account.ssh(f"cd /tmp ; gzip -c {binary} > {save_to}")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -31,8 +31,9 @@ from ducktape.cluster.cluster import ClusterNode
 from prometheus_client.parser import text_string_to_metric_families
 
 from rptest.clients.kafka_cat import KafkaCat
-from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.admin import Admin
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.utils import BadLogLines, NodeCrash
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services import tls
@@ -434,7 +435,8 @@ class RedpandaService(Service):
                  log_level: Optional[str] = None,
                  environment: Optional[dict[str, str]] = None,
                  security: SecurityConfig = SecurityConfig(),
-                 node_ready_timeout_s=None):
+                 node_ready_timeout_s=None,
+                 enable_installer=False):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._enable_rp = enable_rp
@@ -442,6 +444,9 @@ class RedpandaService(Service):
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
         self._security = security
+        self._installer: Optional[RedpandaInstaller] = None
+        if enable_installer:
+            self._installer = RedpandaInstaller(self)
 
         if node_ready_timeout_s is None:
             node_ready_timeout_s = RedpandaService.DEFAULT_NODE_READY_TIMEOUT_SEC
@@ -572,7 +577,10 @@ class RedpandaService(Service):
 
             try:
                 if clean_nodes:
-                    self.clean_node(node)
+                    # Expected usage is that we may install new binaries before
+                    # starting the cluster, and installation-cleaning happened
+                    # when we started the installer.
+                    self.clean_node(node, clean_installs=False)
                 else:
                     self.logger.debug("%s: skip cleaning node" %
                                       self.who_am_i(node))
@@ -1096,14 +1104,18 @@ class RedpandaService(Service):
                 # the original exception that caused the failure.
                 self.logger.exception("Failed to run seastar-addr2line")
 
+    def rp_install_path(self):
+        if self._installer and self._installer._started:
+            # The installer sets up binaries to always use /opt/redpanda.
+            return "/opt/redpanda"
+        return self._context.globals.get("rp_install_path_root", None)
+
     def find_wasm_root(self):
-        rp_install_path_root = self._context.globals.get(
-            "rp_install_path_root", None)
+        rp_install_path_root = self.rp_install_path()
         return f"{rp_install_path_root}/opt/wasm"
 
     def find_binary(self, name):
-        rp_install_path_root = self._context.globals.get(
-            "rp_install_path_root", None)
+        rp_install_path_root = self.rp_install_path()
         return f"{rp_install_path_root}/bin/{name}"
 
     def find_raw_binary(self, name):
@@ -1111,9 +1123,23 @@ class RedpandaService(Service):
         Like `find_binary`, but find the underlying executable rather tha
         a shell wrapper.
         """
-        rp_install_path_root = self._context.globals.get(
-            "rp_install_path_root", None)
+        rp_install_path_root = self.rp_install_path()
         return f"{rp_install_path_root}/libexec/{name}"
+
+    def get_version(self, node):
+        """
+        Returns the version as a string.
+        """
+        version_cmd = f"{self.find_binary('redpanda')} --version"
+        VERSION_LINE_RE = re.compile(".*(v\\d+\\.\\d+\\.\\d+).*")
+        # NOTE: not all versions of Redpanda support the --version field, even
+        # though they print out the version.
+        version_lines = [
+            l for l in node.account.ssh_capture(version_cmd, allow_fail=True) \
+                if VERSION_LINE_RE.match(l)
+        ]
+        assert len(version_lines) == 1, version_lines
+        return VERSION_LINE_RE.findall(version_lines[0])[0]
 
     def stop_node(self, node, timeout=None):
         pids = self.pids(node)
@@ -1145,7 +1171,7 @@ class RedpandaService(Service):
         if self._s3client:
             self.delete_bucket_from_si()
 
-    def clean_node(self, node, preserve_logs=False):
+    def clean_node(self, node, preserve_logs=False, clean_installs=True):
         node.account.kill_process("redpanda", clean_shutdown=False)
         node.account.kill_process("bin/node", clean_shutdown=False)
         if node.account.exists(RedpandaService.PERSISTENT_ROOT):
@@ -1164,6 +1190,10 @@ class RedpandaService(Service):
         if not preserve_logs and node.account.exists(
                 self.EXECUTABLE_SAVE_PATH):
             node.account.remove(self.EXECUTABLE_SAVE_PATH)
+
+        if clean_installs and self._installer is not None:
+            # Get rid of any installed packages.
+            self._installer.clean(node)
 
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -1,0 +1,208 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+import requests
+
+# Match any version that may result from a redpanda binary, which may not be a
+# released version.
+# E.g. "v22.1.1-rc1-1373-g77f868..."
+VERSION_RE = re.compile(".*v(\\d+)\\.(\\d+)\\.(\\d+).*")
+
+
+class RedpandaInstaller:
+    """
+    Provides mechanisms to install multiple Redpanda binaries on a cluster.
+
+    Each installed version is downloaded and kept around for the lifespan of
+    the installer. Thus, once downloaded, switching versions amounts to
+    updating a symlink usable by the RedpandaService.
+
+    This only provides methods for installation; restarting nodes is left up to
+    callers.
+    """
+    # Represents the binaries installed at the time of the call to start(). It
+    # is expected that this is identical across all nodes initially.
+    HEAD = "head"
+    INSTALLER_ROOT = "/opt/redpanda_installs"
+    TGZ_URL_TEMPLATE = "https://packages.vectorized.io/qSZR7V26sJx7tCXe/redpanda/raw/names/redpanda-{arch}/versions/{version}/redpanda-{version}-{arch}.tar.gz"
+
+    @staticmethod
+    def root_for_version(version):
+        """
+        Returns an appropriate root path for the given version. Expects the
+        version to be either a tuple of ints or the string "head".
+        """
+        if version != RedpandaInstaller.HEAD:
+            version = f"v{version[0]}.{version[1]}.{version[2]}"
+        return f"{RedpandaInstaller.INSTALLER_ROOT}/{version}"
+
+    @staticmethod
+    def wait_for_async_ssh(logger, ssh_out_per_node, log_msg):
+        """
+        Waits for each SSHOutputIter to complete.
+        """
+        for node in ssh_out_per_node:
+            logger.debug(f"{log_msg} for {node.account.hostname}")
+            for l in ssh_out_per_node[node]:
+                logger.debug(l)
+
+    def __init__(self, redpanda):
+        """
+        Constructs an installer for the given RedpandaService.
+        """
+        self._started = False
+        self._redpanda = redpanda
+        self._installed_per_node = dict()
+
+        # Keep track if the original install path is /opt/redpanda is used, as
+        # is the case for package-deployed clusters. Since the installer uses
+        # this directory, we'll need to be mindful not to mess with the
+        # original binaries.
+        rp_install_path_root = self._redpanda._context.globals.get(
+            "rp_install_path_root", None)
+        self._head_backed_up = rp_install_path_root == "/opt/redpanda"
+
+    def start(self):
+        """
+        Validates that all nodes in the service have installed the same
+        version, and initializes test-wide state, like the list of released
+        versions.
+        """
+        if self._started:
+            return
+
+        initial_version = None
+        nodes = self._redpanda.nodes
+
+        # Verify that the installations on each node match.
+        for node in nodes:
+            vers = self._redpanda.get_version(node)
+            if initial_version == None:
+                initial_version = vers
+            assert initial_version == vers, \
+                f"Mismatch version {node.account.hostname} has {vers}, {nodes[0].account.hostname} has {initial_version}"
+
+        # Clean up the installer root directory so we start out clean.
+        for node in nodes:
+            if node.account.exists(RedpandaInstaller.INSTALLER_ROOT):
+                node.account.remove(f"{RedpandaInstaller.INSTALLER_ROOT}/*",
+                                    allow_fail=True)
+            else:
+                node.account.mkdir(RedpandaInstaller.INSTALLER_ROOT)
+
+        # Now that we're at a sane starting point, set up our install path for
+        # ease of jumping between versions.
+        ssh_setup_head_per_node = dict()
+        head_root_path = RedpandaInstaller.root_for_version(
+            RedpandaInstaller.HEAD)
+        rp_install_path_root = self._redpanda._context.globals.get(
+            "rp_install_path_root", None)
+        for node in nodes:
+            # For simplicity's sake, always end up with binaries at
+            # 'head_root_path', so we can continue to use root_for_version() to
+            # reference the head root.
+            head_cmd = ""
+            if self._head_backed_up:
+                head_cmd = f"mv /opt/redpanda {head_root_path}"
+            else:
+                head_cmd = f"ln -s {rp_install_path_root} {head_root_path}"
+
+            cmd = f"{head_cmd} && ln -s {head_root_path} /opt/redpanda"
+            ssh_setup_head_per_node[node] = node.account.ssh_capture(cmd)
+            self._installed_per_node[node] = set()
+        self.wait_for_async_ssh(self._redpanda.logger, ssh_setup_head_per_node,
+                                "Setting up head binaries")
+
+        def int_tuple(str_tuple):
+            return (int(str_tuple[0]), int(str_tuple[1]), int(str_tuple[2]))
+
+        # Initialize and order the releases so we can iterate to previous
+        # releases when requested.
+        releases_resp = requests.get(
+            "https://api.github.com/repos/redpanda-data/redpanda/releases")
+        self._released_versions: list[tuple] = [
+            int_tuple(VERSION_RE.findall(f["tag_name"])[0])
+            for f in releases_resp.json()
+        ]
+        self._released_versions.sort(reverse=True)
+        self._started = True
+
+    def install(self, nodes, version):
+        """
+        Installs the release on the given node such that the next time the node
+        is restarted, it will use the newly installed bits.
+
+        TODO: abstract 'version' into a more generic installation that doesn't
+        necessarily correspond to a released version. E.g. a custom build
+        packaged in a private repository.
+        """
+        if not self._started:
+            self.start()
+        assert version == RedpandaInstaller.HEAD or version in self._released_versions, \
+            f"Can't find installation for {version}"
+        ssh_install_per_node = dict()
+        for node in nodes:
+            # If we already have this version installed, just adjust the
+            # symlinks.
+            version_root = self.root_for_version(version)
+            relink_cmd = f"unlink /opt/redpanda && ln -s {version_root} /opt/redpanda"
+            if version == RedpandaInstaller.HEAD or version in self._installed_per_node[
+                    node]:
+                ssh_install_per_node[node] = node.account.ssh_capture(
+                    relink_cmd)
+                continue
+
+            arch = "amd64"
+            uname = str(node.account.ssh_output("uname -m"))
+            if "aarch" in uname or "arm" in uname:
+                arch = "arm64"
+            self._redpanda.logger.debug(
+                f"{node.account.hostname} uname output: {uname}")
+
+            self._installed_per_node[node].add(version)
+            url = RedpandaInstaller.TGZ_URL_TEMPLATE.format( \
+                arch=arch, version=f"{version[0]}.{version[1]}.{version[2]}")
+            tgz = "redpanda.tar.gz"
+            cmd = f"curl -fsSL {url} --create-dir --output-dir {version_root} -o {tgz} && gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root} && rm {version_root}/{tgz} && {relink_cmd}"
+            ssh_install_per_node[node] = node.account.ssh_capture(cmd)
+
+        self.wait_for_async_ssh(self._redpanda.logger, ssh_install_per_node,
+                                "Finished installing binaries")
+
+    def clean(self, node):
+        """
+        Cleans the node such that only the original installation remains.
+
+        This should only be called once there is no longer a need to run the
+        RedpandaService.
+        """
+        if not self._started:
+            self._redpanda.logger.debug(
+                "Ignoring cleanup, installer not started")
+            return
+
+        # Allow failures so the entire cleanup can proceed even on failure.
+        head_root_path = RedpandaInstaller.root_for_version(
+            RedpandaInstaller.HEAD)
+        if self._head_backed_up:
+            cmd = f"unlink /opt/redpanda && mv {head_root_path} /opt/redpanda"
+            node.account.ssh(cmd, allow_fail=True)
+        else:
+            cmd = f"unlink /opt/redpanda && unlink {head_root_path}"
+            node.account.ssh(cmd, allow_fail=True)
+
+        # Also clean up all the downloaded published binaries.
+        roots_to_rm = [
+            RedpandaInstaller.root_for_version(v)
+            for v in self._installed_per_node[node]
+        ]
+        if len(roots_to_rm) == 0:
+            return
+        node.account.remove(' '.join(roots_to_rm), allow_fail=True)

--- a/tests/rptest/services/rpk_consumer.py
+++ b/tests/rptest/services/rpk_consumer.py
@@ -90,10 +90,16 @@ class RpkConsumer(BackgroundThreadService):
                 raise
 
     def _consume(self, node):
+        # NOTE: since this runs on separate nodes from the service, the binary
+        # path used by each node may differ from that returned by
+        # redpanda.find_binary(), e.g. if using a RedpandaInstaller.
+        rp_install_path_root = self._redpanda._context.globals.get(
+            "rp_install_path_root", None)
+        rpk_binary = f"{rp_install_path_root}/bin/rpk"
         # Important to use --read-committed, because otherwise the output parsing would have
         # to somehow handle when rpk errors out on a rewind of the consumed offset
         cmd = '%s topic consume --read-committed --offset %s --pretty-print=false --brokers %s %s' % (
-            self._redpanda.find_binary('rpk'),
+            rpk_binary,
             self._offset,
             self._redpanda.brokers(),
             self._topic,

--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -35,7 +35,12 @@ class RpkProducer(BackgroundThreadService):
         self._produce_timeout = produce_timeout
 
     def _worker(self, _idx, node):
-        rpk_binary = self._redpanda.find_binary("rpk")
+        # NOTE: since this runs on separate nodes from the service, the binary
+        # path used by each node may differ from that returned by
+        # redpanda.find_binary(), e.g. if using a RedpandaInstaller.
+        rp_install_path_root = self._redpanda._context.globals.get(
+            "rp_install_path_root", None)
+        rpk_binary = f"{rp_install_path_root}/bin/rpk"
         key_size = 16
         cmd = f"dd if=/dev/urandom bs={self._msg_size + key_size} count={self._msg_count}"
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -34,6 +34,7 @@ class RedpandaTest(Test):
                  enable_pp=False,
                  enable_sr=False,
                  si_settings=None,
+                 enable_installer=False,
                  **kwargs):
         """
         Any trailing keyword arguments are passed through to the
@@ -42,6 +43,7 @@ class RedpandaTest(Test):
         super(RedpandaTest, self).__init__(test_context)
         self.scale = Scale(test_context)
         self.si_settings = si_settings
+        self.enable_installer = enable_installer
 
         if num_brokers is None:
             # Default to a 3 node cluster if sufficient nodes are available, else
@@ -63,6 +65,7 @@ class RedpandaTest(Test):
                                         enable_pp=enable_pp,
                                         enable_sr=enable_sr,
                                         si_settings=self.si_settings,
+                                        enable_installer=enable_installer,
                                         **kwargs)
         self._client = DefaultClient(self.redpanda)
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -1,0 +1,79 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+
+from ducktape.utils.util import wait_until
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda_installer import RedpandaInstaller
+
+
+def wait_for_num_versions(redpanda, num_versions):
+    def get_unique_versions():
+        node = redpanda.nodes[0]
+        brokers_list = \
+            str(node.account.ssh_output(f"{redpanda.find_binary('rpk')} redpanda admin brokers list"))
+        redpanda.logger.debug(brokers_list)
+        version_re = re.compile("v\\d+\\.\\d+\\.\\d+")
+        return set(version_re.findall(brokers_list))
+
+    # NOTE: allow retries, as the version may not be available immediately
+    # following a restart.
+    wait_until(lambda: len(get_unique_versions()) == num_versions,
+               timeout_sec=30)
+    unique_versions = get_unique_versions()
+    assert len(unique_versions) == num_versions, unique_versions
+    return unique_versions
+
+
+class UpgradeFromSpecificVersion(RedpandaTest):
+    """
+    Basic test that upgrading software works as expected.
+    """
+    def __init__(self, test_context):
+        super(UpgradeFromSpecificVersion,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             enable_installer=True)
+        self.installer = self.redpanda._installer
+
+    def setUp(self):
+        # NOTE: `rpk redpanda admin brokers list` requires versions v22.1.x and
+        # above.
+        self.installer.install(self.redpanda.nodes, (22, 1, 3))
+        super(UpgradeFromSpecificVersion, self).setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_basic_upgrade(self):
+        first_node = self.redpanda.nodes[0]
+
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert "v22.1.3" in unique_versions, unique_versions
+
+        # Upgrade one node to the head version.
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes([first_node])
+        unique_versions = wait_for_num_versions(self.redpanda, 2)
+        assert "v22.1.3" in unique_versions, unique_versions
+
+        # Rollback the partial upgrade and ensure we go back to the original
+        # state.
+        self.installer.install([first_node], (22, 1, 3))
+        self.redpanda.restart_nodes([first_node])
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert "v22.1.3" in unique_versions, unique_versions
+
+        # Only once we upgrade the rest of the nodes do we converge on the new
+        # version.
+        self.installer.install([first_node], RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert "v22.1.3" not in unique_versions, unique_versions


### PR DESCRIPTION
## Cover letter                                                                                      
                                                                                                     
This PR introduces the `RedpandaInstaller` as a means to manage and install binaries across nodes in a `RedpandaService`. It allows developers to, before starting Redpanda, install and run with a different set of binaries, maintaining the old binaries for the sake of upgrade or a post-test revert.
                                                                                                     
The underlying mechanism used to install binaries is the downloading of tarballs from the Redpanda public repository. Downloads are placed in a specific directory, and `/opt/redpanda` is maintained as a symlink to the currently active installation.
                                                                                                     
Upon starting up a test, some sanity checks are performed to ensure the versions across different nodes match. Upon shutting down a test, cleanup is invoked to delete all downloads and restore the original binaries.
                                                                                                     
Also included is a means to upgrade from highest feature release below the current branch, by having the `RedpandaInstaller` traverse a list of releases fetched from Github for a valid candidate.
                                                                                                     
There's certainly room for improvement, of note:                                                     
- downloading tarballs isn't quite the upgrade path we expect most people to use                     
- the current API focuses on a released version being the upgrade target, but it could be useful to package and install custom binaries from unreleased branches
                                                                                                     
Regardless, this should be enough to get us started introducing upgrade tests. A couple of basic ones are added, though they don't do anything interesting -- just verify version expectations to check the downloads went along as expected.
                                                                                                     
## Release notes                                                                                     
* none                                                                                               
                                                                                                     
Fixes #4789 and #1650

[force-push](https://github.com/redpanda-data/redpanda/compare/2749f2c2c5ed845b9693d0000a9d71274f5fc5cc..7c15c77b052ae2e1db190fc3d42ea41b8b73d3d3)
* Changed test to only rollback instead of downgrade

[force-push](https://github.com/redpanda-data/redpanda/compare/89147fe698826f2b015d416608c7973bfd4fe7b3..a50e2fabcd7b7d9ebde12dc88b89a2db1569b245)
* Fixed some issues with non-RedpandaService binary paths
* Fixed post-test saving of executable
* Wrapped `ssh_output` as a string
* Construct `RedpandaInstaller` as a part of `RedpandaService`
* Removed test requirement to explicitly call `RedpandaService::start()`