### PR TITLE
Rate limit leadership transfers

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -261,7 +261,6 @@ ss::future<> controller::start() {
             _raft_manager.local().raft_client(),
             std::ref(_shard_table),
             std::ref(_partition_manager),
-            std::ref(_raft_manager),
             std::ref(_as),
             config::shard_local_cfg().enable_leader_balancer.bind(),
             config::shard_local_cfg().leader_balancer_idle_timeout.bind(),

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -267,6 +267,8 @@ ss::future<> controller::start() {
             config::shard_local_cfg().leader_balancer_idle_timeout.bind(),
             config::shard_local_cfg().leader_balancer_mute_timeout.bind(),
             config::shard_local_cfg().leader_balancer_node_mute_timeout.bind(),
+            config::shard_local_cfg()
+              .leader_balancer_transfer_limit_per_shard.bind(),
             _raft0);
           return _leader_balancer->start();
       })

--- a/src/v/cluster/ntp_callbacks.h
+++ b/src/v/cluster/ntp_callbacks.h
@@ -110,6 +110,30 @@ public:
         }
     }
 
+    // A quicker way to remove a callback for a given id when the ntp is known.
+    void unregister_notify(const model::ntp& ntp, notification_id_type id) {
+        const auto& ns = ntp.ns;
+        const auto& topic = ntp.tp.topic;
+        const auto& part = ntp.tp.partition;
+
+        auto ns_iter = _root.next.find(ns);
+        if (ns_iter == _root.next.end()) {
+            return;
+        }
+
+        auto topic_iter = ns_iter->second.next.find(topic);
+        if (topic_iter == ns_iter->second.next.end()) {
+            return;
+        }
+
+        auto part_iter = topic_iter->second.next.find(part);
+        if (part_iter == topic_iter->second.next.end()) {
+            return;
+        }
+
+        part_iter->second.erase(id);
+    }
+
 private:
     using callbacks_t = absl::flat_hash_map<notification_id_type, Callback>;
 

--- a/src/v/cluster/ntp_callbacks.h
+++ b/src/v/cluster/ntp_callbacks.h
@@ -153,8 +153,8 @@ private:
 
     template<typename... Args>
     void notify(const callbacks_t& callbacks, Args&&... args) const {
-        for (auto& cb : callbacks) {
-            cb.second(std::forward<Args>(args)...);
+        for (auto cb_i = callbacks.cbegin(); cb_i != callbacks.cend();) {
+            (cb_i++)->second(std::forward<Args>(args)...);
         }
     }
 

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -168,6 +168,13 @@ void partition_leaders_table::update_partition_leader(
             promise.second->set_value(*leader_id);
         }
     }
+
+    // Ensure leadership has changed before notifying watchers
+    if (
+      !it->second.previous_leader
+      || leader_id.value() != it->second.previous_leader.value()) {
+        _watchers.notify(ntp, ntp, term, leader_id);
+    }
 }
 
 ss::future<model::node_id> partition_leaders_table::wait_for_leader(
@@ -215,6 +222,28 @@ partition_leaders_table::get_leaders() const {
         ans.push_back(std::move(info));
     }
     return ans;
+}
+
+notification_id_type
+partition_leaders_table::register_leadership_change_notification(
+  leader_change_cb_t cb) {
+    return _watchers.register_notify(std::move(cb));
+}
+
+notification_id_type
+partition_leaders_table::register_leadership_change_notification(
+  const model::ntp& ntp, leader_change_cb_t cb) {
+    return _watchers.register_notify(ntp, std::move(cb));
+}
+
+void partition_leaders_table::unregister_leadership_change_notification(
+  notification_id_type id) {
+    return _watchers.unregister_notify(id);
+}
+
+void partition_leaders_table::unregister_leadership_change_notification(
+  const model::ntp& ntp, notification_id_type id) {
+    return _watchers.unregister_notify(ntp, id);
 }
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -76,7 +76,6 @@ public:
       raft::consensus_client_protocol,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
-      ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
       config::binding<bool>&&,
       config::binding<std::chrono::milliseconds>&&,
@@ -104,7 +103,7 @@ private:
     void on_enable_changed();
 
     void check_if_controller_leader(
-      raft::group_id, model::term_id, std::optional<model::node_id>);
+      model::ntp, model::term_id, std::optional<model::node_id>);
 
     void on_leadership_change(
       model::ntp, model::term_id, std::optional<model::node_id>);
@@ -179,7 +178,6 @@ private:
     raft::consensus_client_protocol _client;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
-    ss::sharded<raft::group_manager>& _group_manager;
     ss::sharded<ss::abort_source>& _as;
     consensus_ptr _raft0;
     ss::gate _gate;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1099,6 +1099,13 @@ configuration::configuration()
       "Leadership rebalancing node mute timeout",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       20s)
+  , leader_balancer_transfer_limit_per_shard(
+      *this,
+      "leader_balancer_transfer_limit_per_shard",
+      "Per shard limit for in progress leadership transfers",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      512,
+      {.min = 1, .max = 2048})
   , internal_topic_replication_factor(
       *this,
       "internal_topic_replication_factor",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -243,6 +243,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;
+    bounded_property<size_t> leader_balancer_transfer_limit_per_shard;
     property<int> internal_topic_replication_factor;
     property<std::chrono::milliseconds> health_manager_tick_interval;
 


### PR DESCRIPTION
## Cover letter

Limits the number of in flight leadership transfers to a tunable amount per shard on the cluster.

## Release notes
* none