### PR TITLE
archival: Truncate archival metadata snapshot

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -12,6 +12,7 @@
 
 #include "archival/archival_policy.h"
 #include "archival/logger.h"
+#include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "cluster/partition_manager.h"
@@ -539,6 +540,70 @@ uint64_t ntp_archiver::estimate_backlog_size() {
     // before it's sealed because the size of the individual segment is small
     // compared to the capacity of the data volume.
     return total_size;
+}
+
+ss::future<std::optional<cloud_storage::partition_manifest>>
+ntp_archiver::maybe_truncate_manifest(retry_chain_node& rtc) {
+    ss::gate::holder gh(_gate);
+    retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
+    vlog(ctxlog.info, "archival metadata cleanup started");
+    model::offset adjusted_start_offset = model::offset::min();
+    for (const auto& [key, meta] : _manifest) {
+        retry_chain_node fib(
+          _manifest_upload_timeout, _upload_loop_initial_backoff, &rtc);
+        auto sname = cloud_storage::generate_segment_name(
+          key.base_offset, key.term);
+        auto spath = cloud_storage::generate_remote_segment_path(
+          _ntp, _rev, sname, meta.archiver_term);
+        auto result = co_await _remote.segment_exists(_bucket, spath, fib);
+        if (result == cloud_storage::download_result::notfound) {
+            vlog(
+              ctxlog.info,
+              "archival metadata cleanup, found segment missing from the "
+              "bucket: {}",
+              spath);
+            adjusted_start_offset = meta.committed_offset + model::offset(1);
+        } else {
+            break;
+        }
+    }
+    std::optional<cloud_storage::partition_manifest> result;
+    if (
+      adjusted_start_offset != model::offset::min()
+      && _partition->archival_meta_stm()) {
+        vlog(
+          ctxlog.info,
+          "archival metadata cleanup, some segments will be removed from the "
+          "manifest, start offset before cleanup: {}",
+          _manifest.get_start_offset());
+        retry_chain_node rc_node(
+          _manifest_upload_timeout, _upload_loop_initial_backoff, &rtc);
+        auto error = co_await _partition->archival_meta_stm()->truncate(
+          adjusted_start_offset,
+          ss::lowres_clock::now() + _manifest_upload_timeout,
+          _as);
+        if (error != cluster::errc::success) {
+            vlog(ctxlog.warn, "archival metadata STM update failed: {}", error);
+            throw std::system_error(error);
+        } else {
+            vlog(
+              ctxlog.debug,
+              "archival metadata STM update passed, re-uploading manifest");
+            co_await upload_manifest();
+        }
+        result = _manifest.truncate(adjusted_start_offset);
+        vlog(
+          ctxlog.info,
+          "archival metadata cleanup completed, start offset after cleanup: {}",
+          _manifest.get_start_offset());
+    } else {
+        // Nothing to cleanup, return empty manifest
+        result = cloud_storage::partition_manifest(_ntp, _rev);
+        vlog(
+          ctxlog.info,
+          "archival metadata cleanup completed, nothing to clean up");
+    }
+    co_return result;
 }
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -114,6 +114,10 @@ public:
 
     uint64_t estimate_backlog_size();
 
+    /// \brief Probe remote storage and truncate the manifest if needed
+    ss::future<std::optional<cloud_storage::partition_manifest>>
+    maybe_truncate_manifest(retry_chain_node& rtc);
+
 private:
     /// Information about started upload
     struct scheduled_upload {

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -381,4 +381,12 @@ uint64_t scheduler_service_impl::estimate_backlog_size() {
     return size;
 }
 
+ss::future<std::optional<cloud_storage::partition_manifest>>
+scheduler_service_impl::maybe_truncate_manifest(const model::ntp& ntp) {
+    if (auto it = _archivers.find(ntp); it != _archivers.end()) {
+        co_return co_await it->second->maybe_truncate_manifest(_rtcnode);
+    }
+    co_return std::nullopt;
+}
+
 } // namespace archival::internal

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -108,6 +108,11 @@ public:
     /// Total size of data that have to be uploaded
     uint64_t estimate_backlog_size();
 
+    /// Invoke syncup procedure for ntp (check if segments are missing and
+    /// truncate)
+    ss::future<std::optional<cloud_storage::partition_manifest>>
+    maybe_truncate_manifest(const model::ntp& ntp);
+
 private:
     /// Remove archivers from the workingset
     ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
@@ -168,6 +173,9 @@ public:
 
     /// Estimate total size of the upload backlog
     using internal::scheduler_service_impl::estimate_backlog_size;
+
+    /// Truncate manifest if needed
+    using internal::scheduler_service_impl::maybe_truncate_manifest;
 };
 
 } // namespace archival

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -191,6 +191,13 @@ const model::offset partition_manifest::get_last_offset() const {
     return _last_offset;
 }
 
+std::optional<model::offset> partition_manifest::get_start_offset() const {
+    if (_segments.empty()) {
+        return std::nullopt;
+    }
+    return _segments.begin()->second.base_offset;
+}
+
 model::initial_revision_id partition_manifest::get_revision_id() const {
     return _rev;
 }
@@ -253,6 +260,20 @@ bool partition_manifest::add(
     }
     key key = {.base_offset = maybe_key->base_offset, .term = maybe_key->term};
     return add(key, meta);
+}
+
+partition_manifest
+partition_manifest::truncate(model::offset starting_rp_offset) {
+    partition_manifest removed(_ntp, _rev);
+    for (auto it : _segments) {
+        if (it.second.committed_offset < starting_rp_offset) {
+            removed.add(it.first, it.second);
+        }
+    }
+    for (auto s : removed._segments) {
+        _segments.erase(s.first);
+    }
+    return removed;
 }
 
 const partition_manifest::segment_meta*

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -104,6 +104,9 @@ public:
     // Get last offset
     const model::offset get_last_offset() const;
 
+    /// Get starting offset
+    std::optional<model::offset> get_start_offset() const;
+
     /// Get revision
     model::initial_revision_id get_revision_id() const;
 
@@ -124,6 +127,11 @@ public:
     /// Add new segment to the manifest
     bool add(const key& key, const segment_meta& meta);
     bool add(const segment_name& name, const segment_meta& meta);
+
+    /// \brief Truncate the manifest
+    /// \param starting_rp_offset is a new starting offset of the manifest
+    /// \return manifest that contains only removed segments
+    partition_manifest truncate(model::offset starting_rp_offset);
 
     /// Get segment if available or nullopt
     const segment_meta* get(const key& key) const;

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -445,20 +445,10 @@ model::offset remote_partition::first_uploaded_offset() {
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
     try {
-        if (_first_uploaded_offset) {
-            return *_first_uploaded_offset;
-        }
-        model::offset starting_offset = model::offset::max();
-        for (const auto& m : _manifest) {
-            starting_offset = std::min(
-              starting_offset, get_kafka_base_offset(m.second));
-        }
-        _first_uploaded_offset = starting_offset;
-        vlog(
-          _ctxlog.debug,
-          "remote partition first_uploaded_offset set to {}",
-          starting_offset);
-        return starting_offset;
+        auto it = _manifest.begin();
+        auto off = get_kafka_base_offset(it->second);
+        vlog(_ctxlog.debug, "remote partition first_uploaded_offset: {}", off);
+        return off;
     } catch (...) {
         vlog(
           _ctxlog.error,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -311,7 +311,6 @@ private:
     remote& _api;
     cache& _cache;
     const partition_manifest& _manifest;
-    std::optional<model::offset> _first_uploaded_offset;
     s3::bucket_name _bucket;
     segment_map_t _segments;
     eviction_list_t _eviction_list;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -10,7 +10,8 @@ set(swags
   hbadger
   transaction
   cluster
-  debug)
+  debug
+  shadow_indexing)
 
 set(swag_files)
 foreach(swag ${swags})

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -1,0 +1,25 @@
+"/v1/shadow_indexing/sync_local_state/{topic}/{partition}": {
+  "post": {
+    "summary": "Sync content of the bucket with local partition metadata",
+    "operationId": "sync_local_state",
+    "parameters": [
+        {
+            "name": "topic",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        {
+            "name":"partition",
+            "in":"path",
+            "required":true,
+            "type":"integer"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Partition metadata is up to date"
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -11,6 +11,8 @@
 
 #include "redpanda/admin_server.h"
 
+#include "archival/service.h"
+#include "cloud_storage/partition_manifest.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
@@ -54,6 +56,7 @@
 #include "redpanda/admin/api-doc/partition.json.h"
 #include "redpanda/admin/api-doc/raft.json.h"
 #include "redpanda/admin/api-doc/security.json.h"
+#include "redpanda/admin/api-doc/shadow_indexing.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
 #include "redpanda/admin/api-doc/transaction.json.h"
 #include "redpanda/request_auth.h"
@@ -90,7 +93,8 @@ admin_server::admin_server(
   ss::sharded<coproc::partition_manager>& cpm,
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
-  ss::sharded<cluster::metadata_cache>& metadata_cache)
+  ss::sharded<cluster::metadata_cache>& metadata_cache,
+  ss::sharded<archival::scheduler_service>& archival_service)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -99,8 +103,8 @@ admin_server::admin_server(
   , _controller(controller)
   , _shard_table(st)
   , _metadata_cache(metadata_cache)
-  , _auth(
-      config::shard_local_cfg().admin_api_require_auth.bind(), _controller) {}
+  , _auth(config::shard_local_cfg().admin_api_require_auth.bind(), _controller)
+  , _archival_service(archival_service) {}
 
 ss::future<> admin_server::start() {
     configure_metrics_route();
@@ -163,6 +167,7 @@ void admin_server::configure_admin_routes() {
     register_transaction_routes();
     register_debug_routes();
     register_cluster_routes();
+    register_shadow_indexing_routes();
 }
 
 struct json_validator {
@@ -2623,5 +2628,51 @@ void admin_server::register_cluster_routes() {
           }
 
           co_return ss::json::json_return_type(ret);
+      });
+}
+
+void admin_server::register_shadow_indexing_routes() {
+    struct manifest_reducer {
+        ss::future<>
+        operator()(std::optional<cloud_storage::partition_manifest>&& value) {
+            _manifest = std::move(value);
+            return ss::make_ready_future<>();
+        }
+        std::optional<cloud_storage::partition_manifest> get() && {
+            return std::move(_manifest);
+        }
+        std::optional<cloud_storage::partition_manifest> _manifest;
+    };
+    register_route<superuser>(
+      ss::httpd::shadow_indexing_json::sync_local_state,
+      [this](std::unique_ptr<ss::httpd::request> request)
+        -> ss::future<ss::json::json_return_type> {
+          vlog(logger.info, "Requested bucket syncup");
+          auto topic = model::topic(request->param["topic"]);
+          auto partition = model::partition_id(
+            boost::lexical_cast<int32_t>(request->param["partition"]));
+          auto ntp = model::ntp(model::kafka_namespace, topic, partition);
+          if (need_redirect_to_leader(ntp, _metadata_cache)) {
+              vlog(logger.info, "Need to redirect bucket syncup request");
+              co_await redirect_to_leader(*request, ntp);
+          } else {
+              auto result = co_await _archival_service.map_reduce(
+                manifest_reducer(),
+                [ntp](archival::scheduler_service& service) {
+                    return service.maybe_truncate_manifest(ntp);
+                });
+              vlog(logger.info, "Requested bucket syncup completed");
+              if (result) {
+                  std::stringstream sts;
+                  result->serialize(sts);
+                  vlog(
+                    logger.info,
+                    "Requested bucket syncup result {}",
+                    sts.str());
+              } else {
+                  vlog(logger.info, "Requested bucket syncup result empty");
+              }
+          }
+          co_return ss::json::json_return_type(ss::json::json_void());
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "archival/service.h"
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
@@ -48,7 +49,8 @@ public:
       ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
-      ss::sharded<cluster::metadata_cache>&);
+      ss::sharded<cluster::metadata_cache>&,
+      ss::sharded<archival::scheduler_service>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -162,6 +164,7 @@ private:
     void register_transaction_routes();
     void register_debug_routes();
     void register_cluster_routes();
+    void register_shadow_indexing_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,
@@ -197,4 +200,5 @@ private:
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     request_authenticator _auth;
     bool _ready{false};
+    ss::sharded<archival::scheduler_service>& _archival_service;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -463,7 +463,8 @@ void application::configure_admin_server() {
       std::ref(cp_partition_manager),
       controller.get(),
       std::ref(shard_table),
-      std::ref(metadata_cache))
+      std::ref(metadata_cache),
+      std::ref(archival_scheduler))
       .get();
 }
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -637,3 +637,10 @@ class Admin:
         self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
         url = "debug/partition_leaders_table"
         return self._request("get", url, node=node).json()
+
+    def si_sync_local_state(self, topic, partition, node=None):
+        """
+        Check data in the S3 bucket and fix local index if needed
+        """
+        path = f"shadow_indexing/sync_local_state/{topic}/{partition}"
+        return self._request('post', path, node=node)

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -1,0 +1,149 @@
+# Copyright 2021 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService, SISettings
+
+from rptest.services.admin import Admin
+from rptest.archival.s3_client import S3Client
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import (
+    produce_until_segments,
+    wait_for_segments_removal,
+)
+from ducktape.utils.util import wait_until
+
+import xxhash
+from collections import namedtuple, defaultdict
+import time
+import os
+import json
+import traceback
+import uuid
+import sys
+import re
+
+# Log errors expected when connectivity between redpanda and the S3
+# backend is disrupted
+CONNECTION_ERROR_LOGS = [
+    "archival - .*Failed to create archivers",
+
+    # e.g. archival - [fiber1] - service.cc:484 - Failed to upload 3 segments out of 4
+    r"archival - .*Failed to upload \d+ segments"
+]
+
+
+class SIAdminApiTest(RedpandaTest):
+    log_segment_size = 1048576  # 1MB
+
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        si_settings = SISettings(
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_enable_remote_read=True,
+            cloud_storage_enable_remote_write=True,
+        )
+        self.s3_bucket_name = si_settings.cloud_storage_bucket
+
+        extra_rp_conf = dict(log_segment_size=self.log_segment_size)
+
+        super(SIAdminApiTest, self).__init__(test_context=test_context,
+                                             extra_rp_conf=extra_rp_conf,
+                                             si_settings=si_settings)
+
+        self._s3_port = si_settings.cloud_storage_api_endpoint_port
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.admin = Admin(self.redpanda,
+                           auth=(self.superuser.username,
+                                 self.superuser.password))
+
+    def setUp(self):
+        super().setUp()
+        # We can't set 'admin_api_require_auth' in 'extra_rp_conf'. The
+        # test will fail to start in this case. But we can swith the
+        # feature on after start.
+        self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+
+    def tearDown(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+        super().tearDown()
+
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
+    def test_bucket_validation(self):
+        """
+        The test produces to the partition and waits untils the
+        data is uploaded to S3 and the oldest segments are picked
+        up by the retention. After that it uses admin api to invoke
+        bucket validation and checks the result.
+
+        The check is performed using describe topic command. The
+        start offset returned by the command is provided by the 
+        shadow indexing subsystem. After validation the starting
+        offset have to change from initial 0 to some other value.
+        """
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 1024,
+            },
+        )
+
+        produce_until_segments(redpanda=self.redpanda,
+                               topic=self.topic,
+                               partition_idx=0,
+                               count=10,
+                               acks=-1)
+
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=5)
+
+        rpk = RpkTool(self.redpanda)
+
+        for partition in rpk.describe_topic(self.topic):
+            self.logger.info(f"describe topic result {partition}")
+            assert partition.start_offset == 0, f"start-offset of the partition is supposed to be 0 instead of {partition.start_offset}"
+
+        segment_to_remove = self.find_deletion_candidate()
+        self.logger.info(f"trying to remove segment {segment_to_remove}")
+        self.s3_client.delete_object(self.s3_bucket_name, segment_to_remove,
+                                     True)
+
+        self.logger.info("trying to sync remote partition")
+        for node in self.redpanda.nodes:
+            validation_result = self.admin.si_sync_local_state(
+                self.topic, 0, node)
+            self.logger.info(f"sync result {validation_result}")
+
+        def start_offset_not_zero():
+            for partition in rpk.describe_topic(self.topic):
+                self.logger.info(f"describe topic result {partition}")
+                return partition.start_offset > 0
+
+        wait_until(start_offset_not_zero, 60)
+
+        for part in self.rpk.describe_topic(self.topic):
+            self.logger.info(f"describe topic result {part}")
+            assert part.start_offset > 0, f"start-offset of the partition is {part.start_offset}, should be greater than 0"
+
+    def find_deletion_candidate(self):
+        for obj in self.s3_client.list_objects(self.s3_bucket_name):
+            key = obj.Key[:-2]
+            if key.endswith("/0-1-v1.log"):
+                return obj.Key
+        return None


### PR DESCRIPTION
## Cover letter

Implement truncation of archival metadata. The truncation can be triggered by the new admin api call.
The `partition_manifest` and `archival_metadata_stm` are modified to support truncation. New command is added to the STM.

The admin api command has the following format:

`curl -XPOST .../shadow_indexing/validate_remote_partition/{topic}/{partition}'

The command has to be invoked per partition on any node (the redirect will be triggered if the node doesn't host a leader of the partition. The command only works for topics in `kafka` namespace.

## Release notes


* Add new admin API that enables safe deletion of data in S3


### Features

* The command `/shadow_indexing/validate_remote_partition` validates the content of the bucket for single partition and truncates archival metadata if needed.

### Improvements

* The data can be safely removed from S3