### PR TITLE
reduce log level of MirrorMaker2 tests from `TRACE` to `DEBUG`

### DIFF
--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -159,7 +159,7 @@ class TestMirrorMakerService(EndToEndTest):
                                          source_cluster=self.source_broker,
                                          target_cluster=self.redpanda,
                                          consumer_group_pattern=consumer_group,
-                                         log_level="TRACE")
+                                         log_level="DEBUG")
         self.mirror_maker.start()
 
         msg_size = 512


### PR DESCRIPTION
## Cover letter

Running the ducktape tests for `TestMirrorMakerService` in a docker environment (like on this PR) generates a `mirror_maker2.log` file of size 291M, but running the same test in CDT generates a `mirror_maker2.log` file of size 5.0G.

The `mirror_maker2.log` file is generated twice: once for each [source_type](https://github.com/redpanda-data/redpanda/blob/afb991de74837d45e4b6ddba413bfc6cd6c86672/tests/rptest/tests/mirror_maker_test.py#L118-L121), so that is approx 10G of logs from this test on CDT. Which adds 30 min to the CDT runtime and storage space on our cloud provider.

If `TRACE` log level is not needed for diagnosing failures, then I suggest to drop it to `DEBUG` log level which this PR does. From my simple `grep -v TRACE mirror_maker2.log`, I suspect this will reduce the log file size from 5.0GB to 201M on CDT and from 291M to 149M in a docker environment.

Feel free to close this PR instead of merging it if dropping the log level is not the desirable thing.

## Release notes

* none