### PR TITLE
Kip-447 (Producer scalability for exactly once semantics)

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -494,7 +494,7 @@ configuration::configuration()
       "abort_timed_out_transactions_interval_ms",
       "How often look for the inactive transactions and abort them",
       {.visibility = visibility::tunable},
-      1min)
+      10s)
   , create_topic_timeout_ms(
       *this,
       "create_topic_timeout_ms",

--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -185,6 +185,8 @@ std::string_view error_code_to_str(error_code error) {
         return "unknown_server_error";
     case error_code::invalid_record:
         return "invalid_record";
+    case error_code::unstable_offset_commit:
+        return "unstable_offset_commit";
     default:
         std::terminate(); // make gcc happy
     }

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -221,6 +221,8 @@ enum class error_code : int16_t {
     fenced_instance_id = 82,
     // This record has failed the validation on broker and hence be rejected.
     invalid_record = 87,
+    // There are unstable offsets that need to be cleared.
+    unstable_offset_commit = 88,
 };
 
 std::ostream& operator<<(std::ostream&, error_code);

--- a/src/v/kafka/protocol/schemata/offset_fetch_request.json
+++ b/src/v/kafka/protocol/schemata/offset_fetch_request.json
@@ -28,7 +28,9 @@
   // Version 3, 4, and 5 are the same as version 2.
   //
   // Version 6 is the first flexible version.
-  "validVersions": "0-6",
+  //
+  // Version 7 is adding the require stable flag.
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
@@ -39,6 +41,8 @@
         "about": "The topic name."},
       { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
         "about": "The partition indexes we would like to fetch offsets for." }
-    ]}
+    ]},
+    {"name": "RequireStable", "type": "bool", "versions": "7+", "default": "false",
+     "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partition."}
   ]
 }

--- a/src/v/kafka/protocol/schemata/offset_fetch_response.json
+++ b/src/v/kafka/protocol/schemata/offset_fetch_response.json
@@ -28,7 +28,9 @@
   // Version 5 adds the leader epoch to the committed offset.
   //
   // Version 6 is the first flexible version.
-  "validVersions": "0-6",
+  //
+  // Version 7 adds pending offset commit as new error response on partition level.
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
@@ -44,14 +46,14 @@
         { "name": "CommittedOffset", "type": "int64", "versions": "0+",
           "about": "The committed message offset." },
         { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "5+", "default": "-1",
-          "about": "The leader epoch." },
+          "ignorable": true, "about": "The leader epoch." },
         { "name": "Metadata", "type": "string", "versions": "0+", "nullableVersions": "0+",
           "about": "The partition metadata." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." }
       ]}
     ]},
-    { "name": "ErrorCode", "type": "int16", "versions": "2+", "default": "0", "ignorable": false,
+    { "name": "ErrorCode", "type": "int16", "versions": "2+", "default": "0", "ignorable": true,
       "about": "The top-level error code, or 0 if there was no error." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/txn_offset_commit_request.json
+++ b/src/v/kafka/protocol/schemata/txn_offset_commit_request.json
@@ -20,8 +20,10 @@
   // Version 1 is the same as version 0.
   //
   // Version 2 adds the committed leader epoch.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  //
+  // Version 3 adds the member.id, group.instance.id and generation.id.
+  "validVersions": "0-3",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "0+",
       "about": "The ID of the transaction." },
@@ -31,8 +33,15 @@
       "about": "The current producer ID in use by the transactional ID." },
     { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
       "about": "The current epoch associated with the producer ID." },
+    { "name": "GenerationId", "type": "int32", "versions": "3+", "default": "-1",
+      "about": "The generation of the consumer." },
+    { "name": "MemberId", "type": "string", "versions": "3+", "default": "",
+      "about": "The member ID assigned by the group coordinator." },
+    { "name": "GroupInstanceId", "type": "string", "versions": "3+",
+      "nullableVersions": "3+", "default": "null",
+      "about": "The unique identifier of the consumer instance provided by end user." },
     { "name": "Topics", "type" : "[]TxnOffsetCommitRequestTopic", "versions": "0+",
-      "about": "Each topic that we want to committ offsets for.", "fields": [
+      "about": "Each topic that we want to commit offsets for.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
       { "name": "Partitions", "type": "[]TxnOffsetCommitRequestPartition", "versions": "0+",

--- a/src/v/kafka/protocol/schemata/txn_offset_commit_response.json
+++ b/src/v/kafka/protocol/schemata/txn_offset_commit_response.json
@@ -18,9 +18,12 @@
   "type": "response",
   "name": "TxnOffsetCommitResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  //
   // Version 2 is the same as version 1.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  //
+  // Version 3 adds illegal generation, fenced instance id, and unknown member id errors.
+  "validVersions": "0-3",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
@@ -31,7 +34,7 @@
       { "name": "Partitions", "type": "[]TxnOffsetCommitResponsePartition", "versions": "0+",
         "about": "The responses for each partition in the topic.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
-          "about": "The partitition index." },
+          "about": "The partition index." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." }
       ]}

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2338,14 +2338,22 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
         for (const auto& e : _offsets) {
             offset_fetch_response_partition p = {
               .partition_index = e.first.partition,
-              .committed_offset = e.second->metadata.offset,
-              .committed_leader_epoch
-              = e.second->metadata.committed_leader_epoch,
-              .metadata = e.second->metadata.metadata,
+              .committed_offset = model::offset(-1),
+              .metadata = "",
               .error_code = error_code::none,
             };
+
+            if (r.data.require_stable && !check_pending_transaction(e.first)) {
+                p.error_code = error_code::unstable_offset_commit;
+            } else {
+                p.committed_offset = e.second->metadata.offset;
+                p.committed_leader_epoch
+                  = e.second->metadata.committed_leader_epoch;
+                p.metadata = e.second->metadata.metadata;
+            }
             tmp[e.first.topic].push_back(std::move(p));
         }
+
         for (auto& e : tmp) {
             resp.data.topics.push_back(
               {.name = e.first, .partitions = std::move(e.second)});
@@ -2360,24 +2368,26 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
         t.name = topic.name;
         for (auto id : topic.partition_indexes) {
             model::topic_partition tp(topic.name, id);
-            auto res = offset(tp);
-            if (res) {
-                offset_fetch_response_partition p = {
-                  .partition_index = id,
-                  .committed_offset = res->offset,
-                  .metadata = res->metadata,
-                  .error_code = error_code::none,
-                };
-                t.partitions.push_back(std::move(p));
+
+            offset_fetch_response_partition p = {
+              .partition_index = id,
+              .committed_offset = model::offset(-1),
+              .metadata = "",
+              .error_code = error_code::none,
+            };
+
+            if (r.data.require_stable && !check_pending_transaction(tp)) {
+                p.error_code = error_code::unstable_offset_commit;
             } else {
-                offset_fetch_response_partition p = {
-                  .partition_index = id,
-                  .committed_offset = model::offset(-1),
-                  .metadata = "",
-                  .error_code = error_code::none,
-                };
-                t.partitions.push_back(std::move(p));
+                auto res = offset(tp);
+                if (res) {
+                    p.partition_index = id;
+                    p.committed_offset = res->offset;
+                    p.metadata = res->metadata;
+                    p.error_code = error_code::none;
+                }
             }
+            t.partitions.push_back(std::move(p));
         }
         resp.data.topics.push_back(std::move(t));
     }

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -710,6 +710,8 @@ private:
         return std::move(builder).build();
     }
 
+    error_code check_group_before_commit_offset(const txn_offset_commit_request& r);
+
     cluster::abort_origin
     get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 

--- a/src/v/kafka/server/handlers/offset_fetch.h
+++ b/src/v/kafka/server/handlers/offset_fetch.h
@@ -17,6 +17,6 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-using offset_fetch_handler = handler<offset_fetch_api, 1, 4>;
+using offset_fetch_handler = handler<offset_fetch_api, 1, 7>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/txn_offset_commit.h
+++ b/src/v/kafka/server/handlers/txn_offset_commit.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using txn_offset_commit_handler = handler<txn_offset_commit_api, 0, 2>;
+using txn_offset_commit_handler = handler<txn_offset_commit_api, 0, 3>;
 
 }

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -166,6 +166,7 @@ std::error_condition make_error_condition(std::error_code ec) {
         case kec::operation_not_attempted:
         case kec::kafka_storage_error:
         case kec::unknown_server_error:
+        case kec::unstable_offset_commit:
             return rec::kafka_error;
         case kec::network_exception:
         case kec::coordinator_load_in_progress:

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -120,7 +120,11 @@ copy_data_segment_reducer::filter(model::record_batch&& batch) {
     // offset translation
     if (
       batch.header().type == model::record_batch_type::raft_configuration
-      || batch.header().type == model::record_batch_type::archival_metadata) {
+      || batch.header().type == model::record_batch_type::archival_metadata
+      || batch.header().type == model::record_batch_type::archival_metadata
+      || batch.header().type == model::record_batch_type::group_abort_tx
+      || batch.header().type == model::record_batch_type::group_commit_tx
+      || batch.header().type == model::record_batch_type::group_prepare_tx) {
         return std::move(batch);
     }
 

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -1,0 +1,222 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+
+import time
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.rpk_consumer import RpkConsumer
+import confluent_kafka as ck
+from rptest.clients.kafka_cat import KafkaCat
+
+import subprocess
+
+
+class TransactionsTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3),
+              TopicSpec(partition_count=1, replication_factor=3))
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "enable_transactions": True,
+            "transaction_coordinator_replication": 3,
+            "id_allocator_replication": 3,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(TransactionsTest, self).__init__(test_context=test_context,
+                                               extra_rp_conf=extra_rp_conf)
+
+        self.input_t = self.topics[0]
+        self.output_t = self.topics[1]
+        self.max_records = 100
+
+    def generate_data(self, topic, num_records):
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+        })
+
+        for i in range(num_records):
+            producer.produce(topic.name, str(i), str(i), 0)
+
+        producer.flush()
+
+    @cluster(num_nodes=3)
+    def simple_test(self):
+        self.generate_data(self.input_t, self.max_records)
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        })
+
+        consumer = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': "test",
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        producer.init_transactions()
+
+        consumer.subscribe([self.input_t])
+
+        num_consumed_records = 0
+        consume_for_one_it = 10
+
+        while num_consumed_records != self.max_records:
+            records = consumer.consume(consume_for_one_it)
+            assert (len(records) != 0)
+
+            producer.begin_transaction()
+
+            for record in records:
+                assert (record.error() == None)
+                producer.produce(self.output_t.name, record.value(),
+                                 record.key(), 0)
+
+            producer.send_offsets_to_transaction(
+                consumer.position(consumer.assignment()),
+                consumer.consumer_group_metadata())
+
+            producer.commit_transaction()
+
+            num_consumed_records += consume_for_one_it
+
+        consumer = ck.Consumer({
+            'group.id': "testtest",
+            'bootstrap.servers': self.redpanda.brokers(),
+            'auto.offset.reset': 'earliest',
+        })
+        consumer.subscribe([self.output_t])
+
+        final_consume_cnt = 0
+        while True:
+            record = consumer.poll(consume_for_one_it)
+            if record is None:
+                break
+
+            expected = bytes(str(final_consume_cnt), 'UTF-8')
+            assert (record.key() == expected)
+            assert (record.value() == expected)
+            final_consume_cnt += 1
+
+        assert (final_consume_cnt == self.max_records)
+
+    @cluster(num_nodes=3)
+    def rejoin_member_test(self):
+        self.generate_data(self.input_t, self.max_records)
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        })
+
+        group_name = "test"
+        consumer1 = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        producer.init_transactions()
+
+        consumer1.subscribe([self.input_t])
+        records = consumer1.consume(10)
+        assert (len(records) != 0)
+
+        producer.begin_transaction()
+
+        for record in records:
+            assert (record.error() == None)
+            producer.produce(self.output_t.name, record.value(), record.key(),
+                             0)
+
+        offsets = consumer1.position(consumer1.assignment())
+        metadata = consumer1.consumer_group_metadata()
+
+        consumer2 = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        consumer2.subscribe([self.input_t])
+        records = consumer2.consume(10)
+
+        try:
+            producer.send_offsets_to_transaction(offsets, metadata, 2)
+        except ck.cimpl.KafkaException as e:
+            kafka_error = e.args[0]
+            assert kafka_error.code() == ck.cimpl.KafkaError.UNKNOWN_MEMBER_ID
+
+        producer.abort_transaction()
+
+    @cluster(num_nodes=3)
+    def change_static_member_test(self):
+        self.generate_data(self.input_t, self.max_records)
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        })
+
+        group_name = "test"
+        static_group_id = "123"
+        consumer1 = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'group.instance.id': static_group_id,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        producer.init_transactions()
+
+        consumer1.subscribe([self.input_t])
+        records = consumer1.consume(10)
+        assert (len(records) != 0)
+
+        producer.begin_transaction()
+
+        for record in records:
+            assert (record.error() == None)
+            producer.produce(self.output_t.name, record.value(), record.key(),
+                             0)
+
+        offsets = consumer1.position(consumer1.assignment())
+        metadata = consumer1.consumer_group_metadata()
+
+        consumer2 = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'group.instance.id': static_group_id,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        consumer2.subscribe([self.input_t])
+        records = consumer2.consume(10)
+
+        try:
+            producer.send_offsets_to_transaction(offsets, metadata, 2)
+        except ck.cimpl.KafkaException as e:
+            kafka_error = e.args[0]
+            assert kafka_error.code() == ck.cimpl.KafkaError.FENCED_INSTANCE_ID
+
+        producer.abort_transaction()


### PR DESCRIPTION
## Cover letter

[RFC](https://github.com/redpanda-data/redpanda/issues/3279#issuecomment-1159801754)

## What
Exactly once semantics (EOS) provides transactional message processing guarantees. Producers can write to multiple partitions atomically so that either all writes succeed or all writes fail. This can be used in the context of stream processing frameworks, such as Kafka Streams, to ensure exactly once processing between topics.

Before this kip transactional producer did not know anything about consumer groups. We can have some problems if ownership of partition will be transfer between consumers, Before this kip this problem can be solved by producer per partition. But this way does not scale.

## Improvement
There are 2 main problems
### Fence Zombie
A zombie process may invoke InitProducerId after falling out of the consumer group. In order to distinguish zombie requests, we need to leverage group coordinator to fence out of sync client. To get info about consumer group lafla consumer has method `ConsumerGroupMetadata`. So we need to pass this information inside `TxnOffsetCommitRequest`. And check in redpanda did consumer group change and producer is zombie, or not.
```
TxnOffsetCommitRequest => TransactionalId GroupId ProducerId ProducerEpoch Offsets GenerationId
  TransactionalId     => String
  GroupId             => String
  ProducerId          => int64      
  ProducerEpoch       => int16
  GenerationId        => int32, default -1 // NEW
  MemberId            => nullable String // NEW
  GroupInstanceId     => nullable String // NEW
  Offsets             => Map<TopicPartition, CommittedOffset>
```

Some important notes:

- User must be utilizing both consumer and producer as a complete EOS application,
- User needs to store transactional offsets inside Kafka group coordinator, not in any other external system for the sake of fencing,
- Producer needs to call sendOffsetsToTransaction(offsets, groupMetadata) to be able to fence properly

### Offset Fetch Request 
Consumers should wait pending transaction in `OffsetFetchRequest` for EOS semantic. So this kip added new error for this case
```
unstable_offset_commit = 88
```

In the meantime, this offset fetch back-off should be only applied to EOS use cases, not general offset fetch use case such as admin client access. We shall also define a flag within offset fetch request so that we only trigger back-off logic when the request is involved in EOS, I.E on isolation level read_committed.

```
OffsetFetchRequest => Partitions GroupId WaitTransaction
  Partitions          => List<TopicPartition>
  GroupId             => String
  WaitTransaction     => Boolean // NEW
```

Fixes #3279 

## Release notes
* Implement KIP-447. In EOS transaction producer can work with consumer groups. 