### PR TITLE
Minimal primary metrics endpoint

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -57,6 +57,7 @@ v_cc_library(
     partition_leaders_table.cc
     topics_frontend.cc
     controller_backend.cc
+    controller_probe.cc
     controller.cc
     partition.cc
     partition_probe.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -71,7 +71,8 @@ controller::controller(
   , _data_policy_manager(data_policy_table)
   , _raft_manager(raft_manager)
   , _feature_table(feature_table)
-  , _cloud_storage_api(cloud_storage_api) {}
+  , _cloud_storage_api(cloud_storage_api)
+  , _probe(*this) {}
 
 ss::future<> controller::wire_up() {
     return _as.start()

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/controller_probe.h"
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/scheduling/leader_balancer.h"
@@ -115,6 +116,9 @@ public:
     ss::future<> stop();
 
 private:
+    friend controller_probe;
+
+private:
     config_manager::preload_result _config_preload;
 
     ss::sharded<ss::abort_source> _as;                     // instance per core
@@ -157,6 +161,7 @@ private:
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+    controller_probe _probe;
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/controller_probe.h"
+
+#include "cluster/controller.h"
+#include "cluster/members_table.h"
+#include "cluster/partition_leaders_table.h"
+#include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
+
+#include <seastar/core/metrics.hh>
+
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster {
+
+controller_probe::controller_probe(controller& c) noexcept
+  : _controller(c) {
+    _controller._raft_manager.local().register_leadership_notification(
+      [this](
+        raft::group_id group,
+        model::term_id /*term*/,
+        std::optional<model::node_id> leader_id) {
+          // We are only interested in notifications regarding the controller
+          // group.
+          if (_controller._raft0->group() != group) {
+              return;
+          }
+
+          if (leader_id != _controller.self()) {
+              _public_metrics.reset();
+          } else {
+              setup_metrics();
+          }
+      });
+}
+
+void controller_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    _public_metrics = std::make_unique<ss::metrics::metric_groups>(
+      ssx::metrics::public_metrics_handle);
+    _public_metrics->add_group(
+      prometheus_sanitize::metrics_name("cluster"),
+      {
+        sm::make_gauge(
+          "brokers",
+          [this] {
+              const auto& members_table
+                = _controller.get_members_table().local();
+              return members_table.all_brokers_count();
+          },
+          sm::description("Number of configured brokers in the cluster"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "topics",
+          [this] {
+              const auto& topic_table = _controller.get_topics_state().local();
+              return topic_table.all_topics_count();
+          },
+          sm::description("Number of topics in the cluster"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "partitions",
+          [this] {
+              const auto& leaders_table
+                = _controller._partition_leaders.local();
+
+              auto partitions_count = 0;
+              leaders_table.for_each_leader(
+                [&partitions_count](auto&&...) { ++partitions_count; });
+
+              return partitions_count;
+          },
+          sm::description(
+            "Number of partitions in the cluster (replicas not included)"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "unavailable_partitions",
+          [this] {
+              const auto& leaders_table
+                = _controller._partition_leaders.local();
+              auto unavailable_partitions_count = 0;
+
+              leaders_table.for_each_leader([&unavailable_partitions_count](
+                                              const auto& /*tp_ns*/,
+                                              auto /*pid*/,
+                                              auto leader,
+                                              auto /*term*/) {
+                  if (!leader.has_value()) {
+                      ++unavailable_partitions_count;
+                  }
+              });
+
+              return unavailable_partitions_count;
+          },
+          sm::description(
+            "Number of partitions that lack quorum among replicants"))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/controller_probe.h
+++ b/src/v/cluster/controller_probe.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "seastarx.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace cluster {
+
+class controller_probe {
+public:
+    explicit controller_probe(cluster::controller&) noexcept;
+
+    void setup_metrics();
+
+private:
+    cluster::controller& _controller;
+    std::unique_ptr<ss::metrics::metric_groups> _public_metrics;
+};
+
+} // namespace cluster

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -32,6 +32,14 @@ std::vector<broker_ptr> members_table::all_brokers() const {
 
     return brokers;
 }
+
+size_t members_table::all_brokers_count() const {
+    return std::count_if(_brokers.begin(), _brokers.end(), [](auto entry) {
+        return entry.second->get_membership_state()
+               != model::membership_state::removed;
+    });
+}
+
 std::vector<model::node_id> members_table::all_broker_ids() const {
     std::vector<model::node_id> ids;
     ids.reserve(_brokers.size());

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -29,6 +29,8 @@ public:
 
     std::vector<broker_ptr> all_brokers() const;
 
+    size_t all_brokers_count() const;
+
     std::vector<model::node_id> all_broker_ids() const;
 
     /// Returns single broker if exists in cache

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -69,12 +69,17 @@ public:
     void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
 
 private:
+    void setup_public_metrics(const model::ntp&);
+    void setup_internal_metrics(const model::ntp&);
+
+private:
     const partition& _partition;
     uint64_t _records_produced{0};
     uint64_t _records_fetched{0};
     uint64_t _bytes_produced{0};
     uint64_t _bytes_fetched{0};
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 partition_probe make_materialized_partition_probe();

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -53,7 +53,12 @@ public:
       : _sgroups(create_scheduling_groups())
       , _group_deleter([this] { _sgroups.destroy_groups().get(); })
       , _base_dir("cluster_test." + random_generators::gen_alphanum_string(6)) {
+        // Disable all metrics to guard against double_registration errors
+        // thrown by seastar. These are simulated nodes which use the same
+        // internal metrics implementation, so the usual metrics registration
+        // process won't work.
         set_configuration("disable_metrics", true);
+        set_configuration("disable_public_metrics", true);
     }
 
     virtual ~cluster_test_fixture() {

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -628,6 +628,8 @@ std::vector<model::topic_namespace> topic_table::all_topics() const {
       [](const topic_metadata& tp) { return tp.get_configuration().tp_ns; });
 }
 
+size_t topic_table::all_topics_count() const { return _topics.size(); }
+
 std::optional<topic_metadata>
 topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -125,6 +125,9 @@ public:
     /// Returns list of all topics that exists in the cluster.
     std::vector<model::topic_namespace> all_topics() const;
 
+    // Returns the number of topics that exist in the cluster.
+    size_t all_topics_count() const;
+
     ///\brief Returns metadata of single topic.
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -238,7 +238,15 @@ configuration::configuration()
   , disable_metrics(
       *this,
       "disable_metrics",
-      "Disable registering metrics",
+      "Disable registering metrics exposed on the internal metrics endpoint "
+      "(/metrics)",
+      base_property::metadata{},
+      false)
+  , disable_public_metrics(
+      *this,
+      "disable_public_metrics",
+      "Disable registering metrics exposed on the public metrics endpoint "
+      "(/public_metrics)",
       base_property::metadata{},
       false)
   , aggregate_metrics(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -82,6 +82,7 @@ struct configuration final : public config_store {
     bounded_property<uint32_t> target_quota_byte_rate;
     property<std::optional<ss::sstring>> cluster_id;
     property<bool> disable_metrics;
+    property<bool> disable_public_metrics;
     property<bool> aggregate_metrics;
     property<std::chrono::milliseconds> group_min_session_timeout_ms;
     property<std::chrono::milliseconds> group_max_session_timeout_ms;

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -20,12 +20,14 @@ namespace pandaproxy {
 
 class probe {
 public:
-    probe(ss::httpd::path_description& path_desc);
+    probe(
+      ss::httpd::path_description& path_desc, const ss::sstring& group_name);
     hdr_hist& hist() { return _request_hist; }
 
 private:
     hdr_hist _request_hist;
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -70,6 +70,7 @@ proxy::proxy(
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(
       "pandaproxy",
+      "rest_proxy",
       ss::api_registry_builder20(_config.api_doc_dir(), "/v1"),
       "header",
       "/definitions",

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -224,7 +224,8 @@ service::service(
   , _client(client)
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(
-      "schema_registry",
+      "schema_registry", // server_name
+      "schema_registry", // public_metric_group_name
       ss::api_registry_builder20(_config.api_doc_dir(), "/v1"),
       "schema_registry_header",
       "/schema_registry_definitions",

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -69,11 +69,12 @@ struct handler_adaptor : ss::httpd::handler_base {
       ss::gate& pending_requests,
       server::context_t& ctx,
       server::function_handler&& handler,
-      ss::httpd::path_description& path_desc)
+      ss::httpd::path_description& path_desc,
+      const ss::sstring& metrics_group_name)
       : _pending_requests(pending_requests)
       , _ctx(ctx)
       , _handler(std::move(handler))
-      , _probe(path_desc) {}
+      , _probe(path_desc, metrics_group_name) {}
 
     ss::future<std::unique_ptr<ss::reply>> handle(
       const ss::sstring&,
@@ -116,11 +117,13 @@ struct handler_adaptor : ss::httpd::handler_base {
 
 server::server(
   const ss::sstring& server_name,
+  const ss::sstring& public_metrics_group_name,
   ss::api_registry_builder20&& api20,
   const ss::sstring& header,
   const ss::sstring& definitions,
   context_t& ctx)
   : _server(server_name)
+  , _public_metrics_group_name(public_metrics_group_name)
   , _pending_reqs()
   , _api20(std::move(api20))
   , _has_routes(false)
@@ -137,7 +140,11 @@ void server::route(server::route_t r) {
     // NOTE: this pointer will be owned by data member _routes of
     // ss::httpd:server. seastar didn't use any unique ptr to express that.
     auto* handler = new handler_adaptor(
-      _pending_reqs, _ctx, std::move(r.handler), r.path_desc);
+      _pending_reqs,
+      _ctx,
+      std::move(r.handler),
+      r.path_desc,
+      _public_metrics_group_name);
     r.path_desc.set(_server._routes, handler);
 }
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -80,6 +80,7 @@ public:
 
     server(
       const ss::sstring& server_name,
+      const ss::sstring& public_metrics_group_name,
       ss::api_registry_builder20&& api20,
       const ss::sstring& header,
       const ss::sstring& definitions,
@@ -97,6 +98,7 @@ public:
 
 private:
     ss::httpd::http_server _server;
+    ss::sstring _public_metrics_group_name;
     ss::gate _pending_reqs;
     ss::api_registry_builder20 _api20;
     bool _has_routes;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3182,6 +3182,10 @@ consensus::get_follower_metrics(model::node_id id) const {
       it->second);
 }
 
+size_t consensus::get_follower_count() const {
+    return is_elected_leader() ? _fstats.size() : 0;
+}
+
 ss::future<std::optional<storage::timequery_result>>
 consensus::timequery(storage::timequery_config cfg) {
     return _log.timequery(cfg).then(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -338,6 +338,7 @@ public:
 
     std::vector<follower_metrics> get_follower_metrics() const;
     result<follower_metrics> get_follower_metrics(model::node_id) const;
+    size_t get_follower_count() const;
     bool has_followers() const { return _fstats.size() > 0; }
 
     offset_monitor& visible_offset_monitor() {

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -170,6 +170,7 @@ public:
             config.get("join_retry_timeout_ms").set_value(100ms);
             config.get("members_backend_retry_ms").set_value(1000ms);
             config.get("disable_metrics").set_value(true);
+            config.get("disable_public_metrics").set_value(true);
 
             auto& node_config = config::node();
             node_config.get("admin").set_value(

--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
     ssx
   HDRS
     "future-util.h"
+    "metrics.h"
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "utils/hdr_hist.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace ssx::metrics {
+
+// The seastar metrics handle to be used for the '/public_metrics' prometheus
+// endpoint.
+const auto public_metrics_handle = seastar::metrics::default_handle() + 1;
+
+// Convert an HDR histogram to a seastar histogram for reporting.
+// Entries with values ranging form 250 microseconds to 1 minute are
+// grouped in 18 buckets of exponentially increasing size.
+inline ss::metrics::histogram report_default_histogram(const hdr_hist& hist) {
+    static constexpr size_t num_buckets = 18;
+    static constexpr size_t first_value = 250;
+    static constexpr double log_base = 2.0;
+    static constexpr int64_t scale = 1000000;
+
+    return hist.seastar_histogram_logform(
+      num_buckets, first_value, log_base, scale);
+}
+
+} // namespace ssx::metrics

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -141,7 +141,11 @@ public:
     double stddev() const;
     double mean() const;
     size_t memory_size() const;
-    ss::metrics::histogram seastar_histogram_logform() const;
+    ss::metrics::histogram seastar_histogram_logform(
+      size_t num_buckets = 26,
+      int64_t first_value = 10,
+      double log_base = 2.0,
+      int64_t scale = 1) const;
 
     std::unique_ptr<measurement> auto_measure();
 

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -1,0 +1,208 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import re
+
+from typing import Optional
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster import ClusterNode
+
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.metrics_check import MetricCheck
+from rptest.services.redpanda import MetricSamples, MetricsEndpoint
+
+
+class ClusterMetricsTest(RedpandaTest):
+    cluster_level_metrics: list[str] = [
+        "cluster_brokers",
+        "cluster_topics",
+        "cluster_partitions",
+        "cluster_unavailable_partitions",
+    ]
+
+    def _stop_controller_node(self) -> ClusterNode:
+        """
+        Stop the current controller node
+        """
+        prev = self.redpanda.controller()
+        self.redpanda.stop_node(prev)
+
+        return prev
+
+    def _wait_until_controller_leader_is_stable(self):
+        """
+        Wait for the controller leader to stabilise.
+        This helper considers the leader stable if the same node
+        is reported by two consecutive admin API queries.
+        """
+        prev = None
+
+        def controller_stable():
+            nonlocal prev
+            curr = self.redpanda.controller()
+
+            if prev != curr:
+                prev = curr
+                return False
+            else:
+                return True
+
+        wait_until(
+            controller_stable,
+            timeout_sec=10,
+            backoff_sec=2,
+            err_msg="Controller leader did not stabilise",
+        )
+
+    def _failover(self):
+        """
+        Stop current controller node and wait for failover
+        """
+        prev = self._stop_controller_node()
+
+        def new_controller_elected():
+            curr = self.redpanda.controller()
+            return curr and curr != prev
+
+        wait_until(
+            new_controller_elected,
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg="Controller did not failover",
+        )
+
+        return prev
+
+    def _get_value_from_samples(self, samples: MetricSamples):
+        """
+        Extract the metric value from the samples.
+        Only one sample is expected as cluster level metrics have no labels.
+        """
+        assert len(samples.samples) == 1
+        return samples.samples[0].value
+
+    def _get_cluster_metrics(
+            self, node: ClusterNode) -> Optional[dict[str, MetricSamples]]:
+        """
+        Get all the cluster level metrics exposed by a specified
+        node in the cluster.
+        """
+        def get_metrics_from_node(pattern: str):
+            return self.redpanda.metrics_sample(pattern, [node],
+                                                MetricsEndpoint.PUBLIC_METRICS)
+
+        metrics_samples = {}
+        for name in ClusterMetricsTest.cluster_level_metrics:
+            samples = get_metrics_from_node(name)
+            if samples is not None:
+                metrics_samples[name] = samples
+
+        if not metrics_samples:
+            return None
+        else:
+            return metrics_samples
+
+    def _assert_reported_by_controller(self):
+        """
+        Enforce the fact that only the controller leader should
+        report cluster level metrics. If there's no leader, no
+        node should report these metrics.
+        """
+        current_controller = self.redpanda.controller()
+        for node in self.redpanda.started_nodes():
+            metrics = self._get_cluster_metrics(node)
+
+            if current_controller is None:
+                assert (
+                    metrics is None
+                ), f"Node {node.name} reported cluster metrics, but the cluster has no leader"
+            elif current_controller == node:
+                assert (
+                    metrics is not None
+                ), f"Node {node.name} is controller leader, but did not report cluster metrics"
+            else:
+                assert (
+                    metrics is None
+                ), f"Node {node.name} is not controller leader, but it reported cluster metrics"
+
+    @cluster(num_nodes=3)
+    def cluster_metrics_reported_only_by_leader_test(self):
+        """
+        Test that only the controller leader reports the cluster
+        level metrics at any given time.
+        """
+        # Assert metrics are reported once in a fresh, three node cluster
+        self._assert_reported_by_controller()
+
+        # Restart the controller node and assert.
+        controller = self.redpanda.controller()
+        self.redpanda.restart_nodes([controller],
+                                    start_timeout=10,
+                                    stop_timeout=10)
+        self._wait_until_controller_leader_is_stable()
+        self._assert_reported_by_controller()
+
+        # Stop the controller node and assert.
+        self._failover()
+        self._assert_reported_by_controller()
+
+        # Stop the controller node and assert again.
+        # This time the metrics should not be reported as a controller
+        # couldn't be elected due to lack of quorum.
+        self._stop_controller_node()
+        self._assert_reported_by_controller()
+
+    @cluster(num_nodes=3)
+    def cluster_metrics_correctness_test(self):
+        """
+        Test that the cluster level metrics move in the expected way
+        after creating a topic.
+        """
+        self._assert_reported_by_controller()
+
+        controller_node = self.redpanda.controller()
+        cluster_metrics = MetricCheck(
+            self.logger,
+            self.redpanda,
+            controller_node,
+            re.compile("redpanda_cluster_.*"),
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+
+        RpkTool(self.redpanda).create_topic("test-topic", partitions=3)
+
+        # Check that the metrics have moved in the expected way by the creation
+        # of one topic with three partitions.
+        cluster_metrics.expect([
+            ("redpanda_cluster_brokers", lambda a, b: a == b == 3),
+            ("redpanda_cluster_topics", lambda a, b: b - a == 1),
+            ("redpanda_cluster_partitions", lambda a, b: b - a == 3),
+            ("redpanda_cluster_unavailable_partitions",
+             lambda a, b: a == b == 0)
+        ])
+
+    @cluster(num_nodes=3)
+    def cluster_metrics_disabled_by_config_test(self):
+        """
+        Test that the cluster level metrics have the expected values
+        before and after creating a topic.
+        """
+        # 'disable_public_metrics' defaults to false so cluster metrics
+        # are expected
+        self._assert_reported_by_controller()
+
+        self.redpanda.set_cluster_config({"disable_public_metrics": "true"},
+                                         expect_restart=True)
+
+        # The 'public_metrics' endpoint that serves cluster level
+        # metrics should not return anything when
+        # 'disable_public_metrics' == true
+        cluster_metrics = self._get_cluster_metrics(self.redpanda.controller())
+        assert cluster_metrics is None


### PR DESCRIPTION
## Cover letter

Currently, Redpanda exposes its full set of metrics in Prometheus format on the `/metrics` endpoint.
A large number of metrics are exposed on this endpoint (e.g. 6275 for a broker with no user topics
added), many of which are only useful to someone with context regarding the inner working of
Redpanda.

To address the, issues with the `/metrics` endpoint, this set of patches adds a new endpoint
lower in cardinality which is meant for external and internal users that don't require such a
high level of granularity.

A list of the metrics that have been added to the new endpoint (exposed on `/public_metrics`)
can be found below.

#### Partition Level Metrics:
* redpanda_kafka_max_offset:
    * Description: latest committed offset for the partition (i.e. the
    offset of the last message safely persisted on most replicas)
    * Labels: namespace, topic, partition, shard
    * Aggregation: shard
* redpanda_kafka_under_replicated_replicas:
    * Description: the number of under replicated replicas for the
      partition
    * Labels: namespace, topic, partition, shard
    * Aggregation: shard

#### Topic Level Metrics:
* redpanda_kafka_request_bytes_total:
    * Description: total number of bytes consumed/produced per topic
    * Labels: namespace, topic, partition,
    request ("produce" | "consume")
    * Aggregation: shard, partition
* redpanda_kafka_replicas:
    * Description: number of configured replicas per topic
    * Labels: namespace, topic, partition
    * Aggregation: shard, partition

#### Broker Level Metrics:
* redpanda_kafka_request_latency_seconds:
    * Description: latency of produce/consume requests per broker
    (measures from the moment a request is initiated on the partition to
    the moment when the response is fulfilled)
    * Labels: shard
    * Aggregation: shard
    
For a few desirable metrics, the decision was made to obtain them
by aggregating in PromQL in order to reduce the amount of work performed on scrapes:
* redpanda_partitions_underreplicated - cluster level
* redpanda_kafka_write_bytes - broker level
* redpanda_kafka_read_bytes - broker level
* redpanda_topic_partitions - topic level

[force push](https://github.com/redpanda-data/redpanda/compare/c4598928897a8da7122ff6253eb9754069e08441..61fa8131e1acd8ea64f4198b04c669fd00920c97):
* use sm::label for specifying the aggregation labels (required due to change in seastar https://github.com/redpanda-data/seastar/pull/26)

[force push](https://github.com/redpanda-data/redpanda/compare/61fa8131e1acd8ea64f4198b04c669fd00920c97..59dc00918964222adc282c5563357eb67f85bca9):
* update the metric creation calls to match the changes in seastar ([PR](https://github.com/redpanda-data/seastar/pull/26))
* optimise metric reporting by using `for_each_leader` and by introducing utility function
* rename the new metrics endpoint to `/public_metrics`
* abstract common metric utilities in the `ssx/metrics.h` header
* tweak commit messages

[force-push](https://github.com/redpanda-data/redpanda/compare/bb55bf4f26364c3b100ded8999a789ffac2a0a75..2ae501fee93165b0d318560809111bed478fbc37)
* Git rebase with intermediate clang-format

[force push](https://github.com/redpanda-data/redpanda/compare/2ae501fee93165b0d318560809111bed478fbc37..aacbd93241afcc73031656e6a62c2461befeb1d9):
* Elaborate metric descriptions

[force push](https://github.com/redpanda-data/redpanda/compare/aacbd93241afcc73031656e6a62c2461befeb1d9..6f9d222eb306f580a59c96641449454f96d22b22):
* Made the `disable_metrics` config option disable only the `/metrics` endpoint metrics
* Added a new config option, `disable_public_metrics` to disable registering metrics on
the `/public_metrics` endpoint.
* Made pandaproxy publish its metrics under the `rest_proxy` name for the `public_metrics`
endpoint. Nothing changes for the `metrics` endpoint.
* Nested the metrics utils in `ssx` in a namespace: `ssx::metrics`.
* Added test for cluster level metrics

[force push](https://github.com/redpanda-data/redpanda/compare/6f9d222eb306f580a59c96641449454f96d22b22..76d85451ff5ae300569dd1b7bc30a2331db06d2d):
* Rebase to fix conflicts

[force push](https://github.com/redpanda-data/redpanda/compare/76d85451ff5ae300569dd1b7bc30a2331db06d2d..2748eb7dd21ea36a73c20aa51e3eff15451f1e42):
* Reformat python with yapf

[force push](https://github.com/redpanda-data/redpanda/compare/76d85451ff5ae300569dd1b7bc30a2331db06d2d..2748eb7dd21ea36a73c20aa51e3eff15451f1e42):
* Disable public metrics for redpanda fixtures used in cluster tests.

[force push](https://github.com/redpanda-data/redpanda/compare/005794d780a8a64f15a3a1cec776c42125c96ab1..910ea7716d5475f1faacd933c3086ec214f76867):
* Changed the added tests to check the metrics delta instead of reported values. Also addressed a few nits.

[force push](https://github.com/redpanda-data/redpanda/compare/910ea7716d5475f1faacd933c3086ec214f76867..66e8f575ea758f7db515e6c302f04d5ebd7393e7):
* Rebase on dev

[force push](https://github.com/redpanda-data/redpanda/compare/66e8f575ea758f7db515e6c302f04d5ebd7393e7..c71b09a8e12ecff6f1e032bf88962434502a122d):
* Fixed test failure caused by throwing on offset translation failure.

[force push](https://github.com/redpanda-data/redpanda/compare/c71b09a8e12ecff6f1e032bf88962434502a122d..334d5c5d48ea2f20526ad1516a1a99c94de98c2a):
* squashed stray commit

## Release notes

### Features
* Redpanda now has a new metrics endpoint, `/public_metrics`, that exposes a small set of
well curated metrics. See the documentation for the full list of published metrics. The `disable_public_metrics`
configuration option disables registering metrics for the `/public_metrics` endpoint. The older `disable_metrics`
configuration option skips registration of metrics for the `/metrics` endpoint.

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features
Redpanda now has a new metrics endpoint, `/public_metrics` that exposes a small set of
well curated metrics. See the documentation for the full list of published metrics.

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->