### PR TITLE
cluster: use remote revision id for read replicas

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1037,8 +1037,10 @@ ss::future<std::error_code> controller_backend::create_partition(
     auto f = ss::now();
     // handle partially created topic
     auto partition = _partition_manager.local().get(ntp);
+
     // initial revision of the partition on the moment when it was created
     // the value is used by shadow indexing
+    // if topic is read replica, the value from remote topic manifest is used
     auto initial_rev = _topics.local().get_initial_revision(ntp);
     if (!initial_rev) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -303,21 +303,26 @@ cluster::assignments_set to_assignments_map(
 } // namespace
 
 topic_metadata::topic_metadata(
-  topic_configuration_assignment c, model::revision_id rid) noexcept
+  topic_configuration_assignment c,
+  model::revision_id rid,
+  std::optional<model::initial_revision_id> remote_revision_id) noexcept
   : _configuration(std::move(c.cfg))
   , _assignments(to_assignments_map(std::move(c.assignments)))
   , _source_topic(std::nullopt)
-  , _revision(rid) {}
+  , _revision(rid)
+  , _remote_revision(remote_revision_id) {}
 
 topic_metadata::topic_metadata(
   topic_configuration cfg,
   assignments_set assignments,
   model::revision_id rid,
-  model::topic st) noexcept
+  model::topic st,
+  std::optional<model::initial_revision_id> remote_revision_id) noexcept
   : _configuration(std::move(cfg))
   , _assignments(std::move(assignments))
   , _source_topic(st)
-  , _revision(rid) {}
+  , _revision(rid)
+  , _remote_revision(remote_revision_id) {}
 
 bool topic_metadata::is_topic_replicable() const {
     return _source_topic.has_value() == false;
@@ -327,6 +332,13 @@ model::revision_id topic_metadata::get_revision() const {
     vassert(
       is_topic_replicable(), "Query for revision_id on a non-replicable topic");
     return _revision;
+}
+
+std::optional<model::initial_revision_id>
+topic_metadata::get_remote_revision() const {
+    vassert(
+      is_topic_replicable(), "Query for revision_id on a non-replicable topic");
+    return _remote_revision;
 }
 
 const model::topic& topic_metadata::get_source_topic() const {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1692,16 +1692,21 @@ using assignments_set
 
 class topic_metadata {
 public:
-    topic_metadata(topic_configuration_assignment, model::revision_id) noexcept;
+    topic_metadata(
+      topic_configuration_assignment,
+      model::revision_id,
+      std::optional<model::initial_revision_id> = std::nullopt) noexcept;
 
     topic_metadata(
       topic_configuration,
       assignments_set,
       model::revision_id,
-      model::topic) noexcept;
+      model::topic,
+      std::optional<model::initial_revision_id> = std::nullopt) noexcept;
 
     bool is_topic_replicable() const;
     model::revision_id get_revision() const;
+    std::optional<model::initial_revision_id> get_remote_revision() const;
     const model::topic& get_source_topic() const;
 
     const topic_configuration& get_configuration() const;
@@ -1715,6 +1720,7 @@ private:
     assignments_set _assignments;
     std::optional<model::topic> _source_topic;
     model::revision_id _revision;
+    std::optional<model::initial_revision_id> _remote_revision;
 };
 
 } // namespace cluster


### PR DESCRIPTION
## Cover letter

Shadow indexing uses stable s3 paths. Revision id is a part of a log path, but revision id is incremented with every partition movement. In order to use stable path, s3 paths use initial revision id -- revision id of when partition was created.

Read replica topics have their own revisiod id, but they need to know initial revision id of original topic in order to download logs from s3. This PR adds remote revision id to topic metadata, that is stored in topic table. Also for read replica remote initial revision id is used to download logs from s3.

Previous Pr that sets remote revision id and remote partition count is https://github.com/redpanda-data/redpanda/pull/5048.
Using remote partition count will come in the next PR. 

Context: https://github.com/redpanda-data/redpanda/issues/4993

## Release notes
* none
