### PR TITLE
docker-compose: constrain limits of docker resources

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -38,6 +38,12 @@ services:
     - redpanda-test
   rp:
     image: vectorized/redpanda-test-node
+    deploy:
+      resources:
+        limits:
+          cpus: '0.75'
+        reservations:
+          cpus: '1'
     privileged: true
     pids_limit: 32768
     ulimits:


### PR DESCRIPTION
## Cover letter

redpanda-test containers should use 1 cpu each. This
way we contrain cpu usage to 1, increasing performance
and isolating host resources per container

## Release notes

* none

fixes: https://github.com/redpanda-data/devprod/issues/300