### PR TITLE
k/group_router: pass func to sharded<>::invoke_on() directly

### DIFF
--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -34,10 +34,7 @@ auto group_router::route(Request&& r, FwdFunc func) {
     r.ntp = std::move(m->first);
     return with_scheduling_group(
       _sg, [this, func, shard = m->second, r = std::move(r)]() mutable {
-          return get_group_manager().invoke_on(
-            shard, _ssg, [func, r = std::move(r)](group_manager& mgr) mutable {
-                return std::invoke(func, mgr, std::move(r));
-            });
+          return get_group_manager().invoke_on(shard, _ssg, func, std::move(r));
       });
 }
 
@@ -63,10 +60,7 @@ auto group_router::route_tx(Request&& r, FwdFunc func) {
     r.ntp = std::move(m->first);
     return with_scheduling_group(
       _sg, [this, func, shard = m->second, r = std::move(r)]() mutable {
-          return get_group_manager().invoke_on(
-            shard, _ssg, [func, r = std::move(r)](group_manager& mgr) mutable {
-                return std::invoke(func, mgr, std::move(r));
-            });
+          return get_group_manager().invoke_on(shard, _ssg, func, std::move(r));
       });
 }
 


### PR DESCRIPTION
just pass func to sharded<>::invoke_on() without using a wrapper
around it, more performant and more readable this way.

since `func` passed in are always function pointers, there is no
need to std::forward<> or std::move() them.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
