### PR TITLE
Data retention in the cloud

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -450,7 +450,7 @@ static ss::future<upload_candidate> create_upload_candidate(
     co_return result;
 }
 
-ss::future<upload_candidate> archival_policy::get_next_candidate(
+ss::future<upload_candidate> archival_policy::get_next_upload_candidate(
   model::offset begin_inclusive,
   model::offset end_exclusive,
   storage::log log,

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -54,7 +54,7 @@ public:
     /// \param end_exclusive is an exclusive end of the range
     /// \param lm is a log manager
     /// \return initializd struct on success, empty struct on failure
-    ss::future<upload_candidate> get_next_candidate(
+    ss::future<upload_candidate> get_next_upload_candidate(
       model::offset begin_inclusive,
       model::offset end_exclusive,
       storage::log,

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -248,7 +248,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
         co_return scheduled_upload{.stop = ss::stop_iteration::yes};
     }
 
-    auto upload = co_await _policy.get_next_candidate(
+    auto upload = co_await _policy.get_next_upload_candidate(
       start_upload_offset,
       last_stable_offset,
       *log,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -114,6 +114,10 @@ public:
 
     uint64_t estimate_backlog_size();
 
+    /// \brief Probe remote storage and truncate the manifest if needed
+    ss::future<std::optional<cloud_storage::partition_manifest>>
+    maybe_truncate_manifest(retry_chain_node& rtc);
+
 private:
     /// Information about started upload
     struct scheduled_upload {

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -244,6 +244,7 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
 
               _archivers.emplace(archiver->get_ntp(), archiver);
               archiver->run_upload_loop();
+              archiver->run_retention_loop();
 
               return ss::now();
           case cloud_storage::download_result::notfound:
@@ -264,6 +265,7 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
 
               _archivers.emplace(archiver->get_ntp(), archiver);
               archiver->run_upload_loop();
+              archiver->run_retention_loop();
 
               return ss::now();
           case cloud_storage::download_result::failed:

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -381,4 +381,12 @@ uint64_t scheduler_service_impl::estimate_backlog_size() {
     return size;
 }
 
+ss::future<std::optional<cloud_storage::partition_manifest>>
+scheduler_service_impl::maybe_truncate_manifest(const model::ntp& ntp) {
+    if (auto it = _archivers.find(ntp); it != _archivers.end()) {
+        co_return co_await it->second->maybe_truncate_manifest(_rtcnode);
+    }
+    co_return std::nullopt;
+}
+
 } // namespace archival::internal

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -108,6 +108,11 @@ public:
     /// Total size of data that have to be uploaded
     uint64_t estimate_backlog_size();
 
+    /// Invoke syncup procedure for ntp (check if segments are missing and
+    /// truncate)
+    ss::future<std::optional<cloud_storage::partition_manifest>>
+    maybe_truncate_manifest(const model::ntp& ntp);
+
 private:
     /// Remove archivers from the workingset
     ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
@@ -168,6 +173,9 @@ public:
 
     /// Estimate total size of the upload backlog
     using internal::scheduler_service_impl::estimate_backlog_size;
+
+    /// Truncate manifest if needed
+    using internal::scheduler_service_impl::maybe_truncate_manifest;
 };
 
 } // namespace archival

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -221,7 +221,8 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     model::offset start_offset;
 
     start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
-    auto upload2 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload2
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -230,7 +231,8 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
     start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
-    auto upload3 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload3
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -239,11 +241,13 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
     start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
-    auto upload4 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload4
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 
     start_offset = lso + model::offset(1);
-    auto upload5 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload5
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload5.source.get() == nullptr);
 }
 
@@ -748,13 +752,15 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     model::offset start_offset{0};
     model::offset lso{9999};
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload1
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
     start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
-    auto upload2 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload2
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset == offset2);
@@ -763,7 +769,8 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
     start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
-    auto upload3 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload3
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset == offset3);
@@ -772,6 +779,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
     start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
-    auto upload4 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
+    auto upload4
+      = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 }

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -213,7 +213,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
 
     // Starting offset is lower than offset1
     auto upload1
-      = policy.get_next_candidate(model::offset(0), lso, *log, tr).get();
+      = policy.get_next_upload_candidate(model::offset(0), lso, *log, tr).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
@@ -221,7 +221,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     model::offset start_offset;
 
     start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
-    auto upload2 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload2 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -230,7 +230,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
     start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
-    auto upload3 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload3 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -239,11 +239,11 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
     start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
-    auto upload4 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload4 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 
     start_offset = lso + model::offset(1);
-    auto upload5 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload5 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload5.source.get() == nullptr);
 }
 
@@ -280,7 +280,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
     auto start_offset = model::offset{0};
     auto last_stable_offset = log.offsets().dirty_offset + model::offset{1};
     auto upload1 = policy
-                     .get_next_candidate(
+                     .get_next_upload_candidate(
                        start_offset, last_stable_offset, log, tr_state)
                      .get();
     BOOST_REQUIRE(upload1.source);
@@ -300,7 +300,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
     start_offset = upload1.final_offset + model::offset{1};
     last_stable_offset = log.offsets().dirty_offset + model::offset{1};
     auto upload2 = policy
-                     .get_next_candidate(
+                     .get_next_upload_candidate(
                        start_offset, last_stable_offset, log, tr_state)
                      .get();
     BOOST_REQUIRE(!upload2.source);
@@ -748,13 +748,13 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     model::offset start_offset{0};
     model::offset lso{9999};
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload1 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
     start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
-    auto upload2 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload2 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset == offset2);
@@ -763,7 +763,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
     start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
-    auto upload3 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload3 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset == offset3);
@@ -772,6 +772,6 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
     start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
-    auto upload4 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
+    auto upload4 = policy.get_next_upload_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -104,6 +104,9 @@ public:
     // Get last offset
     const model::offset get_last_offset() const;
 
+    /// Get starting offset
+    std::optional<model::offset> get_start_offset() const;
+
     /// Get revision
     model::initial_revision_id get_revision_id() const;
 
@@ -124,6 +127,15 @@ public:
     /// Add new segment to the manifest
     bool add(const key& key, const segment_meta& meta);
     bool add(const segment_name& name, const segment_meta& meta);
+
+    /// Remove segment from the manifest only if the metadata matches
+    bool remove(const key& key, const segment_meta& meta);
+    bool remove(const segment_name& key, const segment_meta& meta);
+
+    /// \brief Truncate the manifest
+    /// \param starting_rp_offset is a new starting offset of the manifest
+    /// \return manifest that contains only removed segments
+    partition_manifest truncate(model::offset starting_rp_offset);
 
     /// Get segment if available or nullopt
     const segment_meta* get(const key& key) const;

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -134,6 +134,17 @@ public:
       const remote_segment_path& path,
       retry_chain_node& parent);
 
+    /// \brief Delete segment from S3
+    ///
+    /// The method deletes the segment. It can retry after some errors.
+    ///
+    /// \param segment_path is a segment's name in S3
+    /// \param manifest is a manifest that should have the segment metadata
+    ss::future<upload_result> delete_segment(
+      const s3::bucket_name& bucket,
+      const remote_segment_path& segment_path,
+      retry_chain_node& parent);
+
 private:
     s3::client_pool _pool;
     ss::gate _gate;

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -445,20 +445,10 @@ model::offset remote_partition::first_uploaded_offset() {
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
     try {
-        if (_first_uploaded_offset) {
-            return *_first_uploaded_offset;
-        }
-        model::offset starting_offset = model::offset::max();
-        for (const auto& m : _manifest) {
-            starting_offset = std::min(
-              starting_offset, get_kafka_base_offset(m.second));
-        }
-        _first_uploaded_offset = starting_offset;
-        vlog(
-          _ctxlog.debug,
-          "remote partition first_uploaded_offset set to {}",
-          starting_offset);
-        return starting_offset;
+        auto it = _manifest.begin();
+        auto off = get_kafka_base_offset(it->second);
+        vlog(_ctxlog.debug, "remote partition first_uploaded_offset: {}", off);
+        return off;
     } catch (...) {
         vlog(
           _ctxlog.error,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -311,7 +311,6 @@ private:
     remote& _api;
     cache& _cache;
     const partition_manifest& _manifest;
-    std::optional<model::offset> _first_uploaded_offset;
     s3::bucket_name _bucket;
     segment_map_t _segments;
     eviction_list_t _eviction_list;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -47,10 +47,22 @@ struct archival_metadata_stm::segment
     cloud_storage::partition_manifest::segment_meta meta;
 };
 
+struct archival_metadata_stm::start_offset
+  : public serde::
+      envelope<segment, serde::version<0>, serde::compat_version<0>> {
+    model::offset start_offset;
+};
+
 struct archival_metadata_stm::add_segment_cmd {
     static constexpr cmd_key key{0};
 
     using value = segment;
+};
+
+struct archival_metadata_stm::truncate_cmd {
+    static constexpr cmd_key key{1};
+
+    using value = start_offset;
 };
 
 struct archival_metadata_stm::snapshot
@@ -111,50 +123,21 @@ archival_metadata_stm::archival_metadata_stm(
   , _manifest(raft->ntp(), raft->log_config().get_initial_revision())
   , _cloud_storage_api(remote) {}
 
-// todo: return result
-ss::future<std::error_code> archival_metadata_stm::add_segments(
-  const cloud_storage::partition_manifest& manifest,
+ss::future<std::error_code> archival_metadata_stm::truncate(
+  model::offset start_rp_offset,
   ss::lowres_clock::time_point deadline,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
     auto now = ss::lowres_clock::now();
     auto timeout = now < deadline ? deadline - now : 0ms;
-    return _lock.with(timeout, [this, &manifest, deadline, as] {
-        return do_add_segments(manifest, deadline, as);
+    return _lock.with(timeout, [this, start_rp_offset, deadline, as] {
+        return do_truncate(start_rp_offset, deadline, as);
     });
 }
 
-// todo: return result
-ss::future<std::error_code> archival_metadata_stm::do_add_segments(
-  const cloud_storage::partition_manifest& new_manifest,
+ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
+  model::record_batch batch,
   ss::lowres_clock::time_point deadline,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
-    {
-        auto now = ss::lowres_clock::now();
-        auto timeout = now < deadline ? deadline - now : 0ms;
-        if (!co_await sync(timeout)) {
-            co_return errc::timeout;
-        }
-    }
-
-    if (as) {
-        as->get().check();
-    }
-
-    auto segments = segments_from_manifest(new_manifest.difference(_manifest));
-    if (segments.empty()) {
-        co_return errc::success;
-    }
-
-    storage::record_batch_builder b(
-      model::record_batch_type::archival_metadata, model::offset(0));
-    for (const auto& segment : segments) {
-        iobuf key_buf = serde::to_iobuf(add_segment_cmd::key);
-        auto record_val = add_segment_cmd::value{segment};
-        iobuf val_buf = serde::to_iobuf(std::move(record_val));
-        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
-    }
-
-    auto batch = std::move(b).build();
     auto fut = _raft->replicate(
       _insync_term,
       model::make_memory_record_batch_reader(std::move(batch)),
@@ -192,7 +175,106 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
         co_return errc::replication_error;
     }
 
-    for (const auto& segment : segments) {
+    co_return errc::success;
+}
+
+ss::future<std::error_code> archival_metadata_stm::do_truncate(
+  model::offset start_rp_offset,
+  ss::lowres_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    {
+        auto now = ss::lowres_clock::now();
+        auto timeout = now < deadline ? deadline - now : 0ms;
+        if (!co_await sync(timeout)) {
+            co_return errc::timeout;
+        }
+    }
+
+    if (as) {
+        as->get().check();
+    }
+
+    auto so = _manifest.get_start_offset();
+    if (so && so.value() > start_rp_offset) {
+        co_return errc::success;
+    }
+
+    storage::record_batch_builder b(
+      model::record_batch_type::archival_metadata, model::offset(0));
+    iobuf key_buf = serde::to_iobuf(truncate_cmd::key);
+    auto record_val = truncate_cmd::value{.start_offset = start_rp_offset};
+    iobuf val_buf = serde::to_iobuf(record_val);
+    b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+
+    auto batch = std::move(b).build();
+
+    auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
+    if (!ec) {
+        co_return ec;
+    }
+
+    vlog(
+      _logger.info,
+      "truncate command replicated, truncated up to {}, remote start_offset: "
+      "{}, last_offset: {}",
+      start_rp_offset,
+      _start_offset,
+      _last_offset);
+
+    co_return errc::success;
+}
+
+// todo: return result
+ss::future<std::error_code> archival_metadata_stm::add_segments(
+  const cloud_storage::partition_manifest& manifest,
+  ss::lowres_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    auto now = ss::lowres_clock::now();
+    auto timeout = now < deadline ? deadline - now : 0ms;
+    return _lock.with(timeout, [this, &manifest, deadline, as] {
+        return do_add_segments(manifest, deadline, as);
+    });
+}
+
+// todo: return result
+ss::future<std::error_code> archival_metadata_stm::do_add_segments(
+  const cloud_storage::partition_manifest& new_manifest,
+  ss::lowres_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    {
+        auto now = ss::lowres_clock::now();
+        auto timeout = now < deadline ? deadline - now : 0ms;
+        if (!co_await sync(timeout)) {
+            co_return errc::timeout;
+        }
+    }
+
+    if (as) {
+        as->get().check();
+    }
+
+    auto add_segments = segments_from_manifest(
+      new_manifest.difference(_manifest));
+    if (add_segments.empty()) {
+        co_return errc::success;
+    }
+
+    storage::record_batch_builder b(
+      model::record_batch_type::archival_metadata, model::offset(0));
+    for (const auto& segment : add_segments) {
+        iobuf key_buf = serde::to_iobuf(add_segment_cmd::key);
+        auto record_val = add_segment_cmd::value{segment};
+        iobuf val_buf = serde::to_iobuf(std::move(record_val));
+        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    }
+
+    auto batch = std::move(b).build();
+    auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
+    if (!ec) {
+        co_return ec;
+    }
+
+    for (const auto& segment : add_segments) {
         vlog(
           _logger.info,
           "new remote segment added (name: {}, base_offset: {} last_offset: "
@@ -220,6 +302,10 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
             auto value = serde::from_iobuf<add_segment_cmd::value>(
               r.release_value());
             apply_add_segment(value);
+        } else if (key == truncate_cmd::key) {
+            auto value = serde::from_iobuf<truncate_cmd::value>(
+              r.release_value());
+            apply_truncate(value);
         }
     });
 
@@ -364,6 +450,18 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
         }
 
         _last_offset = meta.committed_offset;
+    }
+}
+
+void archival_metadata_stm::apply_truncate(const start_offset& so) {
+    auto removed = _manifest.truncate(so.start_offset);
+    // TODO: log removed
+    std::ignore = std::move(removed);
+    if (_manifest.size()) {
+        _start_offset = *_manifest.get_start_offset();
+    } else {
+        _start_offset = model::offset{};
+        _last_offset = model::offset{};
     }
 }
 

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -33,7 +33,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 12> supported_configs{
+static constexpr std::array<std::string_view, 14> supported_configs{
   {"compression.type",
    "cleanup.policy",
    "message.timestamp.type",
@@ -45,7 +45,9 @@ static constexpr std::array<std::string_view, 12> supported_configs{
    "redpanda.remote.write",
    "redpanda.remote.read",
    "redpanda.remote.readreplica",
-   "redpanda.remote.readreplica.bucket"}};
+   "redpanda.remote.readreplica.bucket",
+   "redpanda.remote.retention.bytes",
+   "redpanda.remote.retention.ms"}};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -144,6 +144,15 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.read_replica_bucket = get_string_value(
       config_entries, topic_property_read_replica_bucket);
 
+    cfg.properties.remote_cleanup_policy_bitflags
+      = get_config_value<model::cleanup_policy_bitflags>(
+        config_entries, topic_property_remote_cleanup_policy);
+    cfg.properties.remote_retention_bytes = get_tristate_value<size_t>(
+      config_entries, topic_property_remote_retention_bytes);
+    cfg.properties.remote_retention_duration
+      = get_tristate_value<std::chrono::milliseconds>(
+        config_entries, topic_property_remote_retention_duration);
+
     auto ret = cluster::custom_assignable_topic_configuration(cfg);
     /**
      * handle custom assignments

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -56,6 +56,13 @@ static constexpr std::string_view topic_property_read_replica
 static constexpr std::string_view topic_property_read_replica_bucket
   = "redpanda.remote.readreplica.bucket";
 
+static constexpr std::string_view topic_property_remote_cleanup_policy
+  = "redpanda.remote.cleanup.policy";
+static constexpr std::string_view topic_property_remote_retention_bytes
+  = "redpanda.remote.retention.bytes";
+static constexpr std::string_view topic_property_remote_retention_duration
+  = "redpanda.remote.retention.ms";
+
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name
   = "redpanda.datapolicy.function.name";

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -10,7 +10,8 @@ set(swags
   hbadger
   transaction
   cluster
-  debug)
+  debug
+  shadow_indexing)
 
 set(swag_files)
 foreach(swag ${swags})

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -1,0 +1,25 @@
+"/v1/shadow_indexing/validate_remote_partition/{topic}/{partition}": {
+  "post": {
+    "summary": "Check content of the bucket",
+    "operationId": "validate_remote_partition",
+    "parameters": [
+        {
+            "name": "topic",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        {
+            "name":"partition",
+            "in":"path",
+            "required":true,
+            "type":"integer"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Checking content of the remote bucket"
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "archival/service.h"
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
@@ -48,7 +49,8 @@ public:
       ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
-      ss::sharded<cluster::metadata_cache>&);
+      ss::sharded<cluster::metadata_cache>&,
+      ss::sharded<archival::scheduler_service>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -162,6 +164,7 @@ private:
     void register_transaction_routes();
     void register_debug_routes();
     void register_cluster_routes();
+    void register_shadow_indexing_routes();
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,
@@ -197,4 +200,5 @@ private:
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     request_authenticator _auth;
     bool _ready{false};
+    ss::sharded<archival::scheduler_service>& _archival_service;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -433,7 +433,8 @@ void application::configure_admin_server() {
       std::ref(cp_partition_manager),
       controller.get(),
       std::ref(shard_table),
-      std::ref(metadata_cache))
+      std::ref(metadata_cache),
+      std::ref(archival_scheduler))
       .get();
 }
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -47,6 +47,12 @@ public:
         model::shadow_indexing_mode shadow_indexing_mode
           = model::shadow_indexing_mode::disabled;
 
+        // cloud based retention flags
+        std::optional<model::cleanup_policy_bitflags>
+          remote_cleanup_policy_bitflags;
+        tristate<size_t> remote_retention_bytes{std::nullopt};
+        tristate<std::chrono::milliseconds> remote_retention_time{std::nullopt};
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -628,3 +628,10 @@ class Admin:
         self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
         url = "debug/partition_leaders_table"
         return self._request("get", url, node=node).json()
+
+    def si_validate_remote_partition(self, topic, partition, node=None):
+        """
+        Check data in the S3 bucket and fix local index if needed
+        """
+        path = f"shadow_indexing/validate_remote_partition/{topic}/{partition}"
+        return self._request('post', path, node=node)

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -1,0 +1,142 @@
+# Copyright 2021 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService, SISettings
+
+from rptest.services.admin import Admin
+from rptest.archival.s3_client import S3Client
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import (
+    segments_count,
+    produce_until_segments,
+    wait_for_segments_removal,
+    firewall_blocked,
+)
+
+import xxhash
+from collections import namedtuple, defaultdict
+import time
+import os
+import json
+import traceback
+import uuid
+import sys
+import re
+
+# Log errors expected when connectivity between redpanda and the S3
+# backend is disrupted
+CONNECTION_ERROR_LOGS = [
+    "archival - .*Failed to create archivers",
+
+    # e.g. archival - [fiber1] - service.cc:484 - Failed to upload 3 segments out of 4
+    r"archival - .*Failed to upload \d+ segments"
+]
+
+
+class SIAdminApiTest(RedpandaTest):
+    log_segment_size = 1048576  # 1MB
+
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        si_settings = SISettings(
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_enable_remote_read=True,
+            cloud_storage_enable_remote_write=True,
+        )
+        self.s3_bucket_name = si_settings.cloud_storage_bucket
+
+        extra_rp_conf = dict(log_segment_size=self.log_segment_size)
+
+        super(SIAdminApiTest, self).__init__(test_context=test_context,
+                                             extra_rp_conf=extra_rp_conf,
+                                             si_settings=si_settings)
+
+        self._s3_port = si_settings.cloud_storage_api_endpoint_port
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.admin = Admin(self.redpanda,
+                           auth=(self.superuser.username,
+                                 self.superuser.password))
+
+    def setUp(self):
+        super().setUp()
+        # We can't set 'admin_api_require_auth' in 'extra_rp_conf'. The
+        # test will fail to start in this case. But we can swith the
+        # feature on after start.
+        self.redpanda.set_cluster_config({'admin_api_require_auth': True})
+
+    def tearDown(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+        super().tearDown()
+
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
+    def test_bucket_validation(self):
+        """
+        The test produces to the partition and waits untils the
+        data is uploaded to S3 and the oldest segments are picked
+        up by the retention. After that it uses admin api to invoke
+        bucket validation and checks the result.
+
+        The check is performed using describe topic command. The
+        start offset returned by the command is provided by the 
+        shadow indexing subsystem. After validation the starting
+        offset have to change from initial 0 to some other value.
+        """
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 1024,
+            },
+        )
+
+        produce_until_segments(redpanda=self.redpanda,
+                               topic=self.topic,
+                               partition_idx=0,
+                               count=10,
+                               acks=-1)
+
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=2)
+
+        rpk = RpkTool(self.redpanda)
+        for partition in rpk.describe_topic(self.topic):
+            self.logger.info(f"describe topic result {partition}")
+            assert partition.start_offset == 0, f"start-offset of the partition is supposed to be 0 instead of {partition.start_offset}"
+
+        segment_to_remove = self.find_deletion_candidate()
+        self.logger.info(f"trying to remove segment {segment_to_remove}")
+        self.s3_client.delete_object(self.s3_bucket_name, segment_to_remove,
+                                     True)
+
+        self.logger.info("trying to validate remote partition")
+        for node in self.redpanda.nodes:
+            validation_result = self.admin.si_validate_remote_partition(
+                self.topic, 0, node)
+            self.logger.info(f"validation result {validation_result}")
+
+        for part in self.rpk.describe_topic(self.topic):
+            self.logger.info(f"describe topic result {part}")
+            assert part.start_offset > 0, f"start-offset of the partition is {part.start_offset}, should be greater than 0"
+
+    def find_deletion_candidate(self):
+        for obj in self.s3_client.list_objects(self.s3_bucket_name):
+            key = obj.Key[:-2]
+            if key.endswith("/0-1-v1.log"):
+                return obj.Key
+        return None


### PR DESCRIPTION
## Cover letter

This PR adds new topic configs:
- `redpanda.remote.retention.bytes` 
- `redpanda.remote.retention.ms`
- `redpanda.remote.cleanup.policy`

The properties are similar to local properties (`cleanup.policy`, `retention.ms`, `retention.bytes`) and work the same way but with cloud data.

The archiver is modified to support them. There is a background fiber that checks the manifest and tries to maintain retention invariant by deleting old segments from S3 and truncating local metadata.

Current implementation has one problem. There is a time interval between the segment deletion and metadata truncation. If the leadership transfer happens between these two events we will delete segments locally but fail to replicate truncation command for the archival STM. The new leader will do this after it will start its own archiver but for some time it will be possible for SI to access deleted segment. The client will get the 'NoSuchKey' error in this case. This might be improved by introducing two phase removal operation which will be added later.

Also, there is no ducktape test for new feature yet.

Fixes #4050

## Release notes


* TBD



### Features

* TBD

### Improvements

* TBD

-->
