### PR TITLE
Introduce license checks for redpanda

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -93,6 +93,7 @@ static constexpr int8_t cluster_config_status_cmd_type = 1;
 
 // feature_manager command types
 static constexpr int8_t feature_update_cmd_type = 0;
+static constexpr int8_t feature_update_license_update_cmd_type = 1;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -223,6 +224,12 @@ using feature_update_cmd = controller_command<
   feature_update_cmd_data,
   int8_t, // unused
   feature_update_cmd_type,
+  model::record_batch_type::feature_update>;
+
+using feature_update_license_update_cmd = controller_command<
+  feature_update_license_update_cmd_data,
+  int8_t, // unused
+  feature_update_license_update_cmd_type,
   model::record_batch_type::feature_update>;
 
 // typelist utils

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -36,8 +36,9 @@ public:
     }
 
 private:
-    static constexpr auto accepted_commands
-      = make_commands_list<feature_update_cmd>();
+    static constexpr auto accepted_commands = make_commands_list<
+      feature_update_cmd,
+      feature_update_license_update_cmd>();
 
     ss::sharded<feature_table>& _feature_table;
 };

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -145,6 +145,13 @@ ss::future<> feature_manager::start() {
         vlog(clusterlog.warn, "Exception from updater: {}", e);
     });
 
+    // Detach fiber for alerts of possible license violations or notifications
+    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
+        return ss::do_until(
+          [this] { return _as.local().abort_requested(); },
+          [this] { return maybe_log_license_check_info(); });
+    });
+
     co_return;
 }
 ss::future<> feature_manager::stop() {
@@ -153,6 +160,32 @@ ss::future<> feature_manager::stop() {
     _hm_backend.local().unregister_node_callback(_health_notify_handle);
     _update_wait.broken();
     co_await _gate.close();
+}
+
+ss::future<> feature_manager::maybe_log_license_check_info() {
+    static constexpr std::chrono::seconds license_check_retry = 5min;
+    const auto& cfg = config::shard_local_cfg();
+    std::stringstream warn_ss;
+    if (cfg.cloud_storage_enabled) {
+        fmt::print(warn_ss, "{}", "Tired Storage(cloud_storage)");
+    }
+    const auto& warn_log = warn_ss.str();
+    if (!warn_log.empty()) {
+        const auto& license = _feature_table.local().get_license();
+        if (!license || license->is_expired()) {
+            vlog(
+              clusterlog.warn,
+              "Enterprise feature(s) {} detected as enabled without a valid "
+              "license, please contact support and/or upload a valid redpanda "
+              "license",
+              warn_log);
+        }
+    }
+    try {
+        co_await ss::sleep_abortable(license_check_retry, _as.local());
+    } catch (ss::sleep_aborted) {
+        // Shutting down - next iteration will drop out
+    }
 }
 
 ss::future<> feature_manager::maybe_update_active_version() {

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -97,6 +97,8 @@ private:
     ss::future<> do_maybe_update_active_version();
     ss::future<> maybe_update_active_version();
 
+    ss::future<> maybe_log_license_check_info();
+
     ss::sharded<controller_stm>& _stm;
     ss::sharded<ss::abort_source>& _as;
     ss::gate _gate;

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -89,6 +89,8 @@ public:
         return _barrier_state.barrier(tag);
     }
 
+    ss::future<std::error_code> update_license(security::license&& license);
+
 private:
     void update_node_version(model::node_id, cluster_version v);
 

--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -28,6 +28,8 @@ std::string_view to_string_view(feature f) {
         return "mtls_authentication";
     case feature::serde_raft_0:
         return "serde_raft_0";
+    case feature::license:
+        return "license";
     case feature::test_alpha:
         return "__test_alpha";
     }
@@ -292,6 +294,16 @@ feature_table::resolve_name(std::string_view feature_name) const {
     }
 
     return std::nullopt;
+}
+
+void feature_table::set_license(security::license license) {
+    _license = std::move(license);
+}
+
+void feature_table::revoke_license() { _license = std::nullopt; }
+
+const std::optional<security::license>& feature_table::get_license() const {
+    return _license;
 }
 
 } // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -452,6 +452,12 @@ std::ostream& operator<<(std::ostream& o, const feature_update_action& fua) {
     return o;
 }
 
+std::ostream& operator<<(
+  std::ostream& o, const feature_update_license_update_cmd_data& fulu) {
+    fmt::print(o, "{{redpanda_license {}}}", fulu.redpanda_license);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {
@@ -1323,6 +1329,20 @@ adl<cluster::feature_update_cmd_data>::from(iobuf_parser& in) {
     auto logical_version = adl<cluster::cluster_version>{}.from(in);
     auto actions = adl<std::vector<cluster::feature_update_action>>{}.from(in);
     return {.logical_version = logical_version, .actions = std::move(actions)};
+}
+
+void adl<cluster::feature_update_license_update_cmd_data>::to(
+  iobuf& out, cluster::feature_update_license_update_cmd_data&& data) {
+    reflection::serialize(out, data.current_version, data.redpanda_license);
+}
+
+cluster::feature_update_license_update_cmd_data
+adl<cluster::feature_update_license_update_cmd_data>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    std::ignore = version;
+    auto license = adl<security::license>{}.from(in);
+    return cluster::feature_update_license_update_cmd_data{
+      .redpanda_license = std::move(license)};
 }
 
 void adl<cluster::feature_barrier_request>::to(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -22,6 +22,7 @@
 #include "model/timeout_clock.h"
 #include "raft/types.h"
 #include "security/acl.h"
+#include "security/license.h"
 #include "serde/envelope.h"
 #include "serde/serde.h"
 #include "storage/ntp_config.h"
@@ -1872,6 +1873,19 @@ struct cancel_moving_partition_replicas_cmd_data
     auto serde_fields() { return std::tie(force); }
 };
 
+struct feature_update_license_update_cmd_data
+  : serde::envelope<feature_update_license_update_cmd_data, serde::version<0>> {
+    // Struct encoding version
+    static constexpr int8_t current_version = 1;
+
+    security::license redpanda_license;
+
+    auto serde_fields() { return std::tie(redpanda_license); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const feature_update_license_update_cmd_data&);
+};
+
 enum class reconciliation_status : int8_t {
     done,
     in_progress,
@@ -2468,6 +2482,12 @@ template<>
 struct adl<cluster::feature_update_cmd_data> {
     void to(iobuf&, cluster::feature_update_cmd_data&&);
     cluster::feature_update_cmd_data from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::feature_update_license_update_cmd_data> {
+    void to(iobuf& out, cluster::feature_update_license_update_cmd_data&&);
+    cluster::feature_update_license_update_cmd_data from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -38,6 +38,29 @@
             ]
         },
         {
+            "path": "/v1/features/license",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Upload a new license to redpanda",
+                    "nickname": "put_license",
+                    "type": "void",
+                    "produces": ["application/json"],
+                    "responses": {
+                        "200": {
+                            "description": "OK"
+                        },
+                        "400": {
+                            "description": "Invalid or malformed license",
+                            "schema": {
+                                "type": "json"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
             "path": "/v1/features/{feature_name}",
             "operations": [
                 {

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -23,6 +23,21 @@
             ]
         },
         {
+            "path": "/v1/features/license",
+            "operations":[
+                {
+                    "method": "GET",
+                    "summary": "Get currently loaded license information",
+                    "type": "license_response",
+                    "nickname": "get_license",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/features/{feature_name}",
             "operations": [
                 {
@@ -84,6 +99,43 @@
                     "type": "array",
                     "description": "list of feature_state for each feature",
                     "items": {"type": "feature_state"}
+                }
+            }
+        },
+        "license_contents" :{
+            "id": "license_contents",
+            "description": "Parameters belonging to a valid, signed redpanda license",
+            "properties": {
+                "format_version": {
+                    "type": "int",
+                    "description": "license schema version evolution number"
+                },
+                "org": {
+                    "type": "string",
+                    "description": "client the license was generated for"
+                },
+                "type": {
+                    "type": "string",
+                    "description": "type of license, free, enterprise, etc."
+                },
+                "expires": {
+                    "type": "int",
+                    "description": "Number of days the license is valid until, -1 if is expired"
+                }
+            }
+        },
+        "license_response": {
+            "id": "license_response",
+            "description": "Describe properties of currently loaded license file",
+            "properties": {
+                "loaded": {
+                    "type": "boolean",
+                    "description": "true if a non-expired license is loaded"
+                },
+                "license":{
+                    "type": "license_contents",
+                    "nullable": "true",
+                    "description": "Contents of a valid, signed license if loaded"
                 }
             }
         }

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -6,10 +6,12 @@ v_cc_library(
     scram_authenticator.cc
     acl_store.cc
     mtls.cc
+    license.cc
   DEPS
     v::bytes
     absl::flat_hash_map
     absl::flat_hash_set
-)
+    cryptopp
+ )
 
 add_subdirectory(tests)

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/license.h"
+
+#include "json/document.h"
+#include "utils/base64.h"
+
+#include <boost/date_time/gregorian/formatters.hpp>
+#include <boost/date_time/gregorian/parsers.hpp>
+#include <boost/filesystem.hpp>
+#include <cryptopp/base64.h>
+#include <cryptopp/rsa.h>
+#include <cryptopp/sha.h>
+
+namespace security {
+
+namespace crypto {
+
+static ss::sstring parse_pem_contents(const ss::sstring& pem_key) {
+    static ss::sstring public_key_header = "-----BEGIN PUBLIC KEY-----";
+    static ss::sstring public_key_footer = "-----END PUBLIC KEY-----";
+
+    size_t pos1{ss::sstring::npos}, pos2{ss::sstring::npos};
+    pos1 = pem_key.find(public_key_header);
+    if (pos1 == ss::sstring::npos) {
+        throw std::runtime_error(
+          "Embedded public key error: PEM header not found");
+    }
+
+    pos2 = pem_key.find(public_key_footer, pos1 + 1);
+    if (pos2 == ss::sstring::npos) {
+        throw std::runtime_error(
+          "Embedded public key error: PEM footer not found");
+    }
+
+    // Start position and length
+    pos1 = pos1 + public_key_header.length();
+    pos2 = pos2 - pos1;
+    return pem_key.substr(pos1, pos2);
+}
+
+static CryptoPP::ByteQueue convert_pem_to_ber(const ss::sstring& pem_key) {
+    const ss::sstring keystr = parse_pem_contents(pem_key);
+    CryptoPP::StringSource ss{keystr.c_str(), true};
+
+    // Base64 decode, place in a ByteQueue
+    CryptoPP::ByteQueue queue;
+    CryptoPP::Base64Decoder decoder;
+    decoder.Attach(new CryptoPP::Redirector(queue));
+    ss.TransferTo(decoder);
+    decoder.MessageEnd();
+    return queue;
+}
+
+static const CryptoPP::RSA::PublicKey public_key = []() {
+    static const ss::sstring public_key_material
+      = "-----BEGIN PUBLIC KEY-----\n"
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt0Y2jGOLI70xkF4rmpNM\n"
+        "hBqU3cUrwYCREgjT9TT77KusvhPVc16cdK83bpaGQy+Or1WyZpN+TCxT2vlaZet6\n"
+        "RDo+55jRk7epazAHx9s+DLd6IzhSXakf6Sxh5JRK7Zn/75C1hYJMspcJ75EhLv4H\n"
+        "qXj12dkyivcLAecGhWdIGK95J0P7f4EQQGwGL3rilCSlfkVVmE4qaPUaLqULKelq\n"
+        "7T2d+AklR+KwgtHINyKDPJ9+cCAMoEOrRBDPjcQ79k0yvP3BdHV394F+2Vt/AYOL\n"
+        "dcVQBm3tqIySLGFtiJp+RIa+nJhMrd+G4sqwm4FhsmG35Fbr0XQJY0sM6MaFJcDH\n"
+        "swIDAQAB\n"
+        "-----END PUBLIC KEY-----\n";
+    auto queue = convert_pem_to_ber(public_key_material);
+    CryptoPP::RSA::PublicKey public_key;
+    public_key.BERDecode(queue);
+    return public_key;
+}();
+
+/// The redpanda license is comprised of 2 sections seperated by a delimiter.
+/// The first section is the data section (base64 encoded), the second being the
+/// signature, which is a PCKS1.5 sigature of the contents of the data section.
+static bool
+verify_license(const ss::sstring& data, const ss::sstring& signature) {
+    CryptoPP::RSASS<CryptoPP::PKCS1v15, CryptoPP::SHA256>::Verifier verifier(
+      public_key);
+    return verifier.VerifyMessage(
+      reinterpret_cast<const CryptoPP::byte*>(data.c_str()), // NOLINT
+      data.length(),
+      reinterpret_cast<const CryptoPP::byte*>(signature.data()), // NOLINT
+      signature.size());
+}
+
+} // namespace crypto
+
+ss::sstring license_type_to_string(license_type type) {
+    switch (type) {
+    case license_type::free_trial:
+        return "free_trial";
+    case license_type::enterprise:
+        return "enterprise";
+    default:
+        __builtin_unreachable();
+    }
+    return "";
+}
+
+static license_type integer_to_license_type(int type) {
+    switch (type) {
+    case 0:
+        return license_type::free_trial;
+    case 1:
+        return license_type::enterprise;
+    default:
+        throw license_invalid_exception("Unknown license_type");
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const license& lic) {
+    fmt::print(os, "{}", lic);
+    return os;
+}
+
+struct license_components {
+    ss::sstring data;
+    ss::sstring signature;
+};
+
+static license_components parse_license(const ss::sstring& license) {
+    static constexpr auto signature_delimiter = ".";
+    const auto itr = license.find(signature_delimiter);
+    if (itr == ss::sstring::npos) {
+        throw license_malformed_exception("Outer envelope malformed");
+    }
+    /// signature encoded b64 first before encoding as utf-8 string, this is
+    /// done so that it can have a utf-8 interpretation so the license file
+    /// doesn't have to be in binary format
+    return license_components{
+      .data = license.substr(0, itr),
+      .signature = base64_to_string(
+        license.substr(itr + strlen(signature_delimiter)))};
+}
+
+static void parse_data_section(license& lc, const json::Document& doc) {
+    auto parse_int = [](auto& value) {
+        if (!value.IsInt()) {
+            throw license_malformed_exception("Bad cast: expected int");
+        }
+        return value.GetInt();
+    };
+    auto parse_str = [](auto& value) -> std::string {
+        if (!value.IsString()) {
+            throw license_malformed_exception("Bad cast: expected string");
+        }
+        return value.GetString();
+    };
+
+    auto parse_expiry = [&](auto& value) -> boost::gregorian::date {
+        auto expiry_str = parse_str(value);
+        boost::gregorian::date expiry_date;
+        try {
+            expiry_date = boost::gregorian::from_simple_string(expiry_str);
+        } catch (const boost::bad_lexical_cast& ex) {
+            throw license_malformed_exception(
+              fmt::format("Bad cast: Expiry dateformat: {}", ex.what()));
+        }
+        if (expiry_date.is_not_a_date()) {
+            throw license_malformed_exception(
+              "Expiration date not a real calendar date");
+        }
+        const auto today = boost::gregorian::day_clock::universal_day();
+        if (expiry_date < today) {
+            throw license_invalid_exception("Expiry date behind todays date");
+        }
+        return expiry_date;
+    };
+
+    static const std::array<ss::sstring, 4> v0_license_schema{
+      "version", "org", "type", "expiry"};
+
+    const size_t schema_keys_found = std::count_if(
+      doc.MemberBegin(), doc.MemberEnd(), [&](const auto& item) {
+          return std::find(
+                   v0_license_schema.begin(),
+                   v0_license_schema.end(),
+                   parse_str(item.name))
+                 != v0_license_schema.end();
+      });
+    if (schema_keys_found < v0_license_schema.size()) {
+        throw license_malformed_exception(
+          "Missing expected parameters from license");
+    }
+    lc.format_version = parse_int(doc.FindMember("version")->value);
+    if (lc.format_version < 0) {
+        throw license_invalid_exception("Invalid format_version, is < 0");
+    }
+
+    lc.organization = parse_str(doc.FindMember("org")->value);
+    if (lc.organization == "") {
+        throw license_invalid_exception("Cannot have empty string for org");
+    }
+    lc.type = integer_to_license_type(parse_int(doc.FindMember("type")->value));
+    lc.expiry = parse_expiry(doc.FindMember("expiry")->value);
+}
+
+license make_license(const ss::sstring& raw_license) {
+    license lc;
+    auto components = parse_license(raw_license);
+    if (!crypto::verify_license(components.data, components.signature)) {
+        throw license_verifcation_exception("RSA signature invalid");
+    }
+    try {
+        auto decoded_data = base64_to_string(components.data);
+        json::Document doc;
+        doc.Parse(decoded_data);
+        if (doc.HasParseError()) {
+            throw license_malformed_exception("Malformed data section");
+        }
+        parse_data_section(lc, doc);
+        return lc;
+    } catch (const base64_decoder_exception&) {
+        throw license_malformed_exception("Failed to decode data section");
+    }
+}
+
+bool license::is_expired() const noexcept {
+    return expiry < boost::gregorian::day_clock::universal_day();
+}
+
+long license::days_until_expires() const noexcept {
+    return is_expired()
+             ? -1
+             : (expiry - boost::gregorian::day_clock::universal_day()).days();
+}
+
+void license::serde_read(iobuf_parser& in, const serde::header& h) {
+    using serde::read_nested;
+    format_version = read_nested<uint8_t>(in, h._bytes_left_limit);
+    type = read_nested<license_type>(in, h._bytes_left_limit);
+    organization = read_nested<ss::sstring>(in, h._bytes_left_limit);
+    expiry = boost::gregorian::from_simple_string(
+      read_nested<ss::sstring>(in, h._bytes_left_limit));
+}
+
+void license::serde_write(iobuf& out) {
+    using serde::write;
+    write(out, format_version);
+    write(out, type);
+    write(out, organization);
+    write(
+      out,
+      ss::sstring(boost::gregorian::to_iso_extended_string_type<char>(expiry)));
+}
+
+} // namespace security
+
+namespace reflection {
+
+void adl<security::license>::to(iobuf& out, security::license&& l) {
+    vassert(true, "security::license should always use serde, never adl");
+    reflection::serialize(
+      out,
+      l.format_version,
+      l.type,
+      std::move(l.organization),
+      ss::sstring(
+        boost::gregorian::to_iso_extended_string_type<char>(l.expiry)));
+}
+
+security::license adl<security::license>::from(iobuf_parser& in) {
+    vassert(true, "security::license should always use serde, never adl");
+    auto format_version = adl<uint8_t>{}.from(in);
+    auto type = adl<security::license_type>{}.from(in);
+    auto org = adl<ss::sstring>{}.from(in);
+    auto expiry = adl<ss::sstring>{}.from(in);
+    return security::license{
+      .format_version = format_version,
+      .type = type,
+      .organization = std::move(org),
+      .expiry = boost::gregorian::from_simple_string(expiry)};
+}
+
+} // namespace reflection
+
+namespace fmt {
+template<>
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::license, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  const security::license& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
+    return format_to(
+      ctx.out(),
+      "[Version: {0}, Organization: {1}, Type: {2} Expiry(days): {3}]",
+      r.format_version,
+      r.organization,
+      license_type_to_string(r.type),
+      r.days_until_expires());
+}
+
+} // namespace fmt

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/adl.h"
+#include "seastarx.h"
+#include "serde/serde.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/date_time/gregorian/gregorian_types.hpp>
+#include <fmt/core.h>
+
+#include <exception>
+#include <fstream>
+#include <vector>
+
+namespace security {
+
+class license_exception : public std::exception {
+public:
+    explicit license_exception(ss::sstring s) noexcept
+      : _msg(std::move(s)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+class license_invalid_exception final : public license_exception {
+public:
+    explicit license_invalid_exception(ss::sstring s) noexcept
+      : license_exception(std::move(s)) {}
+};
+
+class license_malformed_exception final : public license_exception {
+public:
+    explicit license_malformed_exception(ss::sstring s) noexcept
+      : license_exception(std::move(s)) {}
+};
+
+class license_verifcation_exception final : public license_exception {
+public:
+    explicit license_verifcation_exception(ss::sstring s) noexcept
+      : license_exception(std::move(s)) {}
+};
+
+enum class license_type : uint8_t { free_trial = 0, enterprise = 1 };
+
+ss::sstring license_type_to_string(license_type type);
+
+inline std::ostream& operator<<(std::ostream& os, license_type lt) {
+    os << license_type_to_string(lt);
+    return os;
+}
+
+struct license : serde::envelope<license, serde::version<0>> {
+    /// Expected encoded contents
+    uint8_t format_version;
+    license_type type;
+    ss::sstring organization;
+    boost::gregorian::date expiry;
+
+    /// Explicit serde:: implementations because boost::gregorian is not
+    /// trivally serializable/deserializable
+    void serde_read(iobuf_parser& in, const serde::header& h);
+    void serde_write(iobuf& out);
+
+    /// true if todays date is greater then \ref expiry
+    bool is_expired() const noexcept;
+
+    /// returns -1 in the case the license has already expired
+    long days_until_expires() const noexcept;
+
+private:
+    friend struct fmt::formatter<license>;
+
+    friend std::ostream& operator<<(std::ostream& os, const license& lic);
+};
+
+/// Returns a license or an exception indicating the reason why the method
+/// failed, reasons could be:
+/// 1. Malformed license
+/// 2. Invalid license
+license make_license(const ss::sstring& raw_license);
+
+} // namespace security
+
+namespace reflection {
+
+template<>
+struct adl<security::license> {
+    void to(iobuf& out, security::license&& l);
+    security::license from(iobuf_parser& in);
+};
+} // namespace reflection
+
+namespace fmt {
+template<>
+struct formatter<security::license> {
+    using type = security::license;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};
+
+} // namespace fmt

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rp_test(
     credential_store_test.cc
     authorizer_test.cc
     mtls_test.cc
+    license_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "security/license.h"
+
+#include <boost/date_time/gregorian/parsers.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/test/unit_test.hpp>
+namespace security {
+
+BOOST_AUTO_TEST_CASE(test_license_invalid_signature) {
+    /// This license has been generated with a non matching signature, even
+    /// though the contents section is valid
+    static const auto license_contents_bad_signature
+      = "eyJ2ZXJzaW9uIjogMCwgIm9yZyI6ICJyZWRwYW5kYS10ZXN0aW5nIiwgInR5cGUiOiAxLC"
+        "AiZXhwaXJ5IjogIjIwMjItNy00In0=."
+        "QOPTqwnMwV0hc4ZwsPBQkI9LPmwSgiHGWWxVGutk+"
+        "THrXDtm2UTFxhFpGEYgdmBNCNLKKiBNfyMSsohBAMCr6U5k3211d7+X1++"
+        "6ni3ykinJBhuLYE9+fNnHHxF/"
+        "GnkOGzFwklOUKXR7CuSEMrmUt6cDLkoyjTAtE6ygi7T8hOpbEOf5B9IK72IgSsFw7phtEl"
+        "uy9gFl+XkQZy5cx8roHd/G6PRgirN/"
+        "zDeyC66vIjIU8ZNV4Ly+69asRRakvh6lnLbGIpfmWwUJKi9DX4DEGaw/"
+        "WGYKJB5jzywOcoNdO/t4AT8UeCArICiPmrqCvISvJJk80OKiSEU3ChLNHJPRsQ==";
+    BOOST_CHECK_THROW(
+      make_license(license_contents_bad_signature),
+      license_verifcation_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_license_malformed_content) {
+    /// This license has been generated without the 'expiry' parameter, making
+    /// it malformed
+    static const auto license_contents_malformed_content
+      = "eyJoYWkiOiAiMTIzIn0=."
+        "KM7DNlb3Ja49xImVi6FnwewXXp2Skt72q7RV8xcBCQtlg7frEzTbQmu6eKq2scSU2zqOX5"
+        "FBqJ1ZEZ6RaaSiEqVGrsvHfR8bh4qSSzWUP8ny+"
+        "wcpei8zBfRUR2ulZv9rib3FPKDlNHC3Smtsyosim+"
+        "i2O7A3ARPKHFFBFtKufKTihHPY87JxY8ytAXWNlCfaisaPst9XQtUmy4iJAx5QrJpC4Y03"
+        "u9XOC0/cbwKzotMGP8TojU2V5/zlxMde/VYWI3ic5Jhp4x5rHTDNmV2eaUaDU8h3W55D/"
+        "UJ/feVi5ba2wfBFto/0uZ1M7NvevmfmQ3UC3z6bJnmkdwqZ2TdpWQ==";
+    BOOST_CHECK_THROW(
+      make_license(license_contents_malformed_content),
+      license_malformed_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_license_invalid_content) {
+    /// This license was generated with an expiration date set to a date in the
+    /// past, making it invalid
+    static const auto license_contents_invalid_content
+      = "eyJ2ZXJzaW9uIjogMCwgIm9yZyI6ICJyZWRwYW5kYS10ZXN0aW5nIiwgInR5cGUiOiAxLC"
+        "AiZXhwaXJ5IjogIjE5OTktNy00In0=.RKLx88ZUtzAQofO3F8azuUn8k9q+"
+        "tS37JvsjwZs7YHluupuAQXpQJk2qLVWlJeaMvjhaQTXNl6j7JEoKbUmJESnOjh5ghre64x"
+        "YPF5jLkN+S1N0eoVp0eR7w13vo3RVwfkKWLZKM7JTXdXJiXHqvnXrtjXpCR5T+"
+        "P39KJFDeOTcwY6ojcBJVcYidpvExfNx9S/"
+        "N0Lw4txozdywaYT3W4xABr8k0KlXmf8Oag77qW3kAcKHmjin6R64GTrcDSx/"
+        "SQY18KjPw9J9s2gZRXIHo6U0Jmsv6lNbDAkPtUAN+AQRTBN4ayQEz40yqxO279vz3U4UO/"
+        "4SbXfVdZ524rEmTrMQ==";
+    BOOST_CHECK_THROW(
+      make_license(license_contents_invalid_content),
+      license_invalid_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_license_valid_content) {
+    const char* sample_valid_license = std::getenv("REDPANDA_SAMPLE_LICENSE");
+    if (sample_valid_license == nullptr) {
+        const char* is_on_ci = std::getenv("CI");
+        BOOST_TEST_REQUIRE(
+          !is_on_ci,
+          "Expecting the REDPANDA_SAMPLE_LICENSE env var in the CI "
+          "enviornment");
+        return;
+    }
+    const ss::sstring license_str{sample_valid_license};
+    const auto license = make_license(license_str);
+    BOOST_CHECK_EQUAL(license.format_version, 0);
+    BOOST_CHECK_EQUAL(license.type, license_type::enterprise);
+    BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
+    BOOST_CHECK(
+      license.expiry == boost::gregorian::from_simple_string("2122-06-06"));
+    BOOST_CHECK(!license.is_expired());
+}
+} // namespace security

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -388,6 +388,12 @@ class Admin:
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 
+    def get_license(self, node=None):
+        return self._request("GET", "features/license", node=node).json()
+
+    def put_license(self, license):
+        return self._request("PUT", "features/license", data=license)
+
     def set_log_level(self, name, level, expires=None):
         """
         Set broker log level

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -162,6 +162,13 @@ def decode_feature_command(record):
         cmd['v'] = k_rdr.read_int8()
         cmd['cluster_version'] = k_rdr.read_int64()
         cmd['actions'] = k_rdr.read_vector(decode_feature_update_action)
+    elif cmd['type'] == 1:
+        cmd['type_name'] = 'license_update'
+        k_rdr.read_envelope()
+        cmd['format_v'] = k_rdr.read_uint8()
+        cmd['license_type'] = k_rdr.read_uint8()
+        cmd['org'] = k_rdr.read_string()
+        cmd['expiry'] = k_rdr.read_string()
     else:
         cmd['type_name'] = 'unknown'
     return cmd


### PR DESCRIPTION
## Cover letter
This change makes redpanda license aware. The admin api is updated to include two new endpoints, one to set a new license and another to query current license info.

The license is managed by `cluster::feature_table` and gossiped by `cluster::feature_manager`. Every node should have a copy of the license.

### How it is currently used
A new fiber is spawned to print annoying messages if an enterprise feature is enabled without a valid license loaded. Currently the only feature license guarded is shadow indexing. In the short future we intend to add more log messages like this to `rpk` when enabling the shadow indexing feature flag. `rpk` may query the admin api to decide weather to print this message or not.

### License format
The license essentially is 2 b64 encoded strings separated by a period. Its comprised of the license information plus a signature of the hash of the contents of the license attached to the license info:
```
 <b64encoded_json>.<b64encoded_signature_of_hash_of_payload>
```
The public key used to verify this signature is hardcoded into the source in `security/license.cc`. The private key will obviously be kept in-house privately so that only employees of redpanda can make new licenses with a valid signature.

### Generating a license
This is a separate portion of work that will be checked into vtools

## Release notes
- Redpanda will log license warnings every 5s if enterprise features are enabled but a valid license not uploaded

## Force pushes
Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/0613a88274c9e943bab934eedc98f83803026cfc..aa50518f6918de0e4cde1f9901613200fc4cbb89)
- Updated the signing/verifying/importing key logic by substituting openssl for cryptopp. Builds were failing because we don't include development depenencies of openssl in our build anyway.
- Lengthened amount of time of logging license check messages from 5 seconds to 5 minutes

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/dfb8b951c1980ff646daa8dbf5b3cbf537faf2a8..63548a8a7fc8da81abaf8d9eb0b780b5e970bc61)
- Fix linker error with missing symbol from `license.h`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/63548a8a7fc8da81abaf8d9eb0b780b5e970bc61..a53b043dc049cea1bed5ae1f3bd723b7e2584288)
- Fixed a bug where `feature_manager` was not called on the correct shard.
- Added ducktape test

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/4fcf6261ad470c0e2275f025ef01ac4bc094882e..fbbb3c15937d9682edb26ca7cfd0b7ca91d9013e)
- Removed 3 accidentally committed commits
- Addressed my own nits that were mentioned in the comments below

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/fbbb3c15937d9682edb26ca7cfd0b7ca91d9013e..3ba74a8df433c6f44063e9f8b11991405979ccaf)
- Updated tests to use a license that expires 100 years in the future
- Updated tests to not perform the correct comparison of `days left in license` based on the already known future expiration date of the licenses in the respective test directories 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/3ba74a8df433c6f44063e9f8b11991405979ccaf..36df7bbe9f405f1e371e102c585dfffed94c3910)
- Modified license file to not be a binary file, license is not b64 encoded payload appended to b64 encoded signature

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/162bd1ecc89baa4171f72d2f0316334e03fde185..31a2cf9e46bf6fc6cc267d83c621066a213cde5a)
- Made put_license redirect to leader if called on non leader node
- Returned invalid license exception if org is empty

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/31a2cf9e46bf6fc6cc267d83c621066a213cde5a..e409276d9f39620112bb561197b9fe362d2297cd)
- Updated ducktape test to reflect change in GET v1/features/license response type