### PR TITLE
Catch unhandeled exceptions within `net::server`

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -40,6 +40,11 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         // Happens on unclean client disconnect, typically wrapping
         // an out_of_range
         return "parse error";
+    } catch (...) {
+        // Global catch-all prevents stranded/non-handled exceptional futures.
+        // In all other non-explicity handled cases, the exception will not be
+        // related to disconnect issues, therefore fallthrough to return nullopt
+        // is acceptable.
     }
 
     return std::nullopt;


### PR DESCRIPTION
It has been observed in some situations that erroneous kafka requests can raise an exception that will never be caught. Seastar will then print `exceptional future ignored` messages as shown below:
```
2022-06-22T08:10:10.508951465Z stderr F WARN  2022-06-22 08:10:10,508 [shard 0] seastar - Exceptional future ignored: std::runtime_error (Invalid client_id size -7816), backtrace: 0x40bc0f4 0x3dc90eb 0x3c9b120 0x3e6ebff 0x3e728d7 0x3e6fca9 0x3da6023 0x3da414f 0x1564093 0x416e23f /opt/redpanda/lib/libc.so.6+0x27b74 0x15617ad
2022-06-22T08:10:10.508961742Z stderr F    --------
```

The situation that cause the issue above is easily reproducible by modifying the rpk settings in the `redpanda.yaml`  to something like this:
```
rpk:
  tls: {}
  kafka_api:
    brokers:
      - 127.0.0.1:9092
    tls: {}
  admin_api:
    addresses:
      - 127.0.0.1:9644
    tls: {}
 ```
This will leave the client in a state where TLS is partially in use. The client will not follow the protocol when making requests, which is a bug within `rpk` itself. redpanda will end up throwing, but ignoring exceptions that will arise within early stages of parsing the kafka request header.

## Release notes
- Fixes a bug that causes unhandled exception messages to possibly arise when clients make erroneously formatted request headers.

## Force push history
Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/6ff649b491900b0c27a9ca03b54bdfc2773402ae..f2e8c55920cba286f0c6ba6635754705db84974c)
- Modified `erraneous_protocol`s name