### PR TITLE
Additional detail in config error message

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -717,26 +717,39 @@ members_manager::dispatch_configuration_update(model::broker broker) {
     }
 }
 
-bool is_result_configuration_valid(
+/**
+ * @brief Check that the configuration is valid, if not return a string with the
+ * error cause.
+ *
+ * @param current_brokers current broker vector
+ * @param to_update broker being added
+ * @return std::optional<ss::sstring> - present if there is an error, nullopt
+ * otherwise
+ */
+std::optional<ss::sstring> check_result_configuration(
   const std::vector<broker_ptr>& current_brokers,
   const model::broker& to_update) {
-    /**
-     * validate if any two of the brokers would listen on the same addresses
-     * after applying configuration update
-     */
     for (auto& current : current_brokers) {
         if (current->id() == to_update.id()) {
             /**
              * do no allow to decrease node core count
              */
             if (current->properties().cores > to_update.properties().cores) {
-                return false;
+                return "core count must not decrease on any broker";
             }
             continue;
         }
-        // error, nodes would point to the same addresses
+
+        /**
+         * validate if any two of the brokers would listen on the same addresses
+         * after applying configuration update
+         */
         if (current->rpc_address() == to_update.rpc_address()) {
-            return false;
+            // error, nodes would listen on the same rpc addresses
+            return fmt::format(
+              "duplicate rpc endpoint {} with existing node {}",
+              to_update.rpc_address(),
+              current->id());
         }
         for (auto& current_ep : current->kafka_advertised_listeners()) {
             auto any_is_the_same = std::any_of(
@@ -747,11 +760,16 @@ bool is_result_configuration_valid(
               });
             // error, kafka endpoint would point to the same addresses
             if (any_is_the_same) {
-                return false;
+                return fmt::format(
+                  "duplicate kafka advertised endpoint {} with existing node "
+                  "{}",
+                  current_ep,
+                  current->id());
+                ;
             }
         }
     }
-    return true;
+    return {};
 }
 
 ss::future<result<configuration_update_reply>>
@@ -770,11 +788,12 @@ members_manager::handle_configuration_update_request(
     vlog(
       clusterlog.trace, "Handling node {} configuration update", req.node.id());
     auto all_brokers = _members_table.local().all_brokers();
-    if (!is_result_configuration_valid(all_brokers, req.node)) {
+    if (auto err = check_result_configuration(all_brokers, req.node); err) {
         vlog(
           clusterlog.warn,
-          "Rejecting invalid configuration update: {}, current brokers list: "
-          "{}",
+          "Rejecting invalid configuration update. Reason: {}, new broker: {}, "
+          "current brokers list: {}",
+          err.value(),
           req.node,
           all_brokers);
         return ss::make_ready_future<ret_t>(errc::invalid_configuration_update);


### PR DESCRIPTION
When a cluster configuration change is invalid, we don't give the
reason. This change gives the reason for the cases of core count
decrease and rpc/kafka endpoint clashes.