### PR TITLE
kafka/server: Prefer ss::bool to bool for is_flex

### DIFF
--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -161,10 +161,10 @@ public:
         /// KIP-511 bumps api_versions_request/response to 3, past the first
         /// supported flex version for this API, and makes an exception
         /// that there will be no tags in the response header.
-        bool is_flexible = header().is_flexible();
+        auto is_flexible = flex_enabled(header().is_flexible());
         api_version version = header().version;
         if constexpr (std::is_same_v<ResponseType, api_versions_response>) {
-            is_flexible = false;
+            is_flexible = flex_enabled::no;
             if (r.data.error_code == kafka::error_code::unsupported_version) {
                 /// Furthermore if the client has made an api_versions_request
                 /// outside of the max supported version, any assumptions about

--- a/src/v/kafka/server/response.h
+++ b/src/v/kafka/server/response.h
@@ -23,10 +23,12 @@
 
 namespace kafka {
 
+using flex_enabled = ss::bool_class<struct flex_response_tag>;
+
 class response {
 public:
-    explicit response(bool flexible) noexcept
-      : _flexible(flexible)
+    explicit response(flex_enabled flex) noexcept
+      : _flex(flex)
       , _writer(_buf) {}
 
     response_writer& writer() { return _writer; }
@@ -38,7 +40,7 @@ public:
     correlation_id correlation() const { return _correlation; }
     void set_correlation(correlation_id c) { _correlation = c; }
 
-    bool is_flexible() const { return _flexible; }
+    flex_enabled is_flexible() const { return _flex; }
 
     /// Currently unused
     const std::optional<tagged_fields>& tags() const { return _tags; }
@@ -56,7 +58,7 @@ public:
 private:
     bool _noop{false};
     correlation_id _correlation;
-    bool _flexible{false};
+    flex_enabled _flex{flex_enabled::no};
     std::optional<tagged_fields> _tags;
     iobuf _buf;
     response_writer _writer;


### PR DESCRIPTION
Housekeeping commit, replaces use of bool instead of strongly typed `ss::bool_class`.

## Release notes
- None