### PR TITLE
Add test for full disk threshold config, leave default as-is

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -506,7 +506,7 @@ class RpkTool:
         ]
         return self._execute(cmd).strip()
 
-    def cluster_config_set(self, key, value):
+    def cluster_config_set(self, key: str, value):
         cmd = [
             self._rpk_binary(), "--api-urls",
             self._admin_host(), "cluster", "config", "set", key, value

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from collections import namedtuple
 import time
+from typing import Any, NamedTuple
 import requests
 import json
 import re
@@ -861,8 +861,10 @@ class ClusterConfigTest(RedpandaTest):
         """
         Test RPK's getter+setter helpers
         """
-
-        Example = namedtuple('Example', ['key', 'strval', 'yamlval'])
+        class Example(NamedTuple):
+            key: str
+            strval: str
+            yamlval: Any
 
         valid_examples = [
             Example("kafka_qdc_enable", "true", True),
@@ -870,7 +872,7 @@ class ClusterConfigTest(RedpandaTest):
             Example("superusers", "['bob','alice']", ["bob", "alice"])
         ]
 
-        def yamlize(input):
+        def yamlize(input) -> str:
             """Create a YAML representation that matches
             what yaml-cpp produces: PyYAML includes trailing
             ellipsis lines that must be removed."""

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -869,7 +869,8 @@ class ClusterConfigTest(RedpandaTest):
         valid_examples = [
             Example("kafka_qdc_enable", "true", True),
             Example("append_chunk_size", "32768", 32768),
-            Example("superusers", "['bob','alice']", ["bob", "alice"])
+            Example("superusers", "['bob','alice']", ["bob", "alice"]),
+            Example("storage_min_free_bytes", "1234567890", 1234567890)
         ]
 
         def yamlize(input) -> str:
@@ -891,6 +892,11 @@ class ClusterConfigTest(RedpandaTest):
             cli_readback = self.rpk.cluster_config_get(e.key)
 
             expect_cli_readback = yamlize(e.yamlval)
+
+            # Hack around scientific notation for large int values.
+            # This may be an RPK bug?
+            if cli_readback.find("e+") != -1:
+                cli_readback = str(int(float(cli_readback)))
 
             self.logger.info(
                 f"CLI readback '{cli_readback}' expect '{expect_cli_readback}'"


### PR DESCRIPTION
## Cover letter

~~Value based on discussion with (internal) customer. We want to default to sane production values, and override where necessary for dev / test. Changed default minimum free disk space threshold to 5 GiB.~~

Fixes #4850 

## Release notes
 * None

Force Push: don't increase default `storage_min_free_bytes`. Instead of "defaulting to prod", default to "dev experience", and handle production defaults at configuration time.