### PR TITLE
Pass node report by reference

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -371,9 +371,9 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
 
 ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
   cluster_health_report report) {
-    for (auto& node_report : report.node_reports) {
+    for (const auto& node_report : report.node_reports) {
         co_await _leaders.invoke_on_all(
-          [node_report](partition_leaders_table& leaders) {
+          [&node_report](partition_leaders_table& leaders) {
               for (auto& tp : node_report.topics) {
                   for (auto& p : tp.partitions) {
                       // Nodes may report a null leader if they're out of


### PR DESCRIPTION
We currently pass the node_report by value which leads to a copy which
may be large if the report is large (especially if there are many
partitions). There doesn't seem to be any reason we can't pass this
by value, as we are co_awaiting the return of the invoke_all.

This was implicated in the OOM in #5137. There were too parts to that
OOM: first the lambda was very large due to the issue fixed here and
second seastar was copying the lambda unnecessarily.

Issue #5137.