### PR TITLE
Move feature_table outside from controller

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -38,6 +38,7 @@ public:
       ss::sharded<storage::node_api>& storage_node,
       ss::sharded<raft::group_manager>&,
       ss::sharded<v8_engine::data_policy_table>&,
+      ss::sharded<feature_table>&,
       ss::sharded<cloud_storage::remote>&);
 
     model::node_id self() { return _raft0->self().id(); }
@@ -152,7 +153,7 @@ private:
     ss::sharded<metrics_reporter> _metrics_reporter;
     ss::sharded<feature_manager> _feature_manager; // single instance
     ss::sharded<feature_backend> _feature_backend; // instance per core
-    ss::sharded<feature_table> _feature_table;     // instance per core
+    ss::sharded<feature_table>& _feature_table;    // instance per core
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -708,6 +708,9 @@ void application::wire_up_redpanda_services() {
         cloud_configs.stop().get();
     }
 
+    syschecks::systemd_message("Creating feature table").get();
+    construct_service(_feature_table).get();
+
     syschecks::systemd_message("Adding partition manager").get();
     construct_service(
       partition_manager,
@@ -738,6 +741,7 @@ void application::wire_up_redpanda_services() {
       storage_node,
       std::ref(raft_group_manager),
       data_policies,
+      std::ref(_feature_table),
       std::ref(cloud_storage_api));
 
     controller->wire_up().get0();
@@ -847,6 +851,7 @@ void application::wire_up_redpanda_services() {
           make_upload_controller_config(_scheduling_groups.archival_upload()))
           .get();
     }
+
     // group membership
     syschecks::systemd_message("Creating partition manager").get();
     construct_service(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -157,6 +157,7 @@ private:
     ss::logger _log;
 
     ss::sharded<rpc::connection_cache> _connection_cache;
+    ss::sharded<cluster::feature_table> _feature_table;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<kafka::group_manager> _co_group_manager;
     ss::sharded<net::server> _rpc;


### PR DESCRIPTION
## Cover letter

Move `feature_table` from `controller` to `application`, because we need to use this stuff for another services, like `partition_manager`. It is created before controller and it is part of application. So we can not pass `feature_table` to services like this.

## Release notes
* none
