### PR TITLE
[v22.1.x] rpk: fix ipv6 parsing of ParseHostMaybeScheme function

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -163,7 +163,7 @@ failure of enabling each logger is individually printed.
 	cmd.Flags().StringVarP(&level, "level", "l", "debug", "log level to set (error, warn, info, debug, trace)")
 	cmd.Flags().IntVarP(&expirySeconds, "expiry-seconds", "e", 300, "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown)")
 
-	cmd.Flags().StringVar(&host, "host", "", "either an index into admin_api hosts to issue the request to, or a hostname")
+	cmd.Flags().StringVar(&host, "host", "", "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to")
 	cobra.MarkFlagRequired(cmd.Flags(), "host")
 
 	return cmd

--- a/src/go/rpk/pkg/net/hostport.go
+++ b/src/go/rpk/pkg/net/hostport.go
@@ -23,7 +23,9 @@ func ParseHostMaybeScheme(h string) (scheme, host string, err error) {
 		return "", "", err
 	}
 	if port != "" {
-		return scheme, net.JoinHostPort(host, port), nil
+		// We can return host + port since splitSchemeHostPort already
+		// ensures an IPV6 host is wrapped in brackets.
+		return scheme, host + ":" + port, nil
 	}
 	return scheme, host, nil
 }


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4777.
Fixes https://github.com/redpanda-data/redpanda/issues/5229,