### PR TITLE
cluster: bootstrap user creation during cluster creation

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -118,7 +118,7 @@ public:
 private:
     friend controller_probe;
 
-private:
+    ss::future<> cluster_creation_hook();
     config_manager::preload_result _config_preload;
 
     ss::sharded<ss::abort_source> _as;                     // instance per core

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -54,6 +54,8 @@ public:
       std::vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
+    ss::future<std::error_code> maybe_create_bootstrap_user();
+
 private:
     ss::future<std::vector<errc>> do_create_acls(
       std::vector<security::acl_binding>, model::timeout_clock::duration);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -564,6 +564,18 @@ class Admin:
 
         self._request("delete", path)
 
+    def update_user(self, username, password, algorithm):
+        self.redpanda.logger.info(
+            f"Updating user {username}:{password}:{algorithm}")
+
+        self._request("PUT",
+                      f"security/users/{username}",
+                      json=dict(
+                          username=username,
+                          password=password,
+                          algorithm=algorithm,
+                      ))
+
     def list_users(self, node=None):
         return self._request("get", "security/users", node=node).json()
 


### PR DESCRIPTION
## Cover letter

On cluster creation, accept an environment variable `RP_BOOTSTRAP_USER` to create an initial user account.  This enables starting with SASL + admin API auth switched on.

This environment variable is _only_ consulted on first startup: any attempt to set it later or to modify its value after the fact will have no effect.

Fixes https://github.com/redpanda-data/redpanda/issues/5203

## Release notes

### Features

* The environment variable `RP_BOOTSTRAP_USER` is added.  This may be set in the format `<username>:<password>`, and those credentials will be used to create a user the first time a new cluster starts.  This simplifies configuration of new clusters which have admin API authentication switched on from time of creation.  This environment variable is only consulted on the very first start of a new cluster, and has no effect thereafter.

