### PR TITLE
kafka: fix link error.

### DIFF
--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -94,6 +94,7 @@ v_cc_library(
     Seastar::seastar
     v::bytes
     v::rpc
+    v::kafka
     absl::flat_hash_map
     absl::flat_hash_set
 )


### PR DESCRIPTION
clang-13 complains:

/usr/bin/ld: lib/libv_v_kafka_request_schemata.a(sasl_authenticate_response.cc.o): in function `void fmt::v8::detail::format_value<char, kafka::error_code>(fmt::v8::detail::buffer<char>&, kafka::error_code const&, fmt::v8::detail::locale_ref)':
sasl_authenticate_response.cc:(.text._ZN3fmt2v86detail12format_valueIcN5kafka10error_codeEEEvRNS1_6bufferIT_EERKT0_NS1_10locale_refE[_ZN3fmt2v86detail12format_valueIcN5kafka10error_codeEEEvRNS1_6bufferIT_EERKT0_NS1_10locale_refE]+0x121): undefined reference to `kafka::operator<<(std::ostream&, kafka::error_code)'
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)

Signed-off-by: balus <balus@foxmail.com>