### PR TITLE
chore: `tools/` readability improvements

### DIFF
--- a/tools/metadata_viewer/kvstore.py
+++ b/tools/metadata_viewer/kvstore.py
@@ -179,7 +179,7 @@ def read_vnode(rdr):
     return ret
 
 
-def read_confiugrations_map(rdr):
+def read_configurations_map(rdr):
     ret = {}
     sz = rdr.read_uint64()
     for _ in range(0, sz):
@@ -303,7 +303,7 @@ def decode_raft_value(type, v):
         ret['term'] = rdr.read_int64()
         return ret
     elif type == 1:  # config map
-        return read_confiugrations_map(rdr)
+        return read_configurations_map(rdr)
     elif type == 2:  # config_latest_known_offset
         return rdr.read_int64()
     elif type == 3:  # last_applied_offset

--- a/tools/metadata_viewer/model.py
+++ b/tools/metadata_viewer/model.py
@@ -146,7 +146,7 @@ def decode_acl_resource(r):
 
 def decode_acl_pattern_type(p):
     if p == 0:
-        return 'litteral'
+        return 'literal'
     elif p == 1:
         return 'prefixed'
 

--- a/tools/metadata_viewer/viewer.py
+++ b/tools/metadata_viewer/viewer.py
@@ -92,7 +92,7 @@ def main():
                                 'kafka_records'
                             ],
                             required=True,
-                            help='opertion to execute')
+                            help='operation to execute')
         parser.add_argument(
             '--topic',
             type=str,

--- a/tools/redpanda-gdb.py
+++ b/tools/redpanda-gdb.py
@@ -573,7 +573,7 @@ class span(object):
 
         Due to https://github.com/scylladb/seastar/issues/625 there may be some
         pages at the end of the span which are not used by the small pool.
-        We try to detect this. It's not 100% accurrate but should work in most cases.
+        We try to detect this. It's not 100% accurate but should work in most cases.
 
         Returns 0 for free spans.
         """


### PR DESCRIPTION
## Cover letter
Improve readability in `tools/.py` files.

Could the merger please double-check that updating `decode_acl_pattern_type()` to return [`literal`](https://github.com/redpanda-data/redpanda/commit/bd6fdf6889557e0b4216d379309a277ec4b7e77c) is indeed a fix? 

There are no other references to `litteral` in the codebase, but a second pair of eyes would be good since it's changing a `return` :)