### PR TITLE
build: drop unused set_option.cmake

### DIFF
--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -146,6 +146,5 @@ find_package(Valgrind REQUIRED)
 
 # add code
 include(testing)
-include(set_option)
 include(v_library)
 add_subdirectory(src)

--- a/cmake/set_option.cmake
+++ b/cmake/set_option.cmake
@@ -1,6 +1,0 @@
-# source
-# https://github.com/edsiper/cmake-options
-#
-macro(RP_SET_OPTION option value)
-  set(${option} ${value} CACHE INTERNAL "" FORCE)
-endmacro()


### PR DESCRIPTION
the `RP_SET_OPTION()` macro is not used anywhere, so let's just drop
it.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
