### PR TITLE
cluster: refactor disk space monitoring init

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -38,7 +38,7 @@ public:
       ss::sharded<partition_manager>& pm,
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
-      ss::sharded<storage::node_api>& storage_node,
+      ss::sharded<node::local_monitor>& local_monitor,
       ss::sharded<raft::group_manager>&,
       ss::sharded<v8_engine::data_policy_table>&,
       ss::sharded<features::feature_table>&,
@@ -189,7 +189,7 @@ private:
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<storage::api>& _storage;
-    ss::sharded<storage::node_api>& _storage_node; // single instance
+    ss::sharded<node::local_monitor>& _local_monitor; // single instance
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
     ss::sharded<security::ephemeral_credential_store> _ephemeral_credentials;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -53,4 +53,8 @@ class node_status_backend;
 class node_status_table;
 class ephemeral_credential_frontend;
 
+namespace node {
+class local_monitor;
+} // namespace node
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -613,7 +613,6 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
     node_health_report ret;
     ret.id = _raft0->self().id();
 
-    co_await _local_monitor.local().update_state();
     ret.local_state = _local_monitor.local().get_state_cached();
     ret.local_state.logical_version
       = features::feature_table::get_latest_logical_version();

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -53,13 +53,9 @@ public:
       ss::sharded<partition_manager>&,
       ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
-      ss::sharded<storage::node_api>&,
-      ss::sharded<storage::api>&,
+      ss::sharded<node::local_monitor>&,
       ss::sharded<drain_manager>&,
-      ss::sharded<features::feature_table>&,
-      config::binding<size_t> min_bytes_alert,
-      config::binding<unsigned> min_percent_alert,
-      config::binding<size_t> min_bytes);
+      ss::sharded<features::feature_table>&);
 
     ss::future<> stop();
 
@@ -164,7 +160,7 @@ private:
 
     ss::gate _gate;
     mutex _refresh_mutex;
-    node::local_monitor _local_monitor;
+    ss::sharded<node::local_monitor>& _local_monitor;
 
     std::vector<std::pair<cluster::notification_id_type, health_node_cb_t>>
       _node_callbacks;

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -236,11 +236,6 @@ ss::future<> local_monitor::update_disk_metrics() {
     auto free_space = _state.disks[0].free;
     auto alert = _state.storage_space_alert;
 
-    co_await _storage_api.invoke_on_all(
-      [total_space, free_space](storage::api& api) {
-          api.resources().update_allowance(total_space, free_space);
-      });
-
     co_await _storage_node_api.invoke_on_all(
       &storage::node_api::set_disk_metrics, total_space, free_space, alert);
 }

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -31,6 +31,7 @@ public:
       config::binding<size_t> min_bytes_alert,
       config::binding<unsigned> min_percent_alert,
       config::binding<size_t> min_bytes,
+      ss::sstring data_directory,
       ss::sharded<storage::node_api>&,
       ss::sharded<storage::api>&);
     local_monitor(const local_monitor&) = delete;
@@ -82,6 +83,10 @@ private:
     config::binding<size_t> _free_bytes_alert_threshold;
     config::binding<unsigned> _free_percent_alert_threshold;
     config::binding<size_t> _min_free_bytes;
+
+    // We must carry a copy of data dir, because fixture tests mutate the
+    // global node_config::data_directory
+    ss ::sstring _data_directory;
 
     ss::sharded<storage::node_api>& _storage_node_api; // single instance
     ss::sharded<storage::api>& _storage_api;

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -39,6 +39,9 @@ public:
     local_monitor& operator=(local_monitor const&) = delete;
     local_monitor& operator=(local_monitor&&) = delete;
 
+    ss::future<> start();
+    ss::future<> stop();
+
     ss::future<> update_state();
     const local_state& get_state_cached() const;
     static storage::disk_space_alert
@@ -55,6 +58,9 @@ private:
     // helpers
     static size_t
     alert_percent_in_bytes(unsigned alert_percent, size_t bytes_available);
+
+    /// Periodically check node status until stopped by abort source
+    ss::future<> _update_loop();
 
     ss::future<std::vector<storage::disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring);
@@ -85,6 +91,9 @@ private:
     std::function<struct statvfs(const ss::sstring)> _statvfs_for_test;
 
     std::optional<size_t> _disk_size_for_test;
+
+    ss::gate _gate;
+    ss::abort_source _abort_source;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -37,6 +37,7 @@ local_monitor_fixture::local_monitor_fixture()
     config::shard_local_cfg().storage_space_alert_free_threshold_bytes.bind(),
     config::shard_local_cfg().storage_space_alert_free_threshold_percent.bind(),
     config::shard_local_cfg().storage_min_free_bytes.bind(),
+    config::node_config().data_directory().as_sstring(),
     _storage_node_api,
     _storage_api) {
     _storage_node_api.start_single().get0();

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -140,9 +140,7 @@ void group_manager::trigger_leadership_notification(
         leader_id = st.current_leader->id();
     }
 
-    for (auto& cb : _notifications) {
-        cb.second(st.group, st.term, leader_id);
-    }
+    _notifications.notify(st.group, st.term, leader_id);
 }
 
 void group_manager::setup_metrics() {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1248,6 +1248,16 @@ void application::wire_up_bootstrap_services() {
     }).get();
     syschecks::systemd_message("Constructing storage services").get();
     construct_single_service_sharded(storage_node).get();
+    construct_single_service_sharded(
+      local_monitor,
+      config::shard_local_cfg().storage_space_alert_free_threshold_bytes.bind(),
+      config::shard_local_cfg()
+        .storage_space_alert_free_threshold_percent.bind(),
+      config::shard_local_cfg().storage_min_free_bytes.bind(),
+      std::ref(storage_node),
+      std::ref(storage))
+      .get();
+
     construct_service(
       storage,
       []() { return kvstore_config_from_global_config(); },

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1254,6 +1254,7 @@ void application::wire_up_bootstrap_services() {
       config::shard_local_cfg()
         .storage_space_alert_free_threshold_percent.bind(),
       config::shard_local_cfg().storage_min_free_bytes.bind(),
+      config::node().data_directory().as_sstring(),
       std::ref(storage_node),
       std::ref(storage))
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -898,7 +898,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       partition_manager,
       shard_table,
       storage,
-      storage_node,
+      local_monitor,
       std::ref(raft_group_manager),
       data_policies,
       std::ref(feature_table),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1329,6 +1329,7 @@ void application::start_bootstrap_services() {
 
     // single instance
     storage_node.invoke_on_all(&storage::node_api::start).get0();
+    local_monitor.invoke_on_all(&cluster::node::local_monitor::start).get0();
 
     // Early initialization of disk stats, so that logic for e.g. picking
     // falloc sizes works without having to wait for a local_monitor tick.

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "cluster/node/local_monitor.h"
 #include "cluster/node_status_backend.h"
 #include "cluster/node_status_table.h"
 #include "config/node_config.h"
@@ -117,6 +118,7 @@ public:
 
     ss::sharded<storage::api> storage;
     ss::sharded<storage::node_api> storage_node;
+    ss::sharded<cluster::node::local_monitor> local_monitor;
 
     ss::sharded<v8_engine::data_policy_table> data_policies;
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -41,6 +41,7 @@
 #include "rpc/rpc_server.h"
 #include "seastarx.h"
 #include "ssx/metrics.h"
+#include "storage/api.h"
 #include "storage/fwd.h"
 #include "utils/stop_signal.h"
 #include "v8_engine/fwd.h"

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -20,6 +20,8 @@
 
 namespace storage {
 
+class node_api;
+
 /**
  * This class is used by various storage components to control consumption
  * of shared system resources.  It broadly does this in two ways:

--- a/src/v/utils/notification_list.h
+++ b/src/v/utils/notification_list.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+/**
+ * Enables subscription & unsubscription of multi-use synchronous callbacks
+ *
+ * Type C is a callback prototype that all registered callbacks must
+ * fulfil.
+ *
+ * Type I is an integer-like type to use for registration IDs.
+ *
+ */
+template<typename C, typename I>
+class notification_list {
+public:
+    /**
+     * Register a new callback to be invoked when notify() is called
+     */
+    I register_cb(C cb) {
+        auto id = _notification_id++;
+        _notifications.emplace_back(id, std::move(cb));
+        return id;
+    }
+
+    /**
+     * Deregister a callback that was previously registered with register_cb()
+     */
+    void unregister_cb(I id) {
+        auto it = std::find_if(
+          _notifications.begin(),
+          _notifications.end(),
+          [id](const std::pair<I, C>& n) { return n.first == id; });
+        if (it != _notifications.end()) {
+            _notifications.erase(it);
+        }
+    }
+
+    /**
+     * Call `f` on all registered callbacks
+     */
+    template<typename... Args>
+    void notify(Args&&... args) const {
+        for (auto& [_, cb] : _notifications) {
+            cb(args...);
+        }
+    }
+
+private:
+    I _notification_id{0};
+    std::vector<std::pair<I, C>> _notifications;
+};


### PR DESCRIPTION
## Cover letter

This was a long-dormant spinoff from adding `storage_resources` in Redpanda 22.2.

It addresses some technical debt:
- local_monitor was initialized as part of controller, which was not correct: it has nothing to do with controller and should run early in startup, since it only needs to see local system state.  local_monitor is now initialized as a top level object in `application`.
- there was a hack in application.cc that constructed a temporary local_monitor because it was needed before controller startup: this is now removed.
- local_monitor had knowledge of `storage_resources` in order to tip it off to changes in disk space: this is replaced with a generic notification hook in storage::node_api.  local_monitor now just knows how to update storage::node_api.
- local_monitor's tick frequency was coupled to the health monitor tick frequency, which was unnecessarily infrequent for checking disk space: this is now more frequent and happens every 1s.

## Release notes

### Improvements

* Disk space checks are now more frequent, running every 1 second.  This makes `redpanda_storage_free_space_alert` update more promptly when the system starts to run low on disk space.
