### PR TITLE
rpk: fix build for windows OS

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -24,7 +24,7 @@ jobs:
     name: Test and Build
     strategy:
       matrix:
-        os: [linux, darwin]
+        os: [linux, darwin, windows]
         arch: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
@@ -56,6 +56,7 @@ jobs:
         GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} ./build.sh $tag ${{ github.sha }}
 
     - name: Package
+      if: ${{ ! matrix.os == 'windows'}}
       working-directory: src/go/rpk/
       run: |
         zip -j rpk-${{ matrix.os }}-${{ matrix.arch }}.zip ./${{ matrix.os }}-${{ matrix.arch }}/rpk

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package cmd
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/root_windows.go
+++ b/src/go/rpk/pkg/cli/cmd/root_windows.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cmd
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+// On Windows this is a no-op.
+func addPlatformDependentCmds(fs afero.Fs, cmd *cobra.Command) {
+}

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/afero"
@@ -336,14 +335,9 @@ func (c *Config) Write(fs afero.Fs) (rerr error) {
 			return fmt.Errorf("unable to chmod temp config file: %v", err)
 		}
 
-		// Stat_t is only valid in unix not on Windows.
-		if stat, ok := stat.Sys().(*syscall.Stat_t); ok {
-			gid := int(stat.Gid)
-			uid := int(stat.Uid)
-			err = fs.Chown(temp, uid, gid)
-			if err != nil {
-				return fmt.Errorf("unable to chown temp config file: %v", err)
-			}
+		err = preserveUnixOwnership(fs, stat, temp)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/src/go/rpk/pkg/config/utils.go
+++ b/src/go/rpk/pkg/config/utils.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/spf13/afero"
+)
+
+func preserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
+	// Stat_t is only valid in unix not on Windows.
+	if stat, ok := stat.Sys().(*syscall.Stat_t); ok {
+		gid := int(stat.Gid)
+		uid := int(stat.Uid)
+		err := fs.Chown(file, uid, gid)
+		if err != nil {
+			return fmt.Errorf("unable to chown temp config file: %v", err)
+		}
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/config/utils_windows.go
+++ b/src/go/rpk/pkg/config/utils_windows.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build windows
+
+package config
+
+import (
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// In windows this is a no-op.
+
+func preserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
+	return nil
+}

--- a/src/go/rpk/pkg/os/lock.go
+++ b/src/go/rpk/pkg/os/lock.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package os
 
 import (

--- a/src/go/rpk/pkg/redpanda/launcher.go
+++ b/src/go/rpk/pkg/redpanda/launcher.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/system/filesystem/fs.go
+++ b/src/go/rpk/pkg/system/filesystem/fs.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package filesystem
 
 import (

--- a/src/go/rpk/pkg/system/memory_windows.go
+++ b/src/go/rpk/pkg/system/memory_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package system
+
+import (
+	"errors"
+
+	"github.com/spf13/afero"
+)
+
+func getMemInfo(_ afero.Fs) (*MemInfo, error) {
+	return nil, errors.New("Memory info collection not available in Windows")
+}

--- a/src/go/rpk/pkg/system/metrics.go
+++ b/src/go/rpk/pkg/system/metrics.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package system
 
 import (

--- a/src/go/rpk/pkg/system/metrics_windows.go
+++ b/src/go/rpk/pkg/system/metrics_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package system
+
+import (
+	"errors"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+)
+
+type Metrics struct {
+	CPUPercentage float64 `json:"cpuPercentage"`
+	FreeMemoryMB  float64 `json:"freeMemoryMB"`
+	FreeSpaceMB   float64 `json:"freeSpaceMB"`
+}
+
+func GatherMetrics(
+	fs afero.Fs, timeout time.Duration, conf config.Config,
+) (*Metrics, error) {
+	return nil, errors.New("gathering metrics is not available in Windows")
+}

--- a/src/go/rpk/pkg/system/utils_windows.go
+++ b/src/go/rpk/pkg/system/utils_windows.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package system
+
+import "errors"
+
+func uname() (string, error) {
+	return "", errors.New("uname not available in Windows")
+}

--- a/src/go/rpk/pkg/tuners/ethtool/ethtool.go
+++ b/src/go/rpk/pkg/tuners/ethtool/ethtool.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package ethtool
 
 import "github.com/safchain/ethtool"

--- a/src/go/rpk/pkg/tuners/executors/commands/ethtool_change.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/ethtool_change.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package commands
 
 import (

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package tuners
 
 import (

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package tuners
 
 import (

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package network
 
 import (

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build !windows
+
 package tuners
 
 import (


### PR DESCRIPTION
## Cover letter

Several direct or indirect calls to syscall and sys/unix were making windows build to fail. 


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none