### PR TITLE
gha/rpk: split darwin/linux rpk artifact uploading

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -70,7 +70,7 @@ jobs:
 
   sign-darwin:
     name: Sign and notarize the darwin release_name
-    needs: build
+    needs: upload-release-artifacts-linux
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
@@ -120,7 +120,7 @@ jobs:
 
   create-release:
     name: Create release
-    needs: [build, sign-darwin]
+    needs: [build]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -137,14 +137,13 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_rpk_release.outputs.upload_url }}
 
-  publish-release-artifacts:
-    name: Publish release
-    needs: create-release
+  upload-release-artifacts-linux:
+    name: Upload linux binaries
+    needs: [create-release]
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         arch: [amd64, arm64]
-        os: [linux, darwin]
     runs-on: ubuntu-latest
     steps:
     - name: Download compressed rpk artifacts
@@ -156,6 +155,28 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: rpk-archives/rpk-${{ matrix.os }}-${{ matrix.arch }}.zip
-        asset_name: rpk-${{ matrix.os }}-${{ matrix.arch }}.zip
+        asset_path: rpk-archives/rpk-linux-${{ matrix.arch }}.zip
+        asset_name: rpk-linux-${{ matrix.arch }}.zip
+        asset_content_type: application/zip
+
+  upload-release-artifacts-darwin:
+    name: Upload darwin binaries
+    needs: [sign-darwin]
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download compressed rpk artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Upload rpk artifacts to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: rpk-archives/rpk-darwin-${{ matrix.arch }}.zip
+        asset_name: rpk-darwin-${{ matrix.arch }}.zip
         asset_content_type: application/zip


### PR DESCRIPTION
To avoid having linux binaries not be uploaded when a release is published, this splits the jobs for uploading darwin/linux binaries and orders them in a way that linux binaries always get uploaded regardless of whether the darwin upload fails

fixes https://github.com/redpanda-data/devprod/issues/342

## Release notes

* none
