### PR TITLE
tests: start using RedpandaInstaller in more tests

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -463,9 +463,9 @@ class AdminOperationsFuzzer():
             except Exception as e:
                 error = e
                 self.redpanda.logger.info(
-                    f"Operation: {op_type} error: {error}, retires left: {self.retries-retry}/{self.retries}"
+                    f"Operation: {op_type} error: {error}, retries left: {self.retries-retry}/{self.retries}"
                 )
-                sleep(1)
+                sleep(self.retries_interval)
         raise error
 
     def make_random_operation(self) -> Operation:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1742,8 +1742,9 @@ class RedpandaService(Service):
             # the same binaries.
             return
 
+        # Assume that if 'CI' isn't explicitly set to false, we do want to keep
+        # the executable.
         if os.environ.get('CI', None) == 'false':
-            # We are on a developer workstation
             self.logger.info("Skipping saving executable, not in CI")
             return
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1755,7 +1755,7 @@ class RedpandaService(Service):
         # still have the original binaries available.
         node = self.nodes[0]
         if self._installer._started:
-            head_root_path = self._installer.path_for_version(
+            head_root_path = self._installer.root_for_version(
                 RedpandaInstaller.HEAD)
             binary = f"{head_root_path}/libexec/redpanda"
         else:

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -42,7 +42,10 @@ class InstallOptions:
     """
     Options with which to configure the installation of Redpanda in a cluster.
     """
-    def __init__(self, install_previous_version=False, version=None):
+    def __init__(self,
+                 install_previous_version=False,
+                 version=None,
+                 num_to_upgrade=0):
         # If true, install the highest version of the prior feature version
         # before HEAD.
         self.install_previous_version = install_previous_version
@@ -50,6 +53,11 @@ class InstallOptions:
         # Either RedpandaInstaller.HEAD or a numeric tuple representing the
         # version to install (e.g. (22, 1, 3)).
         self.version = version
+
+        # Number of nodes in a cluster to upgrade to HEAD after starting the
+        # cluster on an older version, e.g. to simulate a mixed-version
+        # environment.
+        self.num_to_upgrade = num_to_upgrade
 
 
 class RedpandaInstaller:

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -38,6 +38,20 @@ def wait_for_num_versions(redpanda, num_versions):
     return unique_versions
 
 
+class InstallOptions:
+    """
+    Options with which to configure the installation of Redpanda in a cluster.
+    """
+    def __init__(self, install_previous_version=False, version=None):
+        # If true, install the highest version of the prior feature version
+        # before HEAD.
+        self.install_previous_version = install_previous_version
+
+        # Either RedpandaInstaller.HEAD or a numeric tuple representing the
+        # version to install (e.g. (22, 1, 3)).
+        self.version = version
+
+
 class RedpandaInstaller:
     """
     Provides mechanisms to install multiple Redpanda binaries on a cluster.

--- a/tests/rptest/services/rolling_restarter.py
+++ b/tests/rptest/services/rolling_restarter.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import requests
+
+from ducktape.utils.util import wait_until
+
+
+class RollingRestarter:
+    """
+    Encapsulates the logic needed to perform a rolling restart.
+    """
+    def __init__(self, redpanda):
+        self.redpanda = redpanda
+
+    def restart_nodes(self,
+                      nodes,
+                      override_cfg_params=None,
+                      start_timeout=None,
+                      stop_timeout=None):
+        """
+        Performs a rolling restart on the given nodes, optionally overriding
+        the given configs.
+        """
+        admin = self.redpanda._admin
+
+        def has_drained_leaders(node):
+            try:
+                node_id = self.redpanda.idx(node)
+                broker_resp = admin.get_broker(node_id)
+                maintenance_status = broker_resp["maintenance_status"]
+                return maintenance_status["draining"] and maintenance_status[
+                    "finished"]
+            except requests.exceptions.HTTPError:
+                return False
+
+        # TODO: incorporate rack awareness into this to support updating
+        # multiple nodes at a time.
+        for node in nodes:
+            wait_until(lambda: self.redpanda.healthy(),
+                       timeout_sec=stop_timeout,
+                       backoff_sec=1)
+
+            admin.maintenance_start(node)
+
+            wait_until(lambda: has_drained_leaders(node),
+                       timeout_sec=stop_timeout,
+                       backoff_sec=1)
+
+            wait_until(lambda: self.redpanda.healthy(),
+                       timeout_sec=stop_timeout,
+                       backoff_sec=1)
+
+            self.redpanda.stop_node(node, timeout=stop_timeout)
+
+            self.redpanda.start_node(node,
+                                     override_cfg_params,
+                                     timeout=start_timeout)
+
+            wait_until(lambda: self.redpanda.healthy(),
+                       timeout_sec=start_timeout,
+                       backoff_sec=1)
+
+            admin.maintenance_stop(node)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -104,6 +104,18 @@ class EndToEndTest(Test):
             self.redpanda._installer.install(self.redpanda.nodes,
                                              version_to_install)
         self.redpanda.start()
+        if version_to_install and install_opts.num_to_upgrade > 0:
+            # Perform the upgrade rather than starting each node on the
+            # appropriate version. Redpanda may not start up if starting a new
+            # cluster with mixed-versions.
+            nodes_to_upgrade = [
+                self.redpanda.get_node(i + 1)
+                for i in range(install_opts.num_to_upgrade)
+            ]
+            self.redpanda._installer.install(nodes_to_upgrade,
+                                             RedpandaInstaller.HEAD)
+            self.redpanda.restart_nodes(nodes_to_upgrade)
+
         self._client = DefaultClient(self.redpanda)
 
     @property

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -15,12 +15,13 @@ import requests
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark import ok_to_fail
+from ducktape.mark import matrix
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
+from rptest.services.redpanda_installer import InstallOptions
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.services.honey_badger import HoneyBadger
 from rptest.services.rpk_producer import RpkProducer
@@ -30,12 +31,25 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
 
 # Errors we should tolerate when moving partitions around
 PARTITION_MOVEMENT_LOG_ERRORS = [
-    # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
+    # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exist on target broker
     "raft - .*raft group does not exist on target broker",
     # e.g.  raft - [group_id:3, {kafka/topic/2}] consensus.cc:2317 - unable to replicate updated configuration: raft::errc::replicated_entry_truncated
     "raft - .*unable to replicate updated configuration: .*",
     # e.g. recovery_stm.cc:432 - recovery append entries error: rpc::errc::client_request_timeout"
     "raft - .*recovery append entries error.*client_request_timeout"
+]
+
+PREV_VERSION_LOG_ALLOW_LIST = [
+    # e.g. cluster - controller_backend.cc:400 - Error while reconciling topics - seastar::abort_requested_exception (abort requested)
+    "cluster - .*Error while reconciling topic.*",
+    # Typo fixed in recent versions.
+    # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
+    "raft - .*raft group does not exists on target broker",
+    # e.g. rpc - Service handler thrown an exception - seastar::gate_closed_exception (gate closed)
+    "rpc - .*gate_closed_exception.*",
+    # Tests on mixed versions will start out with an unclean restart before
+    # starting a workload.
+    "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)"
 ]
 
 
@@ -62,12 +76,19 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             **kwargs)
         self._ctx = ctx
 
-    @cluster(num_nodes=3)
-    def test_moving_not_fully_initialized_partition(self):
+    @cluster(num_nodes=3, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_moving_not_fully_initialized_partition(self, num_to_upgrade):
         """
         Move partition before first leader is elected
         """
-        self.start_redpanda(num_nodes=3)
+        # NOTE: num_to_upgrade=0 indicates that we're just testing HEAD without
+        # any mixed versions.
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         hb = HoneyBadger()
         # if failure injector is not enabled simply skip this test
@@ -123,12 +144,17 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         wait_until(derived_done, timeout_sec=60, backoff_sec=2)
 
-    @cluster(num_nodes=3)
-    def test_empty(self):
+    @cluster(num_nodes=3, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_empty(self, num_to_upgrade):
         """
         Move empty partitions.
         """
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         topics = []
         for partition_count in range(1, 5):
@@ -145,13 +171,20 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         for _ in range(25):
             self._move_and_verify()
 
-    @cluster(num_nodes=4, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
-    def test_static(self):
+    @cluster(num_nodes=4,
+             log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
+             PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_static(self, num_to_upgrade):
         """
         Move partitions with data, but no active producers or consumers.
         """
         self.logger.info(f"Starting redpanda...")
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         topics = []
         for partition_count in range(1, 5):
@@ -235,14 +268,22 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         return throughput, records, moves
 
-    @cluster(num_nodes=5, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
-    def test_dynamic(self):
+    @cluster(num_nodes=5,
+             log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
+             PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_dynamic(self, num_to_upgrade):
         """
         Move partitions with active consumer / producer
         """
         throughput, records, moves = self._get_scale_params()
 
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
         self.start_redpanda(num_nodes=3,
+                            install_opts=install_opts,
                             extra_rp_conf={"default_topic_replications": 3})
         spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
         self.client().create_topic(spec)
@@ -257,8 +298,11 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             consumer_timeout_sec=45,
                             min_records=records)
 
-    @cluster(num_nodes=5, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
-    def test_move_consumer_offsets_intranode(self):
+    @cluster(num_nodes=5,
+             log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
+             PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_move_consumer_offsets_intranode(self, num_to_upgrade):
         """
         Exercise moving the consumer_offsets/0 partition between shards
         within the same nodes.  This reproduces certain bugs in the special
@@ -266,8 +310,18 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         """
         throughput, records, moves = self._get_scale_params()
 
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions()
+        if test_mixed_versions:
+            # Start at a version that supports consumer groups.
+            # TODO: use 'install_previous_version' once it becomes the prior
+            # feature version.
+            install_opts = InstallOptions(version=(22, 1, 3),
+                                          num_to_upgrade=num_to_upgrade)
         self.start_redpanda(num_nodes=3,
+                            install_opts=install_opts,
                             extra_rp_conf={"default_topic_replications": 3})
+
         spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
         self.client().create_topic(spec)
         self.topic = spec.name
@@ -293,12 +347,17 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
     @cluster(num_nodes=5,
              log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
-             RESTART_LOG_ALLOW_LIST)
-    def test_bootstrapping_after_move(self):
+             RESTART_LOG_ALLOW_LIST + PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_bootstrapping_after_move(self, num_to_upgrade):
         """
         Move partitions with active consumer / producer
         """
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
         spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
         self.client().create_topic(spec)
         self.topic = spec.name
@@ -328,13 +387,18 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         wait_until(offsets_are_recovered, 30, 2)
 
-    @cluster(num_nodes=3)
-    def test_invalid_destination(self):
+    @cluster(num_nodes=3, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_invalid_destination(self, num_to_upgrade):
         """
         Check that requuests to move to non-existent locations are properly rejected.
         """
 
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
         spec = TopicSpec(name="topic", partition_count=1, replication_factor=1)
         self.client().create_topic(spec)
         topic = spec.name
@@ -410,14 +474,24 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         r = admin.set_partition_replicas(topic, partition, assignments)
         assert r.status_code == 200
 
-    @cluster(num_nodes=5)
-    def test_overlapping_changes(self):
+    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_overlapping_changes(self, num_to_upgrade):
         """
         Check that while a movement is in flight, rules about
         overlapping operations are properly enforced.
         """
 
-        self.start_redpanda(num_nodes=4)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions()
+        if test_mixed_versions:
+            # Start at a version that supports the RpkProducer workload.
+            # TODO: use 'install_previous_version' once it becomes the prior
+            # feature version.
+            install_opts = InstallOptions(
+                install_previous_version=test_mixed_versions)
+        self.start_redpanda(num_nodes=4, install_opts=install_opts)
+
         node_ids = {1, 2, 3, 4}
 
         # Create topic with enough data that inter-node movement
@@ -499,14 +573,19 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         rpk.delete_topic(name)
         assert name not in rpk.list_topics()
 
-    @cluster(num_nodes=4)
-    def test_deletion_stops_move(self):
+    @cluster(num_nodes=4, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_deletion_stops_move(self, num_to_upgrade):
         """
         Delete topic which partitions are being moved and check status after 
         topic is created again, old move 
         opeartions should not influcence newly created topic
         """
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         # create a single topic with replication factor of 1
         topic = 'test-topic'
@@ -574,6 +653,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         wait_until(lambda: get_status() == 'in_progress', 10, 1)
         # delete the topic
         rpk.delete_topic(topic)
+
         # start the node back up
         self.redpanda.start_node(node)
         # create topic again
@@ -644,8 +724,9 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         partitions = 1 if self.debug_mode else 10
         return throughput, records, moves, partitions
 
-    @cluster(num_nodes=5)
-    def test_shadow_indexing(self):
+    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_shadow_indexing(self, num_to_upgrade):
         """
         Test interaction between the shadow indexing and the partition movement.
         Partition movement generate partitions with different revision-ids and the
@@ -654,7 +735,11 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         """
         throughput, records, moves, partitions = self._get_scale_params()
 
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
         spec = TopicSpec(name="topic",
                          partition_count=partitions,
                          replication_factor=3)
@@ -669,15 +754,21 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             consumer_timeout_sec=45,
                             min_records=records)
 
-    @cluster(num_nodes=5)
-    def test_cross_shard(self):
+    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @matrix(num_to_upgrade=[0, 2])
+    def test_cross_shard(self, num_to_upgrade):
         """
         Test interaction between the shadow indexing and the partition movement.
         Move partitions with SI enabled between shards.
         """
         throughput, records, moves, partitions = self._get_scale_params()
 
-        self.start_redpanda(num_nodes=3)
+        test_mixed_versions = num_to_upgrade > 0
+        install_opts = InstallOptions(
+            install_previous_version=test_mixed_versions,
+            num_to_upgrade=num_to_upgrade)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
+
         spec = TopicSpec(name="topic",
                          partition_count=partitions,
                          replication_factor=3)

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -10,11 +10,12 @@
 import re
 from packaging.version import Version
 
-from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller, wait_for_num_versions
 
 
 class UpgradeFromSpecificVersion(RedpandaTest):
@@ -91,3 +92,38 @@ class UpgradeFromPriorFeatureVersionTest(RedpandaTest):
 
         unique_versions = wait_for_num_versions(self.redpanda, 1)
         assert head_version_str in unique_versions, unique_versions
+
+
+class UpgradeWithWorkloadTest(EndToEndTest):
+    """
+    Test class that performs upgrades while verifying a concurrently running
+    workload is making progress.
+    """
+    def setUp(self):
+        super(UpgradeWithWorkloadTest, self).setUp()
+        # Start at a version that supports rolling restarts.
+        self.initial_version = (22, 1, 3)
+        self.producer_msgs_per_sec = 200
+        install_opts = InstallOptions(version=self.initial_version)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
+        self.installer = self.redpanda._installer
+
+        # Start running a workload.
+        spec = TopicSpec(name="topic", partition_count=2, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(num_nodes=1, throughput=self.producer_msgs_per_sec)
+        self.start_consumer(num_nodes=1)
+        self.await_startup(min_records=self.producer_msgs_per_sec)
+
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_rolling_upgrade(self):
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        # Give ample time to restart, given the running workload.
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
+                                            start_timeout=90,
+                                            stop_timeout=90)
+
+        post_upgrade_num_msgs = self.producer.num_acked
+        self.run_validation(min_records=post_upgrade_num_msgs +
+                            (self.producer_msgs_per_sec * 3))


### PR DESCRIPTION
## Cover letter
This PR starts using the `RedpandaInstaller` to extend some existing tests with upgrades, also adding a means to perform rolling restarts. Along the way, I fixed some test infra issues found in testing.

Also fixes #5378 

## Release notes
* none
