### PR TITLE
gitignore: add .task/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ vbuild/
 /vtools
 /Taskfile.yml
 /.dockerignore
+/.task/
 
 # helm chart dependencies
 *.tgz


### PR DESCRIPTION
This folder is used to store checksums used by Task


## Release notes


* none
