### PR TITLE
tests: extend trim_results.py to reduce tarball size

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -383,7 +383,7 @@ class RedpandaService(Service):
     DEFAULT_COV_OPT = False
 
     # Where we put a compressed binary if saving it after failure
-    EXECUTABLE_SAVE_PATH = "/tmp/redpanda.tar.gz"
+    EXECUTABLE_SAVE_PATH = "/tmp/redpanda.gz"
 
     # When configuring multiple listeners for testing, a secondary port to use
     # instead of the default.

--- a/tests/rptest/trim_results.py
+++ b/tests/rptest/trim_results.py
@@ -17,6 +17,8 @@ import json
 import shutil
 import sys
 import concurrent.futures
+import hashlib
+from collections import defaultdict
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -31,9 +33,7 @@ class Trimmer:
     def __init__(self, result_path):
         self.result_path = result_path
 
-    def get_passed_test_logs(self):
-        results = json.load(open(os.path.join(self.result_path,
-                                              "report.json")))['results']
+    def get_passed_test_logs(self, results: list):
         log_paths = []
         for r in results:
             results_dir = os.path.join(self.result_path,
@@ -70,8 +70,61 @@ class Trimmer:
 
         return log_paths
 
+    def get_saved_executables(self, results: list):
+        EXE_FILENAME = "redpanda.gz"
+
+        exe_paths = []
+        for r in results:
+            results_dir = os.path.join(self.result_path,
+                                       r['relative_results_dir'])
+
+            for service in r['services']:
+                if service['cls_name'] != "RedpandaService":
+                    continue
+
+                service_dir = os.path.join(results_dir, service['service_id'])
+                for node in service['nodes']:
+                    hostname = node.split("@")[-1]
+                    exe_path = os.path.join(service_dir,
+                                            f"{hostname}/{EXE_FILENAME}")
+                    if os.path.exists(exe_path):
+                        exe_paths.append(exe_path)
+
+        return exe_paths
+
+    def deduplicate_executables(self, saved_exes):
+        if len(saved_exes) < 2:
+            return
+
+        by_checksum = defaultdict(list)
+        for e in saved_exes:
+            h = hashlib.sha1()
+            with open(e, 'rb') as f:
+                for chunk in iter(lambda: f.read(16384), b""):
+                    h.update(chunk)
+            hash = h.hexdigest()
+            by_checksum[hash].append(e)
+
+        for hash, filenames in by_checksum.items():
+            keep_file = filenames[0]
+            for f in filenames[1:]:
+                log.info(f"Deleting duplicate executable: {f}")
+                os.unlink(f)
+
+                # Leave a note behind about where to find a copy of the executable
+                note_path = os.path.join(os.path.dirname(f),
+                                         "redpanda.gz.moved")
+                note_message = f"De-duplicated executables in test results: an identical executable is at {keep_file}"
+                open(note_path, "w").write(note_message)
+
     def trim(self):
-        log_paths = self.get_passed_test_logs()
+        results = json.load(open(os.path.join(self.result_path,
+                                              "report.json")))['results']
+
+        log_paths = self.get_passed_test_logs(results)
+        saved_exes = self.get_saved_executables(results)
+
+        self.deduplicate_executables(saved_exes)
 
         executor = concurrent.futures.ThreadPoolExecutor()
 


### PR DESCRIPTION
## Cover letter

These changes were motivated by large size of tarball for https://github.com/redpanda-data/redpanda/issues/5285:
- Trim logs for kafka & mirrormaker services as well as redpanda
- Remove duplicate binaries from tests with crashes

## Release notes

* none