### PR TITLE
redpanda: per listener authentication for kafka

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME config
   SRCS
+    broker_authn_endpoint.cc
     configuration.cc
     node_config.cc
     base_property.cc

--- a/src/v/config/broker_authn_endpoint.cc
+++ b/src/v/config/broker_authn_endpoint.cc
@@ -1,0 +1,104 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/broker_authn_endpoint.h"
+
+#include "kafka/client/exceptions.h"
+#include "model/metadata.h"
+#include "utils/string_switch.h"
+
+namespace config {
+
+std::string_view to_string_view(broker_authn_method m) {
+    switch (m) {
+    case broker_authn_method::none:
+        return "none";
+    case broker_authn_method::sasl:
+        return "sasl";
+    case broker_authn_method::mtls_identity:
+        return "mtls_identity";
+    }
+}
+
+template<>
+std::optional<broker_authn_method>
+from_string_view<broker_authn_method>(std::string_view sv) {
+    return string_switch<broker_authn_method>(sv)
+      .match("none", broker_authn_method::none)
+      .match("sasl", broker_authn_method::sasl)
+      .match("mtls_identity", broker_authn_method::mtls_identity)
+      .default_match(broker_authn_method::none);
+}
+
+std::ostream& operator<<(std::ostream& os, const broker_authn_endpoint& ep) {
+    fmt::print(os, "{{{}:{}:{}}}", ep.name, ep.address, ep.authn_method);
+    return os;
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::broker_authn_endpoint>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["address"] = rhs.address.host();
+    node["port"] = rhs.address.port();
+    if (rhs.authn_method) {
+        node["authentication_method"] = ss::sstring(
+          to_string_view(*rhs.authn_method));
+    }
+    return node;
+}
+
+bool convert<config::broker_authn_endpoint>::decode(
+  const Node& node, type& rhs) {
+    for (auto s : {"address", "port"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+    ss::sstring name;
+    if (node["name"]) {
+        name = node["name"].as<ss::sstring>();
+    }
+    auto address = node["address"].as<ss::sstring>();
+    auto port = node["port"].as<uint16_t>();
+    auto addr = net::unresolved_address(std::move(address), port);
+    std::optional<config::broker_authn_method> method{};
+    if (auto n = node["authentication_method"]; bool(n)) {
+        method = config::from_string_view<config::broker_authn_method>(
+          n.as<ss::sstring>());
+    }
+    rhs = config::broker_authn_endpoint{
+      .name = std::move(name),
+      .address = std::move(addr),
+      .authn_method = method};
+    return true;
+}
+
+} // namespace YAML
+
+void json::rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const config::broker_authn_endpoint& ep) {
+    w.StartObject();
+    w.Key("name");
+    w.String(ep.name);
+    w.Key("address");
+    w.String(ep.address.host());
+    w.Key("port");
+    w.Uint(ep.address.port());
+    if (ep.authn_method) {
+        w.Key("authentication_method");
+        auto method = to_string_view(*ep.authn_method);
+        w.String(method.begin(), method.length());
+    }
+    w.EndObject();
+}

--- a/src/v/config/broker_authn_endpoint.h
+++ b/src/v/config/broker_authn_endpoint.h
@@ -1,0 +1,85 @@
+// Copyright 2021 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/property.h"
+#include "json/_include_first.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+#include "net/unresolved_address.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <yaml-cpp/node/node.h>
+
+#include <iosfwd>
+#include <optional>
+#include <string>
+
+namespace config {
+
+template<typename E>
+std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
+  from_string_view(std::string_view);
+
+enum class broker_authn_method {
+    none = 0,
+    sasl,
+    mtls_identity,
+};
+
+std::string_view to_string_view(broker_authn_method m);
+
+template<>
+std::optional<broker_authn_method>
+from_string_view<broker_authn_method>(std::string_view sv);
+
+struct broker_authn_endpoint {
+    ss::sstring name;
+    net::unresolved_address address;
+    std::optional<broker_authn_method> authn_method;
+
+    friend bool
+    operator==(const broker_authn_endpoint&, const broker_authn_endpoint&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const broker_authn_endpoint& ep);
+};
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<broker_authn_endpoint>() {
+    return "config::broker_auth_endpoint";
+}
+
+} // namespace detail
+
+} // namespace config
+
+namespace YAML {
+
+template<>
+struct convert<config::broker_authn_endpoint> {
+    using type = config::broker_authn_endpoint;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::broker_authn_endpoint& ep);
+
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -13,6 +13,7 @@
 #include "config/node_config.h"
 #include "config/validators.h"
 #include "model/metadata.h"
+#include "security/mtls.h"
 #include "storage/chunk_cache.h"
 #include "storage/segment_appender.h"
 #include "units.h"
@@ -795,6 +796,13 @@ configuration::configuration()
       ". See also: `enable_sasl` and `kafka_api[].authentication_method`",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , kafka_mtls_principal_mapping_rules(
+      *this,
+      "kafka_mtls_principal_mapping_rules",
+      "Principal Mapping Rules for mTLS Authentication on the Kafka API",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      security::tls::validate_rules)
   , controller_backend_housekeeping_interval_ms(
       *this,
       "controller_backend_housekeeping_interval_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -18,6 +18,7 @@
 #include "units.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace config {
 using namespace std::chrono_literals;
@@ -780,9 +781,20 @@ configuration::configuration()
   , enable_sasl(
       *this,
       "enable_sasl",
-      "Enable SASL authentication for Kafka connections.",
+      "Enable SASL authentication for Kafka connections, authorization is "
+      "required. see also `kafka_enable_authorization`",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , kafka_enable_authorization(
+      *this,
+      "kafka_enable_authorization",
+      "Enable authorization for Kafka connections. Values:"
+      "- `nil`: Ignored. Authorization is enabled with `enable_sasl: true`"
+      "; `true`: authorization is required"
+      "; `false`: authorization is disabled"
+      ". See also: `enable_sasl` and `kafka_api[].authentication_method`",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt)
   , controller_backend_housekeeping_interval_ms(
       *this,
       "controller_backend_housekeeping_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -172,7 +172,8 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
     property<std::optional<bool>> kafka_enable_authorization;
-    property<std::optional<ss::sstring>> kafka_mtls_principal_mapping_rules;
+    property<std::optional<std::vector<ss::sstring>>>
+      kafka_mtls_principal_mapping_rules;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -172,6 +172,7 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
     property<std::optional<bool>> kafka_enable_authorization;
+    property<std::optional<ss::sstring>> kafka_mtls_principal_mapping_rules;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -171,6 +171,7 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
+    property<std::optional<bool>> kafka_enable_authorization;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -63,7 +63,9 @@ node_config::node_config() noexcept
       "kafka_api",
       "Address and port of an interface to listen for Kafka API requests",
       {.visibility = visibility::user},
-      {model::broker_endpoint(net::unresolved_address("127.0.0.1", 9092))})
+      {config::broker_authn_endpoint{
+        .address = net::unresolved_address("127.0.0.1", 9092),
+        .authn_method = std::nullopt}})
   , kafka_api_tls(
       *this,
       "kafka_api_tls",

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -60,11 +60,6 @@ void rjson_serialize_impl(
         w.Key("truststore_file");
         w.String((*(v.get_truststore_file())).c_str());
     }
-
-    if (v.get_principal_mapping_rules()) {
-        w.Key("principal_mapping_rules");
-        w.String(*v.get_principal_mapping_rules());
-    }
 }
 
 void rjson_serialize(

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -23,7 +23,6 @@
 #include <seastar/net/tls.hh>
 
 #include <boost/filesystem.hpp>
-#include <security/mtls.h>
 #include <yaml-cpp/yaml.h>
 
 #include <optional>
@@ -57,13 +56,11 @@ public:
       bool enabled,
       std::optional<key_cert> key_cert,
       std::optional<ss::sstring> truststore,
-      bool require_client_auth,
-      std::optional<ss::sstring> principal_mapping_rules)
+      bool require_client_auth)
       : _enabled(enabled)
       , _key_cert(std::move(key_cert))
       , _truststore_file(std::move(truststore))
-      , _require_client_auth(require_client_auth)
-      , _principal_mapping_rules(std::move(principal_mapping_rules)) {}
+      , _require_client_auth(require_client_auth) {}
 
     bool is_enabled() const { return _enabled; }
 
@@ -76,10 +73,6 @@ public:
     }
 
     bool get_require_client_auth() const { return _require_client_auth; }
-
-    const std::optional<ss::sstring>& get_principal_mapping_rules() const {
-        return _principal_mapping_rules;
-    }
 
     ss::future<std::optional<ss::tls::credentials_builder>>
     get_credentials_builder() const& {
@@ -125,19 +118,6 @@ public:
             return "Trust store is required when client authentication is "
                    "enabled";
         }
-        if (c.get_principal_mapping_rules()) {
-            if (!c.get_require_client_auth()) {
-                return "Client authentication is required when principal "
-                       "mapping rules are set";
-            }
-            // Validate regex of the mapping rules
-            try {
-                security::tls::detail::parse_rules(
-                  c.get_principal_mapping_rules());
-            } catch (const std::runtime_error& e) {
-                return e.what();
-            }
-        }
 
         return std::nullopt;
     }
@@ -150,12 +130,9 @@ public:
           << "enabled: " << c.is_enabled() << " "
           << "key/cert files: " << c.get_key_cert_files() << " "
           << "ca file: " << c.get_truststore_file() << " "
-          << "client_auth_required: " << c.get_require_client_auth();
-        if (c.get_principal_mapping_rules()) {
-            o << " principal_mapping_rules: "
-              << c.get_principal_mapping_rules();
-        }
-        return o << " }";
+          << "client_auth_required: " << c.get_require_client_auth() << ""
+          << " }";
+        return o;
     }
 
 private:
@@ -163,7 +140,6 @@ private:
     std::optional<key_cert> _key_cert;
     std::optional<ss::sstring> _truststore_file;
     bool _require_client_auth{false};
-    std::optional<ss::sstring> _principal_mapping_rules;
 };
 
 } // namespace config
@@ -203,11 +179,6 @@ struct convert<config::tls_config> {
             node["truststore_file"] = *rhs.get_truststore_file();
         }
 
-        if (rhs.get_principal_mapping_rules()) {
-            node["principal_mapping_rules"]
-              = *rhs.get_principal_mapping_rules();
-        }
-
         return node;
     }
 
@@ -228,8 +199,7 @@ struct convert<config::tls_config> {
         }
         auto enabled = node["enabled"] && node["enabled"].as<bool>();
         if (!enabled) {
-            rhs = config::tls_config(
-              false, std::nullopt, std::nullopt, false, std::nullopt);
+            rhs = config::tls_config(false, std::nullopt, std::nullopt, false);
         } else {
             auto key_cert
               = node["key_file"]
@@ -237,17 +207,12 @@ struct convert<config::tls_config> {
                     to_absolute(node["key_file"].as<ss::sstring>()),
                     to_absolute(node["cert_file"].as<ss::sstring>())})
                   : std::nullopt;
-            auto principal_mapping_rules
-              = node["principal_mapping_rules"]
-                  ? node["principal_mapping_rules"].as<ss::sstring>()
-                  : std::optional<ss::sstring>();
             rhs = config::tls_config(
               enabled,
               key_cert,
               to_absolute(read_optional(node, "truststore_file")),
               node["require_client_auth"]
-                && node["require_client_auth"].as<bool>(),
-              principal_mapping_rules);
+                && node["require_client_auth"].as<bool>());
         }
         return true;
     }

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -68,10 +68,7 @@ ss::future<> connection_context::process_one_request() {
                       _rs.probe().header_corrupted();
                       return ss::make_ready_future<>();
                   }
-                  return handle_mtls_auth()
-                    .then([this, h = std::move(h.value()), s]() mutable {
-                        return dispatch_method_once(std::move(h), s);
-                    })
+                  return dispatch_method_once(std::move(h.value()), s)
                     .handle_exception_type([this](const std::bad_alloc&) {
                         // In general, dispatch_method_once does not throw,
                         // but bad_allocs are an exception.  Log it cleanly
@@ -84,56 +81,6 @@ ss::future<> connection_context::process_one_request() {
                           _rs.conn->addr);
                     });
               });
-      });
-}
-
-/*
- * handle mtls authentication. this should only happen once when the connection
- * is setup. even though this is called in the normal request handling path,
- * this property should hold becuase:
- *
- * 1. is a noop if a mtls principal has been extracted
- * 2. all code paths that don't set the principal throw and drop the connection
- *
- * NOTE: handle_mtls_auth is called after reading header off the wire. this is
- * odd because we would expect that tls negotation etc... all happens before we
- * here to the application layer. however, it appears that the way seastar works
- * that we need to read some data off the wire to drive this process within the
- * internal connection handling.
- */
-ss::future<> connection_context::handle_mtls_auth() {
-    if (!_use_mtls || _mtls_principal.has_value()) {
-        return ss::now();
-    }
-    return ss::with_timeout(
-             model::timeout_clock::now() + 5s,
-             _rs.conn->get_distinguished_name())
-      .then([this](std::optional<ss::session_dn> dn) {
-          if (!dn.has_value()) {
-              throw security::exception(
-                security::errc::invalid_credentials,
-                "failed to fetch distinguished name");
-          }
-          /*
-           * for now it probably is fine to store the mapping per connection.
-           * but it seems like we could also share this across all connections
-           * with the same tls configuration.
-           */
-          _mtls_principal = _rs.conn->get_principal_mapping()->apply(
-            dn->subject);
-          if (!_mtls_principal) {
-              throw security::exception(
-                security::errc::invalid_credentials,
-                fmt::format(
-                  "failed to extract principal from distinguished name: {}",
-                  dn->subject));
-          }
-
-          vlog(
-            _authlog.debug,
-            "got principal: {}, from distinguished name: {}",
-            *_mtls_principal,
-            dn->subject);
       });
 }
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -68,6 +68,10 @@ public:
     template<typename T>
     bool authorized(
       security::acl_operation operation, const T& name, authz_quiet quiet) {
+        // authorization disabled?
+        if (!_enable_authorizer) {
+            return true;
+        }
         // mtls configured?
         if (_use_mtls) {
             if (_mtls_principal.has_value()) {
@@ -76,12 +80,8 @@ public:
             }
             return false;
         }
-        // sasl configured?
-        if (!_enable_authorizer) {
-            return true;
-        }
-        auto user = sasl().principal();
-        return authorized_user(std::move(user), operation, name, quiet);
+        // use sasl
+        return authorized_user(sasl().principal(), operation, name, quiet);
     }
 
     template<typename T>

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -265,6 +265,24 @@ kafka_endpoint_format(const std::vector<model::broker_endpoint>& endpoints) {
     return ssx::sformat("{}", fmt::join(uris, ","));
 }
 
+static ss::sstring kafka_authn_endpoint_format(
+  const std::vector<config::broker_authn_endpoint>& endpoints) {
+    std::vector<ss::sstring> uris;
+    uris.reserve(endpoints.size());
+    std::transform(
+      endpoints.cbegin(),
+      endpoints.cend(),
+      std::back_inserter(uris),
+      [](const config::broker_authn_endpoint& ep) {
+          return ssx::sformat(
+            "{}://{}:{}",
+            (ep.name.empty() ? "plain" : ep.name),
+            ep.address.host(),
+            ep.address.port());
+      });
+    return ssx::sformat("{}", fmt::join(uris, ","));
+}
+
 static void report_broker_config(
   const describe_configs_resource& resource,
   describe_configs_result& result,
@@ -299,7 +317,7 @@ static void report_broker_config(
       "listeners",
       config::node().kafka_api,
       include_synonyms,
-      &kafka_endpoint_format);
+      &kafka_authn_endpoint_format);
 
     add_broker_config_if_requested(
       resource,

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -21,6 +21,7 @@
 #include "net/server.h"
 #include "security/authorizer.h"
 #include "security/credential_store.h"
+#include "security/mtls.h"
 #include "utils/ema.h"
 #include "v8_engine/data_policy_table.h"
 
@@ -159,6 +160,7 @@ private:
     ss::sharded<v8_engine::data_policy_table>& _data_policy_table;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
+    security::tls::principal_mapper _mtls_principal_mapper;
 
     latency_probe _probe;
 };

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -83,7 +83,7 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                               net::server::resources(nullptr, nullptr),
                               std::move(sasl),
                               false,
-                              false);
+                              std::nullopt);
 
                           return kafka::request_context(
                             conn,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1086,7 +1086,6 @@ void application::wire_up_redpanda_services() {
               auto& tls_config = config::node().kafka_api_tls.value();
               for (const auto& ep : config::node().kafka_api()) {
                   ss::shared_ptr<ss::tls::server_credentials> credentails;
-                  std::optional<security::tls::principal_mapper> tls_pm;
                   // find credentials for this endpoint
                   auto it = find_if(
                     tls_config.begin(),
@@ -1115,20 +1114,10 @@ void application::wire_up_redpanda_services() {
                                   })
                                 .get0()
                             : nullptr;
-
-                      auto tls_pm_rules
-                        = it->config.get_principal_mapping_rules();
-                      if (tls_pm_rules) {
-                          tls_pm = security::tls::principal_mapper(
-                            tls_pm_rules);
-                      }
                   }
 
                   c.addrs.emplace_back(
-                    ep.name,
-                    net::resolve_dns(ep.address).get0(),
-                    credentails,
-                    std::move(tls_pm));
+                    ep.name, net::resolve_dns(ep.address).get0(), credentails);
               }
 
               c.disable_metrics = net::metrics_disabled(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -19,6 +19,7 @@
 #include "cluster/shard_table.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
+#include "config/broker_authn_endpoint.h"
 #include "config/node_config.h"
 #include "coproc/api.h"
 #include "kafka/client/transport.h"
@@ -183,9 +184,10 @@ public:
             node_config.get("rpc_server")
               .set_value(net::unresolved_address("127.0.0.1", rpc_port));
             node_config.get("kafka_api")
-              .set_value(
-                std::vector<model::broker_endpoint>{model::broker_endpoint(
-                  net::unresolved_address("127.0.0.1", kafka_port))});
+              .set_value(std::vector<config::broker_authn_endpoint>{
+                config::broker_authn_endpoint{
+                  .address = net::unresolved_address(
+                    "127.0.0.1", kafka_port)}});
             node_config.get("data_directory")
               .set_value(config::data_directory_path{.path = base_path});
             node_config.get("coproc_supervisor_server")

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -414,7 +414,7 @@ public:
           net::server::resources(nullptr, nullptr),
           std::move(sasl),
           false,
-          false);
+          std::nullopt);
 
         kafka::request_header header;
         auto encoder_context = kafka::request_context(

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -133,8 +133,7 @@ FIXTURE_TEST(echo_round_trip_tls, rpc_integration_fixture) {
                            true,
                            config::key_cert{"redpanda.key", "redpanda.crt"},
                            "root_certificate_authority.chain_cert",
-                           false,
-                           std::nullopt)
+                           false)
                            .get_credentials_builder()
                            .get0();
 
@@ -210,8 +209,7 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     client_key.native(), client_crt.native()},
                                   client_ca.native(),
-                                  true,
-                                  std::nullopt)
+                                  true)
                                   .get_credentials_builder()
                                   .get0();
     // server credentials
@@ -224,8 +222,7 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
                                   config::key_cert{
                                     server_key.native(), server_crt.native()},
                                   server_ca.native(),
-                                  true,
-                                  std::nullopt)
+                                  true)
                                   .get_credentials_builder()
                                   .get0();
 

--- a/src/v/security/errc.h
+++ b/src/v/security/errc.h
@@ -8,6 +8,8 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#pragma once
+
 #include "outcome.h"
 
 namespace security {

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -26,7 +26,7 @@ namespace detail {
 static constexpr const char* const rule_pattern{
   R"((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))"};
 static constexpr const char* const rule_pattern_splitter{
-  R"(\s*((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))\s*(,\s*|$))"};
+  R"(\s*((DEFAULT)|RULE:((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))\s*([,\n]\s*|$))"};
 
 std::regex make_regex(std::string_view sv) {
     return std::regex{

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -147,6 +147,16 @@ std::optional<ss::sstring> rule::apply(std::string_view dn) const {
     return result;
 }
 
+std::optional<ss::sstring>
+validate_rules(const std::optional<ss::sstring>& r) noexcept {
+    try {
+        security::tls::detail::parse_rules(r);
+    } catch (const std::exception& e) {
+        return e.what();
+    }
+    return std::nullopt;
+}
+
 std::ostream& operator<<(std::ostream& os, const rule& r) {
     fmt::print(os, "{}", r);
     return os;

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -55,7 +55,8 @@ private:
 
 class principal_mapper {
 public:
-    explicit principal_mapper(config::binding<std::optional<ss::sstring>> cb);
+    explicit principal_mapper(
+      config::binding<std::optional<std::vector<ss::sstring>>> cb);
     std::optional<ss::sstring> apply(std::string_view sv) const;
 
 private:
@@ -64,7 +65,7 @@ private:
     friend std::ostream&
     operator<<(std::ostream& os, const principal_mapper& p);
 
-    config::binding<std::optional<ss::sstring>> _binding;
+    config::binding<std::optional<std::vector<ss::sstring>>> _binding;
     std::vector<rule> _rules;
 };
 
@@ -80,7 +81,7 @@ private:
 };
 
 std::optional<ss::sstring>
-validate_rules(const std::optional<ss::sstring>& r) noexcept;
+validate_rules(const std::optional<std::vector<ss::sstring>>& r) noexcept;
 
 } // namespace security::tls
 

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "config/property.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -18,7 +19,6 @@
 
 #include <fmt/core.h>
 
-#include <iosfwd>
 #include <optional>
 #include <regex>
 #include <string_view>
@@ -53,25 +53,10 @@ private:
     make_upper _to_upper{false};
 };
 
-namespace detail {
-
-std::vector<rule> parse_rules(std::optional<std::string_view> unparsed_rules);
-
-} // namespace detail
-
 class principal_mapper {
 public:
-    explicit principal_mapper(std::optional<std::string_view> sv)
-      : _rules{detail::parse_rules(sv)} {}
-
-    std::optional<ss::sstring> apply(std::string_view sv) const {
-        for (const auto& r : _rules) {
-            if (auto p = r.apply(sv); p.has_value()) {
-                return {std::move(p).value()};
-            }
-        }
-        return std::nullopt;
-    }
+    explicit principal_mapper(config::binding<std::optional<ss::sstring>> cb);
+    std::optional<ss::sstring> apply(std::string_view sv) const;
 
 private:
     friend struct fmt::formatter<principal_mapper>;
@@ -79,7 +64,19 @@ private:
     friend std::ostream&
     operator<<(std::ostream& os, const principal_mapper& p);
 
+    config::binding<std::optional<ss::sstring>> _binding;
     std::vector<rule> _rules;
+};
+
+class mtls_state {
+public:
+    explicit mtls_state(ss::sstring principal)
+      : _principal{std::move(principal)} {}
+
+    const ss::sstring& principal() { return _principal; }
+
+private:
+    ss::sstring _principal;
 };
 
 std::optional<ss::sstring>

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -82,6 +82,9 @@ private:
     std::vector<rule> _rules;
 };
 
+std::optional<ss::sstring>
+validate_rules(const std::optional<ss::sstring>& r) noexcept;
+
 } // namespace security::tls
 
 template<>

--- a/src/v/security/tests/mtls_test.cc
+++ b/src/v/security/tests/mtls_test.cc
@@ -101,7 +101,7 @@ BOOST_DATA_TEST_CASE(
     BOOST_REQUIRE_EQUAL(c.expected, *mapper.apply(c.input));
 }
 
-static std::array<record, 17> mtls_rule_splitting_data{
+static std::array<record, 18> mtls_rule_splitting_data{
   record{"[]", ""},
   {"[DEFAULT]", "DEFAULT"},
   {"[RULE:/]", "RULE://"},
@@ -124,6 +124,7 @@ static std::array<record, 17> mtls_rule_splitting_data{
    "DEFAULT, /DEFAULT, DEFAULT]",
    "RULE:,RULE:,/,RULE:,\\//U,RULE:,/RULE:,/,RULE:,RULE:,/L,RULE:,/L,RULE:, "
    "DEFAULT, /DEFAULT/,DEFAULT"},
+  {"[RULE:/, DEFAULT]", "RULE://\nDEFAULT"},
 };
 BOOST_DATA_TEST_CASE(
   test_mtls_rule_splitting, bdata::make(mtls_rule_splitting_data), c) {
@@ -151,6 +152,16 @@ BOOST_AUTO_TEST_CASE(test_mtls_parsing_with_multiline) {
       principal_mapper(
         config::mock_binding(std::optional<std::vector<ss::sstring>>{
           {{"RULE:^OU=(.*)/$1/"}, {"RULE:^CN=(.*)/$1/"}}}))
+        .apply("CN=test_cn")
+        .value_or(""));
+}
+
+BOOST_AUTO_TEST_CASE(test_mtls_parsing_with_newline) {
+    BOOST_CHECK_EQUAL(
+      "test_cn",
+      principal_mapper(
+        config::mock_binding(std::optional<std::vector<ss::sstring>>{
+          {"RULE:^OU=(.*)/$1/\nRULE:^CN=(.*)/$1/"}}))
         .apply("CN=test_cn")
         .value_or(""));
 }

--- a/src/v/security/tests/mtls_test.cc
+++ b/src/v/security/tests/mtls_test.cc
@@ -34,7 +34,7 @@ namespace security::tls {
 
 namespace bdata = boost::unit_test::data;
 
-std::array<std::string_view, 8> mtls_valid_rules{
+std::array<ss::sstring, 8> mtls_valid_rules{
   "DEFAULT",
   "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/",
   "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, DEFAULT",
@@ -45,11 +45,11 @@ std::array<std::string_view, 8> mtls_valid_rules{
   "RULE:^CN=([^,DEFAULT,]+)(,.*|$)/$1/"};
 
 BOOST_DATA_TEST_CASE(test_mtls_valid_rules, bdata::make(mtls_valid_rules), c) {
-    BOOST_REQUIRE_NO_THROW(
-      principal_mapper{config::mock_binding(std::optional<ss::sstring>{c})});
+    BOOST_REQUIRE_NO_THROW(principal_mapper{
+      config::mock_binding(std::optional<std::vector<ss::sstring>>{{c}})});
 }
 
-std::array<std::string_view, 10> mtls_invalid_rules{
+std::array<ss::sstring, 10> mtls_invalid_rules{
   "default",
   "DEFAUL",
   "DEFAULT/L",
@@ -64,7 +64,8 @@ std::array<std::string_view, 10> mtls_invalid_rules{
 BOOST_DATA_TEST_CASE(
   test_mtls_invalid_rules, bdata::make(mtls_invalid_rules), c) {
     BOOST_REQUIRE_THROW(
-      principal_mapper{config::mock_binding(std::optional<ss::sstring>{c})},
+      principal_mapper{
+        config::mock_binding(std::optional<std::vector<ss::sstring>>{{c}})},
       std::runtime_error);
 }
 
@@ -91,12 +92,12 @@ static std::array<record, 5> mtls_principal_mapper_data{
 BOOST_DATA_TEST_CASE(
   test_mtls_principal_mapper, bdata::make(mtls_principal_mapper_data), c) {
     security::tls::principal_mapper mapper{
-      config::mock_binding(std::optional<ss::sstring>{
-        "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, "
-        "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L, "
-        "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1@$2/U, "
-        "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/U, "
-        "DEFAULT"})};
+      config::mock_binding(std::optional<std::vector<ss::sstring>>{
+        {"RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, "
+         "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L, "
+         "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1@$2/U, "
+         "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/U, "
+         "DEFAULT"}})};
     BOOST_REQUIRE_EQUAL(c.expected, *mapper.apply(c.input));
 }
 
@@ -130,16 +131,27 @@ BOOST_DATA_TEST_CASE(
       c.expected,
       fmt::format(
         "{}",
-        principal_mapper(
-          config::mock_binding(std::optional<ss::sstring>{c.input}))));
+        principal_mapper(config::mock_binding(
+          std::optional<std::vector<ss::sstring>>{{ss::sstring{c.input}}}))));
 }
 
 BOOST_AUTO_TEST_CASE(test_mtls_comma_with_whitespace) {
     BOOST_CHECK_EQUAL(
       "Tkac\\, Adam",
-      principal_mapper(config::mock_binding(std::optional<ss::sstring>{
-                         "RULE:^CN=((\\\\, *|\\w)+)(,.*|$)/$1/,DEFAULT"}))
+      principal_mapper(
+        config::mock_binding(std::optional<std::vector<ss::sstring>>{
+          {"RULE:^CN=((\\\\, *|\\w)+)(,.*|$)/$1/,DEFAULT"}}))
         .apply("CN=Tkac\\, Adam,OU=ITZ,DC=geodis,DC=cz")
+        .value_or(""));
+}
+
+BOOST_AUTO_TEST_CASE(test_mtls_parsing_with_multiline) {
+    BOOST_CHECK_EQUAL(
+      "test_cn",
+      principal_mapper(
+        config::mock_binding(std::optional<std::vector<ss::sstring>>{
+          {{"RULE:^OU=(.*)/$1/"}, {"RULE:^CN=(.*)/$1/"}}}))
+        .apply("CN=test_cn")
         .value_or(""));
 }
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -539,6 +539,9 @@ class RedpandaService(Service):
     def set_extra_rp_conf(self, conf):
         self._extra_rp_conf = conf
 
+    def add_extra_rp_conf(self, conf):
+        self._extra_rp_conf = {**self._extra_rp_conf, **conf}
+
     def set_extra_node_conf(self, node, conf):
         assert node in self.nodes
         self._extra_node_conf[node] = conf
@@ -1335,10 +1338,6 @@ class RedpandaService(Service):
                 cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
                 truststore_file=RedpandaService.TLS_CA_CRT_FILE,
             )
-            if self.mtls_identity_enabled():
-                tls_config.update(
-                    dict(principal_mapping_rules=self._security.
-                         principal_mapping_rules))
             doc = yaml.full_load(conf)
             doc["redpanda"].update(dict(kafka_api_tls=tls_config))
             conf = yaml.dump(doc)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -21,9 +21,15 @@ redpanda:
     - name: dnslistener
       address: "{{node.account.hostname}}"
       port: 9092
+      {% if endpoint_authn_method %}
+      authentication_method: {{ endpoint_authn_method }}
+      {% endif %}
     - name: iplistener
       address: "{{node_ip}}"
       port: {{kafka_alternate_port}}
+      {% if endpoint_authn_method %}
+      authentication_method: {{ endpoint_authn_method }}
+      {% endif %}
   admin:
     - address: 127.0.0.1
       port: 9644

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -46,10 +46,15 @@ class AccessControlListTest(RedpandaTest):
         # it with custom security settings
         return
 
-    def prepare_cluster(self, use_tls, use_sasl):
+    def prepare_cluster(self,
+                        use_tls,
+                        use_sasl,
+                        enable_authz=None,
+                        authn_method=None):
         self.security = SecurityConfig()
         self.security.enable_sasl = use_sasl
-        self.security.enable_mtls_identity = use_tls and not use_sasl
+        self.security.kafka_enable_authorization = enable_authz
+        self.security.endpoint_authn_method = authn_method
 
         if use_tls:
             self.tls = tls.TLSCertManager(self.logger)
@@ -78,7 +83,7 @@ class AccessControlListTest(RedpandaTest):
 
         admin = Admin(self.redpanda)
 
-        if self.security.enable_mtls_identity:
+        if self.security.mtls_identity_enabled():
             feature_name = "mtls_authentication"
             admin.put_feature(feature_name, {"state": "active"})
 
@@ -92,11 +97,11 @@ class AccessControlListTest(RedpandaTest):
             wait_until(check_feature_active, timeout_sec=10, backoff_sec=1)
 
         # base case user is not a superuser and has no configured ACLs
-        if use_sasl:
+        if use_sasl or enable_authz:
             admin.create_user("base", self.password, self.algorithm)
 
         # only grant cluster describe permission to user cluster_describe
-        if use_sasl:
+        if use_sasl or enable_authz:
             admin.create_user("cluster_describe", self.password,
                               self.algorithm)
         client = self.get_super_client()
@@ -105,7 +110,7 @@ class AccessControlListTest(RedpandaTest):
         # there is not a convenient interface for waiting for acls to propogate
         # to all nodes so when we are using mtls only for identity we inject a
         # sleep here to try to avoid any acl propogation races.
-        if self.security.enable_mtls_identity:
+        if self.security.mtls_identity_enabled():
             time.sleep(5)
             return
 
@@ -120,7 +125,7 @@ class AccessControlListTest(RedpandaTest):
         wait_until(users_propogated, timeout_sec=10, backoff_sec=1)
 
     def get_client(self, username):
-        if self.security.enable_mtls_identity:
+        if self.security.mtls_identity_enabled():
             if username == "base":
                 cert = self.base_user_cert
             elif username == "cluster_describe":
@@ -140,7 +145,7 @@ class AccessControlListTest(RedpandaTest):
                        tls_cert=cert)
 
     def get_super_client(self):
-        if self.security.enable_mtls_identity:
+        if self.security.mtls_identity_enabled():
             return RpkTool(self.redpanda, tls_cert=self.admin_user_cert)
 
         username, password, _ = self.redpanda.SUPERUSER_CREDENTIALS
@@ -154,16 +159,31 @@ class AccessControlListTest(RedpandaTest):
                        sasl_mechanism=self.algorithm,
                        tls_cert=cert)
 
+    # The old config style has use_sasl at the top level, which enables
+    # authorization. New config style has kafka_enable_authorization at the
+    # top-level, with authentication_method on the listener.
     @cluster(num_nodes=3)
+    # plaintext conn + sasl for authn (global sasl config)
     @parametrize(use_tls=False,
-                 use_sasl=True)  # plaintext conn + sasl for authn
-    @parametrize(use_tls=True, use_sasl=True)  # ssl/tls conn + sasl for authn
-    @parametrize(use_tls=True, use_sasl=False)  # ssl/tls conn + mtls for authn
-    def test_describe_acls(self, use_tls, use_sasl):
+                 use_sasl=True,
+                 enable_authz=None,
+                 authn_method=None)
+    # ssl/tls conn + sasl for authn (global sasl config)
+    @parametrize(use_tls=True,
+                 use_sasl=True,
+                 enable_authz=None,
+                 authn_method=None)
+    # ssl/tls conn + mtls for authn (listener mtls config)
+    @parametrize(use_tls=True,
+                 use_sasl=False,
+                 enable_authz=True,
+                 authn_method="mtls_identity")
+    def test_describe_acls(self, use_tls, use_sasl, enable_authz,
+                           authn_method):
         """
         security::acl_operation::describe, security::default_cluster_name
         """
-        self.prepare_cluster(use_tls, use_sasl)
+        self.prepare_cluster(use_tls, use_sasl, enable_authz, authn_method)
 
         # run a few times for good health
         for _ in range(5):

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -81,9 +81,13 @@ class AccessControlListTest(RedpandaTest):
 
             self.security.tls_provider = MTLSProvider(self.tls)
 
-        if self.security.mtls_identity_enabled(
-        ) and principal_mapping_rules is not None:
-            self.security.principal_mapping_rules = principal_mapping_rules
+        if self.security.mtls_identity_enabled():
+            if principal_mapping_rules is not None:
+                self.security.principal_mapping_rules = principal_mapping_rules
+            self.redpanda.add_extra_rp_conf({
+                'kafka_mtls_principal_mapping_rules':
+                self.security.principal_mapping_rules
+            })
 
         self.redpanda.set_security_settings(self.security)
         self.redpanda.start()

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -86,7 +86,7 @@ class AccessControlListTest(RedpandaTest):
                 self.security.principal_mapping_rules = principal_mapping_rules
             self.redpanda.add_extra_rp_conf({
                 'kafka_mtls_principal_mapping_rules':
-                self.security.principal_mapping_rules
+                [self.security.principal_mapping_rules]
             })
 
         self.redpanda.set_security_settings(self.security)
@@ -258,6 +258,11 @@ class AccessControlListTest(RedpandaTest):
         rules=
         "RULE:^O=Redpanda,CN=(cluster_describe|redpanda.service.admin|admin)$/$1/",
         fail=False)
+    # Match admin or empty
+    @parametrize(
+        rules=
+        "RULE:^O=Redpanda,CN=(admin|redpanda.service.admin)$/$1/, RULE:^O=Redpanda,CN=()$/$1/L",
+        fail=True)
     def test_mtls_principal(self, rules=None, fail=False):
         """
         security::acl_operation::describe, security::default_cluster_name

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -50,7 +50,8 @@ class AccessControlListTest(RedpandaTest):
                         use_tls,
                         use_sasl,
                         enable_authz=None,
-                        authn_method=None):
+                        authn_method=None,
+                        principal_mapping_rules=None):
         self.security = SecurityConfig()
         self.security.enable_sasl = use_sasl
         self.security.kafka_enable_authorization = enable_authz
@@ -77,6 +78,10 @@ class AccessControlListTest(RedpandaTest):
                 name="test_admin_client")
 
             self.security.tls_provider = MTLSProvider(self.tls)
+
+        if self.security.mtls_identity_enabled(
+        ) and principal_mapping_rules is not None:
+            self.security.principal_mapping_rules = principal_mapping_rules
 
         self.redpanda.set_security_settings(self.security)
         self.redpanda.start()

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -173,6 +173,11 @@ class AccessControlListTest(RedpandaTest):
                  use_sasl=True,
                  enable_authz=None,
                  authn_method=None)
+    # ssl/tls conn + sasl for authn (listener sasl config)
+    @parametrize(use_tls=True,
+                 use_sasl=False,
+                 enable_authz=True,
+                 authn_method="sasl")
     # ssl/tls conn + mtls for authn (listener mtls config)
     @parametrize(use_tls=True,
                  use_sasl=False,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -484,7 +484,10 @@ class ClusterConfigTest(RedpandaTest):
 
         # Don't change these settings, they prevent the test from subsequently
         # using the cluster
-        exclude_settings = {'enable_sasl'}
+        exclude_settings = {
+            'enable_sasl', 'kafka_enable_authorization',
+            'kafka_mtls_principal_mapping_rules'
+        }
 
         # Don't enable coproc: it generates log errors if its companion service isn't running
         exclude_settings.add('enable_coproc')


### PR DESCRIPTION
## Cover letter

fixes #5153 
fixes #4782 
fixes #4784 
fixes #4785 
closes #4696 

Configuration changes
* `redpanda.kafka_enable_authorization`
  * Allows global runtime configuration of authorization for Kafka API
  * Setting it to null means AuthZ is enabled iff `enable_sasl` is true (as before)
  * Setting it true or false overrides `enable_sasl` for the purpose of enabling AuthZ
* `redpanda.kafka_api_tls.principal_mapping_rules` -> `redpanda.kafka_mtls_principal_mapping_rules`
* `redpanda.kafka_api.authentication_method` is new, per endpoint AuthN (`sasl`, `mtls_identity`, `none`)

E.g., from:
```yaml
redpanda:
  enable_sasl: false
  kafka_api:
    - name: has_mtls_identity
      address: 0.0.0.0
      name: admin
      port: 9092
    - name: requires_sasl
      address: 0.0.0.0
      name: admin
      port: 9093
  kafka_api_tls:
    - name: has_mtls_identity
      cert_file: mtls_server.crt
      enabled: true
      key_file: mtls_server.key
      require_client_auth: true
      truststore_file: mtls_ca.crt
      principal_mapping_rules: RULE:.*CN=([^,]+).*/$1/,DEFAULT
    - name: requires_sasl
      cert_file: mtls_server.crt
      enabled: true
      key_file: mtls_server.key
      require_client_auth: false
      truststore_file: mtls_ca.crt
```
to
```yaml
redpanda:
  enable_sasl: false # overridden by kafka_enable_authorization
  kafka_enable_authorization: true # override enable_sasl
  kafka_mtls_principal_mapping_rules: 
    - RULE:.*CN=([^,]+).*/$1/
    - DEFAULT
  kafka_api:
    - name: has_mtls_identity
      authentication_method: mtls_identity
      address: 0.0.0.0
      name: admin
      port: 9092
    - name: requires_sasl
      authentication_method: sasl
      address: 0.0.0.0
      name: admin
      port: 9093
  kafka_api_tls:
    - name: has_mtls_identity
      cert_file: mtls_server.crt
      enabled: true
      key_file: mtls_server.key
      require_client_auth: true
      truststore_file: mtls_ca.crt
    - name: requires_sasl
      cert_file: mtls_server.crt
      enabled: true
      key_file: mtls_server.key
      require_client_auth: false
      truststore_file: mtls_ca.crt
```

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/5ae99ed1409292b54d6b1d05eacad7d814b356ee..8bc40a57e79dd1132ba0f33fb0ece6ab30fc7aa2)
* First commit resolves the conflict
* `enable_authorization` - > `kafka_enable_authorization`
* `kafka_enable_authorization` has better docs
* `kafka_enable_authorization: false` disables authz.

## Release notes

### Features

* Allow authentication to be configured per-endpoint by setting `redpanda.kafka_api[].authentication_method`. Supported methods are `sasl` and `mtls_identity`.
* Allow principal to be extracted from the Distinguished Name (Subject) of an mTLS certificate, by setting `authentication_method: mtls_identity` on the kafka listener and `redpanda.kafka_mtls_principal_mapping_rules`.
* Allow authorization to be enabled or disabled globally by setting `redpanda.kafka_enable_authorization`
