### PR TITLE
rpk: add rpk tune list command

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda.go
@@ -15,6 +15,7 @@ package cmd
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/tune"
 	rp "github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -29,10 +30,10 @@ func NewRedpandaCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 	command.AddCommand(redpanda.NewStartCommand(fs, launcher))
 	command.AddCommand(redpanda.NewStopCommand(fs))
 	command.AddCommand(redpanda.NewCheckCommand(fs))
-	command.AddCommand(redpanda.NewTuneCommand(fs))
 	command.AddCommand(redpanda.NewModeCommand(fs))
 	command.AddCommand(redpanda.NewConfigCommand(fs))
 
+	command.AddCommand(tune.NewCommand(fs))
 	command.AddCommand(admin.NewCommand(fs))
 
 	return command

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewHelpCommand() *cobra.Command {
+func newHelpCommand() *cobra.Command {
 	tunersHelp := map[string]string{
 		"cpu":                   cpuTunerHelp,
 		"disk_irq":              diskIrqTunerHelp,
@@ -35,7 +35,7 @@ func NewHelpCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "help <tuner>",
 		Short: "Display detailed information about the tuner.",
-		Args: func(cmd *cobra.Command, args []string) error {
+		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("requires the tuner name")
 			}
@@ -45,20 +45,13 @@ func NewHelpCommand() *cobra.Command {
 				", ",
 			)
 			if _, contains := tunersHelp[tuner]; !contains {
-				return fmt.Errorf(
-					"No help found for tuner '%s'."+
-						" Available: %s.",
-					tuner,
-					tunerList,
-				)
+				return fmt.Errorf("no help found for tuner '%s'. Available: %s", tuner, tunerList)
 			}
 			return nil
 		},
-		Run: func(ccmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			tuner := args[0]
-			fmt.Printf("'%s' tuner description", tuner)
-			fmt.Println()
-			fmt.Print(tunersHelp[tuner])
+			fmt.Printf("%q tuner description\n%s\n", tuner, tunersHelp[tuner])
 		},
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/list.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/list.go
@@ -1,0 +1,102 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build linux
+
+package tune
+
+import (
+	"sort"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/factory"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+type tunerInfo struct {
+	Name      string
+	Enabled   bool
+	Supported bool
+	Reason    string
+}
+
+func newListCommand(fs afero.Fs) *cobra.Command {
+	tunerParams := factory.TunerParams{}
+	var cfgFile string
+
+	command := &cobra.Command{
+		Use:   "list",
+		Short: "List available tuners",
+		Long: `List available redpanda tuners and check if they are enabled and 
+supported by your system
+
+To enable a tuner it must be set in the redpanda.yaml configuration file
+under rpk section, e.g:
+
+  rpk:
+      tune_cpu: true
+      tune_swappiness: true
+
+You may use 'rpk redpanda config set' to enable or disable a tuner.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// Using cpu mask and timeout defaults since we are not executing
+			// any tuner.
+			tunerParams.CPUMask = "all"
+			tunerFactory := factory.NewDirectExecutorTunersFactory(fs, *cfg, 10000*time.Millisecond)
+
+			params, err := factory.MergeTunerParamsConfig(&tunerParams, cfg)
+			out.MaybeDieErr(err)
+
+			var list []tunerInfo
+
+			for _, name := range factory.AvailableTuners() {
+				tuner := tunerFactory.CreateTuner(name, params)
+				enabled := factory.IsTunerEnabled(name, cfg.Rpk)
+				supported, reason := tuner.CheckIfSupported()
+				list = append(list, tunerInfo{name, enabled, supported, reason})
+			}
+			printTunerList(list)
+		},
+	}
+	addTunerParamsFlags(command, &tunerParams)
+	command.Flags().StringVar(
+		&cfgFile,
+		config.FlagConfig,
+		"",
+		"Redpanda config file, if not set the file will be searched for"+
+			" in the default locations.",
+	)
+	return command
+}
+
+func printTunerList(list []tunerInfo) {
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+	headers := []string{
+		"Tuner",
+		"Enabled",
+		"Supported",
+		"Unsupported-Reason",
+	}
+	table := out.NewTable(headers...)
+	defer table.Flush()
+	for _, tuner := range list {
+		table.PrintStructFields(tuner)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -14,14 +14,14 @@ package cmd
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/redpanda/tune"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 func NewTuneCommand(fs afero.Fs) *cobra.Command {
 	return common.Deprecated(
-		redpanda.NewTuneCommand(fs),
+		tune.NewCommand(fs),
 		"rpk redpanda tune",
 	)
 }

--- a/src/go/rpk/pkg/tuners/disks_irq_tuner.go
+++ b/src/go/rpk/pkg/tuners/disks_irq_tuner.go
@@ -73,8 +73,7 @@ func (tuner *disksIRQsTuner) CheckIfSupported() (
 		return false, "Directories or devices are required for Disks IRQs Tuner"
 	}
 	if !tuner.cpuMasks.IsSupported() {
-		return false, `Unable to calculate CPU masks required for IRQs tuner.
-		 Please install 'hwloc'`
+		return false, `Unable to calculate CPU masks required for IRQs tuner. Please install 'hwloc'`
 	}
 	return true, ""
 }


### PR DESCRIPTION
## Cover letter

Adds `rpk redpanda tune list` which tells the user which tuners are available, which are supported, and which are enabled (per config file).

Useful if you don't want to execute the tuner and check for errors.

```
$ rpk redpanda tune list

TUNER                  ENABLED  SUPPORTED  UNSUPPORTED-REASON
aio_events             true     true       
ballast_file           true     true       
clocksource            true     true       
coredump               false    true       
cpu                    false    false      Unable to find 'hwloc' library
disk_irq               true     false      Unable to calculate CPU masks required for IRQs tuner. Please install 'hwloc'
disk_nomerges          true     true       
disk_scheduler         true     true       
disk_write_cache       true     false      Disk write cache tuner is only supported in GCP
fstrim                 false    true       
net                    true     false      Tuner is not supported as 'hwloc' is not installed
swappiness             true     true       
transparent_hugepages  false    true     
```

## Release notes
* rpk: add `rpk redpanda tune list` command to check for available tuners.
