### PR TITLE
tests: update ducktape to v0.8.15 plus redpanda patches

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@a60d8e93ac5f13554dae036465a28ece6e407df1',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@59aa1a41bea42a7f2bc8eaf3bc2a9437dd367fe7',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -18,7 +18,7 @@ setup(
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3',
-        'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests'
+        'kafkatest@git+https://github.com/apache/kafka.git@97671528ba54a138e16f41cdc0ed9c77a83ffccf#egg=kafkatest&subdirectory=tests'
     ],
     scripts=[],
 )


### PR DESCRIPTION
## Cover letter

Update ducktape to the codebase: https://github.com/redpanda-data/ducktape/tree/59aa1a4

Which is upstream [v0.8.15](https://github.com/confluentinc/ducktape/releases/tag/v0.8.15) plus redpanda patches. The previous version was based on [v0.8.9](https://github.com/confluentinc/ducktape/releases/tag/v0.8.9)

Comparison of changes between v0.8.9 and v0.8.15: https://github.com/confluentinc/ducktape/compare/v0.8.9...v0.8.15
Comparison of changes between upstream v0.8.15 and redpanda patches: https://github.com/confluentinc/ducktape/compare/v0.8.15...redpanda-data:ducktape:59aa1a4

I also needed to update `kafkatest` to apache kafka [3.1.1](https://github.com/apache/kafka/releases/tag/3.1.1) from [3.1.0.dev0](https://github.com/apache/kafka/tree/058589b03db686803b33052d574ce887fb5cfbd1) so the deps on ducktape could [relax](https://github.com/apache/kafka/blob/97671528ba54a138e16f41cdc0ed9c77a83ffccf/tests/setup.py#L54).

Comparison of changes between 3.1.0.dev0 and 3.1.1: https://github.com/apache/kafka/compare/058589b03db686803b33052d574ce887fb5cfbd1...3.1.1

## Release notes

* none