### PR TITLE
rpk: change default_topic_partitions to -1

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -115,8 +115,8 @@ the cleanup.policy=compact config option set.
 		},
 	}
 	cmd.Flags().StringArrayVarP(&configKVs, "topic-config", "c", nil, "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)")
-	cmd.Flags().Int32VarP(&partitions, "partitions", "p", 1, "Number of partitions to create per topic")
-	cmd.Flags().Int16VarP(&replicas, "replicas", "r", -1, "Replication factor (must be odd); if -1, this will be the broker's default.replication.factor")
+	cmd.Flags().Int32VarP(&partitions, "partitions", "p", -1, "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions")
+	cmd.Flags().Int16VarP(&replicas, "replicas", "r", -1, "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications")
 	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "dry run: validate the topic creation request; do not create topics")
 
 	// Sept 2021


### PR DESCRIPTION
## Cover letter

Fixes https://github.com/redpanda-data/redpanda/issues/5284

### Improvements

* RPK sends -1 for default topic partitions instead of 1
