### PR TITLE
tests: increases timeout for disruptive tests

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -134,7 +134,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                                       partition_idx=0,
                                       count=6)
             self.start_consumer()
-            self.run_validation()
+            self.run_validation(consumer_timeout_sec=100)
         ctx.assert_actions_triggered()
 
 


### PR DESCRIPTION
## Cover letter

shadow indexing e2e test with disruption restarts redpanda processes
while simultaneously running a ducktape test. once in a while the
consumer will fail to consume upto the required offset within 30
seconds.

looking at the logs it appears that there are two scenarios that happen:

1. sometimes the consumer fails to consume any messages. usually this
happens when the consumer takes too long to join a group, because when
it sends a find-coordinator request it gets a response of "node-A", but
when it sends a join-group request to "node-A", that node replies with
"not-coordinator". this happens because the find-coordinator response
comes from the leader table and the join-group request requires "node-A"
to be raft leader. this is eventually true but sometimes there is a gap
between node becoming leader in leader table and node becoming raft
leader. this difference is exacerbated when redpanda processes are
randomly restarted.

2. if we increase the timout for consumer a bit (say around 60 seconds),
the occurence of case 1 disappears and we very rarely get errors, and
those errors are because the consumer consumed messages a little short
of what we required. this is expected because the nodes in group are
experiencing random process kills and restarts.

this change increases the timeout to 100 seconds to allow consumer to
continue while processes are restarted randomly.