### PR TITLE
set default key rotation policy

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/certificate.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/certificate.yaml
@@ -24,4 +24,6 @@ spec:
     kind: Issuer
     name: {{ include "redpanda-operator.fullname" . }}-selfsigned-issuer
   secretName: {{ include "redpanda-operator.webhook-cert" . }}
+  privateKey:
+    rotationPolicy: Never
 {{- end }}


### PR DESCRIPTION
## Cover letter

Upgrading cert-manager to v1.8 requires setting a default rotation policy for the private key. Default is `Never` according to the docs.

Docs:
https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/#validation-of-the-rotationpolicy-field
https://cert-manager.io/v1.8-docs/usage/certificate/
