### PR TITLE
Fix for bug where some requests would not respect min/max version checks

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -66,11 +66,12 @@ public:
                   return std::move(res);
               });
           })
-          .handle_exception_type([this](const std::bad_optional_access&) {
-              // Short read
-              return ss::make_exception_future<Ret>(
-                broker_error(_node_id, error_code::broker_not_available));
-          })
+          .handle_exception_type(
+            [this](const kafka_request_disconnected_exception&) {
+                // Short read
+                return ss::make_exception_future<Ret>(
+                  broker_error(_node_id, error_code::broker_not_available));
+            })
           .finally([b = shared_from_this()]() {});
     }
 


### PR DESCRIPTION
For the requests that have a two phase commit handler (produce, join_group, sync_group, and offset_commit), it was noticed that no kafka api version checks are being performed. This means for example a produce request with version 100 would be accepted by the server.

This PR introduces the version checks for the aforementioned requests. 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/b4a8ccf4004ae7479ca888bd588ccb71abe62e78..7d1d031bf778ed5e1e0bed84ca9f1f21678a52bc)
- Fixed introduced bug that caused CI to fail. Kafka client explicitly searches for `std::bad_optional_access` replace this check with check for newly introduced exception type