### PR TITLE
cloud_storage: support IAM roles in redpanda

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(archival)
 add_subdirectory(security)
 add_subdirectory(serde)
 add_subdirectory(cloud_storage)
+add_subdirectory(cloud_roles)
 add_subdirectory(v8_engine)
 add_subdirectory(rp_util)
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -14,7 +14,6 @@
 #include "bytes/iobuf.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
-#include "cluster/types.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
 #include "raft/offset_translator.h"
@@ -26,10 +25,8 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future-util.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/test/tools/old/interface.hpp>
 
 using namespace std::chrono_literals;
@@ -100,12 +97,26 @@ void log_upload_candidate(const archival::upload_candidate& up) {
       up.source->offsets().dirty_offset);
 }
 
+static void launch_remote(
+  ss::sharded<cloud_storage::remote>& remote,
+  archival::s3_connection_limit connection_limit,
+  const s3::configuration& conf,
+  model::cloud_credentials_source ccs) {
+    remote.start_single(connection_limit, conf, ccs).get();
+    remote.invoke_on(0, &cloud_storage::remote::start).get();
+}
+
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     set_expectations_and_listen({});
     auto [arch_conf, remote_conf] = get_configurations();
-    cloud_storage::remote remote(
-      remote_conf.connection_limit, remote_conf.client_config);
+    ss::sharded<cloud_storage::remote> remote;
+    launch_remote(
+      remote,
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
+    auto remote_stop = ss::defer([&remote] { remote.stop().get(); });
 
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1)},
@@ -128,7 +139,11 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       *part);
 
     archival::ntp_archiver archiver(
-      get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
+      get_ntp_conf(),
+      app.partition_manager.local(),
+      arch_conf,
+      remote.local(),
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -362,10 +377,20 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
 
     set_expectations_and_listen(expectations);
     auto [arch_conf, remote_conf] = get_configurations();
-    cloud_storage::remote remote(
-      remote_conf.connection_limit, remote_conf.client_config);
+    ss::sharded<cloud_storage::remote> remote;
+    launch_remote(
+      remote,
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
+    auto remote_stop = ss::defer([&remote] { remote.stop().get(); });
+
     archival::ntp_archiver archiver(
-      get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
+      get_ntp_conf(),
+      app.partition_manager.local(),
+      arch_conf,
+      remote.local(),
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
@@ -577,10 +602,21 @@ static void test_partial_upload_impl(
     test.set_expectations_and_listen(expectations);
 
     auto [aconf, cconf] = get_configurations();
-    cloud_storage::remote remote(cconf.connection_limit, cconf.client_config);
+    ss::sharded<cloud_storage::remote> remote;
+    launch_remote(
+      remote,
+      cconf.connection_limit,
+      cconf.client_config,
+      cconf.cloud_credentials_source);
+    auto remote_stop = ss::defer([&remote] { remote.stop().get(); });
+
     aconf.time_limit = segment_time_limit(0s);
     archival::ntp_archiver archiver(
-      get_ntp_conf(), test.app.partition_manager.local(), aconf, remote, part);
+      get_ntp_conf(),
+      test.app.partition_manager.local(),
+      aconf,
+      remote.local(),
+      part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -116,6 +116,8 @@ get_configurations() {
     cconf.bucket_name = s3::bucket_name("test-bucket");
     cconf.connection_limit = archival::s3_connection_limit(2);
     cconf.metrics_disabled = cloud_storage::remote_metrics_disabled::yes;
+    cconf.cloud_credentials_source
+      = model::cloud_credentials_source::config_file;
     return std::make_tuple(aconf, cconf);
 }
 

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -16,4 +16,7 @@ v_cc_library(
     v::http
     v::s3
     v::model
+    v::utils
 )
+
+add_subdirectory(tests)

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
     NAME cloud_roles
     SRCS
     apply_credentials.cc
+    probe.cc
     types.cc
     DEPS
     Seastar::seastar

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     apply_credentials.cc
     apply_gcp_credentials.cc
     aws_refresh_impl.cc
+    aws_sts_refresh_impl.cc
     probe.cc
     refresh_credentials.cc
     request_response_helpers.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
     SRCS
     apply_aws_credentials.cc
     apply_credentials.cc
+    apply_gcp_credentials.cc
     probe.cc
     types.cc
     DEPS

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
     NAME cloud_roles
     SRCS
+    apply_aws_credentials.cc
     apply_credentials.cc
     probe.cc
     types.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -4,6 +4,7 @@ v_cc_library(
     apply_aws_credentials.cc
     apply_credentials.cc
     apply_gcp_credentials.cc
+    aws_refresh_impl.cc
     probe.cc
     refresh_credentials.cc
     request_response_helpers.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -1,0 +1,11 @@
+v_cc_library(
+    NAME cloud_roles
+    SRCS
+    apply_credentials.cc
+    types.cc
+    DEPS
+    Seastar::seastar
+    v::http
+    v::s3
+    v::model
+)

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     apply_gcp_credentials.cc
     aws_refresh_impl.cc
     aws_sts_refresh_impl.cc
+    gcp_refresh_impl.cc
     probe.cc
     refresh_credentials.cc
     request_response_helpers.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -5,6 +5,8 @@ v_cc_library(
     apply_credentials.cc
     apply_gcp_credentials.cc
     probe.cc
+    refresh_credentials.cc
+    request_response_helpers.cc
     types.cc
     DEPS
     Seastar::seastar

--- a/src/v/cloud_roles/apply_aws_credentials.cc
+++ b/src/v/cloud_roles/apply_aws_credentials.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/apply_aws_credentials.h"
+
+#include "cloud_roles/logger.h"
+#include "vlog.h"
+
+struct aws_header_names {
+    static constexpr boost::beast::string_view x_amz_security_token
+      = "x-amz-security-token";
+    static constexpr boost::beast::string_view x_amz_content_sha256
+      = "x-amz-content-sha256";
+};
+
+/// Prefix used for testing, so that if testing against minio, tokens are
+/// fetched but not injected to header. Minio does not accept random security
+/// tokens with requests.
+static constexpr std::string_view ci_test_token_prefix
+  = "__REDPANDA_SKIP_IAM_TOKEN";
+
+static bool is_test_token(std::string_view token) {
+    return token.find(ci_test_token_prefix) == 0;
+}
+
+struct aws_signatures {
+    /// SHA256 of an empty string (used in situation when the signed payload is
+    /// has zero length)
+    static constexpr std::string_view emptysig
+      = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    static constexpr std::string_view unsigned_payload = "UNSIGNED-PAYLOAD";
+};
+
+cloud_roles::apply_aws_credentials::apply_aws_credentials(
+  cloud_roles::aws_credentials credentials)
+  : _signature{credentials.region, credentials.access_key_id, credentials.secret_access_key}
+  , _session_token{credentials.session_token} {}
+
+std::error_code cloud_roles::apply_aws_credentials::add_auth(
+  http::client::request_header& header) const {
+    if (_session_token) {
+        auto st = *_session_token;
+        if (!is_test_token(st())) {
+            std::string_view token{st()};
+            header.insert(
+              aws_header_names::x_amz_security_token,
+              {token.data(), token.size()});
+        } else {
+            vlog(clrl_log.trace, "not inserting test token to header: {}", st);
+        }
+    }
+
+    auto sha256 = sha_for_verb(header.method());
+    header.insert(
+      aws_header_names::x_amz_content_sha256, {sha256.data(), sha256.size()});
+    return _signature.sign_header(header, sha256);
+}
+
+std::string_view cloud_roles::apply_aws_credentials::sha_for_verb(
+  boost::beast::http::verb verb) {
+    switch (verb) {
+    case boost::beast::http::verb::get:
+        return aws_signatures::emptysig;
+    case boost::beast::http::verb::head:
+        return aws_signatures::emptysig;
+    case boost::beast::http::verb::delete_:
+        return aws_signatures::emptysig;
+    case boost::beast::http::verb::post:
+        return aws_signatures::unsigned_payload;
+    case boost::beast::http::verb::put:
+        return aws_signatures::unsigned_payload;
+    default:
+        throw std::runtime_error(
+          fmt_with_ctx(fmt::format, "unsupported method: {}", verb));
+    }
+}
+
+void cloud_roles::apply_aws_credentials::reset_creds(
+  cloud_roles::credentials creds) {
+    if (!std::holds_alternative<aws_credentials>(creds)) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "credential applier reset with incorrect credential type {}",
+          creds));
+    }
+    auto aws_creds = std::get<aws_credentials>(creds);
+    _signature = s3::signature_v4(
+      aws_creds.region, aws_creds.access_key_id, aws_creds.secret_access_key);
+    _session_token = aws_creds.session_token;
+}
+
+std::ostream&
+cloud_roles::apply_aws_credentials::print(std::ostream& os) const {
+    fmt::print(os, "apply_aws_credentials");
+    return os;
+}

--- a/src/v/cloud_roles/apply_aws_credentials.h
+++ b/src/v/cloud_roles/apply_aws_credentials.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+#include "s3/signature.h"
+
+namespace cloud_roles {
+
+class apply_aws_credentials final : public apply_credentials::impl {
+public:
+    explicit apply_aws_credentials(aws_credentials credentials);
+
+    std::error_code
+    add_auth(http::client::request_header& header) const override;
+
+    void reset_creds(credentials creds) override;
+    std::ostream& print(std::ostream& os) const override;
+
+private:
+    static std::string_view sha_for_verb(boost::beast::http::verb verb);
+
+private:
+    s3::signature_v4 _signature;
+    std::optional<s3_session_token> _session_token;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -13,23 +13,19 @@
 #include "cloud_roles/apply_aws_credentials.h"
 #include "cloud_roles/apply_gcp_credentials.h"
 
-cloud_roles::apply_credentials
-cloud_roles::make_credentials_applier(cloud_roles::credentials creds) {
+namespace cloud_roles {
+apply_credentials make_credentials_applier(credentials creds) {
     return apply_credentials{ss::visit(
       std::move(creds),
-      [](cloud_roles::aws_credentials ac)
-        -> std::unique_ptr<apply_credentials::impl> {
-          return std::make_unique<cloud_roles::apply_aws_credentials>(
-            std::move(ac));
+      [](aws_credentials ac) -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<apply_aws_credentials>(std::move(ac));
       },
-      [](cloud_roles::gcp_credentials gc)
-        -> std::unique_ptr<apply_credentials::impl> {
-          return std::make_unique<cloud_roles::apply_gcp_credentials>(
-            std::move(gc));
+      [](gcp_credentials gc) -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<apply_gcp_credentials>(std::move(gc));
       })};
 }
 
-std::ostream& cloud_roles::operator<<(
-  std::ostream& os, const cloud_roles::apply_credentials& ac) {
+std::ostream& operator<<(std::ostream& os, const apply_credentials& ac) {
     return ac.print(os);
 }
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/apply_credentials.h"
+
+std::ostream& cloud_roles::operator<<(
+  std::ostream& os, const cloud_roles::apply_credentials& ac) {
+    return ac.print(os);
+}

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -10,6 +10,19 @@
 
 #include "cloud_roles/apply_credentials.h"
 
+#include "cloud_roles/apply_aws_credentials.h"
+
+cloud_roles::apply_credentials
+cloud_roles::make_credentials_applier(cloud_roles::credentials creds) {
+    return apply_credentials{ss::visit(
+      std::move(creds),
+      [](cloud_roles::aws_credentials ac)
+        -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<cloud_roles::apply_aws_credentials>(
+            std::move(ac));
+      })};
+}
+
 std::ostream& cloud_roles::operator<<(
   std::ostream& os, const cloud_roles::apply_credentials& ac) {
     return ac.print(os);

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -11,6 +11,7 @@
 #include "cloud_roles/apply_credentials.h"
 
 #include "cloud_roles/apply_aws_credentials.h"
+#include "cloud_roles/apply_gcp_credentials.h"
 
 cloud_roles::apply_credentials
 cloud_roles::make_credentials_applier(cloud_roles::credentials creds) {
@@ -20,6 +21,11 @@ cloud_roles::make_credentials_applier(cloud_roles::credentials creds) {
         -> std::unique_ptr<apply_credentials::impl> {
           return std::make_unique<cloud_roles::apply_aws_credentials>(
             std::move(ac));
+      },
+      [](cloud_roles::gcp_credentials gc)
+        -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<cloud_roles::apply_gcp_credentials>(
+            std::move(gc));
       })};
 }
 

--- a/src/v/cloud_roles/apply_credentials.h
+++ b/src/v/cloud_roles/apply_credentials.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/types.h"
+#include "http/client.h"
+
+#include <memory>
+
+namespace cloud_roles {
+
+class apply_credentials {
+public:
+    class impl {
+    public:
+        /// Given a request header, adds authentication information to it.
+        /// Depending on the implementation this can vary from a simple oauth
+        /// token added as an authorization header, to multiple headers added
+        /// along with signing of the request payload.
+        virtual std::error_code
+        add_auth(http::client::request_header& header) const = 0;
+
+        /// Changes the authentication key and secret or the oauth token
+        /// associated with the credentials. The concept of temporary
+        /// credentials is based on periodically rotating tokens, and this
+        /// method consumes the newly acquired tokens and uses them to authorize
+        /// headers.
+        virtual void reset_creds(credentials creds) = 0;
+
+        virtual std::ostream& print(std::ostream& os) const = 0;
+
+        virtual ~impl() = default;
+    };
+
+    explicit apply_credentials(std::unique_ptr<impl> impl)
+      : _impl{std::move(impl)} {}
+
+    std::error_code add_auth(http::client::request_header& header) const {
+        return _impl->add_auth(header);
+    }
+
+    void reset_creds(credentials creds) {
+        _impl->reset_creds(std::move(creds));
+    }
+
+    std::ostream& print(std::ostream& os) const { return _impl->print(os); }
+
+private:
+    std::unique_ptr<impl> _impl;
+};
+
+std::ostream& operator<<(std::ostream& os, const apply_credentials& ac);
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_credentials.h
+++ b/src/v/cloud_roles/apply_credentials.h
@@ -59,4 +59,11 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const apply_credentials& ac);
 
+/// Creates a credential applier based on the kind of credentials passed in. The
+/// input credentials object is a sum type, and it can contain any one of the
+/// variants for all supported credentials sources. This function uses the
+/// underlying type to create the corresponding credential applier. If the input
+/// is a gcp credential, then a gcp credential applier is created, and so on.
+apply_credentials make_credentials_applier(credentials creds);
+
 } // namespace cloud_roles

--- a/src/v/cloud_roles/apply_gcp_credentials.cc
+++ b/src/v/cloud_roles/apply_gcp_credentials.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "apply_gcp_credentials.h"
+
+cloud_roles::apply_gcp_credentials::apply_gcp_credentials(
+  cloud_roles::gcp_credentials credentials)
+  : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())} {}
+
+std::error_code cloud_roles::apply_gcp_credentials::add_auth(
+  http::client::request_header& header) const {
+    auto token = _oauth_token();
+    header.insert(
+      boost::beast::http::field::authorization, {token.data(), token.size()});
+    return {};
+}
+
+void cloud_roles::apply_gcp_credentials::reset_creds(
+  cloud_roles::credentials creds) {
+    if (!std::holds_alternative<gcp_credentials>(creds)) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "credential applier reset with incorrect credential type {}",
+          creds));
+    }
+    _oauth_token = cloud_roles::oauth_token_str{
+      fmt::format("Bearer {}", std::get<gcp_credentials>(creds).oauth_token())};
+}
+
+std::ostream&
+cloud_roles::apply_gcp_credentials::print(std::ostream& os) const {
+    fmt::print(os, "apply_gcp_credentials");
+    return os;
+}

--- a/src/v/cloud_roles/apply_gcp_credentials.cc
+++ b/src/v/cloud_roles/apply_gcp_credentials.cc
@@ -10,32 +10,32 @@
 
 #include "apply_gcp_credentials.h"
 
-cloud_roles::apply_gcp_credentials::apply_gcp_credentials(
-  cloud_roles::gcp_credentials credentials)
+namespace cloud_roles {
+apply_gcp_credentials::apply_gcp_credentials(gcp_credentials credentials)
   : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())} {}
 
-std::error_code cloud_roles::apply_gcp_credentials::add_auth(
-  http::client::request_header& header) const {
+std::error_code
+apply_gcp_credentials::add_auth(http::client::request_header& header) const {
     auto token = _oauth_token();
     header.insert(
       boost::beast::http::field::authorization, {token.data(), token.size()});
     return {};
 }
 
-void cloud_roles::apply_gcp_credentials::reset_creds(
-  cloud_roles::credentials creds) {
+void apply_gcp_credentials::reset_creds(credentials creds) {
     if (!std::holds_alternative<gcp_credentials>(creds)) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "credential applier reset with incorrect credential type {}",
           creds));
     }
-    _oauth_token = cloud_roles::oauth_token_str{
+    _oauth_token = oauth_token_str{
       fmt::format("Bearer {}", std::get<gcp_credentials>(creds).oauth_token())};
 }
 
-std::ostream&
-cloud_roles::apply_gcp_credentials::print(std::ostream& os) const {
+std::ostream& apply_gcp_credentials::print(std::ostream& os) const {
     fmt::print(os, "apply_gcp_credentials");
     return os;
 }
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_gcp_credentials.h
+++ b/src/v/cloud_roles/apply_gcp_credentials.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+
+namespace cloud_roles {
+
+class apply_gcp_credentials final
+  : public cloud_roles::apply_credentials::impl {
+public:
+    explicit apply_gcp_credentials(cloud_roles::gcp_credentials credentials);
+
+    std::error_code
+    add_auth(http::client::request_header& header) const override;
+
+    void reset_creds(credentials creds) override;
+    std::ostream& print(std::ostream& os) const override;
+
+private:
+    oauth_token_str _oauth_token;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/aws_refresh_impl.h"
+
+#include "s3/client.h"
+
+struct ec2_response_schema {
+    static constexpr std::string_view expiry = "Expiration";
+    static constexpr std::string_view access_key_id = "AccessKeyId";
+    static constexpr std::string_view secret_access_key = "SecretAccessKey";
+    static constexpr std::string_view session_token = "Token";
+};
+
+cloud_roles::aws_refresh_impl::aws_refresh_impl(
+  seastar::sstring api_host,
+  uint16_t api_port,
+  s3::aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : refresh_credentials::impl(
+    std::move(api_host), api_port, std::move(region), as, retry_params) {}
+
+ss::future<cloud_roles::api_response>
+cloud_roles::aws_refresh_impl::fetch_credentials() {
+    if (unlikely(!_role)) {
+        vlog(clrl_log.info, "initializing role name");
+        auto response = co_await fetch_role_name();
+        // error while fetching the role, make caller handle it
+        if (std::holds_alternative<api_request_error>(response)) {
+            co_return response;
+        }
+
+        iobuf_const_parser parser(std::get<iobuf>(response));
+        _role.emplace(parser.read_string(parser.bytes_left()));
+
+        vlog(clrl_log.info, "fetched iam role name [{}]", *_role);
+        if (_role->empty()) {
+            // TODO (abhijat) create a new error kind for bad system state
+            co_return api_request_error{
+              .reason = "empty role name set on instance",
+              .error_kind = api_request_error_kind::failed_abort};
+        }
+    }
+
+    if (_role->empty()) {
+        vlog(
+          clrl_log.error,
+          "IAM role name not populated, cannot fetch credentials");
+        // TODO (abhijat) create a new error kind for bad system state
+        co_return api_request_error{
+          .reason = "missing IAM role name",
+          .error_kind = api_request_error_kind::failed_retryable};
+    }
+
+    http::client::request_header creds_req;
+    creds_req.method(boost::beast::http::verb::get);
+    creds_req.target(
+      fmt::format("/latest/meta-data/iam/security-credentials/{}", *_role));
+    co_return co_await make_request(make_api_client(), std::move(creds_req));
+}
+
+cloud_roles::api_response_parse_result
+cloud_roles::aws_refresh_impl::parse_response(iobuf resp) {
+    auto doc = parse_json_response(std::move(resp));
+    std::vector<ss::sstring> missing_fields;
+    for (const auto& key :
+         {ec2_response_schema::expiry,
+          ec2_response_schema::access_key_id,
+          ec2_response_schema::secret_access_key,
+          ec2_response_schema::session_token}) {
+        if (!doc.HasMember(key.data())) {
+            missing_fields.emplace_back(key);
+        }
+    }
+
+    if (!missing_fields.empty()) {
+        return malformed_api_response_error{
+          .missing_fields = std::move(missing_fields)};
+    }
+
+    auto expiration = doc[ec2_response_schema::expiry.data()].GetString();
+    next_sleep_duration(
+      calculate_sleep_duration(s3::parse_timestamp(expiration)));
+
+    return aws_credentials{
+      .access_key_id
+      = s3::public_key_str{doc[ec2_response_schema::access_key_id.data()]
+                             .GetString()},
+      .secret_access_key
+      = s3::private_key_str{doc[ec2_response_schema::secret_access_key.data()]
+                              .GetString()},
+      .session_token
+      = s3_session_token{doc[ec2_response_schema::session_token.data()]
+                           .GetString()},
+      .region = region(),
+    };
+}
+
+ss::future<cloud_roles::api_response>
+cloud_roles::aws_refresh_impl::fetch_role_name() {
+    http::client::request_header role_req;
+    role_req.method(boost::beast::http::verb::get);
+    role_req.target("/latest/meta-data/iam/security-credentials/");
+    co_return co_await make_request(make_api_client(), std::move(role_req));
+}
+
+std::ostream& cloud_roles::aws_refresh_impl::print(std::ostream& os) const {
+    fmt::print(
+      os, "aws_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
+    return os;
+}

--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -12,6 +12,7 @@
 
 #include "s3/client.h"
 
+namespace cloud_roles {
 struct ec2_response_schema {
     static constexpr std::string_view expiry = "Expiration";
     static constexpr std::string_view access_key_id = "AccessKeyId";
@@ -19,7 +20,7 @@ struct ec2_response_schema {
     static constexpr std::string_view session_token = "Token";
 };
 
-cloud_roles::aws_refresh_impl::aws_refresh_impl(
+aws_refresh_impl::aws_refresh_impl(
   seastar::sstring api_host,
   uint16_t api_port,
   s3::aws_region_name region,
@@ -28,8 +29,7 @@ cloud_roles::aws_refresh_impl::aws_refresh_impl(
   : refresh_credentials::impl(
     std::move(api_host), api_port, std::move(region), as, retry_params) {}
 
-ss::future<cloud_roles::api_response>
-cloud_roles::aws_refresh_impl::fetch_credentials() {
+ss::future<api_response> aws_refresh_impl::fetch_credentials() {
     if (unlikely(!_role)) {
         vlog(clrl_log.info, "initializing role name");
         auto response = co_await fetch_role_name();
@@ -67,8 +67,7 @@ cloud_roles::aws_refresh_impl::fetch_credentials() {
     co_return co_await make_request(make_api_client(), std::move(creds_req));
 }
 
-cloud_roles::api_response_parse_result
-cloud_roles::aws_refresh_impl::parse_response(iobuf resp) {
+api_response_parse_result aws_refresh_impl::parse_response(iobuf resp) {
     auto doc = parse_json_response(std::move(resp));
     std::vector<ss::sstring> missing_fields;
     for (const auto& key :
@@ -104,16 +103,17 @@ cloud_roles::aws_refresh_impl::parse_response(iobuf resp) {
     };
 }
 
-ss::future<cloud_roles::api_response>
-cloud_roles::aws_refresh_impl::fetch_role_name() {
+ss::future<api_response> aws_refresh_impl::fetch_role_name() {
     http::client::request_header role_req;
     role_req.method(boost::beast::http::verb::get);
     role_req.target("/latest/meta-data/iam/security-credentials/");
     co_return co_await make_request(make_api_client(), std::move(role_req));
 }
 
-std::ostream& cloud_roles::aws_refresh_impl::print(std::ostream& os) const {
+std::ostream& aws_refresh_impl::print(std::ostream& os) const {
     fmt::print(
       os, "aws_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
     return os;
 }
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/aws_refresh_impl.h
+++ b/src/v/cloud_roles/aws_refresh_impl.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/refresh_credentials.h"
+
+namespace cloud_roles {
+
+class aws_refresh_impl final : public refresh_credentials::impl {
+public:
+    static constexpr std::string_view default_host = "169.254.169.254";
+    static constexpr uint16_t default_port = 80;
+
+    aws_refresh_impl(
+      seastar::sstring api_host,
+      uint16_t api_port,
+      s3::aws_region_name region,
+      ss::abort_source& as,
+      retry_params retry_params = default_retry_params);
+    ss::future<api_response> fetch_credentials() override;
+
+    std::ostream& print(std::ostream& os) const override;
+
+protected:
+    api_response_parse_result parse_response(iobuf resp) override;
+
+    /// Fetches the IAM role name from EC2 instance metadata API. This should
+    /// only be required once , we can then cache the role name and use it for
+    /// the duration of the application run
+    ss::future<api_response> fetch_role_name();
+
+private:
+    std::optional<ss::sstring> _role;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/aws_sts_refresh_impl.h"
+
+#include "s3/client.h"
+#include "utils/file_io.h"
+
+#include <boost/property_tree/ptree.hpp>
+
+/// The path to credentials in the XML response returned by STS
+static constexpr std::string_view response_node_credential_path
+  = "AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult."
+    "Credentials";
+
+/// These variables injected by the AWS operator must be present on the redpanda
+/// pod to ensure we can get credentials from STS.
+/// ref:
+/// https://docs.amazonaws.cn/en_us/eks/latest/userguide/specify-service-account-role.html
+struct aws_injected_env_vars {
+    static constexpr std::string_view role_arn = "AWS_ROLE_ARN";
+
+    static constexpr std::string_view token_file_path
+      = "AWS_WEB_IDENTITY_TOKEN_FILE";
+};
+
+struct sts_params {
+    static constexpr std::string_view role_session_name = "redpanda_si";
+
+    static constexpr std::string_view api_version = "2011-06-15";
+
+    static constexpr std::chrono::seconds token_expiry_seconds{3599};
+};
+
+struct sts_response_schema {
+    static constexpr std::string_view expiry = "Expiration";
+    static constexpr std::string_view access_key_id = "AccessKeyId";
+    static constexpr std::string_view secret_access_key = "SecretAccessKey";
+    static constexpr std::string_view session_token = "SessionToken";
+};
+
+static const boost::beast::string_view content_type{
+  "application/x-www-form-urlencoded"};
+
+static constexpr std::string_view request_payload
+  = "Action=AssumeRoleWithWebIdentity"
+    "&DurationSeconds={}"
+    "&Version={}"
+    "&RoleSessionName={}"
+    "&RoleArn={}"
+    "&WebIdentityToken={}";
+
+static ss::sstring load_from_env(std::string_view env_var) {
+    auto env_value = std::getenv(env_var.data());
+    if (!env_value) {
+        throw std::runtime_error(fmt::format(
+          "environment variable {} is not set, the STS client cannot function "
+          "without this.",
+          env_var));
+    }
+    return env_value;
+}
+
+cloud_roles::aws_sts_refresh_impl::aws_sts_refresh_impl(
+  seastar::sstring api_host,
+  uint16_t api_port,
+  s3::aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : refresh_credentials::impl(
+    std::move(api_host), api_port, std::move(region), as, retry_params)
+  , _role{load_from_env(aws_injected_env_vars::role_arn)}
+  , _token_file_path{load_from_env(aws_injected_env_vars::token_file_path)} {}
+
+ss::future<cloud_roles::api_response>
+cloud_roles::aws_sts_refresh_impl::fetch_credentials() {
+    // The content of the token file is periodically rotated by k8s, so we
+    // read it fully each time to avoid stale tokens
+
+    ss::sstring token{};
+    try {
+        token = co_await read_fully_to_string({_token_file_path});
+    } catch (...) {
+        vlog(
+          clrl_log.error,
+          "failed to read IRSA pod token from file {}",
+          _token_file_path);
+        throw;
+    }
+
+    boost::beast::http::request<boost::beast::http::string_body> assume_req;
+    assume_req.method(boost::beast::http::verb::post);
+    assume_req.target("/");
+
+    assume_req.set(boost::beast::http::field::content_type, content_type);
+
+    ss::sstring body = fmt::format(
+      request_payload,
+      sts_params::token_expiry_seconds.count(),
+      sts_params::api_version,
+      sts_params::role_session_name,
+      _role,
+      token);
+
+    co_return co_await post_request(
+      make_api_client(), std::move(assume_req), std::move(body));
+}
+
+cloud_roles::api_response_parse_result
+cloud_roles::aws_sts_refresh_impl::parse_response(iobuf resp) {
+    auto root = s3::iobuf_to_ptree(std::move(resp));
+
+    auto creds_node_maybe = root.get_child_optional(
+      response_node_credential_path.data());
+
+    if (!creds_node_maybe) {
+        return malformed_api_response_error{
+          .missing_fields = {response_node_credential_path.data()}};
+    }
+
+    auto creds_node = *creds_node_maybe;
+
+    std::vector<ss::sstring> missing_fields;
+    for (const auto& key :
+         {sts_response_schema::expiry,
+          sts_response_schema::access_key_id,
+          sts_response_schema::secret_access_key,
+          sts_response_schema::session_token}) {
+        if (!creds_node.count(key.data())) {
+            missing_fields.emplace_back(key);
+        }
+    }
+
+    if (!missing_fields.empty()) {
+        return malformed_api_response_error{.missing_fields = missing_fields};
+    }
+
+    auto expiration = creds_node.get<std::string>(
+      sts_response_schema::expiry.data());
+    auto expiration_time = s3::parse_timestamp(expiration);
+
+    next_sleep_duration(calculate_sleep_duration(expiration_time));
+
+    return aws_credentials{
+      .access_key_id = s3::public_key_str{creds_node.get<std::string>(
+        sts_response_schema::access_key_id.data())},
+      .secret_access_key = s3::private_key_str{creds_node.get<std::string>(
+        sts_response_schema::secret_access_key.data())},
+      .session_token = s3_session_token{creds_node.get<std::string>(
+        sts_response_schema::session_token.data())},
+      .region = region(),
+    };
+}
+
+std::ostream& cloud_roles::aws_sts_refresh_impl::print(std::ostream& os) const {
+    fmt::print(
+      os, "aws_sts_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
+    return os;
+}

--- a/src/v/cloud_roles/aws_sts_refresh_impl.h
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/refresh_credentials.h"
+
+namespace cloud_roles {
+
+class aws_sts_refresh_impl final : public refresh_credentials::impl {
+public:
+    static constexpr std::string_view default_host = "sts.amazonaws.com";
+    static constexpr uint16_t default_port = 443;
+
+    aws_sts_refresh_impl(
+      seastar::sstring api_host,
+      uint16_t api_port,
+      s3::aws_region_name region,
+      ss::abort_source& as,
+      retry_params retry_params = default_retry_params);
+    ss::future<api_response> fetch_credentials() override;
+
+    std::ostream& print(std::ostream& os) const override;
+
+protected:
+    api_response_parse_result parse_response(iobuf resp) override;
+
+private:
+    ss::sstring _role;
+    ss::sstring _token_file_path;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/gcp_refresh_impl.h"
+
+#include "bytes/iobuf_istreambuf.h"
+#include "cloud_roles/logger.h"
+#include "cloud_roles/request_response_helpers.h"
+#include "json/document.h"
+#include "json/istreamwrapper.h"
+
+#include <seastar/core/sleep.hh>
+
+static constexpr std::string_view token_path
+  = "/computeMetadata/v1/instance/service-accounts/default/token";
+
+/// This header must be sent to GCP metadata API along with each request
+struct metadata_flavor {
+    static constexpr std::string_view header_name = "Metadata-Flavor";
+
+    static constexpr std::string_view value = "Google";
+};
+
+struct gcp_response_schema {
+    static constexpr std::string_view expiry_field = "expires_in";
+    static constexpr std::string_view token_field = "access_token";
+};
+
+cloud_roles::gcp_refresh_impl::gcp_refresh_impl(
+  ss::sstring api_host,
+  uint16_t api_port,
+  s3::aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : refresh_credentials::impl(
+    std::move(api_host), api_port, std::move(region), as, retry_params) {}
+
+ss::future<cloud_roles::api_response>
+cloud_roles::gcp_refresh_impl::fetch_credentials() {
+    http::client::request_header oauth_req;
+
+    oauth_req.method(boost::beast::http::verb::get);
+    oauth_req.target(token_path.data());
+    oauth_req.set(
+      metadata_flavor::header_name.data(), metadata_flavor::value.data());
+
+    co_return co_await make_request(make_api_client(), std::move(oauth_req));
+}
+
+cloud_roles::api_response_parse_result
+cloud_roles::gcp_refresh_impl::parse_response(iobuf response) {
+    auto doc = cloud_roles::parse_json_response(std::move(response));
+    std::vector<ss::sstring> missing_fields;
+    if (!doc.HasMember(gcp_response_schema::expiry_field.data())) {
+        missing_fields.emplace_back(gcp_response_schema::expiry_field);
+    }
+
+    if (!doc.HasMember(gcp_response_schema::token_field.data())) {
+        missing_fields.emplace_back(gcp_response_schema::token_field);
+    }
+
+    if (!missing_fields.empty()) {
+        return malformed_api_response_error{
+          .missing_fields = std::move(missing_fields)};
+    }
+
+    next_sleep_duration(calculate_sleep_duration(
+      doc[gcp_response_schema::expiry_field.data()].GetInt64()));
+    return gcp_credentials{
+      .oauth_token = oauth_token_str{
+        doc[gcp_response_schema::token_field.data()].GetString()}};
+}
+
+std::ostream& cloud_roles::gcp_refresh_impl::print(std::ostream& os) const {
+    fmt::print(
+      os, "gcp_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
+    return os;
+}

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -19,6 +19,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 
+namespace cloud_roles {
 static constexpr std::string_view token_path
   = "/computeMetadata/v1/instance/service-accounts/default/token";
 
@@ -34,7 +35,7 @@ struct gcp_response_schema {
     static constexpr std::string_view token_field = "access_token";
 };
 
-cloud_roles::gcp_refresh_impl::gcp_refresh_impl(
+gcp_refresh_impl::gcp_refresh_impl(
   ss::sstring api_host,
   uint16_t api_port,
   s3::aws_region_name region,
@@ -43,8 +44,7 @@ cloud_roles::gcp_refresh_impl::gcp_refresh_impl(
   : refresh_credentials::impl(
     std::move(api_host), api_port, std::move(region), as, retry_params) {}
 
-ss::future<cloud_roles::api_response>
-cloud_roles::gcp_refresh_impl::fetch_credentials() {
+ss::future<api_response> gcp_refresh_impl::fetch_credentials() {
     http::client::request_header oauth_req;
 
     oauth_req.method(boost::beast::http::verb::get);
@@ -55,9 +55,8 @@ cloud_roles::gcp_refresh_impl::fetch_credentials() {
     co_return co_await make_request(make_api_client(), std::move(oauth_req));
 }
 
-cloud_roles::api_response_parse_result
-cloud_roles::gcp_refresh_impl::parse_response(iobuf response) {
-    auto doc = cloud_roles::parse_json_response(std::move(response));
+api_response_parse_result gcp_refresh_impl::parse_response(iobuf response) {
+    auto doc = parse_json_response(std::move(response));
     std::vector<ss::sstring> missing_fields;
     if (!doc.HasMember(gcp_response_schema::expiry_field.data())) {
         missing_fields.emplace_back(gcp_response_schema::expiry_field);
@@ -79,8 +78,10 @@ cloud_roles::gcp_refresh_impl::parse_response(iobuf response) {
         doc[gcp_response_schema::token_field.data()].GetString()}};
 }
 
-std::ostream& cloud_roles::gcp_refresh_impl::print(std::ostream& os) const {
+std::ostream& gcp_refresh_impl::print(std::ostream& os) const {
     fmt::print(
       os, "gcp_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
     return os;
 }
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -16,6 +16,7 @@
 #include "json/document.h"
 #include "json/istreamwrapper.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 
 static constexpr std::string_view token_path

--- a/src/v/cloud_roles/gcp_refresh_impl.h
+++ b/src/v/cloud_roles/gcp_refresh_impl.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/refresh_credentials.h"
+
+namespace cloud_roles {
+
+class gcp_refresh_impl final : public refresh_credentials::impl {
+public:
+    static constexpr std::string_view default_host = "169.254.169.254";
+    static constexpr uint16_t default_port = 80;
+
+    gcp_refresh_impl(
+      ss::sstring api_host,
+      uint16_t api_port,
+      s3::aws_region_name region,
+      ss::abort_source& as,
+      retry_params retry_params = default_retry_params);
+    ss::future<api_response> fetch_credentials() override;
+
+    std::ostream& print(std::ostream& os) const override;
+
+protected:
+    api_response_parse_result parse_response(iobuf response) override;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/logger.h
+++ b/src/v/cloud_roles/logger.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace cloud_roles {
+inline ss::logger clrl_log("cloud_roles");
+} // namespace cloud_roles

--- a/src/v/cloud_roles/probe.cc
+++ b/src/v/cloud_roles/probe.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/probe.h"
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+namespace cloud_roles {
+
+auth_refresh_probe::auth_refresh_probe() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_roles::auth_refresh"),
+      {
+        ss::metrics::make_counter(
+          "successful_fetches",
+          [this] { return _successful_fetches; },
+          ss::metrics::description("Total successful credential fetches")),
+        ss::metrics::make_counter(
+          "fetch_errors",
+          [this] { return _fetch_errors; },
+          ss::metrics::description("Total errors while fetching")),
+      });
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/probe.cc
+++ b/src/v/cloud_roles/probe.cc
@@ -13,6 +13,8 @@
 #include "config/configuration.h"
 #include "prometheus/prometheus_sanitize.h"
 
+#include <seastar/core/metrics.hh>
+
 namespace cloud_roles {
 
 auth_refresh_probe::auth_refresh_probe() {

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -12,7 +12,7 @@
 
 #include "seastarx.h"
 
-#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
 
 namespace cloud_roles {
 
@@ -26,7 +26,7 @@ public:
 private:
     uint64_t _successful_fetches{0};
     uint64_t _fetch_errors{0};
-    ss::metrics::metric_group _metrics;
+    ss::metrics::metric_groups _metrics;
 };
 
 } // namespace cloud_roles

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_roles {
+
+class auth_refresh_probe {
+public:
+    auth_refresh_probe();
+
+    void fetch_success() { ++_successful_fetches; }
+    void fetch_failed() { ++_fetch_errors; }
+
+private:
+    uint64_t _successful_fetches{0};
+    uint64_t _fetch_errors{0};
+    ss::metrics::metric_group _metrics;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -11,6 +11,7 @@
 #include "cloud_roles/refresh_credentials.h"
 
 #include "cloud_roles/aws_refresh_impl.h"
+#include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/logger.h"
 #include "config/node_config.h"
 #include "model/metadata.h"
@@ -254,6 +255,14 @@ cloud_roles::refresh_credentials cloud_roles::make_refresh_credentials(
           fmt::format, "cannot generate refresh with static credentials"));
     case model::cloud_credentials_source::aws_instance_metadata:
         return make_refresh_credentials<aws_refresh_impl>(
+          gate,
+          as,
+          std::move(creds_update_cb),
+          std::move(region),
+          std::move(endpoint),
+          retry_params);
+    case model::cloud_credentials_source::sts:
+        return make_refresh_credentials<aws_sts_refresh_impl>(
           gate,
           as,
           std::move(creds_update_cb),

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -22,6 +22,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
 
+namespace cloud_roles {
+
 /// These environment variables can be used to override the default hostname and
 /// port for fetching temporary credentials for testing.
 struct override_api_endpoint_env_vars {
@@ -34,7 +36,7 @@ struct override_api_endpoint_env_vars {
 /// results in a fetch after 54 minutes.
 static constexpr float sleep_from_expiry_multiplier = 0.9;
 
-cloud_roles::refresh_credentials::refresh_credentials(
+refresh_credentials::refresh_credentials(
   std::unique_ptr<impl> impl,
   ss::gate& gate,
   ss::abort_source& as,
@@ -46,12 +48,12 @@ cloud_roles::refresh_credentials::refresh_credentials(
   , _credentials_update(std::move(creds_update))
   , _region{std::move(region)} {}
 
-void cloud_roles::refresh_credentials::start() {
+void refresh_credentials::start() {
     ssx::background = ssx::spawn_with_gate_then(
       _gate, [this]() mutable { return do_start(); });
 }
 
-ss::future<> cloud_roles::refresh_credentials::do_start() {
+ss::future<> refresh_credentials::do_start() {
     return ss::do_until(
       [this] { return _gate.is_closed() || _as.abort_requested(); },
       [this] { return fetch_and_update_credentials(); });
@@ -67,14 +69,14 @@ load_and_validate_env_var(std::string_view env_var) {
         }
 
         vlog(
-          cloud_roles::clrl_log.warn,
+          clrl_log.warn,
           "override environment variable {} is set but empty, ignoring",
           env_var);
     }
     return std::nullopt;
 }
 
-cloud_roles::refresh_credentials::impl::impl(
+refresh_credentials::impl::impl(
   ss::sstring api_host,
   uint16_t api_port,
   s3::aws_region_name region,
@@ -117,7 +119,7 @@ cloud_roles::refresh_credentials::impl::impl(
     }
 }
 
-ss::future<> cloud_roles::refresh_credentials::fetch_and_update_credentials() {
+ss::future<> refresh_credentials::fetch_and_update_credentials() {
     // Before fetching new credentials, either:
     // 1. do not sleep - this is an initial call to API
     // 2. sleep until we are close to expiry of credentials
@@ -167,14 +169,12 @@ ss::future<> cloud_roles::refresh_credentials::fetch_and_update_credentials() {
 }
 
 ss::lowres_clock::duration
-cloud_roles::refresh_credentials::impl::calculate_sleep_duration(
-  uint32_t expiry_sec) const {
+refresh_credentials::impl::calculate_sleep_duration(uint32_t expiry_sec) const {
     int sleep = std::floor(expiry_sec * sleep_from_expiry_multiplier);
     return std::chrono::seconds{sleep};
 }
 
-ss::lowres_clock::duration
-cloud_roles::refresh_credentials::impl::calculate_sleep_duration(
+ss::lowres_clock::duration refresh_credentials::impl::calculate_sleep_duration(
   std::chrono::system_clock::time_point expires_at) const {
     auto now = std::chrono::system_clock::now();
     auto diff = std::chrono::duration_cast<std::chrono::seconds>(
@@ -183,16 +183,15 @@ cloud_roles::refresh_credentials::impl::calculate_sleep_duration(
     return calculate_sleep_duration(diff);
 }
 
-void cloud_roles::refresh_credentials::impl::increment_retries() {
+void refresh_credentials::impl::increment_retries() {
     _retries += 1;
     auto sleep_ms = _retry_params.backoff_ms * (2 * _retries);
     vlog(clrl_log.info, "retry after {} ms", sleep_ms);
     _sleep_duration = sleep_ms;
 }
 
-cloud_roles::api_response_parse_result
-cloud_roles::refresh_credentials::impl::handle_response(
-  cloud_roles::api_response resp) {
+api_response_parse_result
+refresh_credentials::impl::handle_response(api_response resp) {
     if (std::holds_alternative<iobuf>(resp)) {
         try {
             auto parsed = parse_response(std::move(std::get<iobuf>(resp)));
@@ -221,14 +220,13 @@ cloud_roles::refresh_credentials::impl::handle_response(
     }
 }
 
-ss::future<>
-cloud_roles::refresh_credentials::impl::sleep_until_expiry() const {
+ss::future<> refresh_credentials::impl::sleep_until_expiry() const {
     if (_sleep_duration) {
         co_await ss::sleep_abortable(*_sleep_duration, _as);
     }
 }
 
-http::client cloud_roles::refresh_credentials::impl::make_api_client() const {
+http::client refresh_credentials::impl::make_api_client() const {
     return http::client{
       net::base_transport::configuration{
         .server_addr = net::unresolved_address{_api_host, _api_port},
@@ -238,7 +236,7 @@ http::client cloud_roles::refresh_credentials::impl::make_api_client() const {
       _as};
 }
 
-cloud_roles::refresh_credentials cloud_roles::make_refresh_credentials(
+refresh_credentials make_refresh_credentials(
   model::cloud_credentials_source cloud_credentials_source,
   ss::gate& gate,
   ss::abort_source& as,
@@ -290,7 +288,8 @@ cloud_roles::refresh_credentials cloud_roles::make_refresh_credentials(
     }
 }
 
-std::ostream& cloud_roles::operator<<(
-  std::ostream& os, const cloud_roles::refresh_credentials& rc) {
+std::ostream& operator<<(std::ostream& os, const refresh_credentials& rc) {
     return rc.print(os);
 }
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/refresh_credentials.h"
+
+#include "cloud_roles/logger.h"
+#include "config/node_config.h"
+#include "model/metadata.h"
+#include "s3/client.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
+
+/// These environment variables can be used to override the default hostname and
+/// port for fetching temporary credentials for testing.
+struct override_api_endpoint_env_vars {
+    static constexpr std::string_view host = "RP_SI_CREDS_API_HOST";
+    static constexpr std::string_view port = "RP_SI_CREDS_API_PORT";
+};
+
+/// Multiplier to derive sleep duration from expiry time. Leaves 0.1 * expiry
+/// seconds as buffer to make API calls. For default expiry of 1 hour, this
+/// results in a fetch after 54 minutes.
+static constexpr float sleep_from_expiry_multiplier = 0.9;
+
+cloud_roles::refresh_credentials::refresh_credentials(
+  std::unique_ptr<impl> impl,
+  ss::gate& gate,
+  ss::abort_source& as,
+  credentials_update_cb_t creds_update,
+  s3::aws_region_name region)
+  : _impl(std::move(impl))
+  , _gate(gate)
+  , _as(as)
+  , _credentials_update(std::move(creds_update))
+  , _region{std::move(region)} {}
+
+void cloud_roles::refresh_credentials::start() {
+    ssx::background = ssx::spawn_with_gate_then(
+      _gate, [this]() mutable { return do_start(); });
+}
+
+ss::future<> cloud_roles::refresh_credentials::do_start() {
+    return ss::do_until(
+      [this] { return _gate.is_closed() || _as.abort_requested(); },
+      [this] { return fetch_and_update_credentials(); });
+}
+
+static std::optional<ss::sstring>
+load_and_validate_env_var(std::string_view env_var) {
+    char* override_maybe = std::getenv(env_var.data());
+    if (override_maybe) {
+        ss::sstring override{override_maybe};
+        if (!override.empty()) {
+            return override;
+        }
+
+        vlog(
+          cloud_roles::clrl_log.warn,
+          "override environment variable {} is set but empty, ignoring",
+          env_var);
+    }
+    return std::nullopt;
+}
+
+cloud_roles::refresh_credentials::impl::impl(
+  ss::sstring api_host,
+  uint16_t api_port,
+  s3::aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : _api_host{std::move(api_host)}
+  , _api_port{api_port}
+  , _region{std::move(region)}
+  , _as{as}
+  , _retry_params{retry_params} {
+    if (config::node().developer_mode()) {
+        if (auto host_override = load_and_validate_env_var(
+              override_api_endpoint_env_vars::host);
+            host_override) {
+            vlog(
+              clrl_log.debug,
+              "api_host overridden from {} to {}",
+              _api_host,
+              *host_override);
+            _api_host = {*host_override};
+        }
+        if (auto port_override = load_and_validate_env_var(
+              override_api_endpoint_env_vars::port);
+            port_override) {
+            try {
+                auto override_port = std::stoi(*port_override);
+                vlog(
+                  clrl_log.debug,
+                  "api_port overridden from {} to {}",
+                  _api_port,
+                  override_port);
+                _api_port = override_port;
+            } catch (...) {
+                vlog(
+                  clrl_log.error,
+                  "failed to convert port value {} from string to uint16_t",
+                  *port_override);
+            }
+        }
+    }
+}
+
+ss::future<> cloud_roles::refresh_credentials::fetch_and_update_credentials() {
+    // Before fetching new credentials, either:
+    // 1. do not sleep - this is an initial call to API
+    // 2. sleep until we are close to expiry of credentials
+    // 3. sleep in case of retryable failure for a short duration
+
+    co_await sleep_until_expiry();
+
+    vlog(clrl_log.debug, "fetching credentials");
+    auto fetch_response = co_await fetch_credentials();
+    auto handle_result = handle_response(std::move(fetch_response));
+
+    co_return co_await ss::visit(
+      std::move(handle_result),
+      [this](malformed_api_response_error err) {
+          _probe.fetch_failed();
+          vlog(
+            clrl_log.error,
+            "bad api response, missing fields: {}",
+            err.missing_fields);
+          return ss::now();
+      },
+      [this](api_response_parse_error err) {
+          _probe.fetch_failed();
+          vlog(clrl_log.error, "failed to parse api response: {}", err.reason);
+          return ss::now();
+      },
+      [this](api_request_error err) {
+          _probe.fetch_failed();
+          switch (err.error_kind) {
+          case api_request_error_kind::failed_abort:
+              vlog(clrl_log.error, "api request failed: {}", err.reason);
+          case api_request_error_kind::failed_retryable:
+              // handle_response has set the sleep duration, we will retry after
+              // a cool-off period
+              vlog(
+                clrl_log.error,
+                "api request failed (retrying after cool-off period): {}",
+                err.reason);
+          }
+          return ss::now();
+      },
+      [this](credentials creds) {
+          _probe.fetch_success();
+          vlog(clrl_log.info, "fetched credentials {}", creds);
+          return _credentials_update(std::move(creds));
+      });
+}
+
+ss::lowres_clock::duration
+cloud_roles::refresh_credentials::impl::calculate_sleep_duration(
+  uint32_t expiry_sec) const {
+    int sleep = std::floor(expiry_sec * sleep_from_expiry_multiplier);
+    return std::chrono::seconds{sleep};
+}
+
+ss::lowres_clock::duration
+cloud_roles::refresh_credentials::impl::calculate_sleep_duration(
+  std::chrono::system_clock::time_point expires_at) const {
+    auto now = std::chrono::system_clock::now();
+    auto diff = std::chrono::duration_cast<std::chrono::seconds>(
+                  expires_at - now)
+                  .count();
+    return calculate_sleep_duration(diff);
+}
+
+void cloud_roles::refresh_credentials::impl::increment_retries() {
+    _retries += 1;
+    auto sleep_ms = _retry_params.backoff_ms * (2 * _retries);
+    vlog(clrl_log.info, "retry after {} ms", sleep_ms);
+    _sleep_duration = sleep_ms;
+}
+
+cloud_roles::api_response_parse_result
+cloud_roles::refresh_credentials::impl::handle_response(
+  cloud_roles::api_response resp) {
+    if (std::holds_alternative<iobuf>(resp)) {
+        try {
+            auto parsed = parse_response(std::move(std::get<iobuf>(resp)));
+            // If we were retrying on some error and got a correct response,
+            // reset the retry counter
+            if (unlikely(_retries)) {
+                reset_retries();
+            }
+            return parsed;
+        } catch (const std::exception& e) {
+            // Parsing error: it may be a temporary issue with the API, or it
+            // may be a permanent problem with our request.
+            increment_retries();
+            return api_response_parse_error{.reason = e.what()};
+        }
+    } else {
+        if (!std::holds_alternative<api_request_error>(resp)) {
+            throw std::runtime_error(
+              fmt_with_ctx(fmt::format, "unexpected response variant"));
+        }
+        auto error = std::get<api_request_error>(resp);
+        if (error.error_kind == api_request_error_kind::failed_retryable) {
+            increment_retries();
+        }
+        return error;
+    }
+}
+
+ss::future<>
+cloud_roles::refresh_credentials::impl::sleep_until_expiry() const {
+    if (_sleep_duration) {
+        co_await ss::sleep_abortable(*_sleep_duration, _as);
+    }
+}
+
+http::client cloud_roles::refresh_credentials::impl::make_api_client() const {
+    return http::client{
+      net::base_transport::configuration{
+        .server_addr = net::unresolved_address{_api_host, _api_port},
+        .credentials = {},
+        .disable_metrics = net::metrics_disabled::yes,
+        .tls_sni_hostname = std::nullopt},
+      _as};
+}
+
+std::ostream& cloud_roles::operator<<(
+  std::ostream& os, const cloud_roles::refresh_credentials& rc) {
+    return rc.print(os);
+}

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_roles/refresh_credentials.h"
 
+#include "cloud_roles/aws_refresh_impl.h"
 #include "cloud_roles/logger.h"
 #include "config/node_config.h"
 #include "model/metadata.h"
@@ -233,6 +234,42 @@ http::client cloud_roles::refresh_credentials::impl::make_api_client() const {
         .disable_metrics = net::metrics_disabled::yes,
         .tls_sni_hostname = std::nullopt},
       _as};
+}
+
+cloud_roles::refresh_credentials cloud_roles::make_refresh_credentials(
+  model::cloud_credentials_source cloud_credentials_source,
+  ss::gate& gate,
+  ss::abort_source& as,
+  credentials_update_cb_t creds_update_cb,
+  s3::aws_region_name region,
+  std::optional<endpoint> endpoint,
+  retry_params retry_params) {
+    switch (cloud_credentials_source) {
+    case model::cloud_credentials_source::config_file:
+        vlog(
+          clrl_log.error,
+          "invalid request to create refresh_credentials for static "
+          "credentials");
+        throw std::invalid_argument(fmt_with_ctx(
+          fmt::format, "cannot generate refresh with static credentials"));
+    case model::cloud_credentials_source::aws_instance_metadata:
+        return make_refresh_credentials<aws_refresh_impl>(
+          gate,
+          as,
+          std::move(creds_update_cb),
+          std::move(region),
+          std::move(endpoint),
+          retry_params);
+    default:
+        vlog(
+          clrl_log.error,
+          "unsupported source type {}",
+          cloud_credentials_source);
+        throw std::invalid_argument(fmt_with_ctx(
+          fmt::format,
+          "cannot generate implementation for {}",
+          cloud_credentials_source));
+    }
 }
 
 std::ostream& cloud_roles::operator<<(

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_roles/aws_refresh_impl.h"
 #include "cloud_roles/aws_sts_refresh_impl.h"
+#include "cloud_roles/gcp_refresh_impl.h"
 #include "cloud_roles/logger.h"
 #include "config/node_config.h"
 #include "model/metadata.h"
@@ -263,6 +264,14 @@ cloud_roles::refresh_credentials cloud_roles::make_refresh_credentials(
           retry_params);
     case model::cloud_credentials_source::sts:
         return make_refresh_credentials<aws_sts_refresh_impl>(
+          gate,
+          as,
+          std::move(creds_update_cb),
+          std::move(region),
+          std::move(endpoint),
+          retry_params);
+    case model::cloud_credentials_source::gcp_instance_metadata:
+        return make_refresh_credentials<gcp_refresh_impl>(
           gate,
           as,
           std::move(creds_update_cb),

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/logger.h"
+#include "cloud_roles/probe.h"
+#include "cloud_roles/request_response_helpers.h"
+#include "model/metadata.h"
+#include "s3/signature.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <memory>
+
+namespace cloud_roles {
+
+struct retry_params {
+    ss::lowres_clock::duration backoff_ms;
+    uint8_t max_retries;
+};
+
+class refresh_credentials {
+public:
+    class impl {
+    public:
+        impl(
+          ss::sstring api_host,
+          uint16_t api_port,
+          s3::aws_region_name region,
+          ss::abort_source& as,
+          retry_params retry_params);
+        impl(impl&&) noexcept = default;
+
+        impl& operator=(impl&&) noexcept = delete;
+
+        impl(const impl&) = delete;
+        impl& operator=(const impl&) = delete;
+
+        virtual ~impl() noexcept = default;
+
+        /// Fetches credentials from api, the result can be iobuf or an error
+        /// encountered during the fetch operation
+        virtual ss::future<api_response> fetch_credentials() = 0;
+
+        /// Parses response from API into valid credentials. If errors were
+        /// encountered during fetch, they are returned as is. If the response
+        /// is a valid iobuf, it is parsed into a credentials object.
+        /// Returns the credentials or the parse error
+        api_response_parse_result handle_response(api_response resp);
+
+        ss::future<> sleep_until_expiry() const;
+
+        virtual std::ostream& print(std::ostream& os) const = 0;
+
+    protected:
+        /// Returns an http client with the API host and port applied
+        http::client make_api_client() const;
+
+        /// Helper to parse the iobuf returned from API into a credentials
+        /// object, customized to API response structure
+        virtual api_response_parse_result parse_response(iobuf resp) = 0;
+
+        /// Sets the amount of seconds to sleep before making the next API call
+        /// to fetch credentials. Depends on expiry time of current set of
+        /// credentials.
+        void next_sleep_duration(ss::lowres_clock::duration sd) {
+            vlog(
+              clrl_log.trace,
+              "setting next sleep duration to {} seconds",
+              std::chrono::duration_cast<std::chrono::seconds>(sd).count());
+            _sleep_duration = sd;
+        }
+
+        /// Calculates sleep duration given a time point in future where the
+        /// credentials will expire. Keeps a small buffer to allow for network
+        /// calls
+        ss::lowres_clock::duration calculate_sleep_duration(
+          std::chrono::system_clock::time_point expires_at) const;
+
+        /// Calculates sleep duration given the number of seconds when the
+        /// credentials will expire. Keeps a small buffer to allow for network
+        /// calls
+        ss::lowres_clock::duration
+        calculate_sleep_duration(uint32_t expiry_sec) const;
+
+        /// When a retryable error is seen, increment retries and set a small
+        /// backoff before attempting to fetch credentials again. If the retries
+        /// go over the max limit, abort the operation by throwing an exception.
+        void increment_retries();
+
+        void reset_retries() {
+            vlog(
+              clrl_log.info, "resetting retry counter from {} to 0", _retries);
+            _retries = 0;
+        }
+
+        uint8_t retries() const { return _retries; }
+
+        const ss::sstring& api_host() const { return _api_host; }
+
+        uint16_t api_port() const { return _api_port; }
+
+        s3::aws_region_name region() const { return _region; }
+
+    private:
+        /// The hostname to query for credentials. Can be overridden using env
+        /// variable `RP_SI_CREDS_API_HOST`
+        ss::sstring _api_host;
+
+        /// The port to query for credentials. Can be overridden using env
+        /// variable `RP_SI_CREDS_API_PORT`
+        uint16_t _api_port;
+        s3::aws_region_name _region;
+        uint8_t _retries{0};
+
+        /// The duration to sleep before fetching credentials. Derived from
+        /// credentials expiry time adjusted with a buffer to account for
+        /// network calls.
+        std::optional<ss::lowres_clock::duration> _sleep_duration{std::nullopt};
+        ss::abort_source& _as;
+        retry_params _retry_params;
+    };
+
+    refresh_credentials(
+      std::unique_ptr<impl> impl,
+      ss::gate& gate,
+      ss::abort_source& as,
+      credentials_update_cb_t creds_update,
+      s3::aws_region_name region);
+
+    void start();
+
+    std::ostream& print(std::ostream& os) const { return _impl->print(os); }
+
+    ss::future<api_response> fetch_credentials() {
+        return _impl->fetch_credentials();
+    }
+
+private:
+    ss::future<> do_start();
+
+    /// Fetch the credentials from API using impl and trigger the callback
+    /// function with valid credentials. If an error was encountered when
+    /// fetching credentials, handle retry or abort based on the error.
+    ss::future<> fetch_and_update_credentials();
+
+    api_response_parse_result handle_response(api_response resp) {
+        return _impl->handle_response(std::move(resp));
+    }
+
+    ss::future<> sleep_until_expiry() const {
+        return _impl->sleep_until_expiry();
+    }
+
+private:
+    std::unique_ptr<impl> _impl;
+    ss::gate& _gate;
+    ss::abort_source& _as;
+    credentials_update_cb_t _credentials_update;
+    s3::aws_region_name _region;
+    auth_refresh_probe _probe;
+};
+
+std::ostream& operator<<(std::ostream& os, const refresh_credentials& rc);
+
+struct endpoint {
+    ss::sstring host;
+    uint16_t port;
+};
+
+static constexpr retry_params default_retry_params{
+  .backoff_ms = std::chrono::milliseconds{500}, .max_retries = 8};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -181,4 +181,31 @@ struct endpoint {
 static constexpr retry_params default_retry_params{
   .backoff_ms = std::chrono::milliseconds{500}, .max_retries = 8};
 
+template<typename CredentialsProvider>
+refresh_credentials make_refresh_credentials(
+  ss::gate& gate,
+  ss::abort_source& as,
+  credentials_update_cb_t creds_update_cb,
+  s3::aws_region_name region,
+  std::optional<endpoint> endpoint = std::nullopt,
+  retry_params retry_params = default_retry_params) {
+    auto host = endpoint ? endpoint->host : CredentialsProvider::default_host;
+    auto port = endpoint ? endpoint->port : CredentialsProvider::default_port;
+    auto impl = std::make_unique<CredentialsProvider>(
+      host.data(), port, region, as, retry_params);
+    return cloud_roles::refresh_credentials{
+      std::move(impl), gate, as, std::move(creds_update_cb), std::move(region)};
+}
+
+/// Builds a refresh_credentials object based on the credentials source set in
+/// configuration.
+refresh_credentials make_refresh_credentials(
+  model::cloud_credentials_source cloud_credentials_source,
+  ss::gate& gate,
+  ss::abort_source& as,
+  credentials_update_cb_t creds_update_cb,
+  s3::aws_region_name region,
+  std::optional<endpoint> endpoint = std::nullopt,
+  retry_params retry_params = default_retry_params);
+
 } // namespace cloud_roles

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/request_response_helpers.h"
+
+#include "bytes/iobuf_istreambuf.h"
+#include "json/istreamwrapper.h"
+#include "s3/client.h"
+
+namespace cloud_roles {
+
+ss::future<boost::beast::http::status>
+get_status(http::client::response_stream_ref& resp) {
+    co_await resp->prefetch_headers();
+    co_return resp->get_headers().result();
+}
+
+ss::future<api_response> make_request(
+  http::client client,
+  http::client::request_header req,
+  ss::lowres_clock::duration timeout) {
+    try {
+        auto response_stream = co_await client.request(std::move(req), timeout);
+        auto status = co_await get_status(response_stream);
+        if (
+          std::find(
+            retryable_http_status.begin(), retryable_http_status.end(), status)
+          != retryable_http_status.end()) {
+            co_return api_request_error{
+              .reason = fmt::format("http request failed:{}", status),
+              .error_kind = api_request_error_kind::failed_retryable};
+        }
+
+        if (status != boost::beast::http::status::ok) {
+            co_return api_request_error{
+              .reason = fmt::format("http request failed:{}", status),
+              .error_kind = api_request_error_kind::failed_abort};
+        }
+
+        co_return co_await s3::drain_response_stream(
+          std::move(response_stream));
+    } catch (const std::system_error& ec) {
+        if (auto code = ec.code(); std::find(
+                                     retryable_system_error_codes.begin(),
+                                     retryable_system_error_codes.end(),
+                                     code.value())
+                                   == retryable_system_error_codes.end()) {
+            co_return api_request_error{
+              .reason = ec.what(),
+              .error_kind = api_request_error_kind::failed_abort};
+        }
+        co_return api_request_error{
+          .reason = ec.what(),
+          .error_kind = api_request_error_kind::failed_retryable};
+    } catch (const std::exception& e) {
+        co_return api_request_error{
+          .reason = e.what(),
+          .error_kind = api_request_error_kind::failed_abort};
+    }
+}
+
+json::Document parse_json_response(iobuf resp) {
+    iobuf_istreambuf ibuf{resp};
+    std::istream stream{&ibuf};
+    json::Document doc;
+    json::IStreamWrapper wrapper(stream);
+    doc.ParseStream(wrapper);
+    return doc;
+}
+
+ss::future<api_response> post_request(
+  http::client client,
+  http::client::request_header req,
+  iobuf content,
+  ss::lowres_clock::duration timeout) {
+    try {
+        req.set(
+          boost::beast::http::field::content_length,
+          boost::beast::to_static_string(content.size_bytes()));
+
+        auto [req_str, resp] = co_await client.make_request(
+          std::move(req), timeout);
+        co_await req_str->send_some(std::move(content));
+        co_await req_str->send_eof();
+
+        auto status = co_await get_status(resp);
+        if (
+          std::find(
+            retryable_http_status.begin(), retryable_http_status.end(), status)
+          != retryable_http_status.end()) {
+            co_return api_request_error{
+              .reason = fmt::format("http request failed:{}", status),
+              .error_kind = api_request_error_kind::failed_retryable};
+        }
+
+        if (status != boost::beast::http::status::ok) {
+            co_return api_request_error{
+              .reason = fmt::format("http request failed:{}", status),
+              .error_kind = api_request_error_kind::failed_abort};
+        }
+
+        co_return co_await s3::drain_response_stream(std::move(resp));
+    } catch (const std::system_error& ec) {
+        if (auto code = ec.code(); std::find(
+                                     retryable_system_error_codes.begin(),
+                                     retryable_system_error_codes.end(),
+                                     code.value())
+                                   == retryable_system_error_codes.end()) {
+            co_return api_request_error{
+              .reason = ec.what(),
+              .error_kind = api_request_error_kind::failed_abort};
+        }
+        co_return api_request_error{
+          .reason = ec.what(),
+          .error_kind = api_request_error_kind::failed_retryable};
+    } catch (const std::exception& e) {
+        co_return api_request_error{
+          .reason = e.what(),
+          .error_kind = api_request_error_kind::failed_abort};
+    }
+}
+
+ss::future<api_response> post_request(
+  http::client client,
+  http::client::request_header req,
+  seastar::sstring content,
+  ss::lowres_clock::duration timeout) {
+    iobuf b;
+    b.append(content.data(), content.size());
+    return post_request(
+      std::move(client), std::move(req), std::move(b), timeout);
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/request_response_helpers.h
+++ b/src/v/cloud_roles/request_response_helpers.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/types.h"
+#include "http/client.h"
+#include "json/document.h"
+
+namespace cloud_roles {
+
+inline const ss::lowres_clock::duration default_request_timeout{
+  std::chrono::seconds{5}};
+
+ss::future<api_response> make_request(
+  http::client client,
+  http::client::request_header req,
+  ss::lowres_clock::duration timeout = default_request_timeout);
+
+ss::future<api_response> post_request(
+  http::client client,
+  http::client::request_header req,
+  iobuf content,
+  ss::lowres_clock::duration timeout = default_request_timeout);
+
+ss::future<api_response> post_request(
+  http::client client,
+  http::client::request_header req,
+  ss::sstring content,
+  ss::lowres_clock::duration timeout = default_request_timeout);
+
+ss::future<boost::beast::http::status>
+get_status(http::client::response_stream_ref& resp);
+
+json::Document parse_json_response(iobuf resp);
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/tests/CMakeLists.txt
+++ b/src/v/cloud_roles/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+rp_test(
+    UNIT_TEST
+    BINARY_NAME
+    test_cloud_roles
+    SOURCES role_client_tests.cc categorization_tests.cc fetch_credentials_tests.cc credential_tests.cc
+    DEFINITIONS BOOST_TEST_DYN_LINK
+    LIBRARIES
+    v::seastar_testing_main
+    v::cloud_roles
+    Boost::unit_test_framework
+    ARGS "-- -c 1"
+    LABELS cloud_roles
+)

--- a/src/v/cloud_roles/tests/categorization_tests.cc
+++ b/src/v/cloud_roles/tests/categorization_tests.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/apply_credentials.h"
+#include "cloud_roles/refresh_credentials.h"
+#include "config/node_config.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+
+#include <boost/test/unit_test.hpp>
+
+inline ss::logger test_log("test"); // NOLINT
+
+BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
+    ss::gate gate;
+    ss::abort_source as;
+    s3::aws_region_name region{"atlantis"};
+    {
+        auto rc = cloud_roles::make_refresh_credentials(
+          model::cloud_credentials_source::gcp_instance_metadata,
+          gate,
+          as,
+          [](auto) { return ss::now(); },
+          region);
+        BOOST_REQUIRE_EQUAL(
+          "gcp_refresh_impl{host:169.254.169.254, port:80}",
+          ssx::sformat("{}", rc));
+    }
+
+    {
+        auto rc = cloud_roles::make_refresh_credentials(
+          model::cloud_credentials_source::aws_instance_metadata,
+          gate,
+          as,
+          [](auto) { return ss::now(); },
+          region);
+        BOOST_REQUIRE_EQUAL(
+          "aws_refresh_impl{host:169.254.169.254, port:80}",
+          ssx::sformat("{}", rc));
+    }
+
+    {
+        setenv("AWS_ROLE_ARN", "role", 1);
+        setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "file_path", 1);
+
+        auto rc = cloud_roles::make_refresh_credentials(
+          model::cloud_credentials_source::sts,
+          gate,
+          as,
+          [](auto) { return ss::now(); },
+          region);
+        BOOST_REQUIRE_EQUAL(
+          "aws_sts_refresh_impl{host:sts.amazonaws.com, port:443}",
+          ssx::sformat("{}", rc));
+    }
+
+    BOOST_REQUIRE_THROW(
+      cloud_roles::make_refresh_credentials(
+        model::cloud_credentials_source::config_file,
+        gate,
+        as,
+        [](auto) { return ss::now(); },
+        region),
+      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(
+  test_credential_applier_built_according_to_credential_kind) {
+    {
+        cloud_roles::gcp_credentials gc{};
+        auto applier = cloud_roles::make_credentials_applier(std::move(gc));
+        BOOST_REQUIRE_EQUAL(
+          "apply_gcp_credentials", ssx::sformat("{}", applier));
+    }
+
+    {
+        cloud_roles::aws_credentials ac{};
+        auto applier = cloud_roles::make_credentials_applier(std::move(ac));
+        BOOST_REQUIRE_EQUAL(
+          "apply_aws_credentials", ssx::sformat("{}", applier));
+    }
+}

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/apply_credentials.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace bh = boost::beast::http;
+
+BOOST_AUTO_TEST_CASE(test_gcp_headers) {
+    auto applier = cloud_roles::make_credentials_applier(
+      cloud_roles::gcp_credentials{
+        .oauth_token = cloud_roles::oauth_token_str{"a-token"}});
+
+    {
+        bh::request_header<> h{};
+        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(h.at(bh::field::authorization), "Bearer a-token");
+    }
+
+    applier.reset_creds(cloud_roles::gcp_credentials{
+      .oauth_token = cloud_roles::oauth_token_str{"second-token"}});
+
+    {
+        bh::request_header<> h{};
+        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(
+          h.at(bh::field::authorization), "Bearer second-token");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_aws_headers) {
+    auto applier = cloud_roles::make_credentials_applier(
+      cloud_roles::aws_credentials{
+        .access_key_id = s3::public_key_str{"pub"},
+        .secret_access_key = s3::private_key_str{"priv"},
+        .session_token = cloud_roles::s3_session_token{"tok"},
+      });
+
+    {
+        bh::request_header<> h{};
+        h.method(bh::verb::put);
+        applier.add_auth(h);
+        fmt::print("{}", h);
+        BOOST_REQUIRE_EQUAL(h.at("x-amz-security-token"), "tok");
+        // put request contains unsigned payload
+        BOOST_REQUIRE_EQUAL(h.at("x-amz-content-sha256"), "UNSIGNED-PAYLOAD");
+    }
+
+    applier.reset_creds(cloud_roles::aws_credentials{
+      .access_key_id = s3::public_key_str{"pub2"},
+      .secret_access_key = s3::private_key_str{"priv2"},
+      .session_token = cloud_roles::s3_session_token{"tok2"},
+    });
+
+    {
+        bh::request_header<> h{};
+        h.method(bh::verb::get);
+        applier.add_auth(h);
+        fmt::print("{}", h);
+        BOOST_REQUIRE_EQUAL(h.at("x-amz-security-token"), "tok2");
+        // get request contains empty signature
+        BOOST_REQUIRE_EQUAL(
+          h.at("x-amz-content-sha256"),
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+}

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "cloud_roles/refresh_credentials.h"
+#include "cloud_roles/tests/test_definitions.h"
+#include "test_utils/fixture.h"
+#include "test_utils/http_imposter.h"
+
+#include <seastar/core/file.hh>
+
+#include <fmt/chrono.h>
+
+inline ss::logger test_log("test"); // NOLINT
+
+/// Helps test the credential fetch operation by triggering abort after a single
+/// credential is fetched.
+struct one_shot_fetch {
+    one_shot_fetch(
+      std::optional<cloud_roles::credentials>& credentials,
+      ss::abort_source& as)
+      : credentials(credentials)
+      , as(as) {}
+    std::optional<cloud_roles::credentials>& credentials;
+    ss::abort_source& as;
+
+    ss::future<> operator()(cloud_roles::credentials c) {
+        credentials.emplace(std::move(c));
+        as.request_abort();
+        return ss::now();
+    }
+};
+
+/// Helper to assert refresh calls, aborts after two fetches.
+struct two_fetches {
+    two_fetches(
+      std::optional<cloud_roles::credentials>& credentials,
+      ss::abort_source& as)
+      : credentials(credentials)
+      , as(as) {}
+
+    uint8_t count{};
+    std::optional<cloud_roles::credentials>& credentials;
+    ss::abort_source& as;
+
+    ss::future<> operator()(cloud_roles::credentials c) {
+        ++count;
+        credentials.emplace(std::move(c));
+        if (count == 2) {
+            as.request_abort();
+        }
+        return ss::now();
+    }
+};
+
+using namespace std::chrono_literals;
+
+FIXTURE_TEST(test_get_oauth_token, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::gcp_url)
+      .then_reply_with(cloud_role_tests::gcp_oauth_token);
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    one_shot_fetch s(c, as);
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::gcp_instance_metadata,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    BOOST_REQUIRE_EQUAL(
+      "a-token",
+      std::get<cloud_roles::gcp_credentials>(c.value()).oauth_token());
+}
+
+FIXTURE_TEST(test_token_refresh_on_expiry, http_imposter_fixture) {
+    // Token expires in 5 seconds
+    auto short_token = R"json(
+{"access_token":"a-token","expires_in":5,"token_type":"Bearer"}
+)json";
+    when().request(cloud_role_tests::gcp_url).then_reply_with(short_token);
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    two_fetches s(c, as);
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::gcp_instance_metadata,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    BOOST_REQUIRE_EQUAL(
+      "a-token",
+      std::get<cloud_roles::gcp_credentials>(c.value()).oauth_token());
+
+    BOOST_REQUIRE(
+      has_calls_in_order(cloud_role_tests::gcp_url, cloud_role_tests::gcp_url));
+}
+
+FIXTURE_TEST(test_aws_credentials, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::aws_role_query_url)
+      .then_reply_with(cloud_role_tests::aws_role);
+
+    when()
+      .request(cloud_role_tests::aws_creds_url)
+      .then_reply_with(cloud_role_tests::aws_creds);
+
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    one_shot_fetch s(c, as);
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::aws_instance_metadata,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
+    BOOST_REQUIRE_EQUAL("my-key", aws_creds.access_key_id());
+    BOOST_REQUIRE_EQUAL("my-secret", aws_creds.secret_access_key());
+    BOOST_REQUIRE_EQUAL("my-token", aws_creds.session_token.value());
+
+    BOOST_REQUIRE(has_calls_in_order(
+      cloud_role_tests::aws_role_query_url, cloud_role_tests::aws_creds_url));
+}
+
+FIXTURE_TEST(test_short_lived_aws_credentials, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::aws_role_query_url)
+      .then_reply_with(cloud_role_tests::aws_role);
+
+    using namespace std::chrono_literals;
+
+    auto response = R"json(
+{{
+  "Code" : "Success",
+  "LastUpdated" : "2012-04-26T16:39:16Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "my-key",
+  "SecretAccessKey" : "my-secret",
+  "Token" : "my-token",
+  "Expiration" : "{}"
+}}
+)json";
+
+    when()
+      .request(cloud_role_tests::aws_creds_url)
+      .then_reply_with(fmt::format(
+        fmt::runtime(response),
+        fmt::format(
+          "{:%Y-%m-%dT%H:%M:%SZ}",
+          fmt::gmtime(std::chrono::system_clock::now() + 5s))));
+
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    two_fetches s(c, as);
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::aws_instance_metadata,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
+    BOOST_REQUIRE_EQUAL("my-key", aws_creds.access_key_id());
+    BOOST_REQUIRE_EQUAL("my-secret", aws_creds.secret_access_key());
+    BOOST_REQUIRE_EQUAL("my-token", aws_creds.session_token.value());
+
+    BOOST_REQUIRE(has_calls_in_order(
+      cloud_role_tests::aws_role_query_url,
+      cloud_role_tests::aws_creds_url,
+      cloud_role_tests::aws_creds_url));
+}
+
+FIXTURE_TEST(test_sts_credentials, http_imposter_fixture) {
+    setenv("AWS_ROLE_ARN", cloud_role_tests::aws_role, 1);
+    setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "test_sts_creds_f", 1);
+
+    when()
+      .request("/")
+      .with_method(ss::httpd::POST)
+      .then_reply_with(cloud_role_tests::sts_creds);
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    one_shot_fetch s(c, as);
+
+    auto token_f = ss::open_file_dma(
+                     "test_sts_creds_f",
+                     ss::open_flags::create | ss::open_flags::rw)
+                     .get0();
+    ss::sstring token{"token"};
+    token_f.dma_write(0, token.data(), token.size()).get0();
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::sts,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    token_f.close().get0();
+    ss::remove_file("test_sts_creds_f").get0();
+
+    auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
+    BOOST_REQUIRE_EQUAL("sts-key", aws_creds.access_key_id());
+    BOOST_REQUIRE_EQUAL("sts-secret", aws_creds.secret_access_key());
+    BOOST_REQUIRE_EQUAL("sts-token", aws_creds.session_token.value());
+    BOOST_REQUIRE(has_call("/"));
+}
+
+FIXTURE_TEST(test_short_lived_sts_credentials, http_imposter_fixture) {
+    setenv("AWS_ROLE_ARN", cloud_role_tests::aws_role, 1);
+    setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "test_short_sts_f", 1);
+
+    constexpr const char* sts_creds = R"xml(
+<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>sts-key</AccessKeyId>
+      <SecretAccessKey>sts-secret</SecretAccessKey>
+      <SessionToken>sts-token</SessionToken>
+      <Expiration>{}</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>
+)xml";
+
+    using namespace std::chrono_literals;
+    when()
+      .request("/")
+      .with_method(ss::httpd::POST)
+      .then_reply_with(fmt::format(
+        fmt::runtime(sts_creds),
+        fmt::format(
+          "{:%Y-%m-%dT%H:%M:%SZ}",
+          fmt::gmtime(std::chrono::system_clock::now() + 5s))));
+
+    listen();
+
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    two_fetches s(c, as);
+
+    auto token_f = ss::open_file_dma(
+                     "test_short_sts_f",
+                     ss::open_flags::create | ss::open_flags::rw)
+                     .get0();
+    ss::sstring token{"token"};
+    token_f.dma_write(0, token.data(), token.size()).get0();
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::sts,
+      gate,
+      as,
+      s,
+      s3::aws_region_name{""},
+      cloud_roles::endpoint{
+        .host = httpd_host_name.data(), .port = httpd_port_number});
+
+    refresh.start();
+    gate.close().get();
+
+    token_f.close().get0();
+    ss::remove_file("test_short_sts_f").get0();
+    auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
+    BOOST_REQUIRE_EQUAL("sts-key", aws_creds.access_key_id());
+    BOOST_REQUIRE_EQUAL("sts-secret", aws_creds.secret_access_key());
+    BOOST_REQUIRE_EQUAL("sts-token", aws_creds.session_token.value());
+
+    BOOST_REQUIRE(has_calls_in_order("/", "/"));
+}

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/aws_refresh_impl.h"
+#include "cloud_roles/aws_sts_refresh_impl.h"
+#include "cloud_roles/gcp_refresh_impl.h"
+#include "cloud_roles/tests/test_definitions.h"
+#include "test_utils/fixture.h"
+#include "test_utils/http_imposter.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/test/unit_test.hpp>
+
+inline ss::logger test_log("test"); // NOLINT
+
+namespace ba = boost::algorithm;
+
+static const s3::aws_region_name region{""};
+
+FIXTURE_TEST(test_simple_token_request, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::gcp_url)
+      .then_reply_with(cloud_role_tests::gcp_oauth_token);
+    listen();
+    ss::abort_source as;
+
+    auto cl = cloud_roles::gcp_refresh_impl{
+      httpd_host_name.data(), httpd_port_number, region, as};
+    auto resp = cl.fetch_credentials().get0();
+    BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
+    BOOST_REQUIRE_EQUAL(
+      iobuf_to_bytes(std::get<iobuf>(resp)), cloud_role_tests::gcp_oauth_token);
+    BOOST_REQUIRE(has_call(cloud_role_tests::gcp_url));
+}
+
+FIXTURE_TEST(test_bad_response_handling, http_imposter_fixture) {
+    listen();
+    ss::abort_source as;
+
+    auto cl = cloud_roles::gcp_refresh_impl{
+      httpd_host_name.data(), httpd_port_number, region, as};
+    auto resp = cl.fetch_credentials().get0();
+    BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
+    auto error = std::get<cloud_roles::api_request_error>(resp);
+    BOOST_REQUIRE_EQUAL(
+      error.error_kind, cloud_roles::api_request_error_kind::failed_abort);
+    BOOST_REQUIRE_EQUAL(error.reason, "http request failed:Not Found");
+}
+
+FIXTURE_TEST(test_gateway_down, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::gcp_url)
+      .then_reply_with(ss::httpd::reply::status_type::gateway_timeout);
+    listen();
+    ss::abort_source as;
+
+    auto cl = cloud_roles::gcp_refresh_impl{
+      httpd_host_name.data(), httpd_port_number, region, as};
+    auto resp = cl.fetch_credentials().get0();
+    BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
+    auto error = std::get<cloud_roles::api_request_error>(resp);
+    BOOST_REQUIRE_EQUAL(
+      error.error_kind, cloud_roles::api_request_error_kind::failed_retryable);
+    BOOST_REQUIRE_EQUAL(error.reason, "http request failed:Gateway Timeout");
+}
+
+FIXTURE_TEST(test_aws_role_fetch_on_startup, http_imposter_fixture) {
+    when()
+      .request(cloud_role_tests::aws_role_query_url)
+      .then_reply_with(cloud_role_tests::aws_role);
+    when()
+      .request(cloud_role_tests::aws_creds_url)
+      .then_reply_with(cloud_role_tests::aws_creds);
+    listen();
+    ss::abort_source as;
+
+    auto cl = cloud_roles::aws_refresh_impl{
+      httpd_host_name.data(), httpd_port_number, region, as};
+    auto resp = cl.fetch_credentials().get0();
+    // assert that calls are made in order:
+    // 1. to find the role
+    // 2. to get token
+    BOOST_REQUIRE(has_calls_in_order(
+      cloud_role_tests::aws_role_query_url, cloud_role_tests::aws_creds_url));
+
+    BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
+    BOOST_REQUIRE_EQUAL(
+      iobuf_to_bytes(std::get<iobuf>(resp)), cloud_role_tests::aws_creds);
+}
+
+FIXTURE_TEST(test_sts_credentials_fetch, http_imposter_fixture) {
+    when()
+      .request("/")
+      .with_method(ss::httpd::POST)
+      .then_reply_with(cloud_role_tests::sts_creds);
+    listen();
+    ss::abort_source as;
+
+    // the STS client reads these values from pod environment
+    setenv("AWS_ROLE_ARN", cloud_role_tests::aws_role, 1);
+    setenv("AWS_WEB_IDENTITY_TOKEN_FILE", cloud_role_tests::token_file, 1);
+
+    auto token_f = ss::open_file_dma(
+                     cloud_role_tests::token_file,
+                     ss::open_flags::create | ss::open_flags::rw)
+                     .get0();
+
+    ss::sstring token{"token"};
+    auto wrote = token_f.dma_write(0, token.data(), token.size()).get0();
+    BOOST_REQUIRE_EQUAL(wrote, token.size());
+
+    auto cl = cloud_roles::aws_sts_refresh_impl{
+      httpd_host_name.data(), httpd_port_number, region, as};
+    auto resp = cl.fetch_credentials().get0();
+
+    token_f.close().get0();
+    ss::remove_file(cloud_role_tests::token_file).get0();
+    BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
+    BOOST_REQUIRE_EQUAL(std::get<iobuf>(resp), cloud_role_tests::sts_creds);
+
+    auto posted = get_requests()[0].content;
+    BOOST_REQUIRE(ba::contains(posted, "Action=AssumeRoleWithWebIdentity"));
+    BOOST_REQUIRE(ba::contains(posted, "RoleArn=tomato"));
+    BOOST_REQUIRE(ba::contains(posted, "WebIdentityToken=token"));
+}

--- a/src/v/cloud_roles/tests/test_definitions.h
+++ b/src/v/cloud_roles/tests/test_definitions.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+namespace cloud_role_tests {
+constexpr const char* gcp_oauth_token = R"json(
+{"access_token":"a-token","expires_in":3599,"token_type":"Bearer"}
+)json";
+
+constexpr const char* gcp_url
+  = "/computeMetadata/v1/instance/service-accounts/default/token";
+
+constexpr const char* aws_role_query_url
+  = "/latest/meta-data/iam/security-credentials/";
+
+constexpr const char* aws_role = "tomato";
+
+constexpr const char* aws_creds_url
+  = "/latest/meta-data/iam/security-credentials/tomato";
+
+constexpr const char* aws_creds = R"json(
+{
+  "Code" : "Success",
+  "LastUpdated" : "2012-04-26T16:39:16Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "my-key",
+  "SecretAccessKey" : "my-secret",
+  "Token" : "my-token",
+  "Expiration" : "2017-05-17T15:09:54.1234Z"
+}
+)json";
+
+constexpr const char* sts_creds = R"xml(
+<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>sts-key</AccessKeyId>
+      <SecretAccessKey>sts-secret</SecretAccessKey>
+      <SessionToken>sts-token</SessionToken>
+      <Expiration>2022-06-07T15:10:47.1234Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>
+)xml";
+
+constexpr const char* token_file = "token_here";
+
+} // namespace cloud_role_tests

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -12,6 +12,12 @@
 
 namespace cloud_roles {
 
+std::ostream& operator<<(std::ostream& os, const gcp_credentials& gc) {
+    fmt::print(
+      os, "gcp_credentials{{oauth_token:**{}**}}", gc.oauth_token().size());
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const aws_credentials& ac) {
     fmt::print(
       os,

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -19,7 +19,7 @@ std::ostream& operator<<(std::ostream& os, const aws_credentials& ac) {
       "session_token: **{}**}}",
       ac.access_key_id().size(),
       ac.secret_access_key().size(),
-      ac.session_token.value_or(session_token_str{})().size());
+      ac.session_token.value_or(s3_session_token{})().size());
     return os;
 }
 

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -12,6 +12,34 @@
 
 namespace cloud_roles {
 
+std::ostream& operator<<(std::ostream& os, api_request_error_kind kind) {
+    switch (kind) {
+    case api_request_error_kind::failed_abort:
+        return os << "failed_abort";
+    case api_request_error_kind::failed_retryable:
+        return os << "failed_retryable";
+    }
+}
+
+std::ostream&
+operator<<(std::ostream& os, const api_request_error& request_error) {
+    fmt::print(
+      os,
+      "api_request_error{{reason:{}, error_kind:{}}}",
+      request_error.reason,
+      request_error.error_kind);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const malformed_api_response_error& err) {
+    fmt::print(
+      os,
+      "malformed_api_response_error{{missing_fields:{}}}",
+      err.missing_fields);
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const gcp_credentials& gc) {
     fmt::print(
       os, "gcp_credentials{{oauth_token:**{}**}}", gc.oauth_token().size());

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/types.h"
+
+namespace cloud_roles {
+
+std::ostream& operator<<(std::ostream& os, const aws_credentials& ac) {
+    fmt::print(
+      os,
+      "aws_credentials{{access_key_id: **{}**, secret_access_key: **{}**, "
+      "session_token: **{}**}}",
+      ac.access_key_id().size(),
+      ac.secret_access_key().size(),
+      ac.session_token.value_or(session_token_str{})().size());
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const credentials& c) {
+    ss::visit(c, [&os](auto creds) { os << creds; });
+    return os;
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -22,12 +22,12 @@
 
 namespace cloud_roles {
 
-using session_token_str = named_type<ss::sstring, struct s3_session_token_str>;
+using s3_session_token = named_type<ss::sstring, struct s3_session_token_str>;
 
 struct aws_credentials {
     s3::public_key_str access_key_id;
     s3::private_key_str secret_access_key;
-    std::optional<session_token_str> session_token;
+    std::optional<s3_session_token> session_token;
     s3::aws_region_name region;
 };
 

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -22,6 +22,14 @@
 
 namespace cloud_roles {
 
+using oauth_token_str = named_type<ss::sstring, struct oauth_token_str_tag>;
+
+struct gcp_credentials {
+    oauth_token_str oauth_token;
+};
+
+std::ostream& operator<<(std::ostream& os, const gcp_credentials& gc);
+
 using s3_session_token = named_type<ss::sstring, struct s3_session_token_str>;
 
 struct aws_credentials {
@@ -33,7 +41,7 @@ struct aws_credentials {
 
 std::ostream& operator<<(std::ostream& os, const aws_credentials& ac);
 
-using credentials = std::variant<aws_credentials>;
+using credentials = std::variant<aws_credentials, gcp_credentials>;
 
 std::ostream& operator<<(std::ostream& os, const credentials& c);
 

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -14,6 +14,7 @@
 #include "s3/signature.h"
 #include "seastarx.h"
 
+#include <seastar/core/metrics.hh>
 #include <seastar/core/sstring.hh>
 
 #include <boost/beast/http/status.hpp>
@@ -21,6 +22,45 @@
 #include <unordered_set>
 
 namespace cloud_roles {
+
+static constexpr auto retryable_system_error_codes = std::to_array(
+  {ECONNREFUSED, ENETUNREACH, ETIMEDOUT, ECONNRESET, EPIPE});
+
+static constexpr auto retryable_http_status = std::to_array({
+  boost::beast::http::status::request_timeout,
+  boost::beast::http::status::gateway_timeout,
+  boost::beast::http::status::bad_gateway,
+  boost::beast::http::status::service_unavailable,
+  boost::beast::http::status::internal_server_error,
+  boost::beast::http::status::network_connect_timeout_error,
+});
+
+enum class api_request_error_kind : uint8_t { failed_abort, failed_retryable };
+
+std::ostream& operator<<(std::ostream& os, api_request_error_kind kind);
+
+struct api_request_error {
+    ss::sstring reason;
+    api_request_error_kind error_kind;
+};
+
+std::ostream&
+operator<<(std::ostream& os, const api_request_error& request_error);
+
+using api_response = std::variant<iobuf, api_request_error>;
+
+struct malformed_api_response_error {
+    std::vector<ss::sstring> missing_fields;
+};
+
+std::ostream&
+operator<<(std::ostream& os, const malformed_api_response_error& err);
+
+struct api_response_parse_error {
+    ss::sstring reason;
+};
+
+std::ostream& operator<<(std::ostream& os, const api_response_parse_error& err);
 
 using oauth_token_str = named_type<ss::sstring, struct oauth_token_str_tag>;
 
@@ -44,5 +84,14 @@ std::ostream& operator<<(std::ostream& os, const aws_credentials& ac);
 using credentials = std::variant<aws_credentials, gcp_credentials>;
 
 std::ostream& operator<<(std::ostream& os, const credentials& c);
+
+using api_response_parse_result = std::variant<
+  malformed_api_response_error,
+  api_response_parse_error,
+  api_request_error,
+  credentials>;
+
+using credentials_update_cb_t
+  = ss::noncopyable_function<ss::future<>(credentials)>;
 
 } // namespace cloud_roles

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "s3/signature.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/beast/http/status.hpp>
+
+#include <unordered_set>
+
+namespace cloud_roles {
+
+using session_token_str = named_type<ss::sstring, struct s3_session_token_str>;
+
+struct aws_credentials {
+    s3::public_key_str access_key_id;
+    s3::private_key_str secret_access_key;
+    std::optional<session_token_str> session_token;
+    s3::aws_region_name region;
+};
+
+std::ostream& operator<<(std::ostream& os, const aws_credentials& ac);
+
+using credentials = std::variant<aws_credentials>;
+
+std::ostream& operator<<(std::ostream& os, const credentials& c);
+
+} // namespace cloud_roles

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -26,5 +26,6 @@ v_cc_library(
     v::model
     v::cluster
     v::rphashing
+    v::cloud_roles
 )
 add_subdirectory(tests)

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_roles/refresh_credentials.h"
 #include "cloud_storage/base_manifest.h"
 #include "cloud_storage/probe.h"
 #include "cloud_storage/types.h"
@@ -24,6 +25,46 @@
 
 namespace cloud_storage {
 
+static constexpr ss::shard_id auth_refresh_shard_id = 0;
+
+/// Helper class to start the background operations to periodically refresh
+/// authentication. Selects the implementation for fetch based on the
+/// cloud_credentials_source property.
+class auth_refresh_bg_op {
+public:
+    auth_refresh_bg_op(
+      ss::gate& gate,
+      ss::abort_source& as,
+      s3::configuration s3_conf,
+      model::cloud_credentials_source cloud_credentials_source);
+
+    /// Helper to decide if credentials will be regularly fetched from
+    /// infrastructure APIs or loaded once from config file.
+    bool is_static_config() const;
+
+    /// Builds a set of static AWS compatible credentials, reading values from
+    /// the S3 configuration passed to us.
+    cloud_roles::credentials build_static_credentials() const;
+
+    /// Start a background refresh operation, accepting a callback which is
+    /// called with newly fetched credentials periodically. The operation is
+    /// started on auth_refresh_shard_id and credentials are copied to other
+    /// shards using the callback.
+    void maybe_start_auth_refresh_op(
+      cloud_roles::credentials_update_cb_t credentials_update_cb);
+
+private:
+    void do_start_auth_refresh_op(
+      cloud_roles::credentials_update_cb_t credentials_update_cb);
+
+    ss::gate& _gate;
+    ss::abort_source& _as;
+    s3::configuration _s3_conf;
+    s3::aws_region_name _region_name;
+    model::cloud_credentials_source _cloud_credentials_source;
+    std::optional<cloud_roles::refresh_credentials> _refresh_credentials;
+};
+
 /// \brief Represents remote endpoint
 ///
 /// The `remote` is responsible for remote data
@@ -31,7 +72,7 @@ namespace cloud_storage {
 /// download data. Also, it's responsible for maintaining
 /// correct naming in S3. The remote takes into account
 /// things like reconnects, backpressure and backoff.
-class remote {
+class remote : public ss::peering_sharded_service<remote> {
 public:
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
@@ -56,7 +97,10 @@ public:
     ///
     /// \param limit is a number of simultaneous connections
     /// \param conf is an S3 configuration
-    remote(s3_connection_limit limit, const s3::configuration& conf);
+    remote(
+      s3_connection_limit limit,
+      const s3::configuration& conf,
+      model::cloud_credentials_source cloud_credentials_source);
 
     /// \brief Initialize 'remote'
     ///
@@ -135,10 +179,12 @@ public:
       retry_chain_node& parent);
 
 private:
+    ss::future<> propagate_credentials(cloud_roles::credentials credentials);
     s3::client_pool _pool;
     ss::gate _gate;
     ss::abort_source _as;
     remote_probe _probe;
+    auth_refresh_bg_op _auth_refresh_bg_op;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -58,6 +58,9 @@ using namespace cloud_storage;
 
 inline ss::logger test_log("test"); // NOLINT
 
+static constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
 static std::unique_ptr<storage::continuous_batch_parser>
 make_recording_batch_parser(
   iobuf buf,
@@ -318,7 +321,7 @@ static model::record_batch_header read_single_batch_from_remote_partition(
   cloud_storage_fixture& fixture, model::offset target) {
     auto conf = fixture.get_configuration();
     static auto bucket = s3::bucket_name("bucket");
-    remote api(s3_connection_limit(10), conf);
+    remote api(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&api] { api.stop().get(); });
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
@@ -348,7 +351,7 @@ static std::vector<model::record_batch_header> scan_remote_partition(
   cloud_storage_fixture& imposter, model::offset base, model::offset max) {
     auto conf = imposter.get_configuration();
     static auto bucket = s3::bucket_name("bucket");
-    remote api(s3_connection_limit(10), conf);
+    remote api(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&api] { api.stop().get(); });
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
@@ -884,7 +887,7 @@ scan_remote_partition_incrementally(
   cloud_storage_fixture& imposter, model::offset base, model::offset max) {
     auto conf = imposter.get_configuration();
     static auto bucket = s3::bucket_name("bucket");
-    remote api(s3_connection_limit(10), conf);
+    remote api(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&api] { api.stop().get(); });
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
@@ -1007,7 +1010,7 @@ FIXTURE_TEST(test_remote_partition_read_cached_index, cloud_storage_fixture) {
 
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote api(s3_connection_limit(10), conf);
+    remote api(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&api] { api.stop().get(); });
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -67,12 +67,15 @@ make_reset_fn(iobuf& segment_bytes) {
     };
 }
 
+static constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
 FIXTURE_TEST(
   test_remote_segment_successful_download, cloud_storage_fixture) { // NOLINT
     set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
     auto key = partition_manifest::key{
       .base_offset = model::offset(1), .term = model::term_id(2)};
@@ -115,7 +118,7 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
     auto name = segment_name("7-8-v1.log");
     partition_manifest::key key = parse_segment_name(name).value();
@@ -145,7 +148,7 @@ FIXTURE_TEST(
     set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
     auto key = partition_manifest::key{
       .base_offset = model::offset(1), .term = model::term_id(2)};
@@ -229,7 +232,7 @@ void test_remote_segment_batch_reader(
     fixture.set_expectations_and_listen({});
     auto conf = fixture.get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&remote] { remote.stop().get(); });
 
     partition_manifest m(manifest_ntp, manifest_revision);
@@ -339,7 +342,7 @@ FIXTURE_TEST(
     set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto action = ss::defer([&remote] { remote.stop().get(); });
 
     partition_manifest m(manifest_ntp, manifest_revision);

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -61,6 +61,9 @@ static constexpr std::string_view manifest_payload = R"json({
     }
 })json";
 
+static constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
 static partition_manifest load_manifest_from_str(std::string_view v) {
     partition_manifest m;
     iobuf i;
@@ -74,7 +77,7 @@ FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen({expectation{
       .url = "/" + manifest_url, .body = ss::sstring(manifest_payload)}});
     auto conf = get_configuration();
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto action = ss::defer([&remote] { remote.stop().get(); });
     retry_chain_node fib(100ms, 20ms);
@@ -92,7 +95,7 @@ FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
 
 FIXTURE_TEST(test_download_manifest_timeout, s3_imposter_fixture) { // NOLINT
     auto conf = get_configuration();
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto action = ss::defer([&remote] { remote.stop().get(); });
     retry_chain_node fib(100ms, 20ms);
@@ -109,7 +112,7 @@ FIXTURE_TEST(test_download_manifest_timeout, s3_imposter_fixture) { // NOLINT
 FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen({});
     auto conf = get_configuration();
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -134,7 +137,7 @@ FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
 
 FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
     auto conf = get_configuration();
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -158,7 +161,7 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -196,7 +199,7 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
 FIXTURE_TEST(test_download_segment_timeout, s3_imposter_fixture) { // NOLINT
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -216,7 +219,7 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -246,7 +249,7 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
 FIXTURE_TEST(test_segment_exists_timeout, s3_imposter_fixture) { // NOLINT
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
-    remote remote(s3_connection_limit(10), conf);
+    remote remote(s3_connection_limit(10), conf, config_file);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -53,11 +53,12 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
     fmt::print(
       o,
       "{{connection_limit: {}, client_config: {}, metrics_disabled: {}, "
-      "bucket_name: {}",
+      "bucket_name: {}, cloud_credentials_source: {}}}",
       cfg.connection_limit,
       cfg.client_config,
       cfg.metrics_disabled,
-      cfg.bucket_name);
+      cfg.bucket_name,
+      cfg.cloud_credentials_source);
     return o;
 }
 
@@ -77,12 +78,29 @@ static ss::sstring get_value_or_throw(
 
 ss::future<configuration> configuration::get_config() {
     vlog(cst_log.debug, "Generating archival configuration");
-    auto secret_key = s3::private_key_str(get_value_or_throw(
-      config::shard_local_cfg().cloud_storage_secret_key,
-      "cloud_storage_secret_key"));
-    auto access_key = s3::public_key_str(get_value_or_throw(
-      config::shard_local_cfg().cloud_storage_access_key,
-      "cloud_storage_access_key"));
+
+    auto cloud_credentials_source
+      = config::shard_local_cfg().cloud_storage_credentials_source.value();
+
+    std::optional<s3::private_key_str> secret_key;
+    std::optional<s3::public_key_str> access_key;
+
+    // If the credentials are sourced from config file, the keys must be present
+    // in the file. If the credentials are sourced from infrastructure APIs, the
+    // keys must be absent in the file.
+    // TODO (abhijat) validate and fail if source is not static file and the
+    //  keys are still supplied with the config.
+    if (
+      cloud_credentials_source
+      == model::cloud_credentials_source::config_file) {
+        secret_key = s3::private_key_str(get_value_or_throw(
+          config::shard_local_cfg().cloud_storage_secret_key,
+          "cloud_storage_secret_key"));
+        access_key = s3::public_key_str(get_value_or_throw(
+          config::shard_local_cfg().cloud_storage_access_key,
+          "cloud_storage_access_key"));
+    }
+
     auto region = s3::aws_region_name(get_value_or_throw(
       config::shard_local_cfg().cloud_storage_region, "cloud_storage_region"));
     auto disable_metrics = net::metrics_disabled(
@@ -117,6 +135,7 @@ ss::future<configuration> configuration::get_config() {
       .bucket_name = s3::bucket_name(get_value_or_throw(
         config::shard_local_cfg().cloud_storage_bucket,
         "cloud_storage_bucket")),
+      .cloud_credentials_source = cloud_credentials_source,
     };
     vlog(cst_log.debug, "Cloud storage configuration generated: {}", cfg);
     co_return cfg;

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "s3/client.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
@@ -74,6 +75,8 @@ struct configuration {
     remote_metrics_disabled metrics_disabled;
     /// The bucket to use
     s3::bucket_name bucket_name;
+
+    model::cloud_credentials_source cloud_credentials_source;
 
     friend std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -873,6 +873,18 @@ configuration::configuration()
       "Optional API endpoint",
       {.visibility = visibility::user},
       std::nullopt)
+  , cloud_storage_credentials_source(
+      *this,
+      "cloud_storage_credentials_source",
+      "The source of credentials to connect to cloud services",
+      {.needs_restart = needs_restart::yes,
+       .example = "config_file",
+       .visibility = visibility::user},
+      model::cloud_credentials_source::config_file,
+      {model::cloud_credentials_source::config_file,
+       model::cloud_credentials_source::aws_instance_metadata,
+       model::cloud_credentials_source::sts,
+       model::cloud_credentials_source::gcp_instance_metadata})
   , cloud_storage_reconciliation_ms(
       *this,
       "cloud_storage_reconciliation_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -190,6 +190,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_region;
     property<std::optional<ss::sstring>> cloud_storage_bucket;
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
+    enum_property<model::cloud_credentials_source>
+      cloud_storage_credentials_source;
     property<std::chrono::milliseconds> cloud_storage_reconciliation_ms;
     property<std::chrono::milliseconds>
       cloud_storage_upload_loop_initial_backoff_ms;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -421,6 +421,9 @@ consteval std::string_view property_type_name() {
         return "number";
     } else if constexpr (std::is_integral_v<type>) {
         return "integer";
+    } else if constexpr (std::
+                           is_same_v<type, model::cloud_credentials_source>) {
+        return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -149,4 +149,10 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const model::cloud_credentials_source& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -64,4 +64,7 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::violation_recovery_policy& v);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const model::cloud_credentials_source& v);
 } // namespace json

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -6,7 +6,8 @@ set(srcs
     socket_address_convert_test.cc
     tls_config_convert_test.cc
     advertised_kafka_api_test.cc
-    seed_server_property_test.cc)
+    seed_server_property_test.cc
+    cloud_credentials_source_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/config/tests/cloud_credentials_source_test.cc
+++ b/src/v/config/tests/cloud_credentials_source_test.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "config/configuration.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <yaml-cpp/yaml.h>
+
+static constexpr auto source_mapping
+  = std::to_array<std::pair<model::cloud_credentials_source, std::string_view>>(
+    {
+      {model::cloud_credentials_source::aws_instance_metadata,
+       "aws_instance_metadata"},
+      {model::cloud_credentials_source::sts, "sts"},
+      {model::cloud_credentials_source::config_file, "config_file"},
+      {model::cloud_credentials_source::gcp_instance_metadata,
+       "gcp_instance_metadata"},
+    });
+
+SEASTAR_THREAD_TEST_CASE(test_decode_cloud_credentials_source) {
+    for (const auto& [value, string_repr] : source_mapping) {
+        auto node = YAML::Load(fmt::format("ccs: {}", string_repr))["ccs"];
+        BOOST_REQUIRE_EQUAL(node.as<model::cloud_credentials_source>(), value);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_encode_cloud_credentials_source) {
+    for (const auto& [value, string_repr] : source_mapping) {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> writer(buf);
+        json::rjson_serialize(writer, value);
+        BOOST_REQUIRE_EQUAL(
+          YAML::Dump(YAML::Load(buf.GetString())), string_repr);
+    }
+}

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -383,6 +383,15 @@ operator<<(std::ostream& o, const model::violation_recovery_policy& x) {
     }
 }
 
+enum class cloud_credentials_source {
+    config_file = 0,
+    aws_instance_metadata = 1,
+    sts = 2,
+    gcp_instance_metadata = 3,
+};
+
+std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs);
+
 namespace internal {
 /*
  * Old version for use in backwards compatibility serialization /

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -369,6 +369,19 @@ std::ostream& operator<<(std::ostream& o, membership_state st) {
     return o << "unknown membership state {" << static_cast<int>(st) << "}";
 }
 
+std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs) {
+    switch (cs) {
+    case cloud_credentials_source::config_file:
+        return os << "config_file";
+    case cloud_credentials_source::aws_instance_metadata:
+        return os << "aws_instance_metadata";
+    case cloud_credentials_source::sts:
+        return os << "sts";
+    case cloud_credentials_source::gcp_instance_metadata:
+        return os << "gcp_instance_metadata";
+    }
+}
+
 std::ostream& operator<<(std::ostream& o, const shadow_indexing_mode& si) {
     switch (si) {
     case shadow_indexing_mode::disabled:

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -700,7 +700,7 @@ void application::wire_up_redpanda_services() {
           })
           .get();
         construct_service(cloud_storage_api, std::ref(cloud_configs)).get();
-
+        cloud_storage_api.invoke_on_all(&cloud_storage::remote::start).get();
         construct_service(
           partition_recovery_manager,
           cloud_configs.local().bucket_name,

--- a/src/v/s3/CMakeLists.txt
+++ b/src/v/s3/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::bytes
+    v::cloud_roles
     v::net
   DEFINES
     -DBOOST_ASIO_HAS_STD_INVOKE_RESULT

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -60,8 +60,6 @@ struct aws_header_names {
     static constexpr boost::beast::string_view prefix = "prefix";
     static constexpr boost::beast::string_view start_after = "start-after";
     static constexpr boost::beast::string_view max_keys = "max-keys";
-    static constexpr boost::beast::string_view x_amz_content_sha256
-      = "x-amz-content-sha256";
     static constexpr boost::beast::string_view x_amz_tagging = "x-amz-tagging";
     static constexpr boost::beast::string_view x_amz_request_id
       = "x-amz-request-id";
@@ -71,23 +69,6 @@ struct aws_header_values {
     static constexpr boost::beast::string_view user_agent
       = "redpanda.vectorized.io";
     static constexpr boost::beast::string_view text_plain = "text/plain";
-
-    /// SHA256 of an empty string (used in situation when the signed payload is
-    /// has zero length)
-    static constexpr boost::beast::string_view emptysig
-      = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-
-    static constexpr boost::beast::string_view unsigned_payload
-      = "UNSIGNED-PAYLOAD";
-};
-
-struct aws_signatures {
-    /// SHA256 of an empty string (used in situation when the signed payload is
-    /// has zero length)
-    static constexpr std::string_view emptysig
-      = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-
-    static constexpr std::string_view unsigned_payload = "UNSIGNED-PAYLOAD";
 };
 
 // configuration //
@@ -177,9 +158,11 @@ std::ostream& operator<<(std::ostream& o, const configuration& c) {
 
 // request_creator //
 
-request_creator::request_creator(const configuration& conf)
+request_creator::request_creator(
+  const configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
   : _ap(conf.uri)
-  , _sign(conf.region, conf.access_key.value(), conf.secret_key.value()) {}
+  , _apply_credentials{std::move(apply_credentials)} {}
 
 result<http::client::request_header> request_creator::make_get_object_request(
   bucket_name const& name, object_key const& key) {
@@ -197,9 +180,7 @@ result<http::client::request_header> request_creator::make_get_object_request(
       boost::beast::http::field::user_agent, aws_header_values::user_agent);
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
-    header.insert(
-      aws_header_names::x_amz_content_sha256, aws_header_values::emptysig);
-    auto ec = _sign.sign_header(header, aws_signatures::emptysig);
+    auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
     }
@@ -222,9 +203,7 @@ result<http::client::request_header> request_creator::make_head_object_request(
       boost::beast::http::field::user_agent, aws_header_values::user_agent);
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
-    header.insert(
-      aws_header_names::x_amz_content_sha256, aws_header_values::emptysig);
-    auto ec = _sign.sign_header(header, aws_signatures::emptysig);
+    auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
     }
@@ -259,9 +238,7 @@ request_creator::make_unsigned_put_object_request(
     header.insert(
       boost::beast::http::field::content_length,
       std::to_string(payload_size_bytes));
-    header.insert(
-      aws_header_names::x_amz_content_sha256,
-      aws_header_values::unsigned_payload);
+
     if (!tags.empty()) {
         std::stringstream tstr;
         for (const auto& [key, val] : tags) {
@@ -269,7 +246,8 @@ request_creator::make_unsigned_put_object_request(
         }
         header.insert(aws_header_names::x_amz_tagging, tstr.str().substr(1));
     }
-    auto ec = _sign.sign_header(header, aws_signatures::unsigned_payload);
+
+    auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
     }
@@ -295,8 +273,7 @@ request_creator::make_list_objects_v2_request(
       boost::beast::http::field::user_agent, aws_header_values::user_agent);
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
-    header.insert(
-      aws_header_names::x_amz_content_sha256, aws_header_values::emptysig);
+
     if (prefix) {
         header.insert(aws_header_names::prefix, (*prefix)().string());
     }
@@ -306,7 +283,8 @@ request_creator::make_list_objects_v2_request(
     if (max_keys) {
         header.insert(aws_header_names::start_after, std::to_string(*max_keys));
     }
-    auto ec = _sign.sign_header(header, aws_signatures::emptysig);
+
+    auto ec = _apply_credentials->add_auth(header);
     vlog(s3_log.trace, "ListObjectsV2:\n {}", http::redacted_header(header));
     if (ec) {
         return ec;
@@ -333,9 +311,7 @@ request_creator::make_delete_object_request(
       boost::beast::http::field::user_agent, aws_header_values::user_agent);
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
-    header.insert(
-      aws_header_names::x_amz_content_sha256, aws_header_values::emptysig);
-    auto ec = _sign.sign_header(header, aws_signatures::emptysig);
+    auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
     }
@@ -480,13 +456,18 @@ drain_response_stream(http::client::response_stream_ref resp) {
       });
 }
 
-client::client(const configuration& conf)
-  : _requestor(conf)
+client::client(
+  const configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
   , _client(conf)
   , _probe(conf._probe) {}
 
-client::client(const configuration& conf, const ss::abort_source& as)
-  : _requestor(conf)
+client::client(
+  const configuration& conf,
+  const ss::abort_source& as,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
@@ -713,9 +694,7 @@ client_pool::client_pool(
   size_t size, configuration conf, client_pool_overdraft_policy policy)
   : _max_size(size)
   , _config(std::move(conf))
-  , _policy(policy) {
-    init();
-}
+  , _policy(policy) {}
 
 ss::future<> client_pool::stop() {
     _as.request_abort();
@@ -734,11 +713,21 @@ ss::future<> client_pool::stop() {
 ss::future<client_pool::client_lease> client_pool::acquire() {
     gate_guard guard(_gate);
     try {
+        // If credentials have not yet been acquired, wait for them. It is
+        // possible that credentials are not initialized right after remote
+        // starts, and we have not had a response from the credentials API yet,
+        // but we have scheduled an upload. This wait ensures that when we call
+        // the storage API we have a set of valid credentials.
+        if (unlikely(!_apply_credentials)) {
+            co_await wait_for_credentials();
+        }
+
         while (_pool.empty() && !_gate.is_closed()) {
             if (_policy == client_pool_overdraft_policy::wait_if_empty) {
                 co_await _cvar.wait();
             } else {
-                auto cl = ss::make_shared<client>(_config, _as);
+                auto cl = ss::make_shared<client>(
+                  _config, _as, _apply_credentials);
                 _pool.emplace_back(std::move(cl));
             }
         }
@@ -759,20 +748,49 @@ ss::future<client_pool::client_lease> client_pool::acquire() {
             }
         })};
 }
+
 size_t client_pool::size() const noexcept { return _pool.size(); }
+
 size_t client_pool::max_size() const noexcept { return _max_size; }
-void client_pool::init() {
+
+void client_pool::populate_client_pool() {
     for (size_t i = 0; i < _max_size; i++) {
-        auto cl = ss::make_shared<client>(_config, _as);
+        auto cl = ss::make_shared<client>(_config, _as, _apply_credentials);
         _pool.emplace_back(std::move(cl));
     }
 }
+
 void client_pool::release(ss::shared_ptr<client> leased) {
     if (_pool.size() == _max_size) {
         return;
     }
     _pool.emplace_back(std::move(leased));
     _cvar.signal();
+}
+
+void client_pool::load_credentials(cloud_roles::credentials&& credentials) {
+    if (unlikely(!_apply_credentials)) {
+        _apply_credentials = ss::make_lw_shared(
+          cloud_roles::make_credentials_applier(std::move(credentials)));
+        populate_client_pool();
+        // We signal the waiter only after the client pool is initialized, so
+        // that any upload operations waiting are ready to proceed.
+        _credentials_var.signal();
+    } else {
+        _apply_credentials->reset_creds(std::move(credentials));
+    }
+}
+
+ss::future<> client_pool::wait_for_credentials() {
+    co_await _credentials_var.wait([this]() {
+        return _gate.is_closed() || _as.abort_requested()
+               || (bool{_apply_credentials} && !_pool.empty());
+    });
+
+    if (_gate.is_closed() || _as.abort_requested()) {
+        throw ss::gate_closed_exception();
+    }
+    co_return;
 }
 
 } // namespace s3

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -358,8 +358,7 @@ static void log_buffer_with_rate_limiting(const char* msg, iobuf& buf) {
     vlog(log_with_rate_limit, "{}: {}", msg, sview);
 }
 
-/// Convert iobuf that contains xml data to boost::property_tree
-static boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf) {
+boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf) {
     namespace pt = boost::property_tree;
     try {
         iobuf_istreambuf strbuf(buf);
@@ -374,9 +373,7 @@ static boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf) {
     }
 }
 
-/// Parse timestamp in format that S3 uses
-static std::chrono::system_clock::time_point
-parse_timestamp(std::string_view sv) {
+std::chrono::system_clock::time_point parse_timestamp(std::string_view sv) {
     std::tm tm = {};
     std::stringstream ss({sv.data(), sv.size()});
     ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S.Z%Z");
@@ -465,7 +462,7 @@ ss::future<ResultT> parse_head_error_response(
     }
 }
 
-static ss::future<iobuf>
+ss::future<iobuf>
 drain_response_stream(http::client::response_stream_ref resp) {
     return ss::do_with(
       iobuf(), [resp = std::move(resp)](iobuf& outbuf) mutable {

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -55,6 +55,14 @@ struct default_overrides {
     bool disable_tls = false;
 };
 
+/// Parse timestamp in format that S3 uses
+std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
+
+/// Convert iobuf that contains xml data to boost::property_tree
+boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf);
+
+ss::future<iobuf> drain_response_stream(http::client::response_stream_ref resp);
+
 /// S3 client configuration
 struct configuration : net::base_transport::configuration {
     /// URI of the S3 access point
@@ -288,5 +296,7 @@ private:
     ss::abort_source _as;
     ss::gate _gate;
 };
+
+ss::future<iobuf> drain_response_stream(http::client::response_stream_ref resp);
 
 } // namespace s3

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -67,10 +67,10 @@ ss::future<iobuf> drain_response_stream(http::client::response_stream_ref resp);
 struct configuration : net::base_transport::configuration {
     /// URI of the S3 access point
     access_point_uri uri;
-    /// AWS access key
-    public_key_str access_key;
-    /// AWS secret key
-    private_key_str secret_key;
+    /// AWS access key, optional if configuration uses temporary credentials
+    std::optional<public_key_str> access_key;
+    /// AWS secret key, optional if configuration uses temporary credentials
+    std::optional<private_key_str> secret_key;
     /// AWS region
     aws_region_name region;
     /// Max time that connection can spend idle
@@ -90,8 +90,8 @@ struct configuration : net::base_transport::configuration {
     ///        truststore
     /// \return future that returns initialized configuration
     static ss::future<configuration> make_configuration(
-      const public_key_str& pkey,
-      const private_key_str& skey,
+      const std::optional<public_key_str>& pkey,
+      const std::optional<private_key_str>& skey,
       const aws_region_name& region,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes);

--- a/src/v/s3/signature.cc
+++ b/src/v/s3/signature.cc
@@ -116,7 +116,7 @@ inline void append_hex_utf8(ss::sstring& result, char ch) {
     result.append(h.data(), h.size());
 }
 
-static ss::sstring uri_encode(const ss::sstring& input, bool encode_slash) {
+ss::sstring uri_encode(const ss::sstring& input, bool encode_slash) {
     // The function defined here:
     //     https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
     ss::sstring result;

--- a/src/v/s3/signature.h
+++ b/src/v/s3/signature.h
@@ -122,4 +122,6 @@ template<class Fn>
 time_source::time_source(Fn&& fn, int)
   : _gettime_fn(std::forward<Fn>(fn)) {}
 
+ss::sstring uri_encode(const ss::sstring& input, bool encode_slash);
+
 } // namespace s3

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -181,10 +181,20 @@ s3::configuration transport_configuration() {
     return conf;
 }
 
+static ss::lw_shared_ptr<cloud_roles::apply_credentials>
+make_credentials(const s3::configuration& cfg) {
+    return ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(cloud_roles::aws_credentials{
+        cfg.access_key.value(),
+        cfg.secret_key.value(),
+        std::nullopt,
+        cfg.region}));
+}
+
 /// Create server and client, server is initialized with default
 /// testing paths and listening.
 configured_test_pair started_client_and_server(const s3::configuration& conf) {
-    auto client = ss::make_shared<s3::client>(conf);
+    auto client = ss::make_shared<s3::client>(conf, make_credentials(conf));
     auto server = ss::make_shared<ss::httpd::http_server_control>();
     server->start().get();
     server->set_routes(set_routes).get();

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -428,7 +428,13 @@ configured_server_and_client_pool started_pool_and_server(
   size_t size,
   s3::client_pool_overdraft_policy policy,
   const s3::configuration& conf) {
+    auto credentials = cloud_roles::aws_credentials{
+      conf.access_key.value(),
+      conf.secret_key.value(),
+      std::nullopt,
+      conf.region};
     auto client = ss::make_shared<s3::client_pool>(size, conf, policy);
+    client->load_credentials(std::move(credentials));
     auto server = ss::make_shared<ss::httpd::http_server_control>();
     server->start().get();
     server->set_routes(set_routes).get();

--- a/tests/rptest/remote_scripts/aws_iam_role_mock.py
+++ b/tests/rptest/remote_scripts/aws_iam_role_mock.py
@@ -1,0 +1,182 @@
+import datetime
+import http.server
+import json
+import signal
+import socketserver
+
+
+class BaseHandler(http.server.BaseHTTPRequestHandler):
+    def not_allowed(self):
+        self.send_response(405)
+        self.end_headers()
+        self.wfile.write('method not allowed'.encode())
+        self.json_log(405)
+
+    def log_request(self, *args, **kwargs):
+        return
+
+    def json_log(self, response_code):
+        payload = None
+        if 'Content-Length' in self.headers:
+            payload = self.rfile.read(int(self.headers['Content-Length']))
+        log_item = {
+            'path': self.path,
+            'method': self.command,
+            'payload': payload.decode() if payload else None,
+            'response_code': response_code,
+        }
+        print(json.dumps(log_item))
+
+
+def make_aws_handler(token_ttl):
+    class AWSHandler(BaseHandler):
+        token_expiry = token_ttl
+        canned_role = 'tomato'
+        canned_credentials = {
+            'Code': 'Success',
+            'LastUpdated': '2012-04-26T16:39:16Z',
+            'Type': 'AWS-HMAC',
+            'AccessKeyId': 'panda-user',
+            'SecretAccessKey': 'panda-secret',
+            'Token': '__REDPANDA_SKIP_IAM_TOKEN_x',
+        }
+
+        def get_canned_credentials(self):
+            future = datetime.datetime.now() + datetime.timedelta(
+                seconds=self.token_expiry)
+            cc = self.canned_credentials
+            cc['Expiration'] = future.isoformat()
+            return cc
+
+        # noinspection PyPep8Naming
+        def do_GET(self):
+            if self.path == '/latest/meta-data/iam/security-credentials/':
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(self.canned_role.encode())
+                self.json_log(200)
+            elif self.path == f'/latest/meta-data/iam/security-credentials/{self.canned_role}':
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(self.get_canned_credentials()).encode())
+                self.json_log(200)
+            else:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(f'Bad request for path {self.path}'.encode())
+                self.json_log(400)
+
+        # noinspection PyPep8Naming
+        def do_POST(self):
+            self.not_allowed()
+
+        # noinspection PyPep8Naming
+        def do_PUT(self):
+            self.not_allowed()
+
+        # noinspection PyPep8Naming
+        def do_DELETE(self):
+            self.not_allowed()
+
+    return AWSHandler
+
+
+def make_sts_handler(token_ttl):
+    class STSHandler(BaseHandler):
+        token_expiry = token_ttl
+        canned_credentials = """
+<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>panda-user</AccessKeyId>
+      <SecretAccessKey>panda-secret</SecretAccessKey>
+      <SessionToken>__REDPANDA_SKIP_IAM_TOKEN_x</SessionToken>
+      <Expiration>{}</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>
+        """
+
+        def get_canned_credentials(self):
+            future = datetime.datetime.now() + datetime.timedelta(
+                seconds=self.token_expiry)
+            return self.canned_credentials.format(future.isoformat())
+
+        # noinspection PyPep8Naming
+        def do_GET(self):
+            self.not_allowed()
+
+        # noinspection PyPep8Naming
+        def do_POST(self):
+            if self.path == '/':
+                self.send_response(200)
+                self.send_header('Content-type', 'application/xml')
+                self.end_headers()
+                self.wfile.write(
+                    self.get_canned_credentials().strip().encode())
+                self.json_log(200)
+            else:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write('bad request'.encode())
+                self.json_log(400)
+
+        # noinspection PyPep8Naming
+        def do_PUT(self):
+            self.not_allowed()
+
+        # noinspection PyPep8Naming
+        def do_DELETE(self):
+            self.not_allowed()
+
+    return STSHandler
+
+
+mocks = {
+    'aws': make_aws_handler,
+    'sts': make_sts_handler,
+}
+
+
+def main():
+    import argparse
+
+    def generate_options():
+        p = argparse.ArgumentParser(
+            description='AWS EC2 Instance Metadata Mock Server')
+        p.add_argument('--port',
+                       type=int,
+                       help='Port to listen on',
+                       default=8080)
+        p.add_argument('--mock',
+                       type=str,
+                       help='Implementation to mock',
+                       default='aws')
+        p.add_argument('--ttl_sec',
+                       type=int,
+                       help='Token time to live in seconds',
+                       default=3600)
+        return p
+
+    parser = generate_options()
+    options, _ = parser.parse_known_args()
+
+    class ReuseAddressTcpServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    with ReuseAddressTcpServer(('', options.port),
+                               mocks[options.mock](options.ttl_sec)) as httpd:
+
+        def _stop(*_):
+            httpd.server_close()
+            exit(0)
+
+        signal.signal(signal.SIGTERM, _stop)
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/rptest/services/mock_iam_roles_server.py
+++ b/tests/rptest/services/mock_iam_roles_server.py
@@ -1,0 +1,63 @@
+import os
+
+from ducktape.cluster.remoteaccount import RemoteCommandError
+
+from rptest.services.http_server import HttpServer
+from rptest.util import inject_remote_script
+
+
+class MockIamRolesServer(HttpServer):
+    LOG_DIR = "/tmp/mock_iam_server"
+    STDOUT_CAPTURE = os.path.join(LOG_DIR, "mock_iam_server.stdout")
+
+    logs = {
+        "mock_iam_server_stdout": {
+            "path": STDOUT_CAPTURE,
+            "collect_default": True
+        },
+    }
+
+    def __init__(self,
+                 context,
+                 script,
+                 port=8080,
+                 stop_timeout_sec=2,
+                 mock_target='aws',
+                 ttl_sec=3600):
+        super(HttpServer, self).__init__(context, 1)
+        self.ttl_sec = ttl_sec
+        self.script = script
+        self.port = port
+        self.stop_timeout_sec = stop_timeout_sec
+        self.requests = []
+        self.url = f'http://{self.nodes[0].account.hostname}:{self.port}'
+        self.hostname = self.nodes[0].account.hostname
+        self.remote_script_path = None
+        self.mock_target = mock_target
+
+    def _worker(self, idx, node):
+        node.account.ssh(f"mkdir -p {MockIamRolesServer.LOG_DIR}",
+                         allow_fail=False)
+        self.remote_script_path = inject_remote_script(node, self.script)
+        cmd = f'python3 -u {self.remote_script_path} ' \
+              f'--port {self.port} ' \
+              f'--mock {self.mock_target} ' \
+              f'--ttl_sec {self.ttl_sec} 2>&1'
+        cmd += f' | tee -a {MockIamRolesServer.STDOUT_CAPTURE} &'
+
+        self.logger.debug(f'Starting IAM role server {self.url}')
+        for line in node.account.ssh_capture(cmd):
+            self.logger.debug(f'received request: {line}')
+            if 'response_code' in line:
+                self.requests.append(self.try_parse_json(node, line))
+
+    def pids(self, node):
+        try:
+            cmd = f"ps ax | grep {self.script} | grep -v grep | awk '{{print $1}}'"
+            pid_arr = [
+                pid for pid in node.account.ssh_capture(
+                    cmd, allow_fail=True, callback=int)
+            ]
+            return pid_arr
+        except (RemoteCommandError, ValueError):
+            return []

--- a/tests/rptest/tests/e2e_iam_role_test.py
+++ b/tests/rptest/tests/e2e_iam_role_test.py
@@ -1,0 +1,207 @@
+from ducktape.mark.resource import cluster
+
+from rptest.clients.types import TopicSpec
+from rptest.services.mock_iam_roles_server import MockIamRolesServer
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
+from rptest.tests.e2e_shadow_indexing_test import EndToEndShadowIndexingBase
+from rptest.util import produce_until_segments, wait_for_segments_removal
+
+
+class AWSRoleFetchTests(EndToEndShadowIndexingBase):
+    def __init__(self, test_context, extra_rp_conf=None):
+        self.iam_server = MockIamRolesServer(test_context,
+                                             'aws_iam_role_mock.py')
+        if not extra_rp_conf:
+            extra_rp_conf = {}
+
+        extra_rp_conf[
+            'cloud_storage_credentials_source'] = 'aws_instance_metadata'
+        super().__init__(test_context,
+                         extra_rp_conf,
+                         environment={
+                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
+                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                         })
+
+    def setUp(self):
+        self.iam_server.start()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.iam_server.stop()
+        self.iam_server.wait()
+        self.iam_server.clean()
+
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    def test_write(self):
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+            },
+        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
+        self.start_consumer()
+        self.run_validation()
+
+        # each broker makes two requests to server, one to get role and one for credentials
+        assert self.num_brokers * 2 == len(
+            self.iam_server.requests
+        ), f'{self.num_brokers} and {len(self.iam_server.requests)}'
+        for request in self.iam_server.requests:
+            # We do not know the order of requests, but they will be one of the two paths allowed
+            assert request['path'] in {
+                '/latest/meta-data/iam/security-credentials/',
+                '/latest/meta-data/iam/security-credentials/tomato'
+            }
+            assert request['method'] == 'GET'
+            assert request['response_code'] == 200
+
+
+class STSRoleFetchTests(EndToEndShadowIndexingBase):
+    def __init__(self, test_context, extra_rp_conf=None):
+        self.iam_server = MockIamRolesServer(test_context,
+                                             'aws_iam_role_mock.py',
+                                             mock_target='sts')
+        if not extra_rp_conf:
+            extra_rp_conf = {}
+
+        extra_rp_conf['cloud_storage_credentials_source'] = 'sts'
+        self.token_path = '/tmp/token_file'
+        self.role = 'tomato'
+        self.token = 'token-tomato'
+
+        super().__init__(test_context,
+                         extra_rp_conf,
+                         environment={
+                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
+                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                             'AWS_ROLE_ARN': self.role,
+                             'AWS_WEB_IDENTITY_TOKEN_FILE': self.token_path,
+                         })
+
+        for node in self.redpanda.nodes:
+            node.account.create_file(self.token_path, self.token)
+
+    def setUp(self):
+        self.iam_server.start()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.iam_server.stop()
+        self.iam_server.wait()
+        self.iam_server.clean()
+
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    def test_write(self):
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+            },
+        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
+        self.start_consumer()
+        self.run_validation()
+
+        # each broker makes one request to server
+        assert self.num_brokers == len(self.iam_server.requests)
+        for request in self.iam_server.requests:
+            assert request['path'] == '/'
+            assert request['method'] == 'POST'
+            assert f'RoleArn={self.role}' in request['payload']
+            assert f'WebIdentityToken={self.token}' in request['payload']
+            assert request['response_code'] == 200
+
+
+class ShortLivedCredentialsTests(EndToEndShadowIndexingBase):
+    def __init__(self, test_context, extra_rp_conf=None):
+        self.iam_server = MockIamRolesServer(test_context,
+                                             'aws_iam_role_mock.py',
+                                             mock_target='sts',
+                                             ttl_sec=5)
+        if not extra_rp_conf:
+            extra_rp_conf = {}
+
+        extra_rp_conf['cloud_storage_credentials_source'] = 'sts'
+        self.token_path = '/tmp/token_file'
+        self.role = 'tomato'
+        self.token = 'token-tomato'
+
+        super().__init__(test_context,
+                         extra_rp_conf,
+                         environment={
+                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
+                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                             'AWS_ROLE_ARN': self.role,
+                             'AWS_WEB_IDENTITY_TOKEN_FILE': self.token_path,
+                         })
+
+        for node in self.redpanda.nodes:
+            node.account.create_file(self.token_path, self.token)
+
+    def setUp(self):
+        self.iam_server.start()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.iam_server.stop()
+        self.iam_server.wait()
+        self.iam_server.clean()
+
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    def test_short_lived_credentials(self):
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+            },
+        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
+        self.start_consumer()
+        self.run_validation()
+
+        # each broker makes multiple requests to server as token is short-lived
+        assert self.num_brokers < len(self.iam_server.requests)
+        for request in self.iam_server.requests:
+            assert request['path'] == '/'
+            assert request['method'] == 'POST'
+            assert f'RoleArn={self.role}' in request['payload']
+            assert f'WebIdentityToken={self.token}' in request['payload']
+            assert request['response_code'] == 200


### PR DESCRIPTION
## Cover letter

This set of changes enables redpanda to use temporary credentials for shadow indexing which are sourced from cloud providers where redpanda is deployed.

Broadly, the following changes are introduced:

#### Config changes:
A configuration setting: `cloud_storage_credentials_source` with possible values:
* config_file
* aws_instance_metadata
* sts
* gcp_instance_metadata

#### Acquiring temporary credentials:
* `cloud_roles::refresh_credentials` a utility to acquire credentials, creates internal impl which communicates with GCP, AWS or STS based on the above setting.
* `cloud_roles::gcp_refresh_impl` client to communicate with GCP instance metadata service and acquire an OAuth 2.0 token
* `cloud_roles::aws_refresh_impl` client to communicate with AWS EC2 instance metadata service and acquire AWS keys
* `cloud_roles::aws_sts_refresh_impl` client to communicate with AWS secure token service and acquire AWS keys

In addition, `refresh_credentials` also tracks the expiry of fetched credentials and gets new credentials before the current set is about to expire.

The credentials acquired by the above utilities are then applied to the S3 requests:

#### Applying credentials to S3 requests:
* `cloud_roles::apply_credentials` a utility to inject credential headers into S3 requests, creates internal impl which applies credentials based on the kind of cloud service we are communicating with:
* `cloud_roles::apply_gcp_credentials` Applies previously acquired oauth 2.0 token to S3 requests
* `cloud_roles::apply_aws_credentials` applies previously acquired AWS keys and signs requests to S3

The existing S3 client pool now contains a seastar lw_shared_pointer to the `apply_credentials` object. This object is shared with each client, which uses it to add credentials to outgoing requests to S3.

The credentials held by `apply_credentials` are periodically rotated, the clients automatically use the new credentials.

Fixes #4735

## Release notes

### Features

In redpanda configuration, a new setting called `cloud_storage_credentials_source` is introduced which should be set to an appropriate value based on the type of deployment. For example:
* If deploying on an EC2 VM: aws_instance_metadata
* If deploying on EKS: sts
* If deploying on a GCE VM: gcp_instance_metadata
* If deploying on GKE: gcp_instance_metadata
* If using fixed credentials from config file (not using temporary credentials): config_file

At the same time, the instance deployment must ensure that the correct IAM role is bound to the pod or VM, so that requests made by redpanda are authenticated correctly. 

These changes are outside the scope of this PR and will be handled by cloud deployment.

### Improvements

* If the IAM role integration is enabled, credentials are no longer stored on disk and are rotated frequently, thus reducing risk of exposure.


original PR: https://github.com/redpanda-data/redpanda/pull/5015