### PR TITLE
tests: update offline_log_viewer and use in ducktape tests

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -179,4 +179,7 @@ RUN mkdir -p /opt/scripts && \
     curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line && \
     chmod +x /opt/scripts/seastar-addr2line
 
+RUN mkdir -p /opt/scripts/offline_log_viewer
+COPY --chown=0:0 tools/offline_log_viewer /opt/scripts/offline_log_viewer
+
 CMD service ssh start && tail -f /dev/null

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -4,3 +4,4 @@
 !tests/setup.py
 !tests/python
 !tests/go
+!tools/offline_log_viewer

--- a/tests/rptest/clients/offline_log_viewer.py
+++ b/tests/rptest/clients/offline_log_viewer.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+
+
+class OfflineLogViewer:
+    """
+    Wrap tools/offline_log_viewer for use in tests: this is for tests that
+    want to peek at the structures, but also for validating the tool itself.
+    """
+    def __init__(self, redpanda):
+        self._redpanda = redpanda
+
+    def _cmd(self, suffix):
+        viewer_path = "python3 /opt/scripts/offline_log_viewer/viewer.py"
+        return f"{viewer_path} --path {self._redpanda.DATA_DIR} {suffix}"
+
+    def read_kvstore(self, node):
+        cmd = self._cmd("--type kvstore")
+        kvstore_json = node.account.ssh_output(cmd, combine_stderr=False)
+        return json.loads(kvstore_json)
+
+    def read_controller(self, node):
+        cmd = self._cmd("--type controller")
+        controller_json = node.account.ssh_output(cmd, combine_stderr=False)
+        try:
+            return json.loads(controller_json)
+        except json.decoder.JSONDecodeError:
+            # Log the bad output before re-raising
+            self._redpanda.logger.error(
+                f"Invalid JSON output: {controller_json}")
+            import time
+            time.sleep(3600)
+            raise

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -251,7 +251,7 @@ def decode_topic_command_adl(k_rdr: Reader, rdr: Reader):
 
 
 def decode_topic_command(record):
-    rdr = Reader(BufferedReader(BytesIO(record.value)))
+    rdr = Reader(BytesIO(record.value))
     k_rdr = Reader(BytesIO(record.key))
     either_ald_or_serde = rdr.peek_int8()
     assert either_ald_or_serde >= -1, "unsupported serialization format"

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -234,9 +234,9 @@ def decode_record(batch, record, bin_dump: bool):
         ret['data'] = decode_user_command(record)
     if batch.type == BatchType.acl_management_cmd:
         ret['data'] = decode_acl_command(record)
-    if header.type == BatchType.cluster_config_cmd:
+    if batch.type == BatchType.cluster_config_cmd:
         ret['data'] = decode_config_command(record)
-    if header.type == BatchType.feature_update:
+    if batch.type == BatchType.feature_update:
         ret['data'] = decode_feature_command(record)
     if batch.type == BatchType.cluster_bootstrap_cmd:
         ret['data'] = decode_cluster_bootstrap_command(record)

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -149,7 +149,8 @@ def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
     cmd['type'] = rdr.read_int8()
     if cmd['type'] == 0:
         cmd['type_string'] = 'create_topic'
-        cmd |= read_topic_assignment_serde(rdr)
+        # FIXME: this fails to read messages written on tip of dev ead54dda
+        #cmd |= read_topic_assignment_serde(rdr)
     elif cmd['type'] == 1:
         cmd['type_string'] = 'delete_topic'
         cmd['namespace'] = rdr.read_string()
@@ -577,6 +578,7 @@ def decode_node_management_command(k_rdr: Reader, rdr: Reader):
         }
     return cmd
 
+
 def decode_cluster_bootstrap_command(record):
     def decode_user_and_credential(r):
         user_cred = {}
@@ -603,6 +605,7 @@ def decode_cluster_bootstrap_command(record):
                 decode_user_and_credential)
 
     return cmd
+
 
 def decode_adl_or_serde(k_rdr: Reader, rdr: Reader, adl_fn, serde_fn):
     either_adl_or_serde = rdr.peek_int8()

--- a/tools/offline_log_viewer/kvstore.py
+++ b/tools/offline_log_viewer/kvstore.py
@@ -97,7 +97,7 @@ class KvStoreRecordDecoder:
 
         keyspace = k_rdr.read_int8()
 
-        key_buf = self.k_stream.read()
+        key_buf = k_rdr.stream.read()
 
         ret['key_space'] = self._decode_ks(keyspace)
         ret['key_buf'] = key_buf

--- a/tools/offline_log_viewer/kvstore.py
+++ b/tools/offline_log_viewer/kvstore.py
@@ -216,6 +216,8 @@ def decode_offset_translator_key(k):
 def decode_storage_key_name(key_type):
     if key_type == 0:
         return "start offset"
+    elif key_type == 1:
+        return "clean segment"
 
     return "unknown"
 

--- a/tools/offline_log_viewer/kvstore.py
+++ b/tools/offline_log_viewer/kvstore.py
@@ -331,6 +331,12 @@ class KvStore:
 
         if entry['data'] is not None:
             self.kv[key] = entry['data']
+        else:
+            try:
+                del self.kv[key]
+            except KeyError:
+                # Missing key, that's okay for a deletion
+                pass
 
     def decode(self):
         snapshot_offset = None

--- a/tools/offline_log_viewer/model.py
+++ b/tools/offline_log_viewer/model.py
@@ -83,6 +83,7 @@ def read_configuration_update(rdr):
 
 def read_raft_config(rdr):
     cfg = {}
+
     cfg['version'] = rdr.read_int8()
     cfg['brokers'] = rdr.read_vector(read_broker)
     cfg['current_config'] = read_group_nodes(rdr)

--- a/tools/offline_log_viewer/model.py
+++ b/tools/offline_log_viewer/model.py
@@ -74,6 +74,13 @@ def read_broker(rdr):
     return br
 
 
+def read_configuration_update(rdr):
+    return {
+        'replicas_to_add': rdr.read_vector(read_vnode),
+        'replicas_to_remove': rdr.read_vector(read_vnode)
+    }
+
+
 def read_raft_config(rdr):
     cfg = {}
     cfg['version'] = rdr.read_int8()
@@ -81,6 +88,11 @@ def read_raft_config(rdr):
     cfg['current_config'] = read_group_nodes(rdr)
     cfg['prev_config'] = rdr.read_optional(read_group_nodes)
     cfg['revision'] = rdr.read_int64()
+
+    if cfg['version'] >= 4:
+        cfg['configuration_update'] = rdr.read_optional(
+            lambda ordr: read_configuration_update(ordr))
+
     return cfg
 
 

--- a/tools/offline_log_viewer/reader.py
+++ b/tools/offline_log_viewer/reader.py
@@ -1,5 +1,6 @@
 import struct
 import collections
+from io import BufferedReader, BytesIO
 
 SERDE_ENVELOPE_FORMAT = "<BBI"
 SERDE_ENVELOPE_SIZE = struct.calcsize(SERDE_ENVELOPE_FORMAT)
@@ -9,8 +10,9 @@ SerdeEnvelope = collections.namedtuple('SerdeEnvelope',
 
 
 class Reader:
-    def __init__(self, stream):
-        self.stream = stream
+    def __init__(self, stream: BytesIO):
+        # BytesIO provides .getBuffer(), BufferedReader peek()
+        self.stream = BufferedReader(stream)
 
     @staticmethod
     def _decode_zig_zag(v):
@@ -128,3 +130,6 @@ class Reader:
 
     def skip(self, length):
         self.stream.read(length)
+
+    def remaining(self):
+        return len(self.stream.raw.getbuffer()) - self.stream.tell()

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -218,7 +218,10 @@ class Batch:
                 return None
             assert len(data) == records_size
             return Batch(index, header, data)
-        assert len(data) == 0
+
+        if len(data) < HEADER_SIZE:
+            # Short read, probably log being actively written or unclean shutdown
+            return None
 
     def __len__(self):
         return self.header.record_count

--- a/tools/offline_log_viewer/viewer.py
+++ b/tools/offline_log_viewer/viewer.py
@@ -17,13 +17,21 @@ logger = logging.getLogger('viewer')
 
 
 def print_kv_store(store):
+    # Map of partition ID to list of kvstore items
+    result = {}
+
     for ntp in store.ntps:
         if ntp.nspace == "redpanda" and ntp.topic == "kvstore":
             logger.info(f"inspecting {ntp}")
             kv = KvStore(ntp)
             kv.decode()
             items = kv.items()
-            logger.info(json.dumps(items, indent=2))
+
+            result[ntp.partition] = items
+
+    # Send JSON output to stdout in case caller wants to parse it, other
+    # CLI output goes to stderr via logger
+    print(json.dumps(result, indent=2))
 
 
 def print_controller(store, bin_dump: bool):
@@ -31,7 +39,10 @@ def print_controller(store, bin_dump: bool):
         if ntp.nspace == "redpanda" and ntp.topic == "controller":
             ctrl = ControllerLog(ntp)
             ctrl.decode(bin_dump)
-            logger.info(json.dumps(ctrl.records, indent=2))
+
+            # Send JSON output to stdout in case caller wants to parse it, other
+            # CLI output goes to stderr via logger
+            print(json.dumps(ctrl.records, indent=2))
 
 
 def print_kafka(store, topic, headers_only):


### PR DESCRIPTION
## Cover letter

- Pull in @andijcr changes from https://github.com/redpanda-data/redpanda/pull/6233 to enable serde decode of most controller log messages
- Include the tool in test dockerfile and wrap it in a python client class for ducktape
- Various corner case fixes for general log loading (short reads, reads on systems with no topics
- Update group_configuration decode to support version 4
- Use the tool in deletion test to confirm that kvstore parts of topic state are getting cleaned  up. This follows on from https://github.com/redpanda-data/redpanda/pull/5127, to get better confidence that new kvstore contents are being properly cleaned up.
- Decode controller logs at the end of a multi-version upgrade test, to increase confidence that the tool works on various generations of data.  When we enhance the upgrade tests in https://github.com/redpanda-data/redpanda/issues/7310, this check should be done after the "big upgrade test" that steps through all the historic versions.

The tool is already in clustered ducktape AMI via https://github.com/redpanda-data/vtools/pull/772

## Release notes

* none
