### PR TITLE
config: reduce min allowed storage_min_free_bytes

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1164,7 +1164,7 @@ configuration::configuration()
       "Threshold of minimim bytes free space before rejecting producers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB,
-      {.min = 1_GiB})
+      {.min = 10_MiB})
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",


### PR DESCRIPTION
Allow setting storage_min_free_bytes configuration as low as 10 MiB.
This will help with testing data rebalancing.


## Release notes
* none
