### PR TITLE
Allow rm_stm to control max compaction offset

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -92,15 +92,12 @@ public:
      *
      * There are two important pieces in this comment:
      *
-     *   1) "non-transaction message are considered decided immediately". Since
-     *   redpanda doesn't have transactional messages, that's what we're
-     *   interested in.
+     *   1) "non-transaction message are considered decided immediately".
+     *   Since we currently use the commited_offset to report the end of log to
+     *   kafka clients, simply report the next offset.
      *
      *   2) "first offset such that all lower offsets have been decided". this
      *   is describing a strictly greater than relationship.
-     *
-     * Since we currently use the commited_offset to report the end of log to
-     * kafka clients, simply report the next offset.
      */
     model::offset last_stable_offset() const {
         if (_rm_stm) {

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -66,11 +66,10 @@ struct stm_snapshot {
  *
  * How does it work?
  *
- * When persisted_stm becomes a leader it syncs its state with the tip
- * of the log (by writing a checkout batch checkpoint_batch_type and
- * reading/executing the commands up to its offset) and caches the
- * current raft's term. Then it uses the cached term for conditional
- * replication so in a case when its state becomes stale (a new leader
+ * When persisted_stm becomes a leader it replicates the configuration batch and
+ * uses its offset `last_term_start_offset` as a limit, up to which we read
+ * and execute the commands. It caches the current raft term, and uses that for
+ * conditional replication: In a case when its state becomes stale (a new leader
  * with higher term has been chosen) the conditional replication fails
  * preventing an operation on the stale state.
  *

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -251,6 +251,7 @@ rm_stm::rm_stm(
 }
 
 bool rm_stm::check_tx_permitted() {
+    // TODO support compaction
     if (_c->log_config().is_compacted()) {
         vlog(
           clusterlog.error,

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -174,6 +174,10 @@ public:
     ss::future<std::vector<rm_stm::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
+    model::offset max_collectible_offset() override {
+        return last_stable_offset();
+    }
+
     kafka_stages replicate_in_stages(
       model::batch_identity,
       model::record_batch_reader,

--- a/src/v/hashing/tests/CMakeLists.txt
+++ b/src/v/hashing/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ rp_test(
   BENCHMARK_TEST
   BINARY_NAME hashing_bench
   SOURCES hash_bench.cc
-  LIBRARIES Seastar::seastar_perf_testing v::rphashing
+  LIBRARIES Seastar::seastar_perf_testing v::rphashing v::rprandom
   LABELS hashing
 )

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -24,6 +24,8 @@ struct record_batch_spec {
     bool allow_compression{true};
     int count{0};
     std::optional<int> records{std::nullopt};
+    std::optional<int> max_key_cardinality{std::nullopt};
+
     model::record_batch_type bt{model::record_batch_type::raft_data};
     bool enable_idempotence{false};
     int64_t producer_id{-1};

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -36,6 +36,9 @@ struct record_batch_spec {
     std::optional<model::timestamp> timestamp;
 };
 
+// Makes an random alphanumeric string, encoded in an iobuf.
+iobuf make_iobuf(size_t);
+
 /**
  * Makes random batch starting at requested offset.
  *

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -548,6 +548,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
           ->compact(storage::compaction_config(
             first_ts,
             100_MiB,
+            model::offset::max(),
             ss::default_priority_class(),
             as,
             storage::debug_sanitize_files::yes))

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -61,6 +61,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                     ->compact(storage::compaction_config(
                       retention_timestamp,
                       100_MiB,
+                      model::offset::max(),
                       ss::default_priority_class(),
                       as,
                       storage::debug_sanitize_files::yes))

--- a/src/v/random/CMakeLists.txt
+++ b/src/v/random/CMakeLists.txt
@@ -3,8 +3,11 @@ v_cc_library(
   HRDS
     fast_prng.h
     generators.h
+  SRCS
+    "generators.cc"
   DEPS
     absl::random_seed_sequences
+    Seastar::seastar
 )
 rp_test(
   UNIT_TEST

--- a/src/v/random/CMakeLists.txt
+++ b/src/v/random/CMakeLists.txt
@@ -14,6 +14,6 @@ rp_test(
   BINARY_NAME basic_fast_random_test
   SOURCES random_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::bytes v::rprandom
+  LIBRARIES v::seastar_testing_main v::bytes v::rprandom Boost::unit_test_framework absl::flat_hash_set
   LABELS random
 )

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -32,4 +32,18 @@ ss::sstring gen_alphanum_string(size_t n) {
     return s;
 }
 
+ss::sstring gen_alphanum_max_distinct(size_t cardinality) {
+    static constexpr std::size_t num_chars = chars.size() - 1;
+    // everything is deterministic once you choose key_num
+    auto key_num = get_int(cardinality - 1);
+    auto next_index = key_num % num_chars;
+    auto s = ss::uninitialized_string(alphanum_max_distinct_strlen);
+    std::generate_n(s.begin(), alphanum_max_distinct_strlen, [&] {
+        auto c = chars[next_index];
+        next_index = (next_index + key_num) % num_chars;
+        return c;
+    });
+    return s;
+}
+
 } // namespace random_generators

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "generators.h"
+
+namespace random_generators {
+
+bytes get_bytes(size_t n) {
+    auto b = ss::uninitialized_string<bytes>(n);
+    std::generate_n(b.begin(), n, [] { return get_int<bytes::value_type>(); });
+    return b;
+}
+
+static constexpr std::string_view chars
+  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+ss::sstring gen_alphanum_string(size_t n) {
+    // do not include \0
+    static constexpr std::size_t max_index = chars.size() - 2;
+    std::uniform_int_distribution<size_t> dist(0, max_index);
+    auto s = ss::uninitialized_string(n);
+    std::generate_n(
+      s.begin(), n, [&dist] { return chars[dist(internal::gen)]; });
+    return s;
+}
+
+} // namespace random_generators

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -33,7 +33,23 @@ static thread_local std::default_random_engine gen(internal::get_seed());
 } // namespace internal
 
 bytes get_bytes(size_t n = 128 * 1024);
+
+/**
+ * Random string generator. Total number of distinct values that may be
+ * generated is unlimited (within all possible values of given size).
+ */
 ss::sstring gen_alphanum_string(size_t n);
+
+static constexpr size_t alphanum_max_distinct_strlen = 32;
+/**
+ * Random string generator that limits the maximum number of distinct values
+ * that will be returned. That is, this function is a generator, which creates
+ * members of a set of strings, one at a time. Each generated string has maximum
+ * length `alphanum_max_distinct_strlen`. The total set of generated strings
+ * will have a maximum cardinality of `max_cardinality`. See the unit test
+ * `alphanum_max_distinct_generator` for an example.
+ */
+ss::sstring gen_alphanum_max_distinct(size_t max_cardinality);
 
 template<typename T>
 T get_int() {

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -32,6 +32,9 @@ inline std::random_device::result_type get_seed() {
 static thread_local std::default_random_engine gen(internal::get_seed());
 } // namespace internal
 
+bytes get_bytes(size_t n = 128 * 1024);
+ss::sstring gen_alphanum_string(size_t n);
+
 template<typename T>
 T get_int() {
     std::uniform_int_distribution<T> dist;
@@ -47,24 +50,6 @@ T get_int(T min, T max) {
 template<typename T>
 T get_int(T max) {
     return get_int<T>(0, max);
-}
-
-inline bytes get_bytes(size_t n = 128 * 1024) {
-    auto b = ss::uninitialized_string<bytes>(n);
-    std::generate_n(b.begin(), n, [] { return get_int<bytes::value_type>(); });
-    return b;
-}
-
-inline ss::sstring gen_alphanum_string(size_t n) {
-    static constexpr std::string_view chars
-      = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    // do not include \0
-    static constexpr std::size_t max_index = chars.size() - 2;
-    std::uniform_int_distribution<size_t> dist(0, max_index);
-    auto s = ss::uninitialized_string(n);
-    std::generate_n(
-      s.begin(), n, [&dist] { return chars[dist(internal::gen)]; });
-    return s;
 }
 
 template<typename T>

--- a/src/v/random/random_test.cc
+++ b/src/v/random/random_test.cc
@@ -11,6 +11,7 @@
 #include "random/fast_prng.h"
 #include "random/generators.h"
 
+#include <absl/container/flat_hash_set.h>
 #include <boost/test/unit_test.hpp>
 
 #include <set>
@@ -33,4 +34,19 @@ BOOST_AUTO_TEST_CASE(alphanum_generator) {
             BOOST_REQUIRE('\0' != s[j]);
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(alphanum_max_distinct_generator) {
+    constexpr size_t cardinality = 11;
+    absl::flat_hash_set<ss::sstring> strings;
+    for (auto i = 0; i < 100; i++) {
+        auto s = random_generators::gen_alphanum_max_distinct(cardinality);
+        // ensure no \0 in size
+        for (auto j = 0; j < random_generators::alphanum_max_distinct_strlen;
+             j++) {
+            BOOST_REQUIRE('\0' != s[j]);
+        }
+        strings.emplace(s);
+    }
+    BOOST_REQUIRE(strings.size() <= cardinality);
 }

--- a/src/v/reflection/test/CMakeLists.txt
+++ b/src/v/reflection/test/CMakeLists.txt
@@ -11,6 +11,6 @@ rp_test(
   UNIT_TEST
   BINARY_NAME reflection_async_adl_test
   SOURCES async_adl_test.cc
-  LIBRARIES v::seastar_testing_main absl::flat_hash_map v::reflection v::bytes v::model
+  LIBRARIES v::seastar_testing_main absl::flat_hash_map v::reflection v::bytes v::model v::rprandom
   LABELS reflection
 )

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -113,7 +113,7 @@ public:
       : _list(std::move(l))
       , _appender(a) {}
 
-    ss::future<ss::stop_iteration> operator()(model::record_batch&&);
+    ss::future<ss::stop_iteration> operator()(model::record_batch);
     storage::index_state end_of_stream() { return std::move(_idx); }
 
 private:

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -118,7 +118,7 @@ public:
 
 private:
     ss::future<ss::stop_iteration>
-    do_compaction(model::compression, model::record_batch&&);
+      do_compaction(model::compression, model::record_batch);
 
     bool should_keep(model::offset base, int32_t delta) const {
         const auto o = base + model::offset(delta);

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -181,8 +181,8 @@ public:
         return _impl->stm_manager();
     }
     /**
-     * Controlls the max offset that may be evicted by log retention policy
-     * This offset is non-decreasing.
+     * Controls the max offset that may be compacted or evicted by log
+     * retention policy. This offset is non-decreasing.
      */
     void set_collectible_offset(model::offset o) {
         return _impl->set_collectible_offset(o);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -146,6 +146,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         co_await current_log.handle.compact(compaction_config(
           collection_threshold,
           _config.retention_bytes(),
+          current_log.handle.stm_manager()->max_collectible_offset(),
           _config.compaction_priority,
           _abort_source));
 

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -506,6 +506,7 @@ struct compact_op final : opfuzz::op {
         compaction_config cfg(
           model::timestamp::max(),
           std::nullopt,
+          model::offset::max(),
           ss::default_priority_class(),
           *(ctx._as),
           debug_sanitize_files::yes);

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -342,7 +342,7 @@ segment::do_truncate(model::offset prev_last_offset, size_t physical) {
 ss::future<bool> segment::materialize_index() {
     vassert(
       _tracker.base_offset == _tracker.dirty_offset,
-      "Materializing the index must happen tracking any data. {}",
+      "Materializing the index must happen before tracking any data. {}",
       *this);
     return _idx.materialize_index().then([this](bool yn) {
         if (yn) {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -51,8 +51,12 @@ public:
         /// \brief These offsets are the `batch.last_offset()` and not
         /// `batch.base_offset()` which might be confusing at first,
         /// but allow us to keep track of the actual last logical offset
+
+        // Offset of last message fsync'd to disk
         model::offset committed_offset;
+        // Offset of last message written to this log
         model::offset dirty_offset;
+        // Offset of last message written to disk
         model::offset stable_offset;
         friend std::ostream& operator<<(std::ostream&, const offset_tracker&);
     };

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -3,8 +3,10 @@ v_cc_library(
     storage_test_utils
   HDRS
     "utils/disk_log_builder.h"
+    "utils/log_gap_analysis.h"
   SRCS
     "utils/disk_log_builder.cc"
+    "utils/log_gap_analysis.cc"
   DEPS
     v::storage v::model_test_utils
 )

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -348,8 +348,12 @@ FIXTURE_TEST(
     // garbadge collect first append series
     ss::abort_source as;
     log
-      .compact(
-        compaction_config(ts, std::nullopt, ss::default_priority_class(), as))
+      .compact(compaction_config(
+        ts,
+        std::nullopt,
+        model::offset::max(),
+        ss::default_priority_class(),
+        as))
       .get0();
     // truncate at 0, offset earlier then the one present in log
     log
@@ -526,8 +530,12 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     ss::abort_source as;
 
     // truncate at 0, offset earlier then the one present in log
-    auto f1 = log.compact(
-      compaction_config(ts, std::nullopt, ss::default_priority_class(), as));
+    auto f1 = log.compact(compaction_config(
+      ts,
+      std::nullopt,
+      model::offset::max(),
+      ss::default_priority_class(),
+      as));
 
     auto f2 = log.truncate_prefix(storage::truncate_prefix_config(
       lstats.dirty_offset, ss::default_priority_class()));

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -42,6 +42,19 @@ struct random_batches_generator {
     }
 };
 
+struct key_limited_random_batch_generator {
+    static constexpr int cardinality = 10;
+
+    ss::circular_buffer<model::record_batch> operator()() {
+        return model::test::make_random_batches(model::test::record_batch_spec{
+          .allow_compression = true,
+          .count = random_generators::get_int(1, 10),
+          .max_key_cardinality = cardinality,
+          .bt = model::record_batch_type::raft_data,
+        });
+    }
+};
+
 class storage_test_fixture {
 public:
     ss::sstring test_dir;

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -96,6 +96,7 @@ ss::future<> disk_log_builder::gc(
     return get_log().compact(compaction_config(
       collection_upper_bound,
       max_partition_retention_size,
+      model::offset::max(),
       ss::default_priority_class(),
       _abort_source));
 }

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -26,7 +26,6 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
-#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <vector>

--- a/src/v/storage/tests/utils/log_gap_analysis.cc
+++ b/src/v/storage/tests/utils/log_gap_analysis.cc
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "storage/parser_utils.h"
 
+static ss::logger slog{"test"};
 namespace storage {
 
 log_gap_analysis make_log_gap_analysis(
@@ -30,9 +31,9 @@ log_gap_analysis make_log_gap_analysis(
       [&](const model::record& r, const model::record_batch& b) {
           model::offset msg_offset = model::offset(r.offset_delta())
                                      + b.base_offset();
-
           if (expected_start && !last_offset) {
               last_offset = *expected_start - model::offset(1);
+              slog.info("gap_analysis: starting at {}", *last_offset + 1L);
           }
           if (last_offset) {
               model::offset expected = *last_offset + model::offset(1);
@@ -42,6 +43,17 @@ log_gap_analysis make_log_gap_analysis(
                       ga.first_gap_start = expected;
                   }
                   ga.last_gap_end = msg_offset - model::offset(1);
+                  slog.info(
+                    "gap_analysis: at moffs {} expected {}, gaps {}",
+                    msg_offset,
+                    expected,
+                    ga);
+              } else {
+                  slog.debug(
+                    "gap_analysis: *OK*: at moffs {} = expected {}, gaps {}",
+                    msg_offset,
+                    expected,
+                    ga);
               }
           }
           last_offset = msg_offset;

--- a/src/v/storage/tests/utils/log_gap_analysis.cc
+++ b/src/v/storage/tests/utils/log_gap_analysis.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "log_gap_analysis.h"
+
+#include "model/fundamental.h"
+#include "storage/parser_utils.h"
+
+namespace storage {
+
+log_gap_analysis make_log_gap_analysis(
+  model::record_batch_reader&& reader,
+  std::optional<model::offset> expected_start) {
+    std::optional<model::offset> last_offset;
+    log_gap_analysis ga;
+
+    auto mem_log = model::consume_reader_to_memory(
+                     std::move(reader), model::no_timeout)
+                     .get();
+
+    auto record_consumer =
+      [&](const model::record& r, const model::record_batch& b) {
+          model::offset msg_offset = model::offset(r.offset_delta())
+                                     + b.base_offset();
+
+          if (expected_start && !last_offset) {
+              last_offset = *expected_start - model::offset(1);
+          }
+          if (last_offset) {
+              model::offset expected = *last_offset + model::offset(1);
+              if (msg_offset != expected) {
+                  ga.num_gaps++;
+                  if (ga.first_gap_start < model::offset(0)) {
+                      ga.first_gap_start = expected;
+                  }
+                  ga.last_gap_end = msg_offset - model::offset(1);
+              }
+          }
+          last_offset = msg_offset;
+      };
+
+    auto batch_consumer = [&](model::record_batch& b) {
+        b.for_each_record(
+          [&](const model::record& r) { record_consumer(r, b); });
+    };
+
+    for (auto&& rb : mem_log) {
+        rb = storage::internal::decompress_batch(std::move(rb)).get();
+        batch_consumer(rb);
+    }
+    return ga;
+}
+
+std::ostream& operator<<(std::ostream& o, const log_gap_analysis& a) {
+    fmt::print(
+      o,
+      "{{first_gap_start:{}, last_gap_end:{}, num_gaps:{}}}",
+      a.first_gap_start,
+      a.last_gap_end,
+      a.num_gaps);
+    return o;
+}
+
+} // namespace storage

--- a/src/v/storage/tests/utils/log_gap_analysis.h
+++ b/src/v/storage/tests/utils/log_gap_analysis.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+
+namespace storage {
+
+// Utility to analyze offset gaps in logs, for testing compaction logic.
+
+/**
+ * Results of analysis of message offset gaps within a log instance.
+ * This struct is used to return the total `num_gaps` detected, as well as the
+ * minimum and maximum offsets that were missing.
+ * This is useful for observing which offsets were affected by compaction.
+ */
+struct log_gap_analysis {
+    // For the first gap detected, stores the first offset that of that gap
+    // (offset sequence numbers that were expected, but missing).
+    model::offset first_gap_start{-1};
+    // For the last gap detected, stores the last offset that was missing.
+    model::offset last_gap_end{-1};
+    size_t num_gaps{0};
+    friend std::ostream& operator<<(std::ostream& o, const log_gap_analysis& r);
+};
+
+/**
+ * Return info about gaps in message offsets.
+ * This is useful for testing compaction; key-based compaction preserves the
+ * original message offsets, causing gaps where previous messages were deleted.
+ * If `expected_start` is set, a gap at beginning of log will be detected if the
+ * first message doesn't match this offset. This analysis assumes message
+ * offsets form a perfect contiguous range, starting with the value
+ * `expected_start`.
+ */
+log_gap_analysis make_log_gap_analysis(
+  model::record_batch_reader&& reader,
+  std::optional<model::offset> expected_start);
+
+} // namespace storage

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -153,9 +153,11 @@ std::ostream& operator<<(std::ostream& o, const offset_stats& s) {
 std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
-      "{{evicition_time:{}, max_bytes:{}, should_sanitize:{}}}",
+      "{{evicition_time:{}, max_bytes:{}, max_collectible_offset:{}, "
+      "should_sanitize:{}}}",
       c.eviction_time,
       c.max_bytes.value_or(-1),
+      c.max_collectible_offset,
       c.sanitize);
     return o;
 }

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -308,11 +308,13 @@ struct compaction_config {
     explicit compaction_config(
       model::timestamp upper,
       std::optional<size_t> max_bytes_in_log,
+      model::offset max_collect_offset,
       ss::io_priority_class p,
       ss::abort_source& as,
       debug_sanitize_files should_sanitize = debug_sanitize_files::no)
       : eviction_time(upper)
       , max_bytes(max_bytes_in_log)
+      , max_collectible_offset(max_collect_offset)
       , iopc(p)
       , sanitize(should_sanitize)
       , asrc(&as) {}
@@ -321,6 +323,9 @@ struct compaction_config {
     model::timestamp eviction_time;
     // remove one segment if log is > max_bytes
     std::optional<size_t> max_bytes;
+    // Cannot delete or compact past this offset (i.e. for unresolved txn
+    // records): that is, only offsets <= this may be compacted.
+    model::offset max_collectible_offset;
     // priority for all IO in compaction
     ss::io_priority_class iopc;
     // use proxy fileops with assertions


### PR DESCRIPTION
Allow `rm_stm` to limit maximum offset that compaction may affect, so it can prevent unresolved transactional messages from affecting other records.

Fixes #4823 
## Highlights:
                                                                                                                      
**storage:` add max_collectible_offset to compaction_config**
                                                                                                                      
- Use model::offset::max() as a default value; this means you may compact up to any offset.                                                                                           
- Compaction uses max_collectible_offset, which is set in latter patch in this PR.                                                                                 
                                                                                                                      
### storage/tests: add key-limited random batch generator                                                             
                                                                                                                      
For testing compaction, we want a variant of append_random_batches() which limits the total number of distinct keys used. Unlike fully-random keys, this ensures that compaction can actually do some work.                                 
                                                                                                                      
### s/test/util: basic log gap analysis for compaction tests                                                          
                                                                                                                      
Introduce a utility for compaction testing which helps detect which offset ranges were affected by compaction. This utility makes a single pass over all of the message offsets in a given log instance, and returning the total number of offset gaps, and the min and max offsets that were missing.                                                            
                                                                                                                      
### storage/test: integration test for max compaction (max_collectible) offset                                                          
                                                                                                                      
Three integration tests that verify desired behavior:                                               
                                                                                                                      
- Randomized batch / messsage generaton with a limited number of keys. Verify that compaction only deletes messages less than this max.                                                                                                     
                                                                                                                      
- Single key with max compact offset (MCO): fixed message test that checks that the boundaries of the compacted area are precisely as expected.  
                                                                                                                      
- Single key w/o MCO: same as above, but with max_collectible_offset unset, we validate that compactions works as before.  
                                                                                                                      
### rm_stm: use last stable offset to limit compaction                                                                
                                                                                                                      
Last Stable Offset (LSO) is the largest offset such that no messages, up to and including LSO, are part of an unresolved transaction.                                                                                                                                                                                                                             Use LSO to determine the maximum offset that may be affected by compaction. This ensures that messages for open transactions--which may be aborted or committed in the future--cannot affect compaction. For example, an aborted message cannot replace a previous message with the same key, during compaction.                                                                                                           

### v1 PR
included these changes to support separate control for deletion/eviction versus compaction, which we agreed can be eliminated for now:
~~storage: stm_manager support for compactable_stm~~
 ~~Make stm_manager aware of a new type of stm: compactable_stm. This allows STM implementations to control compaction policy without leaking details into the main compaction logic.~~                                                          
                                                                                                                      
~~For now, this just exposes max_compactable_offset(), which allows rm_stm to prevent unresolved transactional messages from affecting compaction. We also plan to use this plumbing for a per-message predicate which will allow compaction to query the STM, and thus handle things like aborted records properly.~~ 

## Release notes

* none
