### PR TITLE
Implemented nodes recommissioning

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -271,4 +271,14 @@ inline std::vector<model::broker_shard> subtract_replica_sets(
       });
     return ret;
 }
+
+// check if replica set contains a node
+inline bool contains_node(
+  const std::vector<model::broker_shard>& replicas, model::node_id id) {
+    return std::find_if(
+             replicas.begin(),
+             replicas.end(),
+             [id](const model::broker_shard& bs) { return bs.node_id == id; })
+           != replicas.end();
+}
 } // namespace cluster

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -30,8 +30,190 @@
 
 namespace cluster {
 
-/// on every core, sharded
-
+/**
+ *
+ * # Reconciliation
+ *
+ * Controller backend is responsible for making sure that the cluster state is
+ * in align with the topic and partition state gathered in topic_table.
+ *
+ * Controller backend lives on each core on every node in the cluster. Each
+ * instance of controller backend is responsible for dealing with core & node
+ * local partition replicas (instances of `cluster::partition` object that are
+ * supposed to be instantiated on given core and given node). Controller backend
+ * manages partition replica lifecycle. It instantiates/deletes
+ * `cluster::partition` instances and registers them in shard table.
+ *
+ * Controller backend operations are driven by deltas generated in topics table.
+ * Backend waits for the new deltas using condition variable. Each delta
+ * represent an operation that must be executed for ntp f.e. create, update
+ * properties, move, etc.
+ *
+ * Each controller backend in the cluster (on each node and each core) process
+ * all the deltas and based on the situation it either executes an operation or
+ * ignore it (command pattern).
+ *
+ * Deltas vector for each NTP is processed in separate fiber in other words
+ * deltas for different NTPs are executed concurrently but for the same NTP
+ * sequentially.
+ *
+ * Each delta has revision assigned revision for the delta is assigned based on
+ * the raft0 log offset of command that the delta is related with. The same
+ * delta has the same revision globally.
+ *
+ * Deltas are executed in order from oldest revision up to the newest.
+ *
+ *
+ * NTP_1
+ *                                              Loop until finished or cancelled
+ *
+ *                                                    ┌──────────────────┐
+ *                                                    │                  │
+ *                                                    │                  │
+ * ┌────────────┐ ┌────────────┐ ┌────────────┐       │  ┌────────────┐  │
+ * │   delta    │ │   delta    │ │   delta    │       │  │   delta    │  │
+ * │            │ │            │ │            ├──►    └─►│            ├──┘
+ * │ revision: 3│ │ revision: 2│ │ revision: 1│          │ revision: 0│
+ * └────────────┘ └────────────┘ └────────────┘          └────────────┘
+ *
+ *                            .
+ *                            .
+ *                            .
+ * NTP_N
+ *                                              Loop until finished or cancelled
+ *
+ *                                                    ┌──────────────────┐
+ *                                                    │                  │
+ *                                                    │                  │
+ * ┌────────────┐ ┌────────────┐ ┌────────────┐       │  ┌────────────┐  │
+ * │   delta    │ │   delta    │ │   delta    │       │  │   delta    │  │
+ * │            │ │            │ │            ├──►    └─►│            ├──┘
+ * │ revision: 3│ │ revision: 2│ │ revision: 1│          │ revision: 0│
+ * └────────────┘ └────────────┘ └────────────┘          └────────────┘
+ *
+ * # Revisions
+ *
+ * As each reconciliation loops are not coordinated we must be able to recognize
+ * epochs. Consider a situation in which a stream of deltas executed by the
+ * backend leads to the state which is identical from end user perspective f.e.
+ * topic with the same name and configuration was deleted and then created back
+ * again. We must be able to recognize if the instance of partition replica that
+ * has been created for the topic belongs to the original topic or the one that
+ * was re created. In order to introduce differentiation between the two not
+ * distinguishable states we use revision_id as an epoch. Revision is used
+ * whenever partition is created or its replicas are moved. This way controller
+ * backend is able to recognize if partition replicas have already been updated
+ * or if action is required.
+ *
+ * ## Revisions and raft vnode
+ *
+ * Whenever a new replica is added to raft configuration it has new revision
+ * assigned. In raft each raft group participant is described by a tuple of
+ * model::node_id and model::revision_id. This way every time the node is re
+ * added to the configuration (consider a situation in which partition with
+ * single replica is moved back and forth between two nodes f.e. 1 -> 2 -> 1
+ * -> 2...) it is recognized as a new node. This fencing mechanism prevents the
+ * up to date raft group replicas from communicating with one from previous
+ * epoch.
+ *
+ * # Partition movement
+ *
+ * Partition movement in Redpanda is based on the Raft protocol mechanism called
+ * Joint Consensus. When requested Raft implementation is able to move data
+ * between nodes in a safe and consistent way. However requesting Raft to
+ * reconfigure a raft group is not enough to complete a partition move. When
+ * partition move is requested based on the current situation some of the
+ * controller backend may have to create new partition replica instances while
+ * other have to delete the one that are not longer part of raft group.
+ * Additionally there may be a need to move partition instance between cores on
+ * the same node.
+ *
+ * Every time partition move is requested each reconciliation loop executes an
+ * operation based on current and requested state and poll for its completion.
+ *
+ * Partition movement finish is coordinated using a designated finish command.
+ *
+ * Partition movement finish command is replicated from one of the replicas that
+ * was changed during reconfiguration process.
+ *
+ * IMPORTANT:
+ * Partition replicas are only deleted when executing delta for operation
+ * finished command. This way when partition replica is deleted it is guaranteed
+ * to not longer be needed.
+ *
+ * Example:
+ *
+ * Consider moving partition between a set of nodes:
+ *
+ *      replicas on nodes (1,2,3) -> replicas on nodes (2,3,4)
+ *
+ * (for simplicity we ignore core assignment in this example)
+ *
+ * Assumptions:
+ *  - node 1 is a leader for the partition.
+ *
+ * Operations that has to be executed on every node:
+ *
+ * Node 1:
+ * - node 1 is a leader, leader is the only one that can replicate data so it
+ * will be asked for reconfiguration
+ * - after partition replica is not longer needed on this node it may be removed
+ *
+ * Node 2 & 3:
+ * - node 2 will wait until configuration will be up to date with requested. In
+ * case leadership from node 1 moved it will ask for reconfiguration
+ *
+ * Node 4:
+ * - node 4 will create a new instance of partition replica and wait for the
+ * configuration to be up to date.
+ * - after successful reconfiguration node 4 will dispatch finish update command
+ *
+ *
+ * When finish update command will be received by node 1 it will remove the
+ * partition replica instance.
+ *
+ *
+ * ## Interrupting partition movement
+ *
+ * Partition movement interruption may only be accepted after topic table
+ * processed move command but before the finish update command was processed. We
+ * use topics table as a single source of truth to decide if the update may
+ * still be canceled or if it has finished. This way we must be able to revert
+ * configuration change even if raft already finished reconfiguration.
+ *
+ * Partition move interruption does not mark the reconfiguration process as
+ * finished i.e. it will still be represented as in progress when queried from
+ * topic table. Move interruption will only finish when reconfiguration is
+ * finished in raft and finish move command is issued by the controller backend
+ *
+ * In general the interrupt may happen in the following situations:
+ *
+ * 1) before raft reconfiguration was requested
+ * 2) when raft reconfiguration is in progress
+ * 3) when raft reconfiguration has already finished but before finish command
+ * was replicated
+ *
+ * In all of the situations we must move back to the raft group configuration
+ * which was active before the move was scheduled. The set of actions that must
+ * be taken to finish the interruption is different based on the situation in
+ * which interruption happened.
+ *
+ * For 1) controller backend must simply update raft configuration revision to
+ * be able to decide if action related with given revision_id has been executed.
+ *
+ * For 2) controller backend with request reconfiguration cancellation on a
+ * leader and will wait until raft configuration is up to date with what was
+ * observed before the move. Any replicas that were created for the purpose of
+ * move will be removed when processing finished move command.
+ *
+ * For 3) controller backend must request reconfiguration with the same exact
+ * replica set as before the move was requested. It is important to notice that
+ * no partition replicas were yet removed as finish command wasn't yet
+ * processed. Since cancelling partition move does not create new partition
+ * replica instances (instances of `cluster::partition`) but reuse the existing
+ * one we must reuse revision id of currently existing replica instances.
+ *
+ */
 class controller_backend
   : public ss::peering_sharded_service<controller_backend> {
 public:

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -132,6 +132,8 @@ void members_backend::handle_single_update(
         return;
     case update_t::decommissioned:
         stop_node_addition(update.id);
+        _decommission_command_revision.emplace(
+          update.id, model::revision_id(update.offset));
         _updates.emplace_back(update);
         _new_updates.signal();
         return;
@@ -335,7 +337,21 @@ ss::future<> members_backend::reconcile() {
     // if nothing to do, wait
     co_await _new_updates.wait([this] { return !_updates.empty(); });
     auto u = co_await _lock.get_units();
+    // remove stored revisions of previous decommissioning nodes, this will only
+    // happen when update is finished and it is either decommissioning or
+    // recommissioning of a node
+    for (const auto& meta : _updates) {
+        const bool is_decommission
+          = meta.update.type
+            == members_manager::node_update_type::decommissioned;
+        const bool is_recommission
+          = meta.update.type
+            == members_manager::node_update_type::recommissioned;
 
+        if (meta.finished && (is_decommission || is_recommission)) {
+            _decommission_command_revision.erase(meta.update.id);
+        }
+    }
     // remove finished updates
     std::erase_if(
       _updates, [](const update_meta& meta) { return meta.finished; });

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -723,6 +723,11 @@ ss::future<> members_backend::reallocate_replica_set(
               meta.current_replica_set,
               meta.new_replica_set,
               error.message());
+            if (error == errc::no_update_in_progress) {
+                // mark reallocation as finished, reallocations will be
+                // recalculated if required
+                meta.state = reallocation_state::finished;
+            }
             co_return;
         }
         // success, update state and move on

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -524,7 +524,6 @@ ss::future<> members_backend::reconcile() {
 
         const auto allocator_empty = _allocator.local().is_empty(
           meta.update.id);
-
         if (
           is_draining && all_reallocations_finished && allocator_empty
           && !updates_in_progress) {
@@ -552,6 +551,15 @@ ss::future<> members_backend::reconcile() {
               all_reallocations_finished,
               allocator_empty,
               updates_in_progress);
+            if (!allocator_empty && all_reallocations_finished) {
+                // recalculate reallocations
+                vlog(
+                  clusterlog.info,
+                  "[update: {}] decommissioning in progress. recalculating "
+                  "reallocations",
+                  meta.update);
+                calculate_reallocations(meta);
+            }
         }
     }
 }

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -10,6 +10,7 @@
 
 #include <seastar/core/condition-variable.hh>
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
 #include <chrono>
@@ -118,6 +119,14 @@ private:
     ss::timer<> _retry_timer;
     ss::condition_variable _new_updates;
     ss::metrics::metric_groups _metrics;
+    /**
+     * store revision of node decommissioning update, decommissioning command
+     * revision is stored when node is being decommissioned, it is used to
+     * determine which partition movements were scheduled before the node was
+     * decommissioned, recommissioning process will not abort those movements.
+     */
+    absl::flat_hash_map<model::node_id, model::revision_id>
+      _decommission_command_revision;
 };
 std::ostream&
 operator<<(std::ostream&, const members_backend::reallocation_state&);

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -99,6 +99,9 @@ private:
     void reassign_replicas(partition_assignment&, partition_reallocation&);
     void calculate_reallocations_after_node_added(update_meta&) const;
     void calculate_reallocations_after_decommissioned(update_meta&) const;
+    void calculate_reallocations_after_recommissioned(update_meta&) const;
+    std::vector<model::ntp> ntps_moving_from_node_older_than(
+      model::node_id, model::revision_id) const;
     void setup_metrics();
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -53,6 +53,12 @@ public:
         model::node_id id;
         node_update_type type;
         model::offset offset;
+
+        bool is_commissioning() const {
+            return type == members_manager::node_update_type::decommissioned
+                   || type == members_manager::node_update_type::recommissioned;
+        }
+
         friend std::ostream& operator<<(std::ostream&, const node_update&);
     };
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -159,6 +159,13 @@ public:
           std::move(brokers), new_revision_id);
     }
 
+    ss::future<std::error_code> update_replica_set(
+      std::vector<raft::broker_revision> brokers,
+      model::revision_id new_revision_id) {
+        return _raft->replace_configuration(
+          std::move(brokers), new_revision_id);
+    }
+
     raft::group_configuration group_configuration() const {
         return _raft->config();
     }

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -305,7 +305,7 @@ void partition_balancer_planner::get_unavailable_nodes_reassignments(
                     continue;
                 }
                 auto new_allocation_units = get_reallocation(
-                  a, t.second, partition_size.value(), false, rrs);
+                  a, t.second.metadata, partition_size.value(), false, rrs);
                 if (new_allocation_units) {
                     result.reassignments.emplace_back(ntp_reassignments{
                       .ntp = ntp,
@@ -384,7 +384,7 @@ void partition_balancer_planner::get_full_node_reassignments(
             }
             auto new_allocation_units = get_reallocation(
               *current_assignments,
-              topic_metadata,
+              topic_metadata.metadata,
               ntp_size_it->first,
               true,
               rrs);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -175,6 +175,7 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
       in_progress_update{
         .previous_replicas = current_assignment_it->replicas,
         .state = in_progress_state::update_requested,
+        .update_revision = model::revision_id(o),
       });
     auto previous_assignment = *current_assignment_it;
     // replace partition replica set
@@ -190,6 +191,7 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
               in_progress_update{
                 .previous_replicas = current_assignment_it->replicas,
                 .state = in_progress_state::update_requested,
+                .update_revision = model::revision_id(o),
               });
             vassert(
               success,

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -41,17 +41,60 @@ public:
         cancel_requested,
         force_cancel_requested
     };
+    /**
+     * Replicas revision map is used to track revision of brokers in a replica
+     * set. When a node is added into replica set its gets the revision assigned
+     */
+    using replicas_revision_map
+      = absl::flat_hash_map<model::node_id, model::revision_id>;
 
     struct in_progress_update {
         std::vector<model::broker_shard> previous_replicas;
         in_progress_state state;
         model::revision_id update_revision;
+        replicas_revision_map replicas_revisions;
     };
+
+    struct topic_metadata_item {
+        topic_metadata metadata;
+        // replicas revisions for each partition
+        absl::node_hash_map<model::partition_id, replicas_revision_map>
+          replica_revisions;
+
+        bool is_topic_replicable() const {
+            return metadata.is_topic_replicable();
+        }
+
+        assignments_set& get_assignments() {
+            return metadata.get_assignments();
+        }
+
+        const assignments_set& get_assignments() const {
+            return metadata.get_assignments();
+        }
+        model::revision_id get_revision() const {
+            return metadata.get_revision();
+        }
+        std::optional<model::initial_revision_id> get_remote_revision() const {
+            return metadata.get_remote_revision();
+        }
+        const model::topic& get_source_topic() const {
+            return metadata.get_source_topic();
+        }
+
+        const topic_configuration& get_configuration() const {
+            return metadata.get_configuration();
+        }
+        topic_configuration& get_configuration() {
+            return metadata.get_configuration();
+        }
+    };
+
     using delta = topic_table_delta;
 
-    using underlying_t = absl::flat_hash_map<
+    using underlying_t = absl::node_hash_map<
       model::topic_namespace,
-      topic_metadata,
+      topic_metadata_item,
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
     using hierarchy_t = absl::node_hash_map<
@@ -238,7 +281,7 @@ private:
     void notify_waiters();
 
     template<typename Func>
-    std::vector<std::invoke_result_t<Func, const topic_metadata&>>
+    std::vector<std::invoke_result_t<Func, const topic_metadata_item&>>
     transform_topics(Func&&) const;
 
     underlying_t _topics;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -208,6 +208,23 @@ public:
     std::optional<std::vector<model::broker_shard>>
     get_previous_replica_set(const model::ntp&) const;
 
+    const absl::node_hash_map<model::ntp, in_progress_update>&
+    in_progress_updates() const {
+        return _updates_in_progress;
+    }
+
+    /**
+     * Lists all NTPs that replicas are being move to a node
+     */
+    std::vector<model::ntp> ntps_moving_to_node(model::node_id) const;
+
+    /**
+     * Lists all NTPs that replicas are being move from a node
+     */
+    std::vector<model::ntp> ntps_moving_from_node(model::node_id) const;
+
+    std::vector<model::ntp> all_updates_in_progress() const;
+
 private:
     struct waiter {
         explicit waiter(uint64_t id)

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -12,8 +12,12 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
 #include "cluster/partition_leaders_table.h"
+#include "cluster/topic_table.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/types.h"
+
+#include <absl/container/node_hash_map.h>
 
 #include <iterator>
 #include <system_error>
@@ -37,19 +41,29 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
           return ss::visit(
             std::move(cmd),
             [this, base_offset](delete_topic_cmd del_cmd) {
-                // delete case - we need state copy to
-                auto tp_md = _topic_table.local().get_topic_metadata(
-                  del_cmd.value);
+                auto tp_ns = del_cmd.key;
+                auto topic_assignments
+                  = _topic_table.local().get_topic_assignments(del_cmd.value);
+                in_progress_map in_progress;
+
+                if (topic_assignments) {
+                    in_progress = collect_in_progress(
+                      del_cmd.key, *topic_assignments);
+                }
                 return dispatch_updates_to_cores(del_cmd, base_offset)
-                  .then([this, tp_md = std::move(tp_md)](std::error_code ec) {
-                      if (ec == errc::success) {
-                          vassert(
-                            tp_md.has_value(),
-                            "Topic had to exist before successful delete");
-                          deallocate_topic(*tp_md);
-                      }
-                      return ec;
-                  });
+                  .then(
+                    [this,
+                     topic_assignments = std::move(topic_assignments),
+                     in_progress = std::move(in_progress)](std::error_code ec) {
+                        if (ec == errc::success) {
+                            vassert(
+                              topic_assignments.has_value(),
+                              "Topic had to exist before successful delete");
+                            deallocate_topic(*topic_assignments, in_progress);
+                        }
+
+                        return ec;
+                    });
             },
             [this, base_offset](create_topic_cmd create_cmd) {
                 return dispatch_updates_to_cores(create_cmd, base_offset)
@@ -187,6 +201,22 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
             });
       });
 }
+topic_updates_dispatcher::in_progress_map
+topic_updates_dispatcher::collect_in_progress(
+  const model::topic_namespace& tp_ns,
+  const assignments_set& current_assignments) {
+    in_progress_map in_progress;
+    in_progress.reserve(current_assignments.size());
+    // collect in progress assignments
+    for (auto& p : current_assignments) {
+        auto previous = _topic_table.local().get_previous_replica_set(
+          model::ntp(tp_ns.ns, tp_ns.tp, p.id));
+        if (previous) {
+            in_progress.emplace(p.id, std::move(previous.value()));
+        }
+    }
+    return in_progress;
+}
 
 ss::future<> topic_updates_dispatcher::update_leaders_with_estimates(
   std::vector<ntp_leader> leaders) {
@@ -250,10 +280,19 @@ topic_updates_dispatcher::dispatch_updates_to_cores(Cmd cmd, model::offset o) {
       });
 }
 
-void topic_updates_dispatcher::deallocate_topic(const topic_metadata& tp_md) {
-    // we have to deallocate topics
-    for (auto& p : tp_md.get_assignments()) {
-        _partition_allocator.local().deallocate(p.replicas);
+void topic_updates_dispatcher::deallocate_topic(
+  const assignments_set& topic_assignments,
+  const in_progress_map& in_progress) {
+    for (auto& p_as : topic_assignments) {
+        _partition_allocator.local().deallocate(p_as.replicas);
+        auto it = in_progress.find(p_as.id);
+
+        // we must remove the allocation that would normally
+        // be removed with update_finished request
+        if (it != in_progress.end()) {
+            auto to_delete = subtract_replica_sets(it->second, p_as.replicas);
+            _partition_allocator.local().remove_allocations(to_delete);
+        }
     }
 }
 

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -13,6 +13,8 @@
 #include "cluster/commands.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 
 #include <seastar/core/sharded.hh>
@@ -71,6 +73,8 @@ public:
     }
 
 private:
+    using in_progress_map = absl::
+      node_hash_map<model::partition_id, std::vector<model::broker_shard>>;
     template<typename Cmd>
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd, model::offset);
 
@@ -78,7 +82,11 @@ private:
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
     void update_allocations(std::vector<partition_assignment>);
-    void deallocate_topic(const topic_metadata&);
+
+    void deallocate_topic(const assignments_set&, const in_progress_map&);
+
+    in_progress_map
+    collect_in_progress(const model::topic_namespace&, const assignments_set&);
 
     ss::sharded<partition_allocator>& _partition_allocator;
     ss::sharded<topic_table>& _topic_table;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -229,7 +229,7 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
                   authz_quiet{true})) {
                 continue;
             }
-            res.push_back(make_topic_response(ctx, request, md));
+            res.push_back(make_topic_response(ctx, request, md.metadata));
         }
 
         return ss::make_ready_future<std::vector<metadata_response::topic>>(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -45,6 +45,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <system_error>
 
 template<>
 struct fmt::formatter<raft::consensus::vote_state> final
@@ -1032,12 +1033,23 @@ ss::future<std::error_code>
 consensus::cancel_configuration_change(model::revision_id revision) {
     vlog(
       _ctxlog.info,
-      "requested revert of current configuration change - {}",
+      "requested cancellation of current configuration change - {}",
       config());
     return interrupt_configuration_change(
-      revision, [revision](raft::group_configuration cfg) {
-          cfg.cancel_configuration_change(revision);
-          return cfg;
+             revision,
+             [revision](raft::group_configuration cfg) {
+                 cfg.cancel_configuration_change(revision);
+                 return cfg;
+             })
+      .then([this](std::error_code ec) -> ss::future<std::error_code> {
+          if (!ec) {
+              // current leader is not a voter, step down
+              if (!config().is_voter(_self)) {
+                  auto u = co_await _op_lock.get_units();
+                  do_step_down("current leader is not voter");
+              }
+          }
+          co_return ec;
       });
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -994,6 +994,18 @@ ss::future<std::error_code> consensus::replace_configuration(
       });
 }
 
+ss::future<std::error_code> consensus::replace_configuration(
+  std::vector<raft::broker_revision> new_brokers,
+  model::revision_id new_revision) {
+    return change_configuration(
+      [new_brokers = std::move(new_brokers),
+       new_revision](group_configuration current) mutable {
+          current.replace(std::move(new_brokers), new_revision);
+          current.set_revision(new_revision);
+          return result<group_configuration>(std::move(current));
+      });
+}
+
 template<typename Func>
 ss::future<std::error_code>
 consensus::interrupt_configuration_change(model::revision_id revision, Func f) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -123,6 +123,11 @@ public:
     // Replace configuration of raft group with given set of nodes
     ss::future<std::error_code>
       replace_configuration(std::vector<model::broker>, model::revision_id);
+    /**
+     * Replace configuration, uses revision provided with brokers
+     */
+    ss::future<std::error_code>
+      replace_configuration(std::vector<broker_revision>, model::revision_id);
     // Abort ongoing configuration change - may cause data loss
     ss::future<std::error_code> abort_configuration_change(model::revision_id);
     // Revert current configuration change - this is safe and will never cause

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -23,6 +23,11 @@
 
 namespace raft {
 
+struct broker_revision {
+    model::broker broker;
+    model::revision_id rev;
+};
+
 static constexpr model::revision_id no_revision{};
 class vnode : public serde::envelope<vnode, serde::version<0>> {
 public:
@@ -118,6 +123,7 @@ public:
     void add(std::vector<model::broker>, model::revision_id);
     void remove(const std::vector<model::node_id>&);
     void replace(std::vector<model::broker>, model::revision_id);
+    void replace(std::vector<broker_revision>, model::revision_id);
 
     /**
      * Updating broker configuration. This operation does not require entering

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2465,10 +2465,9 @@ void admin_server::register_partition_routes() {
                   replica.core = bs.shard;
                   r.previous_replicas.push(replica);
               }
-              co_await ss::coroutine::maybe_yield();
               ret.push_back(std::move(r));
           }
-          co_return std::move(ret);
+          co_return ret;
       });
 }
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -439,6 +439,14 @@ class Admin:
         self.redpanda.logger.debug(f"decommissioning {path}")
         return self._request('put', path, node=node)
 
+    def recommission_broker(self, id, node=None):
+        """
+        Recommission broker i.e. abort ongoing decommissioning
+        """
+        path = f"brokers/{id}/recommission"
+        self.redpanda.logger.debug(f"recommissioning {id}")
+        return self._request('put', path, node=node)
+
     def list_reconfigurations(self, node=None):
         """
         List pending reconfigurations

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -272,12 +272,8 @@ class NodesDecommissioningTest(EndToEndTest):
 
         # schedule partition move from the node being decommissioned before actually calling decommission
 
-        partitions = admin.get_partitions(
-            node=self.redpanda.get_node(to_decommission))
-
-        partition_to_move = random.choice(partitions)
-        to_move_tp = partition_to_move['topic']
-        to_move_p = partition_to_move['partition_id']
+        to_move_tp, to_move_p, _ = self._partition_to_move(
+            lambda p: to_decommission in p.replicas)
         details = admin.get_partitions(topic=to_move_tp, partition=to_move_p)
 
         new_replicas = self._find_replacement(details['replicas'],

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -44,7 +44,7 @@ class NodesDecommissioningTest(EndToEndTest):
     def _partitions_not_moving(self):
         admin = Admin(self.redpanda)
         reconfigurations = admin.list_reconfigurations()
-        return len(reconfigurations) > 0
+        return len(reconfigurations) == 0
 
     def _partition_to_move(self, predicate):
         rpk = RpkTool(self.redpanda)
@@ -68,6 +68,38 @@ class NodesDecommissioningTest(EndToEndTest):
             if b['node_id'] == removed_id:
                 return False
         return True
+
+    def _find_replacement(self, current_replicas, to_remove):
+        new_replicas = []
+        unique_node_ids = set()
+        for r in current_replicas:
+            if r['node_id'] != to_remove:
+                unique_node_ids.add(r['node_id'])
+                new_replicas.append(r)
+
+        admin = Admin(self.redpanda)
+        brokers = admin.get_brokers()
+
+        to_add = None
+        while len(unique_node_ids) < len(current_replicas):
+            id = random.choice(brokers)['node_id']
+            if id == to_remove:
+                continue
+            to_add = id
+            unique_node_ids.add(to_add)
+
+        new_replicas.append({"node_id": to_add, "core": 0})
+        return new_replicas
+
+    def _wait_until_status(self, node_id, status, timeout_sec=15):
+        def requested_status():
+            brokers = Admin(self.redpanda).get_brokers()
+            for broker in brokers:
+                if broker['node_id'] == node_id:
+                    return broker['membership_status'] == status
+            return False
+
+        wait_until(requested_status, timeout_sec=timeout_sec, backoff_sec=1)
 
     @cluster(
         num_nodes=6,
@@ -174,18 +206,6 @@ class NodesDecommissioningTest(EndToEndTest):
         self.logger.info(f"decommissioning node: {to_decommission}", )
         admin.decommission_broker(to_decommission)
 
-        def check_status(node_id, status):
-            brokers = admin.get_brokers()
-            for broker in brokers:
-                if broker['node_id'] == node_id:
-                    return broker['membership_status'] == status
-
-            return False
-
-        wait_until(lambda: check_status(to_decommission, 'draining'),
-                   timeout_sec=15,
-                   backoff_sec=1)
-
         survivor_node = self._not_decommissioned_node(to_decommission)
         # adjust recovery throttle to make sure moves will finish
         rpk.cluster_config_set("raft_learner_recovery_rate", str(2 << 30))
@@ -198,3 +218,145 @@ class NodesDecommissioningTest(EndToEndTest):
         self.redpanda.stop_node(self.redpanda.get_node(to_decommission))
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=90)
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_recommissioning_node(self):
+        self.start_redpanda(num_nodes=4)
+        self._create_topics()
+
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+        admin = Admin(self.redpanda)
+
+        brokers = admin.get_brokers()
+        to_decommission = random.choice(brokers)['node_id']
+
+        # throttle recovery
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("raft_learner_recovery_rate", str(1))
+
+        self.logger.info(f"decommissioning node: {to_decommission}", )
+        admin.decommission_broker(to_decommission)
+
+        self._wait_until_status(to_decommission, 'draining')
+
+        wait_until(lambda: self._partitions_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+        # recommission broker
+        admin.recommission_broker(to_decommission)
+        self._wait_until_status(to_decommission, 'active')
+
+        wait_until(lambda: self._partitions_not_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_recommissioning_do_not_stop_all_moves_node(self):
+        self.start_redpanda(num_nodes=4)
+        self._create_topics()
+
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+        admin = Admin(self.redpanda)
+
+        brokers = admin.get_brokers()
+        to_decommission = random.choice(brokers)['node_id']
+
+        # throttle recovery
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("raft_learner_recovery_rate", str(1))
+
+        # schedule partition move from the node being decommissioned before actually calling decommission
+
+        partitions = admin.get_partitions(
+            node=self.redpanda.get_node(to_decommission))
+
+        partition_to_move = random.choice(partitions)
+        to_move_tp = partition_to_move['topic']
+        to_move_p = partition_to_move['partition_id']
+        details = admin.get_partitions(topic=to_move_tp, partition=to_move_p)
+
+        new_replicas = self._find_replacement(details['replicas'],
+                                              to_decommission)
+        self.logger.info(
+            f"moving partition {to_move_tp}/{to_move_p} - {details['replicas']} -> {new_replicas}"
+        )
+
+        admin.set_partition_replicas(topic=to_move_tp,
+                                     partition=to_move_p,
+                                     replicas=new_replicas)
+        # moving partition should be present in moving list
+        wait_until(lambda: self._partitions_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+        self.logger.info(f"decommissioning node: {to_decommission}", )
+        admin.decommission_broker(to_decommission)
+
+        self._wait_until_status(to_decommission, 'draining')
+
+        wait_until(lambda: self._partitions_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+        # recommission broker
+        admin.recommission_broker(to_decommission)
+        self._wait_until_status(to_decommission, 'active')
+
+        def one_left_moving():
+            reconfigurations = admin.list_reconfigurations()
+            return len(reconfigurations) == 1
+
+        wait_until(one_left_moving, timeout_sec=15, backoff_sec=1)
+
+    @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_recommissioning_one_of_decommissioned_nodes(self):
+        self.start_redpanda(num_nodes=5)
+        self._create_topics()
+
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+        admin = Admin(self.redpanda)
+
+        brokers = admin.get_brokers()
+        to_decommission_1 = random.choice(brokers)['node_id']
+        to_decommission_2 = to_decommission_1
+
+        while to_decommission_1 == to_decommission_2:
+            to_decommission_2 = random.choice(brokers)['node_id']
+
+        # throttle recovery
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("raft_learner_recovery_rate", str(1))
+
+        self.logger.info(f"decommissioning node: {to_decommission_1}", )
+        admin.decommission_broker(to_decommission_1)
+        self.logger.info(f"decommissioning node: {to_decommission_2}", )
+        admin.decommission_broker(to_decommission_2)
+
+        self._wait_until_status(to_decommission_1, 'draining')
+        self._wait_until_status(to_decommission_2, 'draining')
+
+        wait_until(lambda: self._partitions_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
+
+        # recommission broker that was decommissioned first
+        admin.recommission_broker(to_decommission_1)
+        self._wait_until_status(to_decommission_1, 'active')
+
+        rpk.cluster_config_set("raft_learner_recovery_rate", str(2 << 30))
+
+        def node_removed():
+            brokers = admin.get_brokers()
+            for broker in brokers:
+                if broker['node_id'] == to_decommission_2:
+                    return False
+            return True
+
+        wait_until(node_removed, 60, 2)


### PR DESCRIPTION
## Cover letter

Added full support for nodes decommissioning. Previously node recommissioning wasn't fully supported. Currently recommissioning operation stops decommissioning, prevents node from being deleted and cancels all related partition movements. 

Note: 
All partitions that were already successfully moved from the decommissioned node will not be moved back.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
