### PR TITLE
raft: require full leadership before leadership transfer

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2888,7 +2888,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                *   - shutdown may be in progress
                *   - other: identified by follower not caught-up
                */
-              if (!is_elected_leader()) {
+              if (!is_leader()) {
                   vlog(
                     _ctxlog.warn, "Cannot transfer leadership from non-leader");
                   return seastar::make_ready_future<std::error_code>(


### PR DESCRIPTION
## Cover letter

Previously, we could have achieved an election win but
not yet have completed replication of configuration batches, and
be in a state where we have not learned the committed indices of
our followers.  This causes the needs_recovery check to fail,
and results in a timeout error that appears as a 500 to the
admin API user.

Instead, we should take the "I'm not the leader" path in this
situation, which prompts the admin API client with a 503 to
retry.

Fixes https://github.com/redpanda-data/redpanda/issues/5332

## Release notes

### Improvements

* Under rare circumstances, a leadership transfer request via the admin API could get a 500 error if sent to a node in the process of completing an election.  This is fixed to return a retryable 503 response.
