### PR TITLE
Partition movement interruption APIs

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -24,6 +24,7 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <system_error>
 #include <utility>
 
 namespace detail {
@@ -304,4 +305,7 @@ inline bool contains_node(
              [id](const model::broker_shard& bs) { return bs.node_id == id; })
            != replicas.end();
 }
+
+cluster::errc map_update_interruption_error_code(std::error_code);
+
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -272,6 +272,29 @@ inline std::vector<model::broker_shard> subtract_replica_sets(
     return ret;
 }
 
+/**
+ * Subtracts second replica set from the first one. Result contains only brokers
+ * that node_ids are present in the first list but not the other one
+ */
+inline std::vector<model::broker_shard> subtract_replica_sets_by_node_id(
+  const std::vector<model::broker_shard>& lhs,
+  const std::vector<model::broker_shard>& rhs) {
+    std::vector<model::broker_shard> ret;
+    std::copy_if(
+      lhs.begin(),
+      lhs.end(),
+      std::back_inserter(ret),
+      [&rhs](const model::broker_shard& lhs_bs) {
+          return std::find_if(
+                   rhs.begin(),
+                   rhs.end(),
+                   [&lhs_bs](const model::broker_shard& rhs_bs) {
+                       return rhs_bs.node_id == lhs_bs.node_id;
+                   })
+                 == rhs.end();
+      });
+    return ret;
+}
 // check if replica set contains a node
 inline bool contains_node(
   const std::vector<model::broker_shard>& replicas, model::node_id id) {

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -110,6 +110,16 @@
             "name": "hello",
             "input_type": "hello_request",
             "output_type": "hello_reply"
+        },
+        {
+            "name": "cancel_all_partition_movements",
+            "input_type": "cancel_all_partition_movements_request",
+            "output_type": "cancel_partition_movements_reply"
+        },
+        {
+            "name": "cancel_node_partition_movements",
+            "input_type": "cancel_node_partition_movements_request",
+            "output_type": "cancel_partition_movements_reply"
         }
     ]
 }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -108,9 +108,15 @@ std::vector<raft::broker_revision> create_brokers_set(
               throw std::logic_error(
                 fmt::format("Replica node {} is not available", bs.node_id));
           }
+          auto rev_it = replica_revisions.find(bs.node_id);
+          vassert(
+            rev_it != replica_revisions.end(),
+            "revision for broker {} must be present in replica revisions map. "
+            "revisions map size: {}",
+            bs.node_id,
+            replica_revisions.size());
           return raft::broker_revision{
-            .broker = *br->get(),
-            .rev = replica_revisions.find(bs.node_id)->second};
+            .broker = *br->get(), .rev = rev_it->second};
       });
     return brokers;
 }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -61,6 +61,7 @@ enum class errc : int16_t {
     feature_disabled,
     invalid_request,
     no_update_in_progress,
+    unknown_update_interruption_error
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -173,6 +174,8 @@ struct errc_category final : public std::error_category {
             return "Invalid request";
         case errc::no_update_in_progress:
             return "Partition configuration is not being updated";
+        case errc::unknown_update_interruption_error:
+            return "Error while cancelling partition reconfiguration";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -101,7 +101,14 @@ public:
     ss::future<hello_reply>
     hello(hello_request&&, rpc::streaming_context&) final;
 
+    ss::future<cancel_partition_movements_reply> cancel_all_partition_movements(
+      cancel_all_partition_movements_request&&, rpc::streaming_context&) final;
+    ss::future<cancel_partition_movements_reply>
+    cancel_node_partition_movements(
+      cancel_node_partition_movements_request&&, rpc::streaming_context&) final;
+
 private:
+    static constexpr auto default_move_interruption_timeout = 10s;
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
       fetch_metadata_and_cfg(const std::vector<topic_result>&);
@@ -123,6 +130,13 @@ private:
 
     ss::future<get_cluster_health_reply>
       do_get_cluster_health_report(get_cluster_health_request);
+
+    ss::future<cancel_partition_movements_reply>
+      do_cancel_all_partition_movements(cancel_all_partition_movements_request);
+
+    ss::future<cancel_partition_movements_reply>
+      do_cancel_node_partition_movements(
+        cancel_node_partition_movements_request);
 
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -37,6 +37,7 @@
 #include <chrono>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 using namespace std::chrono_literals; // NOLINT
 
@@ -2293,6 +2294,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .result = raft::append_entries_reply::status::group_unavailable,
         };
         roundtrip_test(data);
+    }
+    {
+        cluster::cancel_node_partition_movements_request request{
+          .node_id = tests::random_named_int<model::node_id>(),
+          .direction = random_generators::random_choice(
+            std::vector<cluster::partition_move_direction>{
+              cluster::partition_move_direction::from_node,
+              cluster::partition_move_direction::to_node,
+              cluster::partition_move_direction::all}),
+        };
+        roundtrip_test(request);
     }
 }
 

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -14,6 +14,8 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 using namespace std::chrono_literals;
 
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
@@ -163,4 +165,235 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     auto d = table.local().wait_for_changes(as).get0();
     // require 3 partition additions
     validate_delta(d, 3, 0);
+}
+
+void validate_brokers_revisions(
+  const model::ntp& ntp,
+  const cluster::topic_table::underlying_t& all_metadata,
+  const absl::flat_hash_map<model::node_id, model::revision_id>&
+    expected_revisions) {
+    // first check if initial revisions of brokers are valid
+
+    auto tp_it = all_metadata.find(model::topic_namespace_view(ntp));
+    BOOST_REQUIRE(tp_it != all_metadata.end());
+
+    auto p_it = tp_it->second.metadata.get_assignments().find(ntp.tp.partition);
+    BOOST_REQUIRE(p_it != tp_it->second.metadata.get_assignments().end());
+
+    auto rev_it = tp_it->second.replica_revisions.find(ntp.tp.partition);
+    BOOST_REQUIRE(rev_it != tp_it->second.replica_revisions.end());
+
+    for (auto& bs : p_it->replicas) {
+        fmt::print("replica: {}\n", bs);
+    }
+    for (auto& bs : expected_revisions) {
+        fmt::print("expected_rev: {} = {}\n", bs.first, bs.second);
+    }
+
+    for (auto& bs : rev_it->second) {
+        fmt::print("current_rev: {} = {}\n", bs.first, bs.second);
+    }
+    BOOST_REQUIRE_EQUAL(expected_revisions.size(), rev_it->second.size());
+    for (auto& bs : p_it->replicas) {
+        auto r = rev_it->second.find(bs.node_id);
+        auto ex = expected_revisions.find(bs.node_id);
+
+        BOOST_REQUIRE(r != rev_it->second.end());
+        BOOST_REQUIRE(ex != expected_revisions.end());
+
+        fmt::print("Checking {} == {}\n", r->second, ex->second);
+        BOOST_REQUIRE_EQUAL(
+          rev_it->second.find(bs.node_id)->second,
+          expected_revisions.find(bs.node_id)->second);
+    }
+}
+
+template<typename Cmd, typename Key, typename Val>
+void apply_cmd(
+  cluster::topic_table& table, Key k, Val v, model::offset revision) {
+    auto ec = table.apply(Cmd(std::move(k), std::move(v)), revision).get();
+
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+}
+
+FIXTURE_TEST(test_tracking_broker_revisions, topic_table_fixture) {
+    auto& topics = table.local();
+    static const model::node_id n_0(0);
+    static const model::node_id n_1(1);
+    static const model::node_id n_2(2);
+    static const model::node_id n_3(3);
+    static const model::node_id n_4(4);
+
+    using rev_map_t = absl::flat_hash_map<model::node_id, model::revision_id>;
+
+    model::topic_namespace tp_ns(
+      model::kafka_namespace, model::topic("test_tp"));
+
+    model::ntp ntp_0(tp_ns.ns, tp_ns.tp, model::partition_id(0));
+
+    cluster::topic_configuration_assignment cfg(
+      cluster::topic_configuration(tp_ns.ns, tp_ns.tp, 1, 3), {});
+
+    std::vector<model::broker_shard> replicas;
+    replicas.reserve(3);
+    for (auto n = 0; n < 3; ++n) {
+        replicas.push_back(
+          model::broker_shard{.node_id = model::node_id(n), .shard = 0});
+    }
+
+    cfg.assignments.emplace_back(
+      raft::group_id(0), ntp_0.tp.partition, std::move(replicas));
+
+    apply_cmd<cluster::create_topic_cmd>(
+      topics, tp_ns, std::move(cfg), model::offset(10));
+
+    auto& topic_metadata = table.local().all_topics_metadata();
+
+    // first check if initial revisions of brokers are valid
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_1, model::revision_id(10)},
+        {n_2, model::revision_id(10)}});
+
+    // move one of the topic partitions to new replica set
+    apply_cmd<cluster::move_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_1, 0},
+        model::broker_shard{n_3, 0}, // new broker
+      },
+      model::offset(11));
+
+    // validate that new broker was added with updated revision
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_1, model::revision_id(10)},
+        {n_3, model::revision_id(11)}});
+
+    apply_cmd<cluster::finish_moving_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_1, 0},
+        model::broker_shard{n_3, 0}, // new broker
+      },
+      model::offset(12));
+
+    apply_cmd<cluster::move_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_4, 0}, // new broker
+        model::broker_shard{n_3, 0},
+      },
+      model::offset(13));
+
+    // finish before validating
+    apply_cmd<cluster::finish_moving_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_4, 0}, // new broker
+        model::broker_shard{n_3, 0},
+      },
+      model::offset(14));
+
+    // validate that new broker was added with updated revision
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_4, model::revision_id(13)},
+        {n_3, model::revision_id(11)}});
+
+    // x-core move should not update revision
+    apply_cmd<cluster::move_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_4, 0},
+        model::broker_shard{n_3, 1}, // updated shard
+      },
+      model::offset(15));
+
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_4, model::revision_id(13)},
+        {n_3, model::revision_id(11)}});
+
+    // finish before validating
+    apply_cmd<cluster::finish_moving_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_4, 0},
+        model::broker_shard{n_3, 1}, // updated shard
+      },
+      model::offset(16));
+
+    apply_cmd<cluster::move_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      std::vector<model::broker_shard>{
+        model::broker_shard{n_0, 0},
+        model::broker_shard{n_1, 0}, // new broker
+        model::broker_shard{n_3, 2}, // shard updated
+      },
+      model::offset(17));
+
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_1, model::revision_id(17)},
+        {n_3, model::revision_id(11)}});
+
+    // cancel should revert replica revisions to previous state
+    apply_cmd<cluster::cancel_moving_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      cluster::cancel_moving_partition_replicas_cmd_data(
+        cluster::force_abort_update::no),
+      model::offset(18));
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_4, model::revision_id(13)},
+        {n_3, model::revision_id(11)}});
+
+    // force cancel should not change the revision tracking
+    apply_cmd<cluster::cancel_moving_partition_replicas_cmd>(
+      topics,
+      ntp_0,
+      cluster::cancel_moving_partition_replicas_cmd_data(
+        cluster::force_abort_update::yes),
+      model::offset(19));
+
+    validate_brokers_revisions(
+      ntp_0,
+      topic_metadata,
+      rev_map_t{
+        {n_0, model::revision_id(10)},
+        {n_4, model::revision_id(13)},
+        {n_3, model::revision_id(11)}});
 }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -775,6 +775,28 @@ topic_table::get_previous_replica_set(const model::ntp& ntp) const {
 }
 
 std::vector<model::ntp>
+topic_table::all_ntps_moving_per_node(model::node_id node) const {
+    std::vector<model::ntp> ret;
+
+    for (const auto& [ntp, state] : _updates_in_progress) {
+        auto current_assignment = get_partition_assignment(ntp);
+        if (unlikely(!current_assignment)) {
+            continue;
+        }
+        const auto in_previous = contains_node(state.previous_replicas, node);
+        const auto in_current = contains_node(
+          current_assignment->replicas, node);
+
+        if ((in_previous && in_current) || (!in_previous && !in_current)) {
+            continue;
+        }
+
+        ret.push_back(ntp);
+    }
+    return ret;
+}
+
+std::vector<model::ntp>
 topic_table::ntps_moving_to_node(model::node_id node) const {
     std::vector<model::ntp> ret;
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -203,14 +203,14 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
      * Update partition replica revisions. Assign new revision to added replicas
      * and erase replicas which are removed from replica set
      */
-    auto added_replicas = subtract_replica_sets(
+    auto added_replicas = subtract_replica_sets_by_node_id(
       current_assignment_it->replicas, previous_assignment.replicas);
 
     for (auto& r : added_replicas) {
         revisions_it->second[r.node_id] = model::revision_id(o);
     }
 
-    auto removed_replicas = subtract_replica_sets(
+    auto removed_replicas = subtract_replica_sets_by_node_id(
       previous_assignment.replicas, current_assignment_it->replicas);
 
     for (auto& removed : removed_replicas) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -266,6 +266,11 @@ public:
      */
     std::vector<model::ntp> ntps_moving_from_node(model::node_id) const;
 
+    /**
+     * Lists all ntps moving either from or to a node
+     */
+    std::vector<model::ntp> all_ntps_moving_per_node(model::node_id) const;
+
     std::vector<model::ntp> all_updates_in_progress() const;
 
 private:

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -19,6 +19,7 @@
 #include "cluster/read_replica_manager.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/topic_table.h"
+#include "cluster/types.h"
 #include "model/metadata.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
@@ -107,6 +108,15 @@ public:
     void disable_partition_movement() { _partition_movement_disabled = true; }
     void enable_partition_movement() { _partition_movement_disabled = false; }
 
+    ss::future<result<std::vector<move_cancellation_result>>>
+      cancel_moving_partition_replicas_node(
+        model::node_id,
+        partition_move_direction,
+        model::timeout_clock::time_point);
+
+    ss::future<result<std::vector<move_cancellation_result>>>
+      cancel_moving_all_partition_replicas(model::timeout_clock::time_point);
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -149,6 +159,10 @@ private:
 
     ss::future<topic_result> do_create_partition(
       create_partitions_configuration, model::timeout_clock::time_point);
+
+    ss::future<std::vector<move_cancellation_result>>
+      do_cancel_moving_partition_replicas(
+        std::vector<model::ntp>, model::timeout_clock::time_point);
 
     model::node_id _self;
     ss::sharded<controller_stm>& _stm;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -76,6 +76,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::leadership_changed:
     case cluster::errc::feature_disabled:
     case cluster::errc::no_update_in_progress:
+    case cluster::errc::unknown_update_interruption_error:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -146,6 +146,28 @@
             ]
         },
         {
+            "path": "/v1/brokers/{id}/cancel_partition_moves",
+            "operations": [
+                {
+                    "method": "POST",
+                    "nickname": "cancel_partition_moves",
+                    "summary": "Cancel all partitions movement transferring replicas either to or from given node",
+                    "type": "void",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/maintenance",
             "operations": [
                 {

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -36,6 +36,21 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/cluster/cancel_reconfigurations",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Cancel all partition reconfigurations",
+                    "type": "cancel_all_partitions_reconfigurations",
+                    "nickname": "cancel_all_partitions_reconfigurations",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -470,6 +470,28 @@
                     "description": "Reconfiguration status"
                 }
             }
+        },
+        "partition_result": {
+            "id": "partition_result",
+            "description": "Partition result",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "Namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "Topic"
+                },
+                "partition": {
+                    "type": "long",
+                    "description": "Partition id"
+                },
+                "result": {
+                    "type": "string",
+                    "description": "Status of operation"
+                }
+            }
         }
     }
 }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -532,6 +532,17 @@ bool need_redirect_to_leader(
 
     return leader_id_opt.value() != config::node().node_id();
 }
+
+model::node_id parse_broker_id(const ss::httpd::request& req) {
+    try {
+        return model::node_id(
+          boost::lexical_cast<model::node_id::type>(req.param["id"]));
+    } catch (...) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("Broker id: {}, must be an integer", req.param["id"]));
+    }
+}
+
 } // namespace
 
 /**
@@ -1614,16 +1625,6 @@ void admin_server::register_features_routes() {
           }
           co_return ss::json::json_void();
       });
-}
-
-model::node_id parse_broker_id(const ss::httpd::request& req) {
-    try {
-        return model::node_id(
-          boost::lexical_cast<model::node_id::type>(req.param["id"]));
-    } catch (...) {
-        throw ss::httpd::bad_param_exception(
-          fmt::format("Broker id: {}, must be an integer", req.param["id"]));
-    }
 }
 
 static ss::httpd::broker_json::maintenance_status fill_maintenance_status(

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -47,6 +47,7 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/record.h"
+#include "model/timeout_clock.h"
 #include "net/dns.h"
 #include "raft/types.h"
 #include "redpanda/admin/api-doc/broker.json.h"
@@ -649,6 +650,24 @@ ss::future<> admin_server::throw_on_error(
         throw ss::httpd::server_error_exception(
           fmt::format("Unexpected error: {}", ec.message()));
     }
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::cancel_node_partition_moves(
+  ss::httpd::request& req, cluster::partition_move_direction direction) {
+    auto node_id = parse_broker_id(req);
+    auto res = co_await _controller->get_topics_frontend()
+                 .local()
+                 .cancel_moving_partition_replicas_node(
+                   node_id, direction, model::timeout_clock::now() + 5s);
+
+    if (res.has_error()) {
+        co_await throw_on_error(
+          req, res.error(), model::controller_ntp, node_id);
+    }
+
+    co_return ss::json::json_return_type(
+      co_await map_partition_results(std::move(res.value())));
 }
 
 bool str_to_bool(std::string_view s) {
@@ -1955,6 +1974,12 @@ void admin_server::register_broker_routes() {
               }
           }
           co_return res;
+      });
+    register_route<superuser>(
+      ss::httpd::broker_json::cancel_partition_moves,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return cancel_node_partition_moves(
+            *req, cluster::partition_move_direction::all);
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -176,6 +176,9 @@ private:
     ss::future<ss::httpd::redirect_exception>
     redirect_to_leader(ss::httpd::request& req, model::ntp const& ntp) const;
 
+    ss::future<ss::json::json_return_type> cancel_node_partition_moves(
+      ss::httpd::request& req, cluster::partition_move_direction direction);
+
     struct level_reset {
         using time_point = ss::timer<>::clock::time_point;
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -455,6 +455,22 @@ class Admin:
 
         return self._request('get', path, node=node).json()
 
+    def cancel_all_reconfigurations(self, node=None):
+        """
+        Cancel all pending reconfigurations
+        """
+        path = "cluster/cancel_reconfigurations"
+
+        return self._request('post', path, node=node).json()
+
+    def cancel_all_node_reconfigurations(self, target_id, node=None):
+        """
+        Cancel all reconfigurations moving partition replicas from node
+        """
+        path = f"brokers/{target_id}/cancel_partition_moves"
+
+        return self._request('post', path, node=node).json()
+
     def get_partitions(self,
                        topic=None,
                        partition=None,

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -45,7 +45,15 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.partition_count = 20
 
     def replace_replicas(self, admin, assignments, x_core_only=False):
-
+        """
+         replaces random number of replicas in `assignments` list of replicas
+        
+        :param admin: admin api client
+        :param assignments: list of dictionaries {"node_id": ...,"core"...} describing partition replica assignments.
+        :param x_core_only: when true assignment nodes will not be changed, only cores
+        
+        :return: a tuple of lists, list of previous assignments and list of replaced assignments
+        """
         if x_core_only:
             selected = assignments.copy()
             brokers = admin.get_brokers()
@@ -71,6 +79,12 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         return selected, replacements
 
     def _dispatch_move(self, partition, x_core_only=False):
+        """
+        Request partition replicas to be randomly moved
+
+        :param partition: partition id to be moved
+        :param x_core_only: when true assignment nodes will not be changed, only cores
+        """
         admin = Admin(self.redpanda)
 
         assignments = self._get_assignments(admin, self.topic, partition)
@@ -94,6 +108,9 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         return prev_assignments, assignments
 
     def _cancel_move(self, unclean_abort, partition, previous_assignment):
+        """
+        Request partition movement to interrupt and validates resulting cancellation against previous assignment
+        """
         admin = Admin(self.redpanda)
 
         def move_in_progress():


### PR DESCRIPTION
## Cover letter

Added admin API allowing user to cancel all partition reconfigurations in a cluster or all reconfigurations moving partition replica from/to the node.

The APIs are as follows:

```
# cancel reconfgurations moving partition replicas to or from node with given `id`
POST /v1/brokers/{id}/cancel_partition_moves

# cancel all reconfigurations in the cluster
POST /v1/cluster/cancel_reconfigurations

```


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes: https://github.com/redpanda-data/redpanda/issues/5326

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
