### PR TITLE
config: fix name+handling of topic_partitions_reserve_shard0

### DIFF
--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -195,8 +195,7 @@ std::error_code partition_allocator::check_cluster_limits(
 
     // Refuse to create a partition count that would violate the per-core
     // limit.
-    const uint64_t core_limit
-      = (effective_cpu_count * _partitions_per_shard() - all_brokers.size() * _partitions_reserve_shard0());
+    const uint64_t core_limit = (effective_cpu_count * _partitions_per_shard());
     if (proposed_total_partitions > core_limit) {
         vlog(
           clusterlog.warn,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -138,7 +138,7 @@ configuration::configuration()
       })
   , topic_partitions_reserve_shard0(
       *this,
-      "topic_reserve_shard0",
+      "topic_partitions_reserve_shard0",
       "Reserved partition slots on shard (CPU core) 0 on each node.  If this "
       "is >= topic_partitions_per_core, no data partitions will be scheduled "
       "on shard 0",


### PR DESCRIPTION
## Cover letter

- Name: this was a typo, omitting the 'partitions' part
of the name.  The PR adding the property only just merged, so this is a non-disruptive change.
- Behavior: I made a mistake assuming we needed to explicitly handle the reserved units when calculating partition allowances: they were already implicitly captured in the way the code calculates the existing partition count (the reserved units are in that count)

## Release notes


* none
