### PR TITLE
r/consensus: try updating leader commit index after aborting config c…

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1069,6 +1069,12 @@ consensus::abort_configuration_change(model::revision_id revision) {
       append_result.base_offset);
     // flush log as all configuration changes must eventually be committed.
     co_await flush_log();
+    // if current node is a leader make sure we will try to update committed
+    // index, it may be required for single participant raft groups
+    if (is_leader()) {
+        maybe_update_majority_replicated_index();
+        maybe_update_leader_commit_idx();
+    }
     co_return errc::success;
 }
 


### PR DESCRIPTION
…hange

When configuration change is aborted we append simple configuration
entry to each raft group member log. If node is a leader we must try to
update the committed index. For single replica raft groups that is the
only way to make the committed offset progress and finish
reconfiguration.

Updating committed offset is possible for single replica raft groups as
the node is the only source of truth for all raft decisions hence an
entry appended to leader log may immediately be committed.

Fixes: #5338
