### PR TITLE
Fix for failure in nodes decommissioning test

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -193,4 +193,5 @@ class NodesDecommissioningTest(EndToEndTest):
         wait_until(lambda: self._node_removed(to_decommission, survivor_node),
                    timeout_sec=120,
                    backoff_sec=2)
-        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
+        self.run_validation(enable_idempotence=False, consumer_timeout_sec=90)

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -194,4 +194,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    timeout_sec=120,
                    backoff_sec=2)
 
+        # stop decommissioned node
+        self.redpanda.stop_node(self.redpanda.get_node(to_decommission))
+
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=90)


### PR DESCRIPTION
## Cover letter

Improved nodes decommissioning test to prevent consumer contacting the node which is not longer part of a cluster and gave consumer more time to finish consuming 

Fixes #5337 

## Release notes

* none

