### PR TITLE
Compaction keyspaces

### DIFF
--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -55,14 +55,23 @@ struct compacted_index {
         }
     };
     enum class recovery_state {
-        // happens during a crash
-        missing,
-        // needs rebuilding - when user 'touch' a file or during a crash
-        needsrebuild,
-        // already recovered - nothing to do - after a reboot
-        recovered,
-        // we need to compact next
-        nonrecovered
+        /**
+         * Index may be missing when either was deleted or not stored when
+         * redpanda crashed
+         */
+        index_missing,
+        /**
+         * Index may needs a rebuild when it is corrupted
+         */
+        index_needs_rebuild,
+        /**
+         * Segment is already compacted
+         */
+        already_compacted,
+        /**
+         * Compaction index is recovered, ready to compaction
+         */
+        index_recovered
     };
     static constexpr size_t footer_size = sizeof(footer::size)
                                           + sizeof(footer::keys)
@@ -83,6 +92,9 @@ struct compacted_index {
         int32_t delta;
     };
 };
+
+std::ostream& operator<<(std::ostream&, compacted_index::recovery_state);
+
 [[gnu::always_inline]] inline compacted_index::footer_flags
 operator|(compacted_index::footer_flags a, compacted_index::footer_flags b) {
     return compacted_index::footer_flags(

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "bytes/bytes.h"
 #include "model/fundamental.h"
+#include "model/record_batch_types.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -27,6 +28,20 @@ struct compaction_key : bytes {
     explicit compaction_key(bytes b)
       : bytes(std::move(b)) {}
 };
+
+inline compaction_key
+prefix_with_batch_type(model::record_batch_type type, bytes_view key) {
+    auto bt_le = ss::cpu_to_le(
+      static_cast<std::underlying_type<model::record_batch_type>::type>(type));
+    auto enriched_key = ss::uninitialized_string<bytes>(
+      sizeof(bt_le) + key.size());
+    auto out = enriched_key.begin();
+    out = std::copy_n(
+      reinterpret_cast<const char*>(&bt_le), sizeof(bt_le), out);
+    std::copy_n(key.begin(), key.size(), out);
+
+    return compaction_key(std::move(enriched_key));
+}
 
 struct compacted_index {
     static constexpr const size_t max_entry_size = size_t(
@@ -48,12 +63,17 @@ struct compacted_index {
         self_compaction = 1U << 1U,
     };
     struct footer {
+        // initial version of footer
+        static constexpr int8_t base_version = 0;
+        // introduced a key being a tuple of batch_type and the key content
+        static constexpr int8_t key_prefixed_with_batch_type = 1;
+
         uint32_t size{0};
         uint32_t keys{0};
         footer_flags flags{0};
         uint32_t crc{0}; // crc32
         // version *must* be the last value
-        int8_t version{0};
+        int8_t version{key_prefixed_with_batch_type};
 
         friend std::ostream&
         operator<<(std::ostream& o, const compacted_index::footer& f) {
@@ -88,14 +108,15 @@ struct compacted_index {
                                           + sizeof(footer::version);
     // for the readers and friends
     struct entry {
-        entry(entry_type t, bytes k, model::offset o, int32_t d) noexcept
+        entry(
+          entry_type t, compaction_key k, model::offset o, int32_t d) noexcept
           : type(t)
           , key(std::move(k))
           , offset(o)
           , delta(d) {}
 
         entry_type type;
-        bytes key;
+        compaction_key key;
         model::offset offset;
         int32_t delta;
     };

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -20,6 +20,14 @@
 namespace storage {
 // simple types shared among readers and writers
 
+/**
+ * Type representing a record key prefixed with batch_type
+ */
+struct compaction_key : bytes {
+    explicit compaction_key(bytes b)
+      : bytes(std::move(b)) {}
+};
+
 struct compacted_index {
     static constexpr const size_t max_entry_size = size_t(
       std::numeric_limits<uint16_t>::max());

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -212,7 +212,8 @@ compacted_index_chunk_reader::load_slice(model::timeout_clock::time_point t) {
                              auto type = reflection::adl<uint8_t>{}.from(p);
                              auto [offset, _1] = p.read_varlong();
                              auto [delta, _2] = p.read_varlong();
-                             auto key = p.read_bytes(p.bytes_left());
+                             auto bytes = p.read_bytes(p.bytes_left());
+                             auto key = compaction_key(std::move(bytes));
                              slice.push_back(compacted_index::entry(
                                compacted_index::entry_type(type),
                                std::move(key),

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -118,12 +118,7 @@ std::optional<model::record_batch>
 copy_data_segment_reducer::filter(model::record_batch&& batch) {
     // do not compact raft configuration and archival metadata as they shift
     // offset translation
-    if (
-      batch.header().type == model::record_batch_type::raft_configuration
-      || batch.header().type == model::record_batch_type::archival_metadata
-      || batch.header().type == model::record_batch_type::group_abort_tx
-      || batch.header().type == model::record_batch_type::group_commit_tx
-      || batch.header().type == model::record_batch_type::group_prepare_tx) {
+    if (!is_compactible(batch)) {
         return std::move(batch);
     }
 

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -97,8 +97,7 @@ index_filtered_copy_reducer::operator()(compacted_index::entry&& e) {
     const bool should_add = _bm.contains(_natural_index);
     ++_natural_index;
     if (should_add) {
-        bytes_view bv = e.key;
-        return _writer->index(bv, e.offset, e.delta)
+        return _writer->index(e.key, e.offset, e.delta)
           .then([k = std::move(e.key)] {
               return ss::make_ready_future<stop_t>(stop_t::no);
           });
@@ -294,8 +293,9 @@ index_rebuilder_reducer::operator()(model::record_batch&& b) {
 ss::future<> index_rebuilder_reducer::do_index(model::record_batch&& b) {
     return ss::do_with(std::move(b), [this](model::record_batch& b) {
         return model::for_each_record(
-          b, [this, o = b.base_offset()](model::record& r) {
-              return _w->index(r.key(), o, r.offset_delta());
+          b,
+          [this, bt = b.header().type, o = b.base_offset()](model::record& r) {
+              return _w->index(bt, r.key(), o, r.offset_delta());
           });
     });
 }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -179,7 +179,7 @@ ss::future<> segment::release_appender(readers_cache* readers_cache) {
      * An exception safe variant of try write lock is simulated since seastar
      * does not have such primitives available on the semaphore. The fast path
      * of try_write_lock is combined with immediately releasing the lock (which
-     * will not also not signal any waiters--there cannot be any!) to guarnatee
+     * will not also not signal any waiters--there cannot be any!) to guarantee
      * that the blocking get_units version will find the lock uncontested.
      *
      * TODO: we should upstream get_units try-variants for semaphore and rwlock.
@@ -447,7 +447,7 @@ ss::future<append_result> segment::append(const model::record_batch& b) {
           auto index_err = std::move(index_fut).get_exception();
           vlog(
             stlog.error,
-            "segment::append index: {}. ignorning append: {}",
+            "segment::append index: {}. ignoring append: {}",
             index_err,
             ret);
           return ss::make_exception_future<append_result>(index_err);

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -357,8 +357,10 @@ ss::future<> segment::do_compaction_index_batch(const model::record_batch& b) {
     vassert(!b.compressed(), "wrong method. Call compact_index_batch. {}", b);
     auto& w = compaction_index();
     return model::for_each_record(
-      b, [o = b.base_offset(), &w](const model::record& r) {
-          return w.index(r.key(), o, r.offset_delta());
+      b,
+      [o = b.base_offset(), batch_type = b.header().type, &w](
+        const model::record& r) {
+          return w.index(batch_type, r.key(), o, r.offset_delta());
       });
 }
 ss::future<> segment::compaction_index_batch(const model::record_batch& b) {

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -365,6 +365,11 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
     if (!has_compaction_index()) {
         return ss::now();
     }
+    // do not index not compactible batches
+    if (!internal::is_compactible(b)) {
+        return ss::now();
+    }
+
     if (!b.compressed()) {
         return do_compaction_index_batch(b);
     }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -283,6 +283,13 @@ ss::future<compacted_index::recovery_state> do_detect_compaction_index_state(
                 if (bool(footer.flags & flags::self_compaction)) {
                     return compacted_index::recovery_state::already_compacted;
                 }
+                // if we deal with old version of index that is not yet
+                // compacted request a rebuild
+                if (
+                  footer.version
+                  < compacted_index::footer::key_prefixed_with_batch_type) {
+                    return compacted_index::recovery_state::index_needs_rebuild;
+                }
                 return compacted_index::recovery_state::index_recovered;
             })
             .finally([reader]() mutable { return reader.close(); });

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -194,4 +194,13 @@ struct clean_segment_value
     ss::sstring segment_name;
 };
 
+inline bool is_compactible(const model::record_batch& b) {
+    return !(
+      b.header().type == model::record_batch_type::raft_configuration
+      || b.header().type == model::record_batch_type::archival_metadata
+      || b.header().type == model::record_batch_type::group_abort_tx
+      || b.header().type == model::record_batch_type::group_commit_tx
+      || b.header().type == model::record_batch_type::group_prepare_tx);
+}
+
 } // namespace storage::internal

--- a/src/v/storage/tests/compaction_idx_bench.cc
+++ b/src/v/storage/tests/compaction_idx_bench.cc
@@ -30,7 +30,10 @@ PERF_TEST_F(reducer_bench, compaction_key_reducer_test) {
     auto key = random_generators::get_bytes(20);
 
     storage::compacted_index::entry entry(
-      storage::compacted_index::entry_type::key, std::move(key), o, 0);
+      storage::compacted_index::entry_type::key,
+      storage::compaction_key(std::move(key)),
+      o,
+      0);
 
     perf_tests::start_measuring_time();
     return reducer(std::move(entry)).discard_result().finally([] {

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -24,13 +24,10 @@
 
 #include <boost/test/unit_test_suite.hpp>
 
-class
-
-  storage::compacted_index_writer
-  make_dummy_compacted_index(
-    tmpbuf_file::store_t& index_data,
-    size_t max_mem,
-    storage::storage_resources& resources) {
+storage::compacted_index_writer make_dummy_compacted_index(
+  tmpbuf_file::store_t& index_data,
+  size_t max_mem,
+  storage::storage_resources& resources) {
     auto f = ss::file(ss::make_shared(tmpbuf_file(index_data)));
     return storage::compacted_index_writer(
       std::make_unique<storage::internal::spill_key_index>(
@@ -41,16 +38,52 @@ struct compacted_topic_fixture {
     storage::storage_resources resources;
 };
 
+model::record_batch_type random_batch_type() {
+    return random_generators::random_choice(
+      std::vector<model::record_batch_type>{
+        model::record_batch_type::raft_data,
+        model::record_batch_type::raft_configuration,
+        model::record_batch_type::controller,
+        model::record_batch_type::kvstore,
+        model::record_batch_type::checkpoint,
+        model::record_batch_type::topic_management_cmd,
+        model::record_batch_type::ghost_batch,
+        model::record_batch_type::id_allocator,
+        model::record_batch_type::tx_prepare,
+        model::record_batch_type::tx_fence,
+        model::record_batch_type::tm_update,
+        model::record_batch_type::user_management_cmd,
+        model::record_batch_type::acl_management_cmd,
+        model::record_batch_type::group_prepare_tx,
+        model::record_batch_type::group_commit_tx,
+        model::record_batch_type::group_abort_tx,
+        model::record_batch_type::node_management_cmd,
+        model::record_batch_type::data_policy_management_cmd,
+        model::record_batch_type::archival_metadata,
+        model::record_batch_type::cluster_config_cmd,
+        model::record_batch_type::feature_update,
+      });
+}
+
+bytes extract_record_key(bytes prefixed_key) {
+    size_t sz = prefixed_key.size() - 1;
+    auto read_key = ss::uninitialized_string<bytes>(sz);
+
+    std::copy_n(prefixed_key.begin() + 1, sz, read_key.begin());
+    return read_key;
+}
+
 FIXTURE_TEST(format_verification, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
     auto idx = make_dummy_compacted_index(index_data, 1_KiB, resources);
     const auto key = random_generators::get_bytes(1024);
-    idx.index(key, model::offset(42), 66).get();
+    auto bt = random_batch_type();
+    idx.index(bt, bytes(key), model::offset(42), 66).get();
     idx.close().get();
     info("{}", idx);
 
     iobuf data = std::move(index_data).release_iobuf();
-    BOOST_REQUIRE_EQUAL(data.size_bytes(), 1047);
+    BOOST_REQUIRE_EQUAL(data.size_bytes(), 1048);
     iobuf_parser p(data.share(0, data.size_bytes()));
     (void)p.consume_type<uint16_t>(); // SIZE
     (void)p.consume_type<uint8_t>();  // TYPE
@@ -58,30 +91,36 @@ FIXTURE_TEST(format_verification, compacted_topic_fixture) {
     BOOST_REQUIRE_EQUAL(model::offset(offset), model::offset(42));
     auto [delta, _2] = p.read_varlong();
     BOOST_REQUIRE_EQUAL(delta, 66);
-    const auto key_result = p.read_bytes(1024);
-    BOOST_REQUIRE_EQUAL(key, key_result);
+    const auto key_result = p.read_bytes(1025);
+
+    auto read_key = extract_record_key(key_result);
+    BOOST_REQUIRE_EQUAL(key, read_key);
     auto footer = reflection::adl<storage::compacted_index::footer>{}.from(p);
     info("{}", footer);
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
     BOOST_REQUIRE_EQUAL(
       footer.size,
-      sizeof(uint16_t)
-        + 1 /*type*/ + 1 /*offset*/ + 2 /*delta*/ + 1024 /*key*/);
-    BOOST_REQUIRE_EQUAL(footer.version, 0);
+      sizeof(uint16_t) + 1 /*type*/ + 1 /*offset*/ + 2 /*delta*/
+        + 1 /*batch_type*/ + 1024 /*key*/);
+    BOOST_REQUIRE_EQUAL(
+      footer.version,
+      storage::compacted_index::footer::key_prefixed_with_batch_type);
     BOOST_REQUIRE(footer.crc != 0);
 }
 FIXTURE_TEST(format_verification_max_key, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
     auto idx = make_dummy_compacted_index(index_data, 1_MiB, resources);
     const auto key = random_generators::get_bytes(1_MiB);
-    idx.index(key, model::offset(42), 66).get();
+    auto bt = random_batch_type();
+    idx.index(bt, bytes(key), model::offset(42), 66).get();
     idx.close().get();
     info("{}", idx);
 
     /**
      * Length of an entry is equal to
      *
-     * max_key_size + sizeof(uint8_t) + sizeof(uint16_t) + vint(42) + vint(66)
+     * max_key_size + sizeof(uint8_t) + sizeof(uint16_t) + vint(42) +
+     * vint(66)
      */
     iobuf data = std::move(index_data).release_iobuf();
 
@@ -104,7 +143,8 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
     auto idx = make_dummy_compacted_index(index_data, 1_MiB, resources);
     const auto key = random_generators::get_bytes(20);
-    idx.index(key, model::offset(42), 66).get();
+    auto bt = random_batch_type();
+    idx.index(bt, bytes(key), model::offset(42), 66).get();
     idx.close().get();
     info("{}", idx);
 
@@ -115,20 +155,23 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
       32_KiB);
     auto footer = rdr.load_footer().get0();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
-    BOOST_REQUIRE_EQUAL(footer.version, 0);
+    BOOST_REQUIRE_EQUAL(
+      footer.version,
+      storage::compacted_index::footer::key_prefixed_with_batch_type);
     BOOST_REQUIRE(footer.crc != 0);
     auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);
     BOOST_REQUIRE_EQUAL(vec[0].offset, model::offset(42));
     BOOST_REQUIRE_EQUAL(vec[0].delta, 66);
-    BOOST_REQUIRE_EQUAL(vec[0].key, key);
+    BOOST_REQUIRE_EQUAL(extract_record_key(vec[0].key), key);
 }
 FIXTURE_TEST(
   format_verification_roundtrip_exceeds_capacity, compacted_topic_fixture) {
     tmpbuf_file::store_t index_data;
     auto idx = make_dummy_compacted_index(index_data, 1_MiB, resources);
     const auto key = random_generators::get_bytes(1_MiB);
-    idx.index(key, model::offset(42), 66).get();
+    auto bt = random_batch_type();
+    idx.index(bt, bytes(key), model::offset(42), 66).get();
     idx.close().get();
     info("{}", idx);
 
@@ -139,7 +182,9 @@ FIXTURE_TEST(
       32_KiB);
     auto footer = rdr.load_footer().get0();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
-    BOOST_REQUIRE_EQUAL(footer.version, 0);
+    BOOST_REQUIRE_EQUAL(
+      footer.version,
+      storage::compacted_index::footer::key_prefixed_with_batch_type);
     BOOST_REQUIRE(footer.crc != 0);
     auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);
@@ -147,7 +192,8 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(vec[0].delta, 66);
     auto max_sz = storage::internal::spill_key_index::max_key_size;
     BOOST_REQUIRE_EQUAL(vec[0].key.size(), max_sz);
-    BOOST_REQUIRE_EQUAL(vec[0].key, bytes_view(key.data(), max_sz));
+    BOOST_REQUIRE_EQUAL(
+      extract_record_key(vec[0].key), bytes_view(key.data(), max_sz - 1));
 }
 
 FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
@@ -157,6 +203,7 @@ FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
 
     const auto key1 = random_generators::get_bytes(1_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
+    auto bt = random_batch_type();
     for (auto i = 0; i < 100; ++i) {
         bytes_view put_key;
         if (i % 2) {
@@ -164,7 +211,7 @@ FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
         } else {
             put_key = key2;
         }
-        idx.index(put_key, model::offset(i), 0).get();
+        idx.index(bt, bytes(put_key), model::offset(i), 0).get();
     }
     idx.close().get();
     info("{}", idx);
@@ -197,6 +244,7 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
 
     const auto key1 = random_generators::get_bytes(1_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
+    auto bt = random_batch_type();
     for (auto i = 0; i < 100; ++i) {
         bytes_view put_key;
         if (i % 2) {
@@ -204,7 +252,7 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
         } else {
             put_key = key2;
         }
-        idx.index(put_key, model::offset(i), 0).get();
+        idx.index(bt, bytes(put_key), model::offset(i), 0).get();
     }
     idx.close().get();
     info("{}", idx);
@@ -262,6 +310,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
 
     const auto key1 = random_generators::get_bytes(128_KiB);
     const auto key2 = random_generators::get_bytes(1_KiB);
+    auto bt = random_batch_type();
     for (auto i = 0; i < 100; ++i) {
         bytes_view put_key;
         if (i % 2) {
@@ -269,7 +318,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
         } else {
             put_key = key2;
         }
-        idx.index(put_key, model::offset(i), 0).get();
+        idx.index(bt, bytes(put_key), model::offset(i), 0).get();
     }
     idx.close().get();
     info("{}", idx);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -9,6 +9,7 @@
 
 #include "storage/types.h"
 
+#include "storage/compacted_index.h"
 #include "storage/ntp_config.h"
 #include "utils/human.h"
 #include "utils/to_string.h"
@@ -169,4 +170,18 @@ std::ostream& operator<<(std::ostream& o, const compaction_result& r) {
     return o;
 }
 
+std::ostream&
+operator<<(std::ostream& o, compacted_index::recovery_state state) {
+    switch (state) {
+    case compacted_index::recovery_state::index_missing:
+        return o << "index_missing";
+    case compacted_index::recovery_state::already_compacted:
+        return o << "already_compacted";
+    case compacted_index::recovery_state::index_needs_rebuild:
+        return o << "index_needs_rebuild";
+    case compacted_index::recovery_state::index_recovered:
+        return o << "index_recovered";
+    }
+    __builtin_unreachable();
+}
 } // namespace storage


### PR DESCRIPTION
## Cover letter

Added batch type prefix to key stored in compaction index, both on disk and in memory. This way a key stored in an index in actually a tuple consisting of (batch_type, key_payload). Thanks to this approach compaction logic is able to compact keys per batch type instead of discriminating the batch type completely.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5243 
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
