### PR TITLE
Per-handler memory estimation, more accurate estimate for metadata handler

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -34,6 +34,7 @@ set(handlers_srcs
   server/handlers/delete_acls.cc
   server/handlers/create_partitions.cc
   server/handlers/offset_for_leader_epoch.cc
+  server/handlers/handler_interface.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -13,10 +13,12 @@
 #include "bytes/iobuf.h"
 #include "config/configuration.h"
 #include "kafka/protocol/sasl_authenticate.h"
+#include "kafka/server/handlers/handler_interface.h"
 #include "kafka/server/protocol.h"
 #include "kafka/server/protocol_utils.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
 #include "security/exceptions.h"
 #include "units.h"
 #include "vlog.h"
@@ -236,8 +238,9 @@ connection_context::throttle_request(
     }
     auto track = track_latency(hdr.key);
     return fut
-      .then(
-        [this, request_size] { return reserve_request_units(request_size); })
+      .then([this, key = hdr.key, request_size] {
+          return reserve_request_units(key, request_size);
+      })
       .then([this, delay, track, tracker = std::move(tracker)](
               ss::semaphore_units<> units) mutable {
           return server().get_request_unit().then(
@@ -262,15 +265,21 @@ connection_context::throttle_request(
 }
 
 ss::future<ss::semaphore_units<>>
-connection_context::reserve_request_units(size_t size) {
-    // Allow for extra copies and bookkeeping
-    auto mem_estimate = size * 2 + 8000; // NOLINT
-    if (mem_estimate >= (size_t)std::numeric_limits<int32_t>::max()) {
+connection_context::reserve_request_units(api_key key, size_t size) {
+    // Defer to the handler for the request type for the memory estimate, but
+    // if the request isn't found, use the default estimate (although in that
+    // case the request is likely for an API we don't support or malformed, so
+    // it is likely to fail shortly anyway).
+    auto handler = handler_for_key(key);
+    auto mem_estimate = handler ? (*handler)->memory_estimate(size)
+                                : default_memory_estimate(size);
+    if (unlikely(mem_estimate >= (size_t)std::numeric_limits<int32_t>::max())) {
         // TODO: Create error response using the specific API?
         throw std::runtime_error(fmt::format(
-          "request too large > 1GB (size: {}; estimate: {})",
+          "request too large > 1GB (size: {}, estimate: {}, API: {})",
           size,
-          mem_estimate));
+          mem_estimate,
+          handler ? (*handler)->name() : "<bad key>"));
     }
     auto fut = ss::get_units(_rs.memory(), mem_estimate);
     if (_rs.memory().waiters()) {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -272,7 +272,7 @@ connection_context::reserve_request_units(api_key key, size_t size) {
     // case the request is likely for an API we don't support or malformed, so
     // it is likely to fail shortly anyway).
     auto handler = handler_for_key(key);
-    auto mem_estimate = handler ? (*handler)->memory_estimate(size)
+    auto mem_estimate = handler ? (*handler)->memory_estimate(size, *this)
                                 : default_memory_estimate(size);
     if (unlikely(mem_estimate >= (size_t)std::numeric_limits<int32_t>::max())) {
         // TODO: Create error response using the specific API?

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -167,7 +167,8 @@ private:
     // Reserve units from memory from the memory semaphore in proportion
     // to the number of bytes the request procesisng is expected to
     // take.
-    ss::future<ss::semaphore_units<>> reserve_request_units(size_t size);
+    ss::future<ss::semaphore_units<>>
+    reserve_request_units(api_key key, size_t size);
 
     // Apply backpressure sequence, where the request processing may be
     // delayed for various reasons, including throttling but also because

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -191,8 +191,16 @@ private:
     ss::future<> handle_auth_v0(size_t);
 
 private:
+    /**
+     * Bundles together a response and its associated resources.
+     */
+    struct response_and_resources {
+        response_ptr response;
+        session_resources resources;
+    };
+
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
-    using map_t = absl::flat_hash_map<sequence_id, response_ptr>;
+    using map_t = absl::flat_hash_map<sequence_id, response_and_resources>;
 
     class ctx_log {
     public:

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -148,7 +148,14 @@ private:
     private:
         net::server_probe& _probe;
     };
-    // used to pass around some internal state
+
+    // Used to hold resources associated with a given request until
+    // the response has been send, as well as to track some statistics
+    // about the request.
+    //
+    // The resources in particular should be not be destroyed until
+    // the request is complete (e.g., all the information written to
+    // the socket so that no userspace buffers remain).
     struct session_resources {
         ss::lowres_clock::duration backpressure_delay;
         ss::semaphore_units<> memlocks;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -166,7 +166,19 @@ private:
 
     ss::future<> handle_mtls_auth();
     ss::future<> dispatch_method_once(request_header, size_t sz);
-    ss::future<> process_next_response();
+
+    /**
+     * Process zero or more ready responses in request order.
+     *
+     * The future<> returned by this method resolves when all ready *and*
+     * in-order responses have been processed, which is not the same as all
+     * ready responses. In particular, responses which are ready may not be
+     * processed if there are earlier (lower sequence number) responses which
+     * are not yet ready: they will be processed by a future invocation.
+     *
+     * @return ss::future<> a future which as described above.
+     */
+    ss::future<> maybe_process_responses();
     ss::future<> do_process(request_context);
 
     ss::future<> handle_auth_v0(size_t);

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -164,10 +164,18 @@ private:
         std::unique_ptr<request_tracker> tracker;
     };
 
-    /// called by throttle_request
+    // Reserve units from memory from the memory semaphore in proportion
+    // to the number of bytes the request procesisng is expected to
+    // take.
     ss::future<ss::semaphore_units<>> reserve_request_units(size_t size);
 
-    /// apply correct backpressure sequence
+    // Apply backpressure sequence, where the request processing may be
+    // delayed for various reasons, including throttling but also because
+    // too few server resources are available to accomodate the request
+    // currently.
+    // When the returned future resolves, the throttling period is over and
+    // the associated resouces have been obtained and are tracked by the
+    // contained session_resources object.
     ss::future<session_resources>
     throttle_request(const request_header&, size_t sz);
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "kafka/server/protocol.h"
 #include "kafka/server/response.h"
+#include "kafka/types.h"
 #include "net/server.h"
 #include "seastarx.h"
 #include "security/acl.h"
@@ -36,6 +37,41 @@ using authz_quiet = ss::bool_class<struct authz_quiet_tag>;
 
 struct request_header;
 class request_context;
+
+// used to track number of pending requests
+class request_tracker {
+public:
+    explicit request_tracker(net::server_probe& probe) noexcept
+      : _probe(probe) {
+        _probe.request_received();
+    }
+    request_tracker(const request_tracker&) = delete;
+    request_tracker(request_tracker&&) = delete;
+    request_tracker& operator=(const request_tracker&) = delete;
+    request_tracker& operator=(request_tracker&&) = delete;
+
+    ~request_tracker() noexcept { _probe.request_completed(); }
+
+private:
+    net::server_probe& _probe;
+};
+
+// Used to hold resources associated with a given request until
+// the response has been send, as well as to track some statistics
+// about the request.
+//
+// The resources in particular should be not be destroyed until
+// the request is complete (e.g., all the information written to
+// the socket so that no userspace buffers remain).
+struct session_resources {
+    using pointer = ss::lw_shared_ptr<session_resources>;
+
+    ss::lowres_clock::duration backpressure_delay;
+    ss::semaphore_units<> memlocks;
+    ss::semaphore_units<> queue_units;
+    std::unique_ptr<hdr_hist::measurement> method_latency;
+    std::unique_ptr<request_tracker> tracker;
+};
 
 class connection_context final
   : public ss::enable_lw_shared_from_this<connection_context> {
@@ -131,39 +167,6 @@ public:
     }
 
 private:
-    // used to track number of pending requests
-    class request_tracker {
-    public:
-        explicit request_tracker(net::server_probe& probe) noexcept
-          : _probe(probe) {
-            _probe.request_received();
-        }
-        request_tracker(const request_tracker&) = delete;
-        request_tracker(request_tracker&&) = delete;
-        request_tracker& operator=(const request_tracker&) = delete;
-        request_tracker& operator=(request_tracker&&) = delete;
-
-        ~request_tracker() noexcept { _probe.request_completed(); }
-
-    private:
-        net::server_probe& _probe;
-    };
-
-    // Used to hold resources associated with a given request until
-    // the response has been send, as well as to track some statistics
-    // about the request.
-    //
-    // The resources in particular should be not be destroyed until
-    // the request is complete (e.g., all the information written to
-    // the socket so that no userspace buffers remain).
-    struct session_resources {
-        ss::lowres_clock::duration backpressure_delay;
-        ss::semaphore_units<> memlocks;
-        ss::semaphore_units<> queue_units;
-        std::unique_ptr<hdr_hist::measurement> method_latency;
-        std::unique_ptr<request_tracker> tracker;
-    };
-
     // Reserve units from memory from the memory semaphore in proportion
     // to the number of bytes the request procesisng is expected to
     // take.
@@ -205,7 +208,7 @@ private:
      */
     struct response_and_resources {
         response_ptr response;
-        session_resources resources;
+        session_resources::pointer resources;
     };
 
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;

--- a/src/v/kafka/server/flex_versions.cc
+++ b/src/v/kafka/server/flex_versions.cc
@@ -18,13 +18,6 @@ namespace kafka {
 static constexpr api_version invalid_api = api_version(-2);
 
 template<typename... RequestTypes>
-static constexpr size_t max_api_key(type_list<RequestTypes...>) {
-    /// Black magic here is an overload of std::max() that takes an
-    /// std::initializer_list
-    return std::max({RequestTypes::api::key()...});
-}
-
-template<typename... RequestTypes>
 static constexpr auto
 get_flexible_request_min_versions_list(type_list<RequestTypes...> r) {
     /// An std::array where the indicies map to api_keys and values at an index

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -13,13 +13,14 @@
 
 namespace kafka {
 
+// sorted
 class coordinator_ntp_mapper;
 class fetch_session_cache;
 class group_manager;
 class group_router;
+class quota_manager;
+class request_context;
 class rm_group_frontend;
 class rm_group_proxy_impl;
-class request_context;
-class quota_manager;
 
 } // namespace kafka

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -14,6 +14,7 @@
 namespace kafka {
 
 // sorted
+class connection_context;
 class coordinator_ntp_mapper;
 class fetch_session_cache;
 class group_manager;

--- a/src/v/kafka/server/handlers/add_offsets_to_txn.h
+++ b/src/v/kafka/server/handlers/add_offsets_to_txn.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using add_offsets_to_txn_handler = handler<add_offsets_to_txn_api, 0, 1>;
+using add_offsets_to_txn_handler
+  = single_stage_handler<add_offsets_to_txn_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.h
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using add_partitions_to_txn_handler = handler<add_partitions_to_txn_api, 0, 2>;
+using add_partitions_to_txn_handler
+  = single_stage_handler<add_partitions_to_txn_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/alter_configs.h
+++ b/src/v/kafka/server/handlers/alter_configs.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using alter_configs_handler = handler<alter_configs_api, 0, 1>;
+using alter_configs_handler = single_stage_handler<alter_configs_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -14,7 +14,8 @@
 
 namespace kafka {
 
-struct api_versions_handler : public handler<api_versions_api, 0, 3> {
+struct api_versions_handler
+  : public single_stage_handler<api_versions_api, 0, 3> {
     static constexpr api_version min_flexible = api_version(3);
 
     static ss::future<response_ptr>

--- a/src/v/kafka/server/handlers/create_acls.h
+++ b/src/v/kafka/server/handlers/create_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using create_acls_handler = handler<create_acls_api, 0, 1>;
+using create_acls_handler = single_stage_handler<create_acls_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/create_partitions.h
+++ b/src/v/kafka/server/handlers/create_partitions.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using create_partitions_handler = handler<create_partitions_api, 0, 1>;
+using create_partitions_handler
+  = single_stage_handler<create_partitions_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/create_topics.h
+++ b/src/v/kafka/server/handlers/create_topics.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using create_topics_handler = handler<create_topics_api, 0, 5>;
+using create_topics_handler = single_stage_handler<create_topics_api, 0, 5>;
 
 }

--- a/src/v/kafka/server/handlers/delete_acls.h
+++ b/src/v/kafka/server/handlers/delete_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using delete_acls_handler = handler<delete_acls_api, 0, 1>;
+using delete_acls_handler = single_stage_handler<delete_acls_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/delete_groups.h
+++ b/src/v/kafka/server/handlers/delete_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using delete_groups_handler = handler<delete_groups_api, 0, 1>;
+using delete_groups_handler = single_stage_handler<delete_groups_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/delete_topics.h
+++ b/src/v/kafka/server/handlers/delete_topics.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using delete_topics_handler = handler<delete_topics_api, 0, 3>;
+using delete_topics_handler = single_stage_handler<delete_topics_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/describe_acls.h
+++ b/src/v/kafka/server/handlers/describe_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using describe_acls_handler = handler<describe_acls_api, 0, 1>;
+using describe_acls_handler = single_stage_handler<describe_acls_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/describe_configs.h
+++ b/src/v/kafka/server/handlers/describe_configs.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using describe_configs_handler = handler<describe_configs_api, 0, 2>;
+using describe_configs_handler
+  = single_stage_handler<describe_configs_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/describe_groups.h
+++ b/src/v/kafka/server/handlers/describe_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using describe_groups_handler = handler<describe_groups_api, 0, 4>;
+using describe_groups_handler = single_stage_handler<describe_groups_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/handlers/describe_log_dirs.h
+++ b/src/v/kafka/server/handlers/describe_log_dirs.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using describe_log_dirs_handler = handler<describe_log_dirs_api, 0, 1>;
+using describe_log_dirs_handler
+  = single_stage_handler<describe_log_dirs_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/end_txn.h
+++ b/src/v/kafka/server/handlers/end_txn.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using end_txn_handler = handler<end_txn_api, 0, 2>;
+using end_txn_handler = single_stage_handler<end_txn_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -17,7 +17,7 @@
 
 namespace kafka {
 
-using fetch_handler = handler<fetch_api, 4, 11>;
+using fetch_handler = single_stage_handler<fetch_api, 4, 11>;
 
 /*
  * Fetch operation context

--- a/src/v/kafka/server/handlers/find_coordinator.h
+++ b/src/v/kafka/server/handlers/find_coordinator.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using find_coordinator_handler = handler<find_coordinator_api, 0, 2>;
+using find_coordinator_handler
+  = single_stage_handler<find_coordinator_api, 0, 2>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -45,4 +45,7 @@ concept KafkaApiTwoPhaseHandler = KafkaApi<typename T::api> && requires(
     { T::handle(std::move(ctx), g) } -> std::same_as<process_result_stages>;
 };
 
+template<typename T>
+concept KafkaApiHandlerAny = KafkaApiHandler<T> || KafkaApiTwoPhaseHandler<T>;
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "kafka/protocol/types.h"
+#include "kafka/server/fwd.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "kafka/types.h"
@@ -18,7 +19,12 @@
 
 namespace kafka {
 
-using memory_estimate_fn = size_t(size_t);
+using memory_estimate_fn = size_t(size_t, connection_context&);
+
+constexpr size_t
+default_estimate_adaptor(size_t request_size, connection_context&) {
+    return default_memory_estimate(request_size);
+}
 
 /**
  * Handlers are generally specializations of this template, via one of the
@@ -46,8 +52,9 @@ struct handler_template {
      * See handler_interface::memory_estimate for a description of this
      * function.
      */
-    static size_t memory_estimate(size_t request_size) {
-        return MemEstimator(request_size);
+    static size_t
+    memory_estimate(size_t request_size, connection_context& conn_ctx) {
+        return MemEstimator(request_size, conn_ctx);
     }
 };
 
@@ -59,7 +66,7 @@ template<
   typename RequestApi,
   api_version::type MinSupported,
   api_version::type MaxSupported,
-  memory_estimate_fn MemEstimator = default_memory_estimate>
+  memory_estimate_fn MemEstimator = default_estimate_adaptor>
 using single_stage_handler = handler_template<
   RequestApi,
   MinSupported,
@@ -78,7 +85,7 @@ template<
   typename RequestApi,
   api_version::type MinSupported,
   api_version::type MaxSupported,
-  memory_estimate_fn MemEstimator = default_memory_estimate>
+  memory_estimate_fn MemEstimator = default_estimate_adaptor>
 using two_phase_handler = handler_template<
   RequestApi,
   MinSupported,

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -18,16 +18,26 @@
 
 namespace kafka {
 
+using memory_estimate_fn = size_t(size_t);
+
 template<
   typename RequestApi,
   api_version::type MinSupported,
-  api_version::type MaxSupported>
+  api_version::type MaxSupported,
+  memory_estimate_fn MemEstimator = default_memory_estimate>
 struct single_stage_handler {
     using api = RequestApi;
     static constexpr api_version min_supported = api_version(MinSupported);
     static constexpr api_version max_supported = api_version(MaxSupported);
     static ss::future<response_ptr>
       handle(request_context, ss::smp_service_group);
+    /**
+     * See handler_interface::memory_estimate for a description of this
+     * function.
+     */
+    static size_t memory_estimate(size_t request_size) {
+        return MemEstimator(request_size);
+    }
 };
 
 template<typename T>

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -22,7 +22,7 @@ template<
   typename RequestApi,
   api_version::type MinSupported,
   api_version::type MaxSupported>
-struct handler {
+struct single_stage_handler {
     using api = RequestApi;
     static constexpr api_version min_supported = api_version(MinSupported);
     static constexpr api_version max_supported = api_version(MaxSupported);

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -125,7 +125,7 @@ constexpr auto make_lut(type_list<Ts...>) {
     return lut;
 }
 
-std::optional<handler> handler_for_key(kafka::api_key key) {
+std::optional<handler> handler_for_key(kafka::api_key key) noexcept {
     static constexpr auto lut = make_lut(request_types{});
     if (key >= (short)0 && key < (short)lut.size()) {
         if (auto handler = lut[key]) {

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -128,6 +128,9 @@ constexpr auto make_lut(type_list<Ts...>) {
 std::optional<handler> handler_for_key(kafka::api_key key) noexcept {
     static constexpr auto lut = make_lut(request_types{});
     if (key >= (short)0 && key < (short)lut.size()) {
+        // We have already checked the bounds above so it is safe to use []
+        // instead of at()
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         if (auto handler = lut[key]) {
             return handler;
         }

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/handlers/handler_interface.h"
+
+#include "kafka/server/handlers/handlers.h"
+#include "kafka/server/handlers/produce.h"
+#include "kafka/types.h"
+
+#include <optional>
+
+namespace kafka {
+
+/**
+ * @brief Packages together basic information common to every handler.
+ */
+struct handler_info {
+    handler_info(
+      api_key key,
+      const char* name,
+      api_version min_api,
+      api_version max_api) noexcept
+      : _key(key)
+      , _name(name)
+      , _min_api(min_api)
+      , _max_api(max_api) {}
+
+    api_key _key;
+    const char* _name;
+    api_version _min_api, _max_api;
+};
+
+/**
+ * @brief Creates a type-erased handler implementation given info and a handle
+ * method.
+ *
+ * There are only two variants of this handler, for one and two pass
+ * implementations.
+ * This keeps the generated code duplication to a minimum, compared to
+ * templating this on the handler type.
+ *
+ * @tparam is_two_pass true if the handler is two-pass
+ */
+template<bool is_two_pass>
+struct handler_base final : public handler_interface {
+    using single_pass_handler
+      = ss::future<response_ptr>(request_context, ss::smp_service_group);
+    using two_pass_handler
+      = process_result_stages(request_context, ss::smp_service_group);
+    using fn_type
+      = std::conditional_t<is_two_pass, two_pass_handler, single_pass_handler>;
+
+    handler_base(const handler_info& info, fn_type* handle_fn) noexcept
+      : _info(info)
+      , _handle_fn(handle_fn) {}
+
+    api_version min_supported() const override { return _info._min_api; }
+    api_version max_supported() const override { return _info._max_api; }
+
+    api_key key() const override { return _info._key; }
+    const char* name() const override { return _info._name; }
+
+    /**
+     * Only handle varies with one or two pass, since one pass handlers
+     * must pass through single_stage() to covert them to two-pass.
+     */
+    process_result_stages
+    handle(request_context&& rc, ss::smp_service_group g) const override {
+        if constexpr (is_two_pass) {
+            return _handle_fn(std::move(rc), g);
+        } else {
+            return process_result_stages::single_stage(
+              _handle_fn(std::move(rc), g));
+        }
+    }
+
+private:
+    handler_info _info;
+    fn_type* _handle_fn;
+};
+
+/**
+ * @brief Instance holder for the handler_base.
+ *
+ * Given a handler type H, exposes a static instance of the assoicated handler
+ * base object.
+ *
+ * @tparam H the handler type.
+ */
+template<KafkaApiHandlerAny H>
+struct handler_holder {
+    static const inline handler_base<KafkaApiTwoPhaseHandler<H>> instance{
+      handler_info{
+        H::api::key, H::api::name, H::min_supported, H::max_supported},
+      H::handle};
+};
+
+template<typename... Ts>
+constexpr auto make_lut(type_list<Ts...>) {
+    constexpr int max_index = std::max({Ts::api::key...});
+    static_assert(max_index < sizeof...(Ts) * 10, "LUT is too sparse");
+
+    std::array<handler, max_index + 1> lut{};
+    ((lut[Ts::api::key] = &handler_holder<Ts>::instance), ...);
+
+    return lut;
+}
+
+std::optional<handler> handler_for_key(kafka::api_key key) {
+    static constexpr auto lut = make_lut(request_types{});
+    if (key >= (short)0 && key < (short)lut.size()) {
+        if (auto handler = lut[key]) {
+            return handler;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -71,8 +71,9 @@ struct handler_base final : public handler_interface {
     api_key key() const override { return _info._key; }
     const char* name() const override { return _info._name; }
 
-    size_t memory_estimate(size_t request_size) const override {
-        return _info._mem_estimate(request_size);
+    size_t memory_estimate(
+      size_t request_size, connection_context& conn_ctx) const override {
+        return _info._mem_estimate(request_size, conn_ctx);
     }
     /**
      * Only handle varies with one or two pass, since one pass handlers

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -12,6 +12,7 @@
 
 #include "kafka/server/handlers/handlers.h"
 #include "kafka/server/handlers/produce.h"
+#include "kafka/server/response.h"
 #include "kafka/types.h"
 
 #include <optional>
@@ -26,15 +27,18 @@ struct handler_info {
       api_key key,
       const char* name,
       api_version min_api,
-      api_version max_api) noexcept
+      api_version max_api,
+      memory_estimate_fn* mem_estimate) noexcept
       : _key(key)
       , _name(name)
       , _min_api(min_api)
-      , _max_api(max_api) {}
+      , _max_api(max_api)
+      , _mem_estimate(mem_estimate) {}
 
     api_key _key;
     const char* _name;
     api_version _min_api, _max_api;
+    memory_estimate_fn* _mem_estimate;
 };
 
 /**
@@ -67,6 +71,9 @@ struct handler_base final : public handler_interface {
     api_key key() const override { return _info._key; }
     const char* name() const override { return _info._name; }
 
+    size_t memory_estimate(size_t request_size) const override {
+        return _info._mem_estimate(request_size);
+    }
     /**
      * Only handle varies with one or two pass, since one pass handlers
      * must pass through single_stage() to covert them to two-pass.
@@ -98,7 +105,11 @@ template<KafkaApiHandlerAny H>
 struct handler_holder {
     static const inline handler_base<KafkaApiTwoPhaseHandler<H>> instance{
       handler_info{
-        H::api::key, H::api::name, H::min_supported, H::max_supported},
+        H::api::key,
+        H::api::name,
+        H::min_supported,
+        H::max_supported,
+        H::memory_estimate},
       H::handle};
 };
 

--- a/src/v/kafka/server/handlers/handler_interface.h
+++ b/src/v/kafka/server/handlers/handler_interface.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/server/fwd.h"
+#include "kafka/server/response.h"
+#include "kafka/types.h"
+
+namespace kafka {
+/**
+ * @brief Runtime polymorphic handler type.
+ *
+ * Allows access to all kafka request handling implementations though a
+ * type erased interface. This avoids the need to bring every handler
+ * type into scope and make everything that touches the handler a template
+ * function on the handler type.
+ *
+ */
+struct handler_interface {
+    /**
+     * @brief The minimum supported API version, inclusive.
+     */
+    virtual api_version min_supported() const = 0;
+
+    /**
+     * @brief The maximum supported API version, inclusive.
+     */
+    virtual api_version max_supported() const = 0;
+
+    /**
+     * @brief The name of the API method.
+     */
+    virtual const char* name() const = 0;
+
+    /**
+     * @brief The API key associated with the method.
+     */
+    virtual api_key key() const = 0;
+
+    /**
+     * @brief Handles the request.
+     *
+     * Invokes the request handler with the given request context
+     * (which will be moved from) and smp_service_groups.
+     *
+     * The result stages objects contains futures for both the initial
+     * dispatch phase, and the find response. For API methods which
+     * are implemented a single phase, the same type is returned, but
+     * the response future will complete as soon as the dispatch one does.
+     *
+     * @return process_result_stages representing the future completion of
+     * the handler.
+     */
+    virtual process_result_stages
+    handle(request_context&&, ss::smp_service_group) const = 0;
+
+    virtual ~handler_interface() = default;
+};
+
+/**
+ * @brief Pointer to a handler.
+ *
+ * Most code will use handler objects, which are simply pointers
+ * to handlers, generally const objects with static storage duration
+ * obtained from handler_for_key.
+ */
+using handler = const handler_interface*;
+
+/**
+ * @brief Return a handler for the given key, if any.
+ *
+ * Returns a pointer to a constant singleton handler for the given
+ * key, or an empty optional if no such handler exists. The contained
+ * any_hanlder is guaranteed to be non-null if the optional as a value.
+ *
+ * This method looks up the handler in a table populated by all handlers
+ * in kafka::request_types.
+ *
+ * @param key the API key for the handler
+ * @return std::optional<handler> the handler, if any
+ */
+std::optional<handler> handler_for_key(api_key key);
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/handler_interface.h
+++ b/src/v/kafka/server/handlers/handler_interface.h
@@ -45,6 +45,27 @@ struct handler_interface {
     virtual api_key key() const = 0;
 
     /**
+     * @brief Estimates the memory used to process the request.
+     *
+     * Returns an esimate of the memory needed to process a request. This is
+     * used to block the request until sufficient memory is available using the
+     * "memory units" semaphore. Ideally this should be a conservative request
+     * (i.e., a possible overestimate in cases where the memory use may vary
+     * significantly) as the result of a too-small estimate may be an
+     * out-of-memory condition, while a too-large estimate will "merely" reduce
+     * performance.
+     *
+     * Handers may also return an initial, small estimate here covering the
+     * first part of processing, then dynamically increase their memory
+     * allocation later on during processing when the full memory size is known.
+     *
+     * Unfortunately, this estimate happens early in the decoding process, after
+     * only the request size and header has been read, so handlers don't have
+     * as much information as they may like to make this decision.
+     */
+    virtual size_t memory_estimate(size_t request_size) const = 0;
+
+    /**
      * @brief Handles the request.
      *
      * Invokes the request handler with the given request context

--- a/src/v/kafka/server/handlers/handler_interface.h
+++ b/src/v/kafka/server/handlers/handler_interface.h
@@ -106,6 +106,6 @@ using handler = const handler_interface*;
  * @param key the API key for the handler
  * @return std::optional<handler> the handler, if any
  */
-std::optional<handler> handler_for_key(api_key key);
+std::optional<handler> handler_for_key(api_key key) noexcept;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/handler_interface.h
+++ b/src/v/kafka/server/handlers/handler_interface.h
@@ -55,15 +55,14 @@ struct handler_interface {
      * out-of-memory condition, while a too-large estimate will "merely" reduce
      * performance.
      *
-     * Handers may also return an initial, small estimate here covering the
-     * first part of processing, then dynamically increase their memory
-     * allocation later on during processing when the full memory size is known.
-     *
      * Unfortunately, this estimate happens early in the decoding process, after
      * only the request size and header has been read, so handlers don't have
-     * as much information as they may like to make this decision.
+     * as much information as they may like to make this decision. The
+     * connection_context for the associated connection is passed to give access
+     * to global state which may be useful in making the estimate.
      */
-    virtual size_t memory_estimate(size_t request_size) const = 0;
+    virtual size_t memory_estimate(
+      size_t request_size, connection_context& conn_ctx) const = 0;
 
     /**
      * @brief Handles the request.

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -87,4 +87,11 @@ using request_types = make_request_types<
   end_txn_handler,
   create_partitions_handler,
   offset_for_leader_epoch_handler>;
+
+template<typename... RequestTypes>
+static constexpr size_t max_api_key(type_list<RequestTypes...>) {
+    /// Black magic here is an overload of std::max() that takes an
+    /// std::initializer_list
+    return std::max({RequestTypes::api::key()...});
+}
 } // namespace kafka

--- a/src/v/kafka/server/handlers/heartbeat.h
+++ b/src/v/kafka/server/handlers/heartbeat.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using heartbeat_handler = handler<heartbeat_api, 0, 3>;
+using heartbeat_handler = single_stage_handler<heartbeat_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.h
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using incremental_alter_configs_handler
-  = handler<incremental_alter_configs_api, 0, 0>;
+  = single_stage_handler<incremental_alter_configs_api, 0, 0>;
 
 }

--- a/src/v/kafka/server/handlers/init_producer_id.h
+++ b/src/v/kafka/server/handlers/init_producer_id.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using init_producer_id_handler = handler<init_producer_id_api, 0, 1>;
+using init_producer_id_handler
+  = single_stage_handler<init_producer_id_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -35,6 +35,7 @@ static void decode_request(request_context& ctx, join_group_request& req) {
       fmt::format("{}", ctx.connection()->client_host()));
 }
 
+template<>
 process_result_stages join_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     join_group_request request;

--- a/src/v/kafka/server/handlers/join_group.h
+++ b/src/v/kafka/server/handlers/join_group.h
@@ -19,5 +19,8 @@ struct join_group_handler {
     static constexpr api_version min_supported = api_version(0);
     static constexpr api_version max_supported = api_version(5);
     static process_result_stages handle(request_context, ss::smp_service_group);
+    static size_t memory_estimate(size_t request_size) {
+        return default_memory_estimate(request_size);
+    }
 };
 } // namespace kafka

--- a/src/v/kafka/server/handlers/join_group.h
+++ b/src/v/kafka/server/handlers/join_group.h
@@ -14,13 +14,6 @@
 
 namespace kafka {
 
-struct join_group_handler {
-    using api = join_group_api;
-    static constexpr api_version min_supported = api_version(0);
-    static constexpr api_version max_supported = api_version(5);
-    static process_result_stages handle(request_context, ss::smp_service_group);
-    static size_t memory_estimate(size_t request_size) {
-        return default_memory_estimate(request_size);
-    }
-};
+using join_group_handler = two_phase_handler<join_group_api, 0, 5>;
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/leave_group.h
+++ b/src/v/kafka/server/handlers/leave_group.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using leave_group_handler = handler<leave_group_api, 0, 3>;
+using leave_group_handler = single_stage_handler<leave_group_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/list_groups.h
+++ b/src/v/kafka/server/handlers/list_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_groups_handler = handler<list_groups_api, 0, 2>;
+using list_groups_handler = single_stage_handler<list_groups_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/list_offsets.h
+++ b/src/v/kafka/server/handlers/list_offsets.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_offsets_handler = handler<list_offsets_api, 0, 4>;
+using list_offsets_handler = single_stage_handler<list_offsets_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -19,6 +19,7 @@
 #include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "likely.h"
 #include "model/metadata.h"
@@ -423,4 +424,68 @@ ss::future<response_ptr> metadata_handler::handle(
     co_return co_await ctx.respond(std::move(reply));
 }
 
+size_t
+metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
+    // We cannot make a precise estimate of the size of a metadata response by
+    // examining only the size of the request (nor even by examining the entire
+    // request) since the response depends on the number of partitions in the
+    // cluster. Instead, we return a conservative estimate based on the current
+    // number of topics & partitions in the cluster.
+
+    // Essentially we need to estimate the size taken by a "maximum size"
+    // metadata_response_data response. The maximum size is when metadata for
+    // all topics is returned, which is also a common case in practice. This
+    // involves calculating the size for each topic's portion of the response,
+    // since the size varies both based on the number of partitions and the
+    // replica count.
+
+    // We start with a base estimate of 10K and then proceed to ignore
+    // everything other than the topic/partition part of the response, since
+    // that's what takes space in large responses and we assume the remaining
+    // part of the response (the broker list being the second largest part) will
+    // fit in this 10000k slush fund.
+    size_t size_estimate = 10000;
+
+    auto& md = conn_ctx.server().metadata_cache().all_topics_metadata();
+
+    for (auto& [tp_ns, topic_metadata] : md) {
+        // metadata_response_topic
+        size_estimate += sizeof(kafka::metadata_response_topic);
+        size_estimate += tp_ns.tp().size();
+
+        using partition = kafka::metadata_response_partition;
+
+        // Base number of bytes needed to represent each partition, ignoring the
+        // variable part attributable to the replica count, we just take as the
+        // size of the partition response structure.
+        constexpr size_t bytes_per_partition = sizeof(partition);
+
+        // Then, we need the number of additional bytes per replica, per
+        // partition, associated with storing the replica list in
+        // metadata_response_partition::replicas/isr_nodes, which we take to
+        // be the size of the elements in those lists (4 bytes each).
+        constexpr size_t bytes_per_replica = sizeof(partition::replica_nodes[0])
+                                             + sizeof(partition::isr_nodes[0]);
+
+        // The actual partition and replica count for this topic.
+        int32_t pcount = topic_metadata.get_configuration().partition_count;
+        int32_t rcount = topic_metadata.get_configuration().replication_factor;
+
+        size_estimate += pcount
+                         * (bytes_per_partition + bytes_per_replica * rcount);
+    }
+
+    // Finally, we double the estimate, because the highwater mark for memory
+    // use comes when the in-memory structures (metadata_response_data and
+    // subobjects) exist on the heap and they are encoded into the reponse,
+    // which will also exist on the heap. The calculation above handles the
+    // first size, and the encoded response ends up being very similar in size,
+    // so we double the estimate to account for both.
+    size_estimate *= 2;
+
+    // We still add on the default_estimate to handle the size of the request
+    // itself and miscellaneous other procesing (this is a small adjustment,
+    // generally ~8000 bytes).
+    return default_memory_estimate(request_size) + size_estimate;
+}
 } // namespace kafka

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -15,6 +15,7 @@
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "kafka/server/errors.h"
+#include "kafka/server/fwd.h"
 #include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/topics/topic_utils.h"

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using metadata_handler = handler<metadata_api, 0, 7>;
+using metadata_handler = single_stage_handler<metadata_api, 0, 7>;
 
 }

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -14,6 +14,17 @@
 
 namespace kafka {
 
-using metadata_handler = single_stage_handler<metadata_api, 0, 7>;
+/**
+ * Estimate the size of a metadata request.
+ *
+ * Metadata requests are generally very small (a request for *all* metadata
+ * about a cluster is less than 30 bytes) but the response may be very large, so
+ * the default estimator is unsuitable. See the implementation for further
+ * notes.
+ */
+memory_estimate_fn metadata_memory_estimator;
 
-}
+using metadata_handler
+  = single_stage_handler<metadata_api, 0, 7, metadata_memory_estimator>;
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -53,6 +53,7 @@ struct offset_commit_ctx {
       , ssg(ssg) {}
 };
 
+template<>
 process_result_stages
 offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_commit_request request;

--- a/src/v/kafka/server/handlers/offset_commit.h
+++ b/src/v/kafka/server/handlers/offset_commit.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/server/handlers/handler.h"
+#include "kafka/server/response.h"
 
 namespace kafka {
 
@@ -22,5 +23,8 @@ struct offset_commit_handler {
     static constexpr api_version min_supported = api_version(1);
     static constexpr api_version max_supported = api_version(7);
     static process_result_stages handle(request_context, ss::smp_service_group);
+    static size_t memory_estimate(size_t request_size) {
+        return default_memory_estimate(request_size);
+    }
 };
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.h
+++ b/src/v/kafka/server/handlers/offset_commit.h
@@ -18,13 +18,6 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-struct offset_commit_handler {
-    using api = offset_commit_api;
-    static constexpr api_version min_supported = api_version(1);
-    static constexpr api_version max_supported = api_version(7);
-    static process_result_stages handle(request_context, ss::smp_service_group);
-    static size_t memory_estimate(size_t request_size) {
-        return default_memory_estimate(request_size);
-    }
-};
+using offset_commit_handler = two_phase_handler<offset_commit_api, 1, 7>;
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_fetch.h
+++ b/src/v/kafka/server/handlers/offset_fetch.h
@@ -17,6 +17,6 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-using offset_fetch_handler = handler<offset_fetch_api, 1, 7>;
+using offset_fetch_handler = single_stage_handler<offset_fetch_api, 1, 7>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.h
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.h
@@ -15,5 +15,5 @@
 namespace kafka {
 
 using offset_for_leader_epoch_handler
-  = handler<offset_for_leader_epoch_api, 0, 3>;
+  = single_stage_handler<offset_for_leader_epoch_api, 0, 3>;
 }

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -43,6 +43,8 @@
 
 namespace kafka {
 
+static constexpr auto despam_interval = std::chrono::minutes(5);
+
 produce_response produce_request::make_error_response(error_code error) const {
     produce_response response;
 
@@ -464,6 +466,7 @@ static std::vector<topic_produce_stages> produce_topics(produce_ctx& octx) {
     return topics;
 }
 
+template<>
 process_result_stages
 produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     produce_request request;

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -20,6 +20,9 @@ struct produce_handler {
     static constexpr api_version max_supported = api_version(7);
     static process_result_stages handle(request_context, ss::smp_service_group);
     static constexpr auto despam_interval = std::chrono::minutes(5);
+    static size_t memory_estimate(size_t request_size) {
+        return default_memory_estimate(request_size);
+    }
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -14,15 +14,6 @@
 
 namespace kafka {
 
-struct produce_handler {
-    using api = produce_api;
-    static constexpr api_version min_supported = api_version(0);
-    static constexpr api_version max_supported = api_version(7);
-    static process_result_stages handle(request_context, ss::smp_service_group);
-    static constexpr auto despam_interval = std::chrono::minutes(5);
-    static size_t memory_estimate(size_t request_size) {
-        return default_memory_estimate(request_size);
-    }
-};
+using produce_handler = two_phase_handler<produce_api, 0, 7>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/sasl_authenticate.h
+++ b/src/v/kafka/server/handlers/sasl_authenticate.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using sasl_authenticate_handler = handler<sasl_authenticate_api, 0, 1>;
+using sasl_authenticate_handler
+  = single_stage_handler<sasl_authenticate_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/sasl_handshake.h
+++ b/src/v/kafka/server/handlers/sasl_handshake.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using sasl_handshake_handler = handler<sasl_handshake_api, 0, 1>;
+using sasl_handshake_handler = single_stage_handler<sasl_handshake_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/sync_group.cc
+++ b/src/v/kafka/server/handlers/sync_group.cc
@@ -21,6 +21,7 @@
 
 namespace kafka {
 
+template<>
 process_result_stages sync_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     sync_group_request request;

--- a/src/v/kafka/server/handlers/sync_group.h
+++ b/src/v/kafka/server/handlers/sync_group.h
@@ -19,6 +19,9 @@ struct sync_group_handler {
     static constexpr api_version min_supported = api_version(0);
     static constexpr api_version max_supported = api_version(3);
     static process_result_stages handle(request_context, ss::smp_service_group);
+    static size_t memory_estimate(size_t request_size) {
+        return default_memory_estimate(request_size);
+    }
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/sync_group.h
+++ b/src/v/kafka/server/handlers/sync_group.h
@@ -14,14 +14,6 @@
 
 namespace kafka {
 
-struct sync_group_handler {
-    using api = sync_group_api;
-    static constexpr api_version min_supported = api_version(0);
-    static constexpr api_version max_supported = api_version(3);
-    static process_result_stages handle(request_context, ss::smp_service_group);
-    static size_t memory_estimate(size_t request_size) {
-        return default_memory_estimate(request_size);
-    }
-};
+using sync_group_handler = two_phase_handler<sync_group_api, 0, 3>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/txn_offset_commit.h
+++ b/src/v/kafka/server/handlers/txn_offset_commit.h
@@ -14,6 +14,7 @@
 
 namespace kafka {
 
-using txn_offset_commit_handler = handler<txn_offset_commit_api, 0, 3>;
+using txn_offset_commit_handler
+  = single_stage_handler<txn_offset_commit_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -219,7 +219,8 @@ private:
 };
 
 // Executes the API call identified by the specified request_context.
-process_result_stages process_request(request_context&&, ss::smp_service_group);
+process_result_stages process_request(
+  request_context&&, ss::smp_service_group, const session_resources&);
 
 bool track_latency(api_key);
 

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -10,6 +10,7 @@
 #include "kafka/protocol/schemata/api_versions_request.h"
 #include "kafka/protocol/schemata/fetch_request.h"
 #include "kafka/protocol/schemata/produce_request.h"
+#include "kafka/server/connection_context.h"
 #include "kafka/server/handlers/api_versions.h"
 #include "kafka/server/handlers/handler_interface.h"
 #include "kafka/server/handlers/sasl_authenticate.h"
@@ -80,16 +81,20 @@ requires(KafkaApiHandler<Request> || KafkaApiTwoPhaseHandler<Request>)
 }
 
 process_result_stages process_generic(
-  handler handler, request_context&& ctx, ss::smp_service_group g) {
+  handler handler,
+  request_context&& ctx,
+  ss::smp_service_group g,
+  const session_resources& sres) {
     vlog(
       klog.trace,
-      "[{}:{}] processing name:{}, key:{}, version:{} for {}",
+      "[{}:{}] processing name:{}, key:{}, version:{} for {}, mem_units: {}",
       ctx.connection()->client_host(),
       ctx.connection()->client_port(),
       handler->name(),
       ctx.header().key,
       ctx.header().version,
-      ctx.header().client_id.value_or(std::string_view("unset-client-id")));
+      ctx.header().client_id.value_or(std::string_view("unset-client-id")),
+      sres.memlocks.count());
 
     // We do a version check for most API requests, but for api_version
     // requests we skip them. We do not apply them for api_versions,
@@ -242,8 +247,10 @@ bool track_latency(api_key key) {
     }
 }
 
-process_result_stages
-process_request(request_context&& ctx, ss::smp_service_group g) {
+process_result_stages process_request(
+  request_context&& ctx,
+  ss::smp_service_group g,
+  const session_resources& sres) {
     /*
      * requests are handled as normal when auth is disabled. otherwise no
      * request is handled until the auth process has completed.
@@ -278,7 +285,7 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
     }
 
     if (auto handler = handler_for_key(key)) {
-        return process_generic(*handler, std::move(ctx), g);
+        return process_generic(*handler, std::move(ctx), g, sres);
     }
 
     throw std::runtime_error(

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -7,8 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "kafka/server/handlers/handlers.h"
-#include "kafka/server/handlers/produce.h"
+#include "kafka/protocol/schemata/api_versions_request.h"
+#include "kafka/protocol/schemata/fetch_request.h"
+#include "kafka/protocol/schemata/produce_request.h"
+#include "kafka/server/handlers/api_versions.h"
+#include "kafka/server/handlers/handler_interface.h"
+#include "kafka/server/handlers/sasl_authenticate.h"
+#include "kafka/server/handlers/sasl_handshake.h"
 #include "kafka/server/request_context.h"
 #include "kafka/types.h"
 #include "utils/to_string.h"
@@ -30,53 +35,6 @@ struct process_dispatch { // clang-format on
     process(request_context&& ctx, ss::smp_service_group g) {
         return process_result_stages::single_stage(
           Request::handle(std::move(ctx), g));
-    }
-};
-
-/**
- * api_versions request processed in one stage however this template
- * specialization exists so that the return value of the request can be examined
- * by the connection layer.
- */
-template<>
-struct process_dispatch<api_versions_handler> {
-    static process_result_stages
-    process(request_context&& ctx, ss::smp_service_group g) {
-        return process_result_stages::single_stage(
-          api_versions_handler::handle(std::move(ctx), g));
-    }
-};
-
-/**
- * Requests processed in two stages
- */
-template<>
-struct process_dispatch<produce_handler> {
-    static process_result_stages
-    process(request_context&& ctx, ss::smp_service_group g) {
-        return produce_handler::handle(std::move(ctx), g);
-    }
-};
-
-template<>
-struct process_dispatch<offset_commit_handler> {
-    static process_result_stages
-    process(request_context&& ctx, ss::smp_service_group g) {
-        return offset_commit_handler::handle(std::move(ctx), g);
-    }
-};
-template<>
-struct process_dispatch<join_group_handler> {
-    static process_result_stages
-    process(request_context&& ctx, ss::smp_service_group g) {
-        return join_group_handler::handle(std::move(ctx), g);
-    }
-};
-template<>
-struct process_dispatch<sync_group_handler> {
-    static process_result_stages
-    process(request_context&& ctx, ss::smp_service_group g) {
-        return sync_group_handler::handle(std::move(ctx), g);
     }
 };
 
@@ -121,6 +79,35 @@ requires(KafkaApiHandler<Request> || KafkaApiTwoPhaseHandler<Request>)
     return process_dispatch<Request>::process(std::move(ctx), g);
 }
 
+process_result_stages process_generic(
+  handler handler, request_context&& ctx, ss::smp_service_group g) {
+    vlog(
+      klog.trace,
+      "[{}:{}] processing name:{}, key:{}, version:{} for {}",
+      ctx.connection()->client_host(),
+      ctx.connection()->client_port(),
+      handler->name(),
+      ctx.header().key,
+      ctx.header().version,
+      ctx.header().client_id.value_or(std::string_view("unset-client-id")));
+
+    // We do a version check for most API requests, but for api_version
+    // requests we skip them. We do not apply them for api_versions,
+    // because the client does not yet know what
+    // versions this server supports. The api versions request is used by a
+    // client to query this information.
+    if (ctx.header().key != api_versions_api::key &&
+      (ctx.header().version < handler->min_supported() ||
+       ctx.header().version > handler->max_supported())) {
+        throw std::runtime_error(fmt::format(
+          "Unsupported version {} for {} API",
+          ctx.header().version,
+          handler->name()));
+    }
+
+    return handler->handle(std::move(ctx), g);
+}
+
 class kafka_authentication_exception : public std::runtime_error {
 public:
     explicit kafka_authentication_exception(const std::string& m)
@@ -161,7 +148,7 @@ handle_auth_handshake(request_context&& ctx, ss::smp_service_group g) {
 static ss::future<response_ptr>
 handle_auth_initial(request_context&& ctx, ss::smp_service_group g) {
     switch (ctx.header().key) {
-    case api_versions_handler::api::key: {
+    case api_versions_api::key: {
         auto r = api_versions_handler::handle_raw(ctx);
         if (r.data.error_code == error_code::none) {
             ctx.sasl().set_state(security::sasl_server::sasl_state::handshake);
@@ -247,8 +234,8 @@ handle_auth(request_context&& ctx, ss::smp_service_group g) {
 // only track latency for push and fetch requests
 bool track_latency(api_key key) {
     switch (key) {
-    case fetch_handler::api::key:
-    case produce_handler::api::key:
+    case fetch_api::key:
+    case produce_api::key:
         return true;
     default:
         return false;
@@ -274,47 +261,14 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
             }));
     }
 
-    switch (ctx.header().key) {
-    case api_versions_handler::api::key:
-        return do_process<api_versions_handler>(std::move(ctx), g);
-    case metadata_handler::api::key:
-        return do_process<metadata_handler>(std::move(ctx), g);
-    case list_groups_handler::api::key:
-        return do_process<list_groups_handler>(std::move(ctx), g);
-    case find_coordinator_handler::api::key:
-        return do_process<find_coordinator_handler>(std::move(ctx), g);
-    case offset_fetch_handler::api::key:
-        return do_process<offset_fetch_handler>(std::move(ctx), g);
-    case produce_handler::api::key:
-        return do_process<produce_handler>(std::move(ctx), g);
-    case list_offsets_handler::api::key:
-        return do_process<list_offsets_handler>(std::move(ctx), g);
-    case offset_commit_handler::api::key:
-        return do_process<offset_commit_handler>(std::move(ctx), g);
-    case fetch_handler::api::key:
-        return do_process<fetch_handler>(std::move(ctx), g);
-    case join_group_handler::api::key:
-        return do_process<join_group_handler>(std::move(ctx), g);
-    case heartbeat_handler::api::key:
-        return do_process<heartbeat_handler>(std::move(ctx), g);
-    case leave_group_handler::api::key:
-        return do_process<leave_group_handler>(std::move(ctx), g);
-    case sync_group_handler::api::key:
-        return do_process<sync_group_handler>(std::move(ctx), g);
-    case create_topics_handler::api::key:
-        return do_process<create_topics_handler>(std::move(ctx), g);
-    case describe_configs_handler::api::key:
-        return do_process<describe_configs_handler>(std::move(ctx), g);
-    case alter_configs_handler::api::key:
-        return do_process<alter_configs_handler>(std::move(ctx), g);
-    case delete_topics_handler::api::key:
-        return do_process<delete_topics_handler>(std::move(ctx), g);
-    case describe_groups_handler::api::key:
-        return do_process<describe_groups_handler>(std::move(ctx), g);
-    case sasl_handshake_handler::api::key:
+    auto& key = ctx.header().key;
+
+    if (key == sasl_handshake_handler::api::key) {
         return process_result_stages::single_stage(ctx.respond(
           sasl_handshake_response(error_code::illegal_sasl_state, {})));
-    case sasl_authenticate_handler::api::key: {
+    }
+
+    if (key == sasl_authenticate_handler::api::key) {
         sasl_authenticate_response_data data{
           .error_code = error_code::illegal_sasl_state,
           .error_message = "Authentication process already completed",
@@ -322,33 +276,11 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return process_result_stages::single_stage(
           ctx.respond(sasl_authenticate_response(std::move(data))));
     }
-    case init_producer_id_handler::api::key:
-        return do_process<init_producer_id_handler>(std::move(ctx), g);
-    case incremental_alter_configs_handler::api::key:
-        return do_process<incremental_alter_configs_handler>(std::move(ctx), g);
-    case delete_groups_handler::api::key:
-        return do_process<delete_groups_handler>(std::move(ctx), g);
-    case describe_acls_handler::api::key:
-        return do_process<describe_acls_handler>(std::move(ctx), g);
-    case describe_log_dirs_handler::api::key:
-        return do_process<describe_log_dirs_handler>(std::move(ctx), g);
-    case create_acls_handler::api::key:
-        return do_process<create_acls_handler>(std::move(ctx), g);
-    case delete_acls_handler::api::key:
-        return do_process<delete_acls_handler>(std::move(ctx), g);
-    case add_partitions_to_txn_handler::api::key:
-        return do_process<add_partitions_to_txn_handler>(std::move(ctx), g);
-    case txn_offset_commit_handler::api::key:
-        return do_process<txn_offset_commit_handler>(std::move(ctx), g);
-    case add_offsets_to_txn_handler::api::key:
-        return do_process<add_offsets_to_txn_handler>(std::move(ctx), g);
-    case end_txn_handler::api::key:
-        return do_process<end_txn_handler>(std::move(ctx), g);
-    case create_partitions_handler::api::key:
-        return do_process<create_partitions_handler>(std::move(ctx), g);
-    case offset_for_leader_epoch_handler::api::key:
-        return do_process<offset_for_leader_epoch_handler>(std::move(ctx), g);
-    };
+
+    if (auto handler = handler_for_key(key)) {
+        return process_generic(*handler, std::move(ctx), g);
+    }
+
     throw std::runtime_error(
       fmt::format("Unsupported API {}", ctx.header().key));
 }

--- a/src/v/kafka/server/response.h
+++ b/src/v/kafka/server/response.h
@@ -105,4 +105,26 @@ struct process_result_stages {
     ss::future<response_ptr> response;
 };
 
+/**
+ * @brief The default memory size estimate.
+ *
+ * Request must make an up-front estimate of the amount of memory they will use,
+ * in order to obtain the corresponding number of units from the memory
+ * semaphore (blocking if they are not available). Each request type can use
+ * their own estimation approach, but if not specified this default estimator
+ * will be used.
+ *
+ * Now, this estimator is very poor for many request types: it only applies a
+ * multiplier to the request size, so only makes
+ * sense for requests (such as produce) where the size of the request is a
+ * good indicator of the total memory size. For requests with a small request
+ * but a large response (fetch, metadata, etc), it is not appropriate.
+ *
+ * @return size_t the estimated size required to process the request
+ */
+constexpr size_t default_memory_estimate(size_t request_size) {
+    // Allow for extra copies and bookkeeping
+    return request_size * 2 + 8000; // NOLINT
+}
+
 } // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -8,10 +8,12 @@ rp_test(
     timeouts_conversion_test.cc
     types_conversion_tests.cc
     topic_utils_test.cc
+    handler_interface_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::kafka
+  LIBRARIES Boost::unit_test_framework v::kafka v::coproc
   LABELS kafka
 )
+
 
 set(srcs
   consumer_groups_test.cc

--- a/src/v/kafka/server/tests/handler_interface_test.cc
+++ b/src/v/kafka/server/tests/handler_interface_test.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/handlers/handler_interface.h"
+#include "kafka/server/handlers/handlers.h"
+
+#include <boost/test/unit_test.hpp>
+
+template<kafka::KafkaApiHandlerAny H>
+void check_any_vs_static() {
+    BOOST_TEST_INFO("Testing " << H::api::name);
+    auto hopt = kafka::handler_for_key(H::api::key);
+    BOOST_REQUIRE(hopt.has_value());
+    auto h = *hopt;
+    BOOST_CHECK_EQUAL(h->min_supported(), H::min_supported);
+    BOOST_CHECK_EQUAL(h->max_supported(), H::max_supported);
+    BOOST_CHECK_EQUAL(h->key(), H::api::key);
+    BOOST_CHECK_EQUAL(h->name(), H::api::name);
+}
+
+template<typename... Ts>
+void check_all_types(kafka::type_list<Ts...>) {
+    (check_any_vs_static<Ts>(), ...);
+}
+
+BOOST_AUTO_TEST_CASE(handler_all_types) {
+    check_all_types(kafka::request_types{});
+}
+
+BOOST_AUTO_TEST_CASE(handler_handler_for_key) {
+    // key too low
+    BOOST_CHECK(!kafka::handler_for_key(kafka::api_key(-1)).has_value());
+    // key too high
+    const auto max_key = kafka::max_api_key(kafka::request_types{});
+    BOOST_CHECK(
+      !kafka::handler_for_key(kafka::api_key(max_key + 1)).has_value());
+    // last key should be present
+    BOOST_CHECK(kafka::handler_for_key(kafka::api_key(max_key)).has_value());
+    // 34 is AlterReplicaLogDirs which we don't currently support, use it as a
+    // test case for handlers which fall in the valid range but we don't support
+    BOOST_CHECK(!kafka::handler_for_key(kafka::api_key(34)).has_value());
+}


### PR DESCRIPTION
Currently we estimate that metadata requests take 8000 + rsize * 2 bytes
of memory to process, where rsize is the size of the request. Since
metadata requests are very small, this end up being roughly 8000 bytes.

However, metadata requests which return information about every
partition and replica may easily be several MBs in size.

To fix this for metadata requests specifically, we use a new more
conservative estimate which uses the current topic and partition
configuration to give an upper bound on the size.

The remainder of this series sets up this change and also prepares
for a more comprehensive change where we will allow a "second
chance" allocation from the memory semaphore.

Fixes: https://github.com/redpanda-data/redpanda/issues/4804
Fixes: https://github.com/redpanda-data/redpanda/issues/5278