### PR TITLE
rpk: allow write_disk_cache to fail in rpk tune

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -181,8 +181,10 @@ func tune(
 		supported, reason := tuner.CheckIfSupported()
 		if !enabled || !supported {
 			includeErr = includeErr || !supported
-			exit1 = exit1 || enabled && !supported
 			results = append(results, result{tunerName, false, enabled, supported, reason})
+			// We exit with code 1 when it's enabled and not supported except
+			// for disk_write_cache since it's only supported for GCP.
+			exit1 = exit1 || enabled && !supported && tunerName != "disk_write_cache"
 			continue
 		}
 		log.Debugf("Tuner parameters %+v", params)
@@ -192,8 +194,6 @@ func tune(
 		errMsg := ""
 		if res.IsFailed() {
 			errMsg = res.Error().Error()
-			// We exit with code 1 when it's enabled and not supported
-			// or when one tuner fails.
 			exit1 = true
 		}
 		results = append(results, result{tunerName, !res.IsFailed(), enabled, supported, errMsg})


### PR DESCRIPTION
## Cover letter

`write_disk_cache` tuner is only supported for GPC and this makes it a good candidate to be an allowed_to_fail tuner.

So if the tuner for `disk_write_cache` is enabled but unsupported it will exit with code 0 instead of 1:

```
$ rpk redpanda tune disk_write_cache      
  TUNER             APPLIED  ENABLED  SUPPORTED  ERROR                           
  disk_write_cache  false    true     false      Disk write cache tuner is       
                                                 only supported in GCP           
$ echo $?
0


$ rpk redpanda tune disk_write_cache,cpu
  TUNER             APPLIED  ENABLED  SUPPORTED  ERROR                           
  cpu               false    true     false      Unable to find 'hwloc'          
                                                 library                         
  disk_write_cache  false    true     false      Disk write cache tuner is       
                                                 only supported in GCP           

$ echo $?
1

```
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
