### PR TITLE
kafka/group: add new consumer group metrics

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -12,15 +12,23 @@
 #pragma once
 
 #include "config/configuration.h"
+#include "kafka/server/member.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics.hh>
+
+#include <absl/container/node_hash_map.h>
 
 namespace kafka {
 class group_offset_probe {
 public:
     explicit group_offset_probe(model::offset& offset) noexcept
-      : _offset(offset) {}
+      : _offset(offset)
+      , _public_metrics(ssx::metrics::public_metrics_handle) {}
 
     void setup_metrics(
       const kafka::group_id& group_id, const model::topic_partition& tp) {
@@ -46,9 +54,88 @@ public:
             labels)});
     }
 
+    void setup_public_metrics(
+      const kafka::group_id& group_id, const model::topic_partition& tp) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_public_metrics()) {
+            return;
+        }
+
+        auto group_label = sm::label("group");
+        auto topic_label = sm::label("topic");
+        auto partition_label = sm::label("partition");
+        std::vector<sm::label_instance> labels{
+          group_label(group_id()),
+          topic_label(tp.topic()),
+          partition_label(tp.partition())};
+
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:consumer:group"),
+          {sm::make_gauge(
+             "committed_offset",
+             [this] { return _offset; },
+             sm::description("Consumer group committed offset"),
+             labels)
+             .aggregate({sm::shard_label})});
+    }
+
 private:
     model::offset& _offset;
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
+};
+
+template<typename KeyType, typename ValType>
+class group_probe {
+    using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
+    using static_member_map
+      = absl::node_hash_map<kafka::group_instance_id, kafka::member_id>;
+    using offsets_map = absl::node_hash_map<KeyType, ValType>;
+
+public:
+    explicit group_probe(
+      member_map& members,
+      static_member_map& static_members,
+      offsets_map& offsets) noexcept
+      : _members(members)
+      , _static_members(static_members)
+      , _offsets(offsets)
+      , _public_metrics(ssx::metrics::public_metrics_handle) {}
+
+    void setup_public_metrics(const kafka::group_id& group_id) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_public_metrics()) {
+            return;
+        }
+
+        auto group_label = sm::label("group");
+
+        std::vector<sm::label_instance> labels{group_label(group_id())};
+
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:consumer:group"),
+          {sm::make_gauge(
+             "consumers",
+             [this] { return _members.size() + _static_members.size(); },
+             sm::description("Number of consumers in a group"),
+             labels)
+             .aggregate({sm::shard_label}),
+
+           sm::make_gauge(
+             "topics",
+             [this] { return _offsets.size(); },
+             sm::description("Number of topics in a group"),
+             labels)
+             .aggregate({sm::shard_label})});
+    }
+
+private:
+    member_map& _members;
+    static_member_map& _static_members;
+    offsets_map& _offsets;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -60,12 +60,17 @@ group::group(
   , _new_member_added(false)
   , _conf(conf)
   , _partition(std::move(partition))
+  , _probe(_members, _static_members, _offsets)
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
-  , _enable_group_metrics(group_metrics) {}
+  , _enable_group_metrics(group_metrics) {
+    if (_enable_group_metrics) {
+        _probe.setup_public_metrics(_id);
+    }
+}
 
 group::group(
   kafka::group_id id,
@@ -79,6 +84,7 @@ group::group(
   , _new_member_added(false)
   , _conf(conf)
   , _partition(std::move(partition))
+  , _probe(_members, _static_members, _offsets)
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _ctxlog(klog, *this)
@@ -102,6 +108,10 @@ group::group(
           }});
         vlog(_ctxlog.trace, "Initializing group with member {}", member);
         add_member_no_join(member);
+    }
+
+    if (_enable_group_metrics) {
+        _probe.setup_public_metrics(_id);
     }
 }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -23,6 +23,7 @@
 #include "kafka/server/member.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
+#include "model/namespace.h"
 #include "model/record.h"
 #include "seastarx.h"
 #include "utils/mutex.h"
@@ -167,6 +168,7 @@ public:
           , probe(metadata.offset) {
             if (enable_metrics) {
                 probe.setup_metrics(group_id, tp);
+                probe.setup_public_metrics(group_id, tp);
             }
         }
     };
@@ -734,6 +736,10 @@ private:
       model::topic_partition,
       std::unique_ptr<offset_metadata_with_probe>>
       _offsets;
+    group_probe<
+      model::topic_partition,
+      std::unique_ptr<offset_metadata_with_probe>>
+      _probe;
     model::violation_recovery_policy _recovery_policy;
     ctx_log _ctxlog;
     ctx_log _ctx_txlog;


### PR DESCRIPTION
## Cover letter

This PR adds consumer group metrics to the new prometheus endpoint (exposed at "public_metrics"). The following metrics were added:

* redpanda_kafka_consumer_group_committed_offset
	* Description: Consumer group comitted offset
	* Labels: group,topic,partition
	* Aggregation: shard
* redpanda_kafka_consumer_group_consumers
	* Description: Number of consumers in a group
	* Labels: group
	* Aggregation: shard
* redpanda_kafka_consumer_group_topics
	* Description: Number of topics in a group
	* Labels: group
	* Aggregation: shard

Changes from force-push `c7301b1`:
- Lint cpp files

Changes from force-push `0c22e8e`:
- Typo fix
- Remove redundant check

Changes from force-push `989456f`:
- Bring `enable_metrics` checks back in

Changes from force-push `1b4d1e9`:
- Use alias for offsets_map

Original PR and set of commits were at https://github.com/VladLazar/redpanda/pull/1/commits/da025c74f0ed0744f71d9a64a3493b0f962bcfc6 

## Release notes
### Improvements
* Adds consumer group metrics to the new prometheus endpoint that gauge the number of committed offsets in a group, the number of topics in a group, and the number of consumers in a group.