### PR TITLE
raft: add serde support for raft message types

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1981,6 +1981,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           tests::random_named_int<model::revision_id>()};
         roundtrip_test(data);
     }
+    {
+        raft::timeout_now_request data{
+          .target_node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .group = tests::random_named_int<raft::group_id>(),
+          .term = tests::random_named_int<model::term_id>(),
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -17,6 +17,7 @@
 #include "model/metadata.h"
 #include "model/tests/randoms.h"
 #include "model/timestamp.h"
+#include "raft/types.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "storage/types.h"
@@ -1957,6 +1958,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // serde serialization does and was added after support for adl so adl
         // semantics are preserved.
         serde_roundtrip_test(data);
+    }
+    {
+        raft::transfer_leadership_request data{
+          .group = tests::random_named_int<raft::group_id>(),
+        };
+        if (tests::random_bool()) {
+            data.target = tests::random_named_int<model::node_id>();
+        }
+        roundtrip_test(data);
     }
 }
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1968,6 +1968,13 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         }
         roundtrip_test(data);
     }
+    {
+        raft::transfer_leadership_reply data{
+          .success = tests::random_bool(),
+          .result = raft::errc::append_entries_dispatch_error,
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2078,6 +2078,16 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         };
         roundtrip_test(data);
     }
+    {
+        raft::vote_reply data{
+          .target_node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .term = tests::random_named_int<model::term_id>(),
+          .granted = tests::random_bool(),
+          .log_ok = tests::random_bool(),
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1975,6 +1975,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         };
         roundtrip_test(data);
     }
+    {
+        raft::vnode data{
+          tests::random_named_int<model::node_id>(),
+          tests::random_named_int<model::revision_id>()};
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2054,6 +2054,16 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             BOOST_REQUIRE(orig == from_adl);
         }
     }
+    {
+        raft::install_snapshot_reply data{
+          .target_node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .term = tests::random_named_int<model::term_id>(),
+          .bytes_stored = random_generators::get_int<uint64_t>(),
+          .success = tests::random_bool(),
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2064,6 +2064,20 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         };
         roundtrip_test(data);
     }
+    {
+        raft::vote_request data{
+          .node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .target_node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .group = tests::random_named_int<raft::group_id>(),
+          .term = tests::random_named_int<model::term_id>(),
+          .prev_log_index = tests::random_named_int<model::offset>(),
+          .prev_log_term = tests::random_named_int<model::term_id>(),
+          .leadership_transfer = tests::random_bool(),
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1992,6 +1992,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         };
         roundtrip_test(data);
     }
+    {
+        raft::timeout_now_reply data{
+          .target_node_id = raft::
+            vnode{tests::random_named_int<model::node_id>(), tests::random_named_int<model::revision_id>()},
+          .term = tests::random_named_int<model::term_id>(),
+          .result = raft::timeout_now_reply::status::failure,
+        };
+        roundtrip_test(data);
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(cluster_property_kv_exchangable_with_pair) {

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -24,7 +24,7 @@
 namespace raft {
 
 static constexpr model::revision_id no_revision{};
-class vnode {
+class vnode : public serde::envelope<vnode, serde::version<0>> {
 public:
     constexpr vnode() = default;
 
@@ -44,6 +44,8 @@ public:
 
     constexpr model::node_id id() const { return _node_id; }
     constexpr model::revision_id revision() const { return _revision; }
+
+    auto serde_fields() { return std::tie(_node_id, _revision); }
 
 private:
     model::node_id _node_id;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -482,13 +482,19 @@ struct timeout_now_request
     }
 };
 
-struct timeout_now_reply {
+struct timeout_now_reply
+  : serde::envelope<timeout_now_reply, serde::version<0>> {
     enum class status : uint8_t { success, failure };
     // node id to validate on receiver
     vnode target_node_id;
 
     model::term_id term;
     status result;
+
+    friend bool operator==(const timeout_now_reply&, const timeout_now_reply&)
+      = default;
+
+    auto serde_fields() { return std::tie(target_node_id, term, result); }
 };
 
 // if not target is specified then the most up-to-date node will be selected

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -483,10 +483,17 @@ struct timeout_now_reply {
 };
 
 // if not target is specified then the most up-to-date node will be selected
-struct transfer_leadership_request {
+struct transfer_leadership_request
+  : serde::envelope<transfer_leadership_request, serde::version<0>> {
     group_id group;
     std::optional<model::node_id> target;
     raft::group_id target_group() const { return group; }
+
+    friend bool operator==(
+      const transfer_leadership_request&, const transfer_leadership_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(group, target); }
 };
 
 struct transfer_leadership_reply {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -589,4 +589,16 @@ struct adl<raft::transfer_leadership_request> {
         return {.group = group, .target = target};
     }
 };
+
+template<>
+struct adl<raft::transfer_leadership_reply> {
+    void to(iobuf& out, raft::transfer_leadership_reply&& r) {
+        serialize(out, r.success, r.result);
+    }
+    raft::transfer_leadership_reply from(iobuf_parser& in) {
+        auto success = adl<bool>{}.from(in);
+        auto result = adl<raft::errc>{}.from(in);
+        return {.success = success, .result = result};
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -374,7 +374,8 @@ struct snapshot_metadata {
       "version is equal to 3, please change it accordignly");
 };
 
-struct install_snapshot_request {
+struct install_snapshot_request
+  : serde::envelope<install_snapshot_request, serde::version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // leader’s term
@@ -396,6 +397,22 @@ struct install_snapshot_request {
     vnode target_node() const { return target_node_id; }
     friend std::ostream&
     operator<<(std::ostream&, const install_snapshot_request&);
+
+    friend bool
+    operator==(const install_snapshot_request&, const install_snapshot_request&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(
+          target_node_id,
+          term,
+          group,
+          node_id,
+          last_included_index,
+          file_offset,
+          chunk,
+          done);
+    }
 };
 
 class install_snapshot_request_foreign_wrapper {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -278,7 +278,7 @@ struct heartbeat_reply {
     friend std::ostream& operator<<(std::ostream& o, const heartbeat_reply& r);
 };
 
-struct vote_request {
+struct vote_request : serde::envelope<vote_request, serde::version<0>> {
     vnode node_id;
     // node id to validate on receiver
     vnode target_node_id;
@@ -295,6 +295,19 @@ struct vote_request {
     vnode target_node() const { return target_node_id; }
 
     friend std::ostream& operator<<(std::ostream& o, const vote_request& r);
+
+    friend bool operator==(const vote_request&, const vote_request&) = default;
+
+    auto serde_fields() {
+        return std::tie(
+          node_id,
+          target_node_id,
+          group,
+          term,
+          prev_log_index,
+          prev_log_term,
+          leadership_transfer);
+    }
 };
 
 struct vote_reply {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -571,4 +571,15 @@ struct adl<raft::snapshot_metadata> {
     raft::snapshot_metadata from(iobuf_parser& in);
 };
 
+template<>
+struct adl<raft::transfer_leadership_request> {
+    void to(iobuf& out, raft::transfer_leadership_request&& r) {
+        serialize(out, r.group, r.target);
+    }
+    raft::transfer_leadership_request from(iobuf_parser& in) {
+        auto group = adl<raft::group_id>{}.from(in);
+        auto target = adl<std::optional<model::node_id>>{}.from(in);
+        return {.group = group, .target = target};
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -461,7 +461,8 @@ struct write_snapshot_cfg {
     iobuf data;
 };
 
-struct timeout_now_request {
+struct timeout_now_request
+  : serde::envelope<timeout_now_request, serde::version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
 
@@ -471,6 +472,14 @@ struct timeout_now_request {
 
     raft::group_id target_group() const { return group; }
     vnode target_node() const { return target_node_id; }
+
+    friend bool
+    operator==(const timeout_now_request&, const timeout_now_request&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(target_node_id, node_id, group, term);
+    }
 };
 
 struct timeout_now_reply {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -496,9 +496,16 @@ struct transfer_leadership_request
     auto serde_fields() { return std::tie(group, target); }
 };
 
-struct transfer_leadership_reply {
+struct transfer_leadership_reply
+  : serde::envelope<transfer_leadership_reply, serde::version<0>> {
     bool success{false};
     raft::errc result;
+
+    friend bool operator==(
+      const transfer_leadership_reply&, const transfer_leadership_reply&)
+      = default;
+
+    auto serde_fields() { return std::tie(success, result); }
 };
 
 // key types used to store data in key-value store

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -786,4 +786,23 @@ struct adl<raft::vote_request> {
         };
     }
 };
+
+template<>
+struct adl<raft::vote_reply> {
+    void to(iobuf& out, raft::vote_reply&& r) {
+        serialize(out, r.target_node_id, r.term, r.granted, r.log_ok);
+    }
+    raft::vote_reply from(iobuf_parser& in) {
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        auto granted = adl<bool>{}.from(in);
+        auto log_ok = adl<bool>{}.from(in);
+        return {
+          .target_node_id = target_node_id,
+          .term = term,
+          .granted = granted,
+          .log_ok = log_ok,
+        };
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -740,4 +740,37 @@ struct adl<raft::install_snapshot_reply> {
         };
     }
 };
+
+template<>
+struct adl<raft::vote_request> {
+    void to(iobuf& out, raft::vote_request&& r) {
+        serialize(
+          out,
+          r.node_id,
+          r.target_node_id,
+          r.group,
+          r.term,
+          r.prev_log_index,
+          r.prev_log_term,
+          r.leadership_transfer);
+    }
+    raft::vote_request from(iobuf_parser& in) {
+        auto node_id = adl<raft::vnode>{}.from(in);
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto group = adl<raft::group_id>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        auto prev_log_index = adl<model::offset>{}.from(in);
+        auto prev_log_term = adl<model::term_id>{}.from(in);
+        auto leadership_transfer = adl<bool>{}.from(in);
+        return {
+          .node_id = node_id,
+          .target_node_id = target_node_id,
+          .group = group,
+          .term = term,
+          .prev_log_index = prev_log_index,
+          .prev_log_term = prev_log_term,
+          .leadership_transfer = leadership_transfer,
+        };
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -659,4 +659,40 @@ struct adl<raft::timeout_now_reply> {
         };
     }
 };
+
+template<>
+struct adl<raft::install_snapshot_request> {
+    void to(iobuf& out, raft::install_snapshot_request&& r) {
+        serialize(
+          out,
+          r.target_node_id,
+          r.term,
+          r.group,
+          r.node_id,
+          r.last_included_index,
+          r.file_offset,
+          std::move(r.chunk),
+          r.done);
+    }
+    raft::install_snapshot_request from(iobuf_parser& in) {
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        auto group = adl<raft::group_id>{}.from(in);
+        auto node_id = adl<raft::vnode>{}.from(in);
+        auto last_included_index = adl<model::offset>{}.from(in);
+        auto file_offset = adl<uint64_t>{}.from(in);
+        auto chunk = adl<iobuf>{}.from(in);
+        auto done = adl<bool>{}.from(in);
+        return {
+          .target_node_id = target_node_id,
+          .term = term,
+          .group = group,
+          .node_id = node_id,
+          .last_included_index = last_included_index,
+          .file_offset = file_offset,
+          .chunk = std::move(chunk),
+          .done = done,
+        };
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -636,4 +636,21 @@ struct adl<raft::timeout_now_request> {
         };
     }
 };
+
+template<>
+struct adl<raft::timeout_now_reply> {
+    void to(iobuf& out, raft::timeout_now_reply&& r) {
+        serialize(out, r.target_node_id, r.term, r.result);
+    }
+    raft::timeout_now_reply from(iobuf_parser& in) {
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        auto result = adl<raft::timeout_now_reply::status>{}.from(in);
+        return {
+          .target_node_id = target_node_id,
+          .term = term,
+          .result = result,
+        };
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -310,7 +310,7 @@ struct vote_request : serde::envelope<vote_request, serde::version<0>> {
     }
 };
 
-struct vote_reply {
+struct vote_reply : serde::envelope<vote_reply, serde::version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's term, for the caller to upate itself
@@ -325,6 +325,12 @@ struct vote_reply {
     bool log_ok = false;
 
     friend std::ostream& operator<<(std::ostream& o, const vote_reply& r);
+
+    friend bool operator==(const vote_reply&, const vote_reply&) = default;
+
+    auto serde_fields() {
+        return std::tie(target_node_id, term, granted, log_ok);
+    }
 };
 
 /// This structure is used by consensus to notify other systems about group

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -712,4 +712,23 @@ struct adl<raft::install_snapshot_request> {
         };
     }
 };
+
+template<>
+struct adl<raft::install_snapshot_reply> {
+    void to(iobuf& out, raft::install_snapshot_reply&& r) {
+        serialize(out, r.target_node_id, r.term, r.bytes_stored, r.success);
+    }
+    raft::install_snapshot_reply from(iobuf_parser& in) {
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        auto bytes_stored = adl<uint64_t>{}.from(in);
+        auto success = adl<bool>{}.from(in);
+        return {
+          .target_node_id = target_node_id,
+          .term = term,
+          .bytes_stored = bytes_stored,
+          .success = success,
+        };
+    }
+};
 } // namespace reflection

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -443,7 +443,8 @@ private:
     ptr_t _ptr;
 };
 
-struct install_snapshot_reply {
+struct install_snapshot_reply
+  : serde::envelope<install_snapshot_reply, serde::version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // current term, for leader to update itself
@@ -462,6 +463,14 @@ struct install_snapshot_reply {
 
     friend std::ostream&
     operator<<(std::ostream&, const install_snapshot_reply&);
+
+    friend bool
+    operator==(const install_snapshot_reply&, const install_snapshot_reply&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(target_node_id, term, bytes_stored, success);
+    }
 };
 
 /**

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -608,4 +608,23 @@ struct adl<raft::transfer_leadership_reply> {
         return {.success = success, .result = result};
     }
 };
+
+template<>
+struct adl<raft::timeout_now_request> {
+    void to(iobuf& out, raft::timeout_now_request&& r) {
+        serialize(out, r.target_node_id, r.node_id, r.group, r.term);
+    }
+    raft::timeout_now_request from(iobuf_parser& in) {
+        auto target_node_id = adl<raft::vnode>{}.from(in);
+        auto node_id = adl<raft::vnode>{}.from(in);
+        auto group = adl<raft::group_id>{}.from(in);
+        auto term = adl<model::term_id>{}.from(in);
+        return {
+          .target_node_id = target_node_id,
+          .node_id = node_id,
+          .group = group,
+          .term = term,
+        };
+    }
+};
 } // namespace reflection


### PR DESCRIPTION
## Cover letter

Adds serde support to raft rpc message types. Covers all raft messages except the two endpoints that use async adl encoding. This will be submitted under a separate PR.

## Release notes

* None