### PR TITLE
Fixed dispatching update finished command after partition reconfiguration

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -149,6 +149,11 @@ private:
     ss::future<std::error_code> create_partition_from_remote_shard(
       model::ntp, ss::shard_id, partition_assignment);
 
+    bool can_finish_update(
+      topic_table_delta::op_type,
+      const std::vector<model::broker_shard>&,
+      const std::vector<model::broker_shard>&);
+
     void housekeeping();
     void setup_metrics();
     ss::sharded<topic_table>& _topics;


### PR DESCRIPTION
## Cover letter

Fixed dispatching update_finished command when no replicas were added to the replica set.

Previously when no replicas were added to the replica set there was no node that would pass the condition allowing it to dispatch update finished command. This way partition reconfiguration never finished causing chaos-tests to fail.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
