### PR TITLE
Bump seastar version for OSS builds

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 0af8ee3d0194db842ece6ace076e06d13f8dc141
+  GIT_TAG 16d4456f86e344d6c240c431045957e111ec213f
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
## Cover letter

Our fork of Seastar has been updated to extend the metric collection capabilities,
but the version for the OSS build hasn't been updated to reflect that. Now that
https://github.com/redpanda-data/redpanda/pull/5166 and https://github.com/redpanda-data/redpanda/pull/5165 have been merged the OSS build fails (see job [here](https://github.com/VladLazar/redpanda/actions/runs/2621858088/workflow)).

The patch in this PR bumps the seastar version to the [head](https://github.com/redpanda-data/seastar/commit/16d4456f86e344d6c240c431045957e111ec213f) of the v22.2.x branch.

## Release notes
* none