### PR TITLE
tests: wait longer to stop verifiable consumer

### DIFF
--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -197,7 +197,7 @@ class VerifiableConsumer(BackgroundThreadService):
                  session_timeout_sec=30,
                  enable_autocommit=False,
                  assignment_strategy=None,
-                 stop_timeout_sec=30,
+                 stop_timeout_sec=45,
                  on_record_consumed=None,
                  reset_policy="earliest",
                  verify_offsets=True):


### PR DESCRIPTION
When consuming using consumer groups it may be require to wait for 30
seconds to finish rebalance. During that phase the verifiable consumer
is unable to be gracefully stopped. Made the stop timeout longer to
account for the rebalance timeout.

Fixes: #5227
