### PR TITLE
[transaction] KIP-360: Improve reliability of idempotent/transactional producer

### DIFF
--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -34,6 +34,8 @@ std::string_view to_string_view(feature f) {
         return "license";
     case feature::raft_improved_configuration:
         return "raft_improved_configuration";
+    case feature::transaction_ga:
+        return "transaction_ga";
     case feature::test_alpha:
         return "__test_alpha";
     }
@@ -62,7 +64,7 @@ std::string_view to_string_view(feature_state::state s) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
-static constexpr cluster_version latest_version = cluster_version{5};
+static constexpr cluster_version latest_version = cluster_version{6};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -29,6 +29,7 @@ enum class feature : std::uint64_t {
     serde_raft_0 = 0x20,
     license = 0x40,
     raft_improved_configuration = 0x80,
+    transaction_ga = 0x100,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -127,6 +128,12 @@ constexpr static std::array feature_schema{
     cluster_version{5},
     "raft_improved_configuration",
     feature::raft_improved_configuration,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{6},
+    "transaction_ga",
+    feature::transaction_ga,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -55,7 +55,8 @@ partition::partition(
         }
 
         if (_is_tx_enabled) {
-            _tm_stm = ss::make_shared<cluster::tm_stm>(clusterlog, _raft.get());
+            _tm_stm = ss::make_shared<cluster::tm_stm>(
+              clusterlog, _raft.get(), feature_table);
             stm_manager->add_stm(_tm_stm);
         }
     } else {

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -11,8 +11,12 @@
 
 #pragma once
 
+#include "cloud_storage/cache_service.h"
 #include "cloud_storage/fwd.h"
+#include "cloud_storage/partition_recovery_manager.h"
+#include "cloud_storage/remote.h"
 #include "cluster/feature_table.h"
+#include "cluster/fwd.h"
 #include "cluster/ntp_callbacks.h"
 #include "cluster/partition.h"
 #include "cluster/types.h"

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/feature_table.h"
 #include "cluster/tm_stm.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
@@ -28,6 +29,14 @@
 
 static ss::logger tm_logger{"tm_stm-test"};
 
+struct ftable_struct {
+    ftable_struct() { table.start().get(); }
+
+    ~ftable_struct() { table.stop().get(); }
+
+    ss::sharded<cluster::feature_table> table;
+};
+
 using op_status = cluster::tm_stm::op_status;
 using tm_transaction = cluster::tm_transaction;
 using tx_status = cluster::tm_transaction::tx_status;
@@ -44,8 +53,9 @@ static tm_transaction expect_tx(checked<tm_transaction, op_status> maybe_tx) {
 
 FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     start_raft();
+    ftable_struct ftable;
 
-    cluster::tm_stm stm(tm_logger, _raft.get());
+    cluster::tm_stm stm(tm_logger, _raft.get(), std::ref(ftable.table));
     auto c = _raft.get();
 
     stm.start().get0();
@@ -105,8 +115,9 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
 
 FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     start_raft();
+    ftable_struct ftable;
 
-    cluster::tm_stm stm(tm_logger, _raft.get());
+    cluster::tm_stm stm(tm_logger, _raft.get(), std::ref(ftable.table));
     auto c = _raft.get();
 
     stm.start().get0();
@@ -146,8 +157,9 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
 
 FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     start_raft();
+    ftable_struct ftable;
 
-    cluster::tm_stm stm(tm_logger, _raft.get());
+    cluster::tm_stm stm(tm_logger, _raft.get(), std::ref(ftable.table));
     auto c = _raft.get();
 
     stm.start().get0();

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -192,10 +192,12 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
 
     auto pid2 = model::producer_identity{1, 1};
-    op_code = stm
-                .re_register_producer(
-                  c->term(), tx_id, std::chrono::milliseconds(0), pid2)
-                .get0();
+    auto expected_pid = model::producer_identity(3, 5);
+    op_code
+      = stm
+          .re_register_producer(
+            c->term(), tx_id, std::chrono::milliseconds(0), pid2, expected_pid)
+          .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
     auto tx7 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx7.id, tx_id);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -344,7 +344,8 @@ ss::future<tm_stm::op_status> tm_stm::re_register_producer(
   model::term_id expected_term,
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
-  model::producer_identity pid) {
+  model::producer_identity pid,
+  model::producer_identity last_pid) {
     vlog(
       clusterlog.trace, "Registering existing tx: id={}, pid={}", tx_id, pid);
 
@@ -355,6 +356,7 @@ ss::future<tm_stm::op_status> tm_stm::re_register_producer(
     tm_transaction tx = tx_opt.value();
     tx.status = tm_transaction::tx_status::ready;
     tx.pid = pid;
+    tx.last_pid = last_pid;
     tx.tx_seq += 1;
     tx.etag = expected_term;
     tx.timeout_ms = transaction_timeout_ms;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/logger.h"
 #include "cluster/types.h"
+#include "model/record.h"
 #include "raft/errc.h"
 #include "raft/types.h"
 #include "storage/record_batch_builder.h"
@@ -298,6 +299,7 @@ ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::reset_tx_ready(
     }
     tm_transaction tx = tx_opt.value();
     tx.status = tm_transaction::tx_status::ready;
+    tx.last_pid = model::unknown_pid;
     tx.partitions.clear();
     tx.groups.clear();
     tx.etag = term;
@@ -397,6 +399,7 @@ ss::future<tm_stm::op_status> tm_stm::do_register_new_producer(
     auto tx = tm_transaction{
       .id = tx_id,
       .pid = pid,
+      .last_pid = model::unknown_pid,
       .tx_seq = model::tx_seq(0),
       .etag = expected_term,
       .status = tm_transaction::tx_status::ready,
@@ -706,6 +709,7 @@ ss::future<> tm_stm::expire_tx(kafka::transactional_id tx_id) {
     tm_transaction tx = tx_opt.value();
     tx.etag = _insync_term;
     tx.status = tm_transaction::tx_status::tombstone;
+    tx.last_pid = model::unknown_pid;
     tx.partitions.clear();
     tx.groups.clear();
     tx.last_update_ts = clock_type::now();

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -49,13 +49,17 @@ std::ostream& operator<<(std::ostream& o, const tm_transaction& tx) {
              << ", tx_seq=" << tx.tx_seq << "}";
 }
 
-tm_stm::tm_stm(ss::logger& logger, raft::consensus* c)
+tm_stm::tm_stm(
+  ss::logger& logger,
+  raft::consensus* c,
+  ss::sharded<feature_table>& feature_table)
   : persisted_stm("tx.coordinator.snapshot", logger, c)
   , _sync_timeout(config::shard_local_cfg().tm_sync_timeout_ms.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
   , _recovery_policy(
-      config::shard_local_cfg().tm_violation_recovery_policy.value()) {}
+      config::shard_local_cfg().tm_violation_recovery_policy.value())
+  , _feature_table(feature_table) {}
 
 std::optional<tm_transaction> tm_stm::get_tx(kafka::transactional_id tx_id) {
     auto tx = _mem_txes.find(tx_id);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -18,13 +18,58 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/util/bool_class.hh>
 
 #include <filesystem>
 #include <optional>
 
 namespace cluster {
 
-static model::record_batch serialize_tx(tm_transaction tx) {
+namespace {
+
+tm_transaction_v1::tx_status
+downgrade_status(tm_transaction::tx_status status) {
+    switch (status) {
+    case tm_transaction::tx_status::ongoing:
+        return tm_transaction_v1::tx_status::ongoing;
+    case tm_transaction::tx_status::preparing:
+        return tm_transaction_v1::tx_status::preparing;
+    case tm_transaction::tx_status::prepared:
+        return tm_transaction_v1::tx_status::prepared;
+    case tm_transaction::tx_status::aborting:
+        return tm_transaction_v1::tx_status::aborting;
+    case tm_transaction::tx_status::killed:
+        return tm_transaction_v1::tx_status::killed;
+    case tm_transaction::tx_status::ready:
+        return tm_transaction_v1::tx_status::ready;
+    case tm_transaction::tx_status::tombstone:
+        return tm_transaction_v1::tx_status::tombstone;
+    }
+    vassert(false, "unknown status: {}", status);
+}
+
+tm_transaction_v1 downgrade_tx(const tm_transaction& tx) {
+    tm_transaction_v1 result;
+    result.id = tx.id;
+    result.pid = tx.pid;
+    result.tx_seq = tx.tx_seq;
+    result.etag = tx.etag;
+    result.status = downgrade_status(tx.status);
+    result.timeout_ms = tx.timeout_ms;
+    result.last_update_ts = tx.last_update_ts;
+    for (auto& partition : tx.partitions) {
+        result.partitions.push_back(tm_transaction_v1::tx_partition{
+          .ntp = partition.ntp, .etag = partition.etag});
+    }
+    for (auto& group : tx.groups) {
+        result.groups.push_back(tm_transaction_v1::tx_group{
+          .group_id = group.group_id, .etag = group.etag});
+    }
+    return result;
+}
+
+template<typename T>
+model::record_batch do_serialize_tx(T tx) {
     iobuf key;
     reflection::serialize(key, model::record_batch_type::tm_update);
     auto pid_id = tx.pid.id;
@@ -32,13 +77,23 @@ static model::record_batch serialize_tx(tm_transaction tx) {
     reflection::serialize(key, pid_id, tx_id);
 
     iobuf value;
-    reflection::serialize(value, tm_transaction::version);
+    reflection::serialize(value, T::version);
     reflection::serialize(value, std::move(tx));
 
     storage::record_batch_builder b(
       model::record_batch_type::tm_update, model::offset(0));
     b.add_raw_kv(std::move(key), std::move(value));
     return std::move(b).build();
+}
+
+} // namespace
+
+model::record_batch tm_stm::serialize_tx(tm_transaction tx) {
+    if (use_new_tx_version()) {
+        return do_serialize_tx(tx);
+    }
+    auto old_tx = downgrade_tx(tx);
+    return do_serialize_tx(old_tx);
 }
 
 std::ostream& operator<<(std::ostream& o, const tm_transaction& tx) {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -43,7 +43,8 @@ static model::record_batch serialize_tx(tm_transaction tx) {
 
 std::ostream& operator<<(std::ostream& o, const tm_transaction& tx) {
     return o << "{tm_transaction: id=" << tx.id << ", status=" << tx.status
-             << ", pid=" << tx.pid << ", etag=" << tx.etag
+             << ", pid=" << tx.pid << ", last_pid=" << tx.last_pid
+             << ", etag=" << tx.etag
              << ", size(partitions)=" << tx.partitions.size()
              << ", tx_seq=" << tx.tx_seq << "}";
 }
@@ -492,16 +493,26 @@ ss::future<> tm_stm::apply(model::record_batch b) {
     auto version = reflection::adl<int8_t>{}.from(val_reader);
 
     tm_transaction tx;
-    if (version == tm_transaction_v0::version) {
+    switch (version) {
+    case tm_transaction_v0::version: {
         auto tx0 = reflection::adl<tm_transaction_v0>{}.from(val_reader);
         tx = tx0.upcast();
-    } else {
+        break;
+    }
+    case tm_transaction_v1::version: {
+        auto tx1 = reflection::adl<tm_transaction_v1>{}.from(val_reader);
+        tx = tx1.upcast();
+        break;
+    }
+    default: {
         vassert(
           version == tm_transaction::version,
           "unknown group inflight tx record version: {} expected: {}",
           version,
           tm_transaction::version);
         tx = reflection::adl<tm_transaction>{}.from(val_reader);
+        break;
+    }
     }
 
     auto key_buf = record.release_key();

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -199,6 +199,7 @@ public:
       model::term_id,
       kafka::transactional_id,
       std::chrono::milliseconds,
+      model::producer_identity,
       model::producer_identity);
     ss::future<tm_stm::op_status> register_new_producer(
       model::term_id,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/feature_table.h"
 #include "cluster/persisted_stm.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
@@ -144,7 +145,7 @@ public:
         partition_not_found
     };
 
-    explicit tm_stm(ss::logger&, raft::consensus*);
+    explicit tm_stm(ss::logger&, raft::consensus*, ss::sharded<feature_table>&);
 
     std::optional<tm_transaction> get_tx(kafka::transactional_id);
     checked<tm_transaction, tm_stm::op_status>
@@ -267,6 +268,8 @@ private:
           model::make_memory_record_batch_reader(std::move(batch)),
           raft::replicate_options{raft::consistency_level::quorum_ack});
     }
+
+    ss::sharded<feature_table>& _feature_table;
 };
 
 // Version 1 added last_update_ts to tx lod record. And new status tombstone to

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -35,6 +35,9 @@
 
 namespace cluster {
 
+using use_tx_version_with_last_pid_bool
+  = ss::bool_class<struct use_tx_version_with_last_pid_tag>;
+
 struct tm_transaction {
     // Version 2 added last_pid field to tx log records
     static constexpr uint8_t version = 2;
@@ -268,6 +271,14 @@ private:
           model::make_memory_record_batch_reader(std::move(batch)),
           raft::replicate_options{raft::consistency_level::quorum_ack});
     }
+
+    use_tx_version_with_last_pid_bool use_new_tx_version() {
+        return _feature_table.local().is_active(feature::transaction_ga)
+                 ? use_tx_version_with_last_pid_bool::yes
+                 : use_tx_version_with_last_pid_bool::no;
+    }
+
+    model::record_batch serialize_tx(tm_transaction tx);
 
     ss::sharded<feature_table>& _feature_table;
 };

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -35,7 +35,8 @@
 namespace cluster {
 
 struct tm_transaction {
-    static constexpr uint8_t version = 1;
+    // Version 2 added last_pid field to tx log records
+    static constexpr uint8_t version = 2;
 
     enum tx_status {
         ongoing,
@@ -67,6 +68,9 @@ struct tm_transaction {
     // session of transactional_id'ed application as any given
     // moment there maybe only one session per tx.id
     model::producer_identity pid;
+    // Inforamtion about last producer_identity who worked with this
+    // transaction. It is needed for restore producer after redpanda failures
+    model::producer_identity last_pid;
     // tx_seq identifues a transactions within a session so a
     // triple (transactional_id, producer_identity, tx_seq) uniquely
     // identidies a transaction
@@ -265,6 +269,97 @@ private:
     }
 };
 
+// Version 1 added last_update_ts to tx lod record. And new status tombstone to
+// tx_status
+struct tm_transaction_v1 {
+    static constexpr uint8_t version = 1;
+
+    enum tx_status {
+        ongoing,
+        preparing,
+        prepared,
+        aborting, // abort is initiated by a client
+        killed,   // abort is initiated by a timeout
+        ready,
+        tombstone,
+    };
+
+    struct tx_partition {
+        model::ntp ntp;
+        model::term_id etag;
+
+        bool operator==(const tx_partition& other) const = default;
+    };
+
+    struct tx_group {
+        kafka::group_id group_id;
+        model::term_id etag;
+    };
+
+    // id of an application executing a transaction. in the early
+    // drafts of Kafka protocol transactional_id used to be named
+    // application_id
+    kafka::transactional_id id;
+    // another misnomer in fact producer_identity identifies a
+    // session of transactional_id'ed application as any given
+    // moment there maybe only one session per tx.id
+    model::producer_identity pid;
+    // tx_seq identifues a transactions within a session so a
+    // triple (transactional_id, producer_identity, tx_seq) uniquely
+    // identidies a transaction
+    model::tx_seq tx_seq;
+    // term of a transaction coordinated started a transaction.
+    // transactions can't span cross term to prevent loss of information stored
+    // only in memory (partitions and groups).
+    model::term_id etag;
+    tx_status status;
+    std::chrono::milliseconds timeout_ms;
+    ss::lowres_system_clock::time_point last_update_ts;
+    std::vector<tx_partition> partitions;
+    std::vector<tx_group> groups;
+
+    tm_transaction::tx_status upcast(tx_status status) {
+        switch (status) {
+        case tx_status::ongoing:
+            return tm_transaction::tx_status::ongoing;
+        case tx_status::preparing:
+            return tm_transaction::tx_status::preparing;
+        case tx_status::prepared:
+            return tm_transaction::tx_status::prepared;
+        case tx_status::aborting:
+            return tm_transaction::tx_status::aborting;
+        case tx_status::killed:
+            return tm_transaction::tx_status::killed;
+        case tx_status::ready:
+            return tm_transaction::tx_status::ready;
+        case tx_status::tombstone:
+            return tm_transaction::tx_status::tombstone;
+        }
+        vassert(false, "unknown status: {}", status);
+    };
+
+    tm_transaction upcast() {
+        tm_transaction result;
+        result.id = id;
+        result.pid = pid;
+        result.last_pid = model::unknown_pid;
+        result.tx_seq = tx_seq;
+        result.etag = etag;
+        result.status = upcast(status);
+        result.timeout_ms = timeout_ms;
+        result.last_update_ts = last_update_ts;
+        for (auto& partition : partitions) {
+            result.partitions.push_back(tm_transaction::tx_partition{
+              .ntp = partition.ntp, .etag = partition.etag});
+        }
+        for (auto& group : groups) {
+            result.groups.push_back(tm_transaction::tx_group{
+              .group_id = group.group_id, .etag = group.etag});
+        }
+        return result;
+    };
+};
+
 struct tm_transaction_v0 {
     static constexpr uint8_t version = 0;
 
@@ -310,15 +405,15 @@ struct tm_transaction_v0 {
             return tm_transaction::tx_status::killed;
         case tx_status::ready:
             return tm_transaction::tx_status::ready;
-        default:
-            vassert(false, "unknown status: {}", status);
         }
+        vassert(false, "unknown status: {}", status);
     };
 
     tm_transaction upcast() {
         tm_transaction result;
         result.id = id;
         result.pid = pid;
+        result.last_pid = model::unknown_pid;
         result.tx_seq = tx_seq;
         result.etag = etag;
         result.status = upcast(status);

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -14,6 +14,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "model/namespace.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 
 #include <seastar/core/coroutine.hh>
@@ -41,7 +42,10 @@ tx_gateway::try_abort(try_abort_request&& request, rpc::streaming_context&) {
 ss::future<init_tm_tx_reply>
 tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().init_tm_tx_locally(
-      request.tx_id, request.transaction_timeout_ms, request.timeout);
+      request.tx_id,
+      request.transaction_timeout_ms,
+      request.timeout,
+      model::unknown_pid);
 }
 
 ss::future<begin_tx_reply>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -539,6 +539,10 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
           tx_id, transaction_timeout_ms, timeout, expected_pid);
     }
 
+    // Kafka does not dispatch this request. So we should delete this logic in
+    // future TODO: https://github.com/redpanda-data/redpanda/issues/6418
+    co_return cluster::init_tm_tx_reply{tx_errc::not_coordinator};
+
     vlog(
       txlog.trace,
       "dispatching name:init_tm_tx, tx_id:{}, from:{}, to:{}",

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -24,6 +24,7 @@
 #include "cluster/tx_helpers.h"
 #include "config/configuration.h"
 #include "errc.h"
+#include "model/record.h"
 #include "rpc/connection_cache.h"
 #include "types.h"
 
@@ -808,7 +809,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
     }
 
     auto op_status = co_await stm->re_register_producer(
-      term, tx.id, transaction_timeout_ms, reply.pid);
+      term, tx.id, transaction_timeout_ms, reply.pid, model::unknown_pid);
     if (op_status == tm_stm::op_status::success) {
         reply.ec = tx_errc::none;
     } else if (op_status == tm_stm::op_status::conflict) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -98,7 +98,8 @@ tx_gateway_frontend::tx_gateway_frontend(
   cluster::controller* controller,
   ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend,
   rm_group_proxy* group_proxy,
-  ss::sharded<cluster::rm_partition_frontend>& rm_partition_frontend)
+  ss::sharded<cluster::rm_partition_frontend>& rm_partition_frontend,
+  ss::sharded<feature_table>& feature_table)
   : _ssg(ssg)
   , _partition_manager(partition_manager)
   , _shard_table(shard_table)
@@ -109,6 +110,7 @@ tx_gateway_frontend::tx_gateway_frontend(
   , _id_allocator_frontend(id_allocator_frontend)
   , _rm_group_proxy(group_proxy)
   , _rm_partition_frontend(rm_partition_frontend)
+  , _feature_table(feature_table)
   , _metadata_dissemination_retries(
       config::shard_local_cfg().metadata_dissemination_retries.value())
   , _metadata_dissemination_retry_delay_ms(
@@ -477,7 +479,14 @@ tx_gateway_frontend::do_commit_tm_tx(
 ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  model::producer_identity expected_pid) {
+    if (
+      expected_pid != model::unknown_pid
+      && !allow_init_tm_request_with_expected_pid()) {
+        co_return cluster::init_tm_tx_reply{tx_errc::not_coordinator};
+    }
+
     auto retries = _metadata_dissemination_retries;
     auto delay_ms = _metadata_dissemination_retry_delay_ms;
     auto aborted = false;
@@ -527,7 +536,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
 
     if (leader == _self) {
         co_return co_await init_tm_tx_locally(
-          tx_id, transaction_timeout_ms, timeout);
+          tx_id, transaction_timeout_ms, timeout, expected_pid);
     }
 
     vlog(
@@ -553,7 +562,8 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
 ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  model::producer_identity expected_pid) {
     vlog(txlog.trace, "processing name:init_tm_tx, tx_id:{}", tx_id);
 
     auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
@@ -578,11 +588,13 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
     auto reply = co_await container().invoke_on(
       shard.value(),
       _ssg,
-      [tx_id, transaction_timeout_ms, timeout](tx_gateway_frontend& self) {
+      [tx_id, transaction_timeout_ms, timeout, expected_pid](
+        tx_gateway_frontend& self) {
           return ss::with_gate(
-            self._gate, [tx_id, transaction_timeout_ms, timeout, &self] {
+            self._gate,
+            [tx_id, transaction_timeout_ms, timeout, expected_pid, &self] {
                 return self.do_init_tm_tx(
-                  tx_id, transaction_timeout_ms, timeout);
+                  tx_id, transaction_timeout_ms, timeout, expected_pid);
             });
       });
 
@@ -627,7 +639,8 @@ ss::future<init_tm_tx_reply> tx_gateway_frontend::dispatch_init_tm_tx(
 ss::future<init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  model::producer_identity expected_pid) {
     auto partition = _partition_manager.local().get(model::tx_manager_ntp);
     if (!partition) {
         vlog(
@@ -648,15 +661,24 @@ ss::future<init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
     }
 
     return stm->read_lock().then(
-      [this, stm, tx_id, transaction_timeout_ms, timeout](
+      [this, stm, tx_id, transaction_timeout_ms, timeout, expected_pid](
         ss::basic_rwlock<>::holder unit) {
           return with(
                    stm,
                    tx_id,
                    "init_tm_tx",
-                   [this, stm, tx_id, transaction_timeout_ms, timeout]() {
+                   [this,
+                    stm,
+                    tx_id,
+                    transaction_timeout_ms,
+                    timeout,
+                    expected_pid]() {
                        return do_init_tm_tx(
-                         stm, tx_id, transaction_timeout_ms, timeout);
+                         stm,
+                         tx_id,
+                         transaction_timeout_ms,
+                         timeout,
+                         expected_pid);
                    })
             .finally([u = std::move(unit)] {});
       });
@@ -666,7 +688,8 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
   ss::shared_ptr<tm_stm> stm,
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  model::producer_identity expected_pid) {
     auto term_opt = co_await stm->sync();
     if (!term_opt.has_value()) {
         if (term_opt.error() == tm_stm::op_status::not_leader) {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -121,7 +121,8 @@ enum class tx_errc {
     // the target node
     request_rejected,
     invalid_producer_id_mapping,
-    invalid_txn_state
+    invalid_txn_state,
+    invalid_producer_epoch
 };
 struct tx_errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::tx_errc"; }
@@ -164,6 +165,8 @@ struct tx_errc_category final : public std::error_category {
             return "Unknown server error";
         case tx_errc::request_rejected:
             return "Request rejected";
+        case tx_errc::invalid_producer_epoch:
+            return "Invalid producer epoch";
         default:
             return "cluster::tx_errc::unknown";
         }

--- a/src/v/kafka/protocol/schemata/init_producer_id_request.json
+++ b/src/v/kafka/protocol/schemata/init_producer_id_request.json
@@ -20,12 +20,18 @@
   // Version 1 is the same as version 0.
   //
   // Version 2 is the first flexible version.
-  "validVersions": "0-2",
+  //
+  // Version 3 adds ProducerId and ProducerEpoch, allowing producers to try to resume after an INVALID_PRODUCER_EPOCH error
+  "validVersions": "0-3",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "0+", "nullableVersions": "0+", "entityType": "transactionalId",
       "about": "The transactional id, or null if the producer is not transactional." },
     { "name": "TransactionTimeoutMs", "type": "int32", "versions": "0+",
-      "about": "The time in ms to wait for before aborting idle transactions sent by this producer. This is only relevant if a TransactionalId has been defined." }
+      "about": "The time in ms to wait before aborting idle transactions sent by this producer. This is only relevant if a TransactionalId has been defined." },
+    { "name": "ProducerId", "type": "int64", "versions": "3+", "default": "-1",
+      "about": "The producer id. This is used to disambiguate requests if a transactional id is reused following its expiration." },
+    { "name": "ProducerEpoch", "type": "int16", "versions": "3+", "default": "-1",
+      "about": "The producer's current epoch. This will be checked against the producer epoch on the broker, and the request will return an error if they do not match." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/init_producer_id_response.json
+++ b/src/v/kafka/protocol/schemata/init_producer_id_response.json
@@ -20,7 +20,9 @@
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
   //
   // Version 2 is the first flexible version.
-  "validVersions": "0-2",
+  //
+  // Version 3 is the same as version 2.
+  "validVersions": "0-3",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -12,6 +12,7 @@
 #include "cluster/id_allocator_frontend.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
@@ -65,6 +66,10 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                       break;
                   case cluster::tx_errc::not_coordinator:
                       reply.data.error_code = error_code::not_coordinator;
+                      break;
+                  case cluster::tx_errc::invalid_producer_epoch:
+                      reply.data.error_code
+                        = error_code::invalid_producer_epoch;
                       break;
                   default:
                       vlog(klog.warn, "failed to allocate pid, ec: {}", r.ec);

--- a/src/v/kafka/server/handlers/init_producer_id.h
+++ b/src/v/kafka/server/handlers/init_producer_id.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using init_producer_id_handler
-  = single_stage_handler<init_producer_id_api, 0, 1>;
+  = single_stage_handler<init_producer_id_api, 0, 3>;
 
 }

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -448,7 +448,7 @@ struct producer_identity
 
     producer_identity() noexcept = default;
 
-    producer_identity(int64_t id, int16_t epoch)
+    constexpr producer_identity(int64_t id, int16_t epoch)
       : id(id)
       , epoch(epoch) {}
 
@@ -480,6 +480,8 @@ struct tx_range {
 
     auto operator<=>(const tx_range&) const = default;
 };
+
+static constexpr producer_identity unknown_pid{-1, -1};
 
 struct batch_identity {
     static int32_t increment_sequence(int32_t sequence, int32_t increment) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1069,7 +1069,8 @@ void application::wire_up_redpanda_services() {
       controller.get(),
       std::ref(id_allocator_frontend),
       _rm_group_proxy.get(),
-      std::ref(rm_partition_frontend))
+      std::ref(rm_partition_frontend),
+      std::ref(_feature_table))
       .get();
     /**
      * Schedule partition stop before the transaction coordinator is asked to be

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -22,7 +22,7 @@ from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.utils.util import wait_until
 from rptest.util import wait_until_result
 
-CURRENT_LOGICAL_VERSION = 5
+CURRENT_LOGICAL_VERSION = 6
 
 # The upgrade tests defined below rely on having a logical version lower than
 # CURRENT_LOGICAL_VERSION. For the sake of these tests, the exact version

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -12,6 +12,7 @@ from rptest.util import wait_until_result
 from rptest.clients.types import TopicSpec
 
 import time
+import uuid
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import RedpandaService
@@ -20,6 +21,10 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.rpk_consumer import RpkConsumer
 import confluent_kafka as ck
 from rptest.clients.kafka_cat import KafkaCat
+from rptest.services.admin import Admin
+from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+import random
+import string
 
 import subprocess
 
@@ -319,3 +324,113 @@ class UpgradeTransactionTest(RedpandaTest):
                 prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
 
             num_consumed += len(records)
+
+
+class UpgradeWithMixedVeersionTransactionTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "enable_transactions": True,
+            "transaction_coordinator_replication": 1,
+            "id_allocator_replication": 1,
+            "enable_leader_balancer": False,
+        }
+
+        super(UpgradeWithMixedVeersionTransactionTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf=extra_rp_conf)
+
+        self.installer = self.redpanda._installer
+
+    def on_delivery(self, err, msg):
+        assert err == None, msg
+
+    def check_consume(self, max_records):
+        topic_name = self.topics[0].name
+
+        consumer = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': f"consumer-{uuid.uuid4()}",
+            'auto.offset.reset': 'earliest',
+        })
+
+        consumer.subscribe([topic_name])
+        num_consumed = 0
+        prev_rec = bytes("0", 'UTF-8')
+
+        while num_consumed != max_records:
+            max_consume_records = 10
+            timeout = 10
+            records = consumer.consume(max_consume_records, timeout)
+
+            for record in records:
+                assert prev_rec == record.key(), f"{prev_rec}, {record.key()}"
+                prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
+
+            num_consumed += len(records)
+
+        consumer.close()
+
+    def setUp(self):
+        self.installer.install(self.redpanda.nodes, (22, 1, 5))
+        super(UpgradeWithMixedVeersionTransactionTest, self).setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def upgrade_test(self):
+        topic_name = self.topics[0].name
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert "v22.1.5" in unique_versions, unique_versions
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        })
+
+        producer.init_transactions()
+        producer.begin_transaction()
+        producer.produce(topic_name, "0", "0", 0, self.on_delivery)
+        producer.commit_transaction()
+        producer.flush()
+
+        self.check_consume(1)
+
+        def get_tx_manager_broker():
+            admin = Admin(self.redpanda)
+            leader_id = admin.get_partition_leader(namespace="kafka_internal",
+                                                   topic="tx",
+                                                   partition=0)
+            return self.redpanda.get_node(leader_id)
+
+        node_with_tx_manager = get_tx_manager_broker()
+
+        # Update node with tx manager
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(node_with_tx_manager)
+        unique_versions = wait_for_num_versions(self.redpanda, 2)
+        assert "v22.1.5" in unique_versions, unique_versions
+
+        # Init dispatch by using old node. Transaction should work
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        })
+
+        producer.init_transactions()
+        producer.begin_transaction()
+        producer.produce(topic_name, "1", "1", 0, self.on_delivery)
+        producer.commit_transaction()
+        producer.flush()
+
+        self.check_consume(2)
+
+        self.installer.install(self.redpanda.nodes, (22, 1, 5))
+        self.redpanda.restart_nodes(node_with_tx_manager)
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert "v22.1.5" in unique_versions, unique_versions
+
+        self.check_consume(2)

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -14,6 +14,9 @@ from rptest.clients.types import TopicSpec
 import time
 
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService
+from rptest.clients.default import DefaultClient
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.rpk_consumer import RpkConsumer
 import confluent_kafka as ck
 from rptest.clients.kafka_cat import KafkaCat
@@ -249,3 +252,70 @@ class TransactionsTest(RedpandaTest):
             assert kafka_error.code() == ck.cimpl.KafkaError.FENCED_INSTANCE_ID
 
         producer.abort_transaction()
+
+
+class UpgradeTransactionTest(RedpandaTest):
+    @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def check_parsing_test(self):
+        self.redpanda = RedpandaService(
+            self.test_context,
+            1,
+            extra_rp_conf={
+                "enable_idempotence": True,
+                "enable_transactions": True,
+                "transaction_coordinator_replication": 1,
+                "id_allocator_replication": 1,
+                "enable_leader_balancer": False,
+                "enable_auto_rebalance_on_node_add": False,
+            },
+            environment={"__REDPANDA_LOGICAL_VERSION": 5})
+
+        self.redpanda.start()
+
+        spec = TopicSpec(partition_count=1, replication_factor=1)
+        self._client = DefaultClient(self.redpanda)
+        self.client().create_topic(spec)
+        topic_name = spec.name
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '123',
+            'transaction.timeout.ms': 10000,
+        })
+
+        producer.init_transactions()
+
+        def on_del(err, msg):
+            assert err == None
+
+        max_tx = 100
+        for i in range(max_tx):
+            producer.begin_transaction()
+            producer.produce(topic_name, str(i), str(i), 0, on_del)
+            producer.commit_transaction()
+
+        self.redpanda.set_environment({"__REDPANDA_LOGICAL_VERSION": 6})
+        for n in self.redpanda.nodes:
+            self.redpanda.restart_nodes(n, stop_timeout=60)
+
+        consumer = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': "test",
+            'auto.offset.reset': 'earliest',
+        })
+
+        consumer.subscribe([topic_name])
+
+        num_consumed = 0
+        prev_rec = bytes("0", 'UTF-8')
+
+        while num_consumed != max_tx:
+            max_records = 10
+            timeout = 10
+            records = consumer.consume(max_records, timeout)
+
+            for record in records:
+                assert prev_rec == record.key()
+                prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
+
+            num_consumed += len(records)


### PR DESCRIPTION
## Cover letter

rfc: [link](https://github.com/redpanda-data/redpanda/issues/3278#issuecomment-1131893976)

## Problem (from [link](https://www.confluent.io/blog/simplified-robust-exactly-one-semantics-in-kafka-2-5/) )
Fatal error occurs when the producer cannot assign sequence numbers to the records that it produces. In order to maintain the correct order, records produced by an idempotent or transactional producer each have a sequence number, and the broker only accepts writes in sequential order, with no gaps or out-of-order records allowed. In order to assign the correct sequence number, the producer needs to know which requests have been successfully written to the log, which requires a successful response from the broker.

If a produce request fails with a retriable error, the producer will retry it until it either succeeds or hits the configured delivery timeout (delivery.timeout.ms), at which point the records are expired by the producer. If the records expire, the producer can’t be sure if the records were written or not. When this happens, the producer can’t continue because it doesn’t know what sequence number to assign to the next record

## How to solve
KIP-360 solves these problems by providing a way to re-initialize a producer ID without having to create a new producer. In addition to the producer’s transactional ID, `InitProducerId` now optionally takes a producer ID and producer epoch as well. When these are present in the request, the broker compares them to the existing producer ID and epoch for that transactional ID. If they match, then no other producer has been initialized for that transactional ID, and it is safe for the producer to continue processing. The broker will increment the producer epoch and return it to the producer. When the epoch is bumped, the sequence number is also reset to zero, allowing the producer to continue through both unknown producer and out of sequence errors.

With a safe way to bump its epoch, the producer can now recover from a number of previously fatal errors. When the producer encounters one of these errors, and the broker supports the new InitProducerId version, it will transition to an abortable error state, rather than a fatal one. When the application aborts the transaction, the producer will internally call InitProducerId after aborting, which bumps the epoch and allows it to continue. Because this epoch bump happens transparently as part of the call to KafkaProducer#abortTransaction

Fixes #3278 

## Testing
Python client has problems with this logic. (It tries to complete send after timeout and etc), so I tested it by hand.

## Release notes

* Support safe epoch incrementing for idempotent/transactional producer in retries cases