### PR TITLE
Fix `rpk topic add-partition` panic

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
@@ -62,7 +62,7 @@ func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
 					if errors.Is(e, kerr.InvalidPartitions) && num > 0 {
 						msg = fmt.Sprintf("INVALID_PARTITIONS: unable to add %d partitions due to hardware constraints", num)
 					} else {
-						msg = err.Error()
+						msg = e.Error()
 					}
 					exit1 = true
 				}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -132,6 +132,10 @@ class RpkTool:
         self._check_stdout_success(output)
         return output
 
+    def add_partitions(self, topic, partitions):
+        cmd = ["add-partitions", topic, "-n", str(partitions)]
+        return self._run_topic(cmd)
+
     def _check_stdout_success(self, output):
         """
         Helper for topic operations where rpk does not surface errors

--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -46,6 +46,13 @@ class RpkToolTest(RedpandaTest):
                               lambda e: "INVALID_CONFIG" in str(e)):
             out = self._rpk.create_topic("topic", config={config_type: "foo"})
 
+    @cluster(num_nodes=1)
+    def test_add_unfeasible_number_of_partitions(self):
+        with expect_exception(RpkException,
+                              lambda e: "INVALID_REQUEST" in str(e)):
+            self._rpk.create_topic("topic")
+            out = self._rpk.add_partitions("topic", 2000000000000)
+
     @cluster(num_nodes=4)
     def test_produce(self):
         topic = 'topic'


### PR DESCRIPTION
## Cover letter

Fixes a bug that caused `rpk topic add-partitions` to panic when an unfeasible number of partitions were passed.

Fixes #5351

## Release notes

* rpk: Fix a bug that caused `rpk topic add-partitions` to panic when an unfeasible number of partitions were passed