### PR TITLE
cluster: fix timeouts creating topics with many partitions

### DIFF
--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -47,6 +47,8 @@ public:
 
     ss::future<ntp_reconciliation_state> get_reconciliation_state(model::ntp);
 
+    ss::future<result<bool>> all_reconciliations_done(std::vector<model::ntp>);
+
     /**
      * API to access both remote and local state
      */


### PR DESCRIPTION
## Cover letter

In the ~100k partition regime, rpk hits a 15 second i/o
timeout waiting for a response.

It's because get_reconcilation_state does a ssx::async_transform,
which runs for each element in serial (this is basically a huge
for loop).

We could just change that to a parallel_transform, but that would
create a really huge number of futures in one go, and those that
call across cores could negatively impact other work going on
by saturating message queues, so we create a specialized
function that does the checks in batches.
    
We do explicit batching rather than using max_concurrent_for_each,
in order to have the opportunity to drop out early if anytyhing
is incomplete: worthwhile when the overall loop might be over
100k partitions but the 1st batch shows it's not ready yet.

## Release notes

### Improvements

* Fix an issue where topic creation could take unexpectedly long for high partition counts, causing CLI tools to timeout.
