### PR TITLE
kafka/probe: seperate internal and public metrics

### DIFF
--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -46,7 +46,14 @@ public:
              labels,
              [this] { return _produce_latency.seastar_histogram_logform(); })
              .aggregate(aggregate_labels)});
+    }
 
+    void setup_public_metrics() {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_public_metrics()) {
+            return;
+        }
         _public_metrics.add_group(
           prometheus_sanitize::metrics_name("kafka"),
           {

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -85,6 +85,7 @@ protocol::protocol(
         _qdc_mon.emplace(*qdc_config);
     }
     _probe.setup_metrics();
+    _probe.setup_public_metrics();
 }
 
 coordinator_ntp_mapper& protocol::coordinator_mapper() {


### PR DESCRIPTION
## Cover letter

Prior to this change the public kafka latency metrics were tracked when `disable_public_metrics: true` is set. That should not happen. This PR separates the public metrics from the internal ones and checks the appropriate config.

## Release notes
* none