### PR TITLE
Handle aborted transactions in shadow indexing

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -163,9 +163,15 @@ private:
 
     /// Upload individual segment to S3.
     ///
-    /// \return true on success and false otherwise
+    /// \return error code
     ss::future<cloud_storage::upload_result>
     upload_segment(upload_candidate candidate);
+
+    /// Upload segment's transactions metadata to S3.
+    ///
+    /// \return error code
+    ss::future<cloud_storage::upload_result>
+    upload_tx(upload_candidate candidate);
 
     /// Upload manifest to the pre-defined S3 location
     ss::future<cloud_storage::upload_result> upload_manifest();

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     remote_segment.cc
     remote_partition.cc
     remote_segment_index.cc
+    tx_range_manifest.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/base_manifest.h
+++ b/src/v/cloud_storage/base_manifest.h
@@ -27,6 +27,7 @@ struct serialized_json_stream {
 enum class manifest_type {
     topic,
     partition,
+    tx_range,
 };
 
 class base_manifest {

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -59,6 +59,22 @@ public:
         return _cnt_partition_manifest_downloads;
     }
 
+    /// Register manifest (re)upload
+    void txrange_manifest_upload() { _cnt_tx_manifest_uploads++; }
+
+    /// Get manifest (re)upload
+    uint64_t get_txrange_manifest_uploads() const {
+        return _cnt_tx_manifest_uploads;
+    }
+
+    /// Register manifest download
+    void txrange_manifest_download() { _cnt_tx_manifest_downloads++; }
+
+    /// Get manifest download
+    uint64_t get_txrange_manifest_downloads() const {
+        return _cnt_tx_manifest_downloads;
+    }
+
     /// Register backof invocation during manifest upload
     void manifest_upload_backoff() { _cnt_manifest_upload_backoff++; }
 
@@ -166,6 +182,10 @@ private:
     uint64_t _cnt_bytes_sent{0};
     /// Number of bytes being successfully received from S3
     uint64_t _cnt_bytes_received{0};
+    /// Number of tx-range manifest uploads
+    uint64_t _cnt_tx_manifest_uploads{0};
+    /// Number of tx-range manifest downloads
+    uint64_t _cnt_tx_manifest_downloads{0};
 
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -216,6 +216,9 @@ ss::future<download_result> remote::download_manifest(
             case manifest_type::topic:
                 _probe.topic_manifest_download();
                 break;
+            case manifest_type::tx_range:
+                _probe.txrange_manifest_download();
+                break;
             }
             co_return download_result::success;
         } catch (...) {
@@ -297,6 +300,9 @@ ss::future<upload_result> remote::upload_manifest(
                 break;
             case manifest_type::topic:
                 _probe.topic_manifest_upload();
+                break;
+            case manifest_type::tx_range:
+                _probe.txrange_manifest_upload();
                 break;
             }
             _probe.register_upload_size(size);

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -133,6 +133,13 @@ private:
 
 } // namespace details
 
+struct offset_range {
+    model::offset begin;
+    model::offset end;
+    model::offset begin_rp;
+    model::offset end_rp;
+};
+
 /// Remote partition manintains list of remote segments
 /// and list of active readers. Only one reader can be
 /// maintained per segment. The idea here is that the
@@ -191,6 +198,10 @@ public:
 
     // returns term last kafka offset
     std::optional<model::offset> get_term_last_offset(model::term_id) const;
+
+    // Get list of aborted transactions that overlap with the offset range
+    ss::future<std::vector<cluster::rm_stm::tx_range>>
+    aborted_transactions(offset_range offsets);
 
 private:
     /// Create new remote_segment instances for all new

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -17,6 +17,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_segment_index.h"
 #include "cloud_storage/types.h"
+#include "cluster/rm_stm.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "s3/client.h"
@@ -118,6 +119,13 @@ public:
 
     bool download_in_progress() const noexcept { return !_wait_list.empty(); }
 
+    /// Return aborted transactions metadata associated with the segment
+    ///
+    /// \param from start redpanda offset
+    /// \param to end redpanda offset
+    ss::future<std::vector<cluster::rm_stm::tx_range>>
+    aborted_transactions(model::offset from, model::offset to);
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available
@@ -133,7 +141,15 @@ private:
 
     /// Actually hydrate the segment. The method downloads the segment file
     /// to the cache dir and updates the segment index.
-    ss::future<> do_hydrate();
+    ss::future<> do_hydrate_segment();
+    /// Hydrate tx manifest. Method downloads the manifest file to the cache
+    /// dir.
+    ss::future<> do_hydrate_txrange();
+    /// Materilize segment. Segment has to be hydrated beforehand. The
+    /// 'materialization' process opens file handle and creates
+    /// compressed segment index in memory.
+    ss::future<bool> do_materialize_segment();
+    ss::future<bool> do_materialize_txrange();
 
     /// Load segment index from file (if available)
     ss::future<> maybe_materialize_index();
@@ -162,6 +178,9 @@ private:
 
     ss::file _data_file;
     std::optional<offset_index> _index;
+
+    using tx_range_vec = fragmented_vector<cluster::rm_stm::tx_range>;
+    std::optional<tx_range_vec> _tx_range;
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     directory_walker_test.cc
     partition_manifest_test.cc
     topic_manifest_test.cc
+    tx_range_manifest_test.cc
     s3_imposter.cc
     remote_test.cc
     offset_translation_layer_test.cc

--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/tx_range_manifest.h"
+#include "cloud_storage/types.h"
+#include "cluster/types.h"
+#include "model/compression.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "seastarx.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+using namespace cloud_storage;
+
+static remote_segment_path
+  segment_path("abcdef01/kafka/topic/0_1/0-1-v1.log.1");
+static remote_manifest_path
+  manifest_path("abcdef01/kafka/topic/0_1/0-1-v1.log.1.tx");
+
+using tx_range_t = cluster::rm_stm::tx_range;
+
+static std::vector<tx_range_t> ranges = {
+  tx_range_t{
+    .pid = model::producer_identity(1, 2),
+    .first = model::offset(3),
+    .last = model::offset(5),
+  },
+  tx_range_t{
+    .pid = model::producer_identity(2, 3),
+    .first = model::offset(4),
+    .last = model::offset(6),
+  }};
+
+SEASTAR_THREAD_TEST_CASE(manifest_type_tx) {
+    tx_range_manifest m(segment_path);
+    BOOST_REQUIRE(m.get_manifest_type() == manifest_type::tx_range);
+}
+
+SEASTAR_THREAD_TEST_CASE(create_tx_manifest) {
+    tx_range_manifest m(segment_path);
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(path, manifest_path);
+}
+
+SEASTAR_THREAD_TEST_CASE(empty_serialization_roundtrip_test) {
+    tx_range_manifest m(segment_path);
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    tx_range_manifest restored(segment_path);
+    restored.update(std::move(rstr)).get();
+    BOOST_REQUIRE(m == restored);
+}
+
+SEASTAR_THREAD_TEST_CASE(serialization_roundtrip_test) {
+    tx_range_manifest m(segment_path, ranges);
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    tx_range_manifest restored(segment_path);
+    restored.update(std::move(rstr)).get();
+    BOOST_REQUIRE(m == restored);
+}

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -1,0 +1,121 @@
+#include "cloud_storage/tx_range_manifest.h"
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_istreambuf.h"
+#include "bytes/iobuf_ostreambuf.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/types.h"
+#include "cluster/rm_stm.h"
+#include "json/istreamwrapper.h"
+#include "model/record.h"
+#include "utils/fragmented_vector.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/writer.h>
+
+namespace cloud_storage {
+
+remote_manifest_path generate_remote_tx_path(const remote_segment_path& path) {
+    return remote_manifest_path(fmt::format("{}.tx", path().native()));
+}
+
+tx_range_manifest::tx_range_manifest(
+  remote_segment_path spath,
+  const std::vector<cluster::rm_stm::tx_range>& range)
+  : _path(std::move(spath)) {
+    for (const auto& tx : range) {
+        _ranges.push_back(tx);
+    }
+    _ranges.shrink_to_fit();
+}
+
+tx_range_manifest::tx_range_manifest(remote_segment_path spath)
+  : _path(std::move(spath)) {}
+
+ss::future<> tx_range_manifest::update(ss::input_stream<char> is) {
+    using namespace rapidjson;
+    iobuf result;
+    auto os = make_iobuf_ref_output_stream(result);
+    co_await ss::copy(is, os);
+    iobuf_istreambuf ibuf(result);
+    std::istream stream(&ibuf);
+    Document m;
+    IStreamWrapper wrapper(stream);
+    m.ParseStream(wrapper);
+    update(m);
+}
+
+void tx_range_manifest::update(const rapidjson::Document& doc) {
+    _ranges = fragmented_vector<cluster::rm_stm::tx_range>();
+    auto version = doc["version"].GetInt();
+    auto compat_version = doc["compat_version"].GetInt();
+    if (
+      compat_version
+      > static_cast<int>(tx_range_manifest_version::current_version)) {
+        throw std::runtime_error(fmt::sprintf(
+          "Can't deserialize tx manifest, supported version {}, manifest "
+          "version {}, compatible version {}",
+          static_cast<int32_t>(tx_range_manifest_version::current_version),
+          version,
+          compat_version));
+    }
+    if (doc.HasMember("ranges")) {
+        const auto& arr = doc["ranges"].GetArray();
+        for (const auto& it : arr) {
+            const auto& tx_range = it.GetObject();
+            auto id = tx_range["pid.id"].GetInt64();
+            auto epoch = tx_range["pid.epoch"].GetInt();
+            auto first = model::offset{tx_range["first"].GetInt64()};
+            auto last = model::offset{tx_range["last"].GetInt64()};
+            model::producer_identity pid(id, static_cast<int16_t>(epoch));
+            _ranges.push_back(cluster::rm_stm::tx_range{pid, first, last});
+        }
+    }
+    _ranges.shrink_to_fit();
+}
+
+serialized_json_stream tx_range_manifest::serialize() const {
+    iobuf serialized;
+    iobuf_ostreambuf obuf(serialized);
+    std::ostream os(&obuf);
+    serialize(os);
+    size_t size_bytes = serialized.size_bytes();
+    return {
+      .stream = make_iobuf_input_stream(std::move(serialized)),
+      .size_bytes = size_bytes};
+}
+
+remote_manifest_path tx_range_manifest::get_manifest_path() const {
+    return generate_remote_tx_path(_path);
+}
+
+void tx_range_manifest::serialize(std::ostream& out) const {
+    using namespace rapidjson;
+    OStreamWrapper wrapper(out);
+    Writer<OStreamWrapper> w(wrapper);
+    w.StartObject();
+    w.Key("version");
+    w.Int(static_cast<int>(tx_range_manifest_version::current_version));
+    w.Key("compat_version");
+    w.Int(static_cast<int>(tx_range_manifest_version::compat_version));
+    w.Key("ranges");
+    w.StartArray();
+    for (const auto& tx : _ranges) {
+        w.StartObject();
+        w.Key("pid.id");
+        w.Int64(tx.pid.id);
+        w.Key("pid.epoch");
+        w.Int(tx.pid.epoch);
+        w.Key("first");
+        w.Int64(tx.first());
+        w.Key("last");
+        w.Int64(tx.last());
+        w.EndObject();
+    }
+    w.EndArray();
+    w.EndObject();
+}
+} // namespace cloud_storage

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/base_manifest.h"
+#include "cluster/rm_stm.h"
+#include "cluster/types.h"
+#include "json/document.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <rapidjson/document.h>
+
+#include <optional>
+
+namespace cloud_storage {
+
+/// Transactional metadata path in S3
+remote_manifest_path generate_remote_tx_path(const remote_segment_path& path);
+
+class tx_range_manifest final : public base_manifest {
+public:
+    /// Create manifest for specific ntp
+    explicit tx_range_manifest(
+      remote_segment_path spath,
+      const std::vector<cluster::rm_stm::tx_range>& range);
+
+    /// Create empty manifest that supposed to be updated later
+    explicit tx_range_manifest(remote_segment_path spath);
+
+    friend bool
+    operator==(const tx_range_manifest& lhs, const tx_range_manifest& rhs) {
+        return lhs._path == rhs._path && lhs._ranges == rhs._ranges;
+    }
+
+    /// Update manifest file from input_stream (remote set)
+    ss::future<> update(ss::input_stream<char> is) override;
+    void update(const rapidjson::Document& is);
+
+    /// Serialize manifest object
+    ///
+    /// \return asynchronous input_stream with the serialized json
+    serialized_json_stream serialize() const override;
+
+    /// Manifest object name in S3
+    remote_manifest_path get_manifest_path() const override;
+
+    /// Serialize manifest object
+    ///
+    /// \param out output stream that should be used to output the json
+    void serialize(std::ostream& out) const;
+
+    manifest_type get_manifest_type() const override {
+        return manifest_type::tx_range;
+    };
+
+    fragmented_vector<cluster::rm_stm::tx_range>&& get_tx_range() && {
+        return std::move(_ranges);
+    }
+
+private:
+    remote_segment_path _path;
+    fragmented_vector<cluster::rm_stm::tx_range> _ranges;
+};
+} // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -60,6 +60,12 @@ enum class manifest_version : int32_t {
     v1 = 1,
 };
 
+enum class tx_range_manifest_version : int32_t {
+    v1 = 1,
+    current_version = v1,
+    compat_version = v1,
+};
+
 static constexpr int32_t topic_manifest_version = 1;
 
 std::ostream& operator<<(std::ostream& o, const download_result& r);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -213,6 +213,11 @@ public:
         return _rm_stm->aborted_transactions(from, to);
     }
 
+    ss::future<std::vector<rm_stm::tx_range>>
+    aborted_transactions_cloud(cloud_storage::offset_range offsets) {
+        return _cloud_storage_partition->aborted_transactions(offsets);
+    }
+
     const ss::shared_ptr<cluster::archival_metadata_stm>&
     archival_meta_stm() const {
         return _archival_meta_stm;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -58,6 +58,8 @@ public:
         model::producer_identity pid;
         model::offset first;
         model::offset last;
+
+        auto operator<=>(const tx_range&) const = default;
     };
 
     struct abort_index {

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -125,6 +125,16 @@ public:
       model::offset, model::timeout_clock::time_point) final;
 
 private:
+    ss::future<std::vector<cluster::rm_stm::tx_range>>
+      aborted_transactions_local(
+        cloud_storage::offset_range,
+        ss::lw_shared_ptr<const storage::offset_translator_state>);
+
+    ss::future<std::vector<cluster::rm_stm::tx_range>>
+    aborted_transactions_remote(
+      cloud_storage::offset_range offsets,
+      ss::lw_shared_ptr<const storage::offset_translator_state> ot_state);
+
     ss::lw_shared_ptr<cluster::partition> _partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
 };


### PR DESCRIPTION
## Cover letter

Previously the information about aborted transactions was extracted from `rm_stm` in the `kafka` layer. There are two problems with this approach:

- This approach doesn't work for topic recovery and read-replicas.
- The data in `rm_stm` snapshot might not be always available (if the snapshot was re-created by scanning the log it won't have any offset ranges for SI data since old log segment are evicted).

In this PR new type of manifest is added. This manifest stores information about aborted transactions in the cloud. The `remote_segment` downloads it alongside the segment and the `remote_partition` uses the manifests to return the ranges.

There is no need to implement a dedicated ducktape test since we're already have one.

## Release notes

* Implement aborted transactions handling in shadow indexing and read replicas.

### Features

* Transactions metadata is uploaded to the cloud storage and used in shadow indexing and read replicas

### Improvements

* Transactions metadata handling in shadow indexing