### PR TITLE
archival: Use correct flag in archival service

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -286,7 +286,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
           auto part = _partition_manager.local().get(ntp);
           if (log.has_value() && part && part->is_elected_leader()
               && (part->get_ntp_config().is_archival_enabled()
-                  || config::shard_local_cfg().cloud_storage_enable_remote_read())) {
+                  || config::shard_local_cfg().cloud_storage_enable_remote_write())) {
               auto archiver = ss::make_lw_shared<ntp_archiver>(
                 log->config(),
                 _partition_manager.local(),


### PR DESCRIPTION

## Cover letter

The code incorrectly used global `cloud_storage_enable_remote_read` flag to enable archival instead of `cloud_storage_enable_remote_write`.

Fixes #5391


## Release notes


* fix handling of shadow indexing flags
