### PR TITLE
docs(/src/.md): Readability improvements

### DIFF
--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -20,7 +20,7 @@ Official Kubernetes quick start documentation can be found at
 * kustomize v3.8.7 or newer
 * cert-manager v1.0.0 or newer
 
-Optionaly to run operator locally:
+Optionally to run operator locally:
 
 * kind v0.9.0 or newer
 
@@ -30,7 +30,7 @@ Optionaly to run operator locally:
 
 Create local Kubernetes cluster using KIND
 
-```
+```bash
 export KUBECONFIG=your/path/to/kubeconfig.yaml
 kind create cluster --config kind.yaml
 ```
@@ -47,19 +47,19 @@ resources. To verify that cert manager is ready please follow
 
 You can simply deploy the Redpanda operator with webhook (recommended) by running the following command
 
-```
+```bash
 kubectl apply -k https://github.com/redpanda-data/redpanda/src/go/k8s/config/default
 ```
 
 You can deploy the Redpanda operator without webhook by running the following command:
 
-```
+```bash
 kubectl apply -k https://github.com/redpanda-data/redpanda/src/go/k8s/config/without-webhook
 ```
 
 Install sample RedpandaCluster custom resource
 
-```
+```bash
 kubectl apply -f https://raw.githubusercontent.com/redpanda-data/redpanda/dev/src/go/k8s/config/samples/one_node_cluster.yaml
 ```
 
@@ -68,26 +68,26 @@ kubectl apply -f https://raw.githubusercontent.com/redpanda-data/redpanda/dev/sr
 
 Create kind cluster
 
-```
+```bash
 make kind-create
 ```
 
 Install cert manager
 
-```
+```bash
 make certmanager-install
 ```
 
 Build docker images for manager and configurator
 
-```
+```bash
 make docker-build
 make docker-build-configurator
 ```
 
 Deploy operator to kind
 
-```
+```bash
 make deploy-to-kind
 ```
 
@@ -96,6 +96,6 @@ make deploy-to-kind
 To remove all resources even the running Redpanda cluster
 please run the following command:
 
-```
+```bash
 kubectl delete -k https://github.com/redpanda-data/redpanda/src/go/k8s/config/default
 ```

--- a/src/go/rpk/pkg/tuners/ReadMe.md
+++ b/src/go/rpk/pkg/tuners/ReadMe.md
@@ -10,7 +10,7 @@ The following tuners are supported
 
 The disk IRQs tuner binds all disk IRQs to requested set of CPUs. This tuner uses `hwloc` library to compute CPU masks. Prevent IRQ Balance from moving tuned devices IRQs. CPU set that is used by the tuner can be limited by CPU mask parameter. If mask parameter is provided then only those CPUs that are masked will be considered as available. Mask covering all host CPUs is used as a default.
 
-IRQs are disstributed according to the following rules:
+IRQs are distributed according to the following rules:
 
 - Distribute NVMe disks IRQs equally among all available CPUs.
 - Distribute non-NVMe disks IRQs equally among designated CPUs or among all available CPUs in the `mq` mode.

--- a/src/v/README.md
+++ b/src/v/README.md
@@ -11,11 +11,11 @@ platform        | Machine dependent settings like ssse3 instructions |
 coproc          | WASM / Coprocessor engine for lambda transforms |
 resource_mgmt   | CPU and IO priority | 
 utils           | code utils |
-hashing         | hashing utility adaptors often used in cryptography or checksuming |
+hashing         | hashing utility adaptors often used in cryptography or checksumming |
 storage         | low level bits of the storage api |
 redpanda        | high level program - main entry point |
 finjector       | failure injector framework for testing and correctness |
-json            | json manipulation utlities |
+json            | json manipulation utilities |
 http            | HTTP conversion and utilities |
 kafka           | Kafka compatibility protocol layer |
 compression     | utilities for supporting multiple compressor types |

--- a/src/v/coding-style.md
+++ b/src/v/coding-style.md
@@ -110,7 +110,7 @@ void a_function() {
 
 An exception is namespaces -- the body is _not_ indented, to prevent files that are almost 100% whitespace left margin.
 
-When making a change, if you need to insert an indentation level, you can temporarily break the rules by insering a half-indent, so that the patch is easily reviewable:
+When making a change, if you need to insert an indentation level, you can temporarily break the rules by inserting a half-indent, so that the patch is easily reviewable:
 
 ```c++
 void a_function() {


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

## Cover letter

Small readability improvements in `src/*.md`. No functional changes.

## Release notes
* none

### Features

* Readability improvements in `src/*.md`.
* Also put `bash` in code snippet markdown in k8s readme for formatting since there was already a grammar fix in this file.

### Improvements

* Docs Readability 
