### PR TITLE
rpk: avoid transmuting CLI args without equal sign

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -843,7 +843,7 @@ func parseFlags(flags []string) map[string]string {
 
 		if i == len(flags)-1 {
 			// We've reached the last element, so it's a single flag
-			parsed[trimmed] = "true"
+			parsed[trimmed] = ""
 			continue
 		}
 
@@ -852,7 +852,7 @@ func parseFlags(flags []string) map[string]string {
 		// boolean flag
 		next := flags[i+1]
 		if strings.HasPrefix(next, "-") {
-			parsed[trimmed] = "true"
+			parsed[trimmed] = ""
 			continue
 		}
 


### PR DESCRIPTION
## Cover letter

Fixed a bug that made rpk to add `=true` to additional CLI arguments, e.g:

   `rpk redpanda start --my-flag`

was interpreted as `redpanda start --my-flag=true`

now rpk will handle the flags correctly:

```
## No Value:
$ rpk redpanda start --abort-on-seastar-bad-alloc

# will be:

redpanda start --abort-on-seastar-bad-alloc

## With Value:
$ rpk redpanda start --abort-on-seastar-bad-alloc=false

# will be:

redpanda start --abort-on-seastar-bad-alloc=false
```

This also applies to rpk.additional_start_flag property in redpanda.yaml
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4778 

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* rpk: fixed a bug that added unexpected `=true` to additional CLI arguments when using `rpk redpanda start`