### PR TITLE
cloud_roles/tests: return UTC time in test script

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -164,17 +164,33 @@ ss::future<> refresh_credentials::fetch_and_update_credentials() {
 
 std::chrono::milliseconds
 refresh_credentials::impl::calculate_sleep_duration(uint32_t expiry_sec) const {
+    vlog(
+      clrl_log.trace, "calculating sleep duration from {} seconds", expiry_sec);
     int sleep = std::floor(expiry_sec * sleep_from_expiry_multiplier);
+    vlog(
+      clrl_log.trace, "sleep duration adjusted with buffer: {} seconds", sleep);
     return std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::seconds{sleep});
 }
 
 std::chrono::milliseconds refresh_credentials::impl::calculate_sleep_duration(
   std::chrono::system_clock::time_point expires_at) const {
+    vlog(
+      clrl_log.trace,
+      "calculating sleep duration for credential expiry at: {}",
+      expires_at.time_since_epoch());
     auto now = std::chrono::system_clock::now();
     auto diff = std::chrono::duration_cast<std::chrono::seconds>(
                   expires_at - now)
                   .count();
+    vlog(
+      clrl_log.trace,
+      "calculating sleep duration for credential expiry at: {}, now: {}, diff "
+      "{} seconds",
+      expires_at.time_since_epoch(),
+      now.time_since_epoch(),
+      diff);
+
     return calculate_sleep_duration(diff);
 }
 

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -68,9 +68,13 @@ public:
         void increment_retries();
 
         void reset_retries() {
-            vlog(
-              clrl_log.info, "resetting retry counter from {} to 0", _retries);
-            _retries = 0;
+            if (unlikely(_retries != 0)) {
+                vlog(
+                  clrl_log.info,
+                  "resetting retry counter from {} to 0",
+                  _retries);
+                _retries = 0;
+            }
         }
 
     protected:

--- a/tests/rptest/remote_scripts/aws_iam_role_mock.py
+++ b/tests/rptest/remote_scripts/aws_iam_role_mock.py
@@ -36,13 +36,11 @@ def make_aws_handler(token_ttl):
             'Code': 'Success',
             'LastUpdated': '2012-04-26T16:39:16Z',
             'Type': 'AWS-HMAC',
-            'AccessKeyId': 'panda-user',
-            'SecretAccessKey': 'panda-secret',
             'Token': '__REDPANDA_SKIP_IAM_TOKEN_x',
         }
 
         def get_canned_credentials(self):
-            future = datetime.datetime.now() + datetime.timedelta(
+            future = datetime.datetime.utcnow() + datetime.timedelta(
                 seconds=self.token_expiry)
             cc = self.canned_credentials
             cc['Expiration'] = future.isoformat()
@@ -101,7 +99,7 @@ def make_sts_handler(token_ttl):
         """
 
         def get_canned_credentials(self):
-            future = datetime.datetime.now() + datetime.timedelta(
+            future = datetime.datetime.utcnow() + datetime.timedelta(
                 seconds=self.token_expiry)
             return self.canned_credentials.format(future.isoformat())
 


### PR DESCRIPTION
the test script used for ducktape returns local time when calculating credentials expiry. it should use utc time to be consistent with AWS api response.

these tests are passing in buildkite because it defaults to utc on the build servers, but for testing locally we should make sure that the remote script returns UTC time explicitly.

On the redpanda side we assume UTC, and if we return `datetime.now()` for example from a laptop in India, the time interpreted by redpanda is off by 5.5 hours from what it should be during the test, causing failure.