### PR TITLE
Strip license key of whitespace and newlines

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -397,7 +397,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
 
 ss::future<std::error_code>
 feature_manager::update_license(security::license&& license) {
-    static const auto timeout = model::timeout_clock::now() + 5s;
+    const auto timeout = model::timeout_clock::now() + 5s;
 
     auto cmd = cluster::feature_update_license_update_cmd(
       cluster::feature_update_license_update_cmd_data{

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -76,6 +76,7 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <fmt/core.h>
@@ -1586,6 +1587,7 @@ void admin_server::register_features_routes() {
           }
 
           try {
+              boost::trim_if(raw_license, boost::is_any_of(" \n"));
               auto license = security::make_license(raw_license);
               if (license.is_expired()) {
                   throw ss::httpd::bad_request_exception(


### PR DESCRIPTION
- Trim leading and trailing whitespace and newlines from license when sent to admin api

- Fix a bug that disabled license uploads after an incorrect hardcoded timeout expires
