### PR TITLE
cloud_roles: adds minio credentials to mock iam server

### DIFF
--- a/tests/rptest/remote_scripts/aws_iam_role_mock.py
+++ b/tests/rptest/remote_scripts/aws_iam_role_mock.py
@@ -36,6 +36,8 @@ def make_aws_handler(token_ttl):
             'Code': 'Success',
             'LastUpdated': '2012-04-26T16:39:16Z',
             'Type': 'AWS-HMAC',
+            'AccessKeyId': 'panda-user',
+            'SecretAccessKey': 'panda-secret',
             'Token': '__REDPANDA_SKIP_IAM_TOKEN_x',
         }
 


### PR DESCRIPTION
the script used to run mock iam server needs to supply credentials for minio to redpanda. this change adds the credentials.