### PR TITLE
tests: mitigate MaintenanceTest failures by disabling leader_balancer

### DIFF
--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -25,7 +25,9 @@ class MaintenanceTest(RedpandaTest):
               TopicSpec(partition_count=20, replication_factor=3))
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args,
+                         extra_rp_conf={'enable_leader_balancer': False},
+                         **kwargs)
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         self._use_rpk = True


### PR DESCRIPTION
## Cover letter

The real fix will be to make the leader balancer aware
of maintenance mode, but the test has become much more
unstable since recent leader balancer changes to do
more movements concurrently, so for the moment just
run the test with the leader balancer disabled.

Related: https://github.com/redpanda-data/redpanda/issues/4772

## Release notes

* none