### PR TITLE
net: add new rpc metrics

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -11,6 +11,7 @@
 #include "net/client_probe.h"
 #include "net/server_probe.h"
 #include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/metrics.hh>
@@ -20,13 +21,13 @@
 
 namespace net {
 void server_probe::setup_metrics(
-  ss::metrics::metric_groups& mgs, const char* proto) {
+  ss::metrics::metric_groups& mgs, std::string_view proto) {
     namespace sm = ss::metrics;
     auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
                               ? std::vector<sm::label>{sm::shard_label}
                               : std::vector<sm::label>{};
     mgs.add_group(
-      prometheus_sanitize::metrics_name(proto),
+      prometheus_sanitize::metrics_name(ss::sstring{proto}),
       {
         sm::make_gauge(
           "active_connections",
@@ -108,6 +109,26 @@ void server_probe::setup_metrics(
             "{}: Number of connections are blocked by connection rate", proto)))
           .aggregate(aggregate_labels),
       });
+}
+
+void server_probe::setup_public_metrics(
+  ss::metrics::metric_groups& mgs, std::string_view proto) {
+    namespace sm = ss::metrics;
+
+    if (proto.ends_with("_rpc")) {
+        proto.remove_suffix(4);
+    }
+
+    auto server_label = sm::label("server");
+
+    mgs.add_group(
+      "rpc",
+      {sm::make_counter(
+         "request_errors_total",
+         [this] { return _service_errors; },
+         sm::description("Number of rpc errors"),
+         {server_label(proto)})
+         .aggregate({sm::shard_label})});
 }
 
 std::ostream& operator<<(std::ostream& o, const server_probe& p) {

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -195,6 +195,7 @@ private:
     friend resources;
     ss::future<> accept(listener&);
     void setup_metrics();
+    void setup_public_metrics();
 
     std::unique_ptr<protocol> _proto;
     ss::semaphore _memory;

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -98,6 +98,8 @@ struct server_configuration {
     std::optional<int> tcp_send_buf;
     std::optional<size_t> stream_recv_buf;
     net::metrics_disabled disable_metrics = net::metrics_disabled::no;
+    net::public_metrics_disabled disable_public_metrics
+      = net::public_metrics_disabled::no;
     ss::sstring name;
     std::optional<config_connection_rate_bindings> connection_rate_bindings;
     // we use the same default as seastar for load balancing algorithm
@@ -203,6 +205,7 @@ private:
     hdr_hist _hist;
     server_probe _probe;
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 
     std::optional<config_connection_rate_bindings> connection_rate_bindings;
     std::optional<connection_rate<>> _connection_rates;

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -52,7 +52,10 @@ public:
 
     void waiting_for_conection_rate() { ++_connections_wait_rate; }
 
-    void setup_metrics(ss::metrics::metric_groups& mgs, const char* name);
+    void setup_metrics(ss::metrics::metric_groups& mgs, std::string_view proto);
+
+    void setup_public_metrics(
+      ss::metrics::metric_groups& mgs, std::string_view proto);
 
 private:
     uint64_t _requests_completed = 0;

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -184,6 +184,7 @@ struct raft_node {
         scfg.addrs.emplace_back(net::resolve_dns(broker.rpc_address()).get());
         scfg.max_service_memory_per_core = 1024 * 1024 * 1024;
         scfg.disable_metrics = net::metrics_disabled::yes;
+        scfg.disable_public_metrics = net::public_metrics_disabled::yes;
         server.start(std::move(scfg)).get0();
         raft_manager.start().get0();
         raft_manager

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -927,6 +927,8 @@ void application::wire_up_redpanda_services() {
               c.max_service_memory_per_core = memory_groups::rpc_total_memory();
               c.disable_metrics = net::metrics_disabled(
                 config::shard_local_cfg().disable_metrics());
+              c.disable_public_metrics = net::public_metrics_disabled(
+                config::shard_local_cfg().disable_public_metrics());
               c.listen_backlog
                 = config::shard_local_cfg().rpc_server_listen_backlog;
               c.tcp_recv_buf
@@ -1116,6 +1118,8 @@ void application::wire_up_redpanda_services() {
 
               c.disable_metrics = net::metrics_disabled(
                 config::shard_local_cfg().disable_metrics());
+              c.disable_public_metrics = net::public_metrics_disabled(
+                config::shard_local_cfg().disable_public_metrics());
 
               net::config_connection_rate_bindings bindings{
                 .config_general_rate
@@ -1287,6 +1291,7 @@ void application::start_redpanda(::stop_signal& app_signal) {
           if (!config::shard_local_cfg().disable_metrics()) {
               proto->setup_metrics();
           }
+
           s.set_protocol(std::move(proto));
       })
       .get();

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -140,6 +140,7 @@ public:
       ss::tls::reload_callback&& cb = {}) override {
         net::server_configuration scfg("unit_test_rpc_sharded");
         scfg.disable_metrics = net::metrics_disabled::yes;
+        scfg.disable_public_metrics = net::public_metrics_disabled::yes;
         auto resolved = net::resolve_dns(_listen_address).get();
         scfg.addrs.emplace_back(
           resolved,


### PR DESCRIPTION
## Cover letter

This PR adds rpc metrics for error counting and latency to the new prometheus endpoint (exposed at "public_metrics"). The following metrics were added:

* redpanda_rpc_request_errors_total
  * Description: Number of rpc errors
  * Labels: server
  * Aggregation: shard
* redpanda_rpc_request_latency_seconds
  * Description: Internal and Kafka RPC latency
  * Labels: server
  * Aggregation: shard

  
Original set of commits and comments at https://github.com/VladLazar/redpanda/pull/1/commits/2023d9740f7f2c5b7901606220a17f0111c6315b and https://github.com/VladLazar/redpanda/pull/1/commits/9591cdb5566a14a94be2da4824e371f1c38d0182

Changes from force-push `f7a30de`:
- Change component label to server label
- Move public metrics out of `ends_with` check in server.cc
- Aggregate on service and method labels in rpcgen 

Changes from force-push `1102471`:
- Change component label to server label in server_probe

Changes from force-push `ebe3fa2`:
- Remove latency measurements in rpcgen
- Add public metrics config to unit tests

## Release notes
### Improvements
* Adds rpc error counting metrics and latency measurements to the new prometheus endpoint.