### PR TITLE
Default partitions count for `__consumer_offsets` topic increased

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -474,7 +474,7 @@ configuration::configuration()
       "group_topic_partitions",
       "Number of partitions in the internal group membership topic",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1)
+      16)
   , default_topic_replication(
       *this,
       "default_topic_replications",

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -127,7 +127,8 @@ class GroupMetricsTest(RedpandaTest):
 
         # Require internal_kafka topic to have an increased replication factor
         extra_rp_conf = dict(default_topic_replications=3,
-                             enable_leader_balancer=False)
+                             enable_leader_balancer=False,
+                             group_topic_partitions=1)
         super(GroupMetricsTest, self).__init__(test_context=ctx,
                                                num_brokers=3,
                                                extra_rp_conf=extra_rp_conf)
@@ -374,6 +375,9 @@ class GroupMetricsTest(RedpandaTest):
                        timeout_sec=30,
                        backoff_sec=5)
 
+            self.logger.debug(
+                f"Waiting for metrics from the single node: {new_leader.account.hostname}"
+            )
             wait_until(lambda: metrics_from_single_node(new_leader),
                        timeout_sec=30,
                        backoff_sec=5)


### PR DESCRIPTION
## Cover letter

When a consumer tries to locate a consumer group coordinator of a cluster for the first time, the `__consumer_offsets` topic is created with the number of partitions as per the `group_topic_partitions` property. The default value for that property was 1 which means that unless a different value was explicitly specified by the customer at a very early stage of cluster's life, all OffsetCommit requests from all consumers will be going to a single broker. This change increases the default value to 16 as a reasonable trade-off between OffsetCommit parallelism for the clusters that will use consumer groups later in their life, and the overhead for the clusters that won't use consumer groups.

Fixes #5222

## Release notes

### Improvements

* The default number of partitions in the internal consumer groups topic has been changed to 16, making it more scaleable. The default change will only take effect on new clusters -- existing clusters will abide by the value effective at the moment the first consumer group was created in the cluster. It is still recommended to explicitly specify a suitable value in the configuration while setting up large scale clusters.
