### PR TITLE
kafka/server: allow only one response loop the same time per connection.

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -411,9 +411,15 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
 }
 
 ss::future<> connection_context::process_next_response() {
+    if (_response_loop_running) {
+        return ss::now();
+    }
+
+    _response_loop_running = true;
     return ss::repeat([this]() mutable {
         auto it = _responses.find(_next_response);
         if (it == _responses.end()) {
+            _response_loop_running = false;
             return ss::make_ready_future<ss::stop_iteration>(
               ss::stop_iteration::yes);
         }
@@ -430,10 +436,17 @@ ss::future<> connection_context::process_next_response() {
 
         auto msg = response_as_scattered(std::move(r));
         try {
-            return _rs.conn->write(std::move(msg)).then([] {
-                return ss::make_ready_future<ss::stop_iteration>(
-                  ss::stop_iteration::no);
-            });
+            return _rs.conn->write(std::move(msg))
+              .then_wrapped([this](ss::future<> f) {
+                  if (f.failed()) {
+                      _response_loop_running = false;
+                      return ss::make_exception_future<ss::stop_iteration>(
+                        f.get_exception());
+                  }
+
+                  return ss::make_ready_future<ss::stop_iteration>(
+                    ss::stop_iteration::no);
+              });
         } catch (...) {
             vlog(
               klog.debug,

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -234,6 +234,7 @@ private:
     const ss::net::inet_address _client_addr;
     const bool _enable_authorizer;
     ctx_log _authlog;
+    bool _response_loop_running{false};
     bool _use_mtls{false};
     std::optional<ss::sstring> _mtls_principal;
 };


### PR DESCRIPTION
When a new response is generated and finds that there is already a
response loop issued by another response running in the background,
we could just put the new response into the map without issue a new
loop and the running loop will help send the response if possible.

Signed-off-by: Jianyong Chen <balus@foxmail.com>