### PR TITLE
rpk: fix panic on cluster config export

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -166,11 +166,12 @@ to include all properties including these low level tunables.
 			var file *os.File
 			if filename == "" {
 				file, err = ioutil.TempFile("/tmp", "config_*.yaml")
+				filename = "/tmp/config_*.yaml"
 			} else {
 				file, err = os.Create(filename)
 			}
 
-			out.MaybeDie(err, "unable to create file %q: %v", file.Name(), err)
+			out.MaybeDie(err, "unable to create file %q: %v", filename, err)
 			err = exportConfig(file, schema, currentConfig, *all)
 			out.MaybeDie(err, "failed to write out config %q: %v", file.Name(), err)
 			err = file.Close()


### PR DESCRIPTION
When the file cannot be created, the File object returned is nil.
Therefore when printing out the error message, rather than call Name()
on the file object to retrieve the filename, just use the filename
string directly.

## Cover letter
Fixes #5420 

## UX changes

When calling MaybeDie, the expected error with the following format is printed rather than causing a panic:
```
unable to create file <filename>: <error>
```

## Release notes
* none