### PR TITLE
pandaproxy: add metrics for error count

### DIFF
--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -30,4 +30,21 @@ private:
     ss::metrics::metric_groups _public_metrics;
 };
 
+class error_probe {
+public:
+    explicit error_probe(const ss::sstring& group_name);
+
+    void increment_5xx(int64_t count = 1) { _5xx_count += count; }
+
+    void increment_4xx(int64_t count = 1) { _4xx_count += count; }
+
+    void increment_3xx(int64_t count = 1) { _3xx_count += count; }
+
+private:
+    int64_t _5xx_count;
+    int64_t _4xx_count;
+    int64_t _3xx_count;
+    ss::metrics::metric_groups _public_metrics;
+};
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -19,6 +19,7 @@
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/exceptions.h"
+#include "pandaproxy/probe.h"
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "seastarx.h"
 
@@ -81,45 +82,73 @@ errored_body(std::error_code ec, ss::sstring msg) {
     return errored_body(make_error_condition(ec), std::move(msg));
 }
 
-inline std::unique_ptr<ss::httpd::reply> unprocessable_entity(ss::sstring msg) {
-    return errored_body(
-      make_error_condition(reply_error_code::kafka_bad_request),
-      std::move(msg));
+inline std::unique_ptr<ss::httpd::reply>
+handle_errors(std::error_condition ec, ss::sstring msg, error_probe& eprobe) {
+    auto rep = errored_body(ec, std::move(msg));
+
+    using status_type = ss::httpd::reply::status_type;
+
+    // See seastar/http/reply.hh::reply::status_type for a list
+    // of supported error status codes.
+    if (rep->_status >= status_type{500}) {
+        eprobe.increment_5xx();
+    } else if (rep->_status >= status_type{400}) {
+        eprobe.increment_4xx();
+    } else if (rep->_status >= status_type{300}) {
+        eprobe.increment_3xx();
+    }
+
+    return rep;
 }
 
-inline std::unique_ptr<ss::httpd::reply> exception_reply(std::exception_ptr e) {
+inline std::unique_ptr<ss::httpd::reply>
+handle_errors(std::error_code ec, ss::sstring msg, error_probe& eprobe) {
+    return handle_errors(make_error_condition(ec), std::move(msg), eprobe);
+}
+
+inline std::unique_ptr<ss::httpd::reply>
+exception_reply(std::exception_ptr e, error_probe& eprobe) {
     try {
         std::rethrow_exception(e);
     } catch (const ss::gate_closed_exception& e) {
-        auto eb = errored_body(
-          reply_error_code::kafka_retriable_error, e.what());
+        auto eb = handle_errors(
+          reply_error_code::kafka_retriable_error, e.what(), eprobe);
         set_reply_unavailable(*eb);
         return eb;
     } catch (const json::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return handle_errors(e.error, e.what(), eprobe);
     } catch (const parse::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return handle_errors(e.error, e.what(), eprobe);
     } catch (const kafka::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return handle_errors(e.error, e.what(), eprobe);
     } catch (const schema_registry::exception_base& e) {
-        return errored_body(e.code(), e.message());
+        return handle_errors(e.code(), e.message(), eprobe);
     } catch (const seastar::httpd::base_exception& e) {
-        return errored_body(
-          reply_error_code::kafka_bad_request,
-          e.what()); // TODO BP: Yarr!!
+        return handle_errors(
+          reply_error_code::kafka_bad_request, e.what(), eprobe);
     } catch (...) {
         vlog(plog.error, "{}", std::current_exception());
+        eprobe.increment_5xx();
         throw;
     }
 }
 
-struct exception_replier {
+class exception_replier {
+public:
     ss::sstring mime_type;
+
+    exception_replier(ss::sstring mt, error_probe& eprobe)
+      : mime_type(mt)
+      , _eprobe(eprobe) {}
+
     std::unique_ptr<ss::httpd::reply> operator()(const std::exception_ptr& e) {
-        auto res = exception_reply(e);
+        auto res = exception_reply(e, _eprobe);
         res->set_mime_type(mime_type);
         return res;
     }
+
+private:
+    error_probe& _eprobe;
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -127,7 +127,8 @@ server::server(
   , _pending_reqs()
   , _api20(std::move(api20))
   , _has_routes(false)
-  , _ctx(ctx) {
+  , _ctx(ctx)
+  , _eprobe(_public_metrics_group_name) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -170,7 +171,7 @@ ss::future<> server::start(
   const std::vector<model::broker_endpoint>& advertised,
   json::serialization_format exceptional_mime_type) {
     _server._routes.register_exeption_handler(
-      exception_replier{ss::sstring{name(exceptional_mime_type)}});
+      exception_replier{ss::sstring{name(exceptional_mime_type)}, _eprobe});
     _ctx.advertised_listeners.reserve(endpoints.size());
     for (auto& server_endpoint : endpoints) {
         auto addr = co_await net::resolve_dns(server_endpoint.address);

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -14,6 +14,7 @@
 #include "config/config_store.h"
 #include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/probe.h"
 #include "seastarx.h"
 
 #include <seastar/core/abort_source.hh>
@@ -103,6 +104,7 @@ private:
     ss::api_registry_builder20 _api20;
     bool _has_routes;
     context_t& _ctx;
+    error_probe _eprobe;
 };
 
 template<typename service_t>


### PR DESCRIPTION
## Cover letter

This PR adds pandaproxy and schema registry error counting metrics to the new prometheus endpoint (exposed at "public_metrics"). The following metrics were added:

* redpanda_rest_proxy_request_errors_total
  * Description: Total number of request errors
  * Labels: status
  * Aggregation: shard
* redpanda_schema_registry_request_errors_total
  * Description: Total number of request errors
  * Labels: status
  * Aggregation: shard

Original set of commits at https://github.com/VladLazar/redpanda/pull/1/commits/a4a0ccfa1b90f4fb3922e2f5223edaea9a1ca8bd

Changes from force-push `1d56596`:
- Changed the approach to use `exception_replier` instead of `handler_adaptor` because the former will capture failures from the seastar level as well

## Release notes
### Improvements
* Adds pandaproxy and schema registry error counting metrics to the public prometheus endpoint. The error counts are differentiated by status code.