### PR TITLE
Handle maintenance nodes in the leader balancer

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -268,6 +268,7 @@ ss::future<> controller::start() {
           _leader_balancer = std::make_unique<leader_balancer>(
             _tp_state.local(),
             _partition_leaders.local(),
+            _members_table.local(),
             _raft_manager.local().raft_client(),
             std::ref(_shard_table),
             std::ref(_partition_manager),

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -56,11 +56,26 @@ public:
         }
     }
 
+    using maintenance_state_cb_t = ss::noncopyable_function<void(
+      model::node_id, model::maintenance_state)>;
+
+    notification_id_type
+      register_maintenance_state_change_notification(maintenance_state_cb_t);
+
+    void unregister_maintenance_state_change_notification(notification_id_type);
+
 private:
     using broker_cache_t = absl::flat_hash_map<model::node_id, broker_ptr>;
     broker_cache_t _brokers;
     model::revision_id _version;
 
     waiter_queue<model::node_id> _waiters;
+
+    notification_id_type _notification_id{0};
+    std::vector<std::pair<notification_id_type, maintenance_state_cb_t>>
+      _notifications;
+
+    void
+      notify_maintenance_state_change(model::node_id, model::maintenance_state);
 };
 } // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -108,6 +108,8 @@ private:
     void on_leadership_change(
       model::ntp, model::term_id, std::optional<model::node_id>);
 
+    void on_maintenance_change(model::node_id, model::maintenance_state);
+
     void check_register_leadership_change_notification();
     void check_unregister_leadership_change_notification();
 
@@ -173,6 +175,7 @@ private:
     cluster::notification_id_type _leader_notify_handle;
     std::optional<cluster::notification_id_type>
       _leadership_change_notify_handle;
+    cluster::notification_id_type _maintenance_state_notify_handle;
     topic_table& _topics;
     partition_leaders_table& _leaders;
     members_table& _members;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -73,6 +73,7 @@ public:
     leader_balancer(
       topic_table&,
       partition_leaders_table&,
+      members_table&,
       raft::consensus_client_protocol,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
@@ -175,6 +176,7 @@ private:
       _leadership_change_notify_handle;
     topic_table& _topics;
     partition_leaders_table& _leaders;
+    members_table& _members;
     raft::consensus_client_protocol _client;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -93,7 +93,6 @@ private:
     using reassignment = leader_balancer_strategy::reassignment;
 
     index_type build_index();
-    std::optional<model::broker_shard> find_leader_shard(const model::ntp&);
     absl::flat_hash_set<raft::group_id> muted_groups() const;
     absl::flat_hash_set<model::node_id> muted_nodes() const;
 

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -25,22 +25,7 @@ class MaintenanceTest(RedpandaTest):
               TopicSpec(partition_count=20, replication_factor=3))
 
     def __init__(self, *args, **kwargs):
-        super().__init__(
-            *args,
-            extra_rp_conf={
-                # Leader balancer configuration changes are a workaround
-                # to https://github.com/redpanda-data/redpanda/issues/4772
-
-                # Faster leader balancer iteration to get partitions moved
-                # back to nodes leaving maintenance mode promptly.
-                'leader_balancer_idle_timeout': 5000,
-
-                # Mute timeout shorter than idle timeout: effectvely disable
-                # node muting.  This enables nodes leaving maintenance mode
-                # to get leaderships moved to them promptly.
-                'leader_balancer_mute_timeout': 1000,
-            },
-            **kwargs)
+        super().__init__(*args, **kwargs)
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         self._use_rpk = True


### PR DESCRIPTION
## Cover letter
This PR prevents the leader balancer from transferring leadership to a maintenance node. It also wakes the balancer up early from an idle state if a node transitions out of a maintenance state. A couple improvements can probably be made before merging though. The notification callback code in the members_table is largely a duplicate of notification code in `src/v/raft/group_manager` so it may be worth creating a separate notification class in `src/v/utils` that they can both use. Also it may be worth adding a notification to wake the balancer up for other status changes of members in the cluster, i.e, if a member is recommissioned. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4772 

## Release notes
* none