### PR TITLE
serde: Support absl::flat_hash_map and absl::btree_set 

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -28,6 +28,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/net/inet_address.hh>
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
@@ -91,6 +92,10 @@ concept has_serde_async_write = requires(T t, iobuf& out) {
     { t.serde_async_write(out) } -> seastar::Future;
 };
 
+template<typename T>
+concept is_absl_flat_hash_map
+  = ::detail::is_specialization_of_v<T, absl::flat_hash_map>;
+
 using serde_enum_serialized_t = int32_t;
 
 #if defined(SERDE_TEST)
@@ -142,6 +147,7 @@ inline constexpr auto const is_serde_compatible_v
     || std::is_same_v<T, iobuf>
     || std::is_same_v<T, ss::sstring>
     || std::is_same_v<T, bytes>
+    || is_absl_flat_hash_map<T>
     || is_absl_node_hash_set<T>
     || is_absl_node_hash_map<T>
     || is_std_unordered_map<T>
@@ -278,11 +284,12 @@ void write(iobuf& out, T t) {
         for (auto& e : t) {
             write(out, e);
         }
-    } else if constexpr (is_absl_node_hash_map<Type>) {
+    } else if constexpr (
+      is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
         if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
             throw serde_exception(fmt_with_ctx(
               ssx::sformat,
-              "serde: absl::node_hash_map size {} exceeds serde_size_t",
+              "serde: absl map size {} exceeds serde_size_t",
               t.size()));
         }
         write(out, static_cast<serde_size_t>(t.size()));
@@ -535,7 +542,8 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
               in, bytes_left_limit);
             t.emplace(std::move(elem));
         }
-    } else if constexpr (is_absl_node_hash_map<Type>) {
+    } else if constexpr (
+      is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         t.reserve(size);
         for (auto i = 0U; i < size; ++i) {

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -753,13 +753,14 @@ SEASTAR_THREAD_TEST_CASE(seastar_inet_address_test) {
       ipv6, serde::from_iobuf<ss::net::inet_address>(std::move(ipv6_buf)));
 }
 
-SEASTAR_THREAD_TEST_CASE(std_unordered_map) {
-    std::unordered_map<ss::sstring, int32_t> a = {
+template<template<class...> class T>
+void map_test() {
+    T<ss::sstring, int32_t> a = {
       {"asdf", 33},
       {"fooo", 44},
     };
 
-    std::unordered_map<int32_t, int32_t> b = {
+    T<int32_t, int32_t> b = {
       {123, 32},
       {456, 66},
       {959, 11},
@@ -768,14 +769,22 @@ SEASTAR_THREAD_TEST_CASE(std_unordered_map) {
     iobuf a_buf = serde::to_iobuf(a);
     iobuf b_buf = serde::to_iobuf(b);
 
-    auto a_from = serde::from_iobuf<std::unordered_map<ss::sstring, int32_t>>(
-      std::move(a_buf));
+    auto a_from = serde::from_iobuf<T<ss::sstring, int32_t>>(std::move(a_buf));
 
-    auto b_from = serde::from_iobuf<std::unordered_map<int32_t, int32_t>>(
-      std::move(b_buf));
+    auto b_from = serde::from_iobuf<T<int32_t, int32_t>>(std::move(b_buf));
 
     BOOST_REQUIRE(a == a_from);
     BOOST_REQUIRE(b == b_from);
+}
+
+SEASTAR_THREAD_TEST_CASE(std_unordered_map) { map_test<std::unordered_map>(); }
+
+SEASTAR_THREAD_TEST_CASE(absl_node_hash_map) {
+    map_test<absl::node_hash_map>();
+}
+
+SEASTAR_THREAD_TEST_CASE(absl_flat_hash_map) {
+    map_test<absl::flat_hash_map>();
 }
 
 SEASTAR_THREAD_TEST_CASE(absl_node_hash_set) {
@@ -797,31 +806,6 @@ SEASTAR_THREAD_TEST_CASE(absl_node_hash_set) {
       std::move(a_buf));
 
     auto b_from = serde::from_iobuf<absl::node_hash_set<int32_t>>(
-      std::move(b_buf));
-
-    BOOST_REQUIRE(a == a_from);
-    BOOST_REQUIRE(b == b_from);
-}
-
-SEASTAR_THREAD_TEST_CASE(absl_node_hash_map) {
-    absl::node_hash_map<ss::sstring, int32_t> a = {
-      {"asdf", 33},
-      {"fooo", 44},
-    };
-
-    absl::node_hash_map<int32_t, int32_t> b = {
-      {123, 32},
-      {456, 66},
-      {959, 11},
-    };
-
-    iobuf a_buf = serde::to_iobuf(a);
-    iobuf b_buf = serde::to_iobuf(b);
-
-    auto a_from = serde::from_iobuf<absl::node_hash_map<ss::sstring, int32_t>>(
-      std::move(a_buf));
-
-    auto b_from = serde::from_iobuf<absl::node_hash_map<int32_t, int32_t>>(
       std::move(b_buf));
 
     BOOST_REQUIRE(a == a_from);

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -777,6 +777,30 @@ void map_test() {
     BOOST_REQUIRE(b == b_from);
 }
 
+template<template<class...> class T>
+void set_test() {
+    T<ss::sstring> a = {
+      "asdf",
+      "fooo",
+    };
+
+    T<int32_t> b = {
+      123,
+      456,
+      959,
+    };
+
+    iobuf a_buf = serde::to_iobuf(a);
+    iobuf b_buf = serde::to_iobuf(b);
+
+    auto a_from = serde::from_iobuf<T<ss::sstring>>(std::move(a_buf));
+
+    auto b_from = serde::from_iobuf<T<int32_t>>(std::move(b_buf));
+
+    BOOST_REQUIRE(a == a_from);
+    BOOST_REQUIRE(b == b_from);
+}
+
 SEASTAR_THREAD_TEST_CASE(std_unordered_map) { map_test<std::unordered_map>(); }
 
 SEASTAR_THREAD_TEST_CASE(absl_node_hash_map) {
@@ -788,26 +812,7 @@ SEASTAR_THREAD_TEST_CASE(absl_flat_hash_map) {
 }
 
 SEASTAR_THREAD_TEST_CASE(absl_node_hash_set) {
-    absl::node_hash_set<ss::sstring> a = {
-      "asdf",
-      "fooo",
-    };
-
-    absl::node_hash_set<int32_t> b = {
-      123,
-      456,
-      959,
-    };
-
-    iobuf a_buf = serde::to_iobuf(a);
-    iobuf b_buf = serde::to_iobuf(b);
-
-    auto a_from = serde::from_iobuf<absl::node_hash_set<ss::sstring>>(
-      std::move(a_buf));
-
-    auto b_from = serde::from_iobuf<absl::node_hash_set<int32_t>>(
-      std::move(b_buf));
-
-    BOOST_REQUIRE(a == a_from);
-    BOOST_REQUIRE(b == b_from);
+    set_test<absl::node_hash_set>();
 }
+
+SEASTAR_THREAD_TEST_CASE(absl_btree_set) { set_test<absl::btree_set>(); }


### PR DESCRIPTION
## Cover letter

We need support for absl::flat_hash_map and btree_set in rm_stm serialization. The patch is just boilerplate code and does some de-duping in test code.

## Release notes

* none