### PR TITLE
serde: support std::chrono::duration

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -143,6 +143,10 @@ template<class T>
 concept is_chrono_duration
   = ::detail::is_specialization_of_v<T, std::chrono::duration>;
 
+template<class T>
+concept is_chrono_time_point
+  = ::detail::is_specialization_of_v<T, std::chrono::time_point>;
+
 template<typename T>
 inline constexpr auto const is_serde_compatible_v
   = is_envelope<T>
@@ -227,6 +231,10 @@ int64_t checked_duration_cast_to_nanoseconds(
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
+    static_assert(
+      !is_chrono_time_point<Type>,
+      "Time point serialization is risky and can have unintended "
+      "consequences. Check with Redpanda team before fixing this.");
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_write<Type> || is_serde_compatible_v<Type>);
 
@@ -502,6 +510,10 @@ header read_header(iobuf_parser& in, std::size_t const bytes_left_limit) {
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
+    static_assert(
+      !is_chrono_time_point<Type>,
+      "Time point serialization is risky and can have unintended "
+      "consequences. Check with Redpanda team before fixing this.");
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -33,8 +33,10 @@
 #include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
+#include <chrono>
 #include <iosfwd>
 #include <numeric>
+#include <ratio>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -137,6 +139,10 @@ template<typename T>
 concept is_absl_node_hash_map
   = ::detail::is_specialization_of_v<T, absl::node_hash_map>;
 
+template<class T>
+concept is_chrono_duration
+  = ::detail::is_specialization_of_v<T, std::chrono::duration>;
+
 template<typename T>
 inline constexpr auto const is_serde_compatible_v
   = is_envelope<T>
@@ -156,6 +162,7 @@ inline constexpr auto const is_serde_compatible_v
     || is_absl_flat_hash_map<T>
     || is_absl_node_hash_set<T>
     || is_absl_node_hash_map<T>
+    || is_chrono_duration<T>
     || is_std_unordered_map<T>
     || is_fragmented_vector<T> || reflection::is_tristate<T> || std::is_same_v<T, ss::net::inet_address>;
 
@@ -165,6 +172,57 @@ inline constexpr auto const are_bytes_and_string_different = !(
 
 template<typename T>
 void write(iobuf&, T);
+
+template<class R, class P>
+int64_t checked_duration_cast_to_nanoseconds(
+  const std::chrono::duration<R, P>& duration) {
+    static_assert(
+      __has_builtin(__builtin_mul_overflow),
+      "__builtin_mul_overflow not supported.");
+    using nano_period = std::chrono::nanoseconds::period;
+    using nano_rep = typename std::chrono::nanoseconds::rep;
+    // This is how duration_cast determines the output type.
+    using output_type = typename std::common_type<R, nano_rep, intmax_t>::type;
+    using ratio = std::ratio_divide<P, nano_period>;
+
+    static_assert(
+      std::is_same_v<output_type, nano_rep>,
+      "Output type is not the same rep as std::chrono::nanoseconds");
+
+    // Extra check to ensure the output type is same as the underlying type
+    // supported in lib[std]c++.
+    static_assert(
+      std::is_same_v<
+        output_type,
+        int64_t> || std::is_same_v<output_type, long long>,
+      "Output type not in supported integer types.");
+
+    constexpr auto ratio_num = static_cast<output_type>(ratio::num);
+    const auto dur = static_cast<output_type>(duration.count());
+    output_type mul;
+    if (unlikely(__builtin_mul_overflow(dur, ratio_num, &mul))) {
+        // Clamp the value.
+        // Log here to ensure that it is picked up by duck tape. Ideally this
+        // should never happen, but in case it does, we have a log trail.
+        //
+        // If you are here because your ducktape test failed with this
+        // BadLogLine check, it means that you serialized a duration type that
+        // caused an overflow when casting to nanoseconds. Clamp your duration
+        // to nanoseconds::max().
+        using input_type = typename std::chrono::duration<R, P>;
+        vlog(
+          serde_log.error,
+          "Overflow or underflow detected when casting to nanoseconds, "
+          "clamping to a limit. Input: {}  type: {}",
+          duration.count(),
+          type_str<input_type>());
+        return duration.count() < 0 ? std::chrono::nanoseconds::min().count()
+                                    : std::chrono::nanoseconds::max().count();
+    }
+    // No overflow/underflow detected, we are safe to cast.
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(duration)
+      .count();
+}
 
 template<typename T>
 void write(iobuf& out, T t) {
@@ -261,8 +319,6 @@ void write(iobuf& out, T t) {
         return write(out, static_cast<typename Type::type>(t));
     } else if constexpr (reflection::is_ss_bool_class<Type>) {
         write(out, static_cast<int8_t>(bool(t)));
-    } else if constexpr (std::is_same_v<Type, std::chrono::milliseconds>) {
-        write<int64_t>(out, t.count());
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         write<serde_size_t>(out, t.size_bytes());
         out.append(t.share(0, t.size_bytes()));
@@ -344,6 +400,28 @@ void write(iobuf& out, T t) {
 
         write(out, t.is_ipv4());
         write(out, std::move(address_bytes));
+    } else if constexpr (is_chrono_duration<Type>) {
+        // We explicitly serialize it as ns to avoid any surprises like
+        // seastar updating underlying duration types without
+        // notice. See https://github.com/redpanda-data/redpanda/pull/5002
+        //
+        // Check for overflows/underflows.
+        // For ex: a millisecond and nanosecond use the same underlying
+        // type int64_t but converting from one to other can easily overflow,
+        // this is by design.
+        // Since we serialize with ns precision, there is a restriction of
+        // nanoseconds::max()'s equivalent on the duration to be serialized.
+        // On a typical platform which uses int64_t for 'rep', it roughly
+        // translates to ~292 years.
+        //
+        // If we detect an overflow, we will clamp it to maximum supported
+        // duration, which is nanosecond::max() and if there is an underflow,
+        // we clamp it to minimum supported duration which is nanosecond::min().
+        static_assert(
+          !std::is_floating_point_v<typename Type::rep>,
+          "Floating point duration conversions are prone to precision and "
+          "rounding issues.");
+        write<int64_t>(out, checked_duration_cast_to_nanoseconds(t));
     }
 }
 
@@ -521,9 +599,6 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
         t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
     } else if constexpr (reflection::is_ss_bool_class<Type>) {
         t = Type{read_nested<int8_t>(in, bytes_left_limit) != 0};
-    } else if constexpr (std::is_same_v<Type, std::chrono::milliseconds>) {
-        t = std::chrono::milliseconds{
-          read_nested<int64_t>(in, bytes_left_limit)};
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
     } else if constexpr (std::is_same_v<Type, ss::sstring>) {
@@ -584,6 +659,13 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
             t.push_back(read_nested<value_type>(in, bytes_left_limit));
         }
         t.shrink_to_fit();
+    } else if constexpr (is_chrono_duration<Type>) {
+        static_assert(
+          !std::is_floating_point_v<typename Type::rep>,
+          "Floating point duration conversions are prone to precision and "
+          "rounding issues.");
+        auto rep = read_nested<int64_t>(in, bytes_left_limit);
+        t = std::chrono::duration_cast<Type>(std::chrono::nanoseconds{rep});
     } else if constexpr (reflection::is_tristate<T>) {
         int8_t flag = read_nested<int8_t>(in, bytes_left_limit);
         if (flag == -1) {

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -85,8 +85,10 @@ inline std::vector<ss::sstring> random_sstrings(size_t size = 20) {
 }
 
 inline std::chrono::milliseconds random_duration_ms() {
-    return std::chrono::milliseconds(random_generators::get_int<uint64_t>(
-      0, std::chrono::milliseconds::max().count()));
+    constexpr auto max_ns = std::chrono::nanoseconds::max().count();
+    auto rand = random_generators::get_int<int64_t>(0, max_ns);
+    auto rand_ns = std::chrono::nanoseconds{rand};
+    return std::chrono::duration_cast<std::chrono::milliseconds>(rand_ns);
 }
 
 /*


### PR DESCRIPTION
## Cover letter

Adds support for duration and time_point.

Notes:
* `std::chrono::duration` is serialized with a nanosecond precision (int64_t) and cast-ed back to the type provided during deserialiation. This makes sure that we have a consistent on disk representation irrespective of subtle type re-definitions in the layers above. Audited all serde callers in `21.11.x` and `22.1.x` for compat issues with existing timestamp serialization and found that two use cases (`cloudstorage::partition_manifest::segment_meta` and `storage::index_state`) do it and both of them use `model::timestamp` which treats timestamps as int64_t, so no backward compatibility issues here.
* Added a concept check to discourage future developers from serializing non-system clock time points.

## Release notes

* none