### PR TITLE
metrics: replicate selected seastar metrics

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -57,6 +57,7 @@
 #include "redpanda/admin_server.h"
 #include "resource_mgmt/io_priority.h"
 #include "rpc/simple_protocol.h"
+#include "ssx/metrics.h"
 #include "storage/backlog_controller.h"
 #include "storage/chunk_cache.h"
 #include "storage/compaction_controller.h"
@@ -312,6 +313,16 @@ void application::initialize(
 }
 
 void application::setup_metrics() {
+    if (!config::shard_local_cfg().disable_public_metrics()) {
+        seastar::metrics::replicate_metric_families(
+          seastar::metrics::default_handle(),
+          {{"io_queue_total_read_ops", ssx::metrics::public_metrics_handle},
+           {"io_queue_total_write_ops", ssx::metrics::public_metrics_handle},
+           {"memory_allocated_memory", ssx::metrics::public_metrics_handle},
+           {"memory_free_memory", ssx::metrics::public_metrics_handle}})
+          .get();
+    }
+
     if (config::shard_local_cfg().disable_metrics()) {
         return;
     }


### PR DESCRIPTION
NB: Depends on https://github.com/redpanda-data/seastar/pull/27

## Cover Letter
This PR replicates a few seastar internal metrics in order to expose them on the `public_metrics` endpoint.
No aggregations are performed on these metrics, but they can be supported by extending the new seastar
API. 

* redpanda_io_queue_total_write_ops
    * Description: Total write operations passed in the queue
    * Labels: class (i.e. the IO priority class used for the write),
      ioshard (i.e. the shard that executes the IO), shard (i.e. the
      shard that issued the IO request), mountpoint

* redpanda_io_queue_total_read_ops
    * Description: Total read operations passed in the queue
    * Labels: class (i.e. the IO priority class used for the write),
      ioshard (i.e. the shard that executes the IO), shard (i.e. the
      shard that issued the IO request), mountpoint

* redpanda_memory_free_memory
    * Description: Free memory size in bytes
    * Labels: shard

* redpanda_memory_allocated_memory
    * Description: Allocated memory size in bytes
    * Labels: shard

## UX changes

The mentioned metrics are exposed on the `public_metrics` Prometheus endpoint and can
be used to create dashboards for end users.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->
