### PR TITLE
cmake: update seastar tag for OSS build

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 16d4456f86e344d6c240c431045957e111ec213f
+  GIT_TAG 8f98d69bcbd2473eb9915204bd8fd1665e609739
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
This PR updates the seastar tag used in the OSS build to include the metric replication chages (https://github.com/redpanda-data/seastar/pull/27).
The commit hash is: [8f98d69bcbd2473eb9915204bd8fd1665e609739](https://github.com/redpanda-data/seastar/commit/8f98d69bcbd2473eb9915204bd8fd1665e609739).