### PR TITLE
Tests: fix upgrade_test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -402,7 +402,6 @@ class RedpandaService(Service):
         'default_topic_partitions': 4,
         'enable_metrics_reporter': False,
         'superusers': [SUPERUSER_CREDENTIALS[0]],
-        'partition_autobalancing_mode': 'node_add_remove'
     }
 
     logs = {

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -51,7 +51,7 @@ class PartitionBalancerTest(EndToEndTest):
 
             partitions = wait_until_result(
                 all_partitions_ready,
-                timeout_sec=30,
+                timeout_sec=120,
                 backoff_sec=1,
                 err_msg="failed to wait until all partitions have leaders")
 
@@ -61,7 +61,7 @@ class PartitionBalancerTest(EndToEndTest):
 
         return ret
 
-    def wait_until_status(self, predicate, timeout_sec=60):
+    def wait_until_status(self, predicate, timeout_sec=120):
         admin = Admin(self.redpanda)
         start = time.time()
 
@@ -82,7 +82,7 @@ class PartitionBalancerTest(EndToEndTest):
             backoff_sec=2,
             err_msg="failed to wait until status condition")
 
-    def wait_until_ready(self, timeout_sec=60):
+    def wait_until_ready(self, timeout_sec=120):
         return self.wait_until_status(
             lambda status: status['status'] == 'ready',
             timeout_sec=timeout_sec)

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -23,8 +23,14 @@ class ScalingUpTest(EndToEndTest):
     """
     @cluster(num_nodes=5)
     def test_adding_nodes_to_cluster(self):
-        self.redpanda = RedpandaService(
-            self.test_context, 3, extra_rp_conf={"group_topic_partitions": 1})
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        extra_rp_conf={
+                                            "group_topic_partitions":
+                                            1,
+                                            "partition_autobalancing_mode":
+                                            "node_add_remove"
+                                        })
         # start single node cluster
         self.redpanda.start(nodes=[self.redpanda.nodes[0]])
         # create some topics


### PR DESCRIPTION
## Cover letter

Upgrade test started failing because older versions of redpanda don't
support the `partition_autobalancing_mode` flag (that was added to the default
config instead of the deprecated `enable_auto_rebalance_on_node_add` flag.
Looks like the only tests that need a non-default value are `node_operations_fuzzy_test` (that sets it explicitly anyway) and `scaling_up_test` (where we explicitly set the value).

Fixes #5437 

## Release notes
* none