### PR TITLE
rpk: standardize command and flag output

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -38,7 +38,7 @@ func NewACLCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "acl",
-		Short: "Manage ACLs and SASL users.",
+		Short: "Manage ACLs and SASL users",
 		Long:  helpACLs,
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -50,7 +50,7 @@ func NewACLCommand(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	command.Flags().BoolVar(&helpOperations, "help-operations", false, "Print more help about ACL operations.")
+	command.Flags().BoolVar(&helpOperations, "help-operations", false, "Print more help about ACL operations")
 
 	common.AddKafkaFlags(
 		command,

--- a/src/go/rpk/pkg/cli/cmd/acl/create.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/create.go
@@ -25,7 +25,7 @@ func NewCreateCommand(fs afero.Fs) *cobra.Command {
 	var a acls
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create ACLs.",
+		Short: "Create ACLs",
 		Long: `Create ACLs.
 
 See the 'rpk acl' help text for a full write up on ACLs. Following the
@@ -88,17 +88,17 @@ Allow write permissions to user buzz to transactional id "txn":
 func (a *acls) addCreateFlags(cmd *cobra.Command) {
 	a.addDeprecatedFlags(cmd)
 
-	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "topic to grant ACLs for (repeatable)")
-	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "group to grant ACLs for (repeatable)")
-	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "whether to grant ACLs to the cluster")
-	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "transactional IDs to grant ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "Topic to grant ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to grant ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to grant ACLs to the cluster")
+	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to grant ACLs for (repeatable)")
 
-	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "literal", "pattern to use when matching resource names (literal or prefixed)")
+	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "literal", "Pattern to use when matching resource names (literal or prefixed)")
 
-	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "operation to grant (repeatable)")
+	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to grant (repeatable)")
 
-	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "principals for which these permissions will be granted (repeatable)")
-	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "hosts from which access will be granted (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "principal for which these permissions will be denied (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "hosts from from access will be denied (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Principals for which these permissions will be granted (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "Hosts from which access will be granted (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "Principal for which these permissions will be denied (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "Hosts from from access will be denied (repeatable)")
 }

--- a/src/go/rpk/pkg/cli/cmd/acl/delete.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete.go
@@ -31,7 +31,7 @@ func NewDeleteCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete ACLs.",
+		Short: "Delete ACLs",
 		Long: `Delete ACLs.
 
 See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
@@ -94,28 +94,28 @@ resource names:
 		},
 	}
 	a.addDeleteFlags(cmd)
-	cmd.Flags().BoolVarP(&printAllFilters, "print-filters", "f", false, "print the filters that were requested (failed filters are always printed)")
-	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "dry run: validate what would be deleted")
-	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "disable confirmation prompt")
+	cmd.Flags().BoolVarP(&printAllFilters, "print-filters", "f", false, "Print the filters that were requested (failed filters are always printed)")
+	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "Dry run: validate what would be deleted")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
 }
 
 func (a *acls) addDeleteFlags(cmd *cobra.Command) {
 	a.addDeprecatedFlags(cmd)
 
-	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "topic to remove ACLs for (repeatable)")
-	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "group to remove ACLs for (repeatable)")
-	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "whether to remove ACLs to the cluster")
-	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "transactional IDs to remove ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "Topic to remove ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to remove ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to remove ACLs to the cluster")
+	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to remove ACLs for (repeatable)")
 
-	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "pattern to use when matching resource names (any, match, literal, or prefixed)")
+	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "Pattern to use when matching resource names (any, match, literal, or prefixed)")
 
-	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "operation to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to remove (repeatable)")
 
-	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "allowed principal ACLs to remove (repeatable)")
-	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "allowed host ACLs to remove (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "denied principal ACLs to remove (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "denied host ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Allowed principal ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "Allowed host ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "Denied principal ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "Denied host ACLs to remove (repeatable)")
 }
 
 func deleteReqResp(

--- a/src/go/rpk/pkg/cli/cmd/acl/list.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/list.go
@@ -28,7 +28,7 @@ func NewListCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls", "describe"},
-		Short:   "List ACLs.",
+		Short:   "List ACLs",
 		Long: `List ACLs.
 
 See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
@@ -64,7 +64,7 @@ resource names:
 		},
 	}
 	a.addListFlags(cmd)
-	cmd.Flags().BoolVarP(&printAllFilters, "print-filters", "f", false, "print the filters that were requested (failed filters are always printed)")
+	cmd.Flags().BoolVarP(&printAllFilters, "print-filters", "f", false, "Print the filters that were requested (failed filters are always printed)")
 	return cmd
 }
 
@@ -79,19 +79,19 @@ func (a *acls) addListFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkDeprecated("principal", "use --{allow,deny}-{host,principal}")
 	cmd.Flags().MarkDeprecated("host", "use --{allow,deny}-{host,principal}")
 
-	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "topic to match ACLs for (repeatable)")
-	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "group to match ACLs for (repeatable)")
-	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "whether to match ACLs to the cluster")
-	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "transactional IDs to match ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "Topic to match ACLs for (repeatable)")
+	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to match ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to match ACLs to the cluster")
+	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to match ACLs for (repeatable)")
 
-	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "pattern to use when matching resource names (any, match, literal, or prefixed)")
+	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "Pattern to use when matching resource names (any, match, literal, or prefixed)")
 
-	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "operation to match (repeatable)")
+	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to match (repeatable)")
 
-	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "allowed principal ACLs to match (repeatable)")
-	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "allowed host ACLs to match (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "denied principal ACLs to match (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "denied host ACLs to match (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Allowed principal ACLs to match (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "Allowed host ACLs to match (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "Denied principal ACLs to match (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "Denied host ACLs to match (repeatable)")
 }
 
 func describeReqResp(

--- a/src/go/rpk/pkg/cli/cmd/acl/user.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user.go
@@ -24,7 +24,7 @@ func NewUserCommand(fs afero.Fs) *cobra.Command {
 	var apiUrls []string
 	cmd := &cobra.Command{
 		Use:   "user",
-		Short: "Manage SASL users.",
+		Short: "Manage SASL users",
 		Long: `Manage SASL users.
 
 If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
@@ -39,7 +39,7 @@ redpanda section of your redpanda.yaml.
 		config.FlagAdminHosts2,
 		[]string{},
 		"The comma-separated list of Admin API addresses (<IP>:<port>)."+
-			" You must specify one for each node.",
+			" You must specify one for each node",
 	)
 
 	cmd.AddCommand(NewCreateUserCommand(fs))
@@ -59,7 +59,7 @@ func NewCreateUserCommand(fs afero.Fs) *cobra.Command {
 	var userOld, pass, passOld, mechanism string
 	cmd := &cobra.Command{
 		Use:   "create [USER] -p [PASS]",
-		Short: "Create a SASL user.",
+		Short: "Create a SASL user",
 		Long: `Create a SASL user.
 
 This command creates a single SASL user with the given password, optionally
@@ -120,11 +120,11 @@ acl help text for more info.
 	}
 
 	cmd.Flags().StringVar(&userOld, "new-username", "", "")
-	cmd.Flags().MarkDeprecated("new-username", "the username now does not require a flag") // Oct 2021
+	cmd.Flags().MarkDeprecated("new-username", "The username now does not require a flag") // Oct 2021
 
-	cmd.Flags().StringVarP(&pass, "password", "p", "", "new user's password")
+	cmd.Flags().StringVarP(&pass, "password", "p", "", "New user's password")
 	cmd.Flags().StringVar(&passOld, "new-password", "", "")
-	cmd.Flags().MarkDeprecated("new-password", "renamed to --password") // Oct 2021
+	cmd.Flags().MarkDeprecated("new-password", "Renamed to --password") // Oct 2021
 
 	cmd.Flags().StringVar(
 		&mechanism,
@@ -140,7 +140,7 @@ func NewDeleteUserCommand(fs afero.Fs) *cobra.Command {
 	var oldUser string
 	cmd := &cobra.Command{
 		Use:   "delete [USER]",
-		Short: "Delete a SASL user.",
+		Short: "Delete a SASL user",
 		Long: `Delete a SASL user.
 
 This command deletes the specified SASL account from Redpanda. This does not
@@ -174,7 +174,7 @@ delete any ACLs that may exist for this user.
 	}
 
 	cmd.Flags().StringVar(&oldUser, "delete-username", "", "The user to be deleted")
-	cmd.Flags().MarkDeprecated("delete-username", "the username now does not require a flag")
+	cmd.Flags().MarkDeprecated("delete-username", "The username now does not require a flag")
 
 	return cmd
 }
@@ -183,7 +183,7 @@ func NewListUsersCommand(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List SASL users.",
+		Short:   "List SASL users",
 		Run: func(cmd *cobra.Command, _ []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -33,7 +33,7 @@ func NewClusterCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "cluster",
-		Short: "Interact with a Redpanda cluster.",
+		Short: "Interact with a Redpanda cluster",
 	}
 	// backcompat: until we switch to -X, we need these flags.
 	common.AddKafkaFlags(

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/config.go
@@ -29,7 +29,7 @@ func NewConfigCommand(fs afero.Fs) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "config",
 		Args:  cobra.ExactArgs(0),
-		Short: "Interact with cluster configuration properties.",
+		Short: "Interact with cluster configuration properties",
 		Long: `Interact with cluster configuration properties.
 
 Cluster properties are redpanda settings which apply to all nodes in
@@ -68,7 +68,7 @@ different redpanda version that does not recognize certain properties.`,
 		&all,
 		"all",
 		false,
-		"Include all properties, including tunables.",
+		"Include all properties, including tunables",
 	)
 
 	command.AddCommand(

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -26,7 +26,7 @@ import (
 func newEditCommand(fs afero.Fs, all *bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
-		Short: "Edit cluster configuration properties.",
+		Short: "Edit cluster configuration properties",
 		Long: `Edit cluster-wide configuration properties.
 
 This command opens a text editor to modify the cluster's configuration.

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -135,7 +135,7 @@ func newExportCommand(fs afero.Fs, all *bool) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "export",
-		Short: "Export cluster configuration.",
+		Short: "Export cluster configuration",
 		Long: `Export cluster configuration.
 
 Writes out a YAML representation of the cluster configuration to a file,

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -216,7 +216,7 @@ func newImportCommand(fs afero.Fs, all *bool) *cobra.Command {
 	var filename string
 	cmd := &cobra.Command{
 		Use:   "import",
-		Short: "Import cluster configuration from a file.",
+		Short: "Import cluster configuration from a file",
 		Long: `Import cluster configuration from a file.
 
 Import configuration from a YAML file, usually generated with

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/lint.go
@@ -24,7 +24,7 @@ import (
 func newLintCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint",
-		Short: "Remove any deprecated content from redpanda.yaml.",
+		Short: "Remove any deprecated content from redpanda.yaml",
 		Long: `Remove any deprecated content from redpanda.yaml.
 
 Deprecated content includes properties which were set via redpanda.yaml

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
@@ -23,7 +23,7 @@ func newForceResetCommand(fs afero.Fs) *cobra.Command {
 	var configCacheFile string
 	cmd := &cobra.Command{
 		Use:   "force-reset [PROPERTY...]",
-		Short: "Forcibly clear a cluster configuration property on this node.",
+		Short: "Forcibly clear a cluster configuration property on this node",
 		Long: `Forcibly clear a cluster configuration property on this node.
 
 This command is not for general changes to cluster configuration: use this only

--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -35,7 +35,7 @@ func NewHealthOverviewCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "health",
-		Short: "Queries cluster for health overview.",
+		Short: "Queries cluster for health overview",
 		Long: `Queries health overview.
 
 Health overview is created based on the health reports collected periodically
@@ -84,8 +84,8 @@ following conditions are met:
 		&adminCAFile,
 	)
 
-	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "blocks and writes out all cluster health changes")
-	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "when used with watch, exits after cluster is back in healthy state")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Blocks and writes out all cluster health changes")
+	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "When used with watch, exits after cluster is back in healthy state")
 	return cmd
 }
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/disable.go
@@ -24,7 +24,7 @@ import (
 func newDisableCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable <broker-id>",
-		Short: "Disable maintenance mode for a node.",
+		Short: "Disable maintenance mode for a node",
 		Long:  `Disable maintenance mode for a node.`,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/enable.go
@@ -26,7 +26,7 @@ func newEnableCommand(fs afero.Fs) *cobra.Command {
 	var wait bool
 	cmd := &cobra.Command{
 		Use:   "enable <node-id>",
-		Short: "Enable maintenance mode for a node.",
+		Short: "Enable maintenance mode for a node",
 		Long: `Enable maintenance mode for a node.
 
 This command enables maintenance mode for the node with the specified ID. If a

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
@@ -27,7 +27,7 @@ func NewMaintenanceCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "maintenance",
-		Short: "Toggle a node's maintenance mode.",
+		Short: "Toggle a node's maintenance mode",
 		Long: `Interact with cluster maintenance mode.
 
 Maintenance mode is a state that a node may be placed into in which the node

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/status.go
@@ -40,7 +40,7 @@ func addBrokerMaintenanceReport(table *out.TabWriter, b admin.Broker) {
 func newStatusCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Report maintenance status.",
+		Short: "Report maintenance status",
 		Long: `Report maintenance status.
 
 This command reports maintenance status for each node in the cluster. The output

--- a/src/go/rpk/pkg/cli/cmd/cluster/metadata.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/metadata.go
@@ -36,7 +36,7 @@ func NewMetadataCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "metadata",
 		Aliases: []string{"status", "info"},
-		Short:   "Request broker metadata.",
+		Short:   "Request broker metadata",
 		Long: `Request broker metadata.
 
 The Kafka protocol's metadata contains information about brokers, topics, and
@@ -120,11 +120,11 @@ In the broker section, the controller node is suffixed with *.
 		},
 	}
 
-	cmd.Flags().BoolVarP(&cluster, "print-cluster", "c", false, "print cluster section")
-	cmd.Flags().BoolVarP(&brokers, "print-brokers", "b", false, "print brokers section")
-	cmd.Flags().BoolVarP(&topics, "print-topics", "t", false, "print topics section (implied if any topics are specified)")
-	cmd.Flags().BoolVarP(&internal, "print-internal-topics", "i", false, "print internal topics (if all topics requested, implies -t)")
-	cmd.Flags().BoolVarP(&detailed, "print-detailed-topics", "d", false, "print per-partition information for topics (implies -t)")
+	cmd.Flags().BoolVarP(&cluster, "print-cluster", "c", false, "Print cluster section")
+	cmd.Flags().BoolVarP(&brokers, "print-brokers", "b", false, "Print brokers section")
+	cmd.Flags().BoolVarP(&topics, "print-topics", "t", false, "Print topics section (implied if any topics are specified)")
+	cmd.Flags().BoolVarP(&internal, "print-internal-topics", "i", false, "Print internal topics (if all topics requested, implies -t)")
+	cmd.Flags().BoolVarP(&detailed, "print-detailed-topics", "d", false, "Print per-partition information for topics (implies -t)")
 	return cmd
 }
 

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -39,7 +39,7 @@ func AddKafkaFlags(
 		"Comma-separated list of broker ip:port pairs (e.g."+
 			" --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' )."+
 			" Alternatively, you may set the REDPANDA_BROKERS environment"+
-			" variable with the comma-separated list of broker addresses.",
+			" variable with the comma-separated list of broker addresses",
 	)
 	command.PersistentFlags().StringVar(
 		configFile,
@@ -52,19 +52,19 @@ func AddKafkaFlags(
 		user,
 		"user",
 		"",
-		"SASL user to be used for authentication.",
+		"SASL user to be used for authentication",
 	)
 	command.PersistentFlags().StringVar(
 		password,
 		"password",
 		"",
-		"SASL password to be used for authentication.",
+		"SASL password to be used for authentication",
 	)
 	command.PersistentFlags().StringVar(
 		saslMechanism,
 		config.FlagSASLMechanism,
 		"",
-		"The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.",
+		"The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512",
 	)
 
 	AddTLSFlags(command, enableTLS, certFile, keyFile, truststoreFile)
@@ -81,25 +81,25 @@ func AddTLSFlags(
 		enableTLS,
 		config.FlagEnableTLS,
 		false,
-		"Enable TLS for the Kafka API (not necessary if specifying custom certs).",
+		"Enable TLS for the Kafka API (not necessary if specifying custom certs)",
 	)
 	command.PersistentFlags().StringVar(
 		certFile,
 		config.FlagTLSCert,
 		"",
-		"The certificate to be used for TLS authentication with the broker.",
+		"The certificate to be used for TLS authentication with the broker",
 	)
 	command.PersistentFlags().StringVar(
 		keyFile,
 		config.FlagTLSKey,
 		"",
-		"The certificate key to be used for TLS authentication with the broker.",
+		"The certificate key to be used for TLS authentication with the broker",
 	)
 	command.PersistentFlags().StringVar(
 		truststoreFile,
 		config.FlagTLSCA,
 		"",
-		"The truststore to be used for TLS communication with the broker.",
+		"The truststore to be used for TLS communication with the broker",
 	)
 
 	return command
@@ -114,25 +114,25 @@ func AddAdminAPITLSFlags(
 		enableTLS,
 		config.FlagEnableAdminTLS,
 		false,
-		"Enable TLS for the Admin API (not necessary if specifying custom certs).",
+		"Enable TLS for the Admin API (not necessary if specifying custom certs)",
 	)
 	command.PersistentFlags().StringVar(
 		certFile,
 		config.FlagAdminTLSCert,
 		"",
-		"The certificate to be used for TLS authentication with the Admin API.",
+		"The certificate to be used for TLS authentication with the Admin API",
 	)
 	command.PersistentFlags().StringVar(
 		keyFile,
 		config.FlagAdminTLSKey,
 		"",
-		"The certificate key to be used for TLS authentication with the Admin API.",
+		"The certificate key to be used for TLS authentication with the Admin API",
 	)
 	command.PersistentFlags().StringVar(
 		truststoreFile,
 		config.FlagAdminTLSCA,
 		"",
-		"The truststore to be used for TLS communication with the Admin API.",
+		"The truststore to be used for TLS communication with the Admin API",
 	)
 
 	return command

--- a/src/go/rpk/pkg/cli/cmd/container.go
+++ b/src/go/rpk/pkg/cli/cmd/container.go
@@ -17,7 +17,7 @@ import (
 func NewContainerCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "container",
-		Short: "Manage a local container cluster.",
+		Short: "Manage a local container cluster",
 	}
 
 	command.AddCommand(container.Start())

--- a/src/go/rpk/pkg/cli/cmd/container/purge.go
+++ b/src/go/rpk/pkg/cli/cmd/container/purge.go
@@ -22,7 +22,7 @@ import (
 func Purge() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "purge",
-		Short: "Stop and remove an existing local container cluster's data.",
+		Short: "Stop and remove an existing local container cluster's data",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := common.NewDockerClient()
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -58,7 +58,7 @@ func Start() *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "start",
-		Short: "Start a local container cluster.",
+		Short: "Start a local container cluster",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			// Allow unknown flags so that arbitrary flags can be passed
 			// through to the containers without the need to pass '--'

--- a/src/go/rpk/pkg/cli/cmd/container/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/container/stop.go
@@ -22,7 +22,7 @@ import (
 func Stop() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "stop",
-		Short: "Stop an existing local container cluster.",
+		Short: "Stop an existing local container cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := common.NewDockerClient()
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -53,7 +53,7 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "bundle",
-		Short: "Collect environment data and create a bundle file for the Redpanda Data support team to inspect.",
+		Short: "Collect environment data and create a bundle file for the Redpanda Data support team to inspect",
 		Long:  bundleHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
@@ -78,7 +78,7 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 		&adminURL,
 		"admin-url",
 		"",
-		"The address to the broker's admin API. Defaults to the one in the config file.",
+		"The address to the broker's admin API. Defaults to the one in the config file",
 	)
 	command.Flags().DurationVar(
 		&timeout,
@@ -102,7 +102,7 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 		&logsSizeLimit,
 		"logs-size-limit",
 		"100MiB",
-		"Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB.",
+		"Read the logs until the given size is reached. Multipliers are also supported, e.g. 3MB, 1GiB",
 	)
 
 	common.AddKafkaFlags(

--- a/src/go/rpk/pkg/cli/cmd/debug/debug.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/debug.go
@@ -17,7 +17,7 @@ import (
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "debug",
-		Short: "Debug the local Redpanda process.",
+		Short: "Debug the local Redpanda process",
 	}
 
 	cmd.AddCommand(

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -34,7 +34,7 @@ func NewInfoCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:     "info",
-		Short:   "Send usage stats to Redpanda Data.",
+		Short:   "Send usage stats to Redpanda Data",
 		Hidden:  true,
 		Aliases: []string{"status"},
 		Args:    cobra.ExactArgs(0),
@@ -95,7 +95,7 @@ func NewInfoCommand(fs afero.Fs) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&configFile, "config", "", "Redpanda config file, if not set the file will be searched for in the default locations")
-	cmd.Flags().BoolVar(&send, "send", false, "If true, send resource usage data to Vectorzed.")
-	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Second, "How long to wait to calculate the Redpanda CPU % utilization.")
+	cmd.Flags().BoolVar(&send, "send", false, "If true, send resource usage data to Redpanda")
+	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Second, "How long to wait to calculate the Redpanda CPU % utilization")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/generate.go
@@ -18,7 +18,7 @@ import (
 func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "generate [template]",
-		Short: "Generate a configuration template for related services.",
+		Short: "Generate a configuration template for related services",
 	}
 	command.AddCommand(generate.NewGrafanaDashboardCmd())
 	command.AddCommand(generate.NewPrometheusConfigCmd(fs))

--- a/src/go/rpk/pkg/cli/cmd/generate/autocomplete.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/autocomplete.go
@@ -19,7 +19,7 @@ import (
 func NewShellCompletionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "shell-completion",
-		Short: "Generate shell completion commands.",
+		Short: "Generate shell completion commands",
 		Long: `
 Shell completion can help autocomplete rpk commands when you press tab.
 

--- a/src/go/rpk/pkg/cli/cmd/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana.go
@@ -65,7 +65,7 @@ func NewGrafanaDashboardCmd() *cobra.Command {
 	var metricsEndpoint string
 	command := &cobra.Command{
 		Use:   "grafana-dashboard",
-		Short: "Generate a Grafana dashboard for redpanda metrics.",
+		Short: "Generate a Grafana dashboard for redpanda metrics",
 		RunE: func(ccmd *cobra.Command, args []string) error {
 			if !(strings.HasPrefix(metricsEndpoint, "http://") ||
 				strings.HasPrefix(metricsEndpoint, "https://")) {

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -46,7 +46,7 @@ func NewPrometheusConfigCmd(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "prometheus-config",
-		Short: "Generate the Prometheus configuration to scrape redpanda nodes.",
+		Short: "Generate the Prometheus configuration to scrape redpanda nodes",
 		Long: `
 Generate the Prometheus configuration to scrape redpanda nodes. This command's
 output should be added to the 'scrape_configs' array in your Prometheus

--- a/src/go/rpk/pkg/cli/cmd/group/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/group/describe.go
@@ -28,7 +28,7 @@ func NewDescribeCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "describe [GROUPS...]",
-		Short: "Describe group offset status & lag.",
+		Short: "Describe group offset status & lag",
 		Long: `Describe group offset status & lag.
 
 This command describes group members, calculates their lag, and prints detailed

--- a/src/go/rpk/pkg/cli/cmd/group/group.go
+++ b/src/go/rpk/pkg/cli/cmd/group/group.go
@@ -25,7 +25,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "group",
 		Aliases: []string{"g"},
-		Short:   `Describe, list, and delete consumer groups and manage their offsets.`,
+		Short:   `Describe, list, and delete consumer groups and manage their offsets`,
 		Long: `Describe, list, and delete consumer groups and manage their offsets.
 
 Consumer groups allow you to horizontally scale consuming from topics. A
@@ -108,7 +108,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List all groups.",
+		Short:   "List all groups",
 		Long: `List all groups.
 
 This command lists all groups currently known to Redpanda, including empty
@@ -144,7 +144,7 @@ groups, or to list groups that need to be cleaned up.
 func newDeleteCommand(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete [GROUPS...]",
-		Short: "Delete groups from brokers.",
+		Short: "Delete groups from brokers",
 		Long: `Delete groups from brokers.
 
 Older versions of the Kafka protocol included a retention_millis field in

--- a/src/go/rpk/pkg/cli/cmd/group/seek.go
+++ b/src/go/rpk/pkg/cli/cmd/group/seek.go
@@ -35,7 +35,7 @@ func newSeekCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ...",
-		Short: "Modify a group's current offsets.",
+		Short: "Modify a group's current offsets",
 		Long: `Modify a group's current offsets.
 
 This command allows you to modify a group's offsets. Sometimes, you may need to

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -33,7 +33,7 @@ func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "iotune",
-		Short: "Measure filesystem performance and create IO configuration file.",
+		Short: "Measure filesystem performance and create IO configuration file",
 		Run: func(cmd *cobra.Command, args []string) {
 			timeout += duration
 			p := config.ParamsFromCommand(cmd)
@@ -57,7 +57,7 @@ func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in the default locations",
 	)
 	command.Flags().StringVar(
 		&outputFile,

--- a/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
@@ -17,7 +17,7 @@ const urlBase = "https://vectorized-public.s3.us-west-2.amazonaws.com/rpk-plugin
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plugin",
-		Short: "List, download, update, and remove rpk plugins.",
+		Short: "List, download, update, and remove rpk plugins",
 		Long: `List, download, update, and remove rpk plugins.
 	
 Plugins augment rpk with new commands.
@@ -76,7 +76,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all available plugins.",
+		Short: "List all available plugins",
 		Long: `List all available plugins.
 
 By default, this command fetches the remote manifest and prints plugins
@@ -156,7 +156,7 @@ func newInstallCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "install [PLUGIN]",
 		Aliases: []string{"download"},
-		Short:   "Install an rpk plugin.",
+		Short:   "Install an rpk plugin",
 		Long: `Install an rpk plugin.
 
 An rpk plugin must be saved in a directory that is in your $PATH. By default,
@@ -246,7 +246,7 @@ func newUninstallCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "uninstall [NAME]",
 		Aliases: []string{"rm"},
-		Short:   "Uninstall / remove an existing local plugin.",
+		Short:   "Uninstall / remove an existing local plugin",
 		Long: `Uninstall / remove an existing local plugin.
 
 This command lists locally installed plugins and removes the first plugin that

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -24,7 +24,7 @@ import (
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin",
-		Short: "Talk to the Redpanda admin listener.",
+		Short: "Talk to the Redpanda admin listener",
 		Args:  cobra.ExactArgs(0),
 	}
 
@@ -50,7 +50,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		config.FlagAdminHosts1,
 		[]string{},
 		"A comma-separated list of Admin API addresses (<IP>:<port>)."+
-			" You must specify one for each node.",
+			" You must specify one for each node",
 	)
 
 	common.AddAdminAPITLSFlags(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -26,7 +26,7 @@ import (
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "brokers",
-		Short: "View and configure Redpanda brokers through the admin listener.",
+		Short: "View and configure Redpanda brokers through the admin listener",
 		Args:  cobra.ExactArgs(0),
 	}
 	cmd.AddCommand(
@@ -41,7 +41,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List the brokers in your cluster.",
+		Short:   "List the brokers in your cluster",
 		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			p := config.ParamsFromCommand(cmd)
@@ -82,7 +82,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 func newDecommissionBroker(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "decommission [BROKER ID]",
-		Short: "Decommission the given broker.",
+		Short: "Decommission the given broker",
 		Long: `Decommission the given broker.
 
 Decommissioning a broker removes it from the cluster.
@@ -116,7 +116,7 @@ leader handles the request.
 func newRecommissionBroker(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "recommission [BROKER ID]",
-		Short: "Recommission the given broker if it is still decommissioning.",
+		Short: "Recommission the given broker if it is still decommissioning",
 		Long: `Recommission the given broker if is is still decommissioning.
 
 Recommissioning can stop an active decommission.

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -20,7 +20,7 @@ import (
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "View or modify Redpanda configuration through the admin listener.",
+		Short: "View or modify Redpanda configuration through the admin listener",
 		Args:  cobra.ExactArgs(0),
 	}
 	cmd.AddCommand(
@@ -35,7 +35,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "print",
 		Aliases: []string{"dump", "list", "ls", "display"},
-		Short:   "Display the current Redpanda configuration.",
+		Short:   "Display the current Redpanda configuration",
 		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			p := config.ParamsFromCommand(cmd)
@@ -65,7 +65,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 func newLogLevelCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "log-level",
-		Short: "Manage a broker's log level.",
+		Short: "Manage a broker's log level",
 		Args:  cobra.ExactArgs(0),
 	}
 	cmd.AddCommand(
@@ -81,7 +81,7 @@ func newLogLevelSetCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "set [LOGGERS...]",
-		Short: "Set broker logger's log level.",
+		Short: "Set broker logger's log level",
 		Long: `Set broker logger's log level.
 
 This command temporarily changes a broker logger's log level. Each Redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -27,7 +27,7 @@ import (
 func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "partitions",
-		Short: "View and configure Redpanda partitions through the admin listener.",
+		Short: "View and configure Redpanda partitions through the admin listener",
 		Args:  cobra.ExactArgs(0),
 	}
 	cmd.AddCommand(
@@ -41,7 +41,7 @@ func newListCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list [BROKER ID]",
 		Aliases: []string{"ls"},
-		Short:   "List the partitions in a broker in the cluster.",
+		Short:   "List the partitions in a broker in the cluster",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			brokerID, err := strconv.Atoi(args[0])

--- a/src/go/rpk/pkg/cli/cmd/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/check.go
@@ -34,7 +34,7 @@ func NewCheckCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "check",
-		Short: "Check if system meets redpanda requirements.",
+		Short: "Check if system meets redpanda requirements",
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -33,7 +33,7 @@ const (
 func NewConfigCommand(fs afero.Fs) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "config <command>",
-		Short: "Edit configuration.",
+		Short: "Edit configuration",
 	}
 	root.AddCommand(set(fs))
 	root.AddCommand(bootstrap(fs))

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
@@ -26,7 +26,7 @@ func NewModeCommand(fs afero.Fs) *cobra.Command {
 	var configFile string
 	command := &cobra.Command{
 		Use:   "mode <mode>",
-		Short: "Enable a default configuration mode.",
+		Short: "Enable a default configuration mode",
 		Long:  "",
 		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -134,7 +134,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "start",
-		Short: "Start redpanda.",
+		Short: "Start redpanda",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			// Allow unknown flags so that arbitrary flags can be passed
 			// through to redpanda/seastar without the need to pass '--'

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
@@ -34,7 +34,7 @@ func NewStopCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "stop",
-		Short: "Stop redpanda.",
+		Short: "Stop redpanda",
 		Long: `Stop a local redpanda process. 'rpk stop'
 first sends SIGINT, and waits for the specified timeout. Then, if redpanda
 hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/help.go
@@ -34,7 +34,7 @@ func newHelpCommand() *cobra.Command {
 
 	return &cobra.Command{
 		Use:   "help <tuner>",
-		Short: "Display detailed information about the tuner.",
+		Short: "Display detailed information about the tuner",
 		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("requires the tuner name")

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -56,11 +56,11 @@ func Execute() {
 
 	root := &cobra.Command{
 		Use:   "rpk",
-		Short: "rpk is the Redpanda CLI & toolbox.",
+		Short: "rpk is the Redpanda CLI & toolbox",
 		Long:  "",
 	}
 	root.PersistentFlags().BoolVarP(&verbose, config.FlagVerbose,
-		"v", false, "Enable verbose logging (default: false).")
+		"v", false, "Enable verbose logging (default: false)")
 
 	root.AddCommand(
 		NewGenerateCommand(fs),
@@ -113,6 +113,13 @@ func Execute() {
 			os.Exit(0)
 		}
 	}
+
+	// Cobra creates help flag as: help for <command> if you want to override
+	// that message (capitalize the first letter) then this is the way.
+	// See: spf13/cobra#480
+	walk(root, func(c *cobra.Command) {
+		c.Flags().BoolP("help", "h", false, "Help for "+c.Name())
+	})
 
 	err := root.Execute()
 	if len(os.Args) > 1 {
@@ -422,4 +429,12 @@ func (*osPluginHandler) exec(path string, args []string) error {
 		}).Run()
 	}
 	return syscall.Exec(path, args, env)
+}
+
+// walk calls f for c and all of its children.
+func walk(c *cobra.Command, f func(*cobra.Command)) {
+	f(c)
+	for _, c := range c.Commands() {
+		walk(c, f)
+	}
 }

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -30,7 +30,7 @@ func NewTopicCommand(fs afero.Fs) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "topic",
-		Short: "Create, delete, produce to and consume from Redpanda topics.",
+		Short: "Create, delete, produce to and consume from Redpanda topics",
 	}
 
 	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &enableTLS, &certFile, &keyFile, &truststoreFile, &brokers)

--- a/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
@@ -27,7 +27,7 @@ func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
 	var num int
 	cmd := &cobra.Command{
 		Use:   "add-partitions [TOPICS...] --num [#]",
-		Short: "Add partitions to existing topics.",
+		Short: "Add partitions to existing topics",
 		Args:  cobra.MinimumNArgs(1),
 		Long:  `Add partitions to existing topics.`,
 		Run: func(cmd *cobra.Command, topics []string) {
@@ -70,6 +70,6 @@ func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().IntVarP(&num, "num", "n", 0, "numer of partitions to add to each topic")
+	cmd.Flags().IntVarP(&num, "num", "n", 0, "Number of partitions to add to each topic")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/config.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/config.go
@@ -33,7 +33,7 @@ func NewAlterConfigCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "alter-config [TOPICS...] --set key=value --delete key2,key3",
-		Short: `Set, delete, add, and remove key/value configs for a topic.`,
+		Short: `Set, delete, add, and remove key/value configs for a topic`,
 		Long: `Set, delete, add, and remove key/value configs for a topic.
 
 This command allows you to incrementally alter the configuration for multiple
@@ -132,7 +132,7 @@ valid, but does not apply it.
 	cmd.Flags().StringArrayVar(&appends, "append", nil, "key=value; Value to append to a list-of-values key (repeatable)")
 	cmd.Flags().StringArrayVar(&subtracts, "subtract", nil, "key=value; Value to remove from list-of-values key (repeatable)")
 
-	cmd.Flags().BoolVar(&dry, "dry", false, "dry run: validate the alter request, but do not apply")
+	cmd.Flags().BoolVar(&dry, "dry", false, "Dry run: validate the alter request, but do not apply")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -66,7 +66,7 @@ func NewConsumeCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "consume TOPICS...",
-		Short: "Consume records from topics.",
+		Short: "Consume records from topics",
 		Long:  helpConsume,
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, topics []string) {
@@ -126,7 +126,7 @@ func NewConsumeCommand(fs afero.Fs) *cobra.Command {
 	cmd.Flags().Int32SliceVarP(&c.partitions, "partitions", "p", nil, "Comma delimited list of specific partitions to consume")
 	cmd.Flags().BoolVarP(&c.regex, "regex", "r", false, "Parse topics as regex; consume any topic that matches any expression")
 
-	cmd.Flags().StringVarP(&c.group, "group", "g", "", "group to use for consuming (incompatible with -p)")
+	cmd.Flags().StringVarP(&c.group, "group", "g", "", "Group to use for consuming (incompatible with -p)")
 	cmd.Flags().StringVarP(&c.balancer, "balancer", "b", "cooperative-sticky", "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
 
 	cmd.Flags().Int32Var(&c.fetchMaxBytes, "fetch-max-bytes", 1<<20, "Maximum amount of bytes per fetch request per broker")
@@ -140,7 +140,7 @@ func NewConsumeCommand(fs afero.Fs) *cobra.Command {
 
 	// Deprecated.
 	cmd.Flags().BoolVar(new(bool), "commit", false, "")
-	cmd.Flags().MarkDeprecated("commit", "group consuming always commits")
+	cmd.Flags().MarkDeprecated("commit", "Group consuming always commits")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -34,7 +34,7 @@ func NewCreateCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "create [TOPICS...]",
-		Short: "Create topics.",
+		Short: "Create topics",
 		Args:  cobra.MinimumNArgs(1),
 		Long: `Create topics.
 
@@ -117,11 +117,11 @@ the cleanup.policy=compact config option set.
 	cmd.Flags().StringArrayVarP(&configKVs, "topic-config", "c", nil, "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)")
 	cmd.Flags().Int32VarP(&partitions, "partitions", "p", -1, "Number of partitions to create per topic; -1 defaults to the cluster's default_topic_partitions")
 	cmd.Flags().Int16VarP(&replicas, "replicas", "r", -1, "Replication factor (must be odd); -1 defaults to the cluster's default_topic_replications")
-	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "dry run: validate the topic creation request; do not create topics")
+	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "Dry run: validate the topic creation request; do not create topics")
 
 	// Sept 2021
-	cmd.Flags().BoolVar(&compact, "compact", false, "alias for -c cleanup.policy=compact")
-	cmd.Flags().MarkDeprecated("compact", "use -c cleanup.policy=compact")
+	cmd.Flags().BoolVar(&compact, "compact", false, "Alias for -c cleanup.policy=compact")
+	cmd.Flags().MarkDeprecated("compact", "Use -c cleanup.policy=compact")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/delete.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/delete.go
@@ -23,7 +23,7 @@ func NewDeleteCommand(fs afero.Fs) *cobra.Command {
 	var re bool
 	cmd := &cobra.Command{
 		Use:   "delete [TOPICS...]",
-		Short: "Delete topics.",
+		Short: "Delete topics",
 		Long: `Delete topics.
 
 This command deletes all requested topics, printing the success or fail status
@@ -75,6 +75,6 @@ For example,
 			}
 		},
 	}
-	cmd.Flags().BoolVarP(&re, "regex", "r", false, "parse topics as regex; delete any topic that matches any input topic expression")
+	cmd.Flags().BoolVarP(&re, "regex", "r", false, "Parse topics as regex; delete any topic that matches any input topic expression")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/describe.go
@@ -37,7 +37,7 @@ func NewDescribeCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe [TOPIC]",
 		Aliases: []string{"info"},
-		Short:   "Describe a topic.",
+		Short:   "Describe a topic",
 		Long: `Describe a topic.
 
 This command prints detailed information about a topic. There are three
@@ -179,10 +179,10 @@ partitions section. By default, the summary and configs sections are printed.
 	cmd.Flags().MarkDeprecated("watermarks", "deprecated - watermarks are always printed if the partition section is requested")
 	cmd.Flags().MarkDeprecated("detailed", "deprecated - info has been merged into describe, use -p to print detailed information")
 
-	cmd.Flags().BoolVarP(&summary, "print-summary", "s", false, "print the summary section")
-	cmd.Flags().BoolVarP(&configs, "print-configs", "c", false, "print the config section")
-	cmd.Flags().BoolVarP(&partitions, "print-partitions", "p", false, "print the detailed partitions section")
-	cmd.Flags().BoolVarP(&all, "print-all", "a", false, "print all sections")
+	cmd.Flags().BoolVarP(&summary, "print-summary", "s", false, "Print the summary section")
+	cmd.Flags().BoolVarP(&configs, "print-configs", "c", false, "Print the config section")
+	cmd.Flags().BoolVarP(&partitions, "print-partitions", "p", false, "Print the detailed partitions section")
+	cmd.Flags().BoolVarP(&all, "print-all", "a", false, "Print all sections")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/list.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/list.go
@@ -29,7 +29,7 @@ func NewListCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List topics, optionally listing specific topics.",
+		Short:   "List topics, optionally listing specific topics",
 		Long: `List topics, optionally listing specific topics.
 
 This command lists all topics that you have access to by default. If specifying
@@ -78,8 +78,8 @@ information.
 		},
 	}
 
-	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "print per-partition information for topics")
-	cmd.Flags().BoolVarP(&internal, "internal", "i", false, "print internal topics")
-	cmd.Flags().BoolVarP(&re, "regex", "r", false, "parse topics as regex; list any topic that matches any input topic expression")
+	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "Print per-partition information for topics")
+	cmd.Flags().BoolVarP(&internal, "internal", "i", false, "Print internal topics")
+	cmd.Flags().BoolVarP(&re, "regex", "r", false, "Parse topics as regex; list any topic that matches any input topic expression")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -43,7 +43,7 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "produce [TOPIC]",
-		Short: "Produce records to a topic.",
+		Short: "Produce records to a topic",
 		Long:  helpProduce,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -160,10 +160,10 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 	// The following flags require parsing before we initialize our client.
 	cmd.Flags().StringVarP(&compression, "compression", "z", "snappy", "Compression to use for producing batches (none, gzip, snapy, lz4, zstd)")
 	cmd.Flags().IntVar(&acks, "acks", -1, "Number of acks required for producing (-1=all, 0=none, 1=leader)")
-	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "per-record delivery timeout, if non-zero, min 1s")
-	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")
+	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "Per-record delivery timeout, if non-zero, min 1s")
+	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")
 
-	cmd.Flags().StringVarP(&inFormat, "format", "f", "%v\n", "input record format")
+	cmd.Flags().StringVarP(&inFormat, "format", "f", "%v\n", "Input record format")
 	cmd.Flags().StringVarP(
 		&outFormat,
 		"output-format",
@@ -173,15 +173,15 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd.Flags().StringArrayVarP(&recHeaders, "header", "H", nil, "Headers in format key:value to add to each record (repeatable)")
 	cmd.Flags().StringVarP(&key, "key", "k", "", "A fixed key to use for each record (parsed input keys take precedence)")
-	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
+	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "Produce empty values as tombstones")
 
 	// Deprecated
 	cmd.Flags().IntVarP(new(int), "num", "n", 1, "")
-	cmd.Flags().MarkDeprecated("num", "invoke rpk multiple times if you wish to repeat records")
+	cmd.Flags().MarkDeprecated("num", "Invoke rpk multiple times if you wish to repeat records")
 	cmd.Flags().BoolVarP(new(bool), "jvm-partitioner", "j", false, "")
-	cmd.Flags().MarkDeprecated("jvm-partitioner", "the default is now the jvm-partitioner")
+	cmd.Flags().MarkDeprecated("jvm-partitioner", "The default is now the jvm-partitioner")
 	cmd.Flags().StringVarP(new(string), "timestamp", "t", "", "")
-	cmd.Flags().MarkDeprecated("timestamp", "record timestamps are set when producing")
+	cmd.Flags().MarkDeprecated("timestamp", "Record timestamps are set when producing")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/version.go
+++ b/src/go/rpk/pkg/cli/cmd/version.go
@@ -19,7 +19,7 @@ import (
 func NewVersionCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "version",
-		Short: "Check the current version.",
+		Short: "Check the current version",
 		Long:  "",
 		Run: func(_ *cobra.Command, _ []string) {
 			log.SetFormatter(cli.NewNoopFormatter())

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -31,7 +31,7 @@ func NewWasmCommand(fs afero.Fs) *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "wasm",
-		Short: "Deploy and remove inline WASM engine scripts.",
+		Short: "Deploy and remove inline WASM engine scripts",
 	}
 	common.AddKafkaFlags(
 		command,

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
@@ -19,7 +19,7 @@ func NewDeployCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "deploy [PATH]",
-		Short: "Deploy inline WASM function.",
+		Short: "Deploy inline WASM function",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
@@ -49,9 +49,9 @@ func NewDeployCommand(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&description, "description", "", "optional description about what the wasm function does")
+	cmd.Flags().StringVar(&description, "description", "", "Optional description about what the wasm function does")
 	cmd.Flags().StringVar(&coprocType, "type", "async", "WASM engine type (async, data-policy)")
-	cmd.Flags().StringVar(&name, "name", "", "unique deploy identifier attached to the instance of this script")
+	cmd.Flags().StringVar(&name, "name", "", "Unique deploy identifier attached to the instance of this script")
 	cmd.MarkFlagRequired("name")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -30,7 +30,7 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 	var skipVersion bool
 	cmd := &cobra.Command{
 		Use:   "generate [PROJECT DIRECTORY]",
-		Short: "Create a npm template project for inline WASM engine.",
+		Short: "Create a npm template project for inline WASM engine",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			path, err := filepath.Abs(args[0])
@@ -39,7 +39,7 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 			out.MaybeDie(err, "unable to generate all manifest files: %v", err)
 		},
 	}
-	cmd.Flags().BoolVar(&skipVersion, "skip-version", false, "omit wasm-api version check from npm, use default instead")
+	cmd.Flags().BoolVar(&skipVersion, "skip-version", false, "Omit wasm-api version check from npm, use default instead")
 	return cmd
 }
 

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -15,7 +15,7 @@ func NewRemoveCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "remove [NAME]",
-		Short: "Remove inline WASM function.",
+		Short: "Remove inline WASM function",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)


### PR DESCRIPTION
## Cover letter

Now all commands and flags descriptions start with a capital letter and shouldn't end with a punctuation mark.

See #4842 for reasoning and context.

Fixes #4632, Fixes #4842

## UX changes

With this PR we are standardizing help output and flag description, e.g
```
Flags:
      --admin-api-tls-cert string         The certificate to be used for TLS authentication with the Admin API.
      --admin-api-tls-enabled             Enable TLS for the Admin API (not necessary if specifying custom certs).
      --admin-api-tls-key string          The certificate key to be used for TLS authentication with the Admin API.
      --admin-api-tls-truststore string   The truststore to be used for TLS communication with the Admin API.
      --api-urls string                   Comma-separated list of admin API addresses (<IP>:<port>)
  -e, --exit-when-healthy                 when used with wait, exits after cluster is back in healthy state
  -h, --help                              help for health
  -w, --watch                             blocks and writes out all cluster health changes
```

Now will look like:

```
Flags:
      --admin-api-tls-cert string         The certificate to be used for TLS authentication with the Admin API
      --admin-api-tls-enabled             Enable TLS for the Admin API (not necessary if specifying custom certs)
      --admin-api-tls-key string          The certificate key to be used for TLS authentication with the Admin API
      --admin-api-tls-truststore string   The truststore to be used for TLS communication with the Admin API
      --api-urls string                   Comma-separated list of admin API addresses (<IP>:<port>)
  -e, --exit-when-healthy                 When used with wait, exits after cluster is back in healthy state
  -h, --help                              Help for health
  -w, --watch                             Blocks and writes out all cluster health changes
```
## Release notes
* none
