### PR TITLE
Bugfix for kafka generator not respecting `nullableVersions` field

### DIFF
--- a/src/v/kafka/protocol/schemata/delete_topics_request.json
+++ b/src/v/kafka/protocol/schemata/delete_topics_request.json
@@ -20,10 +20,20 @@
   // Versions 0, 1, 2, and 3 are the same.
   //
   // Version 4 is the first flexible version.
-  "validVersions": "0-4",
+  //
+  // Version 5 adds ErrorMessage in the response and may return a THROTTLING_QUOTA_EXCEEDED error
+  // in the response if the topics deletion is throttled (KIP-599).
+  //
+  // Version 6 reorganizes topics, adds topic IDs and allows topic names to be null.
+  "validVersions": "0-6",
   "flexibleVersions": "4+",
   "fields": [
-    { "name": "TopicNames", "type": "[]string", "versions": "0+", "entityType": "topicName",
+    { "name": "Topics", "type": "[]DeleteTopicState", "versions": "6+", "about": "The name or topic ID of the topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "6+", "nullableVersions": "6+", "default": "null", "entityType": "topicName", "about": "The topic name"},
+        {"name": "TopicId", "type": "uuid", "versions": "6+", "about": "The unique topic ID"}
+    ]},
+    { "name": "TopicNames", "type": "[]string", "versions": "0-5", "entityType": "topicName", "ignorable": true,
       "about": "The names of the topics to delete" },
     { "name": "TimeoutMs", "type": "int32", "versions": "0+",
       "about": "The length of time in milliseconds to wait for the deletions to complete." }

--- a/src/v/kafka/protocol/schemata/delete_topics_response.json
+++ b/src/v/kafka/protocol/schemata/delete_topics_response.json
@@ -24,17 +24,27 @@
   // Starting in version 3, a TOPIC_DELETION_DISABLED error code may be returned.
   //
   // Version 4 is the first flexible version.
-  "validVersions": "0-4",
+  //
+  // Version 5 adds ErrorMessage in the response and may return a THROTTLING_QUOTA_EXCEEDED error
+  // in the response if the topics deletion is throttled (KIP-599).
+  //
+  // Version 6 adds topic ID to responses. An UNSUPPORTED_VERSION error code will be returned when attempting to
+  // delete using topic IDs when IBP < 2.8. UNKNOWN_TOPIC_ID error code will be returned when IBP is at least 2.8, but
+  // the topic ID was not found.
+  "validVersions": "0-6",
   "flexibleVersions": "4+",
   "fields": [
-    { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+",
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Responses", "type": "[]DeletableTopicResult", "versions": "0+",
       "about": "The results for each topic we tried to delete.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "0+", "nullableVersions": "6+", "mapKey": true, "entityType": "topicName",
         "about": "The topic name" },
+      {"name": "TopicId", "type": "uuid", "versions": "6+", "ignorable": true, "about": "the unique topic ID"},
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
-        "about": "The deletion error, or 0 if the deletion succeeded." }
+        "about": "The deletion error, or 0 if the deletion succeeded." },
+      { "name": "ErrorMessage", "type": "string", "versions": "5+", "nullableVersions": "5+", "ignorable": true, "default": "null",
+        "about": "The error message, or null if there was no error." }
     ]}
   ]
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -444,6 +444,7 @@ STRUCT_TYPES = [
     "EpochEndOffset",
     "SupportedFeatureKey",
     "FinalizedFeatureKey",
+    "DeleteTopicState",
 ]
 
 # a list of struct types which are ineligible to have default-generated

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1080,6 +1080,27 @@ if({{cond}}){
 {%- endif %}
 {%- endmacro %}
 
+{% macro nullable_version_write_guard(field, is_flex, fname, writer) %}
+{%- set guard_enum = field.nullable_versions().guard_enum %}
+{%- set e, cond = field.nullable_versions()._guard() %}
+{%- set flex = "" %}
+{%- if is_flex %}
+{%- set flex = "_flex" %}
+{%- endif %}
+{%- if e == guard_enum.NO_GUARD %}
+{{ writer }}.write{{ flex }}({{ fname }});
+{%- else %}
+if ({{cond}}) {
+    {{ writer }}.write{{ flex }}({{ fname }});
+} else {
+    if(!{{ fname }}.has_value()){
+        throw std::runtime_error(fmt::format("Optional value must be filled at this version: {}", version));
+    }
+    {{ writer }}.write{{ flex }}(*{{ fname }});
+}
+{%- endif %}
+{%- endmacro %}
+
 {% macro field_encoder(field, methods, obj, writer = "writer") %}
 {%- set flex = methods|length > 1 %}
 {%- if obj %}
@@ -1108,6 +1129,8 @@ if({{cond}}){
     {{ writer }}.write(v);
 {%- endif %}
 });
+{%- elif field.nullable() %}
+{{- nullable_version_write_guard(field, (flex and field.type().potentially_flexible_type), fname, writer) }}
 {%- elif flex and field.type().potentially_flexible_type %}
 {{ writer }}.write_flex({{ fname }});
 {%- else %}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1080,14 +1080,6 @@ if ({{ cond }}) {
 {%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
     return reader.{{ decoder }};
-{%- elif field.nullable() %}
-    {
-        auto tmp = reader.{{ decoder }};
-        if (tmp) {
-            return {{ named_type }}(std::move(*tmp));
-        }
-        return std::nullopt;
-    }
 {%- else %}
     return {{ named_type }}(reader.{{ decoder }});
 {%- endif %}

--- a/src/v/kafka/protocol/schemata/produce_request.json
+++ b/src/v/kafka/protocol/schemata/produce_request.json
@@ -33,7 +33,7 @@
   "validVersions": "0-8",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "TransactionalId", "type": "string", "versions": "3+", "nullableVersions": "0+", "entityType": "transactionalId",
+    { "name": "TransactionalId", "type": "string", "versions": "3+", "nullableVersions": "3+", "entityType": "transactionalId",
       "about": "The transactional ID, or null if the producer is not transactional." },
     { "name": "Acks", "type": "int16", "versions": "0+",
       "about": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR." },

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -72,7 +72,8 @@ public:
         }
         // topics are deleted
         for (const auto& r : resp.data.responses) {
-            validate_topic_is_deleteted(r.name);
+            BOOST_REQUIRE(r.name.has_value());
+            validate_topic_is_deleteted(*r.name);
         }
     }
 
@@ -133,8 +134,9 @@ public:
           resp.data.responses.size(), expected_response.size());
 
         for (const auto& tp_r : resp.data.responses) {
+            BOOST_REQUIRE(tp_r.name.has_value());
             BOOST_REQUIRE_EQUAL(
-              tp_r.error_code, expected_response.find(tp_r.name)->second);
+              tp_r.error_code, expected_response.find(*tp_r.name)->second);
         }
     }
 };

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -123,6 +123,8 @@ public:
         return uuid(ul);
     }
 
+    uuid() = default;
+
     explicit uuid(const underlying_t& uuid)
       : _uuid(uuid) {}
 
@@ -133,6 +135,8 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const uuid& u) {
         return os << u.to_string();
     }
+
+    friend bool operator==(const uuid&, const uuid&) = default;
 
 private:
     underlying_t _uuid{};


### PR DESCRIPTION
## Cover letter

The `nullableVersions` property in the kafka schemata denotes at what API versions a field is allowed to be nullable. Currently our generator treats any type tagged with this field as optional, however this somewhat incorrect. `nullableVersions` provides a version schema (i.e. `3-7`) and these are the versions to expect the field to be optional. Example:

```
{ "name": "Name", "type": "string", "versions": "0+", "nullableVersions": "6+", "mapKey": true, "entityType": "topicName", "about": "The topic name" },
```

Currently our generator serializes and deserializes all fields with this `nullableVersions` field as optional, not respecting the min/max versions provided. This patchset fixes this bug.

## Is this a problem today?
AFAIK we haven't directly encountered the issue for two reasons.
1. If `version` and `nullableVersions` are both `0+`, then redpanda treating the type as always `nullable` will work 100% of the time and never pose an issue.
2. For nullable collections, in these conditions, a serialization of the size as nullable or not isn't so serious. Take the following example:
```
{ "name": "Topics", "type": "[]OffsetFetchRequestTopic", "versions": "0+", "nullableVersions": "2+","about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
```
- At `v1` for `OffsetFetchRequest` if redpanda deserialized this field with a call to `read_nullable_array`, instead of `read_array` null will never be observed since a correct client will never write null at `v1`. If a buggy client decided to write null for the field at `v1` then redpanda will not throw and continue parsing the request successfully, containing null for the value of the field.
- If redpanda is serializing this field, it will only write a malformed request in the case the field is explicitly set to null (or left null) by the programmer. A correct client should crash on parsing this, however this never being null, never occurs.

In my opinion the benefits to fixing the above concerns do not outweigh the complexity of modifying the generator to 'correctly' serde these collection types w.r.t. `nullableVersions`. Not to mention the performance considerations to make when adding the necessary conditionals to make this work, conditionals that in practice would rarely be entered. If they are of concern instead of modifying the generator to conditionally call the correct methods, I believe adding a conditional + exception might be a better option. Maybe something like:
```
if(!v.topics.has_value() && request < api_versions(2)) {
    throw std::runtime_error("Should not expect null for field at this version...");
}
```

## Where is the issue observed then?
This becomes more of an issue when we update our request schemas because in more modern variants it is not the case that issue #1 above is true. This PR updates the `delete_topics*` schema to trigger the issue and write tests against it. The following snippet from that schema:
```
{ "name": "Name", "type": "string", "versions": "0+", "nullableVersions": "6+", "mapKey": true, "entityType": "topicName",
```
`nullableVersions` was introduced for this field, and the version does not match the `versions` value. 

## Release notes
- Fixes a bug where certain versions of some requests may not serialize some fields that have the `nullableVersions` property 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/00651b15d266f3818f6de2cd7d33143964a4254f..709e297a97194384e086c6cc28b8750722b54dce)
- Fixed golang comment nits
- Fixed compiler error in `delete_topics` tests arisen due the schema change changing type of `topic` to `optional<topic>`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/709e297a97194384e086c6cc28b8750722b54dce..82b99bdc0778a7c52a42299a601de5bc84ab8cef)
- Fixed a bug introduced making parsing of produce requests to fail