### PR TITLE
pandaproxy: add metrics for error count to /public_metrics

### DIFF
--- a/src/v/pandaproxy/probe.cc
+++ b/src/v/pandaproxy/probe.cc
@@ -21,7 +21,7 @@ namespace pandaproxy {
 
 probe::probe(
   ss::httpd::path_description& path_desc, const ss::sstring& group_name)
-  : _request_hist()
+  : _request_metrics()
   , _metrics()
   , _public_metrics(ssx::metrics::public_metrics_handle) {
     namespace sm = ss::metrics;
@@ -45,7 +45,9 @@ probe::probe(
              "request_latency",
              sm::description("Request latency"),
              labels,
-             [this] { return _request_hist.seastar_histogram_logform(); })
+             [this] {
+                 return _request_metrics.hist().seastar_histogram_logform();
+             })
              .aggregate(internal_aggregate_labels)});
     }
 
@@ -58,7 +60,8 @@ probe::probe(
                ssx::sformat("Internal latency of request for {}", group_name)),
              labels,
              [this] {
-                 return ssx::metrics::report_default_histogram(_request_hist);
+                 return ssx::metrics::report_default_histogram(
+                   _request_metrics.hist());
              })
              .aggregate(aggregate_labels)});
     }

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -61,10 +61,10 @@ class probe {
 public:
     probe(
       ss::httpd::path_description& path_desc, const ss::sstring& group_name);
-    hdr_hist& hist() { return _request_hist; }
+    hdr_hist& hist() { return _request_metrics.hist(); }
 
 private:
-    hdr_hist _request_hist;
+    http_status_metric _request_metrics;
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;
 };

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -61,7 +61,7 @@ class probe {
 public:
     probe(
       ss::httpd::path_description& path_desc, const ss::sstring& group_name);
-    hdr_hist& hist() { return _request_metrics.hist(); }
+    auto auto_measure() { return _request_metrics.auto_measure(); }
 
 private:
     http_status_metric _request_metrics;

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -104,12 +104,13 @@ inline std::unique_ptr<ss::httpd::reply> exception_reply(std::exception_ptr e) {
     } catch (const schema_registry::exception_base& e) {
         return errored_body(e.code(), e.message());
     } catch (const seastar::httpd::base_exception& e) {
-        return errored_body(
-          reply_error_code::kafka_bad_request,
-          e.what()); // TODO BP: Yarr!!
+        return errored_body(reply_error_code::kafka_bad_request, e.what());
     } catch (...) {
-        vlog(plog.error, "{}", std::current_exception());
-        throw;
+        vlog(plog.error, "exception_reply: {}", std::current_exception());
+        auto ise = make_error_condition(
+          reply_error_code::internal_server_error);
+        return errored_body(
+          reply_error_code::internal_server_error, ise.message());
     }
 }
 

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -74,15 +74,15 @@ proxy::proxy(
       ss::api_registry_builder20(_config.api_doc_dir(), "/v1"),
       "header",
       "/definitions",
-      _ctx) {}
+      _ctx,
+      json::serialization_format::application_json) {}
 
 ss::future<> proxy::start() {
     _server.routes(get_proxy_routes());
     return _server.start(
       _config.pandaproxy_api(),
       _config.pandaproxy_api_tls(),
-      _config.advertised_pandaproxy_api(),
-      json::serialization_format::application_json);
+      _config.advertised_pandaproxy_api());
 }
 
 ss::future<> proxy::stop() { return _server.stop(); }

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -229,7 +229,8 @@ service::service(
       ss::api_registry_builder20(_config.api_doc_dir(), "/v1"),
       "schema_registry_header",
       "/schema_registry_definitions",
-      _ctx)
+      _ctx,
+      json::serialization_format::schema_registry_v1_json)
   , _store(store)
   , _writer(sequencer)
   , _ensure_started{[this]() { return do_start(); }} {}
@@ -240,8 +241,7 @@ ss::future<> service::start() {
     return _server.start(
       _config.schema_registry_api(),
       _config.schema_registry_api_tls(),
-      not_advertised,
-      json::serialization_format::schema_registry_v1_json);
+      not_advertised);
 }
 
 ss::future<> service::stop() {

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -91,7 +91,14 @@ struct handler_adaptor : ss::httpd::handler_base {
             measure.set_status(rp.rep->_status);
             co_return std::move(rp.rep);
         }
-        rp = co_await _handler(std::move(rq), std::move(rp));
+        try {
+            rp = co_await _handler(std::move(rq), std::move(rp));
+        } catch (const std::exception& e) {
+            auto eptr = std::current_exception();
+            auto rep = exception_reply(eptr);
+            measure.set_status(rep->_status);
+            std::rethrow_exception(eptr);
+        }
         set_mime_type(*rp.rep, rp.mime_type);
         measure.set_status(rp.rep->_status);
         co_return std::move(rp.rep);

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -116,13 +116,15 @@ server::server(
   ss::api_registry_builder20&& api20,
   const ss::sstring& header,
   const ss::sstring& definitions,
-  context_t& ctx)
+  context_t& ctx,
+  json::serialization_format exceptional_mime_type)
   : _server(server_name)
   , _public_metrics_group_name(public_metrics_group_name)
   , _pending_reqs()
   , _api20(std::move(api20))
   , _has_routes(false)
-  , _ctx(ctx) {
+  , _ctx(ctx)
+  , _exceptional_mime_type(exceptional_mime_type) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -162,10 +164,9 @@ void server::routes(server::routes_t&& rts) {
 ss::future<> server::start(
   const std::vector<model::broker_endpoint>& endpoints,
   const std::vector<config::endpoint_tls_config>& endpoints_tls,
-  const std::vector<model::broker_endpoint>& advertised,
-  json::serialization_format exceptional_mime_type) {
+  const std::vector<model::broker_endpoint>& advertised) {
     _server._routes.register_exeption_handler(
-      exception_replier{ss::sstring{name(exceptional_mime_type)}});
+      exception_replier{ss::sstring{name(_exceptional_mime_type)}});
     _ctx.advertised_listeners.reserve(endpoints.size());
     for (auto& server_endpoint : endpoints) {
         auto addr = co_await net::resolve_dns(server_endpoint.address);

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -80,7 +80,7 @@ struct handler_adaptor : ss::httpd::handler_base {
       const ss::sstring&,
       std::unique_ptr<ss::request> req,
       std::unique_ptr<ss::reply> rep) final {
-        auto measure = _probe.hist().auto_measure();
+        auto measure = _probe.auto_measure();
         auto guard = gate_guard(_pending_requests);
         server::request_t rq{std::move(req), this->_ctx};
         server::reply_t rp{std::move(rep)};

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -88,10 +88,12 @@ struct handler_adaptor : ss::httpd::handler_base {
         auto sem_units = co_await ss::get_units(_ctx.mem_sem, req_size);
         if (_ctx.as.abort_requested()) {
             set_reply_unavailable(*rp.rep);
+            measure.set_status(rp.rep->_status);
             co_return std::move(rp.rep);
         }
         rp = co_await _handler(std::move(rq), std::move(rp));
         set_mime_type(*rp.rep, rp.mime_type);
+        measure.set_status(rp.rep->_status);
         co_return std::move(rp.rep);
     }
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -84,7 +84,8 @@ public:
       ss::api_registry_builder20&& api20,
       const ss::sstring& header,
       const ss::sstring& definitions,
-      context_t& ctx);
+      context_t& ctx,
+      json::serialization_format exceptional_mime_type);
 
     void route(route_t route);
     void routes(routes_t&& routes);
@@ -92,8 +93,7 @@ public:
     ss::future<> start(
       const std::vector<model::broker_endpoint>& endpoints,
       const std::vector<config::endpoint_tls_config>& endpoints_tls,
-      const std::vector<model::broker_endpoint>& advertised,
-      json::serialization_format exceptional_mime_type);
+      const std::vector<model::broker_endpoint>& advertised);
     ss::future<> stop();
 
 private:
@@ -103,6 +103,7 @@ private:
     ss::api_registry_builder20 _api20;
     bool _has_routes;
     context_t& _ctx;
+    json::serialization_format _exceptional_mime_type;
 };
 
 template<typename service_t>


### PR DESCRIPTION
## Cover letter

Count the number of errors of each of 3xx, 4xx, 5xx buckets. If there is an error, don't measure the latency of the request.

Replaces #5422

* redpanda_rest_proxy_request_errors_total
  * Description: Total number of request errors
  * Labels: status
  * Aggregation: shard
* redpanda_schema_registry_request_errors_total
  * Description: Total number of request errors
  * Labels: status
  * Aggregation: shard

## Release notes

### Improvements

* Adds rest proxy and schema registry error counting metrics bucketed by `3xx`, `4xx`, `5xx` HTTP status code to the `/public_metrics` Prometheus endpoint