### PR TITLE
Improve redpanda checkers log

### DIFF
--- a/src/go/rpk/pkg/tuners/check.go
+++ b/src/go/rpk/pkg/tuners/check.go
@@ -10,6 +10,7 @@
 package tuners
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"time"
@@ -32,14 +33,15 @@ func Check(
 
 	for _, checkers := range checkersMap {
 		for _, c := range checkers {
+			log.Debugf("Starting checker %q", c.GetDesc())
 			result := c.Check()
 			if result.Err != nil {
 				if c.GetSeverity() == Fatal {
-					return results, result.Err
+					return results, fmt.Errorf("fatal error during checker %q execution: %v", c.GetDesc(), result.Err)
 				}
-				log.Warnf("System check '%s' failed with non-fatal error '%s'", c.GetDesc(), result.Err)
+				fmt.Printf("System check %q failed with non-fatal error %q\n", c.GetDesc(), result.Err)
 			}
-			log.Debugf("Checker '%s' result %+v", c.GetDesc(), result)
+			log.Debugf("Finished checker %q; result %+v", c.GetDesc(), result)
 			results = append(results, *result)
 		}
 	}

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -13,8 +13,10 @@ package tuners
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloud"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloud/gcp"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -71,8 +73,14 @@ func NewConfigChecker(conf *config.Config) Checker {
 		Fatal,
 		true,
 		func() (interface{}, error) {
-			ok, _ := conf.Check()
-			return ok, nil
+			ok, errs := conf.Check()
+			var err error
+			if len(errs) > 0 {
+				s := multierror.ListFormatFunc(errs)
+				err = fmt.Errorf("config file checker error: %v", s)
+			}
+
+			return ok, err
 		})
 }
 


### PR DESCRIPTION
## Cover letter

Improve redpanda tune checkers log, adds a new log line in -v mode, and fix a small bug in configChecker.

Fixes:
#5424 

## UX changes

1. more descriptive logs so when an end user runs any command that uses tune checker (rpk redpanda start or rpk redpanda tune check), they will be able to see what checker actually failed, e.g:

previously:
```
Error: mkdir @: no such file or directory
```

Now will be
```
Error: got a fatal error during checker "Data directory is writable" execution, mkdir @: no such file or directory
```

2. fixed a small bug, rpk was ignoring the errors from the config file checker:

```
// Previous
Error: System check 'Config file valid' failed. Required: true, Current false

// Now, e.g
Error: fatal error during checker "Config file valid" execution: config file checker error: 2 errors occurred:
	* redpanda.data_directory can't be empty
	* redpanda.node_id can't be a negative integer
```

3. Now when running check commands in verbose mode, you will see a log indicating what/when a checker is starting

```
Starting checker "Swappiness"
Finished checker "Swappiness"; result &{CheckerID:25 IsOk:false Err:<nil> Current:60 Desc:Swappiness Severity:Warning Required:1}
Starting checker "Config file valid"
...
Error: config file checker error: 2 errors occurred:
	* redpanda.data_directory can't be empty
	* redpanda.node_id can't be a negative integer
```
## Release notes

* rpk: more descriptive logs for tuner checkers in `rpk redpanda tune` and `rpk redpanda start` commands.
