### PR TITLE
Add namespace to labels for metrics on public endpoint

### DIFF
--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -99,7 +99,7 @@ remote_probe::remote_probe(
     }
 
     if (!public_disabled) {
-        auto direction_label = sm::label("direction");
+        auto direction_label = ssx::metrics::make_namespaced_label("direction");
 
         _public_metrics.add_group(
           prometheus_sanitize::metrics_name("cloud_storage"),

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -143,10 +143,10 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         return;
     }
 
-    auto request_label = sm::label("request");
-    auto ns_label = sm::label("namespace");
-    auto topic_label = sm::label("topic");
-    auto partition_label = sm::label("partition");
+    auto request_label = ssx::metrics::make_namespaced_label("request");
+    auto ns_label = ssx::metrics::make_namespaced_label("namespace");
+    auto topic_label = ssx::metrics::make_namespaced_label("topic");
+    auto partition_label = ssx::metrics::make_namespaced_label("partition");
 
     const std::vector<sm::label_instance> labels = {
       ns_label(ntp.ns()),

--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -62,9 +62,9 @@ public:
             return;
         }
 
-        auto group_label = sm::label("group");
-        auto topic_label = sm::label("topic");
-        auto partition_label = sm::label("partition");
+        auto group_label = ssx::metrics::make_namespaced_label("group");
+        auto topic_label = ssx::metrics::make_namespaced_label("topic");
+        auto partition_label = ssx::metrics::make_namespaced_label("partition");
         std::vector<sm::label_instance> labels{
           group_label(group_id()),
           topic_label(tp.topic()),
@@ -110,7 +110,7 @@ public:
             return;
         }
 
-        auto group_label = sm::label("group");
+        auto group_label = ssx::metrics::make_namespaced_label("group");
 
         std::vector<sm::label_instance> labels{group_label(group_id())};
 

--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -60,7 +60,7 @@ public:
             sm::make_histogram(
               "request_latency_seconds",
               sm::description("Internal latency of kafka produce requests"),
-              {sm::label("request")("produce")},
+              {ssx::metrics::make_namespaced_label("request")("produce")},
               [this] {
                   return ssx::metrics::report_default_histogram(
                     _produce_latency);
@@ -69,7 +69,7 @@ public:
             sm::make_histogram(
               "request_latency_seconds",
               sm::description("Internal latency of kafka consume requests"),
-              {sm::label("request")("consume")},
+              {ssx::metrics::make_namespaced_label("request")("consume")},
               [this] {
                   return ssx::metrics::report_default_histogram(_fetch_latency);
               })

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -119,7 +119,7 @@ void server_probe::setup_public_metrics(
         proto.remove_suffix(4);
     }
 
-    auto server_label = sm::label("server");
+    auto server_label = ssx::metrics::make_namespaced_label("server");
 
     mgs.add_group(
       "rpc",

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -337,7 +337,7 @@ void server::setup_public_metrics() {
         server_name.remove_suffix(4);
     }
 
-    auto server_label = sm::label("server");
+    auto server_label = ssx::metrics::make_namespaced_label("server");
 
     _public_metrics.add_group(
       prometheus_sanitize::metrics_name("rpc:request"),

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -64,7 +64,13 @@ public:
     auto auto_measure() { return _request_metrics.auto_measure(); }
 
 private:
+    void setup_metrics();
+    void setup_public_metrics();
+
+private:
     http_status_metric _request_metrics;
+    const ss::httpd::path_description& _path;
+    const ss::sstring& _group_name;
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;
 };

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -34,4 +34,10 @@ inline ss::metrics::histogram report_default_histogram(const hdr_hist& hist) {
       num_buckets, first_value, log_base, scale);
 }
 
+const auto label_namespace = "redpanda";
+
+inline ss::metrics::label make_namespaced_label(const seastar::sstring& name) {
+    return ss::metrics::label(ssx::sformat("{}_{}", label_namespace, name));
+}
+
 } // namespace ssx::metrics

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -34,7 +34,7 @@ inline ss::metrics::histogram report_default_histogram(const hdr_hist& hist) {
       num_buckets, first_value, log_base, scale);
 }
 
-const auto label_namespace = "redpanda";
+constexpr auto label_namespace = "redpanda";
 
 inline ss::metrics::label make_namespaced_label(const seastar::sstring& name) {
     return ss::metrics::label(ssx::sformat("{}_{}", label_namespace, name));


### PR DESCRIPTION
## Cover letter

This PR adds a prefix to all labels used when publishing metrics on the "public_metrics" Prometheus endpoint.
The Prometheus documentation recommends it as best practice: "...should have a (single-word) application prefix relevant to the domain the metric belongs to. The prefix is sometimes referred to as namespace by client libraries. For metrics specific to an application, the prefix is usually the application name itself. Sometimes, however, metrics are more generic, like standardized metrics exported by client libraries."

## UX changes
Users get better autocomplete support as they can just type in "redpanda_" and see what labels are available.

[force_push](https://github.com/redpanda-data/redpanda/compare/837dc67c99bd3f1c736e5afd4ea3afdb90e64bde..6ab0f704542c466cf80f6d222db0142905b87013):
* rebased on dev to include pandaproxy probe changes
* use constexpr instead of const

[force_push](https://github.com/redpanda-data/redpanda/compare/6ab0f704542c466cf80f6d222db0142905b87013..974c38233380410149dd2ec801fec087029fcd9e):
* reformat
* remove duplicated metric from rebase mixup
