### PR TITLE
controller/probe: Reduce lifecycle

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -92,7 +92,8 @@ ss::future<> controller::wire_up() {
           return _authorizer.start(
             []() { return config::shard_local_cfg().superusers.bind(); });
       })
-      .then([this] { return _tp_state.start(); });
+      .then([this] { return _tp_state.start(); })
+      .then([this] { _probe.start(); });
 }
 
 ss::future<> controller::start() {
@@ -377,6 +378,7 @@ ss::future<> controller::stop() {
         f = shutdown_input();
     }
 
+    _probe.stop();
     return f.then([this] {
         auto stop_leader_balancer = _leader_balancer ? _leader_balancer->stop()
                                                      : ss::now();

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -49,6 +49,7 @@ void controller_probe::start() {
 }
 
 void controller_probe::stop() {
+    _public_metrics.reset();
     _controller._raft_manager.local().unregister_leadership_notification(
       _leadership_notification_handle);
 }

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -36,7 +36,7 @@ void controller_probe::start() {
           std::optional<model::node_id> leader_id) {
             // We are only interested in notifications regarding the controller
             // group.
-            if (_controller._raft0->group() != group) {
+            if (!_controller._raft0 || _controller._raft0->group() != group) {
                 return;
             }
 

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -87,7 +87,7 @@ void controller_probe::setup_metrics() {
           "partitions",
           [this] {
               const auto& leaders_table
-                = _controller._partition_leaders.local();
+                = _controller.get_partition_leaders().local();
 
               auto partitions_count = 0;
               leaders_table.for_each_leader(
@@ -102,7 +102,7 @@ void controller_probe::setup_metrics() {
           "unavailable_partitions",
           [this] {
               const auto& leaders_table
-                = _controller._partition_leaders.local();
+                = _controller.get_partition_leaders().local();
               auto unavailable_partitions_count = 0;
 
               leaders_table.for_each_leader([&unavailable_partitions_count](

--- a/src/v/cluster/controller_probe.h
+++ b/src/v/cluster/controller_probe.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "cluster/types.h"
 #include "seastarx.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -22,11 +23,15 @@ class controller_probe {
 public:
     explicit controller_probe(cluster::controller&) noexcept;
 
+    void start();
+    void stop();
+
     void setup_metrics();
 
 private:
     cluster::controller& _controller;
     std::unique_ptr<ss::metrics::metric_groups> _public_metrics;
+    cluster::notification_id_type _leadership_notification_handle;
 };
 
 } // namespace cluster


### PR DESCRIPTION
## Cover letter

The probe requires access to members, topics, and partition_leaders.

* Start the probe after all dependencies have been started
* Stop the probe before its dependencies are stopped
* Prefer the public API of controller where possible
* Avoid a null dereference of `raft0` (not sure how `raft0` becomes null, but it does)

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none
