### PR TITLE
cloud_storage: Fix topic recovery

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -34,11 +34,11 @@ ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
       removed);
     model::offset min_offset = model::offset::max();
     model::offset max_offset = model::offset::min();
-    auto pred = [&removed, &ctxlog, &min_offset, &max_offset](
+    auto pred = [this, &removed, &ctxlog, &min_offset, &max_offset](
                   model::record_batch_header& hdr) {
         if (
-          hdr.type == model::record_batch_type::raft_configuration
-          || hdr.type == model::record_batch_type::archival_metadata) {
+          _skip_config_batches
+          && (hdr.type == model::record_batch_type::raft_configuration || hdr.type == model::record_batch_type::archival_metadata)) {
             vlog(ctxlog.debug, "skipping batch {}", hdr);
             removed += hdr.last_offset_delta + 1;
             return storage::batch_consumer::consume_result::skip_batch;

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -26,8 +26,11 @@ namespace cloud_storage {
 /// It consumes information stored in the manifest.
 class offset_translator final {
 public:
-    explicit offset_translator(model::offset initial_delta)
-      : _initial_delta(initial_delta) {}
+    explicit offset_translator(
+      model::offset initial_delta, bool skip_config_batches = true)
+      : _initial_delta(
+        initial_delta < model::offset{0} ? model::offset{0} : initial_delta)
+      , _skip_config_batches(skip_config_batches) {}
 
     struct stream_stats {
         model::offset min_offset;
@@ -52,6 +55,7 @@ public:
 
 private:
     model::offset _initial_delta;
+    bool _skip_config_batches;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -580,7 +580,7 @@ partition_downloader::download_segment_file(
       segm.meta.size_bytes,
       part.part_prefix.string());
 
-    offset_translator otl{segm.meta.delta_offset};
+    offset_translator otl{segm.meta.delta_offset, false};
 
     auto localpath = part.part_prefix
                      / std::string{otl.get_adjusted_segment_name(


### PR DESCRIPTION
## Cover letter

1. If the initial delta is negative treat it as zero. This helps in a
   situation when the manifest is old and it doesn't have a
delta_offset.
2. Don't filter out configuration batches during recovery. This is no
   longer necessary since topic recovery creates raft snapshot before
starting a raft bootstrap process. The fitlering causes a problem when
the segment has only configuration batches. The download produces empty
file and confuses offset translator.



Fixes #5241

## UX changes

N/A

## Release notes


* none

### Features

* none

### Improvements

* Allow recovery from data generated by redpanda versions prior to v21.10