### PR TITLE
rpk: make redpanda_checkers run in order

### DIFF
--- a/src/go/rpk/pkg/tuners/check.go
+++ b/src/go/rpk/pkg/tuners/check.go
@@ -30,7 +30,16 @@ func Check(
 		return results, err
 	}
 
-	for _, checkers := range checkersMap {
+	// We use a sorted list of the checker's ID present in the checkersMap to
+	// run in a consistent order.
+	var ids []int
+	for id := range checkersMap {
+		ids = append(ids, int(id))
+	}
+	sort.Ints(ids)
+
+	for _, id := range ids {
+		checkers := checkersMap[CheckerID(id)]
 		for _, c := range checkers {
 			result := c.Check()
 			if result.Err != nil {


### PR DESCRIPTION
## Cover letter

As the title say, now [redpanda_checkers](https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/tuners/redpanda_checkers.go#L220-L248) will run in order depending on their ID that is given by this enum: https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/tuners/redpanda_checkers.go#L35-L65

Fixes #5425 

## Release notes

* none
