### PR TITLE
Align feature manager's logical versions with v22.1.5

### DIFF
--- a/src/v/cluster/feature_table.cc
+++ b/src/v/cluster/feature_table.cc
@@ -26,12 +26,12 @@ std::string_view to_string_view(feature f) {
         return "maintenance_mode";
     case feature::mtls_authentication:
         return "mtls_authentication";
+    case feature::rm_stm_kafka_cache:
+        return "rm_stm_kafka_cache";
     case feature::serde_raft_0:
         return "serde_raft_0";
     case feature::license:
         return "license";
-    case feature::rm_stm_kafka_cache:
-        return "rm_stm_kafka_cache";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/cluster/feature_table.h
+++ b/src/v/cluster/feature_table.h
@@ -25,9 +25,9 @@ enum class feature : std::uint64_t {
     consumer_offsets = 0x2,
     maintenance_mode = 0x4,
     mtls_authentication = 0x8,
-    serde_raft_0 = 0x10,
-    license = 0x20,
-    rm_stm_kafka_cache = 0x40,
+    rm_stm_kafka_cache = 0x10,
+    serde_raft_0 = 0x20,
+    license = 0x40,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -106,20 +106,20 @@ constexpr static std::array feature_schema{
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{4},
+    "rm_stm_kafka_cache",
+    feature::rm_stm_kafka_cache,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{5},
     "serde_raft_0",
     feature::serde_raft_0,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{4},
+    cluster_version{5},
     "license",
     feature::license,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster_version{5},
-    "rm_stm_kafka_cache",
-    feature::rm_stm_kafka_cache,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{


### PR DESCRIPTION
## Cover letter

We use feature manager to postpone activating a feature until all nodes in the cluster are updated to avoid a situation in which a node with a newer version uses an updated version of a protocol to communicate with an older version which doesn't understand it.
 
We tend to avoid backporting features but there are cases when we need to do it anyway e.g. when a bug fix introduces a protocol change and we need to use the feature manager to perform a non-interruptive upgrade.
 
When we do it we need to do it very carefully to preserve the feature manager invariant:
 

> the series of versions and the definitions of the features must line up perfectly with the history of versions+features in subsequent releases
> https://vectorizedio.atlassian.net/wiki/spaces/CORE/pages/170491930

 
However if the bugfix is added after we already introduced several feature which we don't backport we need to update the dev branch (future release) to be consistent with the minor "backport" release.
 
This change updates the dev to be consistent with v22.1.5 release which contains a bug fix gated by `rm_stm_kafka_cache` feature flag.

## Release notes

* none