### PR TITLE
rpk: Support listener authN

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -223,15 +223,15 @@ func (r *ConfigMapResource) CreateConfiguration(
 	cr := &cfg.NodeConfiguration.Redpanda
 
 	internalListener := r.pandaCluster.InternalListener()
-	cr.KafkaAPI = []config.NamedSocketAddress{} // we don't want to inherit default kafka port
-	cr.KafkaAPI = append(cr.KafkaAPI, config.NamedSocketAddress{
+	cr.KafkaAPI = []config.NamedAuthNSocketAddress{} // we don't want to inherit default kafka port
+	cr.KafkaAPI = append(cr.KafkaAPI, config.NamedAuthNSocketAddress{
 		Address: "0.0.0.0",
 		Port:    internalListener.Port,
 		Name:    InternalListenerName,
 	})
 
 	if r.pandaCluster.ExternalListener() != nil {
-		cr.KafkaAPI = append(cr.KafkaAPI, config.NamedSocketAddress{
+		cr.KafkaAPI = append(cr.KafkaAPI, config.NamedAuthNSocketAddress{
 			Address: "0.0.0.0",
 			Port:    calculateExternalPort(internalListener.Port, r.pandaCluster.ExternalListener().Port),
 			Name:    ExternalListenerName,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -115,7 +115,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 
 			cfg.Redpanda.ID = id
 			cfg.Redpanda.RPCServer.Address = ownIP.String()
-			cfg.Redpanda.KafkaAPI = []config.NamedSocketAddress{{
+			cfg.Redpanda.KafkaAPI = []config.NamedAuthNSocketAddress{{
 				Address: ownIP.String(),
 				Port:    config.DefaultKafkaPort,
 			}}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -196,7 +196,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 					",",
 				),
 			)
-			kafkaAPI, err := parseNamedAddresses(
+			kafkaAPI, err := parseNamedAuthNAddresses(
 				kafkaAddr,
 				config.DefaultKafkaPort,
 			)
@@ -937,6 +937,22 @@ func parseNamedAddress(
 		Port:    port,
 		Name:    scheme,
 	}, nil
+}
+
+func parseNamedAuthNAddresses(
+	addrs []string, defaultPort int,
+) ([]config.NamedAuthNSocketAddress, error) {
+	as := make([]config.NamedAuthNSocketAddress, 0, len(addrs))
+	for _, addr := range addrs {
+		a, err := parseNamedAuthNAddress(addr, defaultPort)
+		if err != nil {
+			return nil, err
+		}
+		if a != nil {
+			as = append(as, *a)
+		}
+	}
+	return as, nil
 }
 
 func parseNamedAuthNAddress(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -939,6 +939,43 @@ func parseNamedAddress(
 	}, nil
 }
 
+func parseNamedAuthNAddress(
+	addrAuthn string, defaultPort int,
+) (*config.NamedAuthNSocketAddress, error) {
+	if addrAuthn == "" {
+		return nil, nil
+	}
+	addr, authn, err := splitAddressAuthN(addrAuthn)
+	if err != nil {
+		return nil, err
+	}
+	scheme, hostport, err := net.ParseHostMaybeScheme(addr)
+	if err != nil {
+		return nil, err
+	}
+	host, port := net.SplitHostPortDefault(hostport, defaultPort)
+
+	return &config.NamedAuthNSocketAddress{
+		Address: host,
+		Port:    port,
+		Name:    scheme,
+		AuthN:   authn,
+	}, nil
+}
+
+func splitAddressAuthN(str string) (addr string, authn *string, err error) {
+	bits := strings.Split(str, "|")
+	if len(bits) > 2 {
+		err = fmt.Errorf(`invalid format for listener, at most one "|" can be present: %q`, str)
+		return
+	}
+	addr = bits[0]
+	if len(bits) == 2 {
+		authn = &bits[1]
+	}
+	return
+}
+
 func sendEnv(fs afero.Fs, env api.EnvironmentPayload, conf *config.Config, skipChecks bool, err error) {
 	if err != nil {
 		env.ErrorMsg = err.Error()

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -200,6 +200,7 @@ func TestParseSeeds(t *testing.T) {
 }
 
 func TestStartCommand(t *testing.T) {
+	authNSasl := "sasl"
 	tests := []struct {
 		name           string
 		launcher       redpanda.Launcher
@@ -929,7 +930,7 @@ func TestStartCommand(t *testing.T) {
 		name: "it should parse the --kafka-addr and persist it (list)",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
-			"--kafka-addr", "nondefaultname://192.168.34.32,host:9092",
+			"--kafka-addr", "nondefaultname://192.168.34.32,host:9092,authn://host:9093|sasl",
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
@@ -941,6 +942,11 @@ func TestStartCommand(t *testing.T) {
 			}, {
 				Address: "host",
 				Port:    9092,
+			}, {
+				Name:    "authn",
+				Address: "host",
+				Port:    9093,
+				AuthN:   &authNSasl,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -310,7 +310,7 @@ func TestStartCommand(t *testing.T) {
 				Address: "192.168.54.2",
 				Port:    9643,
 			}}
-			expectedKafkaAPI := []config.NamedSocketAddress{{
+			expectedKafkaAPI := []config.NamedAuthNSocketAddress{{
 				Name:    "external",
 				Address: "192.168.73.45",
 				Port:    9092,
@@ -375,7 +375,7 @@ func TestStartCommand(t *testing.T) {
 				Address: "192.168.54.2",
 				Port:    9643,
 			}}
-			expectedKafkaAPI := []config.NamedSocketAddress{{
+			expectedKafkaAPI := []config.NamedAuthNSocketAddress{{
 				Name:    "external",
 				Address: "192.168.73.45",
 				Port:    9092,
@@ -426,7 +426,7 @@ func TestStartCommand(t *testing.T) {
 			require.NoError(st, err)
 			// The value set through the --kafka-addr flag should
 			// have been picked.
-			expectedKafkaAPI := []config.NamedSocketAddress{{
+			expectedKafkaAPI := []config.NamedAuthNSocketAddress{{
 				Name:    "flag",
 				Address: "192.168.34.3",
 				Port:    9093,
@@ -873,7 +873,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Address: "192.168.34.32",
 				Port:    33145,
 			}}
@@ -893,7 +893,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Address: "192.168.34.32",
 				Port:    9092,
 			}}
@@ -913,7 +913,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Name:    "nondefaultname",
 				Address: "192.168.34.32",
 				Port:    9092,
@@ -934,7 +934,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Name:    "nondefaultname",
 				Address: "192.168.34.32",
 				Port:    9092,
@@ -971,7 +971,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Address: "host",
 				Port:    3123,
 			}}
@@ -989,7 +989,7 @@ func TestStartCommand(t *testing.T) {
 		},
 		before: func(fs afero.Fs) error {
 			conf := config.Default()
-			conf.Redpanda.KafkaAPI = []config.NamedSocketAddress{{
+			conf.Redpanda.KafkaAPI = []config.NamedAuthNSocketAddress{{
 				Address: "192.168.33.33",
 				Port:    9892,
 			}}
@@ -998,7 +998,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			expectedAddr := []config.NamedSocketAddress{{
+			expectedAddr := []config.NamedAuthNSocketAddress{{
 				Address: "192.168.33.33",
 				Port:    9892,
 			}}

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -36,7 +36,7 @@ func Default() *Config {
 				Address: "0.0.0.0",
 				Port:    33145,
 			},
-			KafkaAPI: []NamedSocketAddress{{
+			KafkaAPI: []NamedAuthNSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9092,
 			}},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -214,7 +214,7 @@ tune_cpu: true`,
   port: 9092
 `,
 			check: func(st *testing.T, c *Config) {
-				expected := []NamedSocketAddress{{
+				expected := []NamedAuthNSocketAddress{{
 					Name:    "external",
 					Address: "192.168.73.45",
 					Port:    9092,
@@ -235,7 +235,7 @@ tune_cpu: true`,
 		}]`,
 			format: "json",
 			check: func(st *testing.T, c *Config) {
-				expected := []NamedSocketAddress{{
+				expected := []NamedAuthNSocketAddress{{
 					Port:    9092,
 					Address: "192.168.54.2",
 				}}
@@ -347,7 +347,7 @@ func TestDefault(t *testing.T) {
 		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{"0.0.0.0", 33145},
-			KafkaAPI: []NamedSocketAddress{{
+			KafkaAPI: []NamedAuthNSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9092,
 			}},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -47,6 +47,7 @@ func getValidConfig() *Config {
 }
 
 func TestSet(t *testing.T) {
+	authNSasl := "sasl"
 	tests := []struct {
 		name      string
 		key       string
@@ -218,6 +219,31 @@ tune_cpu: true`,
 					Name:    "external",
 					Address: "192.168.73.45",
 					Port:    9092,
+				}, {
+					Name:    "internal",
+					Address: "10.21.34.58",
+					Port:    9092,
+				}}
+				require.Exactly(st, expected, c.Redpanda.KafkaAPI)
+			},
+		},
+		{
+			name: "extract kafka_api[].authentication_method",
+			key:  "redpanda.kafka_api",
+			value: `- name: external
+  address: 192.168.73.45
+  port: 9092
+  authentication_method: sasl
+- name: internal
+  address: 10.21.34.58
+  port: 9092
+`,
+			check: func(st *testing.T, c *Config) {
+				expected := []NamedAuthNSocketAddress{{
+					Name:    "external",
+					Address: "192.168.73.45",
+					Port:    9092,
+					AuthN:   &authNSasl,
 				}, {
 					Name:    "internal",
 					Address: "10.21.34.58",

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -259,7 +259,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 				Address: "0.0.0.0",
 				Port:    33145,
 			},
-			KafkaAPI: []NamedSocketAddress{{
+			KafkaAPI: []NamedAuthNSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9092,
 			}},

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -154,7 +154,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    33145,
 			},
-			KafkaAPI: []NamedSocketAddress{{
+			KafkaAPI: []NamedAuthNSocketAddress{{
 				Address: "0.0.0.0",
 				Port:    9092,
 			}},

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -103,6 +103,13 @@ type NamedSocketAddress struct {
 	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
 }
 
+type NamedAuthNSocketAddress struct {
+	Address string  `yaml:"address" json:"address"`
+	Port    int     `yaml:"port" json:"port"`
+	Name    string  `yaml:"name,omitempty" json:"name,omitempty"`
+	AuthN   *string `yaml:"authentication_method,omitempty" json:"authentication_method,omitempty"`
+}
+
 type TLS struct {
 	KeyFile        string `yaml:"key_file,omitempty" json:"key_file"`
 	CertFile       string `yaml:"cert_file,omitempty" json:"cert_file"`

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -44,26 +44,26 @@ func (c *Config) File() *Config {
 }
 
 type RedpandaConfig struct {
-	Directory                  string                 `yaml:"data_directory,omitempty" json:"data_directory"`
-	ID                         int                    `yaml:"node_id" json:"node_id"`
-	Rack                       string                 `yaml:"rack,omitempty" json:"rack"`
-	SeedServers                []SeedServer           `yaml:"seed_servers" json:"seed_servers"`
-	RPCServer                  SocketAddress          `yaml:"rpc_server" json:"rpc_server"`
-	RPCServerTLS               []ServerTLS            `yaml:"rpc_server_tls,omitempty" json:"rpc_server_tls"`
-	KafkaAPI                   []NamedSocketAddress   `yaml:"kafka_api" json:"kafka_api"`
-	KafkaAPITLS                []ServerTLS            `yaml:"kafka_api_tls,omitempty" json:"kafka_api_tls"`
-	AdminAPI                   []NamedSocketAddress   `yaml:"admin" json:"admin"`
-	AdminAPITLS                []ServerTLS            `yaml:"admin_api_tls,omitempty" json:"admin_api_tls"`
-	CoprocSupervisorServer     SocketAddress          `yaml:"coproc_supervisor_server,omitempty" json:"coproc_supervisor_server"`
-	AdminAPIDocDir             string                 `yaml:"admin_api_doc_dir,omitempty" json:"admin_api_doc_dir"`
-	DashboardDir               string                 `yaml:"dashboard_dir,omitempty" json:"dashboard_dir"`
-	CloudStorageCacheDirectory string                 `yaml:"cloud_storage_cache_directory,omitempty" json:"cloud_storage_cache_directory"`
-	AdvertisedRPCAPI           *SocketAddress         `yaml:"advertised_rpc_api,omitempty" json:"advertised_rpc_api,omitempty"`
-	AdvertisedKafkaAPI         []NamedSocketAddress   `yaml:"advertised_kafka_api,omitempty" json:"advertised_kafka_api,omitempty"`
-	DeveloperMode              bool                   `yaml:"developer_mode" json:"developer_mode"`
-	AggregateMetrics           bool                   `yaml:"aggregate_metrics,omitempty" json:"aggregate_metrics,omitempty"`
-	DisablePublicMetrics       bool                   `yaml:"disable_public_metrics,omitempty" json:"disable_public_metrics,omitempty"`
-	Other                      map[string]interface{} `yaml:",inline"`
+	Directory                  string                    `yaml:"data_directory,omitempty" json:"data_directory"`
+	ID                         int                       `yaml:"node_id" json:"node_id"`
+	Rack                       string                    `yaml:"rack,omitempty" json:"rack"`
+	SeedServers                []SeedServer              `yaml:"seed_servers" json:"seed_servers"`
+	RPCServer                  SocketAddress             `yaml:"rpc_server" json:"rpc_server"`
+	RPCServerTLS               []ServerTLS               `yaml:"rpc_server_tls,omitempty" json:"rpc_server_tls"`
+	KafkaAPI                   []NamedAuthNSocketAddress `yaml:"kafka_api" json:"kafka_api"`
+	KafkaAPITLS                []ServerTLS               `yaml:"kafka_api_tls,omitempty" json:"kafka_api_tls"`
+	AdminAPI                   []NamedSocketAddress      `yaml:"admin" json:"admin"`
+	AdminAPITLS                []ServerTLS               `yaml:"admin_api_tls,omitempty" json:"admin_api_tls"`
+	CoprocSupervisorServer     SocketAddress             `yaml:"coproc_supervisor_server,omitempty" json:"coproc_supervisor_server"`
+	AdminAPIDocDir             string                    `yaml:"admin_api_doc_dir,omitempty" json:"admin_api_doc_dir"`
+	DashboardDir               string                    `yaml:"dashboard_dir,omitempty" json:"dashboard_dir"`
+	CloudStorageCacheDirectory string                    `yaml:"cloud_storage_cache_directory,omitempty" json:"cloud_storage_cache_directory"`
+	AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api,omitempty" json:"advertised_rpc_api,omitempty"`
+	AdvertisedKafkaAPI         []NamedSocketAddress      `yaml:"advertised_kafka_api,omitempty" json:"advertised_kafka_api,omitempty"`
+	DeveloperMode              bool                      `yaml:"developer_mode" json:"developer_mode"`
+	AggregateMetrics           bool                      `yaml:"aggregate_metrics,omitempty" json:"aggregate_metrics,omitempty"`
+	DisablePublicMetrics       bool                      `yaml:"disable_public_metrics,omitempty" json:"disable_public_metrics,omitempty"`
+	Other                      map[string]interface{}    `yaml:",inline"`
 }
 
 type Pandaproxy struct {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -329,26 +329,26 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 
 func (rpc *RedpandaConfig) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
-		Directory                  weakString             `yaml:"data_directory"`
-		ID                         weakInt                `yaml:"node_id" `
-		Rack                       weakString             `yaml:"rack"`
-		SeedServers                seedServers            `yaml:"seed_servers"`
-		RPCServer                  SocketAddress          `yaml:"rpc_server"`
-		RPCServerTLS               serverTLSArray         `yaml:"rpc_server_tls"`
-		KafkaAPI                   namedSocketAddresses   `yaml:"kafka_api"`
-		KafkaAPITLS                serverTLSArray         `yaml:"kafka_api_tls"`
-		AdminAPI                   namedSocketAddresses   `yaml:"admin"`
-		AdminAPITLS                serverTLSArray         `yaml:"admin_api_tls"`
-		CoprocSupervisorServer     SocketAddress          `yaml:"coproc_supervisor_server"`
-		AdminAPIDocDir             weakString             `yaml:"admin_api_doc_dir"`
-		DashboardDir               weakString             `yaml:"dashboard_dir"`
-		CloudStorageCacheDirectory weakString             `yaml:"cloud_storage_cache_directory"`
-		AdvertisedRPCAPI           *SocketAddress         `yaml:"advertised_rpc_api"`
-		AdvertisedKafkaAPI         namedSocketAddresses   `yaml:"advertised_kafka_api"`
-		DeveloperMode              weakBool               `yaml:"developer_mode"`
-		AggregateMetrics           weakBool               `yaml:"aggregate_metrics"`
-		DisablePublicMetrics       weakBool               `yaml:"disable_public_metrics"`
-		Other                      map[string]interface{} `yaml:",inline"`
+		Directory                  weakString                `yaml:"data_directory"`
+		ID                         weakInt                   `yaml:"node_id" `
+		Rack                       weakString                `yaml:"rack"`
+		SeedServers                seedServers               `yaml:"seed_servers"`
+		RPCServer                  SocketAddress             `yaml:"rpc_server"`
+		RPCServerTLS               serverTLSArray            `yaml:"rpc_server_tls"`
+		KafkaAPI                   namedAuthNSocketAddresses `yaml:"kafka_api"`
+		KafkaAPITLS                serverTLSArray            `yaml:"kafka_api_tls"`
+		AdminAPI                   namedSocketAddresses      `yaml:"admin"`
+		AdminAPITLS                serverTLSArray            `yaml:"admin_api_tls"`
+		CoprocSupervisorServer     SocketAddress             `yaml:"coproc_supervisor_server"`
+		AdminAPIDocDir             weakString                `yaml:"admin_api_doc_dir"`
+		DashboardDir               weakString                `yaml:"dashboard_dir"`
+		CloudStorageCacheDirectory weakString                `yaml:"cloud_storage_cache_directory"`
+		AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api"`
+		AdvertisedKafkaAPI         namedSocketAddresses      `yaml:"advertised_kafka_api"`
+		DeveloperMode              weakBool                  `yaml:"developer_mode"`
+		AggregateMetrics           weakBool                  `yaml:"aggregate_metrics"`
+		DisablePublicMetrics       weakBool                  `yaml:"disable_public_metrics"`
+		Other                      map[string]interface{}    `yaml:",inline"`
 	}
 
 	if err := n.Decode(&internal); err != nil {

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -989,9 +989,9 @@ rpk:
 						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
 					},
 					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
-					KafkaAPI: []NamedSocketAddress{
-						{"0.0.0.0", 9092, "internal"},
-						{"0.0.0.0", 9093, "external"},
+					KafkaAPI: []NamedAuthNSocketAddress{
+						{"0.0.0.0", 9092, "internal", nil},
+						{"0.0.0.0", 9093, "external", nil},
 					},
 					KafkaAPITLS: []ServerTLS{
 						{Name: "external", KeyFile: "certs/tls-key.pem"},
@@ -1227,9 +1227,9 @@ rpk:
 						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
 					},
 					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
-					KafkaAPI: []NamedSocketAddress{
-						{"0.0.0.0", 9092, "internal"},
-						{"0.0.0.0", 9093, "external"},
+					KafkaAPI: []NamedAuthNSocketAddress{
+						{"0.0.0.0", 9092, "internal", nil},
+						{"0.0.0.0", 9093, "external", nil},
 					},
 					KafkaAPITLS: []ServerTLS{
 						{Name: "external", KeyFile: "certs/tls-key.pem"},


### PR DESCRIPTION
## Cover letter

Support the configuration change introduced in #5292

* Allow per listener authentication to be configured by using the following format: `name://host:port|authn`
* Keep the yaml format

## UX changes

Support per-listener authentication.

## Release notes

### Features

* Allow per listener authentication to be configured by using the following format: `name://host:port|authn`