### PR TITLE
kafka: reject produce requests to read replica topics

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -306,6 +306,13 @@ static partition_produce_stages produce_topic_partition(
                       ntp,
                       source_shard);
                 }
+                if (partition->is_read_replica_mode_enabled()) {
+                    return finalize_request_with_error_code(
+                      error_code::invalid_topic_exception,
+                      std::move(dispatch),
+                      ntp,
+                      source_shard);
+                }
                 auto stages = partition_append(
                   ntp.tp.partition,
                   ss::make_lw_shared<replicated_partition>(


### PR DESCRIPTION
## Cover letter

Return `invalid_topic_exception` if produce request contains at least one
topic that is a read replica.

Fixes #5344

## Release notes
 - produce requests to read replica topics are rejected