### PR TITLE
Upgrade testing for license checks

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -182,21 +182,25 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
               interval_override);
         }
     }
-    const auto& cfg = config::shard_local_cfg();
-    std::stringstream warn_ss;
-    if (cfg.cloud_storage_enabled) {
-        fmt::print(warn_ss, "{}", "Tired Storage(cloud_storage)");
-    }
-    const auto& warn_log = warn_ss.str();
-    if (!warn_log.empty()) {
-        const auto& license = _feature_table.local().get_license();
-        if (!license || license->is_expired()) {
-            vlog(
-              clusterlog.warn,
-              "Enterprise feature(s) {} detected as enabled without a valid "
-              "license, please contact support and/or upload a valid redpanda "
-              "license",
-              warn_log);
+    if (_feature_table.local().is_active(feature::license)) {
+        const auto& cfg = config::shard_local_cfg();
+        std::stringstream warn_ss;
+        if (cfg.cloud_storage_enabled) {
+            fmt::print(warn_ss, "{}", "Tired Storage(cloud_storage)");
+        }
+        const auto& warn_log = warn_ss.str();
+        if (!warn_log.empty()) {
+            const auto& license = _feature_table.local().get_license();
+            if (!license || license->is_expired()) {
+                vlog(
+                  clusterlog.warn,
+                  "Enterprise feature(s) {} detected as enabled without a "
+                  "valid "
+                  "license, please contact support and/or upload a valid "
+                  "redpanda "
+                  "license",
+                  warn_log);
+            }
         }
     }
     try {

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -186,7 +186,7 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
         const auto& cfg = config::shard_local_cfg();
         std::stringstream warn_ss;
         if (cfg.cloud_storage_enabled) {
-            fmt::print(warn_ss, "{}", "Tired Storage(cloud_storage)");
+            fmt::print(warn_ss, "{}", "Tiered Storage(cloud_storage)");
         }
         const auto& warn_log = warn_ss.str();
         if (!warn_log.empty()) {

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -188,13 +188,18 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
         if (cfg.cloud_storage_enabled) {
             fmt::print(warn_ss, "{}", "Tiered Storage(cloud_storage)");
         }
+        if (
+          cfg.partition_autobalancing_mode
+          == model::partition_autobalancing_mode::continuous) {
+            fmt::print(warn_ss, "{} & ", "Continuous partition autobalancing");
+        }
         const auto& warn_log = warn_ss.str();
         if (!warn_log.empty()) {
             const auto& license = _feature_table.local().get_license();
             if (!license || license->is_expired()) {
                 vlog(
                   clusterlog.warn,
-                  "Enterprise feature(s) {} detected as enabled without a "
+                  "Enterprise feature(s) ({}) detected as enabled without a "
                   "valid "
                   "license, please contact support and/or upload a valid "
                   "redpanda "

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1772,3 +1772,21 @@ class RedpandaService(Service):
         else:
             self._saved_executable = True
             self._context.log_collect['executable', self] = True
+
+    def search_log(self, pattern):
+        """
+        Test helper for grepping the redpanda log
+
+        :return:  true if any instances of `pattern` found
+        """
+        for node in self.nodes:
+            for line in node.account.ssh_capture(
+                    f"grep \"{pattern}\" {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
+            ):
+                # We got a match
+                self.logger.debug(
+                    f"Found {pattern} on node {node.name}: {line}")
+                return True
+
+        # Fall through, no matches
+        return False

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -11,6 +11,7 @@ import os
 import time
 import datetime
 
+from rptest.utils.rpenv import sample_license
 from rptest.services.admin import Admin
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
@@ -213,10 +214,8 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         """
         Test uploading and retrieval of license
         """
-        license = os.environ.get("REDPANDA_SAMPLE_LICENSE", None)
+        license = sample_license()
         if license is None:
-            is_ci = os.environ.get("CI", "false")
-            assert is_ci == "false"
             self.logger.info(
                 "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
             return

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -1,0 +1,103 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import re
+import time
+
+from ducktape.utils.util import wait_until
+from rptest.utils.rpenv import sample_license
+from rptest.services.admin import Admin
+from ducktape.utils.util import wait_until
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
+from rptest.services.cluster import cluster
+from requests.exceptions import HTTPError
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+
+
+class UpgradeToLicenseChecks(RedpandaTest):
+    """
+    Test that ensures the licensing work does not incorrectly print license
+    enforcement errors during upgrade when a guarded feature is already
+    enabled. Also tests that the license can only be uploaded once the cluster
+    has completed upgrade to the latest version.
+    """
+    LICENSE_CHECK_INTERVAL_SEC = 1
+
+    def __init__(self, test_context):
+        # Setting 'si_settings' enables a licensed feature, however at v22.1.4 there
+        # are no license checks present. This test verifies behavior between versions
+        # of redpanda that do and do not have the licensing feature built-in.
+        super(UpgradeToLicenseChecks, self).__init__(test_context=test_context,
+                                                     num_brokers=3,
+                                                     si_settings=SISettings())
+        self.installer = self.redpanda._installer
+        self.admin = Admin(self.redpanda)
+
+    def setUp(self):
+        self.installer.install(self.redpanda.nodes, (22, 1, 4))
+        super(UpgradeToLicenseChecks, self).setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_basic_upgrade(self):
+        # Modified environment variables apply to processes restarted from this point onwards
+        self.redpanda.set_environment({
+            '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
+            f'{UpgradeToLicenseChecks.LICENSE_CHECK_INTERVAL_SEC}'
+        })
+
+        license = sample_license()
+        if license is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
+            return
+
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert 'v22.1.4' in unique_versions, unique_versions
+
+        # These logs can't exist in v22.1.4 but double check anyway...
+        assert self.redpanda.search_log("Enterprise feature(s).*") is False
+
+        # Update one node to newest version
+        self.installer.install([self.redpanda.nodes[0]],
+                               RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes([self.redpanda.nodes[0]])
+        unique_versions = wait_for_num_versions(self.redpanda, 2)
+
+        try:
+            # Ensure a valid license cannot be uploaded in this cluster state
+            self.admin.put_license(license)
+            assert False
+        except HTTPError as e:
+            assert e.response.status_code == 400
+
+        # Ensure the log is not written, if the fiber was enabled a log should
+        # appear within one interval of the license check fiber
+        time.sleep(UpgradeToLicenseChecks.LICENSE_CHECK_INTERVAL_SEC * 2)
+        assert self.redpanda.search_log("Enterprise feature(s).*") is False
+
+        # Install new version on all nodes
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+
+        # Restart nodes 2 and 3
+        self.redpanda.restart_nodes(
+            [self.redpanda.nodes[1], self.redpanda.nodes[2]])
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        # Assert that the log was found
+        wait_until(
+            lambda: self.redpanda.search_log("Enterprise feature(s).*"),
+            timeout_sec=UpgradeToLicenseChecks.LICENSE_CHECK_INTERVAL_SEC * 4,
+            backoff_sec=1,
+            err_msg="Timeout waiting for enterprise nag log")
+
+        # Install license
+        assert self.admin.put_license(license).status_code == 200

--- a/tests/rptest/utils/rpenv.py
+++ b/tests/rptest/utils/rpenv.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+# Utilities for checking the environment of a test
+
+import os
+
+
+def sample_license():
+    """
+    Returns the sample license from the env if it exists, asserts if its
+    missing and the environment is CI
+    """
+    license = os.environ.get("REDPANDA_SAMPLE_LICENSE", None)
+    if license is None:
+        is_ci = os.environ.get("CI", "false")
+        assert is_ci == "false"
+        return None
+    return license


### PR DESCRIPTION
## Cover letter

Within this patch series:
- Upgrade testing for license check
- Bugfix when nags may appear before each node in cluster is updated to support license checks
- Addition of `partition_autobalancing_mode` behind the license checks 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/369215655ec7a3cc9aa9f46fe9988f3bc96dd93b..3d376568e5ed13002953066175f07ae8e4bf2259)
- Rebased dev for latest upgrade_test enhancements

## Release notes
- Moving `partition_autobalancing_mode` into our list of enterprise guarded features 