### PR TITLE
Use named semaphores for better debuggability.

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -32,7 +32,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/when_all.hh>

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -26,7 +26,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <functional>

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -208,7 +208,7 @@ private:
     ss::lowres_clock::duration _cloud_storage_initial_backoff;
     ss::lowres_clock::duration _segment_upload_timeout;
     ss::lowres_clock::duration _manifest_upload_timeout;
-    ss::semaphore _mutex{1};
+    ssx::semaphore _mutex{1, "archive/ntp"};
     ss::lowres_clock::duration _upload_loop_initial_backoff;
     ss::lowres_clock::duration _upload_loop_max_backoff;
     config::binding<std::chrono::milliseconds> _sync_manifest_timeout;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -39,7 +39,6 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/scheduling.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -20,7 +20,6 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/defer.hh>

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/recursive_directory_walker.h"
 #include "resource_mgmt/io_priority.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "units.h"
 
 #include <seastar/core/future.hh>
@@ -124,7 +125,7 @@ private:
     uint64_t _total_cleaned;
     /// Current size of the cache directory (only used on shard 0)
     uint64_t _current_cache_size{0};
-    ss::semaphore _cleanup_sm{1};
+    ssx::semaphore _cleanup_sm{1, "cloud/cache"};
     std::set<std::filesystem::path> _files_in_progress;
     cache_probe probe;
     access_time_tracker _access_time_tracker;

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -24,7 +24,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 
 #include <compare>

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -35,7 +35,6 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/when_all.hh>

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -36,7 +36,6 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/later.hh>

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -356,7 +356,7 @@ private:
     ss::sharded<ss::abort_source>& _as;
     underlying_t _topic_deltas;
     ss::timer<> _housekeeping_timer;
-    ss::semaphore _topics_sem{1};
+    ssx::semaphore _topics_sem{1, "c/controller-be"};
     ss::gate _gate;
     /**
      * This map is populated by backend instance on shard that given NTP is

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -13,6 +13,7 @@
 #include "reflection/adl.h"
 #include "seastarx.h"
 #include "serde/serde.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -96,7 +97,7 @@ private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
     std::optional<ss::future<>> _drain;
     bool _draining{false};
-    ss::semaphore _sem{0};
+    ssx::semaphore _sem{0, "c/drain-mgr"};
     drain_status _status;
     ss::abort_source _abort;
 };

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -244,7 +244,7 @@ void health_monitor_backend::abortable_refresh_request::abort() {
 }
 
 health_monitor_backend::abortable_refresh_request::abortable_refresh_request(
-  model::node_id leader_id, ss::gate::holder holder, ss::semaphore_units<> u)
+  model::node_id leader_id, ss::gate::holder holder, ssx::semaphore_units u)
   : leader_id(leader_id)
   , holder(std::move(holder))
   , units(std::move(u)) {}

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -16,8 +16,8 @@
 #include "model/metadata.h"
 #include "raft/consensus.h"
 #include "rpc/fwd.h"
+#include "ssx/semaphore.h"
 
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -90,7 +90,7 @@ private:
     struct abortable_refresh_request
       : ss::enable_lw_shared_from_this<abortable_refresh_request> {
         abortable_refresh_request(
-          model::node_id, ss::gate::holder, ss::semaphore_units<>);
+          model::node_id, ss::gate::holder, ssx::semaphore_units);
 
         ss::future<std::error_code>
           abortable_await(ss::future<std::error_code>);
@@ -99,7 +99,7 @@ private:
         bool finished = false;
         model::node_id leader_id;
         ss::gate::holder holder;
-        ss::semaphore_units<> units;
+        ssx::semaphore_units units;
         ss::promise<std::error_code> done;
     };
 

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -21,7 +21,6 @@
 #include "utils/mutex.h"
 
 #include <seastar/core/abort_source.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace coproc {

--- a/src/v/coproc/script_context_frontend.h
+++ b/src/v/coproc/script_context_frontend.h
@@ -28,7 +28,7 @@ using input_read_results = std::vector<process_batch_request::data>;
 /// Arugments to pass to 'read_from_inputs', trivially copyable
 struct input_read_args {
     script_id id;
-    ss::semaphore& read_sem;
+    ssx::semaphore& read_sem;
     ss::abort_source& abort_src;
     routes_t& inputs;
 };

--- a/src/v/coproc/shared_script_resources.h
+++ b/src/v/coproc/shared_script_resources.h
@@ -15,6 +15,7 @@
 #include "coproc/sys_refs.h"
 #include "random/simple_time_jitter.h"
 #include "rpc/reconnect_transport.h"
+#include "ssx/semaphore.h"
 #include "utils/mutex.h"
 
 #include <seastar/core/semaphore.hh>
@@ -37,8 +38,8 @@ struct shared_script_resources {
     simple_time_jitter<ss::lowres_clock> jitter{1s};
 
     /// Max amount of requests allowed to concurrently hold data in memory
-    ss::semaphore read_sem{
-      config::shard_local_cfg().coproc_max_ingest_bytes.value()};
+    ssx::semaphore read_sem{
+      config::shard_local_cfg().coproc_max_ingest_bytes.value(), "coproc/ssr"};
 
     /// Underlying transport connection to the wasm engine
     rpc::reconnect_transport transport;

--- a/src/v/coproc/shared_script_resources.h
+++ b/src/v/coproc/shared_script_resources.h
@@ -18,8 +18,6 @@
 #include "ssx/semaphore.h"
 #include "utils/mutex.h"
 
-#include <seastar/core/semaphore.hh>
-
 #include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -23,7 +23,6 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -27,7 +27,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -31,7 +31,6 @@
 #include "utils/retry.h"
 
 #include <seastar/core/condition-variable.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -27,6 +27,7 @@
 #include "kafka/protocol/list_offsets.h"
 #include "kafka/types.h"
 #include "net/unresolved_address.h"
+#include "ssx/semaphore.h"
 #include "utils/retry.h"
 
 #include <seastar/core/condition-variable.hh>
@@ -61,7 +62,7 @@ public:
 
 private:
     func _func;
-    ss::semaphore _lock{1};
+    ssx::semaphore _lock{1, "k/client"};
 };
 
 class client {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -190,14 +190,14 @@ ss::future<session_resources> connection_context::throttle_request(
           return reserve_request_units(key, request_size);
       })
       .then([this, delay, track, tracker = std::move(tracker)](
-              ss::semaphore_units<> units) mutable {
+              ssx::semaphore_units units) mutable {
           return server().get_request_unit().then(
             [this,
              delay,
              mem_units = std::move(units),
              track,
              tracker = std::move(tracker)](
-              ss::semaphore_units<> qd_units) mutable {
+              ssx::semaphore_units qd_units) mutable {
                 session_resources r{
                   .backpressure_delay = delay.duration,
                   .memlocks = std::move(mem_units),
@@ -212,7 +212,7 @@ ss::future<session_resources> connection_context::throttle_request(
       });
 }
 
-ss::future<ss::semaphore_units<>>
+ss::future<ssx::semaphore_units>
 connection_context::reserve_request_units(api_key key, size_t size) {
     // Defer to the handler for the request type for the memory estimate, but
     // if the request isn't found, use the default estimate (although in that

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -30,6 +30,7 @@
 #include "model/namespace.h"
 #include "raft/group_manager.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -195,7 +196,7 @@ private:
 
     struct attached_partition {
         bool loading;
-        ss::semaphore sem{1};
+        ssx::semaphore sem{1, "k/group-mgr"};
         ss::abort_source as;
         ss::lw_shared_ptr<cluster::partition> partition;
         ss::basic_rwlock<> catchup_lock;

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -30,7 +30,6 @@
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/metrics.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/log.hh>

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -119,12 +119,12 @@ public:
         }
     }
 
-    ss::future<ss::semaphore_units<>> get_request_unit() {
+    ss::future<ssx::semaphore_units> get_request_unit() {
         if (_qdc_mon) {
             return _qdc_mon->qdc.get_unit();
         }
-        return ss::make_ready_future<ss::semaphore_units<>>(
-          ss::semaphore_units<>());
+        return ss::make_ready_future<ssx::semaphore_units>(
+          ssx::semaphore_units());
     }
 
     cluster::controller_api& controller_api() {

--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -15,7 +15,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/scattered_message.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <fmt/format.h>
 

--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -10,10 +10,12 @@
 #include "net/batched_output_stream.h"
 
 #include "likely.h"
+#include "ssx/semaphore.h"
 #include "vassert.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/scattered_message.hh>
+#include <seastar/core/semaphore.hh>
 
 #include <fmt/format.h>
 
@@ -23,7 +25,7 @@ batched_output_stream::batched_output_stream(
   ss::output_stream<char> o, size_t cache)
   : _out(std::move(o))
   , _cache_size(cache)
-  , _write_sem(std::make_unique<ss::semaphore>(1)) {
+  , _write_sem(std::make_unique<ssx::semaphore>(1, "net/batch-ostream")) {
     // Size zero reserved for identifying default-initialized
     // instances in stop()
     vassert(_cache_size > 0, "Size must be > 0");

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/semaphore.hh>
@@ -73,7 +74,7 @@ private:
 
     ss::output_stream<char> _out;
     size_t _cache_size{0};
-    std::unique_ptr<ss::semaphore> _write_sem;
+    std::unique_ptr<ssx::semaphore> _write_sem;
     size_t _unflushed_bytes{0};
     bool _closed = false;
 };

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -15,7 +15,6 @@
 #include "ssx/semaphore.h"
 
 #include <seastar/core/iostream.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <cstddef>
 #include <memory>

--- a/src/v/net/connection_rate.h
+++ b/src/v/net/connection_rate.h
@@ -23,7 +23,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -17,6 +17,7 @@
 #include "seastar/core/coroutine.hh"
 #include "ssx/future-util.h"
 #include "ssx/metrics.h"
+#include "ssx/semaphore.h"
 #include "ssx/sformat.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -32,7 +33,7 @@ namespace net {
 
 server::server(server_configuration c)
   : cfg(std::move(c))
-  , _memory(cfg.max_service_memory_per_core)
+  , _memory{size_t{static_cast<size_t>(cfg.max_service_memory_per_core)}, "net/server-mem"}
   , _public_metrics(ssx::metrics::public_metrics_handle) {}
 
 server::server(ss::sharded<server_configuration>* s)

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -16,12 +16,12 @@
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
+#include "ssx/semaphore.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/net/tls.hh>
 
@@ -108,7 +108,7 @@ public:
         ss::lw_shared_ptr<net::connection> conn;
 
         server_probe& probe() { return _s->_probe; }
-        ss::semaphore& memory() { return _s->_memory; }
+        ssx::semaphore& memory() { return _s->_memory; }
         hdr_hist& hist() { return _s->_hist; }
         ss::gate& conn_gate() { return _s->_conn_gate; }
         ss::abort_source& abort_source() { return _s->_as; }
@@ -179,7 +179,7 @@ private:
     void setup_public_metrics();
 
     std::unique_ptr<protocol> _proto;
-    ss::semaphore _memory;
+    ssx::semaphore _memory;
     std::vector<std::unique_ptr<listener>> _listeners;
     boost::intrusive::list<net::connection> _connections;
     ss::abort_source _as;

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -65,7 +65,7 @@ proxy::proxy(
   size_t max_memory,
   ss::sharded<kafka::client::client>& client)
   : _config(config)
-  , _mem_sem(max_memory)
+  , _mem_sem(max_memory, "pproxy/mem")
   , _client(client)
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -42,7 +42,7 @@ public:
 
 private:
     configuration _config;
-    ss::semaphore _mem_sem;
+    ssx::semaphore _mem_sem;
     ss::sharded<kafka::client::client>& _client;
     ctx_server<proxy>::context_t _ctx;
     ctx_server<proxy> _server;

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -16,6 +16,7 @@
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "random/simple_time_jitter.h"
+#include "ssx/semaphore.h"
 #include "utils/retry.h"
 
 namespace pandaproxy::schema_registry {
@@ -136,13 +137,13 @@ private:
 
     /// Serialize wait_for operations, to avoid issuing
     /// gratuitous number of reads to the topic on concurrent GETs.
-    ss::semaphore _wait_for_sem{1};
+    ssx::semaphore _wait_for_sem{1, "pproxy/schema-wait"};
 
     /// Shard 0 only: Reads have progressed as far as this offset
     model::offset _loaded_offset{-1};
 
     /// Shard 0 only: Serialize write operations.
-    ss::semaphore _write_sem{1};
+    ssx::semaphore _write_sem{1, "pproxy/schema-write"};
 
     // ======================
     // End of Shard 0 state

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -21,6 +21,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/handlers.h"
 #include "pandaproxy/schema_registry/storage.h"
+#include "ssx/semaphore.h"
 #include "utils/gate_guard.h"
 
 #include <seastar/core/coroutine.hh>
@@ -209,7 +210,7 @@ service::service(
   sharded_store& store,
   ss::sharded<seq_writer>& sequencer)
   : _config(config)
-  , _mem_sem(max_memory)
+  , _mem_sem(max_memory, "pproxy/schema-svc")
   , _client(client)
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -52,7 +52,7 @@ private:
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
     configuration _config;
-    ss::semaphore _mem_sem;
+    ssx::semaphore _mem_sem;
     ss::gate _gate;
     ss::sharded<kafka::client::client>& _client;
     ctx_server<service>::context_t _ctx;

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -41,7 +41,7 @@ class server {
 public:
     struct context_t {
         std::vector<net::unresolved_address> advertised_listeners;
-        ss::semaphore& mem_sem;
+        ssx::semaphore& mem_sem;
         ss::abort_source as;
         ss::smp_service_group smp_sg;
     };

--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -7,7 +7,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -83,19 +82,19 @@ ss::future<> append_entries_buffer::flush() {
       [this,
        requests = std::move(requests),
        response_promises = std::move(response_promises)](
-        ss::semaphore_units<> u) mutable {
+        ssx::semaphore_units u) mutable {
           return do_flush(
             std::move(requests), std::move(response_promises), std::move(u));
       });
 }
 
 ss::future<> append_entries_buffer::do_flush(
-  request_t requests, response_t response_promises, ss::semaphore_units<> u) {
+  request_t requests, response_t response_promises, ssx::semaphore_units u) {
     bool needs_flush = false;
     std::vector<reply_t> replies;
     auto f = ss::now();
     {
-        ss::semaphore_units<> op_lock_units = std::move(u);
+        ssx::semaphore_units op_lock_units = std::move(u);
         replies.reserve(requests.size());
         for (auto& req : requests) {
             if (req.flush) {

--- a/src/v/raft/append_entries_buffer.h
+++ b/src/v/raft/append_entries_buffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
@@ -137,7 +138,7 @@ private:
     using reply_t = std::variant<append_entries_reply, std::exception_ptr>;
 
     ss::future<> flush();
-    ss::future<> do_flush(request_t, response_t, ss::semaphore_units<>);
+    ss::future<> do_flush(request_t, response_t, ssx::semaphore_units);
 
     void propagate_results(std::vector<reply_t>, response_t);
 

--- a/src/v/raft/append_entries_buffer.h
+++ b/src/v/raft/append_entries_buffer.h
@@ -5,7 +5,6 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 
 namespace raft {
 

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -16,6 +16,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/logger.h"
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "units.h"
 #include "utils/mutex.h"
@@ -207,7 +208,7 @@ private:
 
     // Units issued by the storage resource manager to track how many bytes
     // of data is currently pending checkpoint.
-    ss::semaphore_units<> _bytes_since_last_offset_update_units;
+    ssx::semaphore_units _bytes_since_last_offset_update_units;
 
     model::revision_id _initial_revision{};
     ctx_log& _ctxlog;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -33,6 +33,7 @@
 #include "raft/timeout_jitter.h"
 #include "raft/types.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "storage/log.h"
 #include "storage/snapshot.h"
@@ -389,7 +390,7 @@ private:
 
     ss::future<result<replicate_result>> dispatch_replicate(
       append_entries_request,
-      std::vector<ss::semaphore_units<>>,
+      std::vector<ssx::semaphore_units>,
       absl::flat_hash_map<vnode, follower_req_seq>);
     /**
      * Hydrate the consensus state with the data from the snapshot
@@ -430,7 +431,7 @@ private:
     bool needs_recovery(const follower_index_metadata&, model::offset);
     void dispatch_recovery(follower_index_metadata&);
     void maybe_update_leader_commit_idx();
-    ss::future<> do_maybe_update_leader_commit_idx(ss::semaphore_units<>);
+    ss::future<> do_maybe_update_leader_commit_idx(ssx::semaphore_units);
 
     clock_type::time_point majority_heartbeat() const;
     /*
@@ -445,7 +446,7 @@ private:
     /// Replicates configuration to other nodes,
     //  caller have to pass in _op_sem semaphore units
     ss::future<std::error_code>
-    replicate_configuration(ss::semaphore_units<> u, group_configuration);
+    replicate_configuration(ssx::semaphore_units u, group_configuration);
 
     ss::future<> maybe_update_follower_commit_idx(model::offset);
 
@@ -480,7 +481,7 @@ private:
     ss::future<std::error_code>
       interrupt_configuration_change(model::revision_id, Func);
 
-    ss::future<> maybe_commit_configuration(ss::semaphore_units<>);
+    ss::future<> maybe_commit_configuration(ssx::semaphore_units);
     void maybe_promote_to_voter(vnode);
 
     ss::future<model::record_batch_reader>

--- a/src/v/raft/follower_queue.cc
+++ b/src/v/raft/follower_queue.cc
@@ -11,15 +11,18 @@
 
 #include "raft/follower_queue.h"
 
+#include "ssx/semaphore.h"
+
 #include <seastar/core/coroutine.hh>
 
 namespace raft {
 
 follower_queue::follower_queue(uint32_t max_concurrent_append_entries)
   : _max_concurrent_append_entries(max_concurrent_append_entries)
-  , _sem(std::make_unique<ss::semaphore>(_max_concurrent_append_entries)) {}
+  , _sem(std::make_unique<ssx::semaphore>(
+      _max_concurrent_append_entries, "raft/follow")) {}
 
-ss::future<ss::semaphore_units<>> follower_queue::get_append_entries_unit() {
+ss::future<ssx::semaphore_units> follower_queue::get_append_entries_unit() {
     co_return co_await ss::get_units(*_sem, 1);
 }
 

--- a/src/v/raft/follower_queue.h
+++ b/src/v/raft/follower_queue.h
@@ -12,8 +12,6 @@
 #include "raft/group_configuration.h"
 #include "ssx/semaphore.h"
 
-#include <seastar/core/semaphore.hh>
-
 namespace raft {
 
 class follower_queue {

--- a/src/v/raft/follower_queue.h
+++ b/src/v/raft/follower_queue.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "raft/group_configuration.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/semaphore.hh>
 
@@ -27,7 +28,7 @@ public:
         vassert(is_idle(), "can not remove not idle follower queue");
     }
 
-    ss::future<ss::semaphore_units<>> get_append_entries_unit();
+    ss::future<ssx::semaphore_units> get_append_entries_unit();
 
     ss::future<> stop();
 
@@ -50,7 +51,7 @@ private:
      * - token-bucket based throughput limitter
      */
     uint32_t _max_concurrent_append_entries;
-    std::unique_ptr<ss::semaphore> _sem;
+    std::unique_ptr<ssx::semaphore> _sem;
 };
 
 } // namespace raft

--- a/src/v/raft/follower_stats.cc
+++ b/src/v/raft/follower_stats.cc
@@ -47,7 +47,7 @@ void follower_stats::update_with_configuration(const group_configuration& cfg) {
     }
 }
 
-ss::future<ss::semaphore_units<>>
+ss::future<ssx::semaphore_units>
 follower_stats::get_append_entries_unit(vnode id) {
     if (auto it = _queues.find(id); it != _queues.end()) {
         return it->second.get_append_entries_unit();

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -70,7 +70,7 @@ public:
 
     size_t size() const { return _followers.size(); }
 
-    ss::future<ss::semaphore_units<>> get_append_entries_unit(vnode);
+    ss::future<ssx::semaphore_units> get_append_entries_unit(vnode);
 
     void return_append_entries_units(vnode);
 

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -19,7 +19,6 @@
 #include "raft/types.h"
 #include "utils/mutex.h"
 
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/util/log.hh>
 

--- a/src/v/raft/mutex_buffer.h
+++ b/src/v/raft/mutex_buffer.h
@@ -8,7 +8,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace raft::details {

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -24,7 +24,6 @@
 #include "vassert.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/util/bool_class.hh>

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -13,6 +13,7 @@
 
 #include "model/fundamental.h"
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "storage/log.h"
 #include "storage/offset_translator_state.h"
@@ -131,7 +132,7 @@ private:
 
     // Units issued by the storage resource manager to track how many bytes
     // of data is currently pending checkpoint.
-    ss::semaphore_units<> _bytes_processed_units;
+    ssx::semaphore_units _bytes_processed_units;
 
     // If true, the storage resource manager has asked us to checkpoint at the
     // next opportunity.

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -18,6 +18,7 @@
 #include "raft/logger.h"
 #include "raft/raftgen_service.h"
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/util/bool_class.hh>
 
@@ -27,7 +28,7 @@ namespace raft {
 
 prevote_stm::prevote_stm(consensus* p)
   : _ptr(p)
-  , _sem(0)
+  , _sem{0, "raft/prevote"}
   , _ctxlog(_ptr->group(), _ptr->ntp()) {}
 
 prevote_stm::~prevote_stm() {

--- a/src/v/raft/prevote_stm.h
+++ b/src/v/raft/prevote_stm.h
@@ -17,7 +17,6 @@
 #include "raft/vote_stm.h"
 
 #include <seastar/core/future.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_future.hh>
 
 #include <absl/container/flat_hash_map.h>

--- a/src/v/raft/prevote_stm.h
+++ b/src/v/raft/prevote_stm.h
@@ -57,7 +57,7 @@ private:
     vote_request _req;
     bool _success = false;
     // for sequentiality/progress
-    ss::semaphore _sem;
+    ssx::semaphore _sem;
     std::optional<raft::group_configuration> _config;
     clock_type::time_point _prevote_timeout;
     // for safety to wait for all bg ops

--- a/src/v/raft/recovery_memory_quota.h
+++ b/src/v/raft/recovery_memory_quota.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "config/property.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -29,14 +30,14 @@ public:
 
     explicit recovery_memory_quota(config_provider_fn);
 
-    ss::future<ss::semaphore_units<>> acquire_read_memory();
+    ss::future<ssx::semaphore_units> acquire_read_memory();
 
 private:
     void on_max_memory_changed();
 
     configuration _cfg;
     size_t _current_max_recovery_mem;
-    ss::semaphore _memory;
+    ssx::semaphore _memory;
 };
 
 } // namespace raft

--- a/src/v/raft/recovery_memory_quota.h
+++ b/src/v/raft/recovery_memory_quota.h
@@ -13,7 +13,6 @@
 #include "seastarx.h"
 #include "ssx/semaphore.h"
 
-#include <seastar/core/semaphore.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 namespace raft {

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -23,7 +23,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/io_priority_class.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/with_scheduling_group.hh>
 

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -38,9 +38,9 @@ private:
     ss::future<> replicate(
       model::record_batch_reader&&,
       append_entries_request::flush_after_append,
-      ss::semaphore_units<>);
+      ssx::semaphore_units);
     ss::future<result<append_entries_reply>> dispatch_append_entries(
-      append_entries_request&&, std::vector<ss::semaphore_units<>>);
+      append_entries_request&&, std::vector<ssx::semaphore_units>);
     std::optional<follower_index_metadata*> get_follower_meta();
     clock_type::time_point append_entries_timeout();
 

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -18,8 +18,6 @@
 #include "storage/snapshot.h"
 #include "utils/prefix_logger.h"
 
-#include <seastar/core/semaphore.hh>
-
 #include <vector>
 
 namespace raft {

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -24,7 +24,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -19,7 +19,6 @@
 #include "utils/mutex.h"
 
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <absl/container/flat_hash_map.h>
 namespace raft {

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -14,6 +14,7 @@
 #include "model/record_batch_reader.h"
 #include "outcome.h"
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 #include "units.h"
 #include "utils/mutex.h"
 
@@ -38,7 +39,7 @@ public:
          * Item keeps semaphore units until replicate batcher is done with
          * processing the request.
          */
-        ss::semaphore_units<> units;
+        ssx::semaphore_units units;
     };
     using item_ptr = ss::lw_shared_ptr<item>;
     explicit replicate_batcher(consensus* ptr, size_t cache_size);
@@ -54,7 +55,7 @@ public:
       model::record_batch_reader&&,
       consistency_level);
 
-    ss::future<> flush(ss::semaphore_units<> u, bool const transfer_flush);
+    ss::future<> flush(ssx::semaphore_units u, bool const transfer_flush);
 
     ss::future<> stop();
 
@@ -62,7 +63,7 @@ private:
     ss::future<> do_flush(
       std::vector<item_ptr>,
       append_entries_request,
-      std::vector<ss::semaphore_units<>>,
+      std::vector<ssx::semaphore_units>,
       absl::flat_hash_map<vnode, follower_req_seq>);
 
     ss::future<item_ptr> do_cache(
@@ -76,7 +77,7 @@ private:
       consistency_level);
 
     consensus* _ptr;
-    ss::semaphore _max_batch_size_sem;
+    ssx::semaphore _max_batch_size_sem;
     size_t _max_batch_size;
     std::vector<item_ptr> _item_cache;
     mutex _lock;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -102,7 +102,7 @@ replicate_entries_stm::send_append_entries_request(
 
     auto f = _ptr->_fstats.get_append_entries_unit(n).then_wrapped(
       [this, req = std::move(req), opts = std::move(opts), n](
-        ss::future<ss::semaphore_units<>> f) mutable {
+        ss::future<ssx::semaphore_units> f) mutable {
           // we want to signal dispatch semaphore after calling append entries.
           // When dispatch semaphore is released the append_entries_stm releases
           // op_lock so next append entries request can be dispatched to the
@@ -419,7 +419,7 @@ replicate_entries_stm::replicate_entries_stm(
   : _ptr(p)
   , _req(std::make_unique<append_entries_request>(std::move(r)))
   , _followers_seq(std::move(seqs))
-  , _share_sem(1)
+  , _share_sem(1, "raft/repl-entries")
   , _ctxlog(_ptr->_ctxlog) {}
 
 replicate_entries_stm::~replicate_entries_stm() {

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -22,7 +22,6 @@
 #include "storage/types.h"
 
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <absl/container/flat_hash_map.h>

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -18,6 +18,7 @@
 #include "raft/group_configuration.h"
 #include "raft/logger.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "storage/types.h"
 
 #include <seastar/core/gate.hh>
@@ -81,7 +82,7 @@ namespace raft {
 
 class replicate_entries_stm {
 public:
-    using units_t = std::vector<ss::semaphore_units<>>;
+    using units_t = std::vector<ssx::semaphore_units>;
     replicate_entries_stm(
       consensus*,
       append_entries_request,
@@ -91,7 +92,7 @@ public:
     /// caller have to pass semaphore units, the apply call will do the
     /// fine grained locking on behalf of the caller
     ss::future<result<replicate_result>>
-      apply(std::vector<ss::semaphore_units<>>);
+      apply(std::vector<ssx::semaphore_units>);
 
     /**
      * Waits for majority of replicas to successfully execute dispatched
@@ -126,13 +127,13 @@ private:
     /// we keep a copy around until we finish the retries
     std::unique_ptr<append_entries_request> _req;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
-    ss::semaphore _share_sem;
-    ss::semaphore _dispatch_sem{0};
+    ssx::semaphore _share_sem;
+    ssx::semaphore _dispatch_sem{0, "raft/repl-dispatch"};
     ss::gate _req_bg;
     ctx_log _ctxlog;
     model::offset _dirty_offset;
     model::offset _initial_committed_offset;
-    ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> _units;
+    ss::lw_shared_ptr<std::vector<ssx::semaphore_units>> _units;
     std::optional<result<storage::append_result>> _append_result;
     uint16_t _requests_count = 0;
 };

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -17,7 +17,6 @@
 #include "ssx/semaphore.h"
 
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <absl/container/flat_hash_map.h>
 

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -14,6 +14,7 @@
 #include "outcome.h"
 #include "raft/logger.h"
 #include "raft/types.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/semaphore.hh>
@@ -84,17 +85,17 @@ private:
     ss::future<> self_vote();
     ss::future<> dispatch_one(vnode);
     ss::future<result<vote_reply>> do_dispatch_one(vnode);
-    ss::future<> update_vote_state(ss::semaphore_units<>);
+    ss::future<> update_vote_state(ssx::semaphore_units);
     ss::future<> process_replies();
     ss::future<std::error_code>
-      replicate_config_as_new_leader(ss::semaphore_units<>);
+      replicate_config_as_new_leader(ssx::semaphore_units);
     // args
     consensus* _ptr;
     // make sure to always make a copy; never move() this struct
     vote_request _req;
     bool _success = false;
     // for sequentiality/progress
-    ss::semaphore _sem;
+    ssx::semaphore _sem;
     std::optional<raft::group_configuration> _config;
     // for safety to wait for all bg ops
     ss::gate _vote_bg;

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -15,6 +15,7 @@
 #include "rpc/backoff_policy.h"
 #include "rpc/transport.h"
 #include "rpc/types.h"
+#include "ssx/semaphore.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
@@ -52,7 +53,7 @@ private:
 
     rpc::transport _transport;
     rpc::clock_type::time_point _stamp{rpc::clock_type::now()};
-    ss::semaphore _connected_sem{1};
+    ssx::semaphore _connected_sem{1, "raft/connected"};
     ss::gate _dispatch_gate;
     backoff_policy _backoff_policy;
 };

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -11,6 +11,7 @@
 
 #include "rpc/logger.h"
 #include "rpc/types.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/future-util.hh>
 
@@ -29,7 +30,7 @@ struct server_context_impl final : streaming_context {
       , hdr(h) {
         res.probe().request_received();
     }
-    ss::future<ss::semaphore_units<>> reserve_memory(size_t ask) final {
+    ss::future<ssx::semaphore_units> reserve_memory(size_t ask) final {
         auto fut = get_units(res.memory(), ask);
         if (res.memory().waiters()) {
             res.probe().waiting_for_available_memory();

--- a/src/v/rpc/test/response_handler_tests.cc
+++ b/src/v/rpc/test/response_handler_tests.cc
@@ -9,6 +9,7 @@
 
 #include "rpc/response_handler.h"
 #include "rpc/types.h"
+#include "ssx/semaphore.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/sleep.hh>
@@ -18,7 +19,7 @@ using namespace std::chrono_literals; // NOLINT
 
 struct test_str_ctx final : public rpc::streaming_context {
     virtual ~test_str_ctx() noexcept = default;
-    virtual ss::future<ss::semaphore_units<>> reserve_memory(size_t) final {
+    virtual ss::future<ssx::semaphore_units> reserve_memory(size_t) final {
         return get_units(s, 1);
     }
     virtual const rpc::header& get_header() const final { return hdr; }
@@ -27,7 +28,7 @@ struct test_str_ctx final : public rpc::streaming_context {
     virtual void body_parse_exception(std::exception_ptr) final {}
 
     rpc::header hdr;
-    ss::semaphore s{1};
+    ssx::semaphore s{1, "rpc/mock-sc"};
 };
 
 struct test_fixture {

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -20,7 +20,6 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/util/defer.hh>

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -24,7 +24,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -94,7 +94,7 @@ private:
     ss::future<result<std::unique_ptr<streaming_context>>>
     make_response_handler(netbuf&, const rpc::client_opts&);
 
-    ss::semaphore _memory;
+    ssx::semaphore _memory;
     absl::flat_hash_map<uint32_t, std::unique_ptr<internal::response_handler>>
       _correlations;
     uint32_t _correlation_idx{0};

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -23,7 +23,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/scheduling.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timer.hh>

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -17,7 +17,6 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/when_all.hh>
 

--- a/src/v/ssx/semaphore.h
+++ b/src/v/ssx/semaphore.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sstring.hh>
+
+#include <utility>
+
+namespace ssx {
+
+// We use named semaphores because the provided name will be included in
+// exception messages, making diagnoising broken or timed-out semaphores much
+// easier.
+
+// Use `make_samaphore(name)` to create these.
+template<typename Clock = seastar::timer<>::clock>
+class named_semaphore
+  : public seastar::
+      basic_semaphore<seastar::named_semaphore_exception_factory, Clock> {
+public:
+    named_semaphore(size_t count, seastar::sstring name)
+      : seastar::
+        basic_semaphore<seastar::named_semaphore_exception_factory, Clock>(
+          count, seastar::named_semaphore_exception_factory{std::move(name)}) {}
+};
+
+using semaphore = named_semaphore<>;
+
+using semaphore_units = seastar::semaphore_units<semaphore::exception_factory>;
+
+} // namespace ssx

--- a/src/v/ssx/semaphore.h
+++ b/src/v/ssx/semaphore.h
@@ -19,10 +19,9 @@
 namespace ssx {
 
 // We use named semaphores because the provided name will be included in
-// exception messages, making diagnoising broken or timed-out semaphores much
+// exception messages, making diagnosing broken or timed-out semaphores much
 // easier.
 
-// Use `make_samaphore(name)` to create these.
 template<typename Clock = seastar::timer<>::clock>
 class named_semaphore
   : public seastar::

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/record.h"
+#include "ssx/semaphore.h"
 #include "units.h"
 #include "utils/intrusive_list_helpers.h"
 #include "vassert.h"
@@ -344,7 +345,7 @@ private:
             return ss::memory::stats().free_memory() < _min_free_memory;
         }
         bool _stopped = false;
-        ss::semaphore _change{0};
+        ssx::semaphore _change{0, "s/batch-reclaim"};
         batch_cache& _cache;
         size_t _min_free_memory;
         ss::scheduling_group _sg;

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -10,7 +10,6 @@
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/util/later.hh>
 
 #include <boost/iterator/counting_iterator.hpp>

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "resource_mgmt/memory_groups.h"
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "storage/logger.h"
 #include "storage/segment_appender_chunk.h"
 #include "vassert.h"
@@ -72,7 +73,7 @@ public:
             return do_get();
         }
         return ss::get_units(_sem, 1).then(
-          [this](ss::semaphore_units<>) { return do_get(); });
+          [this](ssx::semaphore_units) { return do_get(); });
     }
 
 private:
@@ -81,7 +82,7 @@ private:
             return ss::make_ready_future<chunk_ptr>(c);
         }
         return ss::get_units(_sem, 1).then(
-          [this](ss::semaphore_units<>) { return do_get(); });
+          [this](ssx::semaphore_units) { return do_get(); });
     }
 
     chunk_ptr pop_or_allocate() {
@@ -105,7 +106,7 @@ private:
     }
 
     ss::chunked_fifo<chunk_ptr> _chunks;
-    ss::semaphore _sem{0};
+    ssx::semaphore _sem{0, "s/chunk-cache"};
     size_t _size_available{0};
     size_t _size_total{0};
     const size_t _size_target;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -40,7 +40,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <fmt/format.h>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -192,7 +192,7 @@ private:
     moving_average<double, 5> _compaction_ratio{1.0};
 
     // Bytes written since last time we requested stm snapshot
-    ss::semaphore_units<> _stm_dirty_bytes_units;
+    ssx::semaphore_units _stm_dirty_bytes_units;
 };
 
 } // namespace storage

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -144,7 +144,7 @@ private:
      */
     std::vector<op> _ops;
     ss::timer<> _timer;
-    ss::semaphore _sem{0};
+    ssx::semaphore _sem{0, "s/kvstore"};
     ss::lw_shared_ptr<segment> _segment;
     model::offset _next_offset;
     absl::flat_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -23,7 +23,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/timer.hh>
 
 #include <absl/container/flat_hash_map.h>

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -21,7 +21,6 @@
 #include <seastar/core/align.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/semaphore.hh>
 
 #include <fmt/format.h>
 

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -11,6 +11,7 @@
 
 #include "config/configuration.h"
 #include "likely.h"
+#include "ssx/semaphore.h"
 #include "storage/chunk_cache.h"
 #include "storage/logger.h"
 #include "storage/storage_resources.h"
@@ -50,11 +51,13 @@ size_missmatch_error(const char* ctx, size_t expected, size_t got) {
       "{}. Size missmatch. Expected:{}, Got:{}", ctx, expected, got));
 }
 
+static constexpr auto head_sem_name = "s/appender-head";
+
 segment_appender::segment_appender(ss::file f, options opts)
   : _out(std::move(f))
   , _opts(opts)
-  , _concurrent_flushes(ss::semaphore::max_counter())
-  , _prev_head_write(ss::make_lw_shared<ss::semaphore>(1))
+  , _concurrent_flushes(ss::semaphore::max_counter(), "s/append-flush")
+  , _prev_head_write(ss::make_lw_shared<ssx::semaphore>(1, head_sem_name))
   , _inactive_timer([this] { handle_inactive_timer(); })
   , _chunk_size(config::shard_local_cfg().append_chunk_size()) {
     const auto alignment = _out.disk_write_dma_alignment();
@@ -171,7 +174,7 @@ ss::future<> segment_appender::do_append(const char* buf, const size_t n) {
 
     return ss::get_units(_concurrent_flushes, 1)
       .then([this, next_buf = buf + written, next_sz = n - written](
-              ss::semaphore_units<>) {
+              ssx::semaphore_units) {
           // do not hold the units!
           return internal::chunks().get().then(
             [this, next_buf, next_sz](ss::lw_shared_ptr<chunk> chunk) {
@@ -478,7 +481,7 @@ void segment_appender::dispatch_background_head_write() {
        full]() mutable {
           return units
             .then([this, h, w, start_offset, expected, src, full](
-                    ss::semaphore_units<> u) mutable {
+                    ssx::semaphore_units u) mutable {
                 return _out
                   .dma_write(start_offset, src, expected, _opts.priority)
                   .then([this, h, w, expected, full](size_t got) {
@@ -511,7 +514,7 @@ void segment_appender::dispatch_background_head_write() {
      * dependency chain is reset for the next head.
      */
     if (full) {
-        _prev_head_write = ss::make_lw_shared<ss::semaphore>(1);
+        _prev_head_write = ss::make_lw_shared<ssx::semaphore>(1, head_sem_name);
     }
 }
 

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -127,9 +127,9 @@ private:
     size_t _committed_offset{0};
     size_t _fallocation_offset{0};
     size_t _bytes_flush_pending{0};
-    ss::semaphore _concurrent_flushes;
+    ssx::semaphore _concurrent_flushes;
     ss::lw_shared_ptr<chunk> _head;
-    ss::lw_shared_ptr<ss::semaphore> _prev_head_write;
+    ss::lw_shared_ptr<ssx::semaphore> _prev_head_write;
 
     struct flush_op {
         explicit flush_op(size_t offset)

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -44,7 +44,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/rwlock.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/util/defer.hh>
 

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -15,8 +15,6 @@
 #include "ssx/semaphore.h"
 #include "units.h"
 
-#include <seastar/core/semaphore.hh>
-
 #include <cstdint>
 
 namespace storage {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -28,7 +28,6 @@
 #include "utils/to_string.h"
 
 #include <seastar/core/io_priority_class.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/util/defer.hh>

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1860,7 +1860,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
      *
      */
     auto append_with_lock = [&] {
-        return write_mutex.get_units().then([&](ss::semaphore_units<> u) {
+        return write_mutex.get_units().then([&](ssx::semaphore_units u) {
             return append().then(
               [&, u = std::move(u)](storage::append_result res) mutable {
                   auto f = log.flush();

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/semaphore.hh>
 
@@ -34,8 +35,9 @@ public:
     using duration = typename ss::semaphore::duration;
     using time_point = typename ss::semaphore::time_point;
 
+    // TODO constructor to pass through name & change callers.
     mutex()
-      : _sem(1) {}
+      : _sem(1, "mutex") {}
 
     template<typename Func>
     auto with(Func&& func) noexcept {
@@ -67,5 +69,5 @@ public:
     size_t waiters() const noexcept { return _sem.waiters(); }
 
 private:
-    ss::semaphore _sem;
+    ssx::semaphore _sem;
 };

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -13,8 +13,6 @@
 #include "seastarx.h"
 #include "ssx/semaphore.h"
 
-#include <seastar/core/semaphore.hh>
-
 /*
  * A traditional mutex. If you are trying to count things or need timeouts, you
  * probably want to stick with a standard semaphore. The primary motivation for

--- a/src/v/utils/queue_depth_control.h
+++ b/src/v/utils/queue_depth_control.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "utils/ema.h"
 
 #include <seastar/core/semaphore.hh>
@@ -27,7 +28,7 @@ public:
       , _min_depth(min_depth)
       , _max_depth(max_depth)
       , _curr_depth(_idle_depth)
-      , _queue(_curr_depth) {}
+      , _queue(_curr_depth, "qdc") {}
 
     void update(const double sample) {
         auto new_depth = static_cast<size_t>(
@@ -66,7 +67,7 @@ public:
 
     size_t depth() const { return _curr_depth; }
 
-    ss::future<ss::semaphore_units<>> get_unit() {
+    ss::future<ssx::semaphore_units> get_unit() {
         return ss::get_units(_queue, 1);
     }
 
@@ -77,5 +78,5 @@ private:
     const size_t _min_depth;
     const size_t _max_depth;
     size_t _curr_depth;
-    ss::semaphore _queue;
+    ssx::semaphore _queue;
 };

--- a/src/v/utils/queue_depth_control.h
+++ b/src/v/utils/queue_depth_control.h
@@ -3,8 +3,6 @@
 #include "ssx/semaphore.h"
 #include "utils/ema.h"
 
-#include <seastar/core/semaphore.hh>
-
 /*
  * exponential moving average queue depth control. given a maximum latency
  * update the number of units available in the contained semaphore which can be

--- a/src/v/utils/stream_utils.h
+++ b/src/v/utils/stream_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "utils/gate_guard.h"
 #include "vassert.h"
 
@@ -35,7 +36,7 @@ template<class Ch>
 class input_stream_fanout final {
     struct data_item {
         ss::temporary_buffer<Ch> buf;
-        ss::semaphore_units<> units;
+        ssx::semaphore_units units;
         unsigned mask;
     };
     using ring_buffer = ss::circular_buffer<data_item>;
@@ -58,7 +59,7 @@ public:
       , _bitmask(0)
       , _max_size(max_size ? *max_size / read_ahead : 0)
       , _in(std::move(i))
-      , _sem(read_ahead) {
+      , _sem(read_ahead, "stream-fanout") {
         vassert(
           num_clients <= 10 && num_clients >= 2,
           "input_stream_fanout can have up to 10 clients, {} were given",
@@ -182,7 +183,7 @@ private:
     unsigned _bitmask;
     const size_t _max_size;
     ss::input_stream<Ch> _in;
-    ss::semaphore _sem;
+    ssx::semaphore _sem;
     ss::condition_variable _pcond;
     ring_buffer _buffer;
     ss::gate _gate;

--- a/src/v/utils/stream_utils.h
+++ b/src/v/utils/stream_utils.h
@@ -22,7 +22,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/iostream.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 

--- a/src/v/utils/tests/timed_mutex_test.cc
+++ b/src/v/utils/tests/timed_mutex_test.cc
@@ -1,4 +1,5 @@
 #include "seastarx.h"
+#include "ssx/semaphore.h"
 #include "utils/timed_mutex.h"
 
 #include <seastar/core/loop.hh>
@@ -32,7 +33,8 @@ seastar::future<> slow(timed_mutex& mutex, int& counter) {
 seastar::future<>
 concurrent_increment(int num_fibers, int& variable, timed_mutex& mutex) {
     return seastar::do_with(
-      seastar::semaphore(0), [&mutex, &variable, num_fibers](auto& sem) {
+      ssx::semaphore(0, "test/concurrent-incr"),
+      [&mutex, &variable, num_fibers](auto& sem) {
           for (int i = 0; i < num_fibers; i++) {
               (void)slow(mutex, variable).then([&sem] { sem.signal(1); });
           }

--- a/src/v/v8_engine/internal/script.cc
+++ b/src/v/v8_engine/internal/script.cc
@@ -14,7 +14,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/later.hh>

--- a/src/v/v8_engine/internal/script.h
+++ b/src/v/v8_engine/internal/script.h
@@ -16,7 +16,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timer.hh>

--- a/src/v/v8_engine/internal/tests/executor_stress_test.cc
+++ b/src/v/v8_engine/internal/tests/executor_stress_test.cc
@@ -14,7 +14,6 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/when_all.hh>

--- a/src/v/v8_engine/internal/tests/executor_test.cc
+++ b/src/v/v8_engine/internal/tests/executor_test.cc
@@ -14,7 +14,6 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/when_all.hh>


### PR DESCRIPTION
Named semaphore is an enhancement to the usual seastar::semaphore, which is initialized with a name string that helps to identify which semaphore it is; when the semaphore raises an exception (i.e. timed out, broken), the name string is included in the error message.

Ended up doing a single tree-wide commit to change callers, versus picking out the different uses and the areas their types propagate to. As you can see in the patch the coupling between the semaphore_units<> type and the named
semaphore specialization causes the choice of semaphore to leak quite a bit, making a treewide change a good choice.

Fixes: #5489

### Example Output
```
unknown location(0): fatal error: in "named_mutex_demo": seastar::broken_named_semaphore: Semaphore broken: testing/named-semaphore
```

### Summary of Semaphore Names
I've grepped out the actual semaphore names below, to ~~facilitate some bikeshedding~~ 

edit: Updated with new semaphore names per Alex's suggestion to namespace them with a separating `/`. Still keeping them concise.
```
ss::named_semaphore _mutex = ssx::make_named_semaphore(1, "archive/ntp");                            
ssx::make_named_semaphore(1, "cloud/cache")};                                                        
ssx::make_named_semaphore(1, "c/controller-be")};                                                    
ss::named_semaphore _sem{ssx::make_named_semaphore(0, "c/drain-mgr")};                               
ss::named_semaphore read_sem{ssx::make_named_semaphore(                                              
ss::named_semaphore _lock{ssx::make_named_semaphore(1, "k/client")};                                 
ss::named_semaphore sem{ssx::make_named_semaphore(1, "k/group-mgr")};                                
, _mem_sem(ssx::make_named_semaphore(max_memory, "pproxy/mem"))                                      
, _mem_sem(ssx::make_named_semaphore(max_memory, "pproxy/schema-svc"))                               
_started_sem = ssx::make_named_semaphore(0, "pproxy/oneshot");                                       
ss::named_semaphore _started_sem{ssx::make_named_semaphore(0, "pproxy/oneshot")};                    ssx::make_named_semaphore(1, "pproxy/schema-wait")};                                                 
ssx::make_named_semaphore(1, "pproxy/schema-write")};                                                
, _max_batch_size_sem(ssx::make_named_semaphore(cache_size, "raft/repl-batch"))                      
ssx::make_named_semaphore(0, "raft/repl-dispatch")};                                                 , _sem(ssx::make_named_semaphore(0, "raft/vote"))                                                    
, _memory(ssx::make_named_semaphore(                                                                 
ssx::make_named_semaphore(_max_concurrent_append_entries, "raft/follow"))) {}                        
, _sem(ssx::make_named_semaphore(0, "raft/prevote"))                                                 
, _sem{ssx::make_named_semaphore(get_per_core_rate(), "raft/recovery")}                              
ssx::make_named_semaphore(c.max_queued_bytes, "rpc/transport-mem")) {                                
ss::named_semaphore s{ssx::make_named_semaphore(1, "rpc/mock-sc")};                                  
ssx::make_named_semaphore(1, "raft/connected")};                                                     
::named_semaphore make_named_semaphore(size_t count, T&& name) {                                     
ss::make_lw_shared<>(ssx::make_named_semaphore(1, head_sem_name)))                                   
ssx::make_named_semaphore(1, head_sem_name));                                                        
ss::named_semaphore _sem{ssx::make_named_semaphore(0, "s/chunk-cache")};                             
ss::named_semaphore _sem{ssx::make_named_semaphore(0, "s/kvstore")};                                 
: _sem(ssx::make_named_semaphore(capacity, sem_name))                                                
ssx::make_named_semaphore(0, "s/batch-reclaim")};                                                    
, _queue(ssx::make_named_semaphore(_curr_depth, "qdc")) {}                                           
: _sem(ssx::make_named_semaphore(1, "timed-mutex"))                                                  
, _sem(ssx::make_named_semaphore(read_ahead, "stream-fanout")) {                                     
: _sem(ssx::make_named_semaphore(1, "mutex")) {}                                                     
ssx::make_named_semaphore(1, "net/batch-ostream"))) {                                                
ssx::make_named_semaphore(cfg.max_service_memory_per_core, "net/server-mem"))  
```