### PR TITLE
net: Remove security::tls::principal_mapper

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -56,16 +56,14 @@ connection::connection(
   ss::connected_socket f,
   ss::socket_address a,
   server_probe& p,
-  std::optional<size_t> in_max_buffer_size,
-  std::optional<security::tls::principal_mapper> tls_pm)
+  std::optional<size_t> in_max_buffer_size)
   : addr(a)
   , _hook(hook)
   , _name(std::move(name))
   , _fd(std::move(f))
   , _in(_fd.input())
   , _out(_fd.output())
-  , _probe(p)
-  , _tls_pm(std::move(tls_pm)) {
+  , _probe(p) {
     if (in_max_buffer_size.has_value()) {
         auto in_config = ss::connected_socket_input_stream_config{};
         in_config.max_buffer_size = in_max_buffer_size.value();

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -14,7 +14,6 @@
 #include "net/batched_output_stream.h"
 #include "net/server_probe.h"
 #include "seastarx.h"
-#include "security/mtls.h"
 
 #include <seastar/core/iostream.hh>
 #include <seastar/net/api.hh>
@@ -39,8 +38,7 @@ public:
       ss::connected_socket f,
       ss::socket_address a,
       server_probe& p,
-      std::optional<size_t> in_max_buffer_size,
-      std::optional<security::tls::principal_mapper> tls_pm);
+      std::optional<size_t> in_max_buffer_size);
     ~connection() noexcept;
     connection(const connection&) = delete;
     connection& operator=(const connection&) = delete;
@@ -64,11 +62,6 @@ public:
         return ss::tls::get_dn_information(_fd);
     }
 
-    const std::optional<security::tls::principal_mapper>&
-    get_principal_mapping() const {
-        return _tls_pm;
-    }
-
 private:
     boost::intrusive::list<connection>& _hook;
     ss::sstring _name;
@@ -76,7 +69,6 @@ private:
     ss::input_stream<char> _in;
     net::batched_output_stream _out;
     server_probe& _probe;
-    std::optional<security::tls::principal_mapper> _tls_pm;
 };
 
 } // namespace net

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -215,23 +215,13 @@ ss::future<> server::accept(listener& s) {
                   }
               }
 
-              std::optional<security::tls::principal_mapper> tls_pm;
-              auto se_it = std::find_if(
-                cfg.addrs.begin(), cfg.addrs.end(), [&name](const auto& a) {
-                    return a.name == name;
-                });
-              if (se_it != cfg.addrs.end()) {
-                  tls_pm = se_it->principal_mapper;
-              }
-
               auto conn = ss::make_lw_shared<net::connection>(
                 _connections,
                 name,
                 std::move(ar.connection),
                 ar.remote_address,
                 _probe,
-                cfg.stream_recv_buf,
-                tls_pm);
+                cfg.stream_recv_buf);
               vlog(
                 rpc::rpclog.trace,
                 "{} - Incoming connection from {} on \"{}\"",

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -16,7 +16,6 @@
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
-#include "security/mtls.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/abort_source.hh>
@@ -43,7 +42,6 @@ struct server_endpoint {
     ss::sstring name;
     ss::socket_address addr;
     ss::shared_ptr<ss::tls::server_credentials> credentials;
-    std::optional<security::tls::principal_mapper> principal_mapper;
 
     server_endpoint(ss::sstring name, ss::socket_address addr)
       : name(std::move(name))
@@ -58,26 +56,9 @@ struct server_endpoint {
       , credentials(std::move(creds)) {}
 
     server_endpoint(
-      ss::sstring name,
-      ss::socket_address addr,
-      ss::shared_ptr<ss::tls::server_credentials> creds,
-      std::optional<security::tls::principal_mapper> principal_mapper)
-      : name(std::move(name))
-      , addr(addr)
-      , credentials(std::move(creds))
-      , principal_mapper(std::move(principal_mapper)) {}
-
-    server_endpoint(
       ss::socket_address addr,
       ss::shared_ptr<ss::tls::server_credentials> creds)
       : server_endpoint("", addr, std::move(creds)) {}
-
-    server_endpoint(
-      ss::socket_address addr,
-      ss::shared_ptr<ss::tls::server_credentials> creds,
-      security::tls::principal_mapper principal_mapper)
-      : server_endpoint(
-        "", addr, std::move(creds), std::move(principal_mapper)) {}
 
     explicit server_endpoint(ss::socket_address addr)
       : server_endpoint("", addr) {}


### PR DESCRIPTION
## Cover letter

Revert 77853dbf5b74df1058090ef1621bc035d3c70d31

It was introduced in #4501, as of #5292 is not required.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none