### PR TITLE
cloud_roles: optionally enable tls in http client

### DIFF
--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -63,7 +63,8 @@ ss::future<api_response> aws_refresh_impl::fetch_credentials() {
     creds_req.method(boost::beast::http::verb::get);
     creds_req.target(
       fmt::format("/latest/meta-data/iam/security-credentials/{}", *_role));
-    co_return co_await make_request(make_api_client(), std::move(creds_req));
+    co_return co_await make_request(
+      co_await make_api_client(), std::move(creds_req));
 }
 
 api_response_parse_result aws_refresh_impl::parse_response(iobuf resp) {
@@ -105,7 +106,8 @@ ss::future<api_response> aws_refresh_impl::fetch_role_name() {
     http::client::request_header role_req;
     role_req.method(boost::beast::http::verb::get);
     role_req.target("/latest/meta-data/iam/security-credentials/");
-    co_return co_await make_request(make_api_client(), std::move(role_req));
+    co_return co_await make_request(
+      co_await make_api_client(), std::move(role_req));
 }
 
 std::ostream& aws_refresh_impl::print(std::ostream& os) const {

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -52,7 +52,8 @@ ss::future<api_response> gcp_refresh_impl::fetch_credentials() {
     oauth_req.set(
       metadata_flavor::header_name.data(), metadata_flavor::value.data());
 
-    co_return co_await make_request(make_api_client(), std::move(oauth_req));
+    co_return co_await make_request(
+      co_await make_api_client(), std::move(oauth_req));
 }
 
 api_response_parse_result gcp_refresh_impl::parse_response(iobuf response) {

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -31,6 +31,11 @@ struct retry_params {
 
 class refresh_credentials {
 public:
+    enum class client_tls_enabled : bool {
+        yes = true,
+        no = false,
+    };
+
     class impl {
     public:
         impl(
@@ -79,7 +84,8 @@ public:
 
     protected:
         /// Returns an http client with the API host and port applied
-        http::client make_api_client() const;
+        ss::future<http::client> make_api_client(
+          client_tls_enabled enable_tls = client_tls_enabled::no) const;
 
         /// Helper to parse the iobuf returned from API into a credentials
         /// object, customized to API response structure

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -84,8 +84,8 @@ public:
 
     protected:
         /// Returns an http client with the API host and port applied
-        ss::future<http::client> make_api_client(
-          client_tls_enabled enable_tls = client_tls_enabled::no) const;
+        ss::future<http::client>
+        make_api_client(client_tls_enabled enable_tls = client_tls_enabled::no);
 
         /// Helper to parse the iobuf returned from API into a credentials
         /// object, customized to API response structure
@@ -123,6 +123,10 @@ public:
         aws_region_name region() const { return _region; }
 
     private:
+        /// Initializes certificate_credentials on first client creation.
+        /// Subsequent clients which are created will reuse the certs.
+        ss::future<> init_tls_certs();
+
         /// The hostname to query for credentials. Can be overridden using env
         /// variable `RP_SI_CREDS_API_HOST`
         ss::sstring _api_host;
@@ -139,6 +143,7 @@ public:
         std::optional<std::chrono::milliseconds> _sleep_duration{std::nullopt};
         ss::abort_source& _as;
         retry_params _retry_params;
+        ss::shared_ptr<ss::tls::certificate_credentials> _tls_certs = nullptr;
     };
 
     refresh_credentials(


### PR DESCRIPTION
enables TLS in http client. STS IAM role  impl uses TLS client, and the other implementations use a simple HTTP client.

fixes #5467 