### PR TITLE
Run arroyo test suite in ducktape

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -163,6 +163,13 @@ RUN apt update && \
       file && \
     rm -rf /var/lib/apt/lists/*
 
+# Clone and install the arroyo client library in order to run its test suite.
+RUN mkdir /root/external_test_suites && \
+    git -C /root/external_test_suites clone --depth=1 https://github.com/getsentry/arroyo.git && \
+    cd /root/external_test_suites/arroyo && \
+    git reset --hard 2631cf1406b0cb5bc05c8a37e8f9f5a40fcf31d4 && \
+    python3 -m pip install --force --no-cache-dir -e /root/external_test_suites/arroyo
+
 RUN mkdir -p /opt/scripts && \
     curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/addr2line.py -o /opt/scripts/addr2line.py && \
     curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line && \

--- a/tests/rptest/tests/compatibility/arroyo_test.py
+++ b/tests/rptest/tests/compatibility/arroyo_test.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import subprocess
+
+from rptest.services.cluster import cluster
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from ducktape.cluster.remoteaccount import RemoteCommandError
+
+
+class ArroyoTest(PreallocNodesTest):
+    """
+    Run the arroyo test suite against a redpanda cluster in
+    a ducktape environment.
+
+    The test suite lives here under tests/ in https://github.com/getsentry/arroyo.
+    """
+    TEST_SUITE_PATH = "/root/external_test_suites/arroyo"
+
+    def __init__(self, ctx, *args, **kwargs):
+        super().__init__(test_context=ctx,
+                         node_prealloc_count=1,
+                         *args,
+                         **kwargs)
+
+    def _find_failed_tests(self, pytest_output: list[str]):
+        return [line for line in pytest_output if "FAILED" in line]
+
+    @cluster(num_nodes=4)
+    def test_arroyo_test_suite(self):
+        test_node = self.preallocated_nodes[0]
+
+        try:
+            env_preamble = f"DEFAULT_BROKERS={self.redpanda.brokers()}"
+            capture = test_node.account.ssh_capture(
+                f"{env_preamble} "
+                f"python3 -m pytest {ArroyoTest.TEST_SUITE_PATH} "
+                "-k KafkaStreamsTestCase -rf",
+                combine_stderr=True)
+
+            pytest_output = list(capture)
+            for log_line in pytest_output:
+                self.logger.info(log_line)
+
+            failure_reports = self._find_failed_tests(pytest_output)
+            if len(failure_reports) > 0:
+                assert False, "Arroyo test failures occured. Please check the log file"
+        except RemoteCommandError as err:
+            if err.exit_status == 2:
+                assert False, "Arroyo test suite was interrupted"
+            elif err.exit_status == 3:
+                assert False, "Internal error durring execution of Arroyo test suite"
+            elif err.exit_status == 4:
+                assert False, "Pytest command line invocation error"

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,7 +17,7 @@ setup(
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',
-        'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0',
+        'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests'
     ],
     scripts=[],


### PR DESCRIPTION
## Cover letter

This PR adds a ducktape test that runs part of the [arroyo](https://github.com/getsentry/arroyo) test suite (not all of the tests run against a live cluster and we're only interested in those).

In order to avoid forking the tests (which leads to license complications and having to maintain the fork) I've made it such that the environment clones the external repository and runs the tests from there.

Unfortunately, the arroyo tests use pytest, which makes it difficult to deal with logging and error reporting. The approach I've taken is to log all the output from the pytest invocation and to parse that for failures.

Perhaps these test should only run in the nightly. Any opinions on that?

Fixes #4575 

## Notes

[force_push](https://github.com/redpanda-data/redpanda/compare/2c9621660d469d687a36104b2d66131dea374b3b..7397f371c3bb87ae24f019db16b0a1addc8c7ae1):
* use `--depth 1` when cloning the external repo

[force_push](https://github.com/redpanda-data/redpanda/compare/7397f371c3bb87ae24f019db16b0a1addc8c7ae1..591fc4ff284b447aedb564dbeabe3cb66ab11fde):
* pin arroyo to the current tip of main
* remove stray assertion
