### PR TITLE
rpk: sample config to include empty structs

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -45,10 +45,10 @@ redpanda:
   developer_mode: true
 
 # Enable Pandaproxy
-pandaproxy:
+pandaproxy: {}
 
 # Enable Schema Registry
-schema_registry:
+schema_registry: {}
 
 rpk:
   # TLS configuration.


### PR DESCRIPTION
## Cover letter
Sample config file had empty properties:
`pandaproxy` and `schema_registry`; rpk strips them
out due to the omitempty struct tag.

In the past viper assumed the presence of a
property was enough to include it in the file,
that didn't respect the omitempty tag.

Fixes #5494

## Release notes
* The old default redpanda.yaml incorrectly specified the `pandaproxy` and `schema_registry`, and rpk had a bug that always added those sections by default. rpk will no longer add those sections no matter what, but the yaml file also now includes the sections properly by default. Using a new rpk on an old default yaml will no longer add the missing `pandaproxy` and `schema_registry` sections.