### PR TITLE
cloud_storage: Supress warnings when transactional manifest is missing in the bucket

### DIFF
--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -133,6 +133,25 @@ public:
       base_manifest& manifest,
       retry_chain_node& parent);
 
+    /// \brief Download manifest from pre-defined S3 location
+    ///
+    /// Method downloads the manifest and handles backpressure and
+    /// errors. It retries multiple times until timeout excedes.
+    /// The method expects that the manifest might be missing from
+    /// S3 bucket. It behaves exactly the same as 'download_manifest'.
+    /// The only difference is that 'NoSuchKey' error is not logged
+    /// using 'warn' log level.
+    ///
+    /// \param bucket is a bucket name
+    /// \param key is an object key of the manifest
+    /// \param manifest is a manifest to download
+    /// \return future that returns success code
+    ss::future<download_result> maybe_download_manifest(
+      const s3::bucket_name& bucket,
+      const remote_manifest_path& key,
+      base_manifest& manifest,
+      retry_chain_node& parent);
+
     /// \brief Upload manifest to the pre-defined S3 location
     ///
     /// \param bucket is a bucket name
@@ -177,6 +196,13 @@ public:
       const s3::bucket_name& bucket,
       const remote_segment_path& path,
       retry_chain_node& parent);
+
+    ss::future<download_result> do_download_manifest(
+      const s3::bucket_name& bucket,
+      const remote_manifest_path& key,
+      base_manifest& manifest,
+      retry_chain_node& parent,
+      bool expect_missing = false);
 
 private:
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -307,7 +307,7 @@ ss::future<> remote_segment::do_hydrate_txrange() {
 
     tx_range_manifest manifest(_path);
 
-    auto res = co_await _api.download_manifest(
+    auto res = co_await _api.maybe_download_manifest(
       _bucket, manifest.get_manifest_path(), manifest, local_rtc);
 
     if (res == download_result::notfound) {

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -486,7 +486,8 @@ ss::future<> client::shutdown() {
 ss::future<http::client::response_stream_ref> client::get_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout) {
+  const ss::lowres_clock::duration& timeout,
+  bool expect_no_such_key) {
     auto header = _requestor.make_get_object_request(name, key);
     if (!header) {
         return ss::make_exception_future<http::client::response_stream_ref>(
@@ -497,20 +498,28 @@ ss::future<http::client::response_stream_ref> client::get_object(
       "send https request:\n{}",
       http::redacted_header(header.value()));
     return _client.request(std::move(header.value()), timeout)
-      .then([](http::client::response_stream_ref&& ref) {
+      .then([expect_no_such_key](http::client::response_stream_ref&& ref) {
           // here we didn't receive any bytes from the socket and
           // ref->is_header_done() is 'false', we need to prefetch
           // the header first
-          return ref->prefetch_headers().then([ref = std::move(ref)]() mutable {
+          return ref->prefetch_headers().then([ref = std::move(ref),
+                                               expect_no_such_key]() mutable {
               vassert(ref->is_header_done(), "Header is not received");
               if (
                 ref->get_headers().result() != boost::beast::http::status::ok) {
                   // Got error response, consume the response body and produce
                   // rest api error
-                  vlog(
-                    s3_log.warn,
-                    "S3 replied with error: {}",
-                    ref->get_headers());
+                  if (expect_no_such_key) {
+                      vlog(
+                        s3_log.debug,
+                        "S3 replied with expected error: {}",
+                        ref->get_headers());
+                  } else {
+                      vlog(
+                        s3_log.warn,
+                        "S3 replied with error: {}",
+                        ref->get_headers());
+                  }
                   return drain_response_stream(std::move(ref))
                     .then([](iobuf&& res) {
                         return parse_rest_error_response<
@@ -543,7 +552,14 @@ ss::future<client::head_object_result> client::head_object(
             return ref->prefetch_headers().then(
               [ref, key]() -> ss::future<head_object_result> {
                   auto status = ref->get_headers().result();
-                  if (status != boost::beast::http::status::ok) {
+                  if (status == boost::beast::http::status::not_found) {
+                      vlog(
+                        s3_log.debug,
+                        "Object not available, error: {}",
+                        ref->get_headers());
+                      return parse_head_error_response<head_object_result>(
+                        ref->get_headers(), key);
+                  } else if (status != boost::beast::http::status::ok) {
                       vlog(
                         s3_log.warn,
                         "S3 replied with error: {}",

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -185,11 +185,14 @@ public:
     ///
     /// \param name is a bucket name
     /// \param key is an object key
+    /// \param timeout is a timeout of the operation
+    /// \param expect_no_such_key log 404 as warning if set to false
     /// \return future that gets ready after request was sent
     ss::future<http::client::response_stream_ref> get_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout);
+      const ss::lowres_clock::duration& timeout,
+      bool expect_no_such_key = false);
 
     struct head_object_result {
         uint64_t object_size;


### PR DESCRIPTION
## Cover letter

Archival uploads manifests with aborted transactions alongside every segment. These manifests are optional. If the offset range of the segment doesn't have record batches that belong to aborted transactions the manifest wouldn't be uploaded.
Also, all data uploaded by old versions of redpanda doesn't have these manifests. 

The problem appears when redpanda is trying to read a segment that doesn't have a manifest associated to it. It issues 'GetObject' request and gets a reply with 404 code (NoSuchKey error in the reply body). In this case the S3 client logs error message on WARN level. 

To prevent this this PR introduces `maybe_download_manifest` method that works exactly like `download_manifest` but treats missing manifest as a normal situation. 

## UX changes

N/A

## Release notes


* none



### Features

* NA

### Improvements

* Improves logging