### PR TITLE
cmake: bump seastar tag

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 8f98d69bcbd2473eb9915204bd8fd1665e609739
+  GIT_TAG 79a3038e90c45195a0446a067f516f7ff0ada0be
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
Bump seastar commit tag for OSS build to include https://github.com/redpanda-data/seastar/pull/28.