### PR TITLE
reflection/type_traits: use is_specialization_of<> template helper

### DIFF
--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -121,7 +121,7 @@ public:
             // Extract inner value if we are an optional<>,
             // and pass through into numeric_bounds::validate
             using outer_type = std::decay_t<T>;
-            if constexpr (reflection::is_std_optional_v<outer_type>) {
+            if constexpr (reflection::is_std_optional<outer_type>) {
                 if (new_value.has_value()) {
                     return _bounds.validate(new_value.value());
                 } else {
@@ -147,7 +147,7 @@ public:
         // rather than via admin API.
 
         // If T is a std::optional, then need to unpack the value.
-        if constexpr (reflection::is_std_optional_v<outer_type>) {
+        if constexpr (reflection::is_std_optional<outer_type>) {
             if (val.has_value()) {
                 return property<T>::update_value(
                   std::move(_bounds.clamp(val.value())));
@@ -189,7 +189,7 @@ private:
                 guess -= guess % _bounds.align.value();
             }
         } else {
-            if constexpr (reflection::is_std_optional_v<T>) {
+            if constexpr (reflection::is_std_optional<T>) {
                 if (property<T>::_default.has_value()) {
                     guess = property<T>::_default.value();
                 } else {

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -382,7 +382,7 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::is_same_v<type, bool>) {
         // boolean check must come before is_integral check
         return "boolean";
-    } else if constexpr (reflection::is_std_optional_v<type>) {
+    } else if constexpr (reflection::is_std_optional<type>) {
         return property_type_name<typename type::value_type>();
     } else if constexpr (is_collection<type>) {
         return property_type_name<typename type::value_type>();
@@ -440,7 +440,7 @@ consteval std::string_view property_units_name() {
         return "ms";
     } else if constexpr (std::is_same_v<type, std::chrono::seconds>) {
         return "s";
-    } else if constexpr (reflection::is_std_optional_v<type>) {
+    } else if constexpr (reflection::is_std_optional<type>) {
         return property_units_name<typename type::value_type>();
     } else {
         // This will be transformed to nullopt at runtime: returning
@@ -471,7 +471,7 @@ std::optional<std::string_view> property<T>::units_name() const {
 
 template<typename T>
 bool property<T>::is_nullable() const {
-    if constexpr (reflection::is_std_optional_v<std::decay_t<T>>) {
+    if constexpr (reflection::is_std_optional<std::decay_t<T>>) {
         return true;
     } else {
         return false;

--- a/src/v/pandaproxy/parsing/from_chars.h
+++ b/src/v/pandaproxy/parsing/from_chars.h
@@ -50,11 +50,11 @@ public:
     using type = std::decay_t<T>;
     using result_type = result<type>;
 
-    static constexpr bool is_optional = reflection::is_std_optional_v<type>;
-    static constexpr bool is_named_type = reflection::is_named_type_v<type>;
+    static constexpr bool is_optional = reflection::is_std_optional<type>;
+    static constexpr bool is_named_type = reflection::is_rp_named_type<type>;
     static constexpr bool is_duration = detail::is_duration_v<type>;
     static constexpr bool is_arithmetic = std::is_arithmetic_v<type>;
-    static constexpr bool is_ss_bool = reflection::is_ss_bool_v<type>;
+    static constexpr bool is_ss_bool = reflection::is_ss_bool_class<type>;
     static constexpr bool is_constructible_from_string_view
       = std::is_constructible_v<type, std::string_view>;
     static constexpr bool is_constructible_from_sstring

--- a/src/v/pandaproxy/parsing/httpd.h
+++ b/src/v/pandaproxy/parsing/httpd.h
@@ -32,7 +32,7 @@ namespace ppj = pandaproxy::json;
 
 template<typename T>
 T parse_param(std::string_view type, std::string_view key, ss::sstring value) {
-    if (!reflection::is_std_optional_v<T> && value.empty()) {
+    if (!reflection::is_std_optional<T> && value.empty()) {
         throw error(
           error_code::empty_param,
           fmt::format("Missing mandatory {} '{}'", type, key));

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -30,10 +30,10 @@ namespace reflection {
 template<typename T>
 struct adl {
     using type = std::remove_reference_t<std::decay_t<T>>;
-    static constexpr bool is_optional = is_std_optional_v<type>;
+    static constexpr bool is_optional = is_std_optional<type>;
     static constexpr bool is_sstring = std::is_same_v<type, ss::sstring>;
-    static constexpr bool is_vector = is_std_vector_v<type>;
-    static constexpr bool is_named_type = is_named_type_v<type>;
+    static constexpr bool is_vector = is_std_vector<type>;
+    static constexpr bool is_named_type = is_rp_named_type<type>;
     static constexpr bool is_iobuf = std::is_same_v<type, iobuf>;
     static constexpr bool is_standard_layout = std::is_standard_layout_v<type>;
     static constexpr bool is_not_floating_point
@@ -41,12 +41,12 @@ struct adl {
     static constexpr bool is_trivially_copyable
       = std::is_trivially_copyable_v<type>;
     static constexpr bool is_enum = std::is_enum_v<T>;
-    static constexpr bool is_ss_bool = is_ss_bool_v<T>;
+    static constexpr bool is_ss_bool = is_ss_bool_class<T>;
     static constexpr bool is_chrono_milliseconds
       = std::is_same_v<type, std::chrono::milliseconds>;
     static constexpr bool is_time_point
       = std::is_same_v<type, ss::lowres_system_clock::time_point>;
-    static constexpr bool is_circular_buffer = is_ss_circular_buffer_v<type>;
+    static constexpr bool is_circular_buffer = is_ss_circular_buffer<type>;
 
     static_assert(
       is_optional || is_sstring || is_vector || is_named_type || is_iobuf

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -22,48 +22,38 @@
 #include <type_traits>
 #include <vector>
 
+namespace detail {
+
+template<typename T, template<typename...> class C>
+struct is_specialization_of : std::false_type {};
+template<template<typename...> class C, typename... Args>
+struct is_specialization_of<C<Args...>, C> : std::true_type {};
+template<typename T, template<typename...> class C>
+inline constexpr bool is_specialization_of_v
+  = is_specialization_of<T, C>::value;
+
+} // namespace detail
+
 namespace reflection {
 
 template<typename T>
-struct is_std_vector : std::false_type {};
-template<typename... Args>
-struct is_std_vector<std::vector<Args...>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_std_vector_v = is_std_vector<T>::value;
+concept is_std_vector = ::detail::is_specialization_of_v<T, std::vector>;
 
 template<typename T>
-struct is_ss_circular_buffer : std::false_type {};
-template<typename... Args>
-struct is_ss_circular_buffer<ss::circular_buffer<Args...>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_ss_circular_buffer_v = is_ss_circular_buffer<T>::value;
+concept is_ss_circular_buffer
+  = ::detail::is_specialization_of_v<T, ss::circular_buffer>;
 
 template<typename T>
-struct is_std_optional : std::false_type {};
-template<typename... Args>
-struct is_std_optional<std::optional<Args...>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_std_optional_v = is_std_optional<T>::value;
+concept is_std_optional = ::detail::is_specialization_of_v<T, std::optional>;
 
 template<typename T>
-struct is_named_type : std::false_type {};
-template<typename T, typename Tag>
-struct is_named_type<named_type<T, Tag>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_named_type_v = is_named_type<T>::value;
+concept is_rp_named_type
+  = ::detail::is_specialization_of_v<T, ::detail::base_named_type>;
 
 template<typename T>
-struct is_ss_bool : std::false_type {};
-template<typename T>
-struct is_ss_bool<ss::bool_class<T>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_ss_bool_v = is_ss_bool<T>::value;
+concept is_ss_bool_class = ::detail::is_specialization_of_v<T, ss::bool_class>;
 
 template<typename T>
-struct is_tristate : std::false_type {};
-template<typename T>
-struct is_tristate<tristate<T>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_tristate_v = is_tristate<T>::value;
+concept is_tristate = ::detail::is_specialization_of_v<T, tristate>;
 
 } // namespace reflection

--- a/src/v/serde/test/fuzz.cc
+++ b/src/v/serde/test/fuzz.cc
@@ -71,7 +71,7 @@ void init(
            },
            t.template get_generation<Generation>())),
          ...);
-    } else if constexpr (reflection::is_std_optional_v<T>) {
+    } else if constexpr (reflection::is_std_optional<T>) {
         if (
           depth != max_depth
           && gen.get<std::uint8_t>()
@@ -81,7 +81,7 @@ void init(
         } else {
             t = std::nullopt;
         }
-    } else if constexpr (reflection::is_std_vector_v<T>) {
+    } else if constexpr (reflection::is_std_vector<T>) {
         if (depth != max_depth) {
             t.resize(gen.get<uint8_t>() % max_vector_size);
             for (auto& v : t) {


### PR DESCRIPTION
## Cover letter

this change is a cleanup.

use is_specialization_of<> template helper to check if a class
is a specliazation of a container template classs.

this change is inspired by http://wg21.link/p2098. the only thing
we are missing is, as pointed out by the proposal, the support for
templates like std::array<> and is_fragmented_vector<>.

also an intermediate solution is implemented for `std::array<>`
like template classes before C++ introduces a core change
like "auto" template argument type to unify the class and non-type
argument.

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed. 

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
