### PR TITLE
Change to reporting the number of configured replicas

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -95,6 +95,7 @@ v_cc_library(
     drain_manager.cc
     read_replica_manager.cc
     partition_balancer_planner.cc
+    probed_topic_metadata.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -31,6 +31,7 @@ class members_manager;
 class members_table;
 class metadata_cache;
 class metadata_dissemination_service;
+class probed_topic_metadata;
 class security_frontend;
 class controller_api;
 class members_frontend;

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -212,12 +212,6 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
            topic_label(ntp.tp.topic()),
            partition_label(ntp.tp.partition())})
           .aggregate({sm::shard_label, partition_label}),
-        sm::make_gauge(
-          "replicas",
-          [this] { return _partition._raft->get_follower_count(); },
-          sm::description("Number of replicas per topic"),
-          labels)
-          .aggregate({sm::shard_label, partition_label}),
       });
 }
 

--- a/src/v/cluster/probed_topic_metadata.cc
+++ b/src/v/cluster/probed_topic_metadata.cc
@@ -1,0 +1,100 @@
+#include "cluster/probed_topic_metadata.h"
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cluster {
+
+probed_topic_metadata::probed_topic_metadata(topic_metadata md) noexcept
+  : _topic_metadata(std::move(md))
+  , _public_metrics(ssx::metrics::public_metrics_handle) {
+    setup_metrics();
+}
+
+probed_topic_metadata::probed_topic_metadata(
+  probed_topic_metadata&& other) noexcept
+  : _topic_metadata(std::move(other._topic_metadata))
+  , _public_metrics(std::move(other._public_metrics)) {
+    setup_metrics();
+}
+
+bool probed_topic_metadata::is_topic_replicable() const {
+    return _topic_metadata.is_topic_replicable();
+}
+
+model::revision_id probed_topic_metadata::get_revision() const {
+    return _topic_metadata.get_revision();
+}
+
+std::optional<model::initial_revision_id>
+probed_topic_metadata::get_remote_revision() const {
+    return _topic_metadata.get_remote_revision();
+}
+
+const model::topic& probed_topic_metadata::get_source_topic() const {
+    return _topic_metadata.get_source_topic();
+}
+
+const topic_configuration& probed_topic_metadata::get_configuration() const {
+    return _topic_metadata.get_configuration();
+}
+
+topic_configuration& probed_topic_metadata::get_configuration() {
+    return _topic_metadata.get_configuration();
+}
+
+const assignments_set& probed_topic_metadata::get_assignments() const {
+    return _topic_metadata.get_assignments();
+}
+
+assignments_set& probed_topic_metadata::get_assignments() {
+    return _topic_metadata.get_assignments();
+}
+
+topic_metadata& probed_topic_metadata::get_topic_metadata() {
+    return _topic_metadata;
+}
+
+const topic_metadata& probed_topic_metadata::get_topic_metadata() const {
+    return _topic_metadata;
+}
+
+void probed_topic_metadata::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (ss::this_shard_id() != 0) {
+        return;
+    }
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    if (!is_topic_replicable()) {
+        return;
+    }
+
+    _public_metrics.clear();
+
+    auto tp_ns = _topic_metadata.get_configuration().tp_ns;
+    std::vector<sm::label_instance> labels = {
+      sm::label("rp_namespace")(tp_ns.ns()), sm::label("rp_topic")(tp_ns.tp())};
+
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka"),
+      {
+        sm::make_gauge(
+          "replicas",
+          [this] {
+              return _topic_metadata.get_configuration().replication_factor;
+          },
+          sm::description("Number of configured replicas per topic"),
+          labels)
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/probed_topic_metadata.h
+++ b/src/v/cluster/probed_topic_metadata.h
@@ -1,0 +1,35 @@
+#include "cluster/types.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace cluster {
+
+class probed_topic_metadata {
+public:
+    probed_topic_metadata(topic_metadata md) noexcept;
+    probed_topic_metadata(probed_topic_metadata&&) noexcept;
+
+    bool is_topic_replicable() const;
+    model::revision_id get_revision() const;
+
+    std::optional<model::initial_revision_id> get_remote_revision() const;
+    const model::topic& get_source_topic() const;
+
+    const topic_configuration& get_configuration() const;
+    topic_configuration& get_configuration();
+
+    const assignments_set& get_assignments() const;
+    assignments_set& get_assignments();
+
+    topic_metadata& get_topic_metadata();
+    const topic_metadata& get_topic_metadata() const;
+
+private:
+    void setup_metrics();
+
+private:
+    topic_metadata _topic_metadata;
+    ss::metrics::metric_groups _public_metrics;
+};
+
+} // namespace cluster

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -203,7 +203,7 @@ public:
     }
 
     void populate_all_topics_with_data() {
-        auto md = get_local_cache(model::node_id(0)).all_topics_metadata();
+        auto& md = get_local_cache(model::node_id(0)).all_topics_metadata();
         for (auto& [tp_ns, topic_metadata] : md) {
             for (auto& p : topic_metadata.get_assignments()) {
                 model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -18,7 +18,7 @@ using namespace std::chrono_literals;
 
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -56,7 +56,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
                      model::offset(0))
                    .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
     BOOST_REQUIRE(md.contains(make_tp_ns("test_tp_1")));
 

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -81,7 +81,7 @@ constexpr uint64_t max_cluster_capacity() {
 FIXTURE_TEST(
   test_dispatching_happy_path_create, topic_table_updates_dispatcher_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -128,7 +128,7 @@ FIXTURE_TEST(
                                    .get0())
                    .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
 
     BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_1")), true);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/non_replicable_topics_frontend.h"
+#include "cluster/probed_topic_metadata.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
@@ -51,7 +52,7 @@ public:
 
     using underlying_t = absl::flat_hash_map<
       model::topic_namespace,
-      topic_metadata,
+      probed_topic_metadata,
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
     using hierarchy_t = absl::node_hash_map<

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -10,6 +10,7 @@
 #include "cluster/types.h"
 
 #include "cluster/fwd.h"
+#include "cluster/probed_topic_metadata.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -327,6 +328,9 @@ topic_metadata::topic_metadata(
   , _source_topic(st)
   , _revision(rid)
   , _remote_revision(remote_revision_id) {}
+
+topic_metadata::topic_metadata(const probed_topic_metadata& probed) noexcept
+  : topic_metadata(probed.get_topic_metadata()) {}
 
 bool topic_metadata::is_topic_replicable() const {
     return _source_topic.has_value() == false;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2257,6 +2257,8 @@ public:
       model::topic,
       std::optional<model::initial_revision_id> = std::nullopt) noexcept;
 
+    topic_metadata(const probed_topic_metadata&) noexcept;
+
     bool is_topic_replicable() const;
     model::revision_id get_revision() const;
     std::optional<model::initial_revision_id> get_remote_revision() const;


### PR DESCRIPTION
N.B.: This is a bug fix. It should not block cutting an RC.

## Cover letter

The original intention was for `redpanda_kafka_replicas` to report the number of configured replicas.
I misunderstood the requirement the first time around and this PR fixes the metric.

In order to gain access to the configuration of the topic a wrapper type for `topic_metadata` is introduced.
This wrapper type holds the `topic_metadata` object and inserts a probe into it. Instead of storing
`topic_metadata` objects in the `topic_table`,  `probed_topic_metadata` instances are stored.

I'm not certain that this is the best way to go about it, so suggestions are welcome.