### PR TITLE
serde/type_str: drop MSVC bits

### DIFF
--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -816,3 +816,16 @@ SEASTAR_THREAD_TEST_CASE(absl_node_hash_set) {
 }
 
 SEASTAR_THREAD_TEST_CASE(absl_btree_set) { set_test<absl::btree_set>(); }
+
+struct foo_bar {};
+
+SEASTAR_THREAD_TEST_CASE(type_str) {
+    BOOST_CHECK_EQUAL(serde::type_str<int>(), "int");
+    BOOST_CHECK_EQUAL(serde::type_str<void>(), "void");
+    // the type part of a parameter in __PRETTY_FUNCTION__ may vary when it
+    // comes to a specialization of a template in standard library, but
+    // std::basic_string<char> should always have "string" in its name
+    BOOST_CHECK_NE(
+      serde::type_str<std::string>().find("string"), std::string_view::npos);
+    BOOST_CHECK_EQUAL(serde::type_str<foo_bar>(), "foo_bar");
+}

--- a/src/v/serde/type_str.h
+++ b/src/v/serde/type_str.h
@@ -13,33 +13,21 @@
 
 namespace serde {
 
-#if defined(_MSC_VER)
-#define SERDE_SIG __FUNCSIG__
-#elif defined(__clang__) || defined(__GNUC__)
-#define SERDE_SIG __PRETTY_FUNCTION__
-#else
-#error unsupported compiler
-#endif
-
 template<typename T>
-constexpr std::string_view type_str() {
+consteval std::string_view type_str() {
 #if defined(__clang__)
     constexpr std::string_view prefix
       = "std::string_view serde::type_str() [T = ";
     constexpr std::string_view suffix = "]";
-#elif defined(_MSC_VER)
+#elif defined(__GNUC__)
     constexpr std::string_view prefix
-      = "class std::basic_string_view<char,struct std::char_traits<char> > "
-        "__cdecl serde::type_str<";
-    constexpr std::string_view suffix = ">(void)";
-#else
-    constexpr std::string_view prefix
-      = "constexpr std::string_view serde::type_str() [with T = ";
+      = "consteval std::string_view serde::type_str() [with T = ";
     constexpr std::string_view suffix
       = "; std::string_view = std::basic_string_view<char>]";
+#else
+#error unsupported compiler
 #endif
-
-    auto sig = std::string_view{SERDE_SIG};
+    auto sig = std::string_view{__PRETTY_FUNCTION__};
     sig.remove_prefix(prefix.size());
     sig.remove_suffix(suffix.size());
     return sig;


### PR DESCRIPTION
* we are not likely to compile redpanda using MSVC compiler. probably
  we would be able to compile using GCC in future. so drop
  the branch checking MSVC.
* also replace SERDE_SIG macro with __PRETTY_FUNCTION__. simpler this way.
* s/constexpr/consteval/ to make it explicit that `type_str()`
  *always* returns a compile-time constant

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed. 

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
