### PR TITLE
Make redpanda_kafka_replicas report configured replicas

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -104,6 +104,7 @@ v_cc_library(
     partition_balancer_planner.cc
     partition_balancer_backend.cc
     partition_balancer_rpc_handler.cc
+    topic_metadata_item.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -305,7 +305,11 @@ void partition_balancer_planner::get_unavailable_nodes_reassignments(
                     continue;
                 }
                 auto new_allocation_units = get_reallocation(
-                  a, t.second.metadata, partition_size.value(), false, rrs);
+                  a,
+                  t.second.get_metadata(),
+                  partition_size.value(),
+                  false,
+                  rrs);
                 if (new_allocation_units) {
                     result.reassignments.emplace_back(ntp_reassignments{
                       .ntp = ntp,
@@ -384,7 +388,7 @@ void partition_balancer_planner::get_full_node_reassignments(
             }
             auto new_allocation_units = get_reallocation(
               *current_assignments,
-              topic_metadata.metadata,
+              topic_metadata.get_metadata(),
               ntp_size_it->first,
               true,
               rrs);

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -212,12 +212,6 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
            topic_label(ntp.tp.topic()),
            partition_label(ntp.tp.partition())})
           .aggregate({sm::shard_label, partition_label}),
-        sm::make_gauge(
-          "replicas",
-          [this] { return _partition.raft()->get_follower_count(); },
-          sm::description("Number of replicas per topic"),
-          labels)
-          .aggregate({sm::shard_label, partition_label}),
       });
 }
 

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -207,7 +207,7 @@ public:
     }
 
     void populate_all_topics_with_data() {
-        auto md = get_local_cache(model::node_id(0)).all_topics_metadata();
+        auto& md = get_local_cache(model::node_id(0)).all_topics_metadata();
         for (auto& [tp_ns, topic_metadata] : md) {
             for (auto& p : topic_metadata.get_assignments()) {
                 model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -20,7 +20,7 @@ using namespace std::chrono_literals;
 
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -58,7 +58,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
                      model::offset(0))
                    .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
     BOOST_REQUIRE(md.contains(make_tp_ns("test_tp_1")));
 

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -177,11 +177,11 @@ void validate_brokers_revisions(
     auto tp_it = all_metadata.find(model::topic_namespace_view(ntp));
     BOOST_REQUIRE(tp_it != all_metadata.end());
 
-    auto p_it = tp_it->second.metadata.get_assignments().find(ntp.tp.partition);
-    BOOST_REQUIRE(p_it != tp_it->second.metadata.get_assignments().end());
+    auto p_it = tp_it->second.get_assignments().find(ntp.tp.partition);
+    BOOST_REQUIRE(p_it != tp_it->second.get_assignments().end());
 
-    auto rev_it = tp_it->second.replica_revisions.find(ntp.tp.partition);
-    BOOST_REQUIRE(rev_it != tp_it->second.replica_revisions.end());
+    auto rev_it = tp_it->second.get_replica_revisions().find(ntp.tp.partition);
+    BOOST_REQUIRE(rev_it != tp_it->second.get_replica_revisions().end());
 
     for (auto& bs : p_it->replicas) {
         fmt::print("replica: {}\n", bs);

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -81,7 +81,7 @@ constexpr uint64_t max_cluster_capacity() {
 FIXTURE_TEST(
   test_dispatching_happy_path_create, topic_table_updates_dispatcher_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -128,7 +128,7 @@ FIXTURE_TEST(
                                    .get0())
                    .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
 
     BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_1")), true);

--- a/src/v/cluster/topic_metadata_item.cc
+++ b/src/v/cluster/topic_metadata_item.cc
@@ -10,35 +10,116 @@
  */
 #include "cluster/topic_metadata_item.h"
 
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
+
 namespace cluster {
 
+topic_metadata_item::topic_metadata_item(topic_metadata metadata) noexcept
+  : _metadata(std::move(metadata)) {
+    setup_metrics();
+}
+
+topic_metadata_item::topic_metadata_item(topic_metadata_item&& other) noexcept
+  : _metadata(std::move(other._metadata))
+  , _replica_revisions(std::move(other._replica_revisions))
+  , _public_metrics(std::move(other._public_metrics)) {
+    setup_metrics();
+}
+
+topic_metadata_item&
+topic_metadata_item::operator=(topic_metadata_item&& other) noexcept {
+    _metadata = std::move(other._metadata);
+    _replica_revisions = std::move(other._replica_revisions);
+    _public_metrics = std::move(other._public_metrics);
+
+    setup_metrics();
+
+    return *this;
+}
+
+const topic_metadata& topic_metadata_item::get_metadata() const {
+    return _metadata;
+}
+
+topic_metadata& topic_metadata_item::get_metadata() { return _metadata; }
+
+const replica_revisions& topic_metadata_item::get_replica_revisions() const {
+    return _replica_revisions;
+}
+
+replica_revisions& topic_metadata_item::get_replica_revisions() {
+    return _replica_revisions;
+}
+
 bool topic_metadata_item::is_topic_replicable() const {
-    return metadata.is_topic_replicable();
+    return _metadata.is_topic_replicable();
 }
 
 assignments_set& topic_metadata_item::get_assignments() {
-    return metadata.get_assignments();
+    return _metadata.get_assignments();
 }
 
 const assignments_set& topic_metadata_item::get_assignments() const {
-    return metadata.get_assignments();
+    return _metadata.get_assignments();
 }
+
 model::revision_id topic_metadata_item::get_revision() const {
-    return metadata.get_revision();
+    return _metadata.get_revision();
 }
+
 std::optional<model::initial_revision_id>
 topic_metadata_item::get_remote_revision() const {
-    return metadata.get_remote_revision();
+    return _metadata.get_remote_revision();
 }
+
 const model::topic& topic_metadata_item::get_source_topic() const {
-    return metadata.get_source_topic();
+    return _metadata.get_source_topic();
 }
 
 const topic_configuration& topic_metadata_item::get_configuration() const {
-    return metadata.get_configuration();
+    return _metadata.get_configuration();
 }
+
 topic_configuration& topic_metadata_item::get_configuration() {
-    return metadata.get_configuration();
+    return _metadata.get_configuration();
+}
+
+void topic_metadata_item::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (ss::this_shard_id() != 0) {
+        return;
+    }
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    if (!is_topic_replicable()) {
+        return;
+    }
+
+    _public_metrics.clear();
+
+    auto tp_ns = get_configuration().tp_ns;
+    std::vector<sm::label_instance> labels = {
+      ssx::metrics::make_namespaced_label("namespace")(tp_ns.ns()),
+      ssx::metrics::make_namespaced_label("topic")(tp_ns.tp())};
+
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka"),
+      {
+        sm::make_gauge(
+          "replicas",
+          [this] { return get_configuration().replication_factor; },
+          sm::description("Number of configured replicas per topic"),
+          labels)
+          .aggregate({sm::shard_label}),
+      });
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_metadata_item.cc
+++ b/src/v/cluster/topic_metadata_item.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/topic_metadata_item.h"
+
+namespace cluster {
+
+bool topic_metadata_item::is_topic_replicable() const {
+    return metadata.is_topic_replicable();
+}
+
+assignments_set& topic_metadata_item::get_assignments() {
+    return metadata.get_assignments();
+}
+
+const assignments_set& topic_metadata_item::get_assignments() const {
+    return metadata.get_assignments();
+}
+model::revision_id topic_metadata_item::get_revision() const {
+    return metadata.get_revision();
+}
+std::optional<model::initial_revision_id>
+topic_metadata_item::get_remote_revision() const {
+    return metadata.get_remote_revision();
+}
+const model::topic& topic_metadata_item::get_source_topic() const {
+    return metadata.get_source_topic();
+}
+
+const topic_configuration& topic_metadata_item::get_configuration() const {
+    return metadata.get_configuration();
+}
+topic_configuration& topic_metadata_item::get_configuration() {
+    return metadata.get_configuration();
+}
+
+} // namespace cluster

--- a/src/v/cluster/topic_metadata_item.h
+++ b/src/v/cluster/topic_metadata_item.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/types.h"
+#include "model/fundamental.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace cluster {
+
+/**
+ * Replicas revision map is used to track revision of brokers in a replica
+ * set. When a node is added into replica set its gets the revision assigned
+ */
+using replicas_revision_map
+  = absl::flat_hash_map<model::node_id, model::revision_id>;
+
+struct topic_metadata_item {
+    topic_metadata metadata;
+    // replicas revisions for each partition
+    absl::node_hash_map<model::partition_id, replicas_revision_map>
+      replica_revisions;
+
+    bool is_topic_replicable() const;
+
+    assignments_set& get_assignments();
+    const assignments_set& get_assignments() const;
+
+    model::revision_id get_revision() const;
+
+    std::optional<model::initial_revision_id> get_remote_revision() const;
+
+    const model::topic& get_source_topic() const;
+
+    const topic_configuration& get_configuration() const;
+    topic_configuration& get_configuration();
+};
+
+} // namespace cluster

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -25,7 +25,7 @@
 namespace cluster {
 
 template<typename Func>
-std::vector<std::invoke_result_t<Func, const topic_table::topic_metadata_item&>>
+std::vector<std::invoke_result_t<Func, const topic_metadata_item&>>
 topic_table::transform_topics(Func&& f) const {
     std::vector<std::invoke_result_t<Func, const topic_metadata_item&>> ret;
     ret.reserve(_topics.size());

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/non_replicable_topics_frontend.h"
+#include "cluster/topic_metadata_item.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
@@ -41,53 +42,12 @@ public:
         cancel_requested,
         force_cancel_requested
     };
-    /**
-     * Replicas revision map is used to track revision of brokers in a replica
-     * set. When a node is added into replica set its gets the revision assigned
-     */
-    using replicas_revision_map
-      = absl::flat_hash_map<model::node_id, model::revision_id>;
 
     struct in_progress_update {
         std::vector<model::broker_shard> previous_replicas;
         in_progress_state state;
         model::revision_id update_revision;
         replicas_revision_map replicas_revisions;
-    };
-
-    struct topic_metadata_item {
-        topic_metadata metadata;
-        // replicas revisions for each partition
-        absl::node_hash_map<model::partition_id, replicas_revision_map>
-          replica_revisions;
-
-        bool is_topic_replicable() const {
-            return metadata.is_topic_replicable();
-        }
-
-        assignments_set& get_assignments() {
-            return metadata.get_assignments();
-        }
-
-        const assignments_set& get_assignments() const {
-            return metadata.get_assignments();
-        }
-        model::revision_id get_revision() const {
-            return metadata.get_revision();
-        }
-        std::optional<model::initial_revision_id> get_remote_revision() const {
-            return metadata.get_remote_revision();
-        }
-        const model::topic& get_source_topic() const {
-            return metadata.get_source_topic();
-        }
-
-        const topic_configuration& get_configuration() const {
-            return metadata.get_configuration();
-        }
-        topic_configuration& get_configuration() {
-            return metadata.get_configuration();
-        }
     };
 
     using delta = topic_table_delta;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -232,7 +232,7 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
                   authz_quiet{true})) {
                 continue;
             }
-            res.push_back(make_topic_response(ctx, request, md.metadata));
+            res.push_back(make_topic_response(ctx, request, md.get_metadata()));
         }
 
         return ss::make_ready_future<std::vector<metadata_response::topic>>(


### PR DESCRIPTION
N.B.: This is a bug fix. It should not block cutting an RC.

## Cover letter

The original intention was for `redpanda_kafka_replicas` to report the number of configured replicas.
I misunderstood the requirement the first time around and this PR fixes the metric.

In order to gain access to the configuration of the topic, I've inserted a probe in the recently added
`topic_metadata_item`. I've also lifted the definition of `topic_metadata_item` into its own file to avoid
cluttering the topic table too much.

I'm not certain that this is the best way to go about it, so suggestions are welcome.

## Release notes

* none