### PR TITLE
rpk redpanda config set: improve setting arrays

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -49,18 +49,36 @@ func set(fs afero.Fs) *cobra.Command {
 	)
 	c := &cobra.Command{
 		Use:   "set <key> <value>",
-		Short: "Set configuration values, such as the node IDs or the list of seed servers",
-		Long: `Set configuration values, such as the node IDs or the list of seed servers
+		Short: "Set configuration values, such as the redpanda node ID or the list of seed servers",
+		Long: `Set configuration values, such as the redpanda node ID or the list of seed servers
 
-You can pass a key that represents the configuration property name, if it's a 
-nested property you should pass the group/category where it belongs, e.g:
+This command modifies the redpanda.yaml you have locally on disk. The first
+argument is the key within the yaml representing a property / field that you
+would like to set. Nested fields can be accessed through a dot:
 
   rpk redpanda config set redpanda.developer_mode true
 
-if --format is not used, rpk will use yaml as default, you can also pass
-partial json/yaml config objects:
+The default format is to parse the value as yaml. Individual specific fields
+can be set, or full structs:
+
+  rpk redpanda config set rpk.tune_disk_irq true
+  rpk redpanda config set redpanda.rpc_server '{address: 3.250.158.1, port: 9092}'
+
+You can set an entire array by wrapping all items with braces, or by using one
+struct:
+
+  rpk redpanda config set redpanda.advertised_kafka_api '[{address: 0.0.0.0, port: 9092}]'
+  rpk redpanda config set redpanda.advertised_kafka_api '{address: 0.0.0.0, port: 9092}' # same
+
+Indexing can be used to set specific items in an array. You can index one past
+the end of an array to extend it:
+
+  rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 0.0.0.0, port: 9092}'
+
+The json format can be used to set values as json:
 
   rpk redpanda config set redpanda.rpc_server '{"address":"0.0.0.0","port":33145}' --format json
+
 `,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -466,7 +466,7 @@ func (k *KafkaClient) UnmarshalYAML(n *yaml.Node) error {
 		SASLMechanism *weakString            `yaml:"sasl_mechanism"`
 		SCRAMUsername *weakString            `yaml:"scram_username"`
 		SCRAMPassword *weakString            `yaml:"scram_password"`
-		Other         map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+		Other         map[string]interface{} `yaml:",inline"`
 	}
 	if err := n.Decode(&internal); err != nil {
 		return err
@@ -504,7 +504,7 @@ func (s *ServerTLS) UnmarshalYAML(n *yaml.Node) error {
 		TruststoreFile    weakString             `yaml:"truststore_file"`
 		Enabled           weakBool               `yaml:"enabled"`
 		RequireClientAuth weakBool               `yaml:"require_client_auth"`
-		Other             map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+		Other             map[string]interface{} `yaml:",inline"`
 	}
 	if err := n.Decode(&internal); err != nil {
 		return err
@@ -574,8 +574,8 @@ func (sa *SocketAddress) UnmarshalYAML(n *yaml.Node) error {
 func (nsa *NamedSocketAddress) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
 		Name    weakString `yaml:"name"`
-		Address weakString `yaml:"address" mapstructure:"address"`
-		Port    weakInt    `yaml:"port" mapstructure:"port"`
+		Address weakString `yaml:"address"`
+		Port    weakInt    `yaml:"port"`
 	}
 
 	if err := n.Decode(&internal); err != nil {


### PR DESCRIPTION
Recent rpk improvements now initialize index 0 of a slice if the key we
are setting is deeply inside the slice. e.g., foo.bar.baz would
initialize bar[0] to set baz. However, it was not possible to set
foo.bar[1]. This change fixes that. We also allow setting one past the
end of an array to extend it: if foo.bar[0] exists, then foo.bar[1].baz
adds to the array.

Old rpk never had the ability to set an array key to a single value that
was not wrapped in brackets. For example, `foo.bar = "baz"` would not
work if bar was an array. Now, we use / initialize element 0 and set
that.

Fixes #2958
Fixes #5498
Fixes #5264



## Release notes

### Features

* `rpk redpanda config set` can now modify any element in an array through indexing semantics: `rpk redpanda config set rpk.kafka_api.brokers[1] = "127.0.0.1:9092` modifies the second broker (0 based indexing). Setting one-past-the-end extends the array by one.
* `rpk redpanda config set` now unmarshals single elements as arrays with one element