### PR TITLE
Fix json -> object mapping in cluster health

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -20,7 +20,7 @@ type ClusterHealthOverview struct {
 	ControllerID         int      `json:"controller_id"`
 	AllNodes             []int    `json:"all_nodes"`
 	NodesDown            []int    `json:"nodes_down"`
-	LeaderlessPartitions []string `json:"leaderless_partition"`
+	LeaderlessPartitions []string `json:"leaderless_partitions"`
 }
 
 func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview, error) {


### PR DESCRIPTION
rpk cluster health would never show any leaderless partitoins because
of a missing s in the json mapping: leaderless_partition (incorrect) vs
leaderless_partitions (correct).

Fixes #5521.