### PR TITLE
Show the list of all nodes in rpk health

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -93,8 +93,9 @@ func printHealthOverview(hov *admin.ClusterHealthOverview) {
 	out.Section("CLUSTER HEALTH OVERVIEW")
 	overviewFormat := `Healthy:               %v
 Controller ID:         %v
+All nodes:             %v
 Nodes down:            %v
 Leaderless partitions: %v
 `
-	fmt.Printf(overviewFormat, hov.IsHealthy, hov.ControllerID, hov.NodesDown, hov.LeaderlessPartitions)
+	fmt.Printf(overviewFormat, hov.IsHealthy, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions)
 }


### PR DESCRIPTION
rpk cluster health doesn't show the full list of nodes currenlty, which
can  make some failure scenarios (especially, nodes not successfully
joining the cluster) hard to diagose.

The full node list is already available on the health endpoint, so let us
simply display it.

Fixes #5518.