### PR TITLE
rpk: Add option to generate scrape_config for both metrics endpoints

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -13,14 +13,11 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -58,12 +55,6 @@ directly. Otherwise, 'rpk generate prometheus-conf' will read the redpanda
 config file and use the node IP configured there. --config may be passed to
 specify an arbitrary config file.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			log.SetFormatter(cli.NewNoopFormatter())
-			// The logger's default stream is stderr, which prevents piping to files
-			// from working without redirecting them with '2>&1'.
-			if log.StandardLogger().Out == os.Stderr {
-				log.SetOutput(os.Stdout)
-			}
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
@@ -75,7 +66,7 @@ specify an arbitrary config file.`,
 				seedAddr,
 			)
 			out.MaybeDieErr(err)
-			log.Infof("\n%s", string(yml))
+			fmt.Println(string(yml))
 		},
 	}
 	command.Flags().StringVar(


### PR DESCRIPTION
## Cover letter

Adds the option to generate prometheus `scrape_config` for both `/metrics` and `/public_metrics` endpoints using `--public-metrics ` flag:

``` yaml
# Default:
$ rpk generate prometheus-config --job-name redpanda-metrics-test --node-addrs 'localhost:9644' 
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
  metrics_path: /public_metrics

# Both endpoints:
$ rpk generate prometheus-config --job-name redpanda-metrics-test --node-addrs 'localhost:9644' --internal-metrics
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
  metrics_path: /public_metrics
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
  metrics_path: /metrics

```
Fixes #5501 

## Release notes
* `rpk` now has an option to generate `scrape_config` for both `/metrics` and `/public_metrics` endpoints using the `--internal-metrics` flag
