### PR TITLE
cloud_storage: Fix race condition in topic recovery

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -243,6 +243,13 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
             if (part->get_ntp_config().is_read_replica_mode_enabled()) {
                 archiver->run_sync_manifest_loop();
             } else {
+                if (ntp.tp.partition == 0) {
+                    // Upload manifest once per topic. GCS has strict
+                    // limits for single object updates.
+                    ssx::background = upload_topic_manifest(
+                      model::topic_namespace(ntp.ns, ntp.tp.topic),
+                      archiver->get_revision_id());
+                }
                 _probe.start_archiving_ntp();
                 archiver->run_upload_loop();
             }
@@ -263,7 +270,7 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
                 if (ntp.tp.partition == 0) {
                     // Upload manifest once per topic. GCS has strict
                     // limits for single object updates.
-                    (void)upload_topic_manifest(
+                    ssx::background = upload_topic_manifest(
                       model::topic_namespace(ntp.ns, ntp.tp.topic),
                       archiver->get_revision_id());
                 }

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -302,25 +302,6 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
           target.get_manifest_path());
     }
 
-    // TODO (evgeny): clean up old manifests on success. Take into account
-    //                that old and new manifest names could match.
-
-    // Upload topic manifest for re-created topic (here we don't prevent
-    // other partitions of the same topic to read old topic manifest if the
-    // revision is different).
-    if (mat.topic_manifest.get_revision() != _ntpc.get_initial_revision()) {
-        mat.topic_manifest.set_revision(_ntpc.get_initial_revision());
-        upl_result = co_await _remote->upload_manifest(
-          _bucket, mat.topic_manifest, _rtcnode);
-        if (upl_result != upload_result::success) {
-            // That's probably fine since the archival subsystem will
-            // re-upload topic manifest eventually.
-            vlog(
-              _ctxlog.warn,
-              "Failed to upload new topic manifest {} after recovery",
-              target.get_manifest_path());
-        }
-    }
     log_recovery_result result{
       .completed = true,
       .min_kafka_offset = part.range.min_offset,

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/topic_manifest.h"
 #include "cloud_storage/types.h"
+#include "cluster/types.h"
 #include "model/record.h"
 #include "s3/client.h"
 #include "storage/ntp_config.h"
@@ -71,8 +72,8 @@ public:
     /// \return download result struct that contains 'completed=true'
     ///         if actual download happened. The 'last_offset' field will
     ///         be set to max offset of the downloaded log.
-    ss::future<log_recovery_result>
-    download_log(const storage::ntp_config& ntp_cfg);
+    ss::future<log_recovery_result> download_log(
+      const storage::ntp_config& ntp_cfg, cluster::remote_topic_properties rtp);
 
 private:
     s3::bucket_name _bucket;
@@ -90,6 +91,7 @@ public:
     partition_downloader(
       const storage::ntp_config& ntpc,
       remote* remote,
+      cluster::remote_topic_properties rtp,
       s3::bucket_name bucket,
       ss::gate& gate_root,
       retry_chain_node& parent);
@@ -121,7 +123,6 @@ private:
     download_manifest(const remote_manifest_path& path);
 
     struct recovery_material {
-        topic_manifest topic_manifest;
         partition_manifest partition_manifest;
     };
 
@@ -191,6 +192,7 @@ private:
     const storage::ntp_config& _ntpc;
     s3::bucket_name _bucket;
     remote* _remote;
+    cluster::remote_topic_properties _rtp;
     ss::gate& _gate;
     retry_chain_node _rtcnode;
     retry_chain_logger _ctxlog;

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -100,7 +100,7 @@ v_cc_library(
     feature_barrier.cc
     feature_table.cc
     drain_manager.cc
-    read_replica_manager.cc
+    remote_topic_configuration_source.cc
     partition_balancer_planner.cc
     partition_balancer_backend.cc
     partition_balancer_rpc_handler.cc

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1408,6 +1408,16 @@ ss::future<std::error_code> controller_backend::create_partition(
     }
     // no partition exists, create one
     if (likely(!partition)) {
+        // if topic recovery is enabled the information required by it
+        // need to be passed to the 'manage' call since it's not available
+        // on parition level.
+        auto meta = _topics.local().get_topic_metadata(
+          model::topic_namespace_view(ntp));
+        std::optional<cluster::remote_topic_properties> remote_properties;
+        if (meta->get_configuration().is_recovery_enabled()) {
+            remote_properties
+              = meta->get_configuration().properties.remote_topic_properties;
+        }
         // we use offset as an rev as it is always increasing and it
         // increases while ntp is being created again
         f = _partition_manager.local()
@@ -1415,7 +1425,8 @@ ss::future<std::error_code> controller_backend::create_partition(
                 cfg->make_ntp_config(
                   _data_directory, ntp.tp.partition, rev, initial_rev.value()),
                 group_id,
-                std::move(members))
+                std::move(members),
+                remote_properties)
               .discard_result();
     } else {
         // old partition still exists, wait for it to be removed

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -74,8 +74,11 @@ public:
 
     ss::future<> start() { return ss::now(); }
     ss::future<> stop_partitions();
-    ss::future<consensus_ptr>
-      manage(storage::ntp_config, raft::group_id, std::vector<model::broker>);
+    ss::future<consensus_ptr> manage(
+      storage::ntp_config,
+      raft::group_id,
+      std::vector<model::broker>,
+      std::optional<cluster::remote_topic_properties> = std::nullopt);
 
     ss::future<> shutdown(const model::ntp& ntp);
     ss::future<> remove(const model::ntp& ntp);
@@ -172,8 +175,9 @@ private:
     /// In this case this method always returns false.
     /// \param ntp_cfg is an ntp_config instance to recover
     /// \return true if the recovery was invoked, false otherwise
-    ss::future<cloud_storage::log_recovery_result>
-    maybe_download_log(storage::ntp_config& ntp_cfg);
+    ss::future<cloud_storage::log_recovery_result> maybe_download_log(
+      storage::ntp_config& ntp_cfg,
+      std::optional<cluster::remote_topic_properties> rtp);
 
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -1,4 +1,15 @@
-#include "cluster/read_replica_manager.h"
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/remote_topic_configuration_source.h"
 
 #include "cloud_storage/topic_manifest.h"
 #include "cluster/logger.h"
@@ -7,10 +18,12 @@
 
 namespace cluster {
 
-read_replica_manager::read_replica_manager(cloud_storage::remote& remote)
+remote_topic_configuration_source::remote_topic_configuration_source(
+  cloud_storage::remote& remote)
   : _remote(remote) {}
 
-ss::future<errc> read_replica_manager::set_remote_properties_in_config(
+ss::future<errc>
+remote_topic_configuration_source::set_remote_properties_in_config(
   custom_assignable_topic_configuration& cfg,
   const s3::bucket_name& bucket,
   ss::abort_source& as) {

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -13,6 +13,7 @@
 
 #include "cloud_storage/topic_manifest.h"
 #include "cluster/logger.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "s3/client.h"
 
@@ -22,13 +23,13 @@ remote_topic_configuration_source::remote_topic_configuration_source(
   cloud_storage::remote& remote)
   : _remote(remote) {}
 
-ss::future<errc>
-remote_topic_configuration_source::set_remote_properties_in_config(
+static ss::future<std::tuple<errc, cloud_storage::remote_manifest_path>>
+download_topic_manifest(
+  cloud_storage::remote& remote,
   custom_assignable_topic_configuration& cfg,
+  cloud_storage::topic_manifest& manifest,
   const s3::bucket_name& bucket,
   ss::abort_source& as) {
-    cloud_storage::topic_manifest manifest;
-
     auto timeout
       = config::shard_local_cfg().cloud_storage_manifest_upload_timeout_ms();
     auto backoff = config::shard_local_cfg().cloud_storage_initial_backoff_ms();
@@ -39,7 +40,7 @@ remote_topic_configuration_source::set_remote_properties_in_config(
     cloud_storage::remote_manifest_path key
       = cloud_storage::topic_manifest::get_topic_manifest_path(ns, topic);
 
-    auto res = co_await _remote.download_manifest(
+    auto res = co_await remote.download_manifest(
       bucket, key, manifest, rc_node);
 
     if (res != cloud_storage::download_result::success) {
@@ -49,7 +50,22 @@ remote_topic_configuration_source::set_remote_properties_in_config(
           key,
           bucket,
           res);
-        co_return errc::topic_operation_error;
+        co_return std::make_tuple(errc::topic_operation_error, key);
+    }
+    co_return std::make_tuple(errc::success, key);
+}
+
+ss::future<errc>
+remote_topic_configuration_source::set_remote_properties_in_config(
+  custom_assignable_topic_configuration& cfg,
+  const s3::bucket_name& bucket,
+  ss::abort_source& as) {
+    cloud_storage::topic_manifest manifest;
+
+    auto [res, key] = co_await download_topic_manifest(
+      _remote, cfg, manifest, bucket, as);
+    if (res != errc::success) {
+        co_return res;
     }
 
     if (!manifest.get_topic_config()) {
@@ -59,6 +75,56 @@ remote_topic_configuration_source::set_remote_properties_in_config(
           key);
         co_return errc::topic_operation_error;
     } else {
+        cfg.cfg.properties.remote_topic_properties = remote_topic_properties(
+          manifest.get_revision(),
+          manifest.get_topic_config()->partition_count);
+    }
+    co_return errc::success;
+}
+
+/// If property is set in source apply it to target.
+static void apply_retention_defaults(
+  topic_properties& target, const topic_properties& source) {
+    // If the retention properties are not set explicitly by the command we
+    // should apply them from topic_manifest.
+    if (!target.cleanup_policy_bitflags) {
+        target.cleanup_policy_bitflags = source.cleanup_policy_bitflags;
+    }
+    if (!target.retention_bytes.has_value()) {
+        target.retention_bytes = source.retention_bytes;
+    }
+    if (!target.retention_duration.has_value()) {
+        target.retention_duration = source.retention_duration;
+    }
+}
+
+ss::future<errc>
+remote_topic_configuration_source::set_recovered_topic_properties(
+  custom_assignable_topic_configuration& cfg,
+  const s3::bucket_name& bucket,
+  ss::abort_source& as) {
+    cloud_storage::topic_manifest manifest;
+
+    auto [res, key] = co_await download_topic_manifest(
+      _remote, cfg, manifest, bucket, as);
+    if (res != errc::success) {
+        co_return res;
+    }
+
+    if (!manifest.get_topic_config()) {
+        vlog(
+          clusterlog.warn,
+          "Topic manifest {} doesn't contain topic config",
+          key);
+        co_return errc::topic_operation_error;
+    } else {
+        // Update all topic properties
+        const auto& rc = manifest.get_topic_config();
+        cfg.cfg.partition_count = rc->partition_count;
+        apply_retention_defaults(cfg.cfg.properties, rc->properties);
+
+        // Use remote_topic_properties to pass revision id from the
+        // topic_manifest.json
         cfg.cfg.properties.remote_topic_properties = remote_topic_properties(
           manifest.get_revision(),
           manifest.get_topic_config()->partition_count);

--- a/src/v/cluster/remote_topic_configuration_source.h
+++ b/src/v/cluster/remote_topic_configuration_source.h
@@ -34,6 +34,19 @@ public:
       const s3::bucket_name& bucket,
       ss::abort_source& as);
 
+    /**
+     * Download remote topic manifest and set topic properties to cfg.
+     * This method is used to restore properties of the recovered topic.
+     *
+     * @param cfg custom_assignable_topic_configuration that will be changed
+     * @param bucket s3 bucket where the topic manifeset will be downloaded from
+     * @param as abourt source that caller can use request abort
+     */
+    ss::future<errc> set_recovered_topic_properties(
+      custom_assignable_topic_configuration& cfg,
+      const s3::bucket_name& bucket,
+      ss::abort_source& as);
+
 private:
     cloud_storage::remote& _remote;
 };

--- a/src/v/cluster/remote_topic_configuration_source.h
+++ b/src/v/cluster/remote_topic_configuration_source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Redpanda Data, Inc.
+ * Copyright 2022 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
@@ -18,9 +18,9 @@
 
 namespace cluster {
 
-class read_replica_manager {
+class remote_topic_configuration_source {
 public:
-    read_replica_manager(cloud_storage::remote&);
+    explicit remote_topic_configuration_source(cloud_storage::remote&);
 
     /**
      * Download remote topic manifest and set remote_properties to cfg.

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -19,6 +19,7 @@
 #include "cluster/scheduling/constraints.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/errc.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -30,6 +31,7 @@
 #include "random/generators.h"
 #include "rpc/errc.h"
 #include "rpc/types.h"
+#include "s3/client.h"
 #include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
@@ -38,6 +40,7 @@
 #include <algorithm>
 #include <iterator>
 #include <regex>
+#include <sstream>
 #include <system_error>
 
 namespace cluster {
@@ -455,6 +458,46 @@ ss::future<topic_result> topics_frontend::do_create_topic(
         assignable_config.cfg.partition_count
           = assignable_config.cfg.properties.remote_topic_properties
               ->remote_partition_count;
+    }
+
+    if (assignable_config.is_recovery_enabled()) {
+        // Before running the recovery we need to download topic_manifest.
+
+        auto bucket = config::shard_local_cfg().cloud_storage_bucket.value();
+        if (!bucket.has_value()) {
+            vlog(
+              clusterlog.error,
+              "Can't run topic recovery for the topic {}, bucket is not set",
+              assignable_config.cfg.tp_ns);
+            co_return make_error_result(
+              assignable_config.cfg.tp_ns, errc::topic_operation_error);
+        }
+        auto cfg_source = remote_topic_configuration_source(
+          _cloud_storage_api.local());
+
+        errc download_res = co_await cfg_source.set_recovered_topic_properties(
+          assignable_config, s3::bucket_name(bucket.value()), _as.local());
+
+        if (download_res != errc::success) {
+            vlog(
+              clusterlog.error,
+              "Can't run topic recovery for the topic {}",
+              assignable_config.cfg.tp_ns);
+            co_return make_error_result(
+              assignable_config.cfg.tp_ns, errc::topic_invalid_config);
+        }
+
+        vassert(
+          static_cast<bool>(
+            assignable_config.cfg.properties.remote_topic_properties),
+          "remote_topic_properties not set after successful download of valid "
+          "topic manifest");
+
+        vlog(
+          clusterlog.info,
+          "Configured topic recovery for {}, topic configuration: {}",
+          assignable_config.cfg.tp_ns,
+          assignable_config.cfg);
     }
 
     auto units = co_await _allocator.invoke_on(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -432,7 +432,8 @@ ss::future<topic_result> topics_frontend::do_create_topic(
             co_return make_error_result(
               assignable_config.cfg.tp_ns, errc::topic_invalid_config);
         }
-        auto rr_manager = read_replica_manager(_cloud_storage_api.local());
+        auto rr_manager = remote_topic_configuration_source(
+          _cloud_storage_api.local());
 
         errc download_res = co_await rr_manager.set_remote_properties_in_config(
           assignable_config,

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -16,7 +16,7 @@
 #include "cluster/data_policy_frontend.h"
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
-#include "cluster/read_replica_manager.h"
+#include "cluster/remote_topic_configuration_source.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/topic_table.h"
 #include "model/metadata.h"

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1282,6 +1282,9 @@ struct topic_configuration
     bool is_read_replica() const {
         return properties.read_replica && properties.read_replica.value();
     }
+    bool is_recovery_enabled() const {
+        return properties.recovery && properties.recovery.value();
+    }
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int
@@ -1322,6 +1325,7 @@ struct custom_assignable_topic_configuration {
 
     bool has_custom_assignment() const { return !custom_assignments.empty(); }
     bool is_read_replica() const { return cfg.is_read_replica(); }
+    bool is_recovery_enabled() const { return cfg.is_recovery_enabled(); }
 
     friend std::ostream&
     operator<<(std::ostream&, const custom_assignable_topic_configuration&);

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -149,6 +149,8 @@ struct remote_read_and_write_are_not_supported_for_read_replica {
     static bool is_valid(const creatable_topic& c) {
         auto config_entries = config_map(c.configs);
         auto end = config_entries.end();
+        bool is_recovery
+          = (config_entries.find(topic_property_recovery) != end);
         bool is_read_replica
           = (config_entries.find(topic_property_read_replica) != end);
         bool remote_read
@@ -156,7 +158,7 @@ struct remote_read_and_write_are_not_supported_for_read_replica {
         bool remote_write
           = (config_entries.find(topic_property_remote_write) != end);
 
-        if (is_read_replica && (remote_read || remote_write)) {
+        if (is_read_replica && (remote_read || remote_write || is_recovery)) {
             return false;
         }
         return true;

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1270,7 +1270,6 @@ class TopicRecoveryTest(RedpandaTest):
                                      self.rpk_producer_maker)
         self.do_run(test_case)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4849
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
     def test_missing_segment(self):
@@ -1296,7 +1295,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4960
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
     def test_fast2(self):
         """Basic recovery test. This test stresses successful recovery
@@ -1314,7 +1312,6 @@ class TopicRecoveryTest(RedpandaTest):
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4972
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
     def test_fast3(self):
         """Basic recovery test. This test stresses successful recovery


### PR DESCRIPTION
## Cover letter

This PR fixes race condition in topic recovery.

If during topic recovery any partition 0 replica will complete recovery before any other replica will start downloading the data it will read updated `topic_manifest.json`. This manifest will have revision of the newly created topic instead of the revision of the old one (the one which is being recovered). 

The problem is fixed by downloading `topic_manifest.json` only once and passing parameters needed for recovery (and extracted from topic manifest) to every replica of every partition. The mechanics here is similar to the one used by read replicas. The `topic_manifest.json` is downloaded in `topics_frontend` using the same component which read replicas are using. The data needed by topic recovery is stored in `remote_topic_properties` in `topic_configuration` which is also used by read replicas.
This is OK because it doesn't make sense to use topic recovery on read replica.

Fixes: https://github.com/redpanda-data/redpanda/issues/5474

## UX changes

NA

## Release notes

* Fix race condition in topic recovery

### Features

NA

### Improvements

* Fix race condition in topic recovery