### PR TITLE
metrics: Move disk space metrics to /public_metrics

### DIFF
--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -29,12 +29,12 @@ void node_probe::set_disk_metrics(
 }
 
 void node_probe::setup_node_metrics() {
-    if (config::shard_local_cfg().disable_metrics()) {
+    if (config::shard_local_cfg().disable_public_metrics()) {
         return;
     }
 
     namespace sm = ss::metrics;
-    _metrics.add_group(
+    _public_metrics.add_group(
       prometheus_sanitize::metrics_name("storage:disk"),
       {
         sm::make_total_bytes(

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -40,11 +40,13 @@ void node_probe::setup_node_metrics() {
         sm::make_total_bytes(
           "total_bytes",
           [this] { return _disk.total_bytes; },
-          sm::description("Total size of attached storage, in bytes.")),
+          sm::description("Total size of attached storage, in bytes."))
+          .aggregate({sm::shard_label}),
         sm::make_total_bytes(
           "free_bytes",
           [this] { return _disk.free_bytes; },
-          sm::description("Disk storage bytes free.")),
+          sm::description("Disk storage bytes free."))
+          .aggregate({sm::shard_label}),
         sm::make_gauge(
           "free_space_alert",
           [this] {
@@ -52,7 +54,8 @@ void node_probe::setup_node_metrics() {
                 _disk.space_alert);
           },
           sm::description(
-            "Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded")),
+            "Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded"))
+          .aggregate({sm::shard_label}),
       });
 }
 

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/fundamental.h"
+#include "ssx/metrics.h"
 #include "storage/fwd.h"
 #include "storage/logger.h"
 #include "storage/types.h"
@@ -38,7 +39,8 @@ public:
 
 private:
     disk_metrics _disk;
-    ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
 };
 
 // Per-NTP probe.

--- a/tests/rptest/utils/node_metrics.py
+++ b/tests/rptest/utils/node_metrics.py
@@ -1,7 +1,7 @@
 from math import floor
 
 from ducktape.utils.util import wait_until
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, MetricsEndpoint
 
 
 def all_greater_than_zero(l1: list[float]):
@@ -14,7 +14,9 @@ class NodeMetrics:
         self.redpanda = redpanda
 
     def _get_metrics_vals(self, name_substr: str) -> list[float]:
-        family = self.redpanda.metrics_sample(name_substr)
+        family = self.redpanda.metrics_sample(
+            sample_pattern=name_substr,
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
         assert family
         return list(map(lambda s: floor(s.value), family.samples))
 


### PR DESCRIPTION
## Cover letter

Move disk space metrics to `/public_metrics` and aggregate shard, since it's always 0 for a node-based metric.

E.g.:
```
# HELP redpanda_storage_disk_free_bytes Disk storage bytes free.
# TYPE redpanda_storage_disk_free_bytes counter
redpanda_storage_disk_free_bytes{} 269387415552
# HELP redpanda_storage_disk_free_space_alert Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded
# TYPE redpanda_storage_disk_free_space_alert gauge
redpanda_storage_disk_free_space_alert{} 0.000000
# HELP redpanda_storage_disk_total_bytes Total size of attached storage, in bytes.
# TYPE redpanda_storage_disk_total_bytes counter
redpanda_storage_disk_total_bytes{} 930158792704
```

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/5e6cb8dcb62b7194095263accc450f7fba0e34e8..453271b20ddc02b8c121e4c73e04df7bfb974f22)
* Fix the ducktape test by querying `/public_metrics`.

Signed-off-by: Ben Pope <ben@redpanda.com>


## UX changes

* none

## Release notes

* none
