### PR TITLE
omb/perf: Bump client request timeouts to 5mins

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -78,7 +78,7 @@ class OMBSampleConfigurations:
     SIMPLE_DRIVER = {
         "name": "simple-driver",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "false",
         "acks": "1",
         "linger_ms": 1,
@@ -92,7 +92,7 @@ class OMBSampleConfigurations:
     ACK_ALL_GROUP_LINGER_1MS = {
         "name": "ack-all-group-linger-1-ms-no-idem",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "false",
         "acks": "all",
         "linger_ms": 1,
@@ -106,7 +106,7 @@ class OMBSampleConfigurations:
     ACK_ALL_GROUP_LINGER_1MS_WITH_IDEMPOTENCE = {
         "name": "ack-all-group-linger-1-ms-enable-idem",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "true",
         "acks": "all",
         "linger_ms": 1,
@@ -120,7 +120,7 @@ class OMBSampleConfigurations:
     ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT = {
         "name": "ack-all-group-linger-1-ms-enable-idem",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "true",
         "acks": "all",
         "linger_ms": 1,
@@ -134,7 +134,7 @@ class OMBSampleConfigurations:
     ACK_ALL_GROUP_LINGER_10MS = {
         "name": "ack-all-group-linger-10-ms-no-idem",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "false",
         "acks": "all",
         "linger_ms": 10,
@@ -148,7 +148,7 @@ class OMBSampleConfigurations:
     ACK_ALL_GROUP_LINGER_10MS_WITH_IDEMPOTENCE = {
         "name": "ack-all-group-linger-10-ms-enable-idem",
         "replication_factor": 3,
-        "request_timeout": 120000,
+        "request_timeout": 300000,
         "enable_idempotence": "true",
         "acks": "all",
         "linger_ms": 1,


### PR DESCRIPTION
## Cover letter

Current timeout of 2mins does not seem sufficient in high throughput
runs (> 1GBps) and we run into this client side timeout issue and the
test is flagged as a failure.

java.util.concurrent.CompletionException: \
org.apache.kafka.common.errors.TimeoutException: \
Expiring xxx record(s) for <topic>: 1200xx ms has passed since batch creation

This exception means that the records are lingering on the client side
longer than they should. While this can happen for a variety of reasons,
typically under high load this means that the broker is not able to keep
up with the produce rate. Typical way to solving this

* Add more brokers (load spread)
* Reduce linger.ms (batches don't linger for long)
* Reduce batch.size (batches are shipped more often)
* Increase request timeout.

We are benchmarking on a 3 node cluster and its probably not prudent to
add more nodes in a nightly run ($$$). We run with 1ms linger.ms, which
is already quite low and the batch size is decently low. So we take up
the last option of increasing timeout.

This could potentially mean that we might see latency spikes (and high
P9x) if we let this batches go through, but that is okay. There is an
orthogonal effort to chase down high P9xs and we fix it as a part of
that effort.

I arrived at this 5minute timeout empirically by doing a few runs on the
same cluster spec in ec2 and the perf run seems to pass normally as
expected.

## Release notes

* none
