### PR TITLE
Add an asychronous zstd stream compression class 

### DIFF
--- a/src/v/compression/CMakeLists.txt
+++ b/src/v/compression/CMakeLists.txt
@@ -9,9 +9,11 @@ v_cc_library(
   HDRS
     "compression.h"
     "stream_zstd.h"
+    "async_stream_zstd.h"
   SRCS
     "compression.cc"
     "stream_zstd.cc"
+    "async_stream_zstd.cc"
     "logger.cc"
     "snappy_standard_compressor.cc"
     "internal/snappy_java_compressor.cc"

--- a/src/v/compression/async_stream_zstd.cc
+++ b/src/v/compression/async_stream_zstd.cc
@@ -1,0 +1,196 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "compression/async_stream_zstd.h"
+
+#include "bytes/bytes.h"
+#include "bytes/details/io_allocation_size.h"
+#include "compression/logger.h"
+#include "likely.h"
+#include "units.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <fmt/format.h>
+
+#include <array>
+#include <zstd.h>
+#include <zstd_errors.h>
+
+namespace compression {
+[[gnu::cold]] static void throw_zstd_err(size_t rc) {
+    if (rc == ZSTD_error_memory_allocation) {
+        ss::throw_with_backtrace<std::bad_alloc>();
+    } else {
+        ss::throw_with_backtrace<std::runtime_error>(
+          fmt::format("ZSTD error:{}", ZSTD_getErrorName(rc)));
+    }
+}
+
+static void throw_if_error(size_t rc) {
+    if (unlikely(ZSTD_isError(rc))) {
+        throw_zstd_err(rc);
+    }
+}
+
+static constexpr size_t default_decompression_size = 2_MiB;
+static constexpr int default_compression_level = 3;
+
+static thread_local std::unique_ptr<async_stream_zstd> zstd_instance;
+
+void initialize_async_stream_zstd(size_t decompression_size) {
+    if (zstd_instance) {
+        vassert(
+          decompression_size <= zstd_instance->decompression_size(),
+          "async_stream_zstd initialized multiple times with "
+          "decompression_size > zstd_instance->decompression_size()");
+
+        return;
+    }
+
+    zstd_instance = std::make_unique<async_stream_zstd>(decompression_size);
+}
+
+async_stream_zstd& async_stream_zstd_instance() {
+    if (unlikely(!zstd_instance)) {
+        initialize_async_stream_zstd(default_decompression_size);
+    }
+
+    return *zstd_instance;
+}
+
+async_stream_zstd::async_stream_zstd(size_t decompression_size) {
+    _decompression_size = decompression_size;
+
+    _d_buffer = ss::temporary_buffer<char>(ZSTD_DStreamOutSize());
+    _c_buffer = ss::temporary_buffer<char>(ZSTD_CStreamOutSize());
+
+    auto d_workspace_size = ZSTD_estimateDStreamSize(decompression_size);
+    auto c_workspace_size = ZSTD_estimateCStreamSize(default_compression_level);
+
+    // zstd requires alignment on both of the buffer below.
+    _d_workspace = ss::allocate_aligned_buffer<char>(d_workspace_size, 8);
+    _c_workspace = ss::allocate_aligned_buffer<char>(c_workspace_size, 8);
+
+    vassert(
+      _c_workspace,
+      "Failed to allocate zstd workspace of size {}",
+      c_workspace_size);
+    vassert(
+      _d_workspace,
+      "Failed to allocate zstd workspace of size {}",
+      d_workspace_size);
+
+    _compress_ctx = ZSTD_initStaticCCtx(_c_workspace.get(), c_workspace_size);
+    _decompress_ctx = ZSTD_initStaticDCtx(_d_workspace.get(), d_workspace_size);
+
+    throw_if_error(ZSTD_CCtx_setParameter(
+      _compress_ctx, ZSTD_c_compressionLevel, default_compression_level));
+}
+
+size_t async_stream_zstd::decompression_size() const {
+    return _decompression_size;
+}
+
+ss::future<iobuf> async_stream_zstd::compress(iobuf i_buf) {
+    auto lock = co_await _compress_mtx.get_units();
+
+    // reset compressor ctx
+    ZSTD_CCtx_reset(_compress_ctx, ZSTD_reset_session_only);
+
+    // NOTE: always enable content size. **decompression** depends on this
+    throw_if_error(
+      ZSTD_CCtx_setPledgedSrcSize(_compress_ctx, i_buf.size_bytes()));
+
+    iobuf ret_buf;
+
+    // if the buffer is empty encode and return an empty zstd frame.
+    if (i_buf.empty()) {
+        size_t remaining = 0;
+
+        do {
+            ZSTD_outBuffer out = {
+              .dst = _c_buffer.get_write(), .size = _c_buffer.size(), .pos = 0};
+            remaining = ZSTD_endStream(_compress_ctx, &out);
+            throw_if_error(remaining);
+            ret_buf.append(_c_buffer.get(), out.pos);
+        } while (remaining > 0);
+
+        co_return std::move(ret_buf);
+    }
+
+    // otherwise compress and return the buffer.
+    for (auto it = i_buf.cbegin(); it != i_buf.cend();) {
+        ZSTD_inBuffer in = {.src = it->get(), .size = it->size(), .pos = 0};
+        ++it;
+
+        const auto mode = (it == i_buf.cend()) ? ZSTD_e_end : ZSTD_e_continue;
+
+        int finished;
+        do {
+            ZSTD_outBuffer out = {
+              .dst = _c_buffer.get_write(), .size = _c_buffer.size(), .pos = 0};
+
+            const auto remaining = ZSTD_compressStream2(
+              _compress_ctx, &out, &in, mode);
+            throw_if_error(remaining);
+
+            ret_buf.append(_c_buffer.get(), out.pos);
+            finished = (mode == ZSTD_e_end) ? (remaining == 0)
+                                            : (in.pos == in.size);
+
+            co_await ss::coroutine::maybe_yield();
+        } while (!finished);
+    }
+
+    co_return ret_buf;
+}
+
+ss::future<iobuf> async_stream_zstd::uncompress(iobuf i_buf) {
+    if (unlikely(i_buf.empty())) {
+        throw std::runtime_error(
+          "Asked to stream_zstd::uncompress empty buffer");
+    }
+
+    auto lock = co_await _decompress_mtx.get_units();
+
+    ZSTD_DCtx_reset(_decompress_ctx, ZSTD_reset_session_only);
+
+    iobuf ret_buf;
+    size_t last_zstd_ret = 0;
+
+    for (auto& ibuf : i_buf) {
+        ZSTD_inBuffer in = {.src = ibuf.get(), .size = ibuf.size(), .pos = 0};
+
+        while (in.pos < in.size) {
+            ZSTD_outBuffer out = {
+              .dst = _d_buffer.get_write(), .size = _d_buffer.size(), .pos = 0};
+
+            const auto zstd_ret = ZSTD_decompressStream(
+              _decompress_ctx, &out, &in);
+            throw_if_error(zstd_ret);
+
+            ret_buf.append(_d_buffer.get(), out.pos);
+            last_zstd_ret = zstd_ret;
+
+            co_await ss::coroutine::maybe_yield();
+        }
+    }
+
+    if (last_zstd_ret != 0) {
+        throw std::runtime_error("Input truncated before reading epilog");
+    }
+
+    co_return ret_buf;
+}
+
+} // namespace compression

--- a/src/v/compression/async_stream_zstd.h
+++ b/src/v/compression/async_stream_zstd.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "bytes/iobuf.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/aligned_buffer.hh>
+
+#include <memory>
+#include <zstd.h>
+
+namespace compression {
+/*
+ * A streaming zstd compression class
+ *
+ * Both compress and uncompress process the iobuf
+ * parameter in fixed sized windows and allow for a
+ * scheduling point after each window is processed
+ */
+class async_stream_zstd {
+public:
+    async_stream_zstd() = delete;
+    async_stream_zstd(size_t);
+
+    ss::future<iobuf> compress(iobuf);
+    ss::future<iobuf> uncompress(iobuf);
+
+    size_t decompression_size() const;
+
+private:
+    size_t _decompression_size;
+
+    mutex _compress_mtx;
+    mutex _decompress_mtx;
+
+    ZSTD_CCtx* _compress_ctx;
+    ZSTD_DCtx* _decompress_ctx;
+
+    std::unique_ptr<char[], ss::free_deleter> _d_workspace;
+    std::unique_ptr<char[], ss::free_deleter> _c_workspace;
+
+    ss::temporary_buffer<char> _d_buffer;
+    ss::temporary_buffer<char> _c_buffer;
+};
+
+void initialize_async_stream_zstd(size_t);
+async_stream_zstd& async_stream_zstd_instance();
+
+} // namespace compression

--- a/src/v/compression/tests/zstd_stream_bench.cc
+++ b/src/v/compression/tests/zstd_stream_bench.cc
@@ -56,7 +56,7 @@ inline void uncompress_test(size_t data_size) {
 
 inline ss::future<> async_compress_test(size_t data_size) {
     auto o = gen(data_size);
-    compression::async_stream_zstd fn(2_MiB);
+    compression::async_stream_zstd fn(2_MiB, 1);
 
     perf_tests::start_measuring_time();
     perf_tests::do_not_optimize(co_await fn.compress(std::move(o)));
@@ -64,7 +64,7 @@ inline ss::future<> async_compress_test(size_t data_size) {
 }
 
 inline ss::future<> async_uncompress_test(size_t data_size) {
-    compression::async_stream_zstd fn(2_MiB);
+    compression::async_stream_zstd fn(2_MiB, 1);
     auto o = co_await fn.compress(gen(data_size));
 
     perf_tests::start_measuring_time();

--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -88,7 +88,7 @@ SEASTAR_THREAD_TEST_CASE(stream_zstd_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(async_stream_zstd_test) {
-    compression::async_stream_zstd fn(default_decompression_size);
+    compression::async_stream_zstd fn(default_decompression_size, 1);
     auto test_sizes = get_test_sizes();
     for (size_t i : sizes) {
         iobuf buf = gen(i);
@@ -131,7 +131,7 @@ SEASTAR_THREAD_TEST_CASE(interleaved_async_stream_zstd_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(async_stream_to_stream_test) {
-    compression::async_stream_zstd fn(default_decompression_size);
+    compression::async_stream_zstd fn(default_decompression_size, 1);
     compression::stream_zstd fn_s;
     auto test_sizes = get_test_sizes();
     for (size_t i : sizes) {
@@ -145,7 +145,7 @@ SEASTAR_THREAD_TEST_CASE(async_stream_to_stream_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(stream_to_async_stream_test) {
-    compression::async_stream_zstd fn(default_decompression_size);
+    compression::async_stream_zstd fn(default_decompression_size, 1);
     compression::stream_zstd fn_s;
     auto test_sizes = get_test_sizes();
     for (size_t i : sizes) {

--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "compression/async_stream_zstd.h"
 #include "compression/internal/gzip_compressor.h"
 #include "compression/internal/lz4_frame_compressor.h"
 #include "compression/internal/snappy_java_compressor.h"
@@ -37,6 +38,7 @@ static inline constexpr std::array<size_t, 16> sizes{{
   8_KiB,
   10_KiB,
 }};
+static constexpr size_t default_decompression_size = 2_MiB;
 
 static std::vector<size_t> get_test_sizes() {
     std::vector<size_t> test_sizes;
@@ -81,6 +83,77 @@ SEASTAR_THREAD_TEST_CASE(stream_zstd_test) {
         iobuf buf = gen(i);
         auto cbuf = fn.compress(buf.share(0, i));
         auto dbuf = fn.uncompress(std::move(cbuf));
+        BOOST_CHECK_EQUAL(dbuf, buf);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(async_stream_zstd_test) {
+    compression::async_stream_zstd fn(default_decompression_size);
+    auto test_sizes = get_test_sizes();
+    for (size_t i : sizes) {
+        iobuf buf = gen(i);
+
+        auto cbuf = fn.compress(buf.share(0, i)).get();
+        auto dbuf = fn.uncompress(std::move(cbuf)).get();
+
+        BOOST_CHECK_EQUAL(dbuf, buf);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(interleaved_async_stream_zstd_test) {
+    std::array<size_t, 5> test_sizes{
+      50_MiB,
+      50_MiB,
+      50_MiB,
+      50_MiB,
+      50_MiB,
+    };
+
+    std::vector<iobuf> gen_data;
+    for (size_t i : test_sizes) {
+        gen_data.push_back(gen(i));
+    }
+
+    auto fut = ss::parallel_for_each(
+      gen_data.begin(), gen_data.end(), [](iobuf& buf) {
+          return ss::do_with(
+            std::move(buf),
+            compression::async_stream_zstd(default_decompression_size, 3),
+            [](auto& buf, auto& fn) {
+                return fn.compress(buf.share(0, buf.size_bytes()))
+                  .then(
+                    [&](iobuf cbuf) { return fn.uncompress(std::move(cbuf)); })
+                  .then([&](iobuf dbuf) { BOOST_CHECK_EQUAL(dbuf, buf); });
+            });
+      });
+
+    fut.get();
+}
+
+SEASTAR_THREAD_TEST_CASE(async_stream_to_stream_test) {
+    compression::async_stream_zstd fn(default_decompression_size);
+    compression::stream_zstd fn_s;
+    auto test_sizes = get_test_sizes();
+    for (size_t i : sizes) {
+        iobuf buf = gen(i);
+
+        auto cbuf = fn.compress(buf.share(0, i)).get();
+        auto dbuf = fn_s.uncompress(std::move(cbuf));
+
+        BOOST_CHECK_EQUAL(dbuf, buf);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(stream_to_async_stream_test) {
+    compression::async_stream_zstd fn(default_decompression_size);
+    compression::stream_zstd fn_s;
+    auto test_sizes = get_test_sizes();
+    for (size_t i : sizes) {
+        iobuf buf = gen(i);
+
+        auto cbuf = fn_s.compress(buf.share(0, i));
+        auto dbuf = fn.uncompress(std::move(cbuf)).get();
+
         BOOST_CHECK_EQUAL(dbuf, buf);
     }
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -41,6 +41,8 @@
 #include "cluster/tx_gateway.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
+#include "compression/async_stream_zstd.h"
+#include "compression/stream_zstd.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "config/node_config.h"
@@ -345,11 +347,17 @@ void application::initialize(
   std::optional<YAML::Node> schema_reg_client_cfg,
   std::optional<scheduling_groups> groups) {
     /*
-     * allocate per-core zstd decompression workspace. it can be several
-     * megabytes in size, so do it before memory becomes fragmented.
+     * allocate per-core zstd decompression workspace and per-core
+     * async_stream_zstd workspaces. it can be several megabytes in size, so do
+     * it before memory becomes fragmented.
      */
     ss::smp::invoke_on_all([] {
+        // TODO: remove this when stream_zstd is replaced with async_stream_zstd
+        // in v/kafka
         compression::stream_zstd::init_workspace(
+          config::shard_local_cfg().zstd_decompress_workspace_bytes());
+
+        compression::initialize_async_stream_zstd(
           config::shard_local_cfg().zstd_decompress_workspace_bytes());
     }).get0();
 

--- a/src/v/rpc/netbuf.cc
+++ b/src/v/rpc/netbuf.cc
@@ -27,7 +27,7 @@ iobuf header_as_iobuf(const header& h) {
 }
 /// \brief used to send the bytes down the wire
 /// we re-compute the header-checksum on every call
-ss::scattered_message<char> netbuf::as_scattered() && {
+ss::future<ss::scattered_message<char>> netbuf::as_scattered() && {
     if (_hdr.correlation_id == 0 || _hdr.meta == 0) {
         throw std::runtime_error(
           "cannot compose scattered view with incomplete header. missing "
@@ -54,7 +54,7 @@ ss::scattered_message<char> netbuf::as_scattered() && {
     _out.prepend(header_as_iobuf(_hdr));
 
     // prepare for output
-    return iobuf_as_scattered(std::move(_out));
+    co_return iobuf_as_scattered(std::move(_out));
 }
 
 } // namespace rpc

--- a/src/v/rpc/netbuf.cc
+++ b/src/v/rpc/netbuf.cc
@@ -9,7 +9,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/scattered_message.h"
-#include "compression/stream_zstd.h"
+#include "compression/async_stream_zstd.h"
 #include "hashing/xx.h"
 #include "reflection/adl.h"
 #include "rpc/types.h"
@@ -28,33 +28,37 @@ iobuf header_as_iobuf(const header& h) {
 /// \brief used to send the bytes down the wire
 /// we re-compute the header-checksum on every call
 ss::future<ss::scattered_message<char>> netbuf::as_scattered() && {
-    if (_hdr.correlation_id == 0 || _hdr.meta == 0) {
+    // Move object members into coroutine before first supension.
+    iobuf out_buf = std::move(_out);
+    auto hdr = std::move(_hdr);
+
+    if (hdr.correlation_id == 0 || hdr.meta == 0) {
         throw std::runtime_error(
           "cannot compose scattered view with incomplete header. missing "
           "correlation_id or remote method id");
     }
     if (
-      _out.size_bytes() >= _min_compression_bytes
-      && rpc::compression_type::zstd == _hdr.compression) {
-        compression::stream_zstd fn;
-        _out = fn.compress(std::move(_out));
+      out_buf.size_bytes() >= _min_compression_bytes
+      && rpc::compression_type::zstd == hdr.compression) {
+        auto& zstd_inst = compression::async_stream_zstd_instance();
+        out_buf = co_await zstd_inst.compress(std::move(out_buf));
     } else {
         // didn't meet min requirements
-        _hdr.compression = rpc::compression_type::none;
+        hdr.compression = rpc::compression_type::none;
     }
     incremental_xxhash64 h;
-    auto in = iobuf::iterator_consumer(_out.cbegin(), _out.cend());
-    in.consume(_out.size_bytes(), [&h](const char* src, size_t sz) {
+    auto in = iobuf::iterator_consumer(out_buf.cbegin(), out_buf.cend());
+    in.consume(out_buf.size_bytes(), [&h](const char* src, size_t sz) {
         h.update(src, sz);
         return ss::stop_iteration::no;
     });
-    _hdr.payload_checksum = h.digest();
-    _hdr.payload_size = _out.size_bytes();
-    _hdr.header_checksum = rpc::checksum_header_only(_hdr);
-    _out.prepend(header_as_iobuf(_hdr));
+    hdr.payload_checksum = h.digest();
+    hdr.payload_size = out_buf.size_bytes();
+    hdr.header_checksum = rpc::checksum_header_only(hdr);
+    out_buf.prepend(header_as_iobuf(hdr));
 
     // prepare for output
-    co_return iobuf_as_scattered(std::move(_out));
+    co_return iobuf_as_scattered(std::move(out_buf));
 }
 
 } // namespace rpc

--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "bytes/iostream.h"
-#include "compression/stream_zstd.h"
+#include "compression/async_stream_zstd.h"
 #include "hashing/xx.h"
 #include "likely.h"
 #include "reflection/async_adl.h"
@@ -276,25 +276,28 @@ ss::future<T> parse_type(ss::input_stream<char>& in, const header& h) {
     return read_iobuf_exactly(in, h.payload_size).then([h](iobuf io) {
         validate_payload_and_header(io, h);
 
+        ss::future<iobuf> iobuf_fut = ss::make_ready_future<iobuf>();
+
         switch (h.compression) {
         case compression_type::none:
+            iobuf_fut = ss::make_ready_future<iobuf>(std::move(io));
             break;
-
         case compression_type::zstd: {
-            compression::stream_zstd fn;
-            io = fn.uncompress(std::move(io));
+            auto& zstd_inst = compression::async_stream_zstd_instance();
+            iobuf_fut = zstd_inst.uncompress(std::move(io));
             break;
         }
-
         default:
-            return ss::make_exception_future<T>(std::runtime_error(
+            iobuf_fut = ss::make_exception_future<iobuf>(std::runtime_error(
               fmt::format("no compression supported. header: {}", h)));
         }
 
-        auto p = std::make_unique<iobuf_parser>(std::move(io));
-        auto raw = p.get();
-        return Codec::template decode<T>(*raw, h.version)
-          .finally([p = std::move(p)] {});
+        return iobuf_fut.then([h](iobuf io) {
+            auto p = std::make_unique<iobuf_parser>(std::move(io));
+            auto raw = p.get();
+            return Codec::template decode<T>(*raw, h.version)
+              .finally([p = std::move(p)] {});
+        });
     });
 }
 

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -76,7 +76,7 @@ send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
     buf.set_compression(rpc::compression_type::zstd);
     buf.set_correlation_id(ctx->get_header().correlation_id);
 
-    auto view = std::move(buf).as_scattered();
+    auto view = co_await std::move(buf).as_scattered();
     if (ctx->res.conn_gate().is_closed()) {
         // do not write if gate is closed
         rpclog.debug(

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -14,6 +14,7 @@
 #include "ssx/semaphore.h"
 
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 
 #include <exception>
@@ -80,9 +81,9 @@ send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
         // do not write if gate is closed
         rpclog.debug(
           "Skipping write of {} bytes, connection is closed", view.size());
-        return ss::make_ready_future<>();
+        co_return;
     }
-    return ctx->res.conn->write(std::move(view))
+    co_await ctx->res.conn->write(std::move(view))
       .handle_exception([ctx = std::move(ctx)](std::exception_ptr e) {
           auto disconnect = net::is_disconnect_exception(e);
           if (disconnect) {

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -38,7 +38,7 @@ SEASTAR_THREAD_TEST_CASE(netbuf_pod) {
     n.set_service_method_id(66);
     reflection::async_adl<pod>{}.to(n.buffer(), std::move(src)).get();
     // forces the computation of the header
-    auto bufs = std::move(n).as_scattered().release().release();
+    auto bufs = std::move(n).as_scattered().get().release().release();
     auto in = make_iobuf_input_stream(iobuf(std::move(bufs)));
     const pod dst = rpc::parse_framed<pod>(in).get0();
     BOOST_REQUIRE_EQUAL(src.x, dst.x);

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -195,22 +195,30 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
           // send
           auto sz = b.buffer().size_bytes();
           return get_units(_memory, sz)
-            .then([this,
-                   b = std::move(b),
-                   f = std::move(f),
-                   seq,
-                   u = std::move(opts.resource_units)](
-                    ssx::semaphore_units units) mutable {
-                auto e = entry{
-                  .buffer = std::make_unique<netbuf>(std::move(b)),
-                  .resource_units = std::move(u),
-                };
-
-                _requests_queue.emplace(
-                  seq, std::make_unique<entry>(std::move(e)));
-                dispatch_send();
-                return std::move(f).finally([u = std::move(units)] {});
+            .then([b = std::move(b)](ssx::semaphore_units units) mutable {
+                return std::move(b).as_scattered().then(
+                  [u = std::move(units)](
+                    ss::scattered_message<char> scattered_message) mutable {
+                      return std::make_tuple(
+                        std::move(u), std::move(scattered_message));
+                  });
             })
+            .then_unpack(
+              [this, f = std::move(f), seq, u = std::move(opts.resource_units)](
+                ssx::semaphore_units units,
+                ss::scattered_message<char> scattered_message) mutable {
+                  auto e = entry{
+                    .scattered_message
+                    = std::make_unique<ss::scattered_message<char>>(
+                      std::move(scattered_message)),
+                    .resource_units = std::move(u),
+                  };
+
+                  _requests_queue.emplace(
+                    seq, std::make_unique<entry>(std::move(e)));
+                  dispatch_send();
+                  return std::move(f).finally([u = std::move(units)] {});
+              })
             .finally([this, seq] {
                 // update last sequence to make progress, for successfull
                 // dispatches this will be noop, as _last_seq was already update
@@ -232,14 +240,13 @@ void transport::dispatch_send() {
               [this] {
                   auto it = _requests_queue.begin();
                   _last_seq = it->first;
-                  auto buffer = std::move(it->second->buffer).get();
+                  auto v = std::move(*it->second->scattered_message);
                   // These units are released once we are out of scope here
                   // and that is intentional because the underlying write call
                   // to the batched output stream guarantees us the in-order
                   // delivery of the dispatched write calls, which is the intent
                   // of holding on to the units up until this point.
                   auto units = std::move(it->second->resource_units);
-                  auto v = std::move(*buffer).as_scattered();
                   auto msg_size = v.size();
                   _requests_queue.erase(it->first);
                   auto f = _out.write(std::move(v));

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -237,6 +237,17 @@ void transport::dispatch_send() {
                          || _requests_queue.begin()->first
                               > (_last_seq + sequence_t(1));
               },
+              // Be careful adding any scheduling points in the lambda below.
+              //
+              // If a scheduling point is added before `_requests_queue.erase`
+              // then two concurrent instances of dispatch_send could try
+              // sending the same message. Resulting in one of them throwing a
+              // seg. fault.
+              //
+              // And if a scheduling point is added after
+              // `_requests_queue.erase` the conditional for executing the
+              // lambda could succeed for two different messages concurrently
+              // resulting in incorrect ordering of the sent messages.
               [this] {
                   auto it = _requests_queue.begin();
                   _last_seq = it->first;

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -86,7 +86,7 @@ public:
 private:
     using sequence_t = named_type<uint64_t, struct sequence_tag>;
     struct entry {
-        std::unique_ptr<netbuf> buffer;
+        std::unique_ptr<ss::scattered_message<char>> scattered_message;
         client_opts::resource_units_t resource_units;
     };
     using requests_queue_t

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -208,7 +208,7 @@ class netbuf {
 public:
     /// \brief used to send the bytes down the wire
     /// we re-compute the header-checksum on every call
-    ss::scattered_message<char> as_scattered() &&;
+    ss::future<ss::scattered_message<char>> as_scattered() &&;
 
     void set_status(rpc::status);
     void set_correlation_id(uint32_t);

--- a/src/v/utils/object_pool.h
+++ b/src/v/utils/object_pool.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+
+#include <concepts>
+#include <deque>
+#include <stack>
+
+/*
+ * This class provides a pool of objects that can allocated or released to.
+ *
+ * The pool doesn't allocate objects internally and instead relies on users
+ * releasing an initial group of objects to it.
+ *
+ */
+template<std::movable T>
+class object_pool {
+    struct wait_item {
+        ss::promise<T> p;
+        ss::abort_source::subscription abort_sub;
+    };
+
+public:
+    /*
+     * This function tries to retrieve an object from the pool and return it to
+     * the caller.
+     *
+     * If an object is available in the pool already then it is returned right
+     * away as a ready future.
+     *
+     * Otherwise the returned future is set when a object is released back to
+     * the pool in a first come first serve order.
+     */
+    ss::future<T> allocate_object(ss::abort_source& as) {
+        // Return any available object right away without setting up
+        // a waiter.
+        if (!_objects.empty()) {
+            auto ret = ss::make_ready_future<T>(std::move(_objects.top()));
+            _objects.pop();
+            return ret;
+        }
+
+        auto item = std::make_unique<wait_item>();
+
+        auto sub_opt = as.subscribe([this, item_ptr = item.get()]() noexcept {
+            // it should be safe to use a raw pointer as the lifetime of this
+            // callback is the lifetime of the allocation the pointer points to.
+            item_ptr->p.set_exception(ss::abort_requested_exception());
+            std::erase_if(
+              _waiters, [item_ptr](const std::unique_ptr<wait_item>& it) {
+                  return it.get() == item_ptr;
+              });
+        });
+
+        if (!sub_opt) {
+            // Abort source already fired!
+            return ss::make_exception_future<T>(
+              ss::abort_requested_exception());
+        }
+
+        item->abort_sub = std::move(*sub_opt);
+        _waiters.emplace_back(std::move(item));
+        return _waiters.back()->p.get_future();
+    }
+
+    /*
+     * This function releases an object back into the pool.
+     *
+     * If there are any waiters to allocate an object from the pool
+     * then the oldest waiter is given the object.
+     *
+     * Otherwise the object is returned to the pool.
+     */
+    void release_object(T obj) {
+        if (!_waiters.empty()) {
+            _waiters.front()->p.set_value(std::move(obj));
+            _waiters.pop_front();
+        } else {
+            _objects.emplace(std::move(obj));
+        }
+    }
+
+    struct scoped_object {
+        scoped_object(scoped_object&& so) noexcept
+          : _obj(std::move(so._obj))
+          , _pool(so._pool) {
+            so._pool = std::nullopt;
+        }
+
+        scoped_object(T obj, object_pool<T>& pool) noexcept
+          : _obj(std::move(obj))
+          , _pool(pool) {}
+
+        scoped_object(const scoped_object&) = delete;
+
+        ~scoped_object() {
+            if (_pool) {
+                _pool->get().release_object(std::move(_obj));
+            }
+        }
+
+        T& operator*() noexcept { return _obj; }
+
+    private:
+        T _obj;
+        std::optional<std::reference_wrapper<object_pool<T>>> _pool;
+    };
+
+    /*
+     * This function allocates a `scoped_object` from the pool.
+     *
+     * This scoped_object automatically releases the underlying object to the
+     * pool when its lifetime ends.
+     */
+    ss::future<scoped_object> allocate_scoped_object(ss::abort_source& as) {
+        return allocate_object(as).then(
+          [this](T obj) { return scoped_object(std::move(obj), *this); });
+    }
+
+private:
+    // try to perserve any locality by reusing the
+    // most recently used object
+    std::stack<T> _objects;
+    std::deque<std::unique_ptr<wait_item>> _waiters;
+};

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ rp_test(
     retry_chain_node_test.cc
     input_stream_fanout_test.cc
     waiter_queue_test.cc
+    object_pool_test.cc
     delta_for_test.cc
     token_bucket_test.cc
     uuid_test.cc

--- a/src/v/utils/tests/object_pool_test.cc
+++ b/src/v/utils/tests/object_pool_test.cc
@@ -1,0 +1,147 @@
+
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "seastarx.h"
+#include "utils/object_pool.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+SEASTAR_THREAD_TEST_CASE(test_waiting_on_object) {
+    object_pool<ss::sstring> pool;
+    ss::abort_source as;
+    auto f = pool.allocate_object(as);
+
+    BOOST_REQUIRE(!f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    pool.release_object("obj1");
+
+    BOOST_REQUIRE(f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    auto obj = f.get();
+
+    BOOST_REQUIRE(obj == "obj1");
+};
+
+SEASTAR_THREAD_TEST_CASE(testing_ready_object) {
+    object_pool<std::unique_ptr<int>> pool;
+    pool.release_object(std::make_unique<int>(1));
+    ss::abort_source as;
+    auto f = pool.allocate_object(as);
+
+    BOOST_REQUIRE(f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    auto obj = f.get();
+
+    BOOST_REQUIRE(*obj == 1);
+}
+
+struct move_only {
+    move_only(ss::sstring s)
+      : s(s) {}
+    move_only(move_only&&) = default;
+    move_only& operator=(move_only&&) = default;
+    move_only(const move_only&) = delete;
+    move_only& operator=(const move_only&) = delete;
+
+    ss::sstring s;
+};
+
+SEASTAR_THREAD_TEST_CASE(testing_move_only_object) {
+    object_pool<move_only> pool;
+    pool.release_object(move_only("test"));
+    ss::abort_source as;
+    auto f = pool.allocate_object(as);
+
+    BOOST_REQUIRE(f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    auto obj = f.get();
+
+    BOOST_REQUIRE(obj.s == "test");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_wait) {
+    object_pool<ss::sstring> pool;
+    {
+        ss::abort_source as;
+        auto f = pool.allocate_object(as);
+
+        BOOST_REQUIRE(!f.available());
+        BOOST_REQUIRE(!f.failed());
+
+        as.request_abort();
+        pool.release_object("obj1");
+
+        BOOST_REQUIRE(f.available());
+        BOOST_REQUIRE(f.failed());
+        BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
+    }
+    {
+        ss::abort_source as;
+        auto f = pool.allocate_object(as);
+
+        BOOST_REQUIRE(f.available());
+        BOOST_REQUIRE(!f.failed());
+
+        auto obj = f.get();
+
+        BOOST_REQUIRE(obj == "obj1");
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_after_wait) {
+    object_pool<ss::sstring> pool;
+    ss::abort_source as;
+    auto f = pool.allocate_object(as);
+
+    BOOST_REQUIRE(!f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    pool.release_object("obj1");
+    as.request_abort();
+
+    BOOST_REQUIRE(f.available());
+    BOOST_REQUIRE(!f.failed());
+
+    auto obj = f.get();
+
+    BOOST_REQUIRE(obj == "obj1");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_ordering_waiters) {
+    object_pool<int> pool;
+    ss::abort_source as;
+    auto f1 = pool.allocate_object(as);
+    auto f2 = pool.allocate_object(as);
+    auto f3 = pool.allocate_object(as);
+    pool.release_object(1);
+    pool.release_object(2);
+    pool.release_object(3);
+
+    BOOST_REQUIRE(f1.available());
+    BOOST_REQUIRE(!f1.failed());
+    BOOST_REQUIRE(f1.get() == 1);
+
+    BOOST_REQUIRE(f2.available());
+    BOOST_REQUIRE(!f2.failed());
+    BOOST_REQUIRE(f2.get() == 2);
+
+    BOOST_REQUIRE(f3.available());
+    BOOST_REQUIRE(!f3.failed());
+    BOOST_REQUIRE(f3.get() == 3);
+}


### PR DESCRIPTION
## Cover letter

This PR adds a new Zstd streaming interface `async_stream_zstd` that is different from the existing `stream_zstd` in a few ways. 

Firstly all compression/decompression methods return futures and allow for seastar to interrupt them if they are close to hitting the reactor stall timeout. This interface change is the main justification for a new class instead of modifying the existing one as a lot of non-futurized code in `v/kafka` expects compress/uncompress to be a blocking call that returns the actual result right away. Hopefully we'll be able to migrate users of `stream_zstd` to `async_stream_zstd` in time.

Secondly in `compress` currently `stream_zstd` allocates a large contiguous buffer for the entire expected size for the compressed data block this has shown to cause OOM errors when the data block is too large (see #5566 ). `async_stream_zstd` instead of allocating a large contiguous buffer for the compression output is outputting a Zstd block at a time (128KiB max size) and then appending that block to an iobuf. This change should probably be ported over to `stream_zstd` as well in case any kafka API messages prove to be large enough to cause OOM errors.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5116, #5566

## Release notes
* none