### PR TITLE
schema_registry: Return schemaType for /schemas/ids/<id>

### DIFF
--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -24,6 +24,10 @@ inline void rjson_serialize(
   ::json::Writer<::json::StringBuffer>& w,
   const get_schemas_ids_id_response& res) {
     w.StartObject();
+    if (res.definition.type() != schema_type::avro) {
+        w.Key("schemaType");
+        ::json::rjson_serialize(w, to_string_view(res.definition.type()));
+    }
     w.Key("schema");
     ::json::rjson_serialize(w, res.definition.raw());
     w.EndObject();

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1037,6 +1037,15 @@ class SchemaRegistryTest(RedpandaTest):
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.text.strip() == simple_proto_def.strip()
 
+        result_raw = self._request("GET",
+                                   f"schemas/ids/1",
+                                   headers=HTTP_GET_HEADERS)
+        self.logger.info(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["schemaType"] == "PROTOBUF"
+        assert result["schema"].strip() == simple_proto_def.strip()
+
         result_raw = self._get_subjects_subject_versions_version_referenced_by(
             "simple", 1)
         self.logger.info(result_raw)


### PR DESCRIPTION
## Cover letter

If the schema type is not avro, then set `schemaType` field in the response.

Signed-off-by: Ben Pope <ben@redpanda.com>

Fixes #3633 (fix it even more)

## Release notes

### Improvements

* schema registry: `GET /schemas/ids/<id>` now returns `schemaType` if the type is not avro.
