### PR TITLE
rpk: omit empty/zero values in redpanda.yaml

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "0cb36f0be0d64032a61eb51a5d2985ea",
+			expectedHash:            "2bcfa4a6609253c35503587411b445cb",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "4697714fe9b8f8bcaebb814b93f2b8f6",
+			expectedHash: "42a92bbbe2e3092ac6bc86d705477ec0",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "2f51e71fa4b673fb105f98cb09cb7a00",
+			expectedHash: "49ddb404391b63a9b604aa57e655406e",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -213,23 +213,7 @@ redpanda:
           port: 9644
     developer_mode: true
 rpk:
-    enable_usage_stats: false
-    tune_network: false
-    tune_disk_scheduler: false
-    tune_disk_nomerges: false
-    tune_disk_write_cache: false
-    tune_disk_irq: false
-    tune_fstrim: false
-    tune_cpu: false
-    tune_aio_events: false
-    tune_clocksource: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
     coredump_dir: /var/lib/redpanda/coredump
-    tune_ballast_file: false
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `,
@@ -239,7 +223,7 @@ schema_registry: {}
 			name: "set with loaded config",
 			cfgFile: `config_file: /etc/redpanda/redpanda.yaml
 redpanda:
-    data_directory: ""
+    data_directory: data/dir
     node_id: 0
     rack: redpanda-rack
     seed_servers: []
@@ -254,25 +238,12 @@ redpanda:
           port: 9644
     developer_mode: true
 rpk:
-    enable_usage_stats: false
-    tune_network: false
-    tune_disk_scheduler: false
-    tune_disk_nomerges: false
-    tune_disk_write_cache: false
-    tune_disk_irq: false
-    tune_fstrim: false
-    tune_cpu: false
-    tune_aio_events: false
-    tune_clocksource: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
-    tune_ballast_file: false
-    overprovisioned: false
+    tune_network: true
+    tune_disk_scheduler: true
 `,
 			exp: `config_file: /etc/redpanda/redpanda.yaml
 redpanda:
+    data_directory: data/dir
     node_id: 0
     rack: redpanda-rack
     seed_servers: []
@@ -288,21 +259,8 @@ redpanda:
     developer_mode: true
 rpk:
     enable_usage_stats: true
-    tune_network: false
-    tune_disk_scheduler: false
-    tune_disk_nomerges: false
-    tune_disk_write_cache: false
-    tune_disk_irq: false
-    tune_fstrim: false
-    tune_cpu: false
-    tune_aio_events: false
-    tune_clocksource: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
-    tune_ballast_file: false
-    overprovisioned: false
+    tune_network: true
+    tune_disk_scheduler: true
 `,
 			args: []string{"rpk.enable_usage_stats", "true"},
 		},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -499,7 +499,6 @@ redpanda:
     admin:
         - address: 0.0.0.0
           port: 9644
-    developer_mode: false
 rpk:
     enable_usage_stats: true
     tune_network: true
@@ -518,7 +517,6 @@ rpk:
     coredump_dir: /var/lib/redpanda/coredumps
     tune_ballast_file: true
     well_known_io: vendor:vm:storage
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `,
@@ -556,7 +554,6 @@ redpanda:
     advertised_rpc_api:
         address: 174.32.64.2
         port: 33145
-    developer_mode: false
 rpk:
     enable_usage_stats: true
     tune_network: true
@@ -575,7 +572,6 @@ rpk:
     coredump_dir: /var/lib/redpanda/coredumps
     tune_ballast_file: true
     well_known_io: vendor:vm:storage
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `,
@@ -608,24 +604,6 @@ redpanda:
     admin:
         - address: 0.0.0.0
           port: 9644
-    developer_mode: false
-rpk:
-    enable_usage_stats: false
-    tune_network: false
-    tune_disk_scheduler: false
-    tune_disk_nomerges: false
-    tune_disk_write_cache: false
-    tune_disk_irq: false
-    tune_fstrim: false
-    tune_cpu: false
-    tune_aio_events: false
-    tune_clocksource: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
-    tune_ballast_file: false
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `,
@@ -662,7 +640,6 @@ redpanda:
     admin:
         - address: 0.0.0.0
           port: 9644
-    developer_mode: false
     log_segment_size: 536870912
 rpk:
     enable_usage_stats: true
@@ -682,7 +659,6 @@ rpk:
     coredump_dir: /var/lib/redpanda/coredumps
     tune_ballast_file: true
     well_known_io: vendor:vm:storage
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `,

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -41,7 +41,6 @@ rpk:
     admin_api:
         addresses:
             - 127.0.0.1:9644
-    enable_usage_stats: false
 `,
 		},
 		{
@@ -210,22 +209,7 @@ redpanda:
     developer_mode: true
 rpk:
     enable_usage_stats: true
-    tune_network: false
-    tune_disk_scheduler: false
-    tune_disk_nomerges: false
-    tune_disk_write_cache: false
-    tune_disk_irq: false
-    tune_fstrim: false
-    tune_cpu: false
-    tune_aio_events: false
-    tune_clocksource: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
     coredump_dir: /var/lib/redpanda/coredump
-    tune_ballast_file: false
-    overprovisioned: false
 pandaproxy: {}
 schema_registry: {}
 `, string(file))

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -25,9 +25,9 @@ type Config struct {
 	Organization         string          `yaml:"organization,omitempty" json:"organization"`
 	LicenseKey           string          `yaml:"license_key,omitempty" json:"license_key"`
 	ClusterID            string          `yaml:"cluster_id,omitempty" json:"cluster_id"`
-	ConfigFile           string          `yaml:"config_file" json:"config_file"`
-	Redpanda             RedpandaConfig  `yaml:"redpanda" json:"redpanda"`
-	Rpk                  RpkConfig       `yaml:"rpk" json:"rpk"`
+	ConfigFile           string          `yaml:"config_file,omitempty" json:"config_file"`
+	Redpanda             RedpandaConfig  `yaml:"redpanda,omitempty" json:"redpanda"`
+	Rpk                  RpkConfig       `yaml:"rpk,omitempty" json:"rpk"`
 	Pandaproxy           *Pandaproxy     `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
 	PandaproxyClient     *KafkaClient    `yaml:"pandaproxy_client,omitempty" json:"pandaproxy_client,omitempty"`
 	SchemaRegistry       *SchemaRegistry `yaml:"schema_registry,omitempty" json:"schema_registry,omitempty"`
@@ -48,11 +48,11 @@ type RedpandaConfig struct {
 	ID                         int                       `yaml:"node_id" json:"node_id"`
 	Rack                       string                    `yaml:"rack,omitempty" json:"rack"`
 	SeedServers                []SeedServer              `yaml:"seed_servers" json:"seed_servers"`
-	RPCServer                  SocketAddress             `yaml:"rpc_server" json:"rpc_server"`
+	RPCServer                  SocketAddress             `yaml:"rpc_server,omitempty" json:"rpc_server"`
 	RPCServerTLS               []ServerTLS               `yaml:"rpc_server_tls,omitempty" json:"rpc_server_tls"`
-	KafkaAPI                   []NamedAuthNSocketAddress `yaml:"kafka_api" json:"kafka_api"`
+	KafkaAPI                   []NamedAuthNSocketAddress `yaml:"kafka_api,omitempty" json:"kafka_api"`
 	KafkaAPITLS                []ServerTLS               `yaml:"kafka_api_tls,omitempty" json:"kafka_api_tls"`
-	AdminAPI                   []NamedSocketAddress      `yaml:"admin" json:"admin"`
+	AdminAPI                   []NamedSocketAddress      `yaml:"admin,omitempty" json:"admin"`
 	AdminAPITLS                []ServerTLS               `yaml:"admin_api_tls,omitempty" json:"admin_api_tls"`
 	CoprocSupervisorServer     SocketAddress             `yaml:"coproc_supervisor_server,omitempty" json:"coproc_supervisor_server"`
 	AdminAPIDocDir             string                    `yaml:"admin_api_doc_dir,omitempty" json:"admin_api_doc_dir"`
@@ -60,7 +60,7 @@ type RedpandaConfig struct {
 	CloudStorageCacheDirectory string                    `yaml:"cloud_storage_cache_directory,omitempty" json:"cloud_storage_cache_directory"`
 	AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api,omitempty" json:"advertised_rpc_api,omitempty"`
 	AdvertisedKafkaAPI         []NamedSocketAddress      `yaml:"advertised_kafka_api,omitempty" json:"advertised_kafka_api,omitempty"`
-	DeveloperMode              bool                      `yaml:"developer_mode" json:"developer_mode"`
+	DeveloperMode              bool                      `yaml:"developer_mode,omitempty" json:"developer_mode"`
 	AggregateMetrics           bool                      `yaml:"aggregate_metrics,omitempty" json:"aggregate_metrics,omitempty"`
 	DisablePublicMetrics       bool                      `yaml:"disable_public_metrics,omitempty" json:"disable_public_metrics,omitempty"`
 	Other                      map[string]interface{}    `yaml:",inline"`
@@ -89,23 +89,23 @@ type KafkaClient struct {
 }
 
 type SeedServer struct {
-	Host SocketAddress `yaml:"host" json:"host"`
+	Host SocketAddress `yaml:"host,omitempty" json:"host"`
 }
 
 type SocketAddress struct {
 	Address string `yaml:"address" json:"address"`
-	Port    int    `yaml:"port" json:"port"`
+	Port    int    `yaml:"port,omitempty" json:"port"`
 }
 
 type NamedSocketAddress struct {
 	Address string `yaml:"address" json:"address"`
-	Port    int    `yaml:"port" json:"port"`
+	Port    int    `yaml:"port,omitempty" json:"port"`
 	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
 }
 
 type NamedAuthNSocketAddress struct {
-	Address string  `yaml:"address" json:"address"`
-	Port    int     `yaml:"port" json:"port"`
+	Address string  `yaml:"address,omitempty" json:"address"`
+	Port    int     `yaml:"port,omitempty" json:"port"`
 	Name    string  `yaml:"name,omitempty" json:"name,omitempty"`
 	AuthN   *string `yaml:"authentication_method,omitempty" json:"authentication_method,omitempty"`
 }
@@ -156,26 +156,26 @@ type RpkConfig struct {
 	KafkaAPI                 RpkKafkaAPI `yaml:"kafka_api,omitempty" json:"kafka_api"`
 	AdminAPI                 RpkAdminAPI `yaml:"admin_api,omitempty" json:"admin_api"`
 	AdditionalStartFlags     []string    `yaml:"additional_start_flags,omitempty"  json:"additional_start_flags"`
-	EnableUsageStats         bool        `yaml:"enable_usage_stats" json:"enable_usage_stats"`
-	TuneNetwork              bool        `yaml:"tune_network" json:"tune_network"`
-	TuneDiskScheduler        bool        `yaml:"tune_disk_scheduler" json:"tune_disk_scheduler"`
-	TuneNomerges             bool        `yaml:"tune_disk_nomerges" json:"tune_disk_nomerges"`
-	TuneDiskWriteCache       bool        `yaml:"tune_disk_write_cache" json:"tune_disk_write_cache"`
-	TuneDiskIrq              bool        `yaml:"tune_disk_irq" json:"tune_disk_irq"`
-	TuneFstrim               bool        `yaml:"tune_fstrim" json:"tune_fstrim"`
-	TuneCPU                  bool        `yaml:"tune_cpu" json:"tune_cpu"`
-	TuneAioEvents            bool        `yaml:"tune_aio_events" json:"tune_aio_events"`
-	TuneClocksource          bool        `yaml:"tune_clocksource" json:"tune_clocksource"`
-	TuneSwappiness           bool        `yaml:"tune_swappiness" json:"tune_swappiness"`
-	TuneTransparentHugePages bool        `yaml:"tune_transparent_hugepages" json:"tune_transparent_hugepages"`
-	EnableMemoryLocking      bool        `yaml:"enable_memory_locking" json:"enable_memory_locking"`
-	TuneCoredump             bool        `yaml:"tune_coredump" json:"tune_coredump"`
+	EnableUsageStats         bool        `yaml:"enable_usage_stats,omitempty" json:"enable_usage_stats"`
+	TuneNetwork              bool        `yaml:"tune_network,omitempty" json:"tune_network"`
+	TuneDiskScheduler        bool        `yaml:"tune_disk_scheduler,omitempty" json:"tune_disk_scheduler"`
+	TuneNomerges             bool        `yaml:"tune_disk_nomerges,omitempty" json:"tune_disk_nomerges"`
+	TuneDiskWriteCache       bool        `yaml:"tune_disk_write_cache,omitempty" json:"tune_disk_write_cache"`
+	TuneDiskIrq              bool        `yaml:"tune_disk_irq,omitempty" json:"tune_disk_irq"`
+	TuneFstrim               bool        `yaml:"tune_fstrim,omitempty" json:"tune_fstrim"`
+	TuneCPU                  bool        `yaml:"tune_cpu,omitempty" json:"tune_cpu"`
+	TuneAioEvents            bool        `yaml:"tune_aio_events,omitempty" json:"tune_aio_events"`
+	TuneClocksource          bool        `yaml:"tune_clocksource,omitempty" json:"tune_clocksource"`
+	TuneSwappiness           bool        `yaml:"tune_swappiness,omitempty" json:"tune_swappiness"`
+	TuneTransparentHugePages bool        `yaml:"tune_transparent_hugepages,omitempty" json:"tune_transparent_hugepages"`
+	EnableMemoryLocking      bool        `yaml:"enable_memory_locking,omitempty" json:"enable_memory_locking"`
+	TuneCoredump             bool        `yaml:"tune_coredump,omitempty" json:"tune_coredump"`
 	CoredumpDir              string      `yaml:"coredump_dir,omitempty" json:"coredump_dir"`
-	TuneBallastFile          bool        `yaml:"tune_ballast_file" json:"tune_ballast_file"`
+	TuneBallastFile          bool        `yaml:"tune_ballast_file,omitempty" json:"tune_ballast_file"`
 	BallastFilePath          string      `yaml:"ballast_file_path,omitempty" json:"ballast_file_path"`
 	BallastFileSize          string      `yaml:"ballast_file_size,omitempty" json:"ballast_file_size"`
 	WellKnownIo              string      `yaml:"well_known_io,omitempty" json:"well_known_io"`
-	Overprovisioned          bool        `yaml:"overprovisioned" json:"overprovisioned"`
+	Overprovisioned          bool        `yaml:"overprovisioned,omitempty" json:"overprovisioned"`
 	SMP                      *int        `yaml:"smp,omitempty" json:"smp,omitempty"`
 }
 

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -54,22 +54,6 @@ redpanda:
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
-    enable_memory_locking: false
-    enable_usage_stats: false
-    overprovisioned: false
-    tune_aio_events: false
-    tune_ballast_file: false
-    tune_clocksource: false
-    tune_coredump: false
-    tune_cpu: false
-    tune_disk_irq: false
-    tune_disk_nomerges: false
-    tune_disk_scheduler: false
-    tune_disk_write_cache: false
-    tune_fstrim: false
-    tune_network: false
-    tune_swappiness: false
-    tune_transparent_hugepages: false
 schema_registry: {}
 '''
 
@@ -177,22 +161,9 @@ schema_registry: {}
 
         expected_config = yaml.full_load('''
 coredump_dir: /var/lib/redpanda/coredump
-enable_memory_locking: false
-enable_usage_stats: false  
-overprovisioned: false
 tune_aio_events: true
-tune_ballast_file: false
-tune_clocksource: false
-tune_coredump: false
 tune_cpu: true
 tune_disk_irq: true
-tune_disk_nomerges: false
-tune_disk_scheduler: false
-tune_disk_write_cache: false
-tune_fstrim: false
-tune_network: false
-tune_swappiness: false
-tune_transparent_hugepages: false
 ''')
 
         with tempfile.TemporaryDirectory() as d:
@@ -230,23 +201,17 @@ tune_transparent_hugepages: false
         rpk = RpkRemoteTool(self.redpanda, node)
         rpk.mode_set("prod")
         expected_config = yaml.full_load('''
-    enable_usage_stats: false
     tune_network: true
     tune_disk_scheduler: true
     tune_disk_nomerges: true
     tune_disk_write_cache: true
     tune_disk_irq: true
-    tune_fstrim: false
     tune_cpu: true
     tune_aio_events: true
     tune_clocksource: true
     tune_swappiness: true
-    tune_transparent_hugepages: false
-    enable_memory_locking: false
-    tune_coredump: false
     coredump_dir: /var/lib/redpanda/coredump
     tune_ballast_file: true
-    overprovisioned: false
 ''')
         with tempfile.TemporaryDirectory() as d:
             node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
@@ -261,4 +226,4 @@ tune_transparent_hugepages: false
                     self.logger.error(
                         f"Actual: {yaml.dump(actual_config['rpk'])}")
                 assert actual_config['rpk'] == expected_config
-                assert actual_config['redpanda']['developer_mode'] == False
+                assert 'developer_mode' not in actual_config['redpanda']


### PR DESCRIPTION
## Cover letter

rpk no longer stores/adds empty/zero values in redpanda.yaml (except seed_servers and node_id)

This avoids the unnecessary addition of yaml fields in the config file when performing write operations via rpk. e.g:

previous to this change:
```yaml
$ cat /tmp/test.yaml
config_file: /tmp/test.yaml
redpanda:
    data_directory: /var/lib/redpanda/data
    node_id: 0
    seed_servers: []
pandaproxy: {}

$ rpk redpanda config set redpanda.log_segment_size 536870112 --config /tmp/test-2.yaml

$ cat /tmp/test.yaml                                                                               
config_file: /tmp/test.yaml
redpanda:
    data_directory: /var/lib/redpanda/data
    node_id: 0
    seed_servers: []
    rpc_server:
        address: ""
        port: 0
    kafka_api: []
    admin: []
    developer_mode: false
    log_segment_size: 536870112
rpk:
    enable_usage_stats: false
    tune_network: false
    tune_disk_scheduler: false
    tune_disk_nomerges: false
    tune_disk_write_cache: false
    tune_disk_irq: false
    tune_fstrim: false
    tune_cpu: false
    tune_aio_events: false
    tune_clocksource: false
    tune_swappiness: false
    tune_transparent_hugepages: false
    enable_memory_locking: false
    tune_coredump: false
    tune_ballast_file: false
    overprovisioned: false
pandaproxy: {}
```

now:

```yaml
$ cat /tmp/test.yaml
config_file: /tmp/test.yaml
redpanda:
    data_directory: /var/lib/redpanda/data
    node_id: 0
    seed_servers: []
pandaproxy: {}

$ rpk redpanda config set redpanda.log_segment_size 536870112 --config /tmp/test.yaml 

$ cat /tmp/test.yaml
config_file: /tmp/test.yaml
redpanda:
    data_directory: /var/lib/redpanda/data
    node_id: 0
    seed_servers: []
    log_segment_size: 536870112
pandaproxy: {}
```
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5483

## UX changes

Users won't see unnecessary empty/zero values in their redpanda.yaml after writing to them using rpk, e.g: tuners values (booleans) or listeners (structs)

## Release notes
* rpk no longer stores/adds empty/zero values in redpanda.yaml (except seed_servers and node_id)
