### PR TITLE
[v22.1.x] schema_registry: Return schemaType for /schemas/ids/<id>

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -247,6 +247,9 @@
             "schema": {
               "type": "object",
               "properties": {
+                "schemaType": {
+                  "type": "string"
+                },
                 "schema": {
                   "type": "string"
                 }

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -24,6 +24,10 @@ inline void rjson_serialize(
   ::json::Writer<::json::StringBuffer>& w,
   const get_schemas_ids_id_response& res) {
     w.StartObject();
+    if (res.definition.type() != schema_type::avro) {
+        w.Key("schemaType");
+        ::json::rjson_serialize(w, to_string_view(res.definition.type()));
+    }
     w.Key("schema");
     ::json::rjson_serialize(w, res.definition.raw());
     w.EndObject();

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1037,6 +1037,15 @@ class SchemaRegistryTest(RedpandaTest):
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.text.strip() == simple_proto_def.strip()
 
+        result_raw = self._request("GET",
+                                   f"schemas/ids/1",
+                                   headers=HTTP_GET_HEADERS)
+        self.logger.info(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["schemaType"] == "PROTOBUF"
+        assert result["schema"].strip() == simple_proto_def.strip()
+
         result_raw = self._get_subjects_subject_versions_version_referenced_by(
             "simple", 1)
         self.logger.info(result_raw)


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5568.
Fixes https://github.com/redpanda-data/redpanda/issues/5583,