### PR TITLE
[v21.11.x] schema_registry: Support recursive protobuf structures

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -26,6 +26,8 @@
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 
+#include <unordered_set>
+
 namespace pandaproxy::schema_registry {
 
 namespace pb = google::protobuf;
@@ -317,6 +319,9 @@ struct compatibility_checker {
 
     bool check_compatible(
       const pb::Descriptor* reader, const pb::Descriptor* writer) {
+        if (!_seen_descriptors.insert(reader).second) {
+            return true;
+        }
         for (int i = 0; i < writer->field_count(); ++i) {
             if (reader->IsReservedNumber(i) || writer->IsReservedNumber(i)) {
                 continue;
@@ -372,6 +377,7 @@ struct compatibility_checker {
 
     const protobuf_schema_definition::impl& _reader;
     const protobuf_schema_definition::impl& _writer;
+    std::unordered_set<const pb::Descriptor*> _seen_descriptors;
 };
 
 } // namespace

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -298,3 +298,24 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_missing_field) {
       R"(syntax = "proto3"; message Simple { int32 id = 2; })",
       R"(syntax = "proto3"; message Simple { string res = 1; int32 id = 2; })"));
 }
+
+constexpr std::string_view recursive = R"(syntax = "proto3";
+
+package recursive;
+
+message Payload {
+  oneof payload {
+    .recursive.Message message = 1;
+  }
+}
+
+message Message {
+  string rule_name = 1;
+  .recursive.Payload payload = 2;
+})";
+
+SEASTAR_THREAD_TEST_CASE(
+  test_protobuf_compatibility_of_mutually_recursive_types) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive, recursive, recursive));
+}


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5573.
Fixes https://github.com/redpanda-data/redpanda/issues/5581,