### PR TITLE
[v22.1.x] expiring_promise: fix loss of exception information

### DIFF
--- a/src/v/utils/expiring_promise.h
+++ b/src/v/utils/expiring_promise.h
@@ -87,30 +87,16 @@ public:
 
     bool available() const { return _available; }
 
-    void set_exception(std::exception_ptr&& ex) {
+    template<typename Exception>
+    void set_exception(Exception&& ex) {
         if (_timer.cancel()) {
             unlink_abort_source();
         }
 
         if (likely(!_available)) {
             _available = true;
-            _promise.set_exception(ex);
+            _promise.set_exception(std::forward<Exception>(ex));
         }
-    }
-
-    void set_exception(const std::exception_ptr& ex) {
-        if (_timer.cancel()) {
-            unlink_abort_source();
-        }
-
-        if (likely(!_available)) {
-            _available = true;
-            _promise.set_exception(ex);
-        }
-    }
-
-    void set_exception(const std::exception& ex) {
-        set_exception(std::make_exception_ptr(ex));
     }
 
 private:


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4895.
Fixes https://github.com/redpanda-data/redpanda/issues/5595,