### PR TITLE
tests: fix python type errors around SI tests

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -72,7 +72,8 @@ class EndToEndShadowIndexingBase(EndToEndTest):
             self.kafka_tools.create_topic(topic)
 
     def tearDown(self):
-        self.s3_client.empty_bucket(self.s3_bucket_name)
+        assert self.redpanda and self.redpanda.s3_client
+        self.redpanda.s3_client.empty_bucket(self.s3_bucket_name)
 
 
 class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -67,6 +67,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
     def setUp(self):
+        assert self.redpanda
         self.redpanda.start()
         for topic in self.topics:
             self.kafka_tools.create_topic(topic)
@@ -126,6 +127,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
             {TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size},
         )
 
+        assert self.redpanda
         with random_process_kills(self.redpanda) as ctx:
             wait_for_segments_removal(redpanda=self.redpanda,
                                       topic=self.topic,
@@ -199,7 +201,7 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         # Block until a subset of records are produced
         await_minimum_produced_records(self.redpanda,
                                        producer,
-                                       min_acked=msg_count / 100)
+                                       min_acked=msg_count // 100)
 
         rand_consumer = FranzGoVerifiableRandomConsumer(
             self.test_context, self.redpanda, self.topic, msg_size, 100, 10,

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -20,6 +20,7 @@
 
 from collections import namedtuple
 import os
+from typing import Optional
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.services.redpanda import RedpandaService
@@ -66,7 +67,7 @@ class EndToEndTest(Test):
 
         self.records_consumed = []
         self.last_consumed_offsets = {}
-        self.redpanda = None
+        self.redpanda: Optional[RedpandaService] = None
         self.topic = None
         self._client = None
 

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -26,6 +26,7 @@ from rptest.services.redpanda import RedpandaService
 from rptest.clients.default import DefaultClient
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
+from rptest.archival.s3_client import S3Client
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -90,10 +91,6 @@ class EndToEndTest(Test):
                                         si_settings=self.si_settings)
         self.redpanda.start()
         self._client = DefaultClient(self.redpanda)
-
-    @property
-    def s3_client(self):
-        return self.redpanda.s3_client
 
     def client(self):
         assert self._client is not None

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -103,14 +103,16 @@ class TestReadReplicaService(EndToEndTest):
             else:
                 return True
 
+        assert self.redpanda and self.redpanda.s3_client
         # wait until the read replica topic creation succeeds
         wait_until(
             create_read_replica_topic_success,
             timeout_sec=
             60,  #should be uploaded since cloud_storage_segment_max_upload_interval_sec=5
             backoff_sec=5,
-            err_msg=
-            f"Could not create read replica topic. Most likely because topic manifest is not in S3, in S3 bucket: {list(self.redpanda._s3client.list_objects(self.s3_bucket_name))}"
+            err_msg="Could not create read replica topic. Most likely " +
+            "because topic manifest is not in S3, in S3 bucket: " +
+            f"{list(self.redpanda.s3_client.list_objects(self.s3_bucket_name))}"
         )
 
         second_rpk = RpkTool(self.second_cluster)
@@ -144,15 +146,19 @@ class TestReadReplicaService(EndToEndTest):
         rpk = RpkTool(self.redpanda)
         rpk.alter_topic_config(spec.name, 'redpanda.remote.write', 'true')
 
+        assert self.redpanda and self.redpanda.s3_client  # drops optional types
+
         # Make sure all produced data is uploaded to S3
-        def s3_has_all_data():
+        def s3_has_all_data() -> bool:
+            # pyright doesn't consider the assert in outer scope
+            assert self.redpanda and self.redpanda.s3_client
             objects = list(
-                self.redpanda._s3client.list_objects(self.s3_bucket_name))
+                self.redpanda.s3_client.list_objects(self.s3_bucket_name))
             total_uploaded = 0
             for o in objects:
                 if o.Key.endswith(
                         "/manifest.json") and self.topic_name in o.Key:
-                    data = self.redpanda._s3client.get_object_data(
+                    data = self.redpanda.s3_client.get_object_data(
                         self.s3_bucket_name, o.Key)
                     manifest = json.loads(data)
                     last_upl_offset = manifest['last_offset']
@@ -170,8 +176,8 @@ class TestReadReplicaService(EndToEndTest):
             timeout_sec=
             30,  #should be uploaded since cloud_storage_segment_max_upload_interval_sec=5
             backoff_sec=5,
-            err_msg=
-            f"Not all data is uploaded to S3 bucket, is S3 bucket: {list(self.redpanda._s3client.list_objects(self.s3_bucket_name))}"
+            err_msg="Not all data is uploaded to S3 bucket: " +
+            f"{list(self.redpanda.s3_client.list_objects(self.s3_bucket_name))}"
         )
 
         # Create read replica topic, consume from it and validate


### PR DESCRIPTION
Fixes pyright type errors for some integration tests I was looking at:

- e2e_shadow_indexing_test.py
- read_replica_e2e_test.py

To achieve this, (and inner zen), I followed the trail to:
- A base class, i.e. end_to_end.py
- service/redpanda.py: typing around `S3Client`