### PR TITLE
rpc: assert() only if output type supports both dencoders 

### DIFF
--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -118,12 +118,14 @@ concept is_rpc_serde_exempt = requires {
 /*
  * Encode a client request for the given transport version.
  *
- * Unless the message type T is explicitly exempt from adl<> support, type T
- * must be supported by both adl<> and serde encoding frameworks. When the type
- * is not exempt from adl<> support, serde is used when the version >= v2.
+ * Unless the message type T is explicitly exempt from adl<> or serde support,
+ * type T must be supported by both encoding frameworks. When the type is not
+ * exempt from serde support, serde is used when the version >= v2.
  *
  * The returned version indicates what level of encoding is used. This is always
- * equal to the input version, except for serde-only messags which return v2.
+ * equal to the input version, except for
+ * - adl-only messages which return v0;
+ * - serde-only messags which return v2.
  * Callers are expected to further validate the runtime implications of this.
  */
 template<typename T>


### PR DESCRIPTION
## Cover letter

rpc: assert() only if output type supports both dencoders

* conditionally assert on equality between the version used to encode the output
   and version set by the request's header
* update the comment to reflect the precondition based on which we have
   this assert
* the `std::ignore` statements are added to silence warnings like:
   
   ```
  ../src/v/rpc/service.h:88:30: error: lambda capture 'version' is not used [-Werror,-Wunused-lambda-capture]
                        .then([version, b = std::move(b)](
                               ^
    ```

this change addresses following test failure from `coproc_fixture_unstable_rpunit`:

```
DEBUG 2022-07-24 14:46:15,520 [shard 0] rpc - transport.h:277 - Upgrading connection from v1 to v2
INFO  2022-07-24 14:46:15,521 [shard 0] coproc - coproc_test_fixture.cc:165 - Making request to fetch from tp: {topic_partition: {sttp._identity_topic_}:0}, start_offset: 0, last_offset: 200, records_read: 0
DEBUG 2022-07-24 14:46:15,521 [shard 0] kafka/client - client_fetch_batch_reader.cc:49 - fetch_batch_reader: fetch offset: 0
DEBUG 2022-07-24 14:46:15,523 [shard 0] kafka/client - broker.h:63 - Dispatch: fetch req: {replica_id=-1 max_wait_ms=9966ms min_bytes=0 max_bytes=1048576 isolation_level=read_uncommitted session_id=0 session_epoch=-1 topics={{name={sttp._identity_topic_} fetch_partitions={{partition_index=0 current_leader_epoch=-1 fetch_offset=0 log_start_offset=-1 max_bytes=1048576}}}} forgotten={} rack_id=}
TRACE 2022-07-24 14:46:15,541 [shard 0] kafka - requests.cc:97 - [127.0.0.1:53200] processing name:fetch, key:1, version:10 for test_client, mem_units: 8218
TRACE 2022-07-24 14:46:15,541 [shard 0] kafka - fetch.cc:549 - handling fetch request: {replica_id=-1 max_wait_ms=9966ms min_bytes=0 max_bytes=1048576 isolation_level=read_uncommitted session_id=0 session_epoch=-1 topics={{name={sttp._identity_topic_} fetch_partitions={{partition_index=0 current_leader_epoch=-1 fetch_offset=0 log_start_offset=-1 max_bytes=1048576}}}} forgotten={} rack_id=}
TRACE 2022-07-24 14:46:15,542 [shard 2] storage - readers_cache.cc:88 - {kafka/sttp._identity_topic_/0} - trying to get reader for: {start_offset:{0}, max_offset:{9223372036854775807}, min_bytes:0, max_bytes:1048576, type_filter:nullopt, first_timestamp:nullopt}
TRACE 2022-07-24 14:46:15,543 [shard 2] storage - readers_cache.cc:117 - {kafka/sttp._identity_topic_/0} - reader cache miss for: {start_offset:{0}, max_offset:{9223372036854775807}, min_bytes:0, max_bytes:1048576, type_filter:nullopt, first_timestamp:nullopt}
INFO  2022-07-24 14:46:15,543 [shard 0] coproc - supervisor.cc:233 - Disabling coprocessor with id: 7843
TRACE 2022-07-24 14:46:15,543 [shard 2] storage - readers_cache.cc:75 - {kafka/sttp._identity_topic_/0} - adding reader [0,199]
TRACE 2022-07-24 14:46:15,544 [shard 2] storage - segment_reader.cc:106 - ::get segment file test.dir_1658645165/kafka/sttp._identity_topic_/0_10/0-0-v1.log, refcount=0
DEBUG 2022-07-24 14:46:15,544 [shard 2] storage - segment_reader.cc:110 - Opening segment file test.dir_1658645165/kafka/sttp._identity_topic_/0_10/0-0-v1.log
TRACE 2022-07-24 14:46:15,550 [shard 2] storage - segment_reader.cc:133 - ::put segment file test.dir_1658645165/kafka/sttp._identity_topic_/0_10/0-0-v1.log, refcount=1
DEBUG 2022-07-24 14:46:15,550 [shard 2] storage - segment_reader.cc:137 - Closing segment file test.dir_1658645165/kafka/sttp._identity_topic_/0_10/0-0-v1.log
TRACE 2022-07-24 14:46:15,551 [shard 2] storage - readers_cache.cc:309 - {kafka/sttp._identity_topic_/0} - removing reader: [0,199] lower_bound: 200
TRACE 2022-07-24 14:46:15,552 [shard 2] kafka - fetch.cc:338 - fetch_ntps_in_parallel: for 1 partitions returning 50309 total bytes
TRACE 2022-07-24 14:46:15,557 [shard 0] kafka - request_context.h:160 - [127.0.0.1:53200] sending 1:fetch response {throttle_time_ms=0ms error_code={ error_code: none [0] } session_id=0 topics={{name={sttp._identity_topic_} partitions={{partition_index=0 error_code={ error_code: none [0] } high_watermark=200 last_stable_offset=200 log_start_offset=0 aborted={nullopt} preferred_read_replica=-1 records={{size 50309}}}}}}}
ERROR 2022-07-24 14:46:15,560 [shard 0] assert - Assert failure: (../src/v/rpc/service.h:98) 'effective_version == version' auto rpc::service::execution_helper<detail::base_named_type<signed char, coproc::empty_req_tag, std::integral_constant<bool, true>>, coproc::disable_copros_reply, rpc::default_message_codec>::exec(ss::input_stream<char> &, rpc::streaming_context &, uint32_t, (lambda at src/v/coproc/supervisor.h:204:7) &&)::(anonymous class)::operator()()::(anonymous class)::operator()(coproc::disable_copros_reply)::(anonymous class)::operator()(rpc::transport_version) const [Input = detail::base_named_type<signed char, coproc::empty_req_tag, std::integral_constant<bool, true>>, Output = coproc::disable_copros_reply, Codec = rpc::default_message_codec]: Unexpected encoding at effective rpc::transport_version::v0 != rpc::transport_version::v2
```

in which, `Codec` is `default_message_codec`, `Output`'s type is
`coproc::disable_copros_reply`, which marks itself exempt from the
serde dencoder. `Input` is `coproc::empty_request`. the type
of `Output` is just another part of the RPC method, so `parse_type()` is
not able to determine/check the output's type. hence we cannot assume
the equality between these two versions. the assertion is safe only when
the `output` type is versatile enough to support both encodings, so that
is is able use the given version.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed. 

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.



Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
