### PR TITLE
kafka: fix assertion failure in join_empty_group_static_member

### DIFF
--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -96,12 +96,13 @@ FIXTURE_TEST(join_empty_group_static_member, consumer_offsets_fixture) {
           unknown_member_id, "group-test", {"p1", "p2"}, "random");
         // set group instance id
         req.data.group_instance_id = gr;
-        auto resp
-          = client.dispatch(std::move(req), kafka::api_version(5)).get0();
-        BOOST_REQUIRE(
-          resp.data.error_code == kafka::error_code::none
-          || resp.data.error_code == kafka::error_code::not_coordinator);
-        return resp.data.error_code == kafka::error_code::none
-               && resp.data.member_id != unknown_member_id;
+        return client.dispatch(std::move(req), kafka::api_version(5))
+          .then([&](auto resp) {
+              BOOST_REQUIRE(
+                resp.data.error_code == kafka::error_code::none
+                || resp.data.error_code == kafka::error_code::not_coordinator);
+              return resp.data.error_code == kafka::error_code::none
+                     && resp.data.member_id != unknown_member_id;
+          });
     }).get();
 }


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/commit/4fcd575194924633b5014184efd98d83ca158be5
a call to future<>::get was nested inside tests::cooperative_spin_wait_with_timeout. This is problematic: even though
the spin helper is running in a thread context the spin helper schedules
its body future in non-threaded context. this will lead to:

  | test_kafka_server_fixture_rpunit:
  /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/future.cc:248:
  void seastar::internal::future_base::do_wait(): Assertion `thread' failed.

Fixes: #5606

## Cover letter

* None