### PR TITLE
Support rack awareness on partition reallocation

### DIFF
--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -38,11 +38,19 @@ public:
       topic_table& topic_table,
       partition_allocator& partition_allocator);
 
+    enum class status {
+        empty,
+        movement_planned,
+        cancellations_planned,
+        waiting_for_reports,
+    };
+
     struct plan_data {
         partition_balancer_violations violations;
         std::vector<ntp_reassignments> reassignments;
         std::vector<model::ntp> cancellations;
         size_t failed_reassignments_count = 0;
+        status status = status::empty;
     };
 
     plan_data plan_reassignments(
@@ -111,6 +119,8 @@ private:
 
     std::optional<size_t> get_partition_size(
       const model::ntp& ntp, const reallocation_request_state&);
+
+    bool all_reports_received(const reallocation_request_state&);
 
     planner_config _config;
     topic_table& _topic_table;

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -108,8 +108,9 @@ private:
     std::error_code
     check_cluster_limits(allocation_request const& request) const;
 
-    result<std::vector<model::broker_shard>>
-      allocate_partition(partition_constraints);
+    result<std::vector<model::broker_shard>> allocate_partition(
+      partition_constraints,
+      const std::vector<model::broker_shard>& not_changed_replicas = {});
 
     result<std::vector<model::broker_shard>> do_reallocate_partition(
       partition_constraints, const std::vector<model::broker_shard>&);


### PR DESCRIPTION
Previosly rack awareness constraint was written in such a way that it did not allow the same racks only for the initial partition allocation.
When we start to reallocate partition, constraint takes into account only new nodes.

Now partition allocator rack awareness constraint knows about not changed replicas of the partition.

Fixes: #5571