### PR TITLE
ducktape: Update container to jammy

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:impish-20211102
+FROM ubuntu:jammy-20220531
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@a60d8e93ac5f13554dae036465a28ece6e407df1',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@7ba83f32d5f265aad955a31096dcc0c97d96c0ce',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',


### PR DESCRIPTION
## Cover letter

* impish is EOL and the repository is offline.
* Update ducktape, to update paramiko, to resolve ssh errors

fixes #5630

Signed-off-by: Ben Pope <ben@redpanda.com>

## Release notes

* none