### PR TITLE
[v21.11.x] ducktape: Update container to jammy

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:impish-20211102
+FROM ubuntu:jammy-20220531
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/vectorizedio/ducktape.git@master',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@7ba83f32d5f265aad955a31096dcc0c97d96c0ce',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9'


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5616.
Fixes https://github.com/redpanda-data/redpanda/issues/5632,