### PR TITLE
tests: fix version pin for arroyo

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -165,9 +165,8 @@ RUN apt update && \
 
 # Clone and install the arroyo client library in order to run its test suite.
 RUN mkdir /root/external_test_suites && \
-    git -C /root/external_test_suites clone --depth=1 https://github.com/getsentry/arroyo.git && \
+    git -C /root/external_test_suites clone -b 1.0.0 --depth=1 https://github.com/getsentry/arroyo.git && \
     cd /root/external_test_suites/arroyo && \
-    git reset --hard 2631cf1406b0cb5bc05c8a37e8f9f5a40fcf31d4 && \
     python3 -m pip install --force --no-cache-dir -e /root/external_test_suites/arroyo
 
 RUN mkdir -p /opt/scripts && \


### PR DESCRIPTION
The docker container build failed with the following:

```
 ---> Running in c64f400b37eb
Cloning into 'arroyo'...
fatal: Could not parse object '2631cf1406b0cb5bc05c8a37e8f9f5a40fcf31d4'.
The command '/bin/sh -c mkdir /root/external_test_suites &&     git -C /root/external_test_suites clone --depth=1 https://github.com/getsentry/arroyo.git &&     cd /root/external_test_suites/arroyo &&     git reset --hard 2631cf1406b0cb5bc05c8a37e8f9f5a40fcf31d4 &&     python3 -m pip install --force --no-cache-dir -e /root/external_test_suites/arroyo' returned a non-zero code: 128
task: Failed to run task "rp:run-ducktape-tests": task: Failed to run task "rp:init-ducktape-containers": task: Failed to run task "rp:build-test-docker-image": exit status 128
```

Looks like we only fetch the latest commit, and the pinned commit is no
longer the latest on the default branch. Fortunately, arroyo recently
released 1.0.0 that barely differs[1] from the pinned version, so let's
just use that.

[1] https://github.com/getsentry/arroyo/compare/1.0.0..2631cf1406b0cb5bc05c8a37e8f9f5a40fcf31d4

## Release notes
- none