### PR TITLE
rpc: add latency measurement to internal_rpc

### DIFF
--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -222,8 +222,9 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
                         reply_buf.set_version(ctx->get_header().version);
                     }
                     return send_reply(ctx, std::move(reply_buf))
-                      .finally([m, l = std::move(l)]() mutable {
-                          m->probes.latency_hist().record(std::move(l));
+                      .finally([ctx, m, l = std::move(l)]() mutable {
+                          ctx->res.hist().record(l);
+                          m->probes.latency_hist().record(l);
                       });
                 });
           })

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -149,7 +149,7 @@ public:
 
     std::unique_ptr<measurement> auto_measure();
 
-    void record(std::unique_ptr<measurement> m) {
+    void record(std::unique_ptr<measurement>& m) {
         record(m->compute_duration_micros());
     }
 


### PR DESCRIPTION
## Cover letter

PR #5411 introduced latency measurements for the rpc layer into the new
public endpoint. However, measurements for internal RPCs were lost
during the discussion. This commit adds latency back in.

Fixes #5649

## UX changes
* none

## Release notes
* none