### PR TITLE
tests: lower the max metadata age

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -355,6 +355,12 @@ class FeaturesNodeJoinTest(RedpandaTest):
 
         # Restart it with a sufficiently recent version and join should succeed
         self.installer.install([old_node], RedpandaInstaller.HEAD)
+
+        # Set the maximum age of the health monitor metadata to 5 seconds.
+        # The assertion below relies on the metadata being fresh on all brokers.
+        self.redpanda.set_cluster_config(
+            {"health_monitor_max_metadata_age": 5000})
+
         self.redpanda.restart_nodes([old_node])
         wait_until(lambda: self.redpanda.registered(old_node),
                    timeout_sec=10,


### PR DESCRIPTION
## Cover letter
The final assertion in `test_old_node_join` requires for the `brokers` request on the admin API to return a new cluster member on all followers within 10 seconds. It turns out that in order for this admin request to return an up to date list, a metadata refresh is required in the health monitor. By default the maximum age of that metadata is also 10 seconds. The test failure in #5591 exhibits a race between the updating of the metadata and the test timeout.

The solution chosen here is to perform health metadata refreshes more often .

Fixes #5591 

## Release notes
* none