### PR TITLE
cmake: pin pex==2.1.100

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -309,7 +309,7 @@ ExternalProject_Add(kafka-codegen-pex
   BUILD_COMMAND ""
   INSTALL_COMMAND
   COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 -m venv env
-  COMMAND <SOURCE_DIR>/env/bin/pip install pex
+  COMMAND <SOURCE_DIR>/env/bin/pip install pex=2.1.100
   COMMAND <SOURCE_DIR>/env/bin/pex jsonschema jinja2 -o <INSTALL_DIR>/bin/kafka-codegen-venv)
 
 ExternalProject_Add(kafka-python-pex
@@ -320,7 +320,7 @@ ExternalProject_Add(kafka-python-pex
   BUILD_COMMAND ""
   INSTALL_COMMAND
   COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 -m venv env
-  COMMAND <SOURCE_DIR>/env/bin/pip install pex
+  COMMAND <SOURCE_DIR>/env/bin/pip install pex=2.1.100
   COMMAND <SOURCE_DIR>/env/bin/pex kafka-python -o <INSTALL_DIR>/bin/kafka-python-env
   )
 


### PR DESCRIPTION
There is a [bug](https://github.com/pantsbuild/pex/issues/1866) in 2.1.101 with `site-packages` that produces error:
```
pex.pep_376.RecordNotFoundError: Could not find a site-packages directory under installation prefix /root/.pex/installed_wheels/6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045/pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.2cf21658b1684622b60ee75161a9bfb8: The virtualenv at /root/.pex/installed_wheels/6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045/pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.2cf21658b1684622b60ee75161a9bfb8 is not valid. The expected site-packages directory at /root/.pex/installed_wheels/6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045/pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.2cf21658b1684622b60ee75161a9bfb8/lib/python3.9/site-packages does not exist.
```

Here is the difference between pex 2.1.100 and 2.1.101: https://github.com/pantsbuild/pex/compare/v2.1.100...v2.1.101