### PR TITLE
tests: added restart log allow list to dead group recovery test

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -14,6 +14,7 @@ from rptest.services.cluster import cluster
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.kafka_cli_consumer import KafkaCliConsumer
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.utils.util import wait_until
@@ -304,7 +305,7 @@ class ConsumerGroupTest(RedpandaTest):
             c.wait()
             c.free()
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(static_members=True)
     @parametrize(static_members=False)
     def test_dead_group_recovery(self, static_members):


### PR DESCRIPTION
The `test_dead_group_recovery` test executes node restart to force group
metadata recovery on every node. Added restart log allow list to cluster
annotation to prevent test from failing with BadLogLines error

Fixes: #5626


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
