### PR TITLE
[v21.11.x] tests: Fix group_membership topic_recreation

### DIFF
--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -226,23 +226,36 @@ class GroupMetricsTest(RedpandaTest):
         group = "g0"
 
         def check_metric():
+            if topic_spec.name not in rpk.list_topics():
+                return False
             for i in range(100):
                 payload = str(random.randint(0, 1000))
                 offset = rpk.produce(topic, "", payload, timeout=5)
-
             metric_key = (topic, "0")
             rpk.consume(topic, group=group, n=50)
             metrics_offsets = self._get_offset_from_metrics(group)
-            assert metric_key in metrics_offsets
-            assert metrics_offsets[metric_key] == 50
+            if metric_key not in metrics_offsets:
+                return False
+            if metrics_offsets[metric_key] <= 0:
+                return False
+            return True
 
-            self.redpanda.delete_topic(topic)
+        wait_until(lambda: check_metric(),
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Initial check metric failed")
 
-        check_metric()
-        metrics_offsets = self._get_offset_from_metrics(group)
-        assert metrics_offsets is None
+        self.redpanda.delete_topic(topic)
+        wait_until(lambda: self._get_offset_from_metrics(group) is None,
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Topic metrics haven't dissapeared")
+
         self.redpanda.create_topic(topic_spec)
-        check_metric()
+        wait_until(lambda: check_metric(),
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Topic recreation check metric failed")
 
     @cluster(num_nodes=7)
     def test_leadership_transfer(self):


### PR DESCRIPTION
## Cover letter

Backport #3816 

It wasn't a clean backport, you can see the conflict in the [force push](https://github.com/redpanda-data/redpanda/compare/ef507db7cfb4389bd007b36e27ffc822e274d58d..fd3d1645640d4e72112eb29470d6bac94557f47a)

Fix CI failure here: https://buildkite.com/redpanda/redpanda/builds/13149#01823d24-692c-4d17-9792-ac7a288fbf59

## Release notes

* none