### PR TITLE
cluster: improved logging during shutdown

### DIFF
--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -30,9 +30,6 @@ config_frontend::config_frontend(
   , _as(as)
   , _self(config::node().node_id()) {}
 
-ss::future<> config_frontend::start() { return ss::now(); }
-ss::future<> config_frontend::stop() { return ss::now(); }
-
 /**
  * RPC wrapper on do_patch, to dispatch to the controller leader
  * if we aren't it.

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -45,9 +45,6 @@ public:
     ss::future<std::error_code>
     set_status(config_status&, model::timeout_clock::time_point);
 
-    ss::future<> start();
-    ss::future<> stop();
-
     void set_next_version(config_version v);
 
 private:

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -217,7 +217,7 @@ ss::future<> config_manager::start() {
 }
 
 ss::future<> config_manager::stop() {
-    vlog(clusterlog.info, "stopping cluster::config_manager...");
+    vlog(clusterlog.info, "Stopping Config Manager...");
     _reconcile_wait.broken();
     co_await _gate.close();
 }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -264,6 +264,7 @@ controller_backend::controller_backend(
   , _as(as) {}
 
 ss::future<> controller_backend::stop() {
+    vlog(clusterlog.info, "Stopping Controller Backend...");
     _housekeeping_timer.cancel();
     return _gate.close();
 }

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -155,6 +155,7 @@ ss::future<> feature_manager::start() {
     co_return;
 }
 ss::future<> feature_manager::stop() {
+    vlog(clusterlog.info, "Stopping Feature Manager...");
     _group_manager.local().unregister_leadership_notification(
       _leader_notify_handle);
     _hm_backend.local().unregister_node_callback(_health_notify_handle);

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -53,6 +53,7 @@ ss::future<> health_manager::start() {
 }
 
 ss::future<> health_manager::stop() {
+    vlog(clusterlog.info, "Stopping Health Manager...");
     _timer.cancel();
     return _gate.close();
 }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -116,6 +116,7 @@ void health_monitor_backend::unregister_node_callback(
 }
 
 ss::future<> health_monitor_backend::stop() {
+    vlog(clusterlog.info, "Stopping Health Monitor Backend...");
     _raft_manager.local().unregister_leadership_notification(
       _leadership_notification_handle);
 

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -30,6 +30,7 @@ ss::future<> health_monitor_frontend::start() {
 }
 
 ss::future<> health_monitor_frontend::stop() {
+    vlog(clusterlog.info, "Stopping Health Monitor Frontend...");
     if (ss::this_shard_id() == refresher_shard) {
         if (_refresh_timer.armed()) {
             _refresh_timer.cancel();

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -58,6 +58,7 @@ members_backend::members_backend(
 }
 
 ss::future<> members_backend::stop() {
+    vlog(clusterlog.info, "Stopping Members Backend...");
     _retry_timer.cancel();
     _new_updates.broken();
     return _bg.close();

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -43,10 +43,6 @@ members_frontend::members_frontend(
   , _feature_table(feature_table)
   , _as(as) {}
 
-ss::future<> members_frontend::start() { return ss::now(); }
-
-ss::future<> members_frontend::stop() { return ss::now(); }
-
 ss::future<std::error_code>
 members_frontend::finish_node_reallocations(model::node_id id) {
     auto leader = _leaders.local().get_leader(model::controller_ntp);

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -39,9 +39,6 @@ public:
       ss::sharded<feature_table>&,
       ss::sharded<ss::abort_source>&);
 
-    ss::future<> start();
-    ss::future<> stop();
-
     ss::future<std::error_code> decommission_node(model::node_id);
     ss::future<std::error_code> recommission_node(model::node_id);
     ss::future<std::error_code> finish_node_reallocations(model::node_id);

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -127,6 +127,7 @@ ss::future<> metrics_reporter::start() {
 }
 
 ss::future<> metrics_reporter::stop() {
+    vlog(clusterlog.info, "Stopping Metrics Reporter...");
     _tick_timer.cancel();
     co_await _gate.close();
 }

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -27,6 +27,8 @@ partition_leaders_table::partition_leaders_table(
   : _topic_table(topic_table) {}
 
 ss::future<> partition_leaders_table::stop() {
+    vlog(clusterlog.info, "Stopping Partition Leaders Table...");
+
     while (!_leader_promises.empty()) {
         auto it = _leader_promises.begin();
         for (auto& promise : it->second) {

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -192,6 +192,7 @@ ss::future<> leader_balancer::start() {
 }
 
 ss::future<> leader_balancer::stop() {
+    vlog(clusterlog.info, "Stopping Leader Balancer...");
     _leaders.unregister_leadership_change_notification(
       _raft0->ntp(), _leader_notify_handle);
     _members.unregister_maintenance_state_change_notification(


### PR DESCRIPTION
## Cover letter

In shutdown hangs like https://github.com/redpanda-data/redpanda/issues/5178#issuecomment-1196741472 , it can be hard to get a sense of which part of shutdown is in progress when something goes wrong.

This PR adds some additional INFO level logging so that whether in the field or in automated testing, we have a trail of log messages to give us a hint about where the problem lies.

## UX changes

Slightly more verbose logging during shutdown.

## Release notes

* none
