### PR TITLE
[v22.1.x] raft: require full leadership before leadership transfer

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2803,7 +2803,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                *   - shutdown may be in progress
                *   - other: identified by follower not caught-up
                */
-              if (!is_elected_leader()) {
+              if (!is_leader()) {
                   vlog(
                     _ctxlog.warn, "Cannot transfer leadership from non-leader");
                   return seastar::make_ready_future<std::error_code>(


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5333.
Fixes https://github.com/redpanda-data/redpanda/issues/5673,