### PR TITLE
cluster: fix config status write pre-check

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -473,7 +473,8 @@ ss::future<> config_manager::reconcile_status() {
         } else {
             vlog(
               clusterlog.trace,
-              "reconcile_status: sending status update to leader");
+              "reconcile_status: sending status update to leader: {}",
+              my_latest_status);
             if (_self == *leader) {
                 auto err = co_await _frontend.local().set_status(
                   my_latest_status, model::timeout_clock::now() + timeout);

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -154,7 +154,7 @@ ss::future<> controller::start() {
             std::ref(_as));
       })
       .then([this] {
-          return _config_manager.start(
+          return _config_manager.start_single(
             std::ref(_config_preload),
             std::ref(_config_frontend),
             std::ref(_connections),


### PR DESCRIPTION


## Cover letter

This was meant to avoid writing redundant messages
to controller log, but was checking a potentially-empty
status map on the local core rather than the proper
status map on shard 0.

Fixes https://github.com/redpanda-data/redpanda/issues/5679

## UX changes

None

## Release notes

### Improvements

* An issue is fixed where controller logs could grow unexpectedly when nodes were unhealthy during configuration changes
