### PR TITLE
Fix readers cache truncation deadlock

### DIFF
--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -54,16 +54,16 @@ readers_cache::put(std::unique_ptr<log_reader> reader) {
         return model::record_batch_reader(std::move(reader));
     }
     // check if requested reader belongs to one of the locked range
-    auto lock_it = std::find_if(
-      _locked_offset_ranges.begin(),
-      _locked_offset_ranges.end(),
-      [&reader](const offset_range& range) {
-          return reader->lease_range_base_offset() > range.second
-                 || reader->lease_range_end_offset() < range.first;
-      });
-
     // range locked, do not insert into the cache
-    if (lock_it != _locked_offset_ranges.end()) {
+    if (intersects_with_locked_range(
+          reader->lease_range_base_offset(),
+          reader->lease_range_end_offset())) {
+        vlog(
+          stlog.trace,
+          "{} - range is locked, not adding reader with lease [{},{}]",
+          _ntp,
+          reader->lease_range_base_offset(),
+          reader->lease_range_end_offset());
         return model::record_batch_reader(std::move(reader));
     }
 
@@ -78,6 +78,19 @@ readers_cache::put(std::unique_ptr<log_reader> reader) {
     _in_use.push_back(*ptr);
     _probe.reader_added();
     return ptr->make_cached_reader(this);
+}
+
+bool readers_cache::intersects_with_locked_range(
+  model::offset reader_base_offset, model::offset reader_end_offset) const {
+    auto lock_it = std::find_if(
+      _locked_offset_ranges.begin(),
+      _locked_offset_ranges.end(),
+      [reader_base_offset, reader_end_offset](const offset_range& range) {
+          return reader_base_offset <= range.second
+                 && reader_end_offset >= range.first;
+      });
+
+    return lock_it != _locked_offset_ranges.end();
 }
 
 std::optional<model::record_batch_reader>

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -94,6 +94,7 @@ public:
     ~readers_cache();
 
 private:
+    friend struct readers_cache_test_fixture;
     struct entry;
     void touch(entry* e) {
         e->last_used = ss::lowres_clock::now();

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -174,6 +174,8 @@ private:
         co_await dispose_entries(std::move(to_evict));
     }
 
+    bool intersects_with_locked_range(model::offset, model::offset) const;
+
     model::ntp _ntp;
     std::chrono::milliseconds _eviction_timeout;
     ss::gate _gate;

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ rp_test(
     timequery_test.cc
     kvstore_test.cc
     backlog_controller_test.cc
+    readers_cache_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/readers_cache_test.cc
+++ b/src/v/storage/tests/readers_cache_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "model/fundamental.h"
+#include "seastarx.h"
+#include "storage/readers_cache.h"
+#include "test_utils/fixture.h"
+
+#include <fmt/ostream.h>
+
+namespace storage {
+struct readers_cache_test_fixture {
+    readers_cache_test_fixture()
+      : cache(
+        model::ntp("test", "test", 0), std::chrono::milliseconds(360000)) {}
+
+    bool intersects_locked_range(model::offset begin, model::offset end) {
+        return cache.intersects_with_locked_range(begin, end);
+    }
+
+    void test_intersects_locked(
+      model::offset::type begin, model::offset::type end, bool in_range) {
+        BOOST_REQUIRE_EQUAL(
+          intersects_locked_range(model::offset(begin), model::offset(end)),
+          in_range);
+    }
+
+    readers_cache cache;
+};
+
+} // namespace storage
+using namespace storage;
+
+FIXTURE_TEST(test_range_is_correctly_locked, readers_cache_test_fixture) {
+    {
+        /**
+         * Evict truncate locks range starting from give offset up to max
+         */
+        auto holder = cache.evict_truncate(model::offset(10)).get();
+
+        // [0,1] is not in [10,inf]
+        test_intersects_locked(0, 1, false);
+
+        // [0,10] is in range [10,inf]
+        test_intersects_locked(0, 10, true);
+
+        // [9,12] is in range [10, inf]
+        test_intersects_locked(9, 12, true);
+
+        // [10,12] is in range [10, inf]
+        test_intersects_locked(10, 12, true);
+
+        // [20,25] is in range [10, inf]
+        test_intersects_locked(20, 25, true);
+    }
+
+    {
+        /**
+         * Evict prefix truncate locks range starting from 0 up to given offset
+         */
+        auto holder = cache.evict_prefix_truncate(model::offset(10)).get();
+
+        // [0,1] is in [0,10]
+        test_intersects_locked(0, 1, true);
+
+        // [0,10] is in range [0,10]
+        test_intersects_locked(0, 10, true);
+
+        // [9,12] is in range [0, 10]
+        test_intersects_locked(9, 12, true);
+
+        // [10,12] is in range [0, 10]
+        test_intersects_locked(10, 12, true);
+
+        // [20,25] is not in range [0, 10]
+        test_intersects_locked(20, 25, false);
+    }
+
+    {
+        /**
+         * Evict range locks given range
+         */
+        auto holder
+          = cache.evict_range(model::offset(5), model::offset(10)).get();
+
+        // [0,1] is not in [5,10]
+        test_intersects_locked(0, 1, false);
+
+        // [0,20] is not in range [5,10] but [5,10] is in [0,20]
+        test_intersects_locked(0, 20, true);
+
+        // [9,12] is in range [5,10]
+        test_intersects_locked(9, 12, true);
+
+        // [10,12] is in range [5,10]
+        test_intersects_locked(10, 12, true);
+
+        // [20,25] is not in range [5,10]
+        test_intersects_locked(20, 25, false);
+
+        // [4,5] is in range [5,10]
+        test_intersects_locked(4, 5, true);
+
+        // [6,7] is in range [5,10]
+        test_intersects_locked(6, 7, true);
+    }
+}


### PR DESCRIPTION
## Cover letter
Fixed condition checking if range is locked. Incorrect check resulted in
situations in which log truncation was blocked by pending readers.

Log truncation is multi step process that ends with grabbing necessary
segments write logs and data deletion. In order for truncation to grab
the write lock all readers which own read lock units from range being
truncated must be evicted from `readers_cache`. Since log truncation
contains multiple scheduling points it may interleave with another fiber
creating a reader for log that is currently being truncated. This reader
MUST not be cached as truncation would need to wait for it to be
evicted. Additionally no new readers can be created as truncation
related write lock request is waiting in the `read_write_lock`
underlying semaphore waiters queue.

In order to prevent readers requesting truncated range from being cached
readers cache maintain list of locked ranges i.e. ranges for which
readers can not be cached.

Previously an incorrect condition checking if reader belongs to locked
range allow it to be cached preventing the `truncate` action to
continue. This stopped all other writes and truncation for 60 seconds,
after this duration the reader was evicted from the cache, its lease was
released and truncation was able to finish.

Fixed incorrect condition checking if reader is within the locked
range.

Fixes: #5510 
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
