### PR TITLE
Minor tweaks to k8s operator testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ _e2e_unstable_artifacts/
 _helm_e2e_artifacts/
 /src/go/k8s/testbin/*
 /src/go/k8s/cm-verifier
+/src/go/k8s/*.tar.gz
+/src/go/k8s/*-exit-code
+/src/go/k8s/kubeconfig
 
 # Test binary, build with `go test -c`
 *.test

--- a/src/go/k8s/Dockerfile
+++ b/src/go/k8s/Dockerfile
@@ -1,11 +1,3 @@
-# This template exists so that the same Dockerfile content can be used in both 
-# regular 'docker build' and builkit builds. For the former, the following line 
-# needs to be added at the top:
-#
-#   ARG BUILDPLATFORM
-#
-# For buildkit, the file can be used "as is"
-
 FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 
 ARG TARGETARCH

--- a/src/go/k8s/Dockerfile.dockerignore
+++ b/src/go/k8s/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+**
+!rpk/
+!k8s/apis
+!k8s/cmd
+!k8s/config
+!k8s/controllers
+!k8s/go.mod
+!k8s/go.sum
+!k8s/main.go
+!k8s/pkg

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,7 +1,7 @@
 
 # Image URL to use all building/pushing image targets
-OPERATOR_IMG_LATEST ?= "vectorized/redpanda-operator:dev"
-CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:dev"
+OPERATOR_IMG_LATEST ?= "localhost/redpanda-operator:dev"
+CONFIGURATOR_IMG_LATEST ?= "localhost/configurator:dev"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/src/go/k8s/hack/install-cert-manager.sh
+++ b/src/go/k8s/hack/install-cert-manager.sh
@@ -12,6 +12,8 @@ if [ "$(kubectl get deploy --sort-by=.metadata.name --namespace cert-manager -o=
   exit 0
 fi
 
+mkdir -p ./bin
+
 if [ "$(uname)" == 'Darwin' ]; then
   curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf - -C ./bin
 else

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -2,8 +2,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
-  - vectorized/redpanda-operator:dev
-  - vectorized/configurator:dev
+  - localhost/redpanda-operator:dev
+  - localhost/configurator:dev
 testDirs:
   - ./tests/e2e-helm
 kindConfig: ./kind.yaml

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -2,8 +2,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
-  - vectorized/redpanda-operator:dev
-  - vectorized/configurator:dev
+  - localhost/redpanda-operator:dev
+  - localhost/configurator:dev
 testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -12,7 +12,9 @@ commands:
   - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
   - command: "./hack/install-cert-manager.sh"
   - command: "kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml"
-  - command: "make deploy"
+  - command: "sh -c 'cd config/manager && kustomize edit set image vectorized/redpanda-operator=localhost/redpanda-operator:dev'"
+  - command: "sh -c 'kustomize build config/default | kubectl apply -f -'"
+  - command: "kind load docker-image localhost/redpanda:dev"
   - command: "./hack/wait-for-webhook-ready.sh"
   - command: "mkdir -p tests/_e2e_artifacts"
 artifactsDir: tests/_e2e_artifacts

--- a/src/go/k8s/kuttl-unstable-test.yaml
+++ b/src/go/k8s/kuttl-unstable-test.yaml
@@ -4,8 +4,8 @@ startKIND: true
 skipDelete: true
 skipClusterDelete: true
 kindContainers:
-  - vectorized/redpanda-operator:dev
-  - vectorized/configurator:dev
+  - localhost/redpanda-operator:dev
+  - localhost/configurator:dev
   - localhost/redpanda:dev
 testDirs:
   - ./tests/e2e-unstable

--- a/src/go/k8s/kuttl-unstable-test.yaml
+++ b/src/go/k8s/kuttl-unstable-test.yaml
@@ -15,7 +15,9 @@ commands:
   - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
   - command: "./hack/install-cert-manager.sh"
   - command: "kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml"
-  - command: "make deploy"
+  - command: "sh -c 'cd config/manager && kustomize edit set image vectorized/redpanda-operator=localhost/redpanda-operator:dev'"
+  - command: "sh -c 'kustomize build config/default | kubectl apply -f -'"
+  - command: "kind load docker-image localhost/redpanda:dev"
   - command: "./hack/wait-for-webhook-ready.sh"
   - command: "mkdir -p tests/_e2e_unstable_artifacts"
 artifactsDir: tests/_e2e_unstable_artifacts


### PR DESCRIPTION
Some tweaks to the k8s testing setup:
  * Assume dockerfile for operator is built using buildkit (drop support for "old" `docker build`)
  * Adds dockerignore file to speedup local dev testing
  * Change name of local images to make it explicit that these are not referencing images that exist up in dockerhub

## Release notes

* none