### PR TITLE
Bump macos version in rpk gha workflow

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          curl -LO https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          curl -LO https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip
           unzip gon_macos.zip
           rm gon_macos.zip
 

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
the github action macOS-10.15 environment is now showing a deprecation error when executing the rpk workflow. this PR moves the version to `macos-latest`. it also bumps up the version of gon to the latest.

this needs backport to v22.1.x and v21.11.x

## Release notes

* none