### PR TITLE
Add data serialization compatibility framework

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(serde)
 add_subdirectory(cloud_storage)
 add_subdirectory(cloud_roles)
 add_subdirectory(v8_engine)
+add_subdirectory(compat)
 add_subdirectory(rp_util)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -94,7 +94,17 @@ struct update_leadership_request
     explicit update_leadership_request(std::vector<ntp_leader> leaders)
       : leaders(std::move(leaders)) {}
 
+    friend bool operator==(
+      const update_leadership_request&, const update_leadership_request&)
+      = default;
+
     auto serde_fields() { return std::tie(leaders); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const update_leadership_request& r) {
+        fmt::print(o, "leaders {}", r.leaders);
+        return o;
+    }
 };
 
 struct update_leadership_request_v2

--- a/src/v/compat/CMakeLists.txt
+++ b/src/v/compat/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::json
-    v::utils)
+    v::utils
+    v::raft)
 
 add_subdirectory(tests)

--- a/src/v/compat/CMakeLists.txt
+++ b/src/v/compat/CMakeLists.txt
@@ -1,0 +1,10 @@
+v_cc_library(
+  NAME compat
+  SRCS
+    run.cc
+  DEPS
+    Seastar::seastar
+    v::json
+    v::utils)
+
+add_subdirectory(tests)

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/document.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+#include "reflection/adl.h"
+#include "seastarx.h"
+#include "serde/serde.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <vector>
+
+namespace compat {
+
+/*
+ * Specialize for types that cannot be copied.
+ */
+template<typename T>
+std::tuple<T, T> compat_copy(T t) {
+    return {t, t};
+}
+
+/*
+ * Holder for binary serialization of a data structure along with the name of
+ * the protocol used (e.g. adl, serde).
+ */
+struct compat_binary {
+    ss::sstring name;
+    iobuf data;
+
+    // factory for serde
+    template<typename T>
+    static compat_binary serde(T v) {
+        return {"serde", serde::to_iobuf(v)};
+    }
+
+    // factory for serde and adl
+    template<typename T>
+    static std::vector<compat_binary> serde_and_adl(T v) {
+        auto&& [a, b] = compat_copy(std::move(v));
+        return {
+          compat_binary::serde(std::move(a)),
+          compat_binary("adl", reflection::to_iobuf(std::move(b))),
+        };
+    }
+
+    compat_binary(ss::sstring name, iobuf data)
+      : name(std::move(name))
+      , data(std::move(data)) {}
+
+    compat_binary(compat_binary&&) noexcept = default;
+    compat_binary& operator=(compat_binary&&) noexcept = default;
+
+    /*
+     * copy ctor/assignment are defined for ease of use, which would normally be
+     * disabled due to the move-only iobuf data member.
+     */
+    compat_binary(const compat_binary& other)
+      : name(other.name)
+      , data(other.data.copy()) {}
+
+    compat_binary& operator=(const compat_binary& other) {
+        if (this != &other) {
+            name = other.name;
+            data = other.data.copy();
+        }
+        return *this;
+    }
+
+    ~compat_binary() = default;
+};
+
+/*
+ * Interface for creating a compatibility test.
+ */
+template<typename T>
+struct compat_check {
+    /*
+     * Generate test cases. It's good to build some random cases, as well as
+     * convering edge cases such as min/max values or empty values, etc...
+     */
+    static std::vector<T> create_test_cases();
+
+    /*
+     * Serialize an instance of T to the JSON writer.
+     */
+    static void to_json(T, json::Writer<json::StringBuffer>&);
+
+    /*
+     * Deserialize an instance of T from the JSON value.
+     */
+    static T from_json(json::Value&);
+
+    /*
+     * Serialize an instance of T to supported binary formats.
+     */
+    static std::vector<compat_binary> to_binary(T);
+
+    /*
+     * Check compatibility. Ensure that the instance of T (from JSON) matches
+     * the binary encoded instance of T.
+     */
+    static bool check(T, compat_binary);
+};
+
+/*
+ * Helper that compares an instance of T with an adl or serde instance.
+ */
+template<typename T>
+bool verify_adl_or_serde(T expected, compat_binary test) {
+    const auto decoded = [&] {
+        if (test.name == "adl") {
+            return reflection::from_iobuf<T>(std::move(test.data));
+        } else if (test.name == "serde") {
+            return serde::from_iobuf<T>(std::move(test.data));
+        } else {
+            vassert(false, "unknown type {}", test.name);
+        }
+    }();
+
+    if (expected != decoded) {
+        fmt::print(
+          "Verify of {{{}}} decoding failed:\nExpected: {}\nDecoded: {}\n",
+          test.name,
+          expected,
+          decoded);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace compat

--- a/src/v/compat/generator.h
+++ b/src/v/compat/generator.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include <vector>
+
+namespace compat {
+
+/*
+ * Protocol for building random instance generators.
+ */
+template<typename T>
+struct instance_generator {
+    /*
+     * Return a random instance of T.
+     */
+    static T random();
+
+    /*
+     * Return instances of T which may be interesting for testing. Typically
+     * this involves selecting for edge cases like min/max/empty/large values.
+     */
+    static std::vector<T> limits();
+};
+
+/*
+ * Combine from all instance generator interfaces.
+ */
+template<typename T>
+auto generate_instances(size_t randoms = 1) -> std::vector<T> {
+    using generator = instance_generator<T>;
+    auto res = generator::limits();
+    for (size_t i = 0; i < randoms; i++) {
+        res.push_back(generator::random());
+    }
+    return res;
+}
+
+} // namespace compat

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "json/document.h"
+#include "json/json.h"
+#include "model/fundamental.h"
+
+namespace json {
+
+inline char const* to_str(rapidjson::Type const t) {
+    static char const* str[] = {
+      "Null", "False", "True", "Object", "Array", "String", "Number"};
+    return str[t];
+}
+
+inline void read_value(json::Value const& v, int64_t& target) {
+    target = v.GetInt64();
+}
+
+inline void read_value(json::Value const& v, uint64_t& target) {
+    target = v.GetUint64();
+}
+
+inline void read_value(json::Value const& v, uint32_t& target) {
+    target = v.GetUint();
+}
+
+inline void read_value(json::Value const& v, int32_t& target) {
+    target = v.GetInt();
+}
+
+inline void read_value(json::Value const& v, int16_t& target) {
+    target = v.GetInt();
+}
+
+inline void read_value(json::Value const& v, int8_t& target) {
+    target = v.GetInt();
+}
+
+inline void read_value(json::Value const& v, uint8_t& target) {
+    target = v.GetUint();
+}
+
+inline void read_value(json::Value const& v, bool& target) {
+    target = v.GetBool();
+}
+
+inline void read_value(json::Value const& v, ss::sstring& target) {
+    target = v.GetString();
+}
+
+template<typename T, typename Tag, typename IsConstexpr>
+void read_value(
+  json::Value const& v, detail::base_named_type<T, Tag, IsConstexpr>& target) {
+    auto t = T{};
+    read_value(v, t);
+    target = detail::base_named_type<T, Tag, IsConstexpr>{t};
+}
+
+template<typename T>
+void read_value(json::Value const& v, std::vector<T>& target) {
+    for (auto const& e : v.GetArray()) {
+        auto t = T{};
+        read_value(e, t);
+        target.push_back(t);
+    }
+}
+
+template<typename T>
+void read_value(json::Value const& v, std::optional<T>& target) {
+    if (v.IsNull()) {
+        target = std::nullopt;
+    } else {
+        auto t = T{};
+        read_value(v, t);
+        target = t;
+    }
+}
+
+template<typename Writer, typename T>
+void write_member(Writer& w, char const* key, T const& value) {
+    w.String(key);
+    rjson_serialize(w, value);
+}
+
+template<typename T>
+void read_member(json::Value const& v, char const* key, T& target) {
+    auto const it = v.FindMember(key);
+    if (it != v.MemberEnd()) {
+        read_value(it->value, target);
+    } else {
+        target = {};
+        std::cout << "key " << key << " not found, default initializing";
+    }
+}
+
+template<typename Enum>
+inline auto read_member_enum(json::Value const& v, char const* key, Enum)
+  -> std::underlying_type_t<Enum> {
+    std::underlying_type_t<Enum> value;
+    read_member(v, key, value);
+    return value;
+}
+
+inline void
+rjson_serialize(json::Writer<json::StringBuffer>& w, const model::ntp& ntp) {
+    w.StartObject();
+    w.Key("ns");
+    w.String(ntp.ns());
+    w.Key("topic");
+    w.String(ntp.tp.topic());
+    w.Key("partition");
+    w.Int(ntp.tp.partition());
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, model::ntp& obj) {
+    read_member(rd, "ns", obj.ns);
+    read_member(rd, "topic", obj.tp.topic);
+    read_member(rd, "partition", obj.tp.partition);
+}
+
+#define json_write(_fname) json::write_member(wr, #_fname, obj._fname)
+#define json_read(_fname) json::read_member(rd, #_fname, obj._fname)
+
+} // namespace json

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/metadata_dissemination_types.h"
+#include "compat/check.h"
+#include "compat/metadata_dissemination_generator.h"
+#include "compat/metadata_dissemination_json.h"
+
+namespace compat {
+
+/*
+ * cluster::update_leadership_request
+ */
+template<>
+struct compat_check<cluster::update_leadership_request> {
+    static constexpr std::string_view name
+      = "cluster::update_leadership_request";
+
+    static std::vector<cluster::update_leadership_request> create_test_cases() {
+        return generate_instances<cluster::update_leadership_request>();
+    }
+
+    static void to_json(
+      cluster::update_leadership_request obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(leaders);
+    }
+
+    static cluster::update_leadership_request from_json(json::Value& rd) {
+        cluster::update_leadership_request obj;
+        json_read(leaders);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::update_leadership_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool
+    check(cluster::update_leadership_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/metadata_dissemination_types.h"
+#include "compat/generator.h"
+#include "model/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::update_leadership_request> {
+    static cluster::update_leadership_request random() {
+        return cluster::update_leadership_request({
+          cluster::ntp_leader(
+            model::random_ntp(),
+            tests::random_named_int<model::term_id>(),
+            tests::random_named_int<model::node_id>()),
+        });
+    }
+
+    static std::vector<cluster::update_leadership_request> limits() {
+        return {};
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/metadata_dissemination_json.h
+++ b/src/v/compat/metadata_dissemination_json.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/metadata_dissemination_types.h"
+#include "compat/json.h"
+
+namespace json {
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const cluster::ntp_leader& v) {
+    w.StartObject();
+    w.Key("ntp");
+    rjson_serialize(w, v.ntp);
+    w.Key("term");
+    rjson_serialize(w, v.term);
+    w.Key("leader_id");
+    rjson_serialize(w, v.leader_id);
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, cluster::ntp_leader& obj) {
+    read_member(rd, "ntp", obj.ntp);
+    read_member(rd, "term", obj.term);
+    read_member(rd, "leader_id", obj.leader_id);
+}
+
+} // namespace json

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -54,4 +54,49 @@ struct compat_check<raft::timeout_now_request> {
     }
 };
 
+/*
+ * raft::timeout_now_reply
+ */
+template<>
+struct compat_check<raft::timeout_now_reply> {
+    static constexpr std::string_view name = "raft::timeout_now_reply";
+
+    static std::vector<raft::timeout_now_reply> create_test_cases() {
+        return generate_instances<raft::timeout_now_reply>();
+    }
+
+    static void
+    to_json(raft::timeout_now_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(target_node_id);
+        json_write(term);
+        json_write(result);
+    }
+
+    static raft::timeout_now_reply from_json(json::Value& rd) {
+        raft::timeout_now_reply obj;
+        json_read(target_node_id);
+        json_read(term);
+        auto result = json::read_member_enum(rd, "result", obj.result);
+        switch (result) {
+        case 0:
+            obj.result = raft::timeout_now_reply::status::success;
+            break;
+        case 1:
+            obj.result = raft::timeout_now_reply::status::failure;
+            break;
+        default:
+            vassert(false, "invalid status: {}", result);
+        }
+        return obj;
+    }
+
+    static std::vector<compat_binary> to_binary(raft::timeout_now_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(raft::timeout_now_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -136,4 +136,111 @@ struct compat_check<raft::transfer_leadership_request> {
     }
 };
 
+/*
+ * raft::transfer_leadership_reply
+ */
+template<>
+struct compat_check<raft::transfer_leadership_reply> {
+    static constexpr std::string_view name = "raft::transfer_leadership_reply";
+
+    static std::vector<raft::transfer_leadership_reply> create_test_cases() {
+        return generate_instances<raft::transfer_leadership_reply>();
+    }
+
+    static void to_json(
+      raft::transfer_leadership_reply obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(success);
+        json_write(result);
+    }
+
+    static raft::transfer_leadership_reply from_json(json::Value& rd) {
+        raft::transfer_leadership_reply obj;
+        json_read(success);
+        auto result = json::read_member_enum(rd, "result", obj.result);
+        switch (result) {
+        case 0:
+            obj.result = raft::errc::success;
+            break;
+        case 1:
+            obj.result = raft::errc::disconnected_endpoint;
+            break;
+        case 2:
+            obj.result = raft::errc::exponential_backoff;
+            break;
+        case 3:
+            obj.result = raft::errc::non_majority_replication;
+            break;
+        case 4:
+            obj.result = raft::errc::not_leader;
+            break;
+        case 5: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::vote_dispatch_error;
+            break;
+        case 6: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::append_entries_dispatch_error;
+            break;
+        case 7: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::replicated_entry_truncated;
+            break;
+        case 8: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::leader_flush_failed;
+            break;
+        case 9: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::leader_append_failed;
+            break;
+        case 10: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::timeout;
+            break;
+        case 11: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::configuration_change_in_progress;
+            break;
+        case 12: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::node_does_not_exists;
+            break;
+        case 13: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::leadership_transfer_in_progress;
+            break;
+        case 14: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::transfer_to_current_leader;
+            break;
+        case 15: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::node_already_exists;
+            break;
+        case 16: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::invalid_configuration_update;
+            break;
+        case 17: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::not_voter;
+            break;
+        case 18: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::invalid_target_node;
+            break;
+        case 19: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::shutting_down;
+            break;
+        case 20: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::replicate_batcher_cache_error;
+            break;
+        case 21: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::group_not_exists;
+            break;
+        case 22: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            obj.result = raft::errc::replicate_first_stage_exception;
+            break;
+        default:
+            vassert(false, "invalid raft::errc: {}", result);
+        }
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(raft::transfer_leadership_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(raft::transfer_leadership_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
 } // namespace compat

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "compat/check.h"
+#include "compat/raft_generator.h"
+#include "compat/raft_json.h"
+#include "raft/types.h"
+
+namespace compat {
+
+/*
+ * raft::timeout_now_request
+ */
+template<>
+struct compat_check<raft::timeout_now_request> {
+    static constexpr std::string_view name = "raft::timeout_now_request";
+
+    static std::vector<raft::timeout_now_request> create_test_cases() {
+        return generate_instances<raft::timeout_now_request>();
+    }
+
+    static void to_json(
+      raft::timeout_now_request obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(target_node_id);
+        json_write(node_id);
+        json_write(group);
+        json_write(term);
+    }
+
+    static raft::timeout_now_request from_json(json::Value& rd) {
+        raft::timeout_now_request obj;
+        json_read(target_node_id);
+        json_read(node_id);
+        json_read(group);
+        json_read(term);
+        return obj;
+    }
+
+    static std::vector<compat_binary> to_binary(raft::timeout_now_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(raft::timeout_now_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -99,4 +99,41 @@ struct compat_check<raft::timeout_now_reply> {
     }
 };
 
+/*
+ * raft::transfer_leadership_request
+ */
+template<>
+struct compat_check<raft::transfer_leadership_request> {
+    static constexpr std::string_view name
+      = "raft::transfer_leadership_request";
+
+    static std::vector<raft::transfer_leadership_request> create_test_cases() {
+        return generate_instances<raft::transfer_leadership_request>();
+    }
+
+    static void to_json(
+      raft::transfer_leadership_request obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(group);
+        json_write(target);
+    }
+
+    static raft::transfer_leadership_request from_json(json::Value& rd) {
+        raft::transfer_leadership_request obj;
+        json_read(group);
+        json_read(target);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(raft::transfer_leadership_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool
+    check(raft::transfer_leadership_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -90,4 +90,39 @@ struct instance_generator<raft::timeout_now_reply> {
     }
 };
 
+template<>
+struct instance_generator<raft::transfer_leadership_request> {
+    static raft::transfer_leadership_request random() {
+        return {
+          .group = tests::random_named_int<raft::group_id>(),
+          .target = tests::random_named_int<model::node_id>(),
+        };
+    }
+
+    static std::vector<raft::transfer_leadership_request> limits() {
+        return {
+          {
+            .group = tests::random_named_int<raft::group_id>(),
+            .target = std::nullopt,
+          },
+          {
+            .group = raft::group_id::min(),
+            .target = std::nullopt,
+          },
+          {
+            .group = raft::group_id::max(),
+            .target = std::nullopt,
+          },
+          {
+            .group = raft::group_id::min(),
+            .target = tests::random_named_int<model::node_id>(),
+          },
+          {
+            .group = raft::group_id::max(),
+            .target = tests::random_named_int<model::node_id>(),
+          },
+        };
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -17,6 +17,38 @@
 namespace compat {
 
 template<>
+struct instance_generator<raft::errc> {
+    static raft::errc random() {
+        return random_generators::random_choice(
+          {raft::errc::success,
+           raft::errc::disconnected_endpoint,
+           raft::errc::exponential_backoff,
+           raft::errc::non_majority_replication,
+           raft::errc::not_leader,
+           raft::errc::vote_dispatch_error,
+           raft::errc::append_entries_dispatch_error,
+           raft::errc::replicated_entry_truncated,
+           raft::errc::leader_flush_failed,
+           raft::errc::leader_append_failed,
+           raft::errc::timeout,
+           raft::errc::configuration_change_in_progress,
+           raft::errc::node_does_not_exists,
+           raft::errc::leadership_transfer_in_progress,
+           raft::errc::transfer_to_current_leader,
+           raft::errc::node_already_exists,
+           raft::errc::invalid_configuration_update,
+           raft::errc::not_voter,
+           raft::errc::invalid_target_node,
+           raft::errc::shutting_down,
+           raft::errc::replicate_batcher_cache_error,
+           raft::errc::group_not_exists,
+           raft::errc::replicate_first_stage_exception});
+    }
+
+    static std::vector<raft::errc> limits() { return {}; }
+};
+
+template<>
 struct instance_generator<raft::vnode> {
     static raft::vnode random() {
         return {
@@ -123,6 +155,18 @@ struct instance_generator<raft::transfer_leadership_request> {
           },
         };
     }
+};
+
+template<>
+struct instance_generator<raft::transfer_leadership_reply> {
+    static raft::transfer_leadership_reply random() {
+        return {
+          .success = tests::random_bool(),
+          .result = instance_generator<raft::errc>::random(),
+        };
+    }
+
+    static std::vector<raft::transfer_leadership_reply> limits() { return {}; }
 };
 
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -62,4 +62,32 @@ struct instance_generator<raft::timeout_now_request> {
     }
 };
 
+template<>
+struct instance_generator<raft::timeout_now_reply> {
+    static raft::timeout_now_reply random() {
+        return {
+          .target_node_id = instance_generator<raft::vnode>::random(),
+          .term = tests::random_named_int<model::term_id>(),
+          .result = random_generators::random_choice(
+            {raft::timeout_now_reply::status::success,
+             raft::timeout_now_reply::status::failure}),
+        };
+    }
+
+    static std::vector<raft::timeout_now_reply> limits() {
+        return {
+          {
+            .target_node_id = instance_generator<raft::vnode>::random(),
+            .term = model::term_id::min(),
+            .result = raft::timeout_now_reply::status::success,
+          },
+          {
+            .target_node_id = instance_generator<raft::vnode>::random(),
+            .term = model::term_id::max(),
+            .result = raft::timeout_now_reply::status::failure,
+          },
+        };
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "compat/generator.h"
+#include "raft/types.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<raft::vnode> {
+    static raft::vnode random() {
+        return {
+          tests::random_named_int<model::node_id>(),
+          tests::random_named_int<model::revision_id>()};
+    }
+
+    static std::vector<raft::vnode> limits() {
+        return {
+          {model::node_id::min(), model::revision_id::min()},
+          {model::node_id::max(), model::revision_id::max()},
+          {model::node_id{0}, model::revision_id{0}},
+        };
+    }
+};
+
+template<>
+struct instance_generator<raft::timeout_now_request> {
+    static raft::timeout_now_request random() {
+        return {
+          .target_node_id = instance_generator<raft::vnode>::random(),
+          .node_id = instance_generator<raft::vnode>::random(),
+          .group = tests::random_named_int<raft::group_id>(),
+          .term = tests::random_named_int<model::term_id>(),
+        };
+    }
+
+    static std::vector<raft::timeout_now_request> limits() {
+        return {
+          {
+            .target_node_id = instance_generator<raft::vnode>::random(),
+            .node_id = instance_generator<raft::vnode>::random(),
+            .group = raft::group_id::min(),
+            .term = model::term_id::min(),
+          },
+          {
+            .target_node_id = instance_generator<raft::vnode>::random(),
+            .node_id = instance_generator<raft::vnode>::random(),
+            .group = raft::group_id::max(),
+            .term = model::term_id::max(),
+          },
+        };
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "compat/json.h"
+#include "raft/types.h"
+
+namespace json {
+
+inline void
+rjson_serialize(json::Writer<json::StringBuffer>& w, const raft::vnode& v) {
+    w.StartObject();
+    w.Key("id");
+    rjson_serialize(w, v.id());
+    w.Key("revision");
+    rjson_serialize(w, v.revision());
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, raft::vnode& obj) {
+    model::node_id node_id;
+    model::revision_id revision;
+    read_member(rd, "id", node_id);
+    read_member(rd, "revision", revision);
+    obj = raft::vnode(node_id, revision);
+}
+
+} // namespace json

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -11,6 +11,7 @@
 #include "compat/run.h"
 
 #include "compat/check.h"
+#include "compat/metadata_dissemination_compat.h"
 #include "compat/raft_compat.h"
 #include "json/document.h"
 #include "json/prettywriter.h"
@@ -26,8 +27,10 @@ namespace compat {
 template<typename... Types>
 struct type_list {};
 
-using compat_checks
-  = type_list<raft::timeout_now_request, raft::timeout_now_reply>;
+using compat_checks = type_list<
+  raft::timeout_now_request,
+  raft::timeout_now_reply,
+  cluster::update_leadership_request>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -30,6 +30,7 @@ struct type_list {};
 using compat_checks = type_list<
   raft::timeout_now_request,
   raft::timeout_now_reply,
+  raft::transfer_leadership_request,
   cluster::update_leadership_request>;
 
 struct compat_error final : public std::runtime_error {

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -11,6 +11,7 @@
 #include "compat/run.h"
 
 #include "compat/check.h"
+#include "compat/raft_compat.h"
 #include "json/document.h"
 #include "json/prettywriter.h"
 #include "json/writer.h"
@@ -25,7 +26,7 @@ namespace compat {
 template<typename... Types>
 struct type_list {};
 
-using compat_checks = type_list<>;
+using compat_checks = type_list<raft::timeout_now_request>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -31,6 +31,7 @@ using compat_checks = type_list<
   raft::timeout_now_request,
   raft::timeout_now_reply,
   raft::transfer_leadership_request,
+  raft::transfer_leadership_reply,
   cluster::update_leadership_request>;
 
 struct compat_error final : public std::runtime_error {

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -26,7 +26,8 @@ namespace compat {
 template<typename... Types>
 struct type_list {};
 
-using compat_checks = type_list<raft::timeout_now_request>;
+using compat_checks
+  = type_list<raft::timeout_now_request, raft::timeout_now_reply>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "compat/run.h"
+
+#include "compat/check.h"
+#include "json/document.h"
+#include "json/prettywriter.h"
+#include "json/writer.h"
+#include "seastarx.h"
+#include "utils/base64.h"
+#include "utils/file_io.h"
+
+#include <seastar/core/thread.hh>
+
+namespace compat {
+
+template<typename... Types>
+struct type_list {};
+
+using compat_checks = type_list<>;
+
+struct compat_error final : public std::runtime_error {
+public:
+    explicit compat_error(std::string_view name)
+      : std::runtime_error(
+        fmt::format("compat check failed for {{{}}}", name)) {}
+};
+
+template<typename T>
+struct corpus_helper {
+    using checker = compat_check<T>;
+
+    /*
+     * Builds a test case for an instance of T.
+     *
+     * {
+     *   "version": 0,
+     *   "name": "raft::some_request",
+     *   "fields": { test case field values },
+     *   "binaries": [
+     *     {
+     *       "name": "serde",
+     *       "data": "base64 encoding",
+     *     },
+     *   ]
+     * }
+     */
+    static void write_test_case(T t, json::Writer<json::StringBuffer>& w) {
+        auto&& [ta, tb] = compat_copy(std::move(t));
+
+        w.StartObject();
+        w.Key("version");
+        w.Int(0);
+
+        w.Key("name");
+        w.String(checker::name.data());
+
+        w.Key("fields");
+        w.StartObject();
+        checker::to_json(std::move(ta), w);
+        w.EndObject();
+
+        w.Key("binaries");
+        w.StartArray();
+        for (auto& b : checker::to_binary(std::move(tb))) {
+            w.StartObject();
+            w.Key("name");
+            w.String(b.name);
+            w.Key("data");
+            w.String(iobuf_to_base64(b.data));
+            w.EndObject();
+        }
+        w.EndArray();
+        w.EndObject();
+    }
+
+    /*
+     * Writes all test cases to the provided directory.
+     */
+    static ss::future<> write(const std::filesystem::path& dir) {
+        size_t instance = 0;
+
+        for (auto& test : checker::create_test_cases()) {
+            // json encoded test case
+            auto buf = json::StringBuffer{};
+            auto writer = json::Writer<json::StringBuffer>{buf};
+            write_test_case(std::move(test), writer);
+
+            // save test case to file
+            iobuf data;
+            data.append(buf.GetString(), buf.GetSize());
+            auto fn = fmt::format("{}_{}.json", checker::name, instance++);
+            write_fully(dir / fn, std::move(data)).get();
+        }
+
+        return ss::now();
+    }
+
+    /*
+     * Check a test case.
+     */
+    static void check(json::Document doc) {
+        vassert(doc.HasMember("version"), "document doesn't contain version");
+        vassert(doc["version"].IsInt(), "version is not an int");
+        auto version = doc["version"].GetInt();
+        vassert(version == 0, "expected version to be 0 != {}", version);
+
+        // fields is the content of the test instance
+        vassert(doc.HasMember("fields"), "document doesn't contain fields");
+        vassert(doc["fields"].IsObject(), "fields is not an object");
+        auto instance = checker::from_json(doc["fields"].GetObject());
+
+        // binary encodings of the test instance
+        vassert(doc.HasMember("binaries"), "document doesn't contain binaries");
+        vassert(doc["binaries"].IsArray(), "binaries is not an array");
+        auto binaries = doc["binaries"].GetArray();
+
+        for (const auto& encoding : binaries) {
+            vassert(encoding.IsObject(), "binaries entry is not an object");
+            auto binary = encoding.GetObject();
+
+            vassert(binary.HasMember("name"), "encoding doesn't have name");
+            vassert(binary["name"].IsString(), "encoding name is not string");
+            vassert(binary.HasMember("data"), "encoding doesn't have data");
+            vassert(binary["data"].IsString(), "encoding data is not string");
+
+            compat_binary data(
+              binary["name"].GetString(),
+              bytes_to_iobuf(base64_to_bytes(binary["data"].GetString())));
+
+            // keep copy for next round
+            auto&& [ia, ib] = compat_copy(std::move(instance));
+            instance = std::move(ia);
+
+            if (!checker::check(std::move(ib), std::move(data))) {
+                json::StringBuffer buf;
+                json::PrettyWriter<json::StringBuffer> writer(buf);
+                doc.Accept(writer);
+                fmt::print("Input JSON: {}\n", buf.GetString());
+                throw compat_error(checker::name);
+            }
+        }
+    }
+};
+
+template<typename T>
+static void maybe_check(const std::string& name, json::Document& doc) {
+    using type = corpus_helper<T>;
+    if (type::checker::name == name) {
+        type::check(std::move(doc));
+    }
+}
+
+template<typename... Types>
+static void
+check_types(type_list<Types...>, std::string name, json::Document& doc) {
+    /*
+     * check for duplicate test names
+     */
+    const auto names_arr = std::to_array(
+      {corpus_helper<Types>::checker::name...});
+    const std::set<std::string> names_set{
+      std::string(corpus_helper<Types>::checker::name)...};
+    vassert(
+      names_arr.size() == names_set.size(), "duplicate test name detected");
+
+    /*
+     * check that target test name exists
+     */
+    vassert(names_set.contains(name), "test {} not found", name);
+
+    (maybe_check<Types>(name, doc), ...);
+}
+
+static void check(json::Document doc) {
+    vassert(doc.HasMember("name"), "doc doesn't have name");
+    vassert(doc["name"].IsString(), "name is doc is not a string");
+    auto name = doc["name"].GetString();
+    check_types(compat_checks{}, name, doc);
+}
+
+ss::future<> write_corpus(const std::filesystem::path& dir) {
+    return ss::async([dir] {
+        [dir]<typename... Types>(type_list<Types...>) {
+            (corpus_helper<Types>::write(dir).get(), ...);
+        }(compat_checks{});
+    });
+}
+
+ss::future<> check_type(const std::filesystem::path& file) {
+    return read_fully_to_string(file).then([file](auto data) {
+        json::Document doc;
+        doc.Parse(data);
+        vassert(!doc.HasParseError(), "JSON {} has parse errors", file);
+        check(std::move(doc));
+    });
+}
+
+} // namespace compat

--- a/src/v/compat/run.h
+++ b/src/v/compat/run.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+#include <filesystem>
+
+namespace compat {
+
+ss::future<> write_corpus(const std::filesystem::path&);
+ss::future<> check_type(const std::filesystem::path&);
+
+} // namespace compat

--- a/src/v/compat/tests/CMakeLists.txt
+++ b/src/v/compat/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_compat
+  SOURCES compat_test.cc
+  LIBRARIES v::seastar_testing_main v::compat)

--- a/src/v/compat/tests/compat_test.cc
+++ b/src/v/compat/tests/compat_test.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "compat/run.h"
+#include "seastarx.h"
+#include "test_utils/tmp_dir.h"
+#include "utils/directory_walker.h"
+#include "utils/file_io.h"
+
+#include <seastar/core/thread.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+/*
+ * process all the json files in the directory
+ */
+ss::future<> check_corpus(const std::filesystem::path& dir) {
+    return directory_walker::walk(dir.string(), [dir](ss::directory_entry ent) {
+        if (!ent.type || *ent.type != ss::directory_entry_type::regular) {
+            return ss::now();
+        }
+        if (ent.name.find(".json") == ss::sstring::npos) {
+            return ss::now();
+        }
+        if (ent.name == "compile_commands.json") {
+            return ss::now();
+        }
+        const auto fn = dir / ent.name.c_str();
+        fmt::print("Checking {}\n", fn);
+        return compat::check_type(fn);
+    });
+}
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(compat_self_test) {
+    temporary_dir corpus("compat_self_test");
+    compat::write_corpus(corpus.get_path()).get();
+    check_corpus(corpus.get_path()).get();
+}

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -646,6 +646,17 @@ struct timeout_now_reply
       = default;
 
     auto serde_fields() { return std::tie(target_node_id, term, result); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const timeout_now_reply& r) {
+        fmt::print(
+          o,
+          "target_node_id {} term {} result {}",
+          r.target_node_id,
+          r.term,
+          static_cast<std::underlying_type_t<status>>(r.result));
+        return o;
+    }
 };
 
 // if not target is specified then the most up-to-date node will be selected

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -689,6 +689,12 @@ struct transfer_leadership_reply
       = default;
 
     auto serde_fields() { return std::tie(success, result); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const transfer_leadership_reply& r) {
+        fmt::print(o, "success {} result {}", r.success, r.result);
+        return o;
+    }
 };
 
 // key types used to store data in key-value store

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -619,6 +619,18 @@ struct timeout_now_request
     auto serde_fields() {
         return std::tie(target_node_id, node_id, group, term);
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const timeout_now_request& r) {
+        fmt::print(
+          o,
+          "target_node_id {} node_id {} group {} term {}",
+          r.target_node_id,
+          r.node_id,
+          r.group,
+          r.term);
+        return o;
+    }
 };
 
 struct timeout_now_reply

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -671,6 +671,12 @@ struct transfer_leadership_request
       = default;
 
     auto serde_fields() { return std::tie(group, target); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const transfer_leadership_request& r) {
+        fmt::print(o, "group {} target {}", r.group, r.target);
+        return o;
+    }
 };
 
 struct transfer_leadership_reply

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -74,6 +74,13 @@ const T& random_choice(const std::vector<T>& elements) {
 }
 
 template<typename T>
+T random_choice(std::initializer_list<T> choices) {
+    auto idx = get_int<size_t>(0, choices.size() - 1);
+    auto& choice = *(choices.begin() + idx);
+    return std::move(choice);
+}
+
+template<typename T>
 struct gen {};
 
 template<typename T>

--- a/src/v/rp_util/CMakeLists.txt
+++ b/src/v/rp_util/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Packages utilities exposed by core that are useful to clients.
 add_executable(rp_util main.cc)
 set_property(TARGET rp_util PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(rp_util PUBLIC v::clientutil)
+target_link_libraries(rp_util PUBLIC v::clientutil v::compat)
 install(TARGETS rp_util DESTINATION bin)

--- a/src/v/rp_util/main.cc
+++ b/src/v/rp_util/main.cc
@@ -15,7 +15,6 @@
 
 #include <iostream>
 
-namespace po = boost::program_options;
 
 /**
  * This binary is meant to host developer friendly utilities related to core.
@@ -27,10 +26,16 @@ namespace po = boost::program_options;
  * - This tool provides _no backward compatibility_ of any sorts.
  */
 int main(int ac, char* av[]) {
+    namespace po = boost::program_options;
     po::options_description desc("Allowed options");
-    desc.add_options()("help", "Allowed options")(
-      "config_schema_json", "Generates JSON schema for cluster configuration")(
-      "version", "Redpanda core version for this utility");
+
+    // clang-format off
+    desc.add_options()
+      ("help", "Allowed options")
+      ("config_schema_json", "Generates JSON schema for cluster configuration")
+      ("version", "Redpanda core version for this utility");
+    // clang-format on
+
     po::variables_map vm;
     po::store(po::parse_command_line(ac, av, desc), vm);
     po::notify(vm);


### PR DESCRIPTION
## Cover letter

Introduces a compatibility framework based on the structure found in #3935 except generalized to handle multiple serialization types and multiple test cases.

This is the main interface for supporting a type in the framework, which for a given type, allow:

1. test cases to be generated
2. to/from json for the given test cases
3. to/from binary for the given test cases
4. checking compatibility between instances

```
template<typename T>
struct compat_check {
    static std::vector<T> create_test_cases();
    static void to_json(T, json::Writer<json::StringBuffer>&);
    static T from_json(json::Value&);
    static std::vector<compat_binary> to_binary(T);
    static void check(T, compat_binary);
};
```

For a given release we'll collect a corpus of data by dump all types known to the system:

```
./bin/rp_util --corpus_write <dir>
```

Then an external test orchestration framework (not included in this PR) will consume test cases from previous corpora (or future for forward compat checking) and according to compatibility rules invoke a verification check:

```
./bin/rp_util --corpus_check <test_case.json>
```

## Supporting new types

In order to seed the tree with support for all existing types, the following generator can be used. It produces a rough template that supports the happy case. Most of the time you'll need to add some json support for types, and sometimes need to included special logic for decoding/encoding, based on how complicated the structure is.

Invoke the script like `gen.py cluster::some_type_request <field1> <field2> ...`

```python
import sys
import jinja2

template = """
/*
 * TODO:
 * 
 *   Fill in this instance generator and place in randoms.h
 *   file for the relevant subsystem (e.g. raft/tests/randoms.h).
 *
 *   See: src/v/cluster/tests/serialization_rt_test.cc for random helpers.
 */
namespace tests {
template<>
struct instance_generator<{{ type_name }}> {
    static {{ type_name }} random() {
        return {
{%- for field in fields %}
          // .{{ field }} = ,
{%- endfor %}
        };
    }
    static std::vector<{{ type_name }}> limits() {
        return {
          {
{%- for field in fields %}
            // .{{ field }} = ,
{%- endfor %}
          },
          {
{%- for field in fields %}
            // .{{ field }} = ,
{%- endfor %}
          },
        };
    }
};
} // namespace tests
/*
 * {{ type_name }}
 */
template<>
struct compat_check<{{ type_name }}> {
    static constexpr std::string_view name = "{{ type_name }}";
    static std::vector<{{ type_name }}> create_test_cases() {
        return tests::generate_instances<{{ type_name }}>();
    }
    static void to_json(
      {{ type_name }} obj, json::Writer<json::StringBuffer>& wr) {
{%- for field in fields %}
        json_write({{ field }});
{%- endfor %}
    }
    static {{ type_name }} from_json(json::Value& rd) {
        {{ type_name }} obj;
{%- for field in fields %}
        json_read({{ field }});
{%- endfor %}
        return obj;
    }
    static std::vector<compat_binary> to_binary({{ type_name }} obj) {
        return compat_binary::serde_and_adl(obj);
    }
    static void check({{ type_name }} obj, compat_binary test) {
        verify_adl_or_serde(obj, std::move(test));
    }
};
"""

print(jinja2.Template(template).render(
    type_name = sys.argv[1],
    fields = sys.argv[2:]))
```

Which will produce something like

```c++
/*
 * TODO:
 *
 *   Fill in this instance generator and place in randoms.h
 *   file for the relevant subsystem (e.g. raft/tests/randoms.h).
 *
 *   See: src/v/cluster/tests/serialization_rt_test.cc for random helpers.
 */
namespace compat {

template<>
struct instance_generator<cluster::update_leadership_request> {
    static cluster::update_leadership_request random() {
        return {
          // .leaders = ,
          // .field2 = ,
          // .field3 = ,
          // .field4 = ,
        };
    }

    static std::vector<cluster::update_leadership_request> limits() {
        return {
          {
            // .leaders = ,
            // .field2 = ,
            // .field3 = ,
            // .field4 = ,
          },
          {
            // .leaders = ,
            // .field2 = ,
            // .field3 = ,
            // .field4 = ,
          },
        };
    }
};

} // namespace compat

/*
 * cluster::update_leadership_request
 */
template<>
struct compat_check<cluster::update_leadership_request> {
    static constexpr std::string_view name
      = "cluster::update_leadership_request";

    static std::vector<cluster::update_leadership_request> create_test_cases() {
        return generate_instances<cluster::update_leadership_request>();
    }

    static void to_json(
      cluster::update_leadership_request obj,
      json::Writer<json::StringBuffer>& wr) {
        json_write(leaders);
        json_write(field2);
        json_write(field3);
        json_write(field4);
    }

    static cluster::update_leadership_request from_json(json::Value& rd) {
        cluster::update_leadership_request obj;
        json_read(leaders);
        json_read(field2);
        json_read(field3);
        json_read(field4);
        return obj;
    }

    static std::vector<compat_binary>
    to_binary(cluster::update_leadership_request obj) {
        return compat_binary::serde_and_adl(obj);
    }

    static bool
    check(cluster::update_leadership_request obj, compat_binary test) {
        return verify_adl_or_serde(obj, std::move(test));
    }
};
```

## Wire up support

Wire up support for a type into the framework:

```diff
diff --git a/src/v/compat/run.cc b/src/v/compat/run.cc
index 903d0be45..257734af0 100644
--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -11,6 +11,7 @@
 #include "compat/run.h"
 
 #include "compat/check.h"
+#include "compat/metadata_dissemination_compat.h"
 #include "compat/raft_compat.h"
 #include "json/document.h"
 #include "json/writer.h"
@@ -149,6 +150,14 @@ static void check(json::Document doc) {
         }
     }
 
+    {
+        using type = corpus_helper<cluster::update_leadership_request>;
+        if (type::checker::name == name) {
+            type::check(std::move(doc));
+            return;
+        }
+    }
+
     vassert(false, "Type {} not found", name);
 }
 
@@ -159,6 +168,7 @@ ss::future<> write_corpus(const std::filesystem::path& dir) {
          */
         corpus_helper<raft::timeout_now_request>::write(dir).get();
         corpus_helper<raft::timeout_now_reply>::write(dir).get();
+        corpus_helper<cluster::update_leadership_request>::write(dir).get();
     });
 }
 ```

## Testing

The tree contains a simple self-test which verifies that all of the test cases are consistent with themselves. Run it like:

```
bin/test_compat_rpunit
```

## Release notes

* None