### PR TITLE
rpk: replace ioutil with io and os

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -480,7 +479,7 @@ func maybeUnmarshalRespInto(
 	if into == nil {
 		return nil
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("unable to read %s %s response body: %w", method, url, err)
 	}
@@ -551,7 +550,7 @@ func (a *AdminAPI) sendAndReceive(
 	}
 
 	if res.StatusCode/100 != 2 {
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		status := http.StatusText(res.StatusCode)
 		if err != nil {
 			return nil, fmt.Errorf("request %s %s failed: %s, unable to read body: %w", method, url, status, err)

--- a/src/go/rpk/pkg/api/api_test.go
+++ b/src/go/rpk/pkg/api/api_test.go
@@ -11,7 +11,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +38,7 @@ func TestSendMetrics(t *testing.T) {
 
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Exactly(t, bs, b)
 			w.WriteHeader(http.StatusOK)
@@ -130,7 +130,7 @@ func TestSendEnvironment(t *testing.T) {
 
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Exactly(t, expectedBytes, b)
 			w.WriteHeader(http.StatusOK)

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -12,7 +12,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -74,7 +73,7 @@ func executeEdit(
 	all *bool,
 ) error {
 	// Generate a yaml template for editing
-	file, err := ioutil.TempFile("/tmp", "config_*.yaml")
+	file, err := os.CreateTemp("/tmp", "config_*.yaml")
 	filename := file.Name()
 	defer func() {
 		err := os.Remove(filename)

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -11,7 +11,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -165,7 +164,7 @@ to include all properties including these low level tunables.
 			// Generate a yaml template for editing
 			var file *os.File
 			if filename == "" {
-				file, err = ioutil.TempFile("/tmp", "config_*.yaml")
+				file, err = os.CreateTemp("/tmp", "config_*.yaml")
 				filename = "/tmp/config_*.yaml"
 			} else {
 				file, err = os.Create(filename)

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_test.go
@@ -13,7 +13,7 @@
 package debug
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,7 +38,7 @@ func TestLimitedWriter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
 			lim := &limitedWriter{
-				w:          ioutil.Discard,
+				w:          io.Discard,
 				limitBytes: tt.limit,
 			}
 			var writeErr error

--- a/src/go/rpk/pkg/cli/cmd/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -436,7 +436,7 @@ func fetchMetrics(
 			res.StatusCode,
 		)
 	}
-	bs, err := ioutil.ReadAll(res.Body)
+	bs, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/utils/os.go
+++ b/src/go/rpk/pkg/utils/os.go
@@ -11,7 +11,7 @@ package utils
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -40,7 +40,7 @@ func IsAWSi3MetalInstance() bool {
 		return false
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	instanceType := string(body)
 	if err != nil {
 		log.Debug("Can not read AWS meta-data API response body")


### PR DESCRIPTION
## Cover letter

`ioutil` was deprecated in [Go 1.16](https://go.dev/doc/go1.16#ioutil)

## UX changes

* none

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
