### PR TITLE
Report brokers without liveness

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1776,68 +1776,13 @@ void admin_server::register_broker_routes() {
     register_route<user>(
       ss::httpd::broker_json::get_cluster_view,
       [this](std::unique_ptr<ss::httpd::request>) {
-          cluster::node_report_filter filter;
-
-          return _controller->get_health_monitor()
-            .local()
-            .get_cluster_health(
-              cluster::cluster_report_filter{
-                .node_report_filter = std::move(filter),
-              },
-              cluster::force_refresh::no,
-              model::no_timeout)
-            .then([this](result<cluster::cluster_health_report> h_report) {
-                if (h_report.has_error()) {
-                    throw ss::httpd::base_exception(
-                      fmt::format(
-                        "Unable to get cluster health: {}",
-                        h_report.error().message()),
-                      ss::httpd::reply::status_type::service_unavailable);
-                }
-
-                std::map<model::node_id, ss::httpd::broker_json::broker> result;
-
+          return get_brokers(_controller)
+            .then([this](std::vector<ss::httpd::broker_json::broker> brokers) {
                 auto& members_table = _controller->get_members_table().local();
-                for (auto& broker : members_table.all_brokers()) {
-                    ss::httpd::broker_json::broker b;
-                    b.node_id = broker->id();
-                    b.num_cores = broker->properties().cores;
-                    b.membership_status = fmt::format(
-                      "{}", broker->get_membership_state());
-                    b.is_alive = true;
-                    result[broker->id()] = b;
-                }
-
-                for (auto& ns : h_report.value().node_states) {
-                    auto it = result.find(ns.id);
-                    if (it == result.end()) {
-                        continue;
-                    }
-                    it->second.is_alive = (bool)ns.is_alive;
-
-                    auto r_it = std::find_if(
-                      h_report.value().node_reports.begin(),
-                      h_report.value().node_reports.end(),
-                      [id = ns.id](const cluster::node_health_report& nhr) {
-                          return nhr.id == id;
-                      });
-                    if (r_it != h_report.value().node_reports.end()) {
-                        it->second.version = r_it->local_state.redpanda_version;
-                        for (auto& ds : r_it->local_state.disks) {
-                            ss::httpd::broker_json::disk_space_info dsi;
-                            dsi.path = ds.path;
-                            dsi.free = ds.free;
-                            dsi.total = ds.total;
-                            it->second.disk_space.push(dsi);
-                        }
-                    }
-                }
 
                 ss::httpd::broker_json::cluster_view ret;
                 ret.version = members_table.version();
-                for (auto& [_, b] : result) {
-                    ret.brokers.push(b);
-                }
+                ret.brokers = std::move(brokers);
 
                 return ss::make_ready_future<ss::json::json_return_type>(
                   std::move(ret));

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -586,6 +586,90 @@ ss::httpd::broker_json::maintenance_status fill_maintenance_status(
     return ret;
 }
 
+// Fetch brokers from the members table and enrich with
+// metadata from the health monitor.
+ss::future<std::vector<ss::httpd::broker_json::broker>>
+get_brokers(cluster::controller* const controller) {
+    cluster::node_report_filter filter;
+
+    return controller->get_health_monitor()
+      .local()
+      .get_cluster_health(
+        cluster::cluster_report_filter{
+          .node_report_filter = std::move(filter),
+        },
+        cluster::force_refresh::no,
+        model::no_timeout)
+      .then([controller](result<cluster::cluster_health_report> h_report) {
+          if (h_report.has_error()) {
+              throw ss::httpd::base_exception(
+                fmt::format(
+                  "Unable to get cluster health: {}",
+                  h_report.error().message()),
+                ss::httpd::reply::status_type::service_unavailable);
+          }
+
+          std::map<model::node_id, ss::httpd::broker_json::broker> broker_map;
+
+          // Collect broker information from the members table.
+          auto& members_table = controller->get_members_table().local();
+          for (auto& broker : members_table.all_brokers()) {
+              ss::httpd::broker_json::broker b;
+              b.node_id = broker->id();
+              b.num_cores = broker->properties().cores;
+              b.membership_status = fmt::format(
+                "{}", broker->get_membership_state());
+
+              // These fields are defaults that will be overwritten with
+              // data from the health report.
+              b.is_alive = true;
+              b.maintenance_status = fill_maintenance_status(std::nullopt);
+
+              broker_map[broker->id()] = b;
+          }
+
+          // Enrich the broker information with data from the health report.
+          for (auto& ns : h_report.value().node_states) {
+              auto it = broker_map.find(ns.id);
+              if (it == broker_map.end()) {
+                  continue;
+              }
+
+              it->second.is_alive = static_cast<bool>(ns.is_alive);
+
+              auto r_it = std::find_if(
+                h_report.value().node_reports.begin(),
+                h_report.value().node_reports.end(),
+                [id = ns.id](const cluster::node_health_report& nhr) {
+                    return nhr.id == id;
+                });
+
+              if (r_it != h_report.value().node_reports.end()) {
+                  it->second.version = r_it->local_state.redpanda_version;
+                  it->second.maintenance_status = fill_maintenance_status(
+                    r_it->drain_status);
+
+                  for (auto& ds : r_it->local_state.disks) {
+                      ss::httpd::broker_json::disk_space_info dsi;
+                      dsi.path = ds.path;
+                      dsi.free = ds.free;
+                      dsi.total = ds.total;
+                      it->second.disk_space.push(dsi);
+                  }
+              }
+          }
+
+          std::vector<ss::httpd::broker_json::broker> brokers;
+          brokers.reserve(broker_map.size());
+
+          for (auto&& broker : broker_map) {
+              brokers.push_back(std::move(broker.second));
+          }
+
+          return ss::make_ready_future<decltype(brokers)>(std::move(brokers));
+      });
+};
+
 } // namespace
 
 /**


### PR DESCRIPTION
## Cover letter

Previously, only brokers present in the health monitor report were being returned by the "/brokers" admin request.
It turns out that for a new-broker to be present in the report, a health metadata refresh needs to have happened.
This can lead to timeouts and longer waits for tests that use the "/brokers" request to ensure cluster consistency.

The solution is to include entries in the members table that are not present in the health report in the response.
All such members, are considered alive, as this should only happen when a new node joins the cluster.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5591

## UX changes
* The "/brokers" admin request now returns the full list of brokers even when health metadata is stale.
* The "/cluster_view" admin request now returns the "maintenance_status" for each broker

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none