### PR TITLE
archival: Always stop the ntp_archiver on shutdown

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -231,6 +231,8 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
     if (_gate.is_closed()) {
         return ss::now();
     }
+
+    _archivers.emplace(archiver->get_ntp(), archiver);
     return archiver->download_manifest().then([this, archiver](
                                                 cloud_storage::download_result
                                                   result) {
@@ -246,7 +248,6 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
                 _probe.start_archiving_ntp();
                 archiver->run_upload_loop();
             }
-            _archivers.emplace(ntp, archiver);
 
             return ss::now();
         case cloud_storage::download_result::notfound:
@@ -271,13 +272,15 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
 
                 archiver->run_upload_loop();
             }
-            _archivers.emplace(ntp, archiver);
 
             return ss::now();
         case cloud_storage::download_result::failed:
         case cloud_storage::download_result::timedout:
             vlog(_rtclog.warn, "Manifest download failed");
-            return ss::make_exception_future<>(ss::timed_out_error());
+            _archivers.erase(archiver->get_ntp());
+            return archiver->stop().finally([archiver]() {
+                return ss::make_exception_future<>(ss::timed_out_error());
+            });
         }
         return ss::now();
     });


### PR DESCRIPTION
## Cover letter

If an `ntp_archiver` is added, and the service is stopped prior
to completion of manifest download, the `ntp_archiver` will not be,
stopped, and its gate not waited on.

Fix that by always adding the `ntp_archiver` to `_archivers`.

Fix #4601

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x (not branched yet)
- [x] v22.1.x
- [x] v21.11.x (this won't be clean, but looks straightforward)

## Release notes

* none