### PR TITLE
github: Add Backport section to PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,18 @@ Describe in plain language the motivation (bug, feature, etc.) behind the change
 <!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
 Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
 
+## Backport Required
+
+<!-- Specify which branches this should be backported to, e.g.: -->
+- [ ] not a bug fix
+- [ ] papercut/not impactful enough to backport
+- [ ] v22.2.x
+- [ ] v22.1.x
+- [ ] v21.11.x
+
 ## UX changes
 
-Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed. 
+Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.
 
 <!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->
 


### PR DESCRIPTION
## Cover letter

Add a section to encourage a committer to think about whether a backport is required

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix (GitHub uses the PR template from the default branch)
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none