### PR TITLE
cloud_storage: use stable iterator for absl::btree

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -544,10 +544,10 @@ remote_partition::aborted_transactions(offset_range offsets) {
       "found {} aborted transactions for {}-{} offset range ({}-{} before "
       "offset translaction)",
       result.size(),
-      offsets.begin_rp,
       offsets.begin,
-      offsets.end_rp,
-      offsets.end);
+      offsets.end,
+      offsets.begin_rp,
+      offsets.end_rp);
     co_return result;
 }
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage/types.h"
 #include "storage/parser_errc.h"
 #include "storage/types.h"
+#include "utils/gate_guard.h"
 #include "utils/retry_chain_node.h"
 #include "utils/stream_utils.h"
 
@@ -501,6 +502,7 @@ remote_partition::get_term_last_offset(model::term_id term) const {
 
 ss::future<std::vector<cluster::rm_stm::tx_range>>
 remote_partition::aborted_transactions(offset_range offsets) {
+    gate_guard guard(_gate);
     // Here we have to use kafka offsets to locate the segments and
     // redpanda offsets to extract aborted transactions metadata because
     // tx-manifests contains redpanda offsets.


### PR DESCRIPTION
## Cover letter

Use stable iterator for `absl::btree`. `absl::btree_map` doesn't provide a pointer stability, so incirementing
iterator in a loop that has a scheduling point can lead to segfault.
`remote_partition` uses stable iterator that make a lookup on every
iterator increment.

Fixes #5613

## Release notes

* none
