### PR TITLE
cluster: fix shutting down while controller log replay is in progress

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -139,8 +139,11 @@ public:
      * Create raft0, and start the services that the \c controller owns.
      * \param initial_raft0_brokers Brokers to start raft0 with. Empty for
      *      non-seeds.
+     * \param shard0_as an abort source only usable on shard0, and only for
+     *        use within this start function -- for the rest of the lifetime
+     *        of controller, it has its own member abort source.
      */
-    ss::future<> start(cluster_discovery&);
+    ss::future<> start(cluster_discovery&, ss::abort_source&);
 
     // prevents controller from accepting new requests
     ss::future<> shutdown_input();

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -53,9 +53,11 @@ ss::future<> state_machine::stop() {
 }
 
 ss::future<> state_machine::wait(
-  model::offset offset, model::timeout_clock::time_point timeout) {
-    return ss::with_gate(_gate, [this, timeout, offset] {
-        return _waiters.wait(offset, timeout, std::nullopt);
+  model::offset offset,
+  model::timeout_clock::time_point timeout,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    return ss::with_gate(_gate, [this, timeout, offset, as] {
+        return _waiters.wait(offset, timeout, as);
     });
 }
 

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -69,7 +69,11 @@ public:
     virtual ss::future<> stop();
 
     // wait until at least offset is applied to state machine
-    ss::future<> wait(model::offset, model::timeout_clock::time_point);
+    ss::future<> wait(
+      model::offset,
+      model::timeout_clock::time_point,
+      std::optional<std::reference_wrapper<ss::abort_source>> as
+      = std::nullopt);
 
     /**
      * This must be implemented by the state machine. The state machine should

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -145,7 +145,7 @@ private:
 
     // Starts the services meant for Redpanda runtime. Must be called after
     // having constructed the subsystems via the corresponding `wire_up` calls.
-    void start_runtime_services(cluster::cluster_discovery&);
+    void start_runtime_services(cluster::cluster_discovery&, ::stop_signal&);
     void start_kafka(const model::node_id&, ::stop_signal&);
 
     // All methods are calleds from Seastar thread


### PR DESCRIPTION
## Cover letter

Previously, while we waited for the controller applied offset to reach last_applied, we would ignore SIGINT signals.

This is noticeable if you have a very long controller log.

Fixed it by giving controller::start a reference to the ::stop_signal abort source from application.cc (more explanation as to why in the commit messages).

## UX changes

None

## Release notes

### Improvements

* Redpanda now shuts down more quickly if it is signalled while still starting up.
