### PR TITLE
rpk: remove config_file from redpanda.yaml

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "2bcfa4a6609253c35503587411b445cb",
+			expectedHash:            "62bdc61185e7b81b8f96b400db98ed2f",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "42a92bbbe2e3092ac6bc86d705477ec0",
+			expectedHash: "979cb39eb1bebf515348713f4cd2d6da",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "49ddb404391b63a9b604aa57e655406e",
+			expectedHash: "fad668348b9d5c88dae6f4db3ffe4041",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -62,7 +62,7 @@ func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
 	command.Flags().StringVar(
 		&outputFile,
 		"out",
-		filepath.Join(filepath.Dir(config.Default().ConfigFile), "io-config.yaml"),
+		filepath.Join(filepath.Dir(config.DefaultPath), "io-config.yaml"),
 		"The file path where the IO config will be written",
 	)
 	command.Flags().StringSliceVar(&directories,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -128,7 +128,7 @@ func TestBootstrap(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			_, err = fs.Stat(config.Default().ConfigFile)
+			_, err = fs.Stat(config.DefaultPath)
 			require.NoError(t, err)
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestInitNode(t *testing.T) {
 
 			bs, err := yaml.Marshal(c)
 			require.NoError(t, err)
-			err = afero.WriteFile(fs, c.ConfigFile, bs, 0o644)
+			err = afero.WriteFile(fs, config.DefaultPath, bs, 0o644)
 			require.NoError(t, err)
 
 			cmd := initNode(fs)
@@ -196,8 +196,7 @@ func TestSetCommand(t *testing.T) {
 	}{
 		{
 			name: "set without config file on disk",
-			exp: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			exp: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     rack: redpanda-rack
@@ -221,8 +220,7 @@ schema_registry: {}
 		},
 		{
 			name: "set with loaded config",
-			cfgFile: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			cfgFile: `redpanda:
     data_directory: data/dir
     node_id: 0
     rack: redpanda-rack
@@ -241,8 +239,7 @@ rpk:
     tune_network: true
     tune_disk_scheduler: true
 `,
-			exp: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			exp: `redpanda:
     data_directory: data/dir
     node_id: 0
     rack: redpanda-rack

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
@@ -62,7 +62,7 @@ func executeMode(fs afero.Fs, cmd *cobra.Command, mode string) error {
 		return err
 	}
 
-	fmt.Printf("Writing %q mode defaults to %q\n", mode, cfg.ConfigFile)
+	fmt.Printf("Writing %q mode defaults to %q\n", mode, cfg.FileLocation())
 	err = cfg.Write(fs)
 	if err != nil {
 		return err

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -85,9 +85,6 @@ const (
 )
 
 func updateConfigWithFlags(conf *config.Config, flags *pflag.FlagSet) {
-	if flags.Changed(configFlag) {
-		conf.ConfigFile, _ = flags.GetString(configFlag)
-	}
 	if flags.Changed(lockMemoryFlag) {
 		conf.Rpk.EnableMemoryLocking, _ = flags.GetBool(lockMemoryFlag)
 	}
@@ -579,7 +576,7 @@ func buildRedpandaFlags(
 		// If --io-properties-file and --io-properties weren't set, try
 		// finding an IO props file in the default location.
 		sFlags.ioPropertiesFile = rp.GetIOConfigPath(
-			filepath.Dir(conf.ConfigFile),
+			filepath.Dir(conf.FileLocation()),
 		)
 		if exists, _ := afero.Exists(fs, sFlags.ioPropertiesFile); !exists {
 			sFlags.ioPropertiesFile = ""
@@ -619,14 +616,14 @@ func buildRedpandaFlags(
 					" remove it and pass '--%s' directly"+
 					" to `rpk start`.",
 				n,
-				conf.ConfigFile,
+				conf.FileLocation(),
 				n,
 			)
 		}
 		finalFlags[n] = fmt.Sprint(v)
 	}
 	return &rp.RedpandaArgs{
-		ConfigFilePath: conf.ConfigFile,
+		ConfigFilePath: conf.FileLocation(),
 		SeastarFlags:   finalFlags,
 	}, nil
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
@@ -80,7 +80,7 @@ func TestStopCommand(t *testing.T) {
 
 			var out bytes.Buffer
 			c := cmd.NewStopCommand(fs)
-			args := append([]string{"--config", conf.ConfigFile}, tt.args...)
+			args := append([]string{"--config", conf.FileLocation()}, tt.args...)
 			c.SetArgs(args)
 
 			logrus.SetOutput(&out)

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -29,7 +29,7 @@ const (
 
 func Default() *Config {
 	return &Config{
-		ConfigFile: "/etc/redpanda/redpanda.yaml",
+		fileLocation: DefaultPath,
 		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{
@@ -147,13 +147,13 @@ func AvailableModes() []string {
 // the default configuration if there is no file loaded.
 func (c *Config) FileOrDefaults() *Config {
 	if c.File() != nil {
-		cfg := c.File()
-		cfg.loadedPath = c.loadedPath
-		cfg.ConfigFile = c.ConfigFile // preserve loaded ConfigFile property.
-		return cfg
+		return c.File()
 	} else {
 		cfg := Default()
-		cfg.ConfigFile = c.ConfigFile
+		// --config set but the file doesn't exist yet:
+		if c.fileLocation != "" {
+			cfg.fileLocation = c.fileLocation
+		}
 		return cfg // no file, write the defaults
 	}
 }

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -43,6 +43,7 @@ func getValidConfig() *Config {
 		CoredumpDir:              "/var/lib/redpanda/coredumps",
 		WellKnownIo:              "vendor:vm:storage",
 	}
+	conf.fileLocation = DefaultPath
 	return conf
 }
 
@@ -443,7 +444,7 @@ tune_cpu: true`,
 func TestDefault(t *testing.T) {
 	defaultConfig := Default()
 	expected := &Config{
-		ConfigFile:     "/etc/redpanda/redpanda.yaml",
+		fileLocation:   DefaultPath,
 		Pandaproxy:     &Pandaproxy{},
 		SchemaRegistry: &SchemaRegistry{},
 		Redpanda: RedpandaConfig{
@@ -479,8 +480,7 @@ func TestWrite(t *testing.T) {
 		{
 			name: "write default values",
 			conf: getValidConfig,
-			expected: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     seed_servers:
@@ -531,8 +531,7 @@ schema_registry: {}
 				}
 				return c
 			},
-			expected: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     seed_servers:
@@ -584,8 +583,7 @@ schema_registry: {}
 				return c
 			},
 			wantErr: false,
-			expected: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     seed_servers:
@@ -620,8 +618,7 @@ schema_registry: {}
 				return c
 			},
 			wantErr: false,
-			expected: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     seed_servers:
@@ -666,7 +663,7 @@ schema_registry: {}
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := tt.conf().ConfigFile
+			path := tt.conf().FileLocation()
 			fs := afero.NewMemMapFs()
 			if tt.existingConf != "" {
 				_, err := utils.WriteBytes(fs, []byte(tt.existingConf), path)

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -19,8 +19,7 @@ func TestParams_Write(t *testing.T) {
 	}{
 		{
 			name: "create default config file if there is no config file yet",
-			exp: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			exp: `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 0
     seed_servers: []
@@ -45,8 +44,7 @@ rpk:
 		},
 		{
 			name: "write loaded config",
-			inCfg: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			inCfg: `redpanda:
     data_directory: ""
     node_id: 1
     rack: my_rack
@@ -55,16 +53,14 @@ redpanda:
 				c.Redpanda.ID = 6
 				return c
 			},
-			exp: `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+			exp: `redpanda:
     node_id: 6
     rack: my_rack
 `,
 		},
 		{
 			name: "write empty structs",
-			inCfg: `config_file: /etc/redpanda/redpanda.yaml
-rpk:
+			inCfg: `rpk:
     tls:
         truststore_file: ""
         cert_file: ""
@@ -101,9 +97,9 @@ rpk:
 
 			// We use the loaded filepath, or the default in-mem generated
 			// config path if no file was loaded.
-			path := cfg.loadedPath
+			path := cfg.fileLocation
 			if path == "" {
-				path = Default().ConfigFile
+				path = DefaultPath
 			}
 
 			if test.cfgChanges != nil {
@@ -145,8 +141,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 		return
 	}
 	expCfg := &Config{
-		ConfigFile: "/etc/redpanda/redpanda.yaml",
-		loadedPath: "/etc/redpanda/redpanda.yaml",
+		fileLocation: "/etc/redpanda/redpanda.yaml",
 		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{
@@ -192,8 +187,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 		t.Errorf("unexpected error while reading config file from fs: %s", err)
 		return
 	}
-	require.Equal(t, `config_file: /etc/redpanda/redpanda.yaml
-redpanda:
+	require.Equal(t, `redpanda:
     data_directory: /var/lib/redpanda/data
     node_id: 1
     seed_servers: []

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -18,14 +18,13 @@ import (
 )
 
 type Config struct {
-	file       *Config
-	loadedPath string
+	file         *Config
+	fileLocation string
 
 	NodeUUID             string          `yaml:"node_uuid,omitempty" json:"node_uuid"`
 	Organization         string          `yaml:"organization,omitempty" json:"organization"`
 	LicenseKey           string          `yaml:"license_key,omitempty" json:"license_key"`
 	ClusterID            string          `yaml:"cluster_id,omitempty" json:"cluster_id"`
-	ConfigFile           string          `yaml:"config_file,omitempty" json:"config_file"`
 	Redpanda             RedpandaConfig  `yaml:"redpanda,omitempty" json:"redpanda"`
 	Rpk                  RpkConfig       `yaml:"rpk,omitempty" json:"rpk"`
 	Pandaproxy           *Pandaproxy     `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
@@ -41,6 +40,12 @@ type Config struct {
 // no file was read.
 func (c *Config) File() *Config {
 	return c.file
+}
+
+// FileLocation returns the loaded file location; this is the path that
+// rpk uses for write operations.
+func (c *Config) FileLocation() string {
+	return c.fileLocation
 }
 
 type RedpandaConfig struct {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -298,7 +298,6 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 		Organization         weakString      `yaml:"organization"`
 		LicenseKey           weakString      `yaml:"license_key"`
 		ClusterID            weakString      `yaml:"cluster_id"`
-		ConfigFile           weakString      `yaml:"config_file"`
 		Redpanda             RedpandaConfig  `yaml:"redpanda"`
 		Rpk                  RpkConfig       `yaml:"rpk"`
 		Pandaproxy           *Pandaproxy     `yaml:"pandaproxy"`
@@ -315,7 +314,6 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	c.Organization = string(internal.Organization)
 	c.LicenseKey = string(internal.LicenseKey)
 	c.ClusterID = string(internal.ClusterID)
-	c.ConfigFile = string(internal.ConfigFile)
 	c.Redpanda = internal.Redpanda
 	c.Rpk = internal.Rpk
 	c.Pandaproxy = internal.Pandaproxy

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -842,8 +842,7 @@ func TestConfig_UnmarshalYAML(t *testing.T) {
 	}{
 		{
 			name: "Config file with normal types",
-			data: `config_file: "/etc/redpanda/redpanda.yaml"
-organization: "my_organization"
+			data: `organization: "my_organization"
 cluster_id: "cluster_id"
 node_uuid: "node_uuid"
 redpanda:
@@ -969,7 +968,6 @@ rpk:
   tune_clocksource: true
 `,
 			exp: &Config{
-				ConfigFile:   "/etc/redpanda/redpanda.yaml",
 				Organization: "my_organization",
 				ClusterID:    "cluster_id",
 				NodeUUID:     "node_uuid",
@@ -1074,8 +1072,7 @@ rpk:
 		},
 		{
 			name: "Config file with weak types",
-			data: `config_file: 123123
-organization: true
+			data: `organization: true
 cluster_id: "cluster_id"
 node_uuid: 124.42
 redpanda:
@@ -1207,7 +1204,6 @@ rpk:
   tune_clocksource: 1
 `,
 			exp: &Config{
-				ConfigFile:   "123123",
 				Organization: "1",
 				ClusterID:    "cluster_id",
 				NodeUUID:     "124.42",

--- a/src/go/rpk/pkg/tuners/check.go
+++ b/src/go/rpk/pkg/tuners/check.go
@@ -25,7 +25,7 @@ func Check(
 	fs afero.Fs, conf *config.Config, timeout time.Duration,
 ) ([]CheckResult, error) {
 	var results []CheckResult
-	ioConfigFile := redpanda.GetIOConfigPath(filepath.Dir(conf.ConfigFile))
+	ioConfigFile := redpanda.GetIOConfigPath(filepath.Dir(conf.FileLocation()))
 	checkersMap, err := RedpandaCheckers(fs, ioConfigFile, conf, timeout)
 	if err != nil {
 		return results, err

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -35,8 +35,7 @@ class RpkConfigTest(RedpandaTest):
         with tempfile.TemporaryDirectory() as d:
             node.account.copy_from(path, d)
             with open(os.path.join(d, path)) as f:
-                expected_out = '''config_file: /root/redpanda-test.yaml
-# node_uuid: (the uuid is random so we don't compare it)
+                expected_out = '''# node_uuid: (the uuid is random so we don't compare it)
 pandaproxy: {}
 redpanda:
     data_directory: /var/lib/redpanda/data


### PR DESCRIPTION
## Cover letter

config_file property is confusing and very unusual for config files to reference its own path and is immediately broken if cp/mv the file.

Fixes #5458

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
<!-- - [ ] papercut/not impactful enough to backport
- [ ] v22.2.x  
- [ ] v22.1.x
- [ ] v21.11.x -->

## UX changes

- For existing redpanda.yaml files, the `config_file` field will now be “unknown” and will be dumped into the Other section: the field will not be stripped. A person upgrading from pre-v22.2 to v22.2 will be able to rollback.

- For new redpanda.yaml files, the config_file field will not be written. A person will not be able to rollback to old versions if they setup a new cluster with v22.2. As well, they will not be able to use an old rpk with the new cluster.

## Release notes

* rpk: the redpanda.config_file field in redpanda.yaml is no longer written in new config files.