### PR TITLE
rpk: disable tune checkers in rp start unit test

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -1428,7 +1428,10 @@ func TestStartCommand(t *testing.T) {
 			var out bytes.Buffer
 			logrus.SetOutput(&out)
 			c := NewStartCommand(fs, launcher)
-			c.SetArgs(tt.args)
+			// We disable --check flag to avoid running tuner checks in Afero's
+			// memory backed file system.
+			args := append([]string{"--check=false"}, tt.args...)
+			c.SetArgs(args)
 			err := c.Execute()
 			if tt.expectedErrMsg != "" {
 				require.Contains(st, err.Error(), tt.expectedErrMsg)


### PR DESCRIPTION
## Cover letter

Small change to avoid running the tune checkers in the unit tests for `rpk redpanda start`. This will reduce unit test time by ~70%:

```
# From
go test ./... -count=1  11.36s user 2.66s system 18% cpu 1:17.14 total

# To
go test ./... -count=1  11.25s user 1.94s system 70% cpu 18.609 total
```

### Why?
- It doesn't make much sense to run the checkers in a memory-backed filesystem (Afero.MemMapFs) during unit testing.
- We already have unit tests for checkers in `rpk/pkg/tuners` and tuner tests in ducktape: https://github.com/redpanda-data/redpanda/blob/dev/tests/rptest/tests/rpk_tuner_test.py
- 11 checkers always fail:
```
System check "Free memory per CPU [MB]" failed with non-fatal error "open /proc/self/cgroup: file does not exist"
System check "Transparent huge pages active" failed with non-fatal error "open /sys/kernel/mm/transparent_hugepage/enabled: file does not exist"
System check "Dir '/var/lib/redpanda/data' scheduler tuned" failed with non-fatal error "open /sys/devices/virtual/block/dm-1/uevent: file does not exist"
System check "Dir '/var/lib/redpanda/data' nomerges tuned" failed with non-fatal error "open /sys/devices/virtual/block/dm-1/uevent: file does not exist"
System check "Dir '/var/lib/redpanda/data' IRQs affinity static" failed with non-fatal error "open /sys/devices/virtual/block/dm-1/uevent: file does not exist"
System check "Dir '/var/lib/redpanda/data' IRQs affinity set" failed with non-fatal error "open /sys/devices/virtual/block/dm-1/uevent: file does not exist"
System check "Connections listen backlog size" failed with non-fatal error "open /proc/sys/net/core/somaxconn: file does not exist"
System check "Max syn backlog size" failed with non-fatal error "open /proc/sys/net/ipv4/tcp_max_syn_backlog: file does not exist"
System check "Max AIO Events" failed with non-fatal error "open /proc/sys/fs/aio-max-nr: file does not exist"
System check "Clock Source" failed with non-fatal error "open /sys/devices/system/clocksource/clocksource0/current_clocksource: file does not exist"
System check "Swappiness" failed with non-fatal error "open /proc/sys/vm/swappiness: file does not exist"
```

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix

## UX changes

* none

## Release notes
* none
