### PR TITLE
cloud_storage/tests: unmarks test ok to fail

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1270,7 +1270,6 @@ class TopicRecoveryTest(RedpandaTest):
                                      self.rpk_producer_maker)
         self.do_run(test_case)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4849
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
     def test_missing_segment(self):


### PR DESCRIPTION
test_missing_segment was ok_to_fail, recent changes in pr https://github.com/redpanda-data/redpanda/pull/5372 should improve this test by frequently uploading segments to s3, the test failure had been because the sole segment in s3 was deleted resulting in an empty restored topic.

however looking at pandaresults reveals this test has been OPASS in the last 30 days with no failures. unmarking this test - the issue will be closed in a few days if no further failures are seen.
