### PR TITLE
r/heartbeat_manager: validate received heartbeat response group

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -102,7 +102,8 @@ static heartbeat_requests requests_for_range(
             if (rni == ptr->self()) {
                 auto hb_metadata = ptr->meta();
                 pending_beats[rni.id()].emplace_back(
-                  heartbeat_metadata{hb_metadata, rni},
+                  heartbeat_metadata{
+                    .meta = hb_metadata, .node_id = rni, .target_node_id = rni},
                   heartbeat_manager::follower_request_meta(
                     ptr, follower_req_seq(0), hb_metadata.prev_log_index, rni));
                 return;

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -285,16 +285,17 @@ void heartbeat_manager::process_reply(
                 vlog(hbeatlog.error, "cannot find consensus group:{}", g);
                 continue;
             }
+            auto consensus = *it;
 
-            (*it)->update_heartbeat_status(req_meta.follower_vnode, false);
+            consensus->update_heartbeat_status(req_meta.follower_vnode, false);
 
             // propagate error
-            (*it)->process_append_entries_reply(
+            consensus->process_append_entries_reply(
               n,
               result<append_entries_reply>(r.error()),
               req_meta.seq,
               req_meta.dirty_offset);
-            (*it)->get_probe().heartbeat_request_error();
+            consensus->get_probe().heartbeat_request_error();
         }
         return;
     }
@@ -307,15 +308,13 @@ void heartbeat_manager::process_reply(
               m.group);
             continue;
         }
+        auto consensus = *it;
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);
         auto meta = std::move(groups.find(m.group)->second);
-        (*it)->update_heartbeat_status(meta.follower_vnode, true);
+        consensus->update_heartbeat_status(meta.follower_vnode, true);
 
-        (*it)->process_append_entries_reply(
-          n,
-          result<append_entries_reply>(std::move(m)),
-          meta.seq,
-          meta.dirty_offset);
+        consensus->process_append_entries_reply(
+          n, result<append_entries_reply>(m), meta.seq, meta.dirty_offset);
     }
 }
 


### PR DESCRIPTION
It may be possible (due to serialization issue or other logical error)
that the node will receive a heartbeat response for the group which
wasn't requested.

Added check if received group id exists in requested heartbeats map.

Fixes: #4623

Signed-off-by: Michal Maslanka <michal@redpanda.com>
