### PR TITLE
cloud_storage/tests: match topic name when deleting manifest

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -345,7 +345,8 @@ class MissingPartition(BaseCase):
     only one key).
     """
 
-    topics = (TopicSpec(name='panda-topic',
+    topic_name = 'panda-topic'
+    topics = (TopicSpec(name=topic_name,
                         partition_count=2,
                         replication_factor=3), )
 
@@ -377,8 +378,9 @@ class MissingPartition(BaseCase):
         consistent in Minio S3 implementation)."""
         manifest = None
         for key in self._list_objects():
-            if key.endswith("/manifest.json"):
+            if key.endswith("/manifest.json") and self.topic_name in key:
                 attr = parse_s3_manifest_path(key)
+                assert attr.ntp.topic == self.topic_name
                 if attr.ntp.partition == 0:
                     manifest = key
                 else:


### PR DESCRIPTION
when deleting manifest in test_missing_partition we should match topic name with the manifest path. fixes #5711 


[force push: adjust assertion to happen after topic match](https://github.com/redpanda-data/redpanda/compare/97c619a9b43d58aabd7ba11df8f6d2348cfe8132..9333fa8d15e2002489832f4f201faaf178c9ca12)