### PR TITLE
kafka/client: improve list_offsets response error handling

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -36,6 +36,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/std-coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <absl/container/node_hash_map.h>
 
@@ -295,18 +296,18 @@ client::create_topic(kafka::creatable_topic req) {
 
 ss::future<list_offsets_response>
 client::list_offsets(model::topic_partition tp) {
-    return gated_retry_with_mitigation([this, tp]() {
-        return _topic_cache.leader(tp)
-          .then(
-            [this](model::node_id node_id) { return _brokers.find(node_id); })
-          .then([tp](auto broker) mutable {
-              return broker->dispatch(kafka::list_offsets_request{
-                .data = {.topics{
-                  {{.name{std::move(tp.topic)},
-                    .partitions{
-                      {{.partition_index{tp.partition},
-                        .max_num_offsets = 1}}}}}}}});
-          });
+    using result = ss::future<list_offsets_response>;
+    return gated_retry_with_mitigation([this, _tp = std::move(tp)]() -> result {
+        auto me = this;
+        auto tp = _tp;
+        auto node_id = co_await me->_topic_cache.leader(tp);
+        auto broker = co_await me->_brokers.find(node_id);
+        auto res = co_await broker->dispatch(kafka::list_offsets_request{
+          .data = {.topics{
+            {{.name{tp.topic},
+              .partitions{
+                {{.partition_index{tp.partition}, .max_num_offsets = 1}}}}}}}});
+        co_return res;
     });
 }
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -307,6 +307,17 @@ client::list_offsets(model::topic_partition tp) {
             {{.name{tp.topic},
               .partitions{
                 {{.partition_index{tp.partition}, .max_num_offsets = 1}}}}}}}});
+
+        const auto& topics = res.data.topics;
+        auto ec = error_code::none;
+        if (topics.size() != 1 || topics[0].partitions.size() != 1) {
+            co_return ss::coroutine::make_exception(
+              broker_error(node_id, error_code::unknown_server_error));
+        }
+        ec = topics[0].partitions[0].error_code;
+        if (ec != error_code::none) {
+            co_return ss::coroutine::make_exception(partition_error(tp, ec));
+        }
         co_return res;
     });
 }

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -190,18 +190,7 @@ ss::future<> service::fetch_internal_topic() {
 
     auto offset_res = co_await _client.local().list_offsets(
       model::schema_registry_internal_tp);
-    const auto& topics = offset_res.data.topics;
-    if (topics.size() != 1 || topics.front().partitions.size() != 1) {
-        auto ec = kafka::error_code::unknown_topic_or_partition;
-        throw kafka::exception(ec, make_error_code(ec).message());
-    }
-    const auto& partition = topics.front().partitions.front();
-    if (partition.error_code != kafka::error_code::none) {
-        auto ec = partition.error_code;
-        throw kafka::exception(ec, make_error_code(ec).message());
-    }
-
-    auto max_offset = partition.offset;
+    auto max_offset = offset_res.data.topics[0].partitions[0].offset;
     vlog(plog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
     co_await kafka::client::make_client_fetch_batch_reader(


### PR DESCRIPTION
## Cover letter

In `kafka/client`, errors are mitigated by returning an exception of a specific type.

Traverse the `list_offsets_response` and convert an error to an exception, so that `gated_retry_with_mitigation` has a chance to mitigate an error.

Fix #5725 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x (not branched yet)
- [x] v22.1.x
- [x] v21.11.x

## Release notes

* Schema Registry: `list_offsets` is retried on failure. In particular, this  prevents a rare startup issue.
* REST Proxy: `list_offsets` is retried on failure.
