### PR TITLE
rpc/transport: Release resource units right after dispatching send

### DIFF
--- a/src/v/rpc/test/echo_service.json
+++ b/src/v/rpc/test/echo_service.json
@@ -21,9 +21,9 @@
             "output_type": "echo_resp"
         },
         {
-            "name": "sleep_1s",
-            "input_type": "echo_req",
-            "output_type": "echo_resp"
+            "name": "sleep_for",
+            "input_type": "sleep_req",
+            "output_type": "sleep_resp"
         },
         {
             "name": "counter",

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -72,11 +72,11 @@ struct echo_impl final : echo::echo_service_base<Codec> {
           echo::echo_resp{.str = ssx::sformat("{}_suffix", req.str)});
     }
 
-    ss::future<echo::echo_resp>
-    sleep_1s(echo::echo_req&&, rpc::streaming_context&) final {
-        using namespace std::chrono_literals;
-        return ss::sleep(1s).then(
-          []() { return echo::echo_resp{.str = "Zzz..."}; });
+    ss::future<echo::sleep_resp>
+    sleep_for(echo::sleep_req&& req, rpc::streaming_context&) final {
+        return ss::sleep(std::chrono::seconds(req.secs)).then([]() {
+            return echo::sleep_resp{.str = "Zzz..."};
+        });
     }
 
     ss::future<echo::cnt_resp>
@@ -354,9 +354,9 @@ FIXTURE_TEST(timeout_test, rpc_integration_fixture) {
 
     rpc::client<echo::echo_client_protocol> client(client_config());
     client.connect(model::no_timeout).get();
-    info("Calling echo method");
-    auto echo_resp = client.sleep_1s(
-      echo::echo_req{.str = "testing..."},
+    info("Calling sleep for.. 1s");
+    auto echo_resp = client.sleep_for(
+      echo::sleep_req{.secs = 1},
       rpc::client_opts(rpc::clock_type::now() + 100ms));
     BOOST_REQUIRE_EQUAL(
       echo_resp.get0().error(), rpc::errc::client_request_timeout);

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -17,6 +17,7 @@
 #include "rpc/test/rpc_gen_types.h"
 #include "rpc/test/rpc_integration_fixture.h"
 #include "rpc/types.h"
+#include "test_utils/async.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/condition-variable.hh>
@@ -360,6 +361,35 @@ FIXTURE_TEST(timeout_test, rpc_integration_fixture) {
       rpc::client_opts(rpc::clock_type::now() + 100ms));
     BOOST_REQUIRE_EQUAL(
       echo_resp.get0().error(), rpc::errc::client_request_timeout);
+    client.stop().get();
+}
+
+FIXTURE_TEST(timeout_test_cleanup_resources, rpc_integration_fixture) {
+    configure_server();
+    register_services();
+    start_server();
+
+    rpc::client<echo::echo_client_protocol> client(client_config());
+    client.connect(model::no_timeout).get();
+    using units_t = std::vector<ssx::semaphore_units>;
+    ::mutex lock;
+    units_t units;
+    units.push_back(std::move(lock.get_units().get()));
+
+    auto opts = rpc::client_opts(rpc::clock_type::now() + 1s);
+    opts.resource_units = ss::make_foreign(
+      ss::make_lw_shared(std::move(units)));
+
+    // Resources should now be owned by the client.
+    BOOST_REQUIRE(lock.try_get_units().has_value() == false);
+    auto echo_resp = client.sleep_for(
+      echo::sleep_req{.secs = 10}, std::move(opts));
+    BOOST_REQUIRE_EQUAL(
+      echo_resp.get0().error(), rpc::errc::client_request_timeout);
+    // Verify that the resources are released correctly after timeout.
+    tests::cooperative_spin_wait_with_timeout(5s, [&] {
+        return lock.try_get_units().has_value();
+    }).get();
     client.stop().get();
 }
 

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -62,6 +62,16 @@ struct cnt_resp {
     uint64_t current;
 };
 
+struct sleep_req {
+    using rpc_serde_exempt = std::true_type;
+    uint64_t secs;
+};
+
+struct sleep_resp {
+    using rpc_serde_exempt = std::true_type;
+    ss::sstring str;
+};
+
 enum class failure_type { throw_exception, exceptional_future, none };
 
 struct throw_req {

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -222,14 +222,18 @@ void transport::dispatch_send() {
                   auto it = _requests_queue.begin();
                   _last_seq = it->first;
                   auto buffer = std::move(it->second->buffer).get();
+                  // These units are released once we are out of scope here
+                  // and that is intentional because the underlying write call
+                  // to the batched output stream guarantees us the in-order
+                  // delivery of the dispatched write calls, which is the intent
+                  // of holding on to the units up until this point.
                   auto units = std::move(it->second->resource_units);
                   auto v = std::move(*buffer).as_scattered();
                   auto msg_size = v.size();
                   _requests_queue.erase(it->first);
-                  return _out.write(std::move(v))
-                    .finally([this, msg_size, units = std::move(units)] {
-                        _probe.add_bytes_sent(msg_size);
-                    });
+                  auto f = _out.write(std::move(v));
+                  return std::move(f).finally(
+                    [this, msg_size] { _probe.add_bytes_sent(msg_size); });
               });
         }).handle_exception([this](std::exception_ptr e) {
             vlog(rpclog.info, "Error dispatching socket write:{}", e);

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -1,0 +1,98 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import threading
+from ducktape.utils.util import wait_until
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.admin import Admin
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+
+
+class ShutdownTest(EndToEndTest):
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_timely_shutdown_with_failures(self):
+        '''
+        Validates that a leader node can shutdown in a timely manner when
+        a follower node is unresponsive. Specifically the test targets
+        timely cleanup of the consensus class in flaky conditions.
+        '''
+        self.topic = TopicSpec(partition_count=1, replication_factor=3)
+        rp_conf = {
+            'enable_leader_balancer': False,
+            'auto_create_topics_enabled': True
+        }
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        extra_rp_conf=rp_conf)
+        admin = Admin(self.redpanda)
+
+        def checked_get_leader():
+            try:
+                leader = admin.get_partition_leader(namespace="kafka",
+                                                    topic=self.topic.name,
+                                                    partition=0)
+                return next(
+                    filter(lambda n: self.redpanda.idx(n) == leader,
+                           self.redpanda.nodes))
+            except:
+                return None
+
+        self.redpanda.start()
+        # Background load generation
+        self.start_producer(2)
+        # Wait until a leader is available.
+        wait_until(lambda: checked_get_leader(),
+                   timeout_sec=10,
+                   backoff_sec=2,
+                   err_msg=f"Leader not found for ntp: {self.topic}/0")
+
+        stopped = False
+
+        def pause_non_leader_node():
+            """Picks a non leader node for the ntp and isolates it repeatedly"""
+            with FailureInjector(self.redpanda) as finjector:
+                timeout_s = 5
+                failure = FailureSpec.FAILURE_ISOLATE
+                while not stopped:
+                    node = random.choice(self.redpanda.nodes)
+                    assert node
+                    if node == checked_get_leader():
+                        continue
+                    # Suspend for longer than send timeouts
+                    finjector.inject_failure(
+                        FailureSpec(node=node, type=failure, length=timeout_s))
+
+        # Inject failures in the background.
+        background_failures = threading.Thread(target=pause_non_leader_node,
+                                               args=(),
+                                               daemon=True)
+        background_failures.start()
+        pending_attempts = 5
+        while pending_attempts != 0:
+            # Pick the current leader and restart it, repeat
+            wait_until(lambda: checked_get_leader,
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       err_msg=f"Leader not found for ntp: {self.topic}/0")
+            leader = checked_get_leader()
+            assert leader
+            self.redpanda.logger.info(
+                f"Restarting leader node {leader.account.hostname}")
+            self.redpanda.restart_nodes(leader)
+            pending_attempts -= 1
+
+        # Stop the finjector
+        stopped = True
+        background_failures.join()  # Wait for ip tables rules reset.
+        assert not background_failures.is_alive()
+        self.producer.stop()


### PR DESCRIPTION
## Cover letter

Currently we have a timer that throws in case of timeouts but does not actually cleanup the underlying resource units. So if the dispatch of send blocks due to a remote issue (eg: in flush), the resources are held up until that returns or fails. In the linked issue, we believe the sequence of events is as follows.

* raft `_op_lock` is grabbed by replicate_entries_stm and propagated to the transport#send (append_entries)
* Test issues a shut down (blocks on consensus stop, request in progress)
* send blocked for 2+ mins holding the op_lock resources (to another node in a questionable state)
* Test timed out after 60 secs
* send returned, request failed and the shutdown got unblocked.

Looking closely, we can actually release the units early as dispatch of send guarantees the ordering for us by using a semaphore.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5324

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* none

### Features

* None.

### Improvements

* Recovers from failures quickly by cleaning up resources.