### PR TITLE
test: patch rpk cluster license test

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -247,14 +247,14 @@ class RpkClusterTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_upload_cluster_license_error(self):
+        license = get_cluster_license()
+        if license is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
+            return
+
         with expect_exception(RpkException,
                               lambda e: "Internal Server Error" in str(e)):
-            license = get_cluster_license()
-            if license is None:
-                self.logger.info(
-                    "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
-                return
-
             with tempfile.NamedTemporaryFile() as tf:
                 tf.write(bytes(license + 'r', 'UTF-8'))
                 tf.seek(0)


### PR DESCRIPTION


## Cover letter

Moving the license check above of
`with expect_exception` so we can gracefully skip
the test if we are not in CI

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] v22.2.x

## UX changes

* none

## Release notes
* none
