### PR TITLE
consensus: fix expected condition variable exception

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2780,7 +2780,7 @@ consensus::prepare_transfer_leadership(vnode target_rni) {
         meta.follower_state_change.broadcast();
         try {
             co_await meta.recovery_finished.wait(timeout);
-        } catch (const ss::timed_out_error&) {
+        } catch (const ss::condition_variable_timed_out&) {
             vlog(
               _ctxlog.warn,
               "transfer leadership: timed out waiting on node {} "


### PR DESCRIPTION
The Seastar docs[1] say wait() returns condition_variable_timed_out, not
timed_out_error. This resulted in error logs like:

```
INFO  2022-07-29 00:03:16,777 [shard 0] raft - [group_id:5, {kafka/topic-fhmhqjvhxd/4}] consensus.cc:2757 - Starting leadership transfer from {id: {5}, revision: {32}} to {id: {4}, revision: {32}} in term 1
INFO  2022-07-29 00:03:16,777 [shard 0] raft - [group_id:5, {kafka/topic-fhmhqjvhxd/4}] consensus.cc:2660 - transfer leadership: waiting for node {id: {4}, revision: {32}} to catch up
...
ERROR 2022-07-29 00:03:26,777 [shard 0] rpc - Service handler threw an exception: seastar::condition_variable_timed_out (Condition variable timed out)
// ... no corresponding message about the end of the leadership transfer
```

[1] https://docs.seastar.io/master/classseastar_1_1condition__variable.html#a69703300a8e56a520269062f062aebda

Partially fixes #5378
I think this also fixes #5461