### PR TITLE
ducktape: Fix topic recovery e2e test

### DIFF
--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -106,7 +106,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         rpk.describe_topic_configs(topic)
 
     @cluster(num_nodes=4)
-    @matrix(message_size=[10000],
+    @matrix(message_size=[5000],
             num_messages=[100000],
             recovery_overrides=[{}, {
                 'retention.bytes': 1024
@@ -143,7 +143,7 @@ class EndToEndTopicRecovery(RedpandaTest):
 
         time.sleep(10)
         wait_until(s3_has_all_data,
-                   timeout_sec=300,
+                   timeout_sec=600,
                    backoff_sec=5,
                    err_msg=f"Not all data is uploaded to S3 bucket")
 


### PR DESCRIPTION
## Cover letter

Fixes #5474 'Not all data is uploaded to S3 bucket'.
The problem is caused by the fact that we're generating huge number of
segments in this test (message size was 10000, and number of messages
was 100000). This commit decreases the message size to 5000 and
increases the timeout for upload to 10 minutes.

## Backport Required

- [x] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

N/A

## Release notes

* none

### Features

N/A

### Improvements

N/A