### PR TITLE
heartbeat_manager: reduce log severity when missing partition

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -281,7 +281,11 @@ void heartbeat_manager::process_reply(
         for (auto& [g, req_meta] : groups) {
             auto it = _consensus_groups.find(g);
             if (it == _consensus_groups.end()) {
-                vlog(hbeatlog.error, "cannot find consensus group:{}", g);
+                vlog(
+                  hbeatlog.warn,
+                  "cannot find consensus group:{}, may have been moved or "
+                  "deleted",
+                  g);
                 continue;
             }
 


### PR DESCRIPTION
The heartbeat manager logs an error message when it attempts parses a
bad heartbeat response that includes a partition it doesn't know about.
A similar message is logged at the debug level when handling a good
response that includes a partition it doesn't know about, since the
following is a valid series of events:

1. replica R becomes leader of topic partition P
2. R sends out heartbeat requests to P's followers
3. an admin deletes P
4. the controller leader sends the requests to delete P
5. R shuts down its consensus
6. the reply to P's heartbeat is received by R, but the partition no
   longer exsts

This sequence is possible regardless whether or not the request was
successfully sent out. With the current logging, we log an error e.g. if
before step 6, the request timed out, and we process the response.

This commit makes this log line less severe, instead logging at the
debug level, since it isn't an immediately actionable message for
users anyway.

Fixes #5378