### PR TITLE
rpc: fix request/response codec mismatch

### DIFF
--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -373,7 +373,7 @@ ss::future<result<bool>> script_dispatcher::heartbeat(int8_t connect_attempts) {
     auto size = co_await _sdb.invoke_on(
       script_database_main_shard,
       [](script_database& sdb) { return sdb.size(); });
-    if (heartbeat.value().data() == static_cast<long>(size)) {
+    if (heartbeat.value().data.size == static_cast<long>(size)) {
         co_return true;
     }
     /// There is a discrepency between the number of registered coprocs

--- a/src/v/coproc/tests/utils/supervisor.cc
+++ b/src/v/coproc/tests/utils/supervisor.cc
@@ -320,10 +320,11 @@ ss::future<state_size_t>
 supervisor::heartbeat(empty_request&&, rpc::streaming_context&) {
     if (!*_delay_heartbeat.local()) {
         auto unique_scripts = co_await registered_scripts();
-        co_return state_size_t(unique_scripts.size());
+        co_return state_size_t{
+          .size = static_cast<int64_t>(unique_scripts.size())};
     }
     vlog(coproclog.warn, "Simulating node restart... heartbeat request");
-    co_return state_size_t(-1);
+    co_return state_size_t{.size = -1};
 }
 
 } // namespace coproc

--- a/src/v/coproc/types.h
+++ b/src/v/coproc/types.h
@@ -71,9 +71,15 @@ struct enable_copros_reply {
     std::vector<data> acks;
 };
 
-/// Stub for what should be 0 parameter method, 'disable_all_coprocessors'
-using empty_request = named_type<int8_t, struct empty_req_tag>;
-using state_size_t = named_type<int64_t, struct state_size_tag>;
+struct empty_request {
+    using rpc_serde_exempt = std::true_type;
+    int8_t empty;
+};
+
+struct state_size_t {
+    using rpc_serde_exempt = std::true_type;
+    int64_t size;
+};
 
 /// \brief deregistration request, remove all topics registered to a coprocessor
 /// with id 'script_id'.

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -87,7 +87,7 @@ struct echo_impl final : echo::echo_service_base<Codec> {
 
     ss::future<echo::throw_resp>
     throw_exception(echo::throw_req&& req, rpc::streaming_context&) final {
-        switch (req) {
+        switch (req.type) {
         case echo::failure_type::exceptional_future:
             return ss::make_exception_future<echo::throw_resp>(
               std::runtime_error("gentle crash"));
@@ -406,7 +406,7 @@ FIXTURE_TEST(server_exception_test, rpc_integration_fixture) {
     client.connect(model::no_timeout).get();
     auto ret = client
                  .throw_exception(
-                   echo::failure_type::exceptional_future,
+                   {.type = echo::failure_type::exceptional_future},
                    rpc::client_opts(model::no_timeout))
                  .get0();
 

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -64,7 +64,10 @@ struct cnt_resp {
 
 enum class failure_type { throw_exception, exceptional_future, none };
 
-using throw_req = failure_type;
+struct throw_req {
+    using rpc_serde_exempt = std::true_type;
+    failure_type type;
+};
 
 struct throw_resp {
     using rpc_serde_exempt = std::true_type;


### PR DESCRIPTION
## Cover letter

Another approach to fixing this is here: https://github.com/redpanda-data/redpanda/pull/5605

Fixes scenario in which a request is encoded at version 2 becuase the
transport was upgraded, but the server encoded the response at version
0. The response was exempt from serde which forces v0. But the request
didn't have the exemption. So when the transport was upgraded the
request at v2 didn't match on the server.

```
   ERROR 2022-07-24 14:46:15,560 [shard 0] assert - Assert failure:
   (../src/v/rpc/service.h:98) 'effective_version == version' auto
   rpc::service::execution_helper<detail::base_named_type<signed char,
   coproc::empty_req_tag, std::integral_constant<bool, true>>,
   coproc::disable_copros_reply,
   rpc::default_message_codec>::exec(ss::input_stream<char> &,
   rpc::streaming_context &, uint32_t, (lambda at
   src/v/coproc/supervisor.h:204:7) &&)::(anonymous
   class)::operator()()::(anonymous
   class)::operator()(coproc::disable_copros_reply)::(anonymous
   class)::operator()(rpc::transport_version) const [Input =
   detail::base_named_type<signed char, coproc::empty_req_tag,
   std::integral_constant<bool, true>>, Output =
   coproc::disable_copros_reply, Codec = rpc::default_message_codec]:
   Unexpected encoding at effective rpc::transport_version::v0 !=
   rpc::transport_version::v2
```

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* None