### PR TITLE
cmake: install pex==2.1.100 not pex=2.1.00

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -309,7 +309,7 @@ ExternalProject_Add(kafka-codegen-pex
   BUILD_COMMAND ""
   INSTALL_COMMAND
   COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 -m venv env
-  COMMAND <SOURCE_DIR>/env/bin/pip install pex=2.1.100
+  COMMAND <SOURCE_DIR>/env/bin/pip install pex==2.1.100
   COMMAND <SOURCE_DIR>/env/bin/pex jsonschema jinja2 -o <INSTALL_DIR>/bin/kafka-codegen-venv)
 
 ExternalProject_Add(kafka-python-pex
@@ -320,7 +320,7 @@ ExternalProject_Add(kafka-python-pex
   BUILD_COMMAND ""
   INSTALL_COMMAND
   COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 -m venv env
-  COMMAND <SOURCE_DIR>/env/bin/pip install pex=2.1.100
+  COMMAND <SOURCE_DIR>/env/bin/pip install pex==2.1.100
   COMMAND <SOURCE_DIR>/env/bin/pex kafka-python -o <INSTALL_DIR>/bin/kafka-python-env
   )
 


### PR DESCRIPTION
as pip's requirement spec uses "==" for this purpose, see
https://pip.pypa.io/en/stable/reference/requirement-specifiers/#requirement-specifiers,
https://peps.python.org/pep-0508/ and
https://peps.python.org/pep-0440/#version-specifiers

otherwise we'd have:
```
FAILED: kafka-codegen-pex-prefix/src/kafka-codegen-pex-stamp/kafka-codegen-pex-install
cd /home/kefu/dev/redpanda/build/deps_build/kafka-codegen-pex-prefix/src/kafka-codegen-pex-build && /usr/bin/cmake -E chdir /home/kefu/dev/redpanda/build/deps_build/kafka-codegen-pex-prefix/src/kafka-codegen-pex py
thon3 -m venv env && /home/kefu/dev/redpanda/build/deps_build/kafka-codegen-pex-prefix/src/kafka-codegen-pex/env/bin/pip install pex=2.1.100 && /home/kefu/dev/redpanda/build/deps_build/kafka-codegen-pex-prefix/src/
kafka-codegen-pex/env/bin/pex jsonschema jinja2 -o /home/kefu/dev/redpanda/build/deps_install/bin/kafka-codegen-venv && /usr/bin/cmake -E touch /home/kefu/dev/redpanda/build/deps_build/kafka-codegen-pex-prefix/src/
kafka-codegen-pex-stamp/kafka-codegen-pex-install
ERROR: Invalid requirement: 'pex=2.1.100'
Hint: = is not a valid operator. Did you mean == ?
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
