### PR TITLE
Partition movements amount metrics

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -306,6 +306,34 @@ inline bool contains_node(
            != replicas.end();
 }
 
+// check if replica is moving from node
+inline bool moving_from_node(
+  model::node_id node,
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (!contains_node(previous_replicas, node)) {
+        return false;
+    }
+    if (!contains_node(result_replicas, node)) {
+        return true;
+    }
+    return false;
+}
+
+// check if replica is moving to node
+inline bool moving_to_node(
+  model::node_id node,
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (contains_node(previous_replicas, node)) {
+        return false;
+    }
+    if (contains_node(result_replicas, node)) {
+        return true;
+    }
+    return false;
+}
+
 cluster::errc map_update_interruption_error_code(std::error_code);
 
 } // namespace cluster

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -342,10 +342,10 @@ std::vector<model::ntp> members_backend::ntps_moving_from_node_older_than(
     std::vector<model::ntp> ret;
 
     for (const auto& [ntp, state] : _topics.local().in_progress_updates()) {
-        if (state.update_revision < revision) {
+        if (state.get_update_revision() < revision) {
             continue;
         }
-        if (!contains_node(state.previous_replicas, node)) {
+        if (!contains_node(state.get_previous_replicas(), node)) {
             continue;
         }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -532,14 +532,14 @@ void partition_balancer_planner::get_unavailable_node_movement_cancellations(
   plan_data& result, const reallocation_request_state& rrs) {
     for (const auto& update : _topic_table.updates_in_progress()) {
         if (
-          update.second.state
+          update.second.get_state()
           != topic_table::in_progress_state::update_requested) {
             continue;
         }
 
         absl::flat_hash_set<model::node_id> previous_replicas_set;
         bool was_on_decommissioning_node = false;
-        for (const auto& r : update.second.previous_replicas) {
+        for (const auto& r : update.second.get_previous_replicas()) {
             previous_replicas_set.insert(r.node_id);
             if (rrs.decommissioning_nodes.contains(r.node_id)) {
                 was_on_decommissioning_node = true;

--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -9,14 +9,122 @@
 
 #include "cluster/topic_table_probe.h"
 
+#include "cluster/cluster_utils.h"
 #include "cluster/topic_table.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "prometheus/prometheus_sanitize.h"
 
 namespace cluster {
 
 topic_table_probe::topic_table_probe(const topic_table& topic_table)
-  : _topic_table(topic_table) {}
+  : _topic_table(topic_table)
+  , _node_id(config::node().node_id()) {
+    setup_metrics();
+}
+
+void topic_table_probe::setup_metrics() {
+    setup_public_metrics();
+    setup_internal_metrics();
+}
+
+void topic_table_probe::setup_internal_metrics() {
+    if (
+      config::shard_local_cfg().disable_metrics() || ss::this_shard_id() != 0) {
+        return;
+    }
+
+    // TODO: Delete this metric after public is supported in scraping
+    // configurations
+    namespace sm = ss::metrics;
+    _internal_metrics.add_group(
+      prometheus_sanitize::metrics_name("cluster:partition"),
+      {
+        sm::make_gauge(
+          "moving_to_node",
+          [this] { return _moving_to_partitions; },
+          sm::description("Amount of partitions that are moving to node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "moving_from_node",
+          [this] { return _moving_from_partitions; },
+          sm::description("Amount of partitions that are moving from node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "node_cancelling_movements",
+          [this] { return _cancelling_movements; },
+          sm::description("Amount of cancelling partition movements for node"))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+void topic_table_probe::setup_public_metrics() {
+    if (
+      config::shard_local_cfg().disable_public_metrics()
+      || ss::this_shard_id() != 0) {
+        return;
+    }
+    namespace sm = ss::metrics;
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("cluster:partition"),
+      {
+        sm::make_gauge(
+          "moving_to_node",
+          [this] { return _moving_to_partitions; },
+          sm::description("Amount of partitions that are moving to node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "moving_from_node",
+          [this] { return _moving_from_partitions; },
+          sm::description("Amount of partitions that are moving from node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "node_cancelling_movements",
+          [this] { return _cancelling_movements; },
+          sm::description("Amount of cancelling partition movements for node"))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+void topic_table_probe::handle_update(
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (moving_from_node(_node_id, previous_replicas, result_replicas)) {
+        _moving_from_partitions += 1;
+    } else if (moving_to_node(_node_id, previous_replicas, result_replicas)) {
+        _moving_to_partitions += 1;
+    }
+}
+
+void topic_table_probe::handle_update_finish(
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (moving_from_node(_node_id, previous_replicas, result_replicas)) {
+        _moving_from_partitions -= 1;
+    } else if (moving_to_node(_node_id, previous_replicas, result_replicas)) {
+        _moving_to_partitions -= 1;
+    }
+}
+
+void topic_table_probe::handle_update_cancel(
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (
+      moving_from_node(_node_id, previous_replicas, result_replicas)
+      || moving_to_node(_node_id, previous_replicas, result_replicas)) {
+        _cancelling_movements += 1;
+    }
+}
+
+void topic_table_probe::handle_update_cancel_finish(
+  const std::vector<model::broker_shard>& previous_replicas,
+  const std::vector<model::broker_shard>& result_replicas) {
+    if (
+      moving_from_node(_node_id, previous_replicas, result_replicas)
+      || moving_to_node(_node_id, previous_replicas, result_replicas)) {
+        _cancelling_movements -= 1;
+    }
+}
 
 void topic_table_probe::handle_topic_creation(
   create_topic_cmd::key_t topic_namespace) {

--- a/src/v/cluster/topic_table_probe.h
+++ b/src/v/cluster/topic_table_probe.h
@@ -21,13 +21,42 @@ class topic_table_probe {
 public:
     explicit topic_table_probe(const topic_table&);
 
+    topic_table_probe(const topic_table_probe&) = delete;
+    topic_table_probe(topic_table_probe&&) = delete;
+    topic_table_probe& operator=(const topic_table_probe&) = delete;
+    topic_table_probe& operator=(topic_table_probe&&) = delete;
+
     void handle_topic_creation(create_topic_cmd::key_t);
     void handle_topic_deletion(const delete_topic_cmd::key_t&);
 
+    void handle_update(
+      const std::vector<model::broker_shard>& previous_replicas,
+      const std::vector<model::broker_shard>& result_replicas);
+    void handle_update_finish(
+      const std::vector<model::broker_shard>& previous_replicas,
+      const std::vector<model::broker_shard>& result_replicas);
+    void handle_update_cancel(
+      const std::vector<model::broker_shard>& previous_replicas,
+      const std::vector<model::broker_shard>& result_replicas);
+    void handle_update_cancel_finish(
+      const std::vector<model::broker_shard>& previous_replicas,
+      const std::vector<model::broker_shard>& result_replicas);
+
 private:
+    void setup_metrics();
+    void setup_public_metrics();
+    void setup_internal_metrics();
+
     const topic_table& _topic_table;
+    model::node_id _node_id;
     absl::flat_hash_map<model::topic_namespace, ss::metrics::metric_groups>
       _topics_metrics;
+    ss::metrics::metric_groups _internal_metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
+    int32_t _moving_to_partitions = 0;
+    int32_t _moving_from_partitions = 0;
+    int32_t _cancelling_movements = 0;
 };
 
 } // namespace cluster

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2510,7 +2510,7 @@ void admin_server::register_partition_routes() {
         -> ss::future<ss::json::json_return_type> {
           using reconfiguration = ss::httpd::partition_json::reconfiguration;
           std::vector<reconfiguration> ret;
-          auto in_progress
+          auto& in_progress
             = _controller->get_topics_state().local().updates_in_progress();
 
           ret.reserve(in_progress.size());
@@ -2519,9 +2519,9 @@ void admin_server::register_partition_routes() {
               r.ns = ntp.ns;
               r.topic = ntp.tp.topic;
               r.partition = ntp.tp.partition;
-              r.status = fmt::format("{}", status.state);
+              r.status = fmt::format("{}", status.get_state());
 
-              for (auto& bs : status.previous_replicas) {
+              for (auto& bs : status.get_previous_replicas()) {
                   ss::httpd::partition_json::assignment replica;
                   replica.node_id = bs.node_id;
                   replica.core = bs.shard;

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -8,7 +8,7 @@ import requests
 from rptest.services.cluster import cluster
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import matrix
+from ducktape.mark import matrix, parametrize
 from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
@@ -17,7 +17,7 @@ from rptest.services.verifiable_producer import TopicPartition
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.tests.partition_movement import PartitionMovementMixin
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings, MetricsEndpoint
 
 NO_RECOVERY = "no_recovery"
 RESTART_RECOVERY = "restart_recovery"
@@ -54,17 +54,85 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             self.throughput = 10000
             self.min_records = 100000
 
+    def get_moving_to_node_metrics(self, node):
+        metrics = self.redpanda.metrics_sample(
+            "moving_to_node", [node],
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        return int(sum([metric.value for metric in metrics.samples]))
+
+    def get_moving_from_node_metrics(self, node):
+        metrics = self.redpanda.metrics_sample(
+            "moving_from_node", [node],
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        return int(sum([metric.value for metric in metrics.samples]))
+
+    def get_cancelling_movements_for_node_metrics(self, node):
+        metrics = self.redpanda.metrics_sample(
+            "node_cancelling_movements", [node],
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        return int(sum([metric.value for metric in metrics.samples]))
+
+    def metrics_correct(self, prev_assignment, assignmets):
+        prev_assignment_nodes = [a["node_id"] for a in prev_assignment]
+        assignment_nodes = [a["node_id"] for a in assignmets]
+        moving_from_node_sum = 0
+        moving_to_node_sum = 0
+        self.logger.debug(
+            f"Checking metrics for movement from {prev_assignment_nodes} to {assignment_nodes}"
+        )
+        for node in self.redpanda.nodes:
+            node_id = self.redpanda.idx(node)
+            moving_to_node_partitions_amount = self.get_moving_to_node_metrics(
+                node)
+            moving_to_node_sum += moving_to_node_partitions_amount
+            moving_from_node_partitions_amount = self.get_moving_from_node_metrics(
+                node)
+            moving_from_node_sum += moving_from_node_partitions_amount
+            cancelling_movements_for_node = self.get_cancelling_movements_for_node_metrics(
+                node)
+
+            self.logger.debug(f"Node: {node_id}, \
+                moving_to_node_partitions_amount: {moving_to_node_partitions_amount}, \
+                moving_from_node_partitions_amount: {moving_from_node_partitions_amount}, \
+                cancelling_movements_for_node: {cancelling_movements_for_node}"
+                              )
+
+            if node_id in prev_assignment_nodes and node_id not in assignment_nodes:
+                if moving_to_node_partitions_amount != 0 or \
+                    moving_from_node_partitions_amount != 1:
+                    return False
+            elif node_id not in prev_assignment_nodes and node_id in assignment_nodes:
+                if moving_to_node_partitions_amount != 1 or \
+                    moving_from_node_partitions_amount != 0:
+                    return False
+            else:
+                if moving_to_node_partitions_amount != 0 or \
+                    moving_from_node_partitions_amount != 0:
+                    return False
+
+            if cancelling_movements_for_node != 0:
+                return False
+
+        return moving_to_node_sum == moving_from_node_sum
+
+    def check_metrics(self, prev_assignment=[], assignmets=[]):
+        return wait_until(
+            lambda: self.metrics_correct(prev_assignment, assignmets),
+            timeout_sec=10)
+
     def _random_move_and_cancel(self, unclean_abort):
         metadata = self.client().describe_topics()
         topic, partition = self._random_partition(metadata)
-        prev_assignment, _ = self._dispatch_random_partition_move(
+        prev_assignment, assignments = self._dispatch_random_partition_move(
             topic=topic, partition=partition, allow_no_op=False)
 
         self._wait_for_move_in_progress(topic, partition)
+        self.check_metrics(prev_assignment, assignments)
         self._request_move_cancel(unclean_abort=unclean_abort,
                                   topic=topic,
                                   partition=partition,
                                   previous_assignment=prev_assignment)
+        self.check_metrics()
 
     def _throttle_recovery(self, new_value):
         self.redpanda.set_cluster_config(
@@ -104,7 +172,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
                     [random.choice(self.redpanda.nodes)])
 
         if unclean_abort:
-            # do not run offsets validation as we may experience data loss since partition movement is forcibly cancelled
+            # do not run offsets validation as we may experience data loss since partition movement is forcibly cancelling
             wait_until(lambda: self.producer.num_acked > 20000, timeout_sec=60)
 
             self.producer.stop()
@@ -166,7 +234,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
                     [random.choice(self.redpanda.nodes)])
 
         if unclean_abort:
-            # do not run offsets validation as we may experience data loss since partition movement is forcibly cancelled
+            # do not run offsets validation as we may experience data loss since partition movement is forcibly cancelling
             wait_until(lambda: self.producer.num_acked > 20000, timeout_sec=60)
 
             self.producer.stop()


### PR DESCRIPTION
## Cover letter

Add metrics with current partition movements amount and cancelled movements amount to topic table probe

New metric names:
redpanda_cluster_partition_moving_to_node
redpanda_cluster_partition_moving_from_node
redpanda_cluster_partition_node_cancelled_movements

Fixes: #4871
## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* New metric for partition movements amount

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
