### PR TITLE
config: correct value of expected retention

### DIFF
--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -441,7 +441,8 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
 
     auto describe_resp = describe_configs(test_tp);
-    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+    assert_property_value(
+      test_tp, "retention.ms", fmt::format("{}", 1234ms), describe_resp);
     assert_property_value(test_tp, "cleanup.policy", "compact", describe_resp);
     assert_property_value(
       test_tp, "redpanda.remote.read", "true", describe_resp);
@@ -475,7 +476,8 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     BOOST_REQUIRE_EQUAL(resp.data.responses[1].resource_name, topic_2);
 
     auto describe_resp_1 = describe_configs(topic_1);
-    assert_property_value(topic_1, "retention.ms", "1234", describe_resp_1);
+    assert_property_value(
+      topic_1, "retention.ms", fmt::format("{}", 1234ms), describe_resp_1);
     assert_property_value(
       topic_1, "cleanup.policy", "compact", describe_resp_1);
 
@@ -536,7 +538,8 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
 
     auto describe_resp = describe_configs(test_tp);
-    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+    assert_property_value(
+      test_tp, "retention.ms", fmt::format("{}", 1234ms), describe_resp);
 
     /**
      * Set custom retention.bytes, previous settings should be overriden
@@ -552,8 +555,7 @@ FIXTURE_TEST(
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}",
-        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
+        "{}", config::shard_local_cfg().delete_retention_ms().value_or(-1ms)),
       new_describe_resp);
     assert_property_value(
       test_tp, "retention.bytes", "4096", new_describe_resp);
@@ -581,7 +583,8 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
 
     auto describe_resp = describe_configs(test_tp);
-    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+    assert_property_value(
+      test_tp, "retention.ms", fmt::format("{}", 1234ms), describe_resp);
 
     /**
      * Set custom retention.bytes, only this property should be updated
@@ -600,7 +603,7 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     auto new_describe_resp = describe_configs(test_tp);
     // retention.ms should stay untouched
     assert_property_value(
-      test_tp, "retention.ms", fmt::format("1234"), new_describe_resp);
+      test_tp, "retention.ms", fmt::format("{}", 1234ms), new_describe_resp);
     assert_property_value(
       test_tp, "retention.bytes", "4096", new_describe_resp);
 }
@@ -649,7 +652,8 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
 
     auto describe_resp = describe_configs(test_tp);
-    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+    assert_property_value(
+      test_tp, "retention.ms", fmt::format("{}", 1234ms), describe_resp);
 
     /**
      * Remove retention.bytes
@@ -671,8 +675,7 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
       test_tp,
       "retention.ms",
       fmt::format(
-        "{}",
-        config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()),
+        "{}", config::shard_local_cfg().delete_retention_ms().value_or(-1ms)),
       new_describe_resp);
 }
 
@@ -766,7 +769,10 @@ FIXTURE_TEST(
 
     auto alter_config_describe_resp = describe_configs(test_tp);
     assert_property_value(
-      test_tp, "retention.ms", "1234", alter_config_describe_resp);
+      test_tp,
+      "retention.ms",
+      fmt::format("{}", 1234ms),
+      alter_config_describe_resp);
 
     std::ostringstream stream2;
     stream2 << dp1;


### PR DESCRIPTION
the config's type of "retention.ms" is defined in `topic_properties`,
like
```c++
tristate<std::chrono::milliseconds> retention_duration{std::nullopt};
```

and we use `describe_as_string()` to format the value of config
description, and `describe_as_string()` in turn uses `fmt::format()`
to stringify the value of config's value. in this case, the type
of "retention.ms" is `std::chrono::milliseconds`, which is formatted
like `1234ms` if its value is `std::chrono::milliseconds(1234)` in
fmtlib v6.x, v7.x, v8.x and v.9.0.

in this change, the expected value is changed from `"1234"` to
`fmt::format("{}", 1234ms)` to more future-proof, in case fmtlib
changes its formatting in future.

for the same reason, the calls like
`config::shard_local_cfg().delete_retention_ms().value_or(-1ms).count()`
are also changed to
`config::shard_local_cfg().delete_retention_ms().value_or(-1ms)`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
