### PR TITLE
cluster: fix shutdown hang in health_monitor_backend

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -121,6 +121,7 @@ ss::future<> health_monitor_backend::stop() {
       _leadership_notification_handle);
 
     auto f = _gate.close();
+    _refresh_mutex.broken();
     abort_current_refresh();
     _tick_timer.cancel();
 
@@ -479,6 +480,9 @@ health_monitor_backend::maybe_refresh_cluster_health(
                   err.message());
                 co_return err;
             }
+        } catch (const ss::broken_semaphore&) {
+            // Refresh was waiting on _refresh_mutex during shutdown
+            co_return errc::shutting_down;
         } catch (const ss::timed_out_error&) {
             vlog(
               clusterlog.info,


### PR DESCRIPTION
## Cover letter

If refresh_cluster_health_cache was waiting on _refresh_mutex
while ::stop ran, and another fiber had a refresh in progress,
then ::stop cancels the other fiber's refresh + the first fiber
proceeds to try and refresh again, holding the gate open
while ::stop is waiting for it to close.

Fixes https://github.com/redpanda-data/redpanda/issues/5178

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Fix a rare shutdown hang that occurs when a peer is unresponsive.
