### PR TITLE
cloud_storage/tests: wait for partition metadata during topic recovery tests

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -560,7 +560,7 @@ class RpkTool:
             p.kill()
             raise RpkException(f"command {' '.join(cmd)} timed out")
 
-        self._redpanda.logger.debug(output)
+        self._redpanda.logger.debug(f'\n{output}')
 
         if p.returncode:
             self._redpanda.logger.error(error)

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -176,17 +176,42 @@ class BaseCase:
 
     def _produce_and_verify(self, topic_spec):
         """Try to produce to the topic. The method produces data to the topic and
-        checks that high watermark advanced."""
-        old_hw = None
-        new_hw = None
-        for partition in self._rpk.describe_topic(topic_spec.name):
-            old_hw = partition.high_watermark
-        assert old_hw is not None
+        checks that high watermark advanced. Wait for partition metadata to appear
+        in case of a recent leader election"""
+
+        # Utility to capture the watermark using wait_until as soon as it is not None.
+        class PartitionState:
+            def __init__(self, rpk, topic_name):
+                self.rpk = rpk
+                self.topic_name = topic_name
+                self.hwm = None
+
+            def watermark_is_present(self):
+                for partition_info in self.rpk.describe_topic(self.topic_name):
+                    self.hwm = partition_info.high_watermark
+                return self.hwm is not None
+
+        old_state = PartitionState(self._rpk, topic_spec.name)
+        wait_until(
+            lambda: old_state.watermark_is_present(),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=
+            f'failed to get high watermark before produce for {topic_spec}')
+
         self._kafka_tools.produce(topic_spec.name, 10000, 1024)
-        for topic in self._rpk.describe_topic(topic_spec.name):
-            new_hw = topic.high_watermark
-        assert new_hw is not None
-        assert old_hw != new_hw
+
+        new_state = PartitionState(self._rpk, topic_spec.name)
+        wait_until(
+            lambda: new_state.watermark_is_present(),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=
+            f'failed to get high watermark after produce for {topic_spec}')
+
+        assert old_state.hwm != new_state.hwm, \
+            f'old_hw {old_state.hwm} unexpectedly same as new_hw {new_state.hwm} ' \
+            f'for topic spec: {topic_spec}'
 
     def _list_objects(self):
         """Return list of all topics in the bucket (only names)"""


### PR DESCRIPTION
If a leader election happened right before we verify topic watermark, rpk may return an error such as "not leader for partition" due to stale metadata.

Instead of failing immediately this change makes the caller wait for upto 1 minute so that the new leadership info is propagated to the cluster and rpk returns the correct partition metadata.

in a failed test in linked CI failure the following logs are seen due to metadata returned during leader election:
```
INFO  2022-07-29 18:08:38,744 [shard 1] raft - [group_id:1, {kafka/panda-topic-1/0}] vote_stm.cc:255 - becoming the leader term:5
INFO  2022-07-29 18:08:38,764 [shard 1] raft - [group_id:2, {kafka/panda-topic-1/1}] vote_stm.cc:255 - becoming the leader term:5
TRACE 2022-07-29 18:08:38,858 [shard 0] kafka - request_context.h:160 - [172.16.16.27:48330] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=0 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
TRACE 2022-07-29 18:08:38,863 [shard 0] kafka - request_context.h:160 - [172.16.16.27:55628] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=1 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
TRACE 2022-07-29 18:08:38,865 [shard 0] kafka - request_context.h:160 - [172.16.16.27:55628] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=1 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
TRACE 2022-07-29 18:08:38,866 [shard 0] kafka - request_context.h:160 - [172.16.16.27:48330] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=0 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
TRACE 2022-07-29 18:08:38,869 [shard 0] kafka - request_context.h:160 - [172.16.16.27:55628] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=1 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
TRACE 2022-07-29 18:08:38,869 [shard 0] kafka - request_context.h:160 - [172.16.16.27:48330] sending 2:list_offsets response {throttle_time_ms=0 topics={{name={panda-topic-1} partitions={{partition_index=0 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets={} timestamp={timestamp: missing} offset=-1 leader_epoch=-1}}}}}
INFO  2022-07-29 18:08:39,027 [shard 1] raft - [group_id:1, {kafka/panda-topic-1/0}] vote_stm.cc:270 - became the leader term:5
INFO  2022-07-29 18:08:39,033 [shard 1] raft - [group_id:2, {kafka/panda-topic-1/1}] vote_stm.cc:270 - became the leader term:5
```

fixes #5737 

[force push: fix capturing the variable in wait_until](https://github.com/redpanda-data/redpanda/compare/33394691efd4985a6f1f3887b87219c16593dce8..4cd151efd7abe41dab52832e99301e388c439bcb)