### PR TITLE
tests: minor quality of life fixes

### DIFF
--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -10,6 +10,7 @@
 import signal
 import threading
 from ducktape.utils.util import wait_until
+from ducktape.errors import TimeoutError
 
 
 class FailureSpec:


### PR DESCRIPTION
## Cover letter

- Fix the recently added shutdown hang detection in failure_injector
- Fix upgrade tests version regex on systems with no_version redpanda packages built on a workstation.

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none