### PR TITLE
cluster: do not log errors on shutdown from persisted_stm

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -304,6 +304,10 @@ ss::future<bool> persisted_stm::wait_no_throw(
     auto deadline = model::timeout_clock::now() + timeout;
     return wait(offset, deadline)
       .then([] { return true; })
+      .handle_exception_type([](const raft::offset_monitor::wait_aborted&) {
+          vlog(clusterlog.trace, "aborted while waiting (shutting down)");
+          return false;
+      })
       .handle_exception([offset, ntp = _c->ntp()](std::exception_ptr e) {
           vlog(
             clusterlog.error,


### PR DESCRIPTION
## Cover letter

This is a stray shutdown case that shouldn't be logged as error.

Fixes https://github.com/redpanda-data/redpanda/issues/5764

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none