### PR TITLE
cloud_storage: use is_elected_leader for leadership query

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -157,7 +157,7 @@ ss::future<> ntp_archiver::upload_loop() {
             vlog(
               _rtclog.debug,
               "Cancelled upload of {} segments",
-              result.num_succeded);
+              result.num_cancelled);
         }
 
         if (!upload_loop_can_continue()) {
@@ -339,13 +339,13 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
       "current term: {}, "
       "original term: {}",
       [this, original_term](cloud_storage::lazy_abort_source& las) {
-          auto lost_leadership = !_partition->is_leader()
+          auto lost_leadership = !_partition->is_elected_leader()
                                  || _partition->term() != original_term;
           if (unlikely(lost_leadership)) {
               std::string reason{las.abort_reason()};
               las.abort_reason(fmt::format(
                 fmt::runtime(reason),
-                _partition->is_leader(),
+                _partition->is_elected_leader(),
                 _partition->term(),
                 original_term));
           }


### PR DESCRIPTION
During segment upload we check for leadership lost and cancel the upload if so, using raft's `is_leader` method. This PR replaces the query method from `is_leader` to `is_elected_leader`. 

`is_elected_leader` has weaker requirements - it is true when the node wins election - and is used in the rest of ntp archival subsystem, whereas the more stringent check `is_leader` - which is true if node wins election AND config batch is replicated and commit index of leader has advanced - is used in upload leadership check. This mismatch in the queries causes uploads to cancel.

As the rest of the system moves to `is_leader`, this leadership check will also be moved to that method.

fixes #5755 

the leadership check was introduced in #4642 