### PR TITLE
Make redpanda_kafka_replicas report configured replicas

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -58,6 +58,7 @@ v_cc_library(
     types.cc
     notification_latch.cc
     topic_table.cc
+    topic_table_probe.cc
     topic_updates_dispatcher.cc
     members_table.cc
     members_manager.cc

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -212,12 +212,6 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
            topic_label(ntp.tp.topic()),
            partition_label(ntp.tp.partition())})
           .aggregate({sm::shard_label, partition_label}),
-        sm::make_gauge(
-          "replicas",
-          [this] { return _partition.raft()->get_follower_count(); },
-          sm::description("Number of replicas per topic"),
-          labels)
-          .aggregate({sm::shard_label, partition_label}),
       });
 }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -72,6 +72,8 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
       std::move(md),
     });
     notify_waiters();
+
+    _probe.handle_topic_creation(std::move(cmd.key));
     return ss::make_ready_future<std::error_code>(errc::success);
 }
 
@@ -116,8 +118,11 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
             _pending_deltas.emplace_back(
               std::move(ntp), p_as, offset, delete_type);
         }
+
         _topics.erase(tp);
         notify_waiters();
+        _probe.handle_topic_deletion(cmd.key);
+
         return ss::make_ready_future<std::error_code>(errc::success);
     }
     return ss::make_ready_future<std::error_code>(errc::topic_not_exists);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/non_replicable_topics_frontend.h"
+#include "cluster/topic_table_probe.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
@@ -105,6 +106,9 @@ public:
 
     using delta_cb_t
       = ss::noncopyable_function<void(const std::vector<delta>&)>;
+
+    explicit topic_table()
+      : _probe(*this){};
 
     cluster::notification_id_type register_delta_notification(delta_cb_t cb) {
         auto id = _notification_id++;
@@ -302,6 +306,7 @@ private:
     uint64_t _waiter_id{0};
     model::offset _last_consumed_by_notifier{
       model::model_limits<model::offset>::min()};
+    topic_table_probe _probe;
 };
 
 std::ostream& operator<<(std::ostream&, topic_table::in_progress_state);

--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -1,0 +1,68 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/topic_table_probe.h"
+
+#include "cluster/topic_table.h"
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+namespace cluster {
+
+topic_table_probe::topic_table_probe(const topic_table& topic_table)
+  : _topic_table(topic_table) {}
+
+void topic_table_probe::handle_topic_creation(
+  create_topic_cmd::key_t topic_namespace) {
+    if (
+      config::shard_local_cfg().disable_public_metrics()
+      || ss::this_shard_id() != 0) {
+        return;
+    }
+
+    const auto labels = {
+      ssx::metrics::make_namespaced_label("namespace")(topic_namespace.ns()),
+      ssx::metrics::make_namespaced_label("topic")(topic_namespace.tp())};
+
+    namespace sm = ss::metrics;
+
+    sm::metric_groups topic_metrics{ssx::metrics::public_metrics_handle};
+
+    topic_metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka"),
+      {sm::make_gauge(
+         "replicas",
+         [this, topic_namespace] {
+             auto md = _topic_table.get_topic_metadata_ref(topic_namespace);
+             if (md) {
+                 return md.value().get().get_configuration().replication_factor;
+             }
+
+             return int16_t{0};
+         },
+         sm::description("Configured number of replicas for the topic"),
+         labels)
+         .aggregate({sm::shard_label})});
+
+    _topics_metrics.emplace(
+      std::move(topic_namespace), std::move(topic_metrics));
+}
+
+void topic_table_probe::handle_topic_deletion(
+  const delete_topic_cmd::key_t& topic_namespace) {
+    if (
+      config::shard_local_cfg().disable_public_metrics()
+      || ss::this_shard_id() != 0) {
+        return;
+    }
+
+    _topics_metrics.erase(topic_namespace);
+}
+
+} // namespace cluster

--- a/src/v/cluster/topic_table_probe.h
+++ b/src/v/cluster/topic_table_probe.h
@@ -1,0 +1,33 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "cluster/commands.h"
+#include "cluster/fwd.h"
+#include "ssx/metrics.h"
+
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster {
+
+class topic_table_probe {
+public:
+    explicit topic_table_probe(const topic_table&);
+
+    void handle_topic_creation(create_topic_cmd::key_t);
+    void handle_topic_deletion(const delete_topic_cmd::key_t&);
+
+private:
+    const topic_table& _topic_table;
+    absl::flat_hash_map<model::topic_namespace, ss::metrics::metric_groups>
+      _topics_metrics;
+};
+
+} // namespace cluster


### PR DESCRIPTION
## Cover letter

The original intention was for `redpanda_kafka_replicas` to report the number of configured replicas.
I misunderstood the requirement the first time around and this PR fixes the metric.

This PR adds a probe to the topic table which is explicitly called when a new topic is created.
At that point, the probe will register a new metric if required.

Original PR for this fix is https://github.com/redpanda-data/redpanda/pull/5517.

## Backport Required

While this is a bug fix, it doesn't need backporting because the original code was not
released yet.

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
