### PR TITLE
tests: Fix rare failure in test_recreated_topic_metadata_are_valid

### DIFF
--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -18,6 +18,12 @@ from rptest.services.rpk_producer import RpkProducer
 
 from rptest.tests.redpanda_test import RedpandaTest
 
+# When quickly recreating topics after deleting them, redpanda's topic
+# dir creation can trip up over the topic dir deletion.  This is not
+# harmful because creation is retried, but it does generate a log error.
+# See https://github.com/redpanda-data/redpanda/issues/5768
+RECREATE_LOG_ALLOW_LIST = ["mkdir failed: No such file or directory"]
+
 
 class RecreateTopicMetadataTest(RedpandaTest):
     def __init__(self, test_context):
@@ -31,7 +37,7 @@ class RecreateTopicMetadataTest(RedpandaTest):
                 'enable_leader_balancer': False
             })
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=RECREATE_LOG_ALLOW_LIST)
     @parametrize(replication_factor=3)
     @parametrize(replication_factor=5)
     def test_recreated_topic_metadata_are_valid(self, replication_factor):

--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -86,7 +86,7 @@ class RecreateTopicMetadataTest(RedpandaTest):
         rpk.delete_topic(topic)
         rpk.create_topic(topic='tp-test',
                          partitions=partition_count,
-                         replicas=3)
+                         replicas=replication_factor)
 
         def metadata_consistent():
             # validate leadership information on each node


### PR DESCRIPTION
## Cover letter

This test could fail on a retryable storage error creating the topic directory.  It would be nicer if redpanda didn't overlap creations + deletions on the same topic name, but it is not harmful + we shouldn't fail the test on it.

Fixes https://github.com/redpanda-data/redpanda/issues/5768

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
