### PR TITLE
Partition balancer admin ops fuzz test + small improvements

### DIFF
--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -15,7 +15,6 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
-#include "reflection/adl.h"
 #include "serde/serde.h"
 
 namespace cluster {
@@ -133,13 +132,16 @@ operator<<(std::ostream& os, partition_balancer_status status) {
 
 struct partition_balancer_overview_request
   : serde::envelope<partition_balancer_overview_request, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
     auto serde_fields() { return std::tie(); }
 };
 
 struct partition_balancer_overview_reply
   : serde::envelope<partition_balancer_overview_reply, serde::version<0>> {
-    errc error;
+    using rpc_adl_exempt = std::true_type;
 
+    errc error;
     model::timestamp last_tick_time;
     partition_balancer_status status;
     std::optional<partition_balancer_violations> violations;
@@ -155,79 +157,3 @@ struct partition_balancer_overview_reply
 };
 
 } // namespace cluster
-
-namespace reflection {
-
-template<>
-struct adl<cluster::partition_balancer_violations::unavailable_node> {
-    void to(
-      iobuf& out,
-      cluster::partition_balancer_violations::unavailable_node&& n) {
-        serialize(out, n.id, uint64_t(n.unavailable_since.value()));
-    }
-    cluster::partition_balancer_violations::unavailable_node
-    from(iobuf_parser& in) {
-        auto id = adl<model::node_id>{}.from(in);
-        auto unavailable_since = adl<uint64_t>{}.from(in);
-        return cluster::partition_balancer_violations::unavailable_node(
-          id, model::timestamp(unavailable_since));
-    }
-};
-
-template<>
-struct adl<cluster::partition_balancer_violations::full_node> {
-    void to(iobuf& out, cluster::partition_balancer_violations::full_node&& n) {
-        serialize(out, n.id, n.disk_used_percent);
-    }
-    cluster::partition_balancer_violations::full_node from(iobuf_parser& in) {
-        auto id = adl<model::node_id>{}.from(in);
-        auto disk_used_percent = adl<uint32_t>{}.from(in);
-        return cluster::partition_balancer_violations::full_node(
-          id, disk_used_percent);
-    }
-};
-
-template<>
-struct adl<cluster::partition_balancer_violations> {
-    void to(iobuf& out, cluster::partition_balancer_violations&& v) {
-        serialize(out, v.unavailable_nodes, v.full_nodes);
-    }
-    cluster::partition_balancer_violations from(iobuf_parser& in) {
-        auto unavailable_nodes = adl<std::vector<
-          cluster::partition_balancer_violations::unavailable_node>>{}
-                                   .from(in);
-        auto full_nodes
-          = adl<
-              std::vector<cluster::partition_balancer_violations::full_node>>{}
-              .from(in);
-        return cluster::partition_balancer_violations(
-          std::move(unavailable_nodes), std::move(full_nodes));
-    }
-};
-
-template<>
-struct adl<cluster::partition_balancer_overview_request> {
-    void to(iobuf&, cluster::partition_balancer_overview_request&&) {}
-    cluster::partition_balancer_overview_request from(iobuf_parser&) {
-        return cluster::partition_balancer_overview_request{};
-    }
-};
-
-template<>
-struct adl<cluster::partition_balancer_overview_reply> {
-    void to(iobuf& out, cluster::partition_balancer_overview_reply&& r) {
-        serialize(
-          out, r.error, r.last_tick_time.value(), r.status, r.violations);
-    }
-    cluster::partition_balancer_overview_reply from(iobuf_parser& in) {
-        cluster::partition_balancer_overview_reply ret;
-        ret.error = adl<cluster::errc>{}.from(in);
-        ret.last_tick_time = model::timestamp(
-          adl<decltype(ret.last_tick_time.value())>{}.from(in));
-        ret.status = adl<decltype(ret.status)>{}.from(in);
-        ret.violations = adl<decltype(ret.violations)>{}.from(in);
-        return ret;
-    }
-};
-
-} // namespace reflection

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -37,7 +37,7 @@ struct partition_allocator_fixture {
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg()
               .get("partition_autobalancing_mode")
-              .set_value(model::partition_autobalancing_mode::node_add_remove);
+              .set_value(model::partition_autobalancing_mode::node_add);
         }).get0();
     }
 

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -28,7 +28,7 @@ public:
       : test_logger("rebalancing-test") {
         set_configuration(
           "partition_autobalancing_mode",
-          model::partition_autobalancing_mode::node_add_remove);
+          model::partition_autobalancing_mode::node_add);
     }
 
     ~rebalancing_tests_fixture() {
@@ -65,7 +65,7 @@ public:
         set_configuration("disable_metrics", true);
         set_configuration(
           "partition_autobalancing_mode",
-          model::partition_autobalancing_mode::node_add_remove);
+          model::partition_autobalancing_mode::node_add);
     }
 
     cluster::topic_configuration create_topic_cfg(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1191,7 +1191,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "node_add",
        .visibility = visibility::user},
-      model::partition_autobalancing_mode::off,
+      model::partition_autobalancing_mode::node_add,
       {
         model::partition_autobalancing_mode::off,
         model::partition_autobalancing_mode::node_add,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1203,7 +1203,7 @@ configuration::configuration()
       "Node unavailability timeout that triggers moving partitions from the "
       "node",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      30min)
+      15min)
   , partition_autobalancing_max_disk_usage_percent(
       *this,
       "partition_autobalancing_max_disk_usage_percent",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1189,12 +1189,12 @@ configuration::configuration()
       "partition_autobalancing_mode",
       "Partition autobalancing mode",
       {.needs_restart = needs_restart::no,
-       .example = "node_add_remove",
+       .example = "node_add",
        .visibility = visibility::user},
       model::partition_autobalancing_mode::off,
       {
         model::partition_autobalancing_mode::off,
-        model::partition_autobalancing_mode::node_add_remove,
+        model::partition_autobalancing_mode::node_add,
         model::partition_autobalancing_mode::continuous,
       })
   , partition_autobalancing_node_availability_timeout_sec(

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -302,8 +302,8 @@ struct convert<model::partition_autobalancing_mode> {
 
         if (value == "off") {
             rhs = model::partition_autobalancing_mode::off;
-        } else if (value == "node_add_remove") {
-            rhs = model::partition_autobalancing_mode::node_add_remove;
+        } else if (value == "node_add") {
+            rhs = model::partition_autobalancing_mode::node_add;
         } else if (value == "continuous") {
             rhs = model::partition_autobalancing_mode::continuous;
         } else {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -404,7 +404,7 @@ std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs);
 
 enum class partition_autobalancing_mode {
     off = 0,
-    node_add_remove,
+    node_add,
     continuous,
 };
 
@@ -413,8 +413,8 @@ operator<<(std::ostream& o, const partition_autobalancing_mode& m) {
     switch (m) {
     case model::partition_autobalancing_mode::off:
         return o << "off";
-    case model::partition_autobalancing_mode::node_add_remove:
-        return o << "node_add_remove";
+    case model::partition_autobalancing_mode::node_add:
+        return o << "node_add";
     case model::partition_autobalancing_mode::continuous:
         return o << "continuous";
     }

--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -113,7 +113,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
             # Use the deprecated config to bootstrap older nodes.
             extra_rp_conf["enable_auto_rebalance_on_node_add"] = True
         else:
-            extra_rp_conf["partition_autobalancing_mode"] = "node_add_remove"
+            extra_rp_conf["partition_autobalancing_mode"] = "node_add"
         self.redpanda = RedpandaService(self.test_context,
                                         5,
                                         extra_rp_conf=extra_rp_conf)

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -41,7 +41,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
                                         3,
                                         extra_rp_conf={
                                             "partition_autobalancing_mode":
-                                            "node_add_remove",
+                                            "node_add",
                                             "group_topic_partitions": 1,
                                             "default_topic_replications": 3,
                                         })
@@ -69,7 +69,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
                                         3,
                                         extra_rp_conf={
                                             "partition_autobalancing_mode":
-                                            "node_add_remove",
+                                            "node_add",
                                             "group_topic_partitions": 1,
                                             "default_topic_replications": 3,
                                         })

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -97,41 +97,46 @@ class PartitionBalancerTest(EndToEndTest):
             lambda status: status["status"] == "ready",
             timeout_sec=timeout_sec)
 
-    def run_node_stop_start_chain(self, steps, additional_check=None):
+    def check_no_replicas_on_node(self, node):
+        node2pc = self.node2partition_count()
+        self.logger.info(f"partition counts: {node2pc}")
+        total_replicas = self.topic.partition_count * self.topic.replication_factor
+        assert sum(node2pc.values()) == total_replicas
+        assert self.redpanda.idx(node) not in node2pc
 
-        total_replicas = sum(self.node2partition_count().values())
+    class NodeStopper:
+        """Stop/kill/freeze one node at a time and wait for partition balancer."""
+        def __init__(self, test):
+            self.test = test
+            self.f_injector = FailureInjector(test.redpanda)
+            self.cur_failure = None
 
-        f_injector = FailureInjector(self.redpanda)
-        prev_failure = None
+        def make_unavailable(self, node):
+            if self.cur_failure:
+                # heal the previous failure
+                self.f_injector._stop_func(self.cur_failure.type)(
+                    self.cur_failure.node)
 
-        for n in range(steps):
-            node = self.redpanda.nodes[n % len(self.redpanda.nodes)]
             failure_types = [
                 FailureSpec.FAILURE_KILL,
                 FailureSpec.FAILURE_TERMINATE,
                 FailureSpec.FAILURE_SUSPEND,
             ]
-            failure = FailureSpec(random.choice(failure_types), node)
-            f_injector._start_func(failure.type)(failure.node)
+            self.cur_failure = FailureSpec(random.choice(failure_types), node)
+            self.f_injector._start_func(self.cur_failure.type)(
+                self.cur_failure.node)
+            time.sleep(self.test.NODE_AVAILABILITY_TIMEOUT)
 
-            if prev_failure:
-                # heal the previous failure
-                f_injector._stop_func(prev_failure.type)(prev_failure.node)
+        def step_and_wait_for_in_progress(self, node):
+            self.make_unavailable(node)
+            self.test.logger.info(f"waiting for partition balancer to kick in")
+            self.test.wait_until_status(lambda s: s["status"] == "in_progress"
+                                        or s["status"] == "ready")
 
-            time.sleep(self.NODE_AVAILABILITY_TIMEOUT)
-
-            self.wait_until_ready()
-
-            node2pc = self.node2partition_count()
-            self.logger.info(f"partition counts after: {node2pc}")
-
-            assert sum(node2pc.values()) == total_replicas
-            assert self.redpanda.idx(node) not in node2pc
-
-            if additional_check:
-                additional_check()
-
-            prev_failure = failure
+        def step_and_wait_for_ready(self, node):
+            self.make_unavailable(node)
+            self.test.logger.info(f"waiting for quiescent state")
+            self.test.wait_until_ready()
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_unavailable_nodes(self):
@@ -144,7 +149,14 @@ class PartitionBalancerTest(EndToEndTest):
         self.start_consumer(1)
         self.await_startup()
 
-        self.run_node_stop_start_chain(steps=7)
+        ns = self.NodeStopper(self)
+        for n in range(7):
+            node = self.redpanda.nodes[n % len(self.redpanda.nodes)]
+            if n in {1, 3, 4}:
+                ns.step_and_wait_for_in_progress(node)
+            else:
+                ns.step_and_wait_for_ready(node)
+                self.check_no_replicas_on_node(node)
 
         self.run_validation()
 
@@ -174,14 +186,10 @@ class PartitionBalancerTest(EndToEndTest):
         time.sleep(self.NODE_AVAILABILITY_TIMEOUT)
         self.wait_until_ready()
         f_injector._stop_func(initial_failure.type)(initial_failure.node)
-        node2pc = self.node2partition_count()
-        self.logger.info(f"partition counts after: {node2pc}")
-        assert self.redpanda.idx(empty_node) not in node2pc
+        self.check_no_replicas_on_node(empty_node)
 
         # throttle recovery to prevent partition move from finishing
         self._throttle_recovery(10)
-
-        total_replicas = sum(self.node2partition_count().values())
 
         for n in range(3):
             node = self.redpanda.nodes[n % 3]
@@ -201,11 +209,7 @@ class PartitionBalancerTest(EndToEndTest):
             # wait until movements are cancelled
             self.wait_until_ready()
 
-            node2pc = self.node2partition_count()
-            self.logger.info(f"partition counts after: {node2pc}")
-
-            assert sum(node2pc.values()) == total_replicas
-            assert self.redpanda.idx(empty_node) not in node2pc
+            self.check_no_replicas_on_node(empty_node)
 
             f_injector._stop_func(initial_failure.type)(initial_failure.node)
 
@@ -241,7 +245,11 @@ class PartitionBalancerTest(EndToEndTest):
         self.start_consumer(1)
         self.await_startup()
 
-        self.run_node_stop_start_chain(steps=3,
-                                       additional_check=check_rack_placement)
+        ns = self.NodeStopper(self)
+        for n in range(7):
+            node = self.redpanda.nodes[n % len(self.redpanda.nodes)]
+            ns.step_and_wait_for_ready(node)
+            self.check_no_replicas_on_node(node)
+            check_rack_placement()
 
         self.run_validation()

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -29,7 +29,7 @@ class ScalingUpTest(EndToEndTest):
                                             "group_topic_partitions":
                                             1,
                                             "partition_autobalancing_mode":
-                                            "node_add_remove"
+                                            "node_add"
                                         })
         # start single node cluster
         self.redpanda.start(nodes=[self.redpanda.nodes[0]])


### PR DESCRIPTION
## Cover letter

Test that partition autobalancing works while doing random admin operations.

Other changes:
* Remove adl-based rpc balancer-related types serialization (serialization is no serde-only)
* Rename `node_add_remove` -> `node_add` (because decommissioning doesn't really depend on any config values)
* Lower the default `partition_autobalancing_node_availability_timeout_sec` as per @emaxerrno request
* Enable `node_add` by default (fixes #4985 )

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Enable partition balancing on node addition by default.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
### Improvements
* Enable partition balancing on node addition by default.
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
