### PR TITLE
rpk: set cluster properties on start for sandbox mode

### DIFF
--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -316,7 +316,7 @@ func (c *Config) Write(fs afero.Fs) (rerr error) {
 			return fmt.Errorf("unable to chmod temp config file: %v", err)
 		}
 
-		err = preserveUnixOwnership(fs, stat, temp)
+		err = PreserveUnixOwnership(fs, stat, temp)
 		if err != nil {
 			return err
 		}

--- a/src/go/rpk/pkg/config/utils.go
+++ b/src/go/rpk/pkg/config/utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func preserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
+func PreserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
 	// Stat_t is only valid in unix not on Windows.
 	if stat, ok := stat.Sys().(*syscall.Stat_t); ok {
 		gid := int(stat.Gid)

--- a/src/go/rpk/pkg/config/utils_windows.go
+++ b/src/go/rpk/pkg/config/utils_windows.go
@@ -19,6 +19,6 @@ import (
 
 // In windows this is a no-op.
 
-func preserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
+func PreserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
 	return nil
 }


### PR DESCRIPTION
## Cover letter
Follow up of: https://github.com/redpanda-data/redpanda/pull/5628

`rpk redpanda start --sandbox` now creates a file (.bootstrap.yaml) that contains recommended cluster properties in sandbox mode:

```yaml
topic_partitions_per_shard: 1000
group_topic_partitions: 1
auto_create_topics_enabled: true
storage_min_free_bytes: 1073741824
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. , Fixes #ISSUE-NUMBER, ...-->
Fixes #5183 

Ducktape test will be added in #5519 
## Backport Required
- [x] not a bug fix
- [x] v22.2.x


## UX changes

When a user runs `rpk redpanda start --sandbox` rpk will generate a file that contains the recommended cluster properties for sandbox mode, this file will live in the same directory as the `redpanda.yaml` and only will be picked up by redpanda on the first start.

## Release notes

### Features

* `rpk redpanda start --sandbox` now creates a file (.bootstrap.yaml) that contains recommended cluster properties in sandbox mode.