### PR TITLE
archival: Handle archival metadata stm sync errors

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -167,7 +167,10 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
     bool applied = false;
     {
         auto now = ss::lowres_clock::now();
-        auto timeout = now < deadline ? deadline - now : 0ms;
+        if (now >= deadline) {
+            co_return errc::replication_error;
+        }
+        auto timeout = deadline - now;
         applied = co_await wait_no_throw(result.value().last_offset, timeout);
     }
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -61,6 +61,8 @@ public:
       const cloud_storage::partition_manifest& m,
       model::offset insync_offset);
 
+    using persisted_stm::sync;
+
 private:
     ss::future<std::error_code> do_add_segments(
       const cloud_storage::partition_manifest&,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1056,6 +1056,12 @@ configuration::configuration()
       "replica",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30s)
+  , cloud_storage_metadata_sync_timeout_ms(
+      *this,
+      "cloud_storage_metadata_sync_timeout_ms",
+      "Timeout for SI metadata synchronization",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10s)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -223,6 +223,7 @@ struct configuration final : public config_store {
       cloud_storage_segment_max_upload_interval_sec;
     property<std::chrono::milliseconds>
       cloud_storage_readreplica_manifest_sync_timeout_ms;
+    property<std::chrono::milliseconds> cloud_storage_metadata_sync_timeout_ms;
 
     // Archival upload controller
     property<std::chrono::milliseconds>


### PR DESCRIPTION
## Cover letter

The `archival_metadata_stm` can lag behind if the producers are very active which could cause synchronization timeout errors.
To prevent this this PR adds an explicit `sync` call in the upload loop `ntp_archival_service`. The method is called on every loop iteration but actual upload (that invokes `sync` method of the `persisted_stm`) happens rarely. 

Also, this PR adds a new configuration parameter `cloud_storage_metadata_sync_timeout_ms` that can be used to control timeout of the STM sync operation.

Fixes #5472 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none