### PR TITLE
tests/ACLs: add cluster wide mtls migration test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2016,13 +2016,18 @@ class RedpandaService(Service):
             self._saved_executable = True
             self._context.log_collect['executable', self] = True
 
-    def search_log(self, pattern):
-        """
-        Test helper for grepping the redpanda log
+    def search_log_any(self, pattern: str, nodes: list[ClusterNode] = None):
+        # Test helper for grepping the redpanda log.
+        # The design follows python's built-in any() function.
+        # https://docs.python.org/3/library/functions.html#any
 
-        :return:  true if any instances of `pattern` found
-        """
-        for node in self.nodes:
+        # :param pattern: the string to search for
+        # :param nodes: a list of nodes to run grep on
+        # :return:  true if any instances of `pattern` found
+        if nodes is None:
+            nodes = self.nodes
+
+        for node in nodes:
             for line in node.account.ssh_capture(
                     f"grep \"{pattern}\" {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             ):
@@ -2033,3 +2038,28 @@ class RedpandaService(Service):
 
         # Fall through, no matches
         return False
+
+    def search_log_all(self, pattern: str, nodes: list[ClusterNode] = None):
+        # Test helper for grepping the redpanda log
+        # The design follows python's  built-in all() function.
+        # https://docs.python.org/3/library/functions.html#all
+
+        # :param pattern: the string to search for
+        # :param nodes: a list of nodes to run grep on
+        # :return:  true if `pattern` is found in all nodes
+        if nodes is None:
+            nodes = self.nodes
+
+        for node in nodes:
+            exit_status = node.account.ssh(
+                f"grep \"{pattern}\" {RedpandaService.STDOUT_STDERR_CAPTURE}",
+                allow_fail=True)
+
+            # Match not found
+            if exit_status != 0:
+                self.logger.debug(
+                    f"Did not find {pattern} on node {node.name}: {line}")
+                return False
+
+        # Fall through, match on all nodes
+        return True

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -137,7 +137,6 @@ class TLSCertManager:
                     common_name: typing.Optional[str] = None,
                     name: typing.Optional[str] = None):
         name = name or host
-        assert name not in self.certs, f"cert '{name}' already exists"
 
         cfg = self._with_dir(f"{name}.conf")
         key = self._with_dir(f"{name}.key")

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -184,6 +184,68 @@ class AccessControlListTest(RedpandaTest):
                        sasl_mechanism=self.algorithm,
                        tls_cert=self.base_user_cert)
 
+    def check_permissions(self,
+                          pass_w_base_user: Optional[bool] = None,
+                          pass_w_cluster_user: Optional[bool] = None,
+                          pass_w_super_user: Optional[bool] = None,
+                          timeout_sec: int = 90,
+                          err_msg: str = '',
+                          repeat_check: int = 3):
+        # Check user permissions on the cluster
+        #
+        # :param pass_w_base_user: Should perms check pass with the base user?
+        # :param pass_w_cluster_user: Should perms check pass with the user with cluster describe perms?
+        # :param pass_w_super_user: Should perms check pass with the super user?
+        # :param err_msg: error message to pass to wait until
+        # :param repeat_check: how many times to repeat perms check?
+
+        # :raise:  TimeoutError if a perms check fails. Pass otherwise
+        def check_base_user_perms():
+            self.logger.debug(
+                f'list acls with base user, expect pass: {pass_w_base_user}')
+            try:
+                self.get_client("base").acl_list()
+                return pass_w_base_user
+            except ClusterAuthorizationError:
+                return not pass_w_base_user
+
+        def check_cluster_user_perms():
+            self.logger.debug(
+                f'list acls with cluster user, expect pass: {pass_w_cluster_user}'
+            )
+            try:
+                self.get_client("cluster_describe").acl_list()
+                return pass_w_cluster_user
+            except Exception:
+                return not pass_w_cluster_user
+
+        def check_super_user_perms():
+            self.logger.debug(
+                f'list acls with super user, expect pass: {pass_w_super_user}')
+            try:
+                self.get_super_client().acl_list()
+                return pass_w_super_user
+            except Exception:
+                return not pass_w_super_user
+
+        # Run a few times for good health. The target condition
+        # should be consistent
+        for _ in range(repeat_check):
+            if pass_w_base_user != None:
+                wait_until(check_base_user_perms,
+                           timeout_sec=timeout_sec,
+                           err_msg=f'base user: {err_msg}')
+
+            if pass_w_cluster_user != None:
+                wait_until(check_cluster_user_perms,
+                           timeout_sec=timeout_sec,
+                           err_msg=f'cluster user: {err_msg}')
+
+            if pass_w_super_user != None:
+                wait_until(check_super_user_perms,
+                           timeout_sec=timeout_sec,
+                           err_msg=f'super user: {err_msg}')
+
     '''
     The old config style has use_sasl at the top level, which enables
     authorization. New config style has kafka_enable_authorization at the
@@ -250,25 +312,10 @@ class AccessControlListTest(RedpandaTest):
         pass_w_authn_user = should_pass_w_authn_user(use_tls, use_sasl,
                                                      enable_authz, client_auth)
 
-        # run a few times for good health
-        for _ in range(2):
-            try:
-                self.get_client("base").acl_list()
-                assert pass_w_base_user, "list acls should have failed for base user"
-            except ClusterAuthorizationError:
-                assert not pass_w_base_user
-
-            try:
-                self.get_client("cluster_describe").acl_list()
-                assert pass_w_authn_user, "list acls should have failed for cluster user"
-            except ClusterAuthorizationError:
-                assert not pass_w_authn_user
-
-            try:
-                self.get_super_client().acl_list()
-                assert pass_w_authn_user, "list acls should have failed for super user"
-            except ClusterAuthorizationError:
-                assert not pass_w_authn_user
+        self.check_permissions(pass_w_base_user=pass_w_base_user,
+                               pass_w_cluster_user=pass_w_authn_user,
+                               pass_w_super_user=pass_w_authn_user,
+                               err_msg='check_permissions failed')
 
     # Test mtls identity
     # Principals in use:
@@ -307,31 +354,14 @@ class AccessControlListTest(RedpandaTest):
                              authn_method="mtls_identity",
                              principal_mapping_rules=rules)
 
-        # run a few times for good health
-        for _ in range(5):
-            try:
-                self.get_client("cluster_describe").acl_list()
-                assert not fail, "list acls should have failed"
-            except ClusterAuthorizationError:
-                assert fail, "list acls should have succeeded"
+        self.check_permissions(pass_w_cluster_user=not fail,
+                               err_msg='check_permissions failed')
 
 
 class AccessControlListTestUpgrade(AccessControlListTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.installer = self.redpanda._installer
-
-    def check_permissions(self):
-        # run a few times for good health
-        for _ in range(5):
-            try:
-                self.get_client("base").acl_list()
-                assert False, "list acls should have failed"
-            except ClusterAuthorizationError:
-                pass
-
-            self.get_client("cluster_describe").acl_list()
-            self.get_super_client().acl_list()
 
     # Test that a cluster configured with enable_sasl can be upgraded
     # from v22.1.x, and still have sasl enabled. See PR 5292.
@@ -345,11 +375,19 @@ class AccessControlListTestUpgrade(AccessControlListTest):
                              authn_method=None,
                              principal_mapping_rules=None)
 
-        self.check_permissions()
+        self.check_permissions(
+            pass_w_base_user=False,
+            pass_w_cluster_user=True,
+            pass_w_super_user=True,
+            err_msg='check_permissions failed before upgrade')
 
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
         self.redpanda.restart_nodes(self.redpanda.nodes)
         unique_versions = wait_for_num_versions(self.redpanda, 1)
         assert "v22.1.3" not in unique_versions
 
-        self.check_permissions()
+        self.check_permissions(
+            pass_w_base_user=False,
+            pass_w_cluster_user=True,
+            pass_w_super_user=True,
+            err_msg='check_permissions failed after upgrade')

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -65,7 +65,7 @@ class ClusterConfigUpgradeTest(RedpandaTest):
         self.redpanda.restart_nodes(
             [node], override_cfg_params={'delete_retention_ms': '1234'})
         assert admin.get_cluster_config()['delete_retention_ms'] == 9876
-        assert self.redpanda.search_log(
+        assert self.redpanda.search_log_any(
             "Ignoring value for 'delete_retention_ms'")
 
 
@@ -990,11 +990,11 @@ class ClusterConfigTest(RedpandaTest):
             self._wait_for_version_sync(patch_result['config_version'])
 
             # Check value was/was not printed to log while applying
-            assert self.redpanda.search_log(value) is expect_log
+            assert self.redpanda.search_log_any(value) is expect_log
 
             # Check we do/don't print on next startup
             self.redpanda.restart_nodes(self.redpanda.nodes)
-            assert self.redpanda.search_log(value) is expect_log
+            assert self.redpanda.search_log_any(value) is expect_log
 
         # Default valued secrets are still shown.
         self._check_value_everywhere("cloud_storage_secret_key", None)

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -64,7 +64,7 @@ class UpgradeToLicenseChecks(RedpandaTest):
         assert 'v22.1.4' in unique_versions, unique_versions
 
         # These logs can't exist in v22.1.4 but double check anyway...
-        assert self.redpanda.search_log("Enterprise feature(s).*") is False
+        assert self.redpanda.search_log_any("Enterprise feature(s).*") is False
 
         # Update one node to newest version
         self.installer.install([self.redpanda.nodes[0]],
@@ -82,7 +82,7 @@ class UpgradeToLicenseChecks(RedpandaTest):
         # Ensure the log is not written, if the fiber was enabled a log should
         # appear within one interval of the license check fiber
         time.sleep(UpgradeToLicenseChecks.LICENSE_CHECK_INTERVAL_SEC * 2)
-        assert self.redpanda.search_log("Enterprise feature(s).*") is False
+        assert self.redpanda.search_log_any("Enterprise feature(s).*") is False
 
         # Install new version on all nodes
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
@@ -100,7 +100,7 @@ class UpgradeToLicenseChecks(RedpandaTest):
 
         # Assert that the log was found
         wait_until(
-            lambda: self.redpanda.search_log("Enterprise feature(s).*"),
+            lambda: self.redpanda.search_log_any("Enterprise feature(s).*"),
             timeout_sec=(UpgradeToLicenseChecks.LICENSE_CHECK_INTERVAL_SEC * 4)
             * len(self.redpanda.nodes),
             backoff_sec=1,

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -37,7 +37,7 @@ class RpkRedpandaStartTest(RedpandaTest):
         self.redpanda.start_node_with_rpk(node)
 
         # By default we start with developer_mode: true.
-        assert self.redpanda.search_log(
+        assert self.redpanda.search_log_any(
             "WARNING: This is a setup for development purposes only")
 
     @cluster(num_nodes=1)
@@ -67,7 +67,7 @@ class RpkRedpandaStartTest(RedpandaTest):
                 )
             assert cli_readback == expected_cluster_properties[p]
 
-        assert self.redpanda.search_log(
+        assert self.redpanda.search_log_any(
             "WARNING: This is a setup for development purposes only")
 
     @cluster(num_nodes=1)
@@ -95,11 +95,11 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # This is production, just checking that we are not setting
         # anything that makes rpk think that is a dev environment.
-        assert not self.redpanda.search_log(
+        assert not self.redpanda.search_log_any(
             "WARNING: This is a setup for development purposes only")
 
         # We execute checks when starting redpanda if production mode is enabled
-        assert self.redpanda.search_log("System check - PASSED")
+        assert self.redpanda.search_log_any("System check - PASSED")
 
     @cluster(num_nodes=1)
     def test_seastar_flag(self):
@@ -113,5 +113,5 @@ class RpkRedpandaStartTest(RedpandaTest):
         self.redpanda.start_node_with_rpk(node, "--abort-on-seastar-bad-alloc")
 
         # This was the original issue:
-        assert not self.redpanda.search_log(
+        assert not self.redpanda.search_log_any(
             f"\-\-abort-on-seastar-bad-alloc=true")


### PR DESCRIPTION
## Cover letter

PRs such as #4501 and #5292 extended Redpanda security to use mtls with principal mapping rules. These features are enabled with new configs, `endpoint_authn_method` and `kafka_enable_authorization`, in the YAML file. This PR adds a test that checks for successful authn and authz when a user migrates all brokers from a state with the new configs disabled to a state with them enabled.

Closes #5740

Changes from force-push `224eefe`:
- Removed duplicate code
- Cleaned up comments

Changes from force-push `224eefe`:
- Removed duplicate code
- Cleaned up comments

Changes from force-push `d36a0d4:`
- Undo changes to security settings reset

Changes from force-push `0ff8106`:
- Add a flag to RedpandaService that does not init tls certs
- Use rolling restart

Changes from force-push `1cbff68`:
- Comment addition

Changes from force-push `dfc4613` and `14a2770`:
- Linter fix
- Change comment format
- Use a counter instead of array of booleans. Also strengthens RedpandaService.search_log to return true when log is found on all nodes
- Check cluster intermediate state
- Generalize permission check

Changes from force-push `09971f3 ` and ` c71d3d5 `:
- Rename RedpandaService.search_log() to RedpandaService.search_log_any() since it follows python's [any()](https://docs.python.org/3/library/functions.html#any) design
- Add RedpandaService.search_log_all() and it follows python's [all()](https://docs.python.org/3/library/functions.html#all) design
- Linter fixes

Changes from force-push `6de4331`:
- Rebase on dev for test infra updates

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* Adds a test to check cluster wide migration to new authorization and authentication features