### PR TITLE
Improved logging in `VerifiableConsumer` and `EndToEnd`, fixed `partition_move_interruption_test`

### DIFF
--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -24,6 +24,7 @@ from collections import namedtuple
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.services.background_thread import BackgroundThreadService
+from datetime import datetime
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -215,6 +216,8 @@ class VerifiableConsumer(BackgroundThreadService):
         self.stop_timeout_sec = stop_timeout_sec
         self.on_record_consumed = on_record_consumed
         self.verify_offsets = verify_offsets
+        self.last_committed = None
+        self.last_consumed = None
 
         self.event_handlers = {}
         self.global_position = {}
@@ -302,6 +305,7 @@ class VerifiableConsumer(BackgroundThreadService):
                        consumed_partition["minOffset"]))
 
             self.global_position[tp] = consumed_partition["maxOffset"] + 1
+            self.last_consumed = datetime.now()
 
     def _update_global_committed(self, commit_event):
         if commit_event["success"]:
@@ -313,6 +317,7 @@ class VerifiableConsumer(BackgroundThreadService):
                     "Committed offset %d for partition %s is ahead of the current position %d" % \
                     (offset, str(tp), self.global_position[tp])
                 self.global_committed[tp] = offset
+                self.last_committed = datetime.now()
 
     def _update_global_committed_fetched(self, fetch_offsets_ev):
         for offset in fetch_offsets_ev["offsets"]:
@@ -469,3 +474,11 @@ class VerifiableConsumer(BackgroundThreadService):
     def get_committed_offsets(self):
         with self.lock:
             return self.global_committed.copy()
+
+    def get_last_consumed(self):
+        with self.lock:
+            return self.last_consumed
+
+    def get_last_committed(self):
+        with self.lock:
+            return self.last_committed

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -465,3 +465,7 @@ class VerifiableConsumer(BackgroundThreadService):
                 handler.node for handler in self.event_handlers.values()
                 if handler.state != ConsumerState.Dead
             ]
+
+    def get_committed_offsets(self):
+        with self.lock:
+            return self.global_committed.copy()

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -177,10 +177,12 @@ class EndToEndTest(Test):
                     return False
             return True
 
-        wait_until(has_finished_consuming,
-                   timeout_sec=timeout_sec,
-                   err_msg="Consumer failed to consume up to offsets %s after waiting %ds, last consumed offsets: %s." %\
-                   (str(last_acked_offsets), timeout_sec, list(self.last_consumed_offsets)))
+        wait_until(
+            has_finished_consuming,
+            timeout_sec=timeout_sec,
+            err_msg=lambda:
+            f"Consumer failed to consume up to offsets {str(last_acked_offsets)} after waiting {timeout_sec}s, last committed offsets: {self.consumer.get_committed_offsets()}."
+        )
 
     def await_num_produced(self, min_records, timeout_sec=30):
         wait_until(lambda: self.producer.num_acked > min_records,

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -172,7 +172,10 @@ class EndToEndTest(Test):
                 last_commit = self.consumer.last_commit(partition)
                 if not last_commit or last_commit <= offset:
                     self.logger.debug(
-                        f"waiting for partition {partition} offset {offset} to be committed, last committed offset: {last_commit}"
+                        f"waiting for partition {partition} offset {offset} "
+                        f"to be committed, last committed offset: {last_commit}, "
+                        f"last committed timestamp: {self.consumer.get_last_consumed()}, "
+                        f"last consumed timestamp: {self.consumer.get_last_consumed()}"
                     )
                     return False
             return True

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -43,6 +43,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.moves = 10
         self.min_records = 100000
         self.partition_count = 20
+        self.consumer_timeout_seconds = 90
 
     def replace_replicas(self, admin, assignments, x_core_only=False):
         """
@@ -183,9 +184,10 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             self.producer.stop()
             self.consumer.stop()
         else:
-            self.run_validation(enable_idempotence=False,
-                                consumer_timeout_sec=45,
-                                min_records=self.min_records)
+            self.run_validation(
+                enable_idempotence=False,
+                consumer_timeout_sec=self.consumer_timeout_seconds,
+                min_records=self.min_records)
 
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(replication_factor=[1, 3],
@@ -241,9 +243,10 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             self.producer.stop()
             self.consumer.stop()
         else:
-            self.run_validation(enable_idempotence=False,
-                                consumer_timeout_sec=45,
-                                min_records=self.min_records)
+            self.run_validation(
+                enable_idempotence=False,
+                consumer_timeout_sec=self.consumer_timeout_seconds,
+                min_records=self.min_records)
 
     def increase_replication_factor(self, topic, partition,
                                     requested_replication_factor):
@@ -387,7 +390,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         wait_until(lambda: len(admin.list_reconfigurations()) == 0, 60, 1)
 
         self.run_validation(enable_idempotence=False,
-                            consumer_timeout_sec=60,
+                            consumer_timeout_sec=self.consumer_timeout_seconds,
                             min_records=self.min_records)
 
     def is_moving_to_node(previous_replicas, current_replicas, id):
@@ -465,5 +468,5 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         wait_until(has_no_node_reconfigurations, 60, 1)
 
         self.run_validation(enable_idempotence=False,
-                            consumer_timeout_sec=60,
+                            consumer_timeout_sec=self.consumer_timeout_seconds,
                             min_records=self.min_records)


### PR DESCRIPTION
## Cover letter

Improved logging in case of errors when consumer wasn't able to finish consuming produced messages in `EndToEnd` test. 
New improved logging includes a timestamp of last consumed and committed message as well as current consumer committed offsets. This way one will be able to determine if the test failed because of consumer failure or it being slow to receive messages.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
