### PR TITLE
serde/compat: Add some more types to serde-compat testing

### DIFF
--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -162,6 +162,12 @@ struct get_leadership_reply
     explicit get_leadership_reply(std::vector<ntp_leader> leaders)
       : leaders(std::move(leaders)) {}
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const get_leadership_reply& r) {
+        fmt::print(o, "leaders {}", r.leaders);
+        return o;
+    }
+
     auto serde_fields() { return std::tie(leaders); }
 };
 

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -114,6 +114,12 @@ struct update_leadership_request_v2
 
     update_leadership_request_v2() noexcept = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const update_leadership_request_v2& r) {
+        fmt::print(o, "leaders {}", r.leaders);
+        return o;
+    }
+
     explicit update_leadership_request_v2(
       std::vector<ntp_leader_revision> leaders)
       : leaders(std::move(leaders)) {}

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -144,6 +144,12 @@ struct get_leadership_request
   : serde::envelope<get_leadership_request, serde::version<0>> {
     get_leadership_request() noexcept = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const get_leadership_request&) {
+        fmt::print(o, "{{}}");
+        return o;
+    }
+
     auto serde_fields() { return std::tie(); }
 };
 

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -131,6 +131,12 @@ struct update_leadership_reply
   : serde::envelope<update_leadership_reply, serde::version<0>> {
     update_leadership_reply() noexcept = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const update_leadership_reply&) {
+        fmt::print(o, "{{}}");
+        return o;
+    }
+
     auto serde_fields() { return std::tie(); }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -62,6 +62,12 @@ struct allocate_id_request
     operator==(const allocate_id_request&, const allocate_id_request&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const allocate_id_request& req) {
+        fmt::print(o, "timeout: {}", req.timeout.count());
+        return o;
+    }
+
     auto serde_read(iobuf_parser& in, const serde::header& h) {
         using serde::read_nested;
         timeout = std::chrono::duration_cast<model::timeout_clock::duration>(
@@ -88,6 +94,12 @@ struct allocate_id_reply
 
     friend bool operator==(const allocate_id_reply&, const allocate_id_reply&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const allocate_id_reply& rep) {
+        fmt::print(o, "id: {}, ec: {}", rep.id, rep.ec);
+        return o;
+    }
 
     auto serde_fields() { return std::tie(id, ec); }
 };

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -23,6 +23,24 @@
 
 #include <vector>
 
+// Utility that generates compat check class for empty objects.
+#define EMPTY_COMPAT_CHECK(class_name)                                         \
+    template<>                                                                 \
+    struct compat_check<class_name> {                                          \
+        static constexpr std::string_view name = #class_name;                  \
+        static std::vector<class_name> create_test_cases() {                   \
+            return generate_instances<class_name>();                           \
+        }                                                                      \
+        static void to_json(class_name, json::Writer<json::StringBuffer>&) {}  \
+        static class_name from_json(json::Value&) { return class_name{}; }     \
+        static std::vector<compat_binary> to_binary(class_name obj) {          \
+            return compat_binary::serde_and_adl(obj);                          \
+        }                                                                      \
+        static bool check(class_name obj, compat_binary test) {                \
+            return verify_adl_or_serde(obj, std::move(test));                  \
+        }                                                                      \
+    };
+
 namespace compat {
 
 /*

--- a/src/v/compat/generator.h
+++ b/src/v/compat/generator.h
@@ -11,6 +11,14 @@
 #pragma once
 #include <vector>
 
+// Utility to create a generator for empty objects.
+#define EMPTY_COMPAT_GENERATOR(class_name)                                     \
+    template<>                                                                 \
+    struct instance_generator<class_name> {                                    \
+        static class_name random() { return {}; }                              \
+        static std::vector<class_name> limits() { return {}; }                 \
+    };
+
 namespace compat {
 
 /*

--- a/src/v/compat/id_allocator_compat.h
+++ b/src/v/compat/id_allocator_compat.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/errc.h"
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/id_allocator_generator.h"
+#include "compat/json.h"
+#include "model/timeout_clock.h"
+
+#include <cstdint>
+
+namespace compat {
+
+/*
+ * cluster::allocate_id_request
+ */
+template<>
+struct compat_check<cluster::allocate_id_request> {
+    static constexpr std::string_view name = "cluster::allocate_id_request";
+
+    static std::vector<cluster::allocate_id_request> create_test_cases() {
+        return compat::generate_instances<cluster::allocate_id_request>();
+    }
+
+    static void to_json(
+      cluster::allocate_id_request obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(timeout);
+    }
+
+    static cluster::allocate_id_request from_json(json::Value& rd) {
+        cluster::allocate_id_request obj{};
+        json_read(timeout);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::allocate_id_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(cluster::allocate_id_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+/*
+ * cluster::allocate_id_reply
+ */
+template<>
+struct compat_check<cluster::allocate_id_reply> {
+    static constexpr std::string_view name = "cluster::allocate_id_reply";
+
+    static std::vector<cluster::allocate_id_reply> create_test_cases() {
+        return compat::generate_instances<cluster::allocate_id_reply>();
+    }
+
+    static void to_json(
+      cluster::allocate_id_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(id);
+        json_write(ec);
+    }
+
+    static cluster::allocate_id_reply from_json(json::Value& rd) {
+        cluster::allocate_id_reply obj;
+        json_read(id);
+        obj.ec = cluster::errc(json::read_member_enum(rd, "ec", obj.ec));
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::allocate_id_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(cluster::allocate_id_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+}; // namespace compat

--- a/src/v/compat/id_allocator_generator.h
+++ b/src/v/compat/id_allocator_generator.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/errc.h"
+#include "cluster/id_allocator.h"
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "model/timeout_clock.h"
+#include "random/generators.h"
+#include "test_utils/randoms.h"
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::allocate_id_request> {
+    static cluster::allocate_id_request random() {
+        return cluster::allocate_id_request{
+          tests::random_duration<model::timeout_clock::duration>()};
+    }
+
+    static std::vector<cluster::allocate_id_request> limits() {
+        return {
+          cluster::allocate_id_request{model::timeout_clock::duration(0)},
+          cluster::allocate_id_request{std::chrono::milliseconds::min()},
+          cluster::allocate_id_request{std::chrono::milliseconds::max()},
+        };
+    }
+};
+
+template<>
+struct instance_generator<cluster::allocate_id_reply> {
+    using errc_type = typename std::underlying_type_t<cluster::errc>;
+    static constexpr auto int64_min = std::numeric_limits<int64_t>::min();
+    static constexpr auto int64_max = std::numeric_limits<int64_t>::min();
+    static constexpr auto errc_min = static_cast<errc_type>(
+      cluster::errc::success);
+    static constexpr auto errc_max = static_cast<errc_type>(
+      cluster::errc::unknown_update_interruption_error);
+
+    static cluster::allocate_id_reply random() {
+        const auto errc_rand = random_generators::get_int<errc_type>(
+          errc_min, errc_max);
+        return {
+          random_generators::get_int<int64_t>(int64_min, int64_max),
+          cluster::errc(errc_rand)};
+    }
+
+    static std::vector<cluster::allocate_id_reply> limits() {
+        return {
+          {int64_min, cluster::errc::success},
+          {int64_max, cluster::errc::success},
+          {int64_min, cluster::errc::unknown_update_interruption_error},
+          {int64_max, cluster::errc::unknown_update_interruption_error},
+        };
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -52,4 +52,40 @@ struct compat_check<cluster::update_leadership_request> {
     }
 };
 
+/*
+ * cluster::update_leadership_request_v2
+ */
+template<>
+struct compat_check<cluster::update_leadership_request_v2> {
+    static constexpr std::string_view name
+      = "cluster::update_leadership_request_v2";
+
+    static std::vector<cluster::update_leadership_request_v2>
+    create_test_cases() {
+        return generate_instances<cluster::update_leadership_request_v2>();
+    }
+
+    static void to_json(
+      cluster::update_leadership_request_v2 obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(leaders);
+    }
+
+    static cluster::update_leadership_request_v2 from_json(json::Value& rd) {
+        cluster::update_leadership_request_v2 obj;
+        json_read(leaders);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::update_leadership_request_v2 obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool
+    check(cluster::update_leadership_request_v2 obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -98,4 +98,31 @@ EMPTY_COMPAT_CHECK(cluster::update_leadership_reply);
  */
 EMPTY_COMPAT_CHECK(cluster::get_leadership_request);
 
+/*
+ * cluster::get_leadership_reply
+ */
+template<>
+struct compat_check<cluster::get_leadership_reply> {
+    static constexpr std::string_view name = "cluster::get_leadership_reply";
+    static std::vector<cluster::get_leadership_reply> create_test_cases() {
+        return generate_instances<cluster::get_leadership_reply>();
+    }
+    static void to_json(
+      cluster::get_leadership_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(leaders);
+    }
+    static cluster::get_leadership_reply from_json(json::Value& rd) {
+        cluster::get_leadership_reply obj;
+        json_read(leaders);
+        return obj;
+    }
+    static std::vector<compat_binary>
+    to_binary(cluster::get_leadership_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+    static bool check(cluster::get_leadership_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -93,4 +93,9 @@ struct compat_check<cluster::update_leadership_request_v2> {
  */
 EMPTY_COMPAT_CHECK(cluster::update_leadership_reply);
 
+/*
+ * cluster::get_leadership_request
+ */
+EMPTY_COMPAT_CHECK(cluster::get_leadership_request);
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -88,4 +88,9 @@ struct compat_check<cluster::update_leadership_request_v2> {
     }
 };
 
+/*
+ * cluster::update_leadership_reply
+ */
+EMPTY_COMPAT_CHECK(cluster::update_leadership_reply);
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -12,6 +12,7 @@
 
 #include "cluster/metadata_dissemination_types.h"
 #include "compat/generator.h"
+#include "model/metadata.h"
 #include "model/tests/randoms.h"
 #include "test_utils/randoms.h"
 
@@ -29,6 +30,23 @@ struct instance_generator<cluster::update_leadership_request> {
     }
 
     static std::vector<cluster::update_leadership_request> limits() {
+        return {};
+    }
+};
+
+template<>
+struct instance_generator<cluster::update_leadership_request_v2> {
+    static cluster::update_leadership_request_v2 random() {
+        return cluster::update_leadership_request_v2({
+          cluster::ntp_leader_revision(
+            model::random_ntp(),
+            tests::random_named_int<model::term_id>(),
+            tests::random_named_int<model::node_id>(),
+            tests::random_named_int<model::revision_id>()),
+        });
+    }
+
+    static std::vector<cluster::update_leadership_request_v2> limits() {
         return {};
     }
 };

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -51,4 +51,6 @@ struct instance_generator<cluster::update_leadership_request_v2> {
     }
 };
 
+EMPTY_COMPAT_GENERATOR(cluster::update_leadership_reply);
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -53,4 +53,6 @@ struct instance_generator<cluster::update_leadership_request_v2> {
 
 EMPTY_COMPAT_GENERATOR(cluster::update_leadership_reply);
 
+EMPTY_COMPAT_GENERATOR(cluster::get_leadership_request);
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -55,4 +55,18 @@ EMPTY_COMPAT_GENERATOR(cluster::update_leadership_reply);
 
 EMPTY_COMPAT_GENERATOR(cluster::get_leadership_request);
 
+template<>
+struct instance_generator<cluster::get_leadership_reply> {
+    static cluster::get_leadership_reply random() {
+        return cluster::get_leadership_reply({
+          cluster::ntp_leader(
+            model::random_ntp(),
+            tests::random_named_int<model::term_id>(),
+            tests::random_named_int<model::node_id>()),
+        });
+    }
+
+    static std::vector<cluster::get_leadership_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/metadata_dissemination_json.h
+++ b/src/v/compat/metadata_dissemination_json.h
@@ -12,6 +12,7 @@
 
 #include "cluster/metadata_dissemination_types.h"
 #include "compat/json.h"
+#include "json/json.h"
 
 namespace json {
 
@@ -31,6 +32,28 @@ inline void read_value(json::Value const& rd, cluster::ntp_leader& obj) {
     read_member(rd, "ntp", obj.ntp);
     read_member(rd, "term", obj.term);
     read_member(rd, "leader_id", obj.leader_id);
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const cluster::ntp_leader_revision& v) {
+    w.StartObject();
+    w.Key("ntp");
+    rjson_serialize(w, v.ntp);
+    w.Key("term");
+    rjson_serialize(w, v.term);
+    w.Key("leader_id");
+    rjson_serialize(w, v.leader_id);
+    w.Key("revision_id");
+    rjson_serialize(w, v.revision);
+    w.EndObject();
+}
+
+inline void
+read_value(json::Value const& rd, cluster::ntp_leader_revision& obj) {
+    read_member(rd, "ntp", obj.ntp);
+    read_member(rd, "term", obj.term);
+    read_member(rd, "leader_id", obj.leader_id);
+    read_member(rd, "revision_id", obj.revision);
 }
 
 } // namespace json

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -68,7 +68,8 @@ using compat_checks = type_list<
   cluster::try_abort_request,
   cluster::try_abort_reply,
   cluster::allocate_id_request,
-  cluster::allocate_id_reply>;
+  cluster::allocate_id_reply,
+  cluster::update_leadership_request_v2>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -72,7 +72,8 @@ using compat_checks = type_list<
   cluster::allocate_id_reply,
   cluster::update_leadership_request_v2,
   cluster::update_leadership_reply,
-  cluster::get_leadership_request>;
+  cluster::get_leadership_request,
+  cluster::get_leadership_reply>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -10,6 +10,7 @@
  */
 #include "compat/run.h"
 
+#include "cluster/metadata_dissemination_types.h"
 #include "cluster/types.h"
 #include "compat/begin_tx_compat.h"
 #include "compat/check.h"
@@ -69,7 +70,8 @@ using compat_checks = type_list<
   cluster::try_abort_reply,
   cluster::allocate_id_request,
   cluster::allocate_id_reply,
-  cluster::update_leadership_request_v2>;
+  cluster::update_leadership_request_v2,
+  cluster::update_leadership_reply>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -14,6 +14,7 @@
 #include "compat/begin_tx_compat.h"
 #include "compat/check.h"
 #include "compat/cluster_compat.h"
+#include "compat/id_allocator_compat.h"
 #include "compat/init_tm_tx_compat.h"
 #include "compat/metadata_dissemination_compat.h"
 #include "compat/prepare_tx_compat.h"
@@ -65,7 +66,9 @@ using compat_checks = type_list<
   cluster::prepare_tx_request,
   cluster::prepare_tx_reply,
   cluster::try_abort_request,
-  cluster::try_abort_reply>;
+  cluster::try_abort_reply,
+  cluster::allocate_id_request,
+  cluster::allocate_id_reply>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -71,7 +71,8 @@ using compat_checks = type_list<
   cluster::allocate_id_request,
   cluster::allocate_id_reply,
   cluster::update_leadership_request_v2,
-  cluster::update_leadership_reply>;
+  cluster::update_leadership_reply,
+  cluster::get_leadership_request>;
 
 struct compat_error final : public std::runtime_error {
 public:


### PR DESCRIPTION
## Cover letter

Adds the following types to the framework.

* cluster::allocate_id_request
* cluster::allocate_id_reply
* cluster::update_leadership_request_v2
* cluster::update_leadership_reply
* cluster::get_leadership_request
* cluster::get_leadership_reply

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none
