### PR TITLE
Log contents of node status cache update

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -42,6 +42,7 @@
 
 #include <absl/container/node_hash_set.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <iterator>
 
@@ -374,6 +375,7 @@ health_monitor_backend::dispatch_refresh_cluster_health_request(
     for (auto& n_status : reply.value().report->node_states) {
         _status.emplace(n_status.id, n_status);
     }
+    vlog(clusterlog.trace, "Status cache updated from the leader: {}", _status);
 
     storage::disk_space_alert cluster_disk_health
       = storage::disk_space_alert::ok;


### PR DESCRIPTION
## Cover letter

There is a class of test failures where a follower's health monitor is apparently unaware of one of the nodes in the cluster. The existing logging is insufficient to trace whether the node status cache has been updated or not. This change adds the log line that makes it possible.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5647

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.
-->
* none
<!--
Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
