### PR TITLE
c/controller_backend: do not require accessing topic metadata

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1437,15 +1437,9 @@ ss::future<std::error_code> controller_backend::create_partition(
     }
     // no partition exists, create one
     if (likely(!partition)) {
-        // if topic recovery is enabled the information required by it
-        // need to be passed to the 'manage' call since it's not available
-        // on parition level.
-        auto meta = _topics.local().get_topic_metadata(
-          model::topic_namespace_view(ntp));
         std::optional<cluster::remote_topic_properties> remote_properties;
-        if (meta->get_configuration().is_recovery_enabled()) {
-            remote_properties
-              = meta->get_configuration().properties.remote_topic_properties;
+        if (cfg->is_recovery_enabled()) {
+            remote_properties = cfg->properties.remote_topic_properties;
         }
         // we use offset as an rev as it is always increasing and it
         // increases while ntp is being created again


### PR DESCRIPTION
We do not need to query for the whole topic metadata object when
querying for configuration options during partition creation in
controller backend. Instead we can use topic configuration which is
simple object not containing a copy of partition assignments.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
