### PR TITLE
test: use snapshots for detecting segment removal

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1512,7 +1512,7 @@ class RedpandaService(Service):
 
             return [p[0] for p in paths if safe_isdir(p[1])]
 
-        store = NodeStorage(RedpandaService.DATA_DIR)
+        store = NodeStorage(node.name, RedpandaService.DATA_DIR)
         for ns in listdir(store.data_dir, True):
             if ns == '.coprocessor_offset_checkpoints':
                 continue

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -118,9 +118,10 @@ class Namespace:
 
 
 class NodeStorage:
-    def __init__(self, data_dir):
+    def __init__(self, name, data_dir):
         self.data_dir = data_dir
         self.ns = dict()
+        self.name = name
 
     def add_namespace(self, ns, path):
         n = Namespace(ns, path)

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -10,6 +10,7 @@
 import os
 import re
 import itertools
+from typing import Optional
 
 
 class Segment:
@@ -117,6 +118,10 @@ class Namespace:
         return self.name
 
 
+class PartitionNotFoundError(Exception):
+    pass
+
+
 class NodeStorage:
     def __init__(self, name, data_dir):
         self.data_dir = data_dir
@@ -135,6 +140,17 @@ class NodeStorage:
                 return [p[1] for p in parts.items()]
         return []
 
+    def segments(self, ns: str, topic: str,
+                 partition_idx: int) -> Optional[list[Segment]]:
+        partitions = self.partitions(ns, topic)
+        if len(partitions) <= partition_idx:
+            # Segments for unkown partition requested
+            raise PartitionNotFoundError(
+                f"Partition {partition_idx} of topic {topic} is not present on node {self.name}"
+            )
+
+        return partitions[partition_idx].segments.values()
+
 
 class ClusterStorage:
     def __init__(self):
@@ -146,3 +162,10 @@ class ClusterStorage:
     def partitions(self, ns, topic):
         return itertools.chain(
             *map(lambda n: n.partitions(ns, topic), self.nodes))
+
+    def segments_by_node(self, ns: str, topic: str,
+                         partition_idx: int) -> dict[str, list[Segment]]:
+        return {
+            node.name: node.segments(ns, topic, partition_idx)
+            for node in self.nodes
+        }

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -27,7 +27,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import Scale
 from rptest.util import (
     produce_until_segments,
-    wait_for_segments_removal,
+    wait_for_removal_of_n_segments,
 )
 
 
@@ -89,16 +89,29 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             count=10,
         )
 
+        # Get a snapshot of the current segments, before tightening the
+        # retention policy.
+        original_snapshot = self.redpanda.storage(
+            all_nodes=True).segments_by_node("kafka", self.topic, 0)
+
+        for node, node_segments in original_snapshot.items():
+            assert len(
+                node_segments
+            ) >= 10, f"Expected at least 10 segments, but got {len(node_segments)} on {node}"
+
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
             },
         )
-        wait_for_segments_removal(redpanda=self.redpanda,
-                                  topic=self.topic,
-                                  partition_idx=0,
-                                  count=6)
+
+        wait_for_removal_of_n_segments(redpanda=self.redpanda,
+                                       topic=self.topic,
+                                       partition_idx=0,
+                                       n=6,
+                                       original_snapshot=original_snapshot)
+
         self.start_consumer()
         self.run_validation()
 
@@ -120,16 +133,28 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
             count=10,
         )
 
+        # Get a snapshot of the current segments, before tightening the
+        # retention policy.
+        original_snapshot = self.redpanda.storage(
+            all_nodes=True).segments_by_node("kafka", self.topic, 0)
+
+        for node, node_segments in original_snapshot.items():
+            assert len(
+                node_segments
+            ) >= 10, f"Expected at least 10 segments, but got {len(node_segments)} on {node}"
+
         self.kafka_tools.alter_topic_config(
             self.topic,
             {TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size},
         )
 
         with random_process_kills(self.redpanda) as ctx:
-            wait_for_segments_removal(redpanda=self.redpanda,
-                                      topic=self.topic,
-                                      partition_idx=0,
-                                      count=6)
+            wait_for_removal_of_n_segments(redpanda=self.redpanda,
+                                           topic=self.topic,
+                                           partition_idx=0,
+                                           n=6,
+                                           original_snapshot=original_snapshot)
+
             self.start_consumer()
             self.run_validation()
         ctx.assert_actions_triggered()


### PR DESCRIPTION
## Cover letter

Previously, the shadow indexing end-to-end test asserted against the current
number of segments when checking for segment removal. This approach has
the downside that a restart/failure of a redpanda node causes a segment
roll, which makes the assertion unreliable in a context with simulated
failures. See #5390 for more context.

This PR introduces a new utility for waiting for segments removal
which uses snapshots to determine what was removed. The changes
deflakes the test against a high number of injected node failures.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5390

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

* none