### PR TITLE
config: Support optional arrays

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -458,6 +458,8 @@ consteval bool is_array() {
         return false;
     } else if constexpr (detail::is_collection<std::decay_t<T>>) {
         return true;
+    } else if constexpr (reflection::is_std_optional<T>) {
+        return is_array<typename T::value_type>();
     } else {
         return false;
     }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -487,11 +487,7 @@ std::optional<std::string_view> property<T>::units_name() const {
 
 template<typename T>
 bool property<T>::is_nullable() const {
-    if constexpr (reflection::is_std_optional<std::decay_t<T>>) {
-        return true;
-    } else {
-        return false;
-    }
+    return reflection::is_std_optional<std::decay_t<T>>;
 }
 
 template<typename T>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -449,6 +449,20 @@ consteval std::string_view property_units_name() {
     }
 }
 
+template<typename T>
+consteval bool is_array() {
+    if constexpr (
+      std::is_same_v<T, ss::sstring> || std::is_same_v<T, std::string>) {
+        // Special case for strings, which are collections but we do not
+        // want to report them that way.
+        return false;
+    } else if constexpr (detail::is_collection<std::decay_t<T>>) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 } // namespace detail
 
 template<typename T>
@@ -480,16 +494,7 @@ bool property<T>::is_nullable() const {
 
 template<typename T>
 bool property<T>::is_array() const {
-    if constexpr (
-      std::is_same_v<T, ss::sstring> || std::is_same_v<T, std::string>) {
-        // Special case for strings, which are collections but we do not
-        // want to report them that way.
-        return false;
-    } else if constexpr (detail::is_collection<std::decay_t<T>>) {
-        return true;
-    } else {
-        return false;
-    }
+    return detail::is_array<T>();
 }
 
 /*

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -33,6 +33,7 @@ struct test_config : public config::config_store {
     config::property<std::vector<ss::sstring>> strings;
     config::property<std::optional<int16_t>> nullable_int;
     config::property<std::optional<ss::sstring>> nullable_string;
+    config::property<std::optional<std::vector<ss::sstring>>> nullable_strings;
     config::property<bool> boolean;
     config::property<std::chrono::seconds> seconds;
     config::property<std::optional<std::chrono::seconds>> optional_seconds;
@@ -75,6 +76,12 @@ struct test_config : public config::config_store {
           *this,
           "optional_string",
           "An optional string value",
+          {},
+          std::nullopt)
+      , nullable_strings(
+          *this,
+          "optional_strings",
+          "An optional strings vector",
           {},
           std::nullopt)
       , boolean(
@@ -357,6 +364,10 @@ SEASTAR_THREAD_TEST_CASE(property_metadata) {
     BOOST_TEST(cfg.nullable_string.type_name() == "string");
     BOOST_TEST(cfg.nullable_string.is_nullable() == true);
     BOOST_TEST(cfg.nullable_string.is_array() == false);
+
+    BOOST_TEST(cfg.nullable_strings.type_name() == "string");
+    BOOST_TEST(cfg.nullable_strings.is_nullable() == true);
+    BOOST_TEST(cfg.nullable_strings.is_array() == true);
 
     BOOST_TEST(cfg.nullable_int.type_name() == "integer");
     BOOST_TEST(cfg.nullable_int.is_nullable() == true);


### PR DESCRIPTION
## Cover letter

config: Support optional arrays

This is required for `kafka_mtls_principal_mapping` introduced in #5292 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] bugfix to a feature that's not released
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
