### PR TITLE
gha/rpk: fix upload of darwin binaries

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -71,7 +71,7 @@ jobs:
 
   sign-darwin:
     name: Sign and notarize the darwin release_name
-    needs: upload-release-artifacts-linux
+    needs: create-release
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
@@ -118,6 +118,8 @@ jobs:
         with:
           name: rpk-archives
           path: zip/rpk-darwin-${{ matrix.arch }}.zip
+    outputs:
+      upload_url: ${{ needs.create-release.outputs.upload_url }}
 
   create-release:
     name: Create release
@@ -177,7 +179,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        upload_url: ${{ needs.sign-darwin.outputs.upload_url }}
         asset_path: rpk-archives/rpk-darwin-${{ matrix.arch }}.zip
         asset_name: rpk-darwin-${{ matrix.arch }}.zip
         asset_content_type: application/zip


### PR DESCRIPTION
## Cover letter

Fixes `Upload darwin binaries` [failure](https://github.com/redpanda-data/redpanda/runs/7579138211?check_suite_focus=true) in [v22.2.1-rc2](https://github.com/redpanda-data/redpanda/tree/v22.2.1-rc2) release that was introduced in PR #5265:
```
Error: Input required and not supplied: upload_url
```

This fix passes along the `upload_url` value so the final `upload-release-artifacts-darwin` step has a destination.

This PR also removes an unnecessary dependency from `sign-darwin` step on `upload-release-artifacts-linux` step.

Related issue: https://github.com/redpanda-data/vtools/issues/824

## Backport Required

After this PR is merged, needs backport to the supported release branches:
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none