### PR TITLE
tests: update ManyPartitionsTest

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -755,7 +755,7 @@ ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
       clusterlog.info,
       "Leadership transfer of group {} failed with error: {}",
       transfer.group,
-      raft::make_error_code(res.value().result));
+      raft::make_error_code(res.value().result).message());
 
     co_return false;
 }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,8 +146,8 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard dd7dce41012af14e62c1db23a0aa88ec6f39a5f1 && \
-    go mod tidy && go build
+    cd /opt/kgo-verifier && git reset --hard dbb32effd519334929976ba5bcd725c735d81550 && \
+    go mod tidy && make
 
 # Expose port 8080 for any http examples within clients
 EXPOSE 8080

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -73,11 +73,10 @@ RUN apt update && \
     echo 'root soft nofile 65535' >> /etc/security/limits.conf && \
     echo 'root hard nofile 65535' >> /etc/security/limits.conf
 
-# install go
-RUN mkdir -p /usr/local/go/ && \
-    bash -c 'if [[ $(uname -m) = "aarch64" ]]; then ARCHID="arm64"; else export ARCHID="amd64"; fi && \
-    curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 https://golang.org/dl/go1.17.linux-${ARCHID}.tar.gz | tar -xz -C /usr/local/go/ --strip 1'
-ENV PATH="${PATH}:/usr/local/go/bin"
+
+# Install the OMB tool
+RUN git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git && \
+    cd /opt/openmessaging-benchmark && git reset --hard 43b737c357cde3b418a6aee4c95107d6ef28b8a2 && mvn package
 
 # install kafka binary dependencies, librdkafka dev, kcat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
@@ -95,8 +94,6 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     make install && \
     cd /opt/librdkafka/tests && \
     make build -j$(nproc) && \
-    go get github.com/birdayz/kaf/cmd/kaf && \
-    mv /root/go/bin/kaf /usr/local/bin/ && \
     mkdir /tmp/kcat && \
     curl -SL "https://github.com/edenhill/kcat/archive/1.7.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kcat && \
     cd /tmp/kcat && \
@@ -104,6 +101,29 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     make -j$(nproc) && \
     make install && \
     ldconfig
+
+# install go
+RUN mkdir -p /usr/local/go/ && \
+    bash -c 'if [[ $(uname -m) = "aarch64" ]]; then ARCHID="arm64"; else export ARCHID="amd64"; fi && \
+    curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 https://golang.org/dl/go1.17.linux-${ARCHID}.tar.gz | tar -xz -C /usr/local/go/ --strip 1'
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+# Install `kaf`
+RUN go get github.com/birdayz/kaf/cmd/kaf && \
+    mv /root/go/bin/kaf /usr/local/bin/
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+# Compile and install rust-based workload generator.
+# Install & remove compiler in the same step, to avoid bulking
+# out the resulting container image.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    export PATH="/root/.cargo/bin:${PATH}" && \
+    git clone https://github.com/redpanda-data/client-swarm.git && \
+    cd client-swarm && \
+    git reset --hard 28790f8 && \
+    cargo build --release && \
+    cp target/release/client-swarm /usr/local/bin && \
+    cd .. && rm -rf client-swarm && rm -rf /root/.cargo
 
 # Install golang dependencies for kafka clients such as sarama
 RUN git -C /opt clone -b v1.32.0 --single-branch https://github.com/Shopify/sarama.git && \
@@ -141,22 +161,6 @@ COPY --chown=0:0 tests/docker/ssh /root/.ssh
 COPY --chown=0:0 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
     python3 -m pip install --force --no-cache-dir -e /root/tests/
-
-# Install the OMB tool
-RUN git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git && \
-    cd /opt/openmessaging-benchmark && git reset --hard 43b737c357cde3b418a6aee4c95107d6ef28b8a2 && mvn package
-
-# Compile and install rust-based workload generator.
-# Install & remove compiler in the same step, to avoid bulking
-# out the resulting container image.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    export PATH="/root/.cargo/bin:${PATH}" && \
-    git clone https://github.com/redpanda-data/client-swarm.git && \
-    cd client-swarm && \
-    git reset --hard 28790f8 && \
-    cargo build --release && \
-    cp target/release/client-swarm /usr/local/bin && \
-    cd .. && rm -rf client-swarm && rm -rf /root/.cargo
 
 # Seastar addrress to line utility
 RUN apt update && \

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -415,6 +415,10 @@ class RpkTool:
                 if "COORDINATOR_NOT_AVAILABLE" in e.msg:
                     # Transient, return None to retry
                     return None
+                elif "Kafka replied that group" in e.msg:
+                    # Transient, return None to retry
+                    # e.g. Kafka replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list
+                    return None
                 else:
                     raise
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -361,6 +361,10 @@ class RpkTool:
                 # We should wait until server will get information about it.
                 if line.find('UNKNOWN_TOPIC_OR_PARTITION') != -1:
                     return False
+
+                # Leadership movements are underway
+                if 'NOT_LEADER_FOR_PARTITION' in line:
+                    return False
             return True
 
         def parse_partition(string):

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -339,7 +339,7 @@ class RpkTool:
         cmd = ["seek", group, "--to", to]
         self._run_group(cmd)
 
-    def group_describe(self, group):
+    def group_describe(self, group, summary=False):
         def parse_field(field_name, string):
             pattern = re.compile(f" *{field_name} +(?P<value>.+)")
             m = pattern.match(string)
@@ -365,6 +365,11 @@ class RpkTool:
                 # Leadership movements are underway
                 if 'NOT_LEADER_FOR_PARTITION' in line:
                     return False
+
+                # Cluster not ready yet
+                if 'unknown broker' in line:
+                    return False
+
             return True
 
         def parse_partition(string):
@@ -399,7 +404,11 @@ class RpkTool:
                                      host=m['host'])
 
         def try_describe_group(group):
-            cmd = ["describe", group]
+            if summary:
+                cmd = ["describe", "-s", group]
+            else:
+                cmd = ["describe", group]
+
             try:
                 out = self._run_group(cmd)
             except RpkException as e:

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -9,15 +9,20 @@
 
 import time
 import concurrent.futures
+from collections import defaultdict
+
+from ducktape.utils.util import wait_until, TimeoutError
+import numpy
 
 from rptest.services.cluster import cluster
-from ducktape.utils.util import wait_until
-
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST, LoggingConfig
 from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
+from rptest.services.kgo_repeater_service import KgoRepeaterService, repeater_traffic
+from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
+from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 
 # An unreasonably large fetch request: we submit requests like this in the
 # expectation that the server will properly clamp the amount of data it
@@ -31,15 +36,149 @@ BIG_FETCH = 104857600
 # functions.
 HARD_PARTITION_LIMIT = 100000
 
-# How many partitions we will create per shard: this value enables
-# reaching HARD_PARTITION_LIMIT on 6x i3en.6xlarge nodes.
-PARTITIONS_PER_SHARD = 2200
+# How many partitions we will create per shard: this is the primary scaling
+# factor that controler how many partitions a given cluster will get.
+PARTITIONS_PER_SHARD = 1000
 
 # Number of partitions to create when running in docker (i.e.
 # when dedicated_nodes=false).  This is independent of the
 # amount of RAM or CPU that the nodes claim to have, because
 # we know they are liable to be oversubscribed.
-DOCKER_PARTITION_LIMIT = 1000
+# This is _not_ for running on oversubscribed CI environments: it's for
+# runnig on a reasonably powerful developer machine while they work
+# on the test.
+DOCKER_PARTITION_LIMIT = 128
+
+
+class ScaleParameters:
+    def __init__(self, redpanda, replication_factor):
+        self.redpanda = redpanda
+
+        node_count = len(self.redpanda.nodes)
+
+        # If we run on nodes with more memory than our HARD_PARTITION_LIMIT, then
+        # artificially throttle the nodes' memory to avoid the test being too easy.
+        # We are validating that the system works up to the limit, and that it works
+        # up to the limit within the default per-partition memory footprint.
+        node_memory = self.redpanda.get_node_memory_mb()
+        self.node_cpus = self.redpanda.get_node_cpu_count()
+        node_disk_free = self.redpanda.get_node_disk_free()
+
+        self.logger.info(
+            f"Nodes have {self.node_cpus} cores, {node_memory}MB memory, {node_disk_free / (1024 * 1024)}MB free disk"
+        )
+
+        # On large nodes, reserve half of shard 0 to minimize interference
+        # between data and control plane, as control plane messages become
+        # very large.
+        shard0_reserve = None
+        if self.node_cpus >= 8:
+            shard0_reserve = PARTITIONS_PER_SHARD / 2
+
+        # Reserve a few slots for internal partitions, do not be
+        # super specific about how many because we may add some in
+        # future for e.g. audit logging.
+        internal_partition_slack = 10
+
+        # Calculate how many partitions we will aim to create, based
+        # on the size & count of nodes.  This enables running the
+        # test on various instance sizes without explicitly adjusting.
+        self.partition_limit = int(
+            (node_count * self.node_cpus * PARTITIONS_PER_SHARD) /
+            replication_factor - internal_partition_slack)
+        if shard0_reserve:
+            self.partition_limit -= node_count * shard0_reserve
+
+        self.partition_limit = min(HARD_PARTITION_LIMIT, self.partition_limit)
+
+        if not self.redpanda.dedicated_nodes:
+            self.partition_limit = min(DOCKER_PARTITION_LIMIT,
+                                       self.partition_limit)
+
+        self.logger.info(f"Selected partition limit {self.partition_limit}")
+
+        # Emulate seastar's policy for default reserved memory
+        reserved_memory = max(1536, int(0.07 * node_memory) + 1)
+        effective_node_memory = node_memory - reserved_memory
+
+        # Aim to use about half the disk space: set retention limits
+        # to enforce that.  This enables traffic tests to run as long
+        # as they like without risking filling the disk.
+        partition_replicas_per_node = int(
+            (self.partition_limit * replication_factor) / node_count)
+        self.retention_bytes = int(
+            (node_disk_free / 2) / partition_replicas_per_node)
+
+        # Choose an appropriate segment size to enable retention
+        # rules to kick in promptly.
+        # TODO: redpanda should figure this out automatically by
+        #       rolling segments pre-emptively if low on disk space
+        self.segment_size = int(self.retention_bytes / 4)
+
+        # The expect_bandwidth is just for calculating sensible
+        # timeouts when waiting for traffic: it is not a scientific
+        # success condition for the tests.
+        if self.redpanda.dedicated_nodes:
+            # A 24 core i3en.6xlarge has about 2GB/s disk write
+            # bandwidth.  Divide by 2 to give comfortable room for variation.
+            # This is total bandwidth from a group of producers.
+
+            # self.expect_bandwidth = (node_count / replication_factor) * (
+            #     self.node_cpus / 24.0) * 1E9
+
+            # FIXME: surprisingly low throughput sometimes.
+            self.expect_bandwidth = (node_count / replication_factor) * (
+                self.node_cpus / 24.0) * 200E6
+
+            # Single-producer tests are slower, bottlenecked on the
+            # client side.
+            self.expect_single_bandwidth = 200E6
+        else:
+            # Docker environment: curb your expectations.  Not only is storage
+            # liable to be slow, we have many nodes sharing the same drive.
+            self.expect_bandwidth = 5 * 1024 * 1024
+            self.expect_single_bandwidth = 10E6
+
+        self.logger.info(
+            f"Selected retention.bytes={self.retention_bytes}, segment.bytes={self.segment_size}"
+        )
+
+        mb_per_partition = 1
+        if not self.redpanda.dedicated_nodes:
+            # In docker, assume we're on a laptop drive and not doing
+            # real testing, so disable fsync to make test run faster.
+            resource_settings_args = {'bypass_fsync': True}
+
+            # In docker, make the test a bit more realistic by clamping
+            # memory if nodes have more memory than should be required
+            # to exercise the partition limit.
+            if effective_node_memory > partition_replicas_per_node / mb_per_partition:
+                clamp_memory = mb_per_partition * (
+                    (partition_replicas_per_node + internal_partition_slack) +
+                    reserved_memory)
+
+                # Handy if hacking HARD_PARTITION_LIMIT to something low to run on a workstation
+                clamp_memory = max(clamp_memory, 500)
+                resource_settings_args['memory_mb'] = clamp_memory
+
+            self.redpanda.set_resource_settings(
+                ResourceSettings(**resource_settings_args))
+        else:
+            # On dedicated nodes we will use an explicit reactor stall threshold
+            # as a success condition.
+            self.redpanda.set_resource_settings(
+                ResourceSettings(reactor_stall_threshold=100))
+
+        # Should not happen on the expected EC2 instance types where
+        # the cores-RAM ratio is sufficient to meet our shards-per-core
+        if effective_node_memory < partition_replicas_per_node / mb_per_partition:
+            raise RuntimeError(
+                f"Node memory is too small ({node_memory}MB - {reserved_memory}MB)"
+            )
+
+    @property
+    def logger(self):
+        return self.redpanda.logger
 
 
 class ManyPartitionsTest(PreallocNodesTest):
@@ -49,30 +188,68 @@ class ManyPartitionsTest(PreallocNodesTest):
     """
     topics = ()
 
+    # Redpanda is responsible for bounding its own startup time via
+    # STORAGE_TARGET_REPLAY_BYTES.  The resulting walltime for startup
+    # depends on the speed of the disk.  60 seconds is long enough
+    # for an i3en.xlarge (and more than enough for faster instance types)
+    EXPECT_START_TIME = 60
+
+    LEADER_BALANCER_PERIOD_MS = 30000
+
     def __init__(self, test_ctx, *args, **kwargs):
         self._ctx = test_ctx
         super(ManyPartitionsTest, self).__init__(
             test_ctx,
             *args,
-            num_brokers=6,
-            node_prealloc_count=1,
+            num_brokers=9,
+            node_prealloc_count=3,
             extra_rp_conf={
                 # Disable leader balancer initially, to enable us to check for
                 # stable leadership during initial elections and post-restart
                 # elections.  We will switch it on later, to exercise it during
                 # the traffic stress test.
-                'enable_leader_balancer': False,
+                #'enable_leader_balancer': False,
+
+                # Avoid having to wait 5 minutes for leader balancer to activate
+                "leader_balancer_idle_timeout": self.LEADER_BALANCER_PERIOD_MS,
+                "leader_balancer_mute_timeout": self.LEADER_BALANCER_PERIOD_MS,
+
+                # TODO: ensure that the systme works well _without_ these non-default
+                # properties, or if they are necessary and we choose not to make them
+                # the defaults, then that they are reflected propertly in cloud config profiles
+                'reclaim_batch_cache_min_free': 256000000,
+                'storage_read_buffer_size': 32768,
+                'storage_read_readahead_count': 2,
+                'disable_metrics': True,
+                'disable_public_metrics': False,
+                'append_chunk_size': 32768,
+                'kafka_rpc_server_tcp_recv_buf': 131072,
+                'kafka_rpc_server_tcp_send_buf': 131072,
+                'kafka_rpc_server_stream_recv_buf': 32768,
+
+                # Enable all the rate limiting things we would have in production, to ensure
+                # their effect is accounted for, but with high enough limits that we do
+                # not expect to hit them.
+                'kafka_connection_rate_limit': 10000,
+                'kafka_connections_max': 50000,
             },
-            # Usually tests run with debug or trace logs, but when testing resource
-            # limits we want to test in a more production-like configuration.
-            log_level='info',
+            # Configure logging the same way a user would when they have
+            # very many partitions: set logs with per-partition messages
+            # to warn instead of info.
+            log_config=LoggingConfig('info',
+                                     logger_levels={
+                                         'storage': 'warn',
+                                         'storage-gc': 'warn',
+                                         'raft': 'warn',
+                                         'offset_translator': 'warn'
+                                     }),
             **kwargs)
         self.rpk = RpkTool(self.redpanda)
 
     def _all_elections_done(self, topic_names: list[str], p_per_topic: int):
         any_incomplete = False
         for tn in topic_names:
-            partitions = list(self.rpk.describe_topic(tn))
+            partitions = list(self.rpk.describe_topic(tn, tolerant=True))
             if len(partitions) < p_per_topic:
                 self.logger.info(f"describe omits partitions for topic {tn}")
                 any_incomplete = True
@@ -86,6 +263,73 @@ class ManyPartitionsTest(PreallocNodesTest):
                     any_incomplete = True
 
         return not any_incomplete
+
+    def _node_leadership_evacuated(self, topic_names: list[str],
+                                   p_per_topic: int, node_id: int):
+        any_incomplete = False
+        for tn in topic_names:
+            partitions = list(self.rpk.describe_topic(tn, tolerant=True))
+            if len(partitions) < p_per_topic:
+                self.logger.info(f"describe omits partitions for topic {tn}")
+                any_incomplete = True
+                continue
+
+            assert len(partitions) == p_per_topic
+            for p in partitions:
+                if p.leader == node_id:
+                    self.logger.info(
+                        f"partition {tn}/{p.id} still on node {node_id}")
+                    any_incomplete = True
+
+        return not any_incomplete
+
+    def _node_leadership_balanced(self, topic_names: list[str],
+                                  p_per_topic: int):
+        node_leader_counts = defaultdict(int)
+        any_incomplete = False
+        for tn in topic_names:
+            try:
+                partitions = list(self.rpk.describe_topic(tn, tolerant=True))
+            except RpkException as e:
+                self.logger.warn(f"rpk timeout: {e}")
+                return False
+
+            if len(partitions) < p_per_topic:
+                self.logger.info(f"describe omits partitions for topic {tn}")
+                any_incomplete = True
+                continue
+
+            assert len(partitions) == p_per_topic
+            for p in partitions:
+                node_leader_counts[p.leader] += 1
+
+        for n, c in node_leader_counts.items():
+            self.logger.info(f"node {n} leaderships: {c}")
+
+        if len(node_leader_counts) != len(self.redpanda.nodes):
+            self.logger.info("Not all nodes have leaderships")
+            return False
+
+        if any_incomplete:
+            return False
+
+        data = list(node_leader_counts.values())
+        stddev = numpy.std(data)
+        error = stddev / (
+            (len(topic_names) * p_per_topic) / len(self.redpanda.nodes))
+
+        # FIXME: this isn't the same check the leader balancer itself does, but it
+        # should suffice to check the leader balancer is progressing.
+        threshold = 0.1
+        if (p_per_topic * len(topic_names)) < 5000:
+            # Low scale systems have bumpier stats
+            threshold = 0.25
+
+        balanced = error < threshold
+        self.logger.info(
+            f"leadership balanced={balanced} (stddev: {stddev}, error {error})"
+        )
+        return balanced
 
     def _consume_all(self, topic_names: list[str], msg_count_per_topic: int,
                      timeout_per_topic: int):
@@ -120,8 +364,346 @@ class ManyPartitionsTest(PreallocNodesTest):
         # ResourceSettings based on its parameters.
         pass
 
-    @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def _get_fd_counts(self):
+        counts = {}
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(self.redpanda.nodes)) as executor:
+            futs = {}
+            for node in self.redpanda.nodes:
+                futs[node.name] = executor.submit(
+                    lambda: sum(1 for _ in self.redpanda.lsof_node(node)))
+
+            for node_name, fut in futs.items():
+                file_count = fut.result()
+                counts[node_name] = file_count
+
+        return counts
+
+    def _concurrent_restart(self):
+        """
+        Restart the whole cluster, all nodes in parallel.
+        """
+
+        # Normal restarts are rolling restarts, but because replay takes substantial time,
+        # on an idle system it is helpful to do a concurrent global restart rather than
+        # waiting for each node one by one.
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(self.redpanda.nodes)) as executor:
+            futs = []
+            for node in self.redpanda.nodes:
+                futs.append(
+                    executor.submit(self.redpanda.restart_nodes,
+                                    nodes=[node],
+                                    start_timeout=self.EXPECT_START_TIME))
+
+            for f in futs:
+                # Raise on error
+                f.result()
+
+    def _single_node_restart(self, scale: ScaleParameters, topic_names: list,
+                             n_partitions: int):
+        """
+        Restart a single node to check stability through the movement of
+        leadership to other nodes, plus the subsequent leader balancer
+        activity to redistribute after it comes back up.
+        """
+
+        node = self.redpanda.nodes[-1]
+        self.logger.info(f"Single node restart on node {node.name}")
+        node_id = self.redpanda.idx(node)
+
+        self.redpanda.stop_node(node)
+
+        # Wait for leaderships to stabilize on the surviving nodes
+        wait_until(
+            lambda: self._node_leadership_evacuated(topic_names, n_partitions,
+                                                    node_id), 30, 1)
+
+        self.redpanda.start_node(node, timeout=self.EXPECT_START_TIME)
+
+        # Heuristic: in testing we see leaderships transfer at about 10
+        # per second.  2x margin for error.  Up to the leader balancer period
+        # wait for it to activate.
+        transfers_per_sec = 10
+        expect_leader_transfer_time = 2 * (
+            n_partitions / len(self.redpanda.nodes)) / transfers_per_sec + (
+                self.LEADER_BALANCER_PERIOD_MS / 1000) * 2
+
+        # Wait for leaderships to achieve balance.  This is bounded by:
+        #  - Time for leader_balancer to issue+await all the transfers
+        #  - Time for raft to achieve recovery, a prerequisite for
+        #    leadership.
+        t1 = time.time()
+        wait_until(
+            lambda: self._node_leadership_balanced(topic_names, n_partitions),
+            expect_leader_transfer_time, 10)
+        self.logger.info(
+            f"Leaderships balanced in {time.time() - t1:.2f} seconds")
+
+    def _restart_stress(self, scale: ScaleParameters, topic_names: list,
+                        n_partitions: int, inter_restart_check: callable):
+        """
+        Restart the cluster several times, to check stability
+        """
+
+        # Measure the impact of restarts on resource utilization on an idle system:
+        # at time of writing we know that the used FD count will go up substantially
+        # on each restart (https://github.com/redpanda-data/redpanda/issues/4057)
+        restart_count = 2
+
+        for node_name, file_count in self._get_fd_counts().items():
+            self.logger.info(
+                f"Open files before restarts on {node_name}: {file_count}")
+
+        self.logger.info("Entering restart stress test")
+        for i in range(1, restart_count + 1):
+            self.logger.info(f"Cluster restart {i}/{restart_count}...")
+            self._concurrent_restart()
+
+            self.logger.info(
+                f"Restart {i}/{restart_count} complete.  Waiting for elections..."
+            )
+
+            wait_until(
+                lambda: self._all_elections_done(topic_names, n_partitions),
+                timeout_sec=60,
+                backoff_sec=5)
+            self.logger.info(f"Post-restart elections done.")
+
+            inter_restart_check()
+
+            for node_name, file_count in self._get_fd_counts().items():
+                self.logger.info(
+                    f"Open files after {i} restarts on {node_name}: {file_count}"
+                )
+
+    def _write_and_random_read(self, scale: ScaleParameters, topic_names):
+        """
+        This is a relatively low intensity test, that covers random
+        and sequential reads & validates correctness of offsets in the
+        partitions written to.
+
+        It answers the question "is the cluster basically working properly"?  Before
+        we move on to more stressful testing, and in the process ensures there
+        is enough data in the system that we aren't in the "everything fits in
+        memory" regime.
+
+        Note: run this before other workloads, so that kgo-verifier's random
+        readers are able to validate most of what they read (otherwise they
+        will mostly be reading data written by a different workload, which
+        drives traffic but is a less strict test because it can't validate
+        the offsets of those messages)
+        """
+        # Now that we've tested basic ability to form consensus and survive some
+        # restarts, move on to a more general stress test.
+        self.logger.info("Entering traffic stress test")
+        target_topic = topic_names[0]
+
+        # Assume fetches will be 10MB, the franz-go default
+        fetch_mb_per_partition = 10 * 1024 * 1024
+
+        # * Need enough data that if a consumer tried to fetch it all at once
+        # in a single request, it would run out of memory.  OR the amount of
+        # data that would fill a 10MB max_bytes per partition in a fetch, whichever
+        # is lower (avoid writing excessive data for tests with fewer partitions).
+        # * Then apply a factor of two to make sure we have enough data to drive writes
+        # to disk during consumption, not just enough data to hold it all in the batch
+        # cache.
+
+        # Partitions per topic
+        n_partitions = int(scale.partition_limit / len(topic_names))
+
+        write_bytes_per_topic = min(
+            int((self.redpanda.get_node_memory_mb() * 1024 * 1024) /
+                len(topic_names)), fetch_mb_per_partition * n_partitions) * 2
+
+        if not self.redpanda.dedicated_nodes:
+            # Docker developer mode: likely to be on a workstation with lots of RAM
+            # and we don't want to wait to fill it all up.
+            write_bytes_per_topic = int(1E9 / len(topic_names))
+
+        msg_size = 128 * 1024
+        msg_count_per_topic = int((write_bytes_per_topic / msg_size))
+
+        # Approx time to write or read all messages, for timeouts
+        # Pessimistic bandwidth guess, accounting for the sub-disk bandwidth
+        # that a single-threaded consumer may see
+
+        expect_transmit_time = int(write_bytes_per_topic /
+                                   scale.expect_single_bandwidth)
+        expect_transmit_time = max(expect_transmit_time, 30)
+
+        for tn in topic_names:
+            t1 = time.time()
+            producer = FranzGoVerifiableProducer(
+                self.test_context,
+                self.redpanda,
+                tn,
+                msg_size,
+                msg_count_per_topic,
+                custom_node=[self.preallocated_nodes[0]])
+            producer.start()
+            producer.wait(timeout_sec=expect_transmit_time)
+            self.free_preallocated_nodes()
+            duration = time.time() - t1
+            self.logger.info(
+                f"Wrote {write_bytes_per_topic} bytes to {tn} in {duration}s, bandwidth {(write_bytes_per_topic / duration)/(1024 * 1024)}MB/s"
+            )
+
+        stress_msg_size = 32768
+        stress_data_size = 1024 * 1024 * 1024 * 100
+
+        if not self.redpanda.dedicated_nodes:
+            stress_data_size = 2E9
+
+        stress_msg_count = int(stress_data_size / stress_msg_size)
+        fast_producer = FranzGoVerifiableProducer(
+            self.test_context,
+            self.redpanda,
+            target_topic,
+            stress_msg_size,
+            stress_msg_count,
+            custom_node=[self.preallocated_nodes[0]])
+        fast_producer.start()
+
+        # Don't start consumers until the producer has written out its first
+        # checkpoint with valid ranges.
+        wait_until(lambda: fast_producer.produce_status.acked > 0,
+                   timeout_sec=30,
+                   backoff_sec=1.0)
+
+        rand_ios = 100
+        rand_parallel = 100
+        if not self.redpanda.dedicated_nodes:
+            rand_parallel = 10
+            rand_ios = 10
+
+        rand_consumer = FranzGoVerifiableRandomConsumer(
+            self.test_context,
+            self.redpanda,
+            target_topic,
+            msg_size=0,
+            rand_read_msgs=rand_ios,
+            parallel=rand_parallel,
+            nodes=[self.preallocated_nodes[1]])
+        rand_consumer.start(clean=False)
+        rand_consumer.shutdown()
+        rand_consumer.wait()
+
+        fast_producer.stop()
+        fast_producer.wait()
+        self.logger.info(
+            "Write+randread stress test complete, verifying sequentially")
+
+        seq_consumer = FranzGoVerifiableSeqConsumer(
+            self.test_context, self.redpanda, target_topic, 0,
+            [self.preallocated_nodes[2]])
+        seq_consumer.start(clean=False)
+        seq_consumer.shutdown()
+        seq_consumer.wait()
+        assert seq_consumer.consumer_status.invalid_reads == 0
+        assert seq_consumer.consumer_status.valid_reads >= fast_producer.produce_status.acked + msg_count_per_topic
+
+        self.free_preallocated_nodes()
+
+    def _run_omb(self, scale: ScaleParameters):
+
+        # 1.25GB/s is a rather gentle rate on 12*i3en.xlarge 12 core nodes
+        # when using 1000 partitions per shard, use it as a baseline.
+        # (OMB is not good at stress testing, the worker nodes start throwing
+        # exceptions if a cluster isn't keeping up with the rate requested
+        # by the workload, so we are not aiming to aggressively saturate the system)
+        producer_bw = (
+            (len(self.redpanda.nodes) * scale.node_cpus) / 144.0) * 1.25E9
+
+        # It is necessary to scale the producer+consumer counts as well
+        # as the total throughput: otherwise there are too few messages
+        # per producer, and OMB reports this as a very high E2E latency.
+        # Roughly node_cpus is of the right order of magnitude.
+        producer_count = scale.node_cpus
+        consumer_count = scale.node_cpus
+
+        # Don't tweak this without also adjusting payload_file
+        message_size = 4096
+
+        producer_rate = producer_bw / message_size
+
+        # For really high partition counts, the throughput can't keep up
+        # with what the cluster did at more modest density, and this
+        # causes OMB to start failing internally with 500s when it backs up,
+        # or when it runs through, to fail because it didn't hit its latency
+        # target.
+        if PARTITIONS_PER_SHARD > 1000:
+            producer_rate *= (1000.0 / PARTITIONS_PER_SHARD)
+
+        # on 12x i3en.3xlarge
+        # it is stable driving 1159.661 MB/s
+        # across 16 producers per topic, 16 consumers per topic
+
+        topic_count = 10 if self.redpanda.dedicated_nodes else 2
+        workload = {
+            "name":
+            "ManyPartitionsWorkload",
+            "topics":
+            topic_count,
+            "partitions_per_topic":
+            scale.partition_limit / topic_count,
+            "subscriptions_per_topic":
+            1,
+            "consumer_per_subscription":
+            producer_count if self.redpanda.dedicated_nodes else 2,
+            "producers_per_topic":
+            consumer_count if self.redpanda.dedicated_nodes else 2,
+            "producer_rate":
+            producer_rate if self.redpanda.dedicated_nodes else 1000,
+            "message_size":
+            message_size,
+            "payload_file":
+            "payload/payload-4Kb.data",
+            "consumer_backlog_size_GB":
+            0,
+            "test_duration_minutes":
+            3,
+            "warmup_duration_minutes":
+            1,
+        }
+
+        bench_node = self.preallocated_nodes[0]
+        worker_nodes = self.preallocated_nodes[1:]
+
+        # TODO: use PROD_ENV_VALIDATOR?
+        benchmark = OpenMessagingBenchmark(
+            self._ctx,
+            self.redpanda,
+            "SIMPLE_DRIVER",
+            (workload, OMBSampleConfigurations.UNIT_TEST_LATENCY_VALIDATOR),
+            node=bench_node,
+            worker_nodes=worker_nodes)
+        benchmark.start()
+        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
+        benchmark.check_succeed()
+
+        self.free_preallocated_nodes()
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_many_partitions_compacted(self):
+        self._test_many_partitions(compacted=True)
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_many_partitions(self):
+        self._test_many_partitions(compacted=False)
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_omb(self):
+        scale = ScaleParameters(self.redpanda, replication_factor=3)
+        self.redpanda.start(parallel=True)
+
+        # We have other OMB benchmark tests, but this one runs at the
+        # peak partition count.
+        self._run_omb(scale)
+
+    def _test_many_partitions(self, compacted):
         """
         Validate that redpanda works with partition counts close to its resource
         limits.
@@ -153,123 +735,38 @@ class ManyPartitionsTest(PreallocNodesTest):
         assert not self.debug_mode
 
         replication_factor = 3
-        node_count = len(self.redpanda.nodes)
 
-        # If we run on nodes with more memory than our HARD_PARTITION_LIMIT, then
-        # artificially throttle the nodes' memory to avoid the test being too easy.
-        # We are validating that the system works up to the limit, and that it works
-        # up to the limit within the default per-partition memory footprint.
-        node_memory = self.redpanda.get_node_memory_mb()
-        node_cpus = self.redpanda.get_node_cpu_count()
-        node_disk_free = self.redpanda.get_node_disk_free()
-
-        self.logger.info(
-            f"Nodes have {node_cpus} cores, {node_memory}MB memory, {node_disk_free / (1024 * 1024)}MB free disk"
-        )
-
-        # On large nodes, reserve half of shard 0 to minimize interference
-        # between data and control plane, as control plane messages become
-        # very large.
-
-        shard0_reserve = None
-        if node_cpus >= 8:
-            shard0_reserve = PARTITIONS_PER_SHARD / 2
-
-        # Reserve a few slots for internal partitions, do not be
-        # super specific about how many because we may add some in
-        # future for e.g. audit logging.
-        internal_partition_slack = 10
-
-        # Calculate how many partitions we will aim to create, based
-        # on the size & count of nodes.  This enables running the
-        # test on various instance sizes without explicitly adjusting.
-        partition_limit = (node_count * node_cpus * PARTITIONS_PER_SHARD
-                           ) / replication_factor - internal_partition_slack
-        if shard0_reserve:
-            partition_limit -= node_count * shard0_reserve
-
-        partition_limit = min(HARD_PARTITION_LIMIT, partition_limit)
-
-        if not self.redpanda.dedicated_nodes:
-            partition_limit = min(DOCKER_PARTITION_LIMIT, partition_limit)
-
-        self.logger.info(f"Selected partition limit {partition_limit}")
-
-        # Emulate seastar's policy for default reserved memory
-        reserved_memory = max(1536, int(0.07 * node_memory) + 1)
-        effective_node_memory = node_memory - reserved_memory
-
-        # Aim to use about half the disk space: set retention limits
-        # to enforce that.  This enables traffic tests to run as long
-        # as they like without risking filling the disk.
-        partition_replicas_per_node = int(
-            (partition_limit * replication_factor) / node_count)
-        retention_bytes = int(
-            (node_disk_free / 2) / partition_replicas_per_node)
-
-        # Choose an appropriate segment size to enable retention
-        # to kick in.
-        # TODO: redpanda should figure this out automatically by
-        #       rolling segments pre-emptively if low on disk space
-        segment_size = int(retention_bytes / 2)
-
-        self.logger.info(
-            f"Selected retention.bytes={retention_bytes}, segment.bytes={segment_size}"
-        )
-
-        mb_per_partition = 1
-        if not self.redpanda.dedicated_nodes:
-            # In docker, assume we're on a laptop drive and not doing
-            # real testing, so disable fsync to make test run faster.
-            resource_settings_args = {'bypass_fsync': True}
-
-            # In docker, make the test a bit more realistic by clamping
-            # memory if nodes have more memory than should be required
-            # to exercise the partition limit.
-            if effective_node_memory > partition_replicas_per_node / mb_per_partition:
-                clamp_memory = mb_per_partition * (
-                    (partition_replicas_per_node + internal_partition_slack) +
-                    reserved_memory)
-
-                # Handy if hacking HARD_PARTITION_LIMIT to something low to run on a workstation
-                clamp_memory = max(clamp_memory, 500)
-                resource_settings_args['memory_mb'] = clamp_memory
-
-            self.redpanda.set_resource_settings(
-                ResourceSettings(**resource_settings_args))
-
-        # Should not happen on the expected EC2 instance types where
-        # the cores-RAM ratio is sufficient to meet our shards-per-core
-        if effective_node_memory < partition_replicas_per_node / mb_per_partition:
-            raise RuntimeError(
-                f"Node memory is too small ({node_memory}MB - {reserved_memory}MB)"
-            )
+        scale = ScaleParameters(self.redpanda, replication_factor)
 
         # Run with one huge topic: this is the more stressful case for Redpanda, compared
         # with multiple modestly-sized topics, so it's what we test to find the system's limits.
         n_topics = 1
 
         # Partitions per topic
-        n_partitions = int(partition_limit / n_topics)
+        n_partitions = int(scale.partition_limit / n_topics)
 
         self.logger.info(
             f"Running partition scale test with {n_partitions} partitions on {n_topics} topics"
         )
 
-        self.redpanda.start()
+        self.redpanda.start(parallel=True)
 
         self.logger.info("Entering topic creation")
         topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]
         for tn in topic_names:
             self.logger.info(
                 f"Creating topic {tn} with {n_partitions} partitions")
+            config = {
+                'segment.bytes': scale.segment_size,
+                'retention.bytes': scale.retention_bytes
+            }
+            if compacted:
+                config['cleanup.policy'] = 'compact'
+
             self.rpk.create_topic(tn,
                                   partitions=n_partitions,
                                   replicas=replication_factor,
-                                  config={
-                                      'segment.bytes': segment_size,
-                                      'retention.bytes': retention_bytes
-                                  })
+                                  config=config)
 
         self.logger.info(f"Awaiting elections...")
         wait_until(lambda: self._all_elections_done(topic_names, n_partitions),
@@ -277,205 +774,101 @@ class ManyPartitionsTest(PreallocNodesTest):
                    backoff_sec=5)
         self.logger.info(f"Initial elections done.")
 
-        for node in self.redpanda.nodes:
-            files = self.redpanda.lsof_node(node)
-            file_count = sum(1 for _ in files)
+        for node_name, file_count in self._get_fd_counts().items():
             self.logger.info(
-                f"Open files after initial selection on {node.name}: {file_count}"
+                f"Open files after initial elections on {node_name}: {file_count}"
             )
 
-        # Assume fetches will be 10MB, the franz-go default
-        fetch_mb_per_partition = 10 * 1024 * 1024
+        self.logger.info(
+            "Entering initial traffic test, writes + random reads")
+        self._write_and_random_read(scale, topic_names)
 
-        # * Need enough data that if a consumer tried to fetch it all at once
-        # in a single request, it would run out of memory.  OR the amount of
-        # data that would fill a 10MB max_bytes per partition in a fetch, whichever
-        # is lower (avoid writing excessive data for tests with fewer partitions).
-        # * Then apply a factor of two to make sure we have enough data to drive writes
-        # to disk during consumption, not just enough data to hold it all in the batch
-        # cache.
-        write_bytes_per_topic = min(
-            int((self.redpanda.get_node_memory_mb() * 1024 * 1024) / n_topics),
-            fetch_mb_per_partition * n_partitions) * 2
+        # Start kgo-repeater
+        # 768 workers on a 24 core node has been seen to work well.
+        workers = 32 * scale.node_cpus
 
-        if self.scale.release:
-            # Release tests can be much longer running: 10x the amount of
-            # data we fire through the system
-            write_bytes_per_topic *= 10
+        if not self.redpanda.dedicated_nodes:
+            workers = min(workers, 4)
 
-        msg_size = 128 * 1024
-        msg_count_per_topic = int((write_bytes_per_topic / msg_size))
+        repeater_kwargs = {}
+        if compacted:
+            # Each parititon gets roughly 10 unique keys, after which
+            # compaction should kick in.
+            repeater_kwargs['key_count'] = int(scale.partition_limit * 10)
+        else:
+            # Not doing compaction, doesn't matter how big the keyspace
+            # is, use whole 32 bit range to get best possible distribution
+            # across partitions.
+            repeater_kwargs['key_count'] = 2**32
 
-        # Approx time to write or read all messages, for timeouts
-        # Pessimistic bandwidth guess, accounting for the sub-disk bandwidth
-        # that a single-threaded consumer may see
+        # Main test phase: with continuous background traffic, exercise restarts and
+        # any other cluster changes that might trip up at scale.
+        repeater_msg_size = 16384
+        with repeater_traffic(context=self._ctx,
+                              redpanda=self.redpanda,
+                              nodes=self.preallocated_nodes,
+                              topic=topic_names[0],
+                              msg_size=repeater_msg_size,
+                              workers=workers,
+                              cleanup=lambda: self.free_preallocated_nodes(),
+                              **repeater_kwargs) as repeater:
+            repeater_await_bytes = 1E9
+            repeater_await_msgs = int(repeater_await_bytes / repeater_msg_size)
 
-        expect_bandwidth = 50 * 1024 * 1024
+            def progress_check():
+                # Explicit wait for consumer group, because we might have e.g.
+                # just restarted the cluster, and don't want to include that
+                # delay in our throughput-driven timeout expectations
+                self.logger.info(f"Checking repeater group is ready...")
+                repeater.await_group_ready()
 
-        expect_transmit_time = int(write_bytes_per_topic / expect_bandwidth)
-        expect_transmit_time = max(expect_transmit_time, 30)
-
-        self.logger.info("Entering initial produce")
-        for tn in topic_names:
-            t1 = time.time()
-            producer = FranzGoVerifiableProducer(
-                self.test_context,
-                self.redpanda,
-                tn,
-                msg_size,
-                msg_count_per_topic,
-                custom_node=self.preallocated_nodes)
-            producer.start()
-            producer.wait(timeout_sec=expect_transmit_time)
-            self.free_preallocated_nodes()
-            duration = time.time() - t1
-            self.logger.info(
-                f"Wrote {write_bytes_per_topic} bytes to {tn} in {duration}s, bandwidth {(write_bytes_per_topic / duration)/(1024 * 1024)}MB/s"
-            )
-
-        def get_fd_counts():
-            counts = {}
-            with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=node_count) as executor:
-                futs = {}
-                for node in self.redpanda.nodes:
-                    futs[node.name] = executor.submit(
-                        lambda: sum(1 for _ in self.redpanda.lsof_node(node)))
-
-                for node_name, fut in futs.items():
-                    file_count = fut.result()
-                    counts[node_name] = file_count
-
-            return counts
-
-        for node_name, file_count in get_fd_counts().items():
-            self.logger.info(
-                f"Open files before restarts on {node_name}: {file_count}")
-
-        # Over large partition counts, the startup time is linear with the
-        # amount of data we played in, because no one partition gets far
-        # enough to snapshot.
-        expect_start_time = expect_transmit_time
-
-        # Measure the impact of restarts on resource utilization on an idle system:
-        # at time of writing we know that the used FD count will go up substantially
-        # on each restart (https://github.com/redpanda-data/redpanda/issues/4057)
-        restart_count = 2
-
-        self.logger.info("Entering restart stress test")
-        for i in range(1, restart_count + 1):
-            self.logger.info(f"Cluster restart {i}/{restart_count}...")
-
-            # Normal restarts are rolling restarts, but because replay takes substantial time,
-            # on an idle system it is helpful to do a concurrent global restart rather than
-            # waiting for each node one by one.
-            with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=node_count) as executor:
-                futs = []
-                for node in self.redpanda.nodes:
-                    futs.append(
-                        executor.submit(self.redpanda.restart_nodes,
-                                        nodes=[node],
-                                        start_timeout=expect_start_time))
-
-                for f in futs:
-                    # Raise on error
-                    f.result()
-            self.logger.info(
-                f"Restart {i}/{restart_count} complete.  Waiting for elections..."
-            )
-
-            wait_until(
-                lambda: self._all_elections_done(topic_names, n_partitions),
-                timeout_sec=60,
-                backoff_sec=5)
-            self.logger.info(f"Post-restart elections done.")
-
-            for node_name, file_count in get_fd_counts().items():
+                t = repeater_await_bytes / scale.expect_bandwidth
                 self.logger.info(
-                    f"Open files after {i} restarts on {node_name}: {file_count}"
+                    f"Waiting for {repeater_await_msgs} messages in {t} seconds"
+                )
+                t1 = time.time()
+                repeater.await_progress(repeater_await_msgs, t)
+                t2 = time.time()
+
+                # This is approximate, because await_progress isn't returning the very
+                # instant the workers hit their collective target.
+                self.logger.info(
+                    f"Wait complete, approx bandwidth {(repeater_await_bytes / (t2-t1))/(1024*1024.0)}MB/s"
                 )
 
-        # With increased overhead from all those segment rolls during restart,
-        # check that consume still works.
-        self._consume_all(topic_names, msg_count_per_topic,
-                          expect_transmit_time)
+            progress_check()
 
-        # Now that we've tested basic ability to form consensus and survive some
-        # restarts, move on to a more general stress test.
-        self.logger.info("Entering traffic stress test")
-        target_topic = topic_names[0]
+            self.logger.info(f"Entering single node restart phase")
+            self._single_node_restart(scale, topic_names, n_partitions)
+            progress_check()
 
-        stress_msg_size = 32768
+            self.logger.info(f"Entering restart stress test phase")
+            self._restart_stress(scale, topic_names, n_partitions,
+                                 progress_check)
 
-        stress_data_size = 1024 * 1024 * 1024 * 100
+            self.logger.info(
+                f"Post-restarts: checking repeater group is ready...")
+            repeater.await_group_ready()
 
-        stress_msg_count = int(stress_data_size / stress_msg_size)
-        fast_producer = FranzGoVerifiableProducer(
-            self.test_context,
-            self.redpanda,
-            target_topic,
-            stress_msg_size,
-            stress_msg_count,
-            custom_node=self.preallocated_nodes)
-        fast_producer.start()
+            # Done with restarts, now do a longer traffic soak
+            self.logger.info(f"Entering traffic soak phase")
+            soak_await_bytes = 100E9
+            if not self.redpanda.dedicated_nodes:
+                soak_await_bytes = 10E9
 
-        # Don't start consumers until the producer has written out its first
-        # checkpoint with valid ranges.
-        wait_until(lambda: fast_producer.produce_status.acked > 0,
-                   timeout_sec=30,
-                   backoff_sec=1.0)
-
-        rand_consumer = FranzGoVerifiableRandomConsumer(
-            self.test_context,
-            self.redpanda,
-            target_topic,
-            0,
-            100,
-            10,
-            nodes=self.preallocated_nodes)
-        rand_consumer.start(clean=False)
-        rand_consumer.shutdown()
-        rand_consumer.wait()
-
-        fast_producer.wait()
-        self.logger.info(
-            "Write+randread stress test complete, verifying sequentially")
-
-        seq_consumer = FranzGoVerifiableSeqConsumer(self.test_context,
-                                                    self.redpanda,
-                                                    target_topic, 0,
-                                                    self.preallocated_nodes)
-        seq_consumer.start(clean=False)
-        seq_consumer.shutdown()
-        seq_consumer.wait()
-        assert seq_consumer.consumer_status.invalid_reads == 0
-        assert seq_consumer.consumer_status.valid_reads == stress_msg_count + msg_count_per_topic
-
-        self.logger.info("Entering leader balancer stress test")
-
-        # Enable the leader balancer and check that the system remains stable
-        # under load.  We do not leave the leader balancer on for most of the test, because
-        # it makes reads _much_ slower, because the consumer keeps stalling and waiting for
-        # elections: at any moment in a 10k partition topic, it's highly likely at least
-        # one partition is offline for a leadership migration.
-        self.redpanda.set_cluster_config({'enable_leader_balancer': True},
-                                         expect_restart=False)
-        lb_stress_period = 120
-        lb_stress_produce_bytes = expect_bandwidth * lb_stress_period
-        lb_stress_message_count = int(lb_stress_produce_bytes /
-                                      stress_msg_size)
-        fast_producer = FranzGoVerifiableProducer(
-            self.test_context,
-            self.redpanda,
-            target_topic,
-            stress_msg_size,
-            lb_stress_message_count,
-            custom_node=self.preallocated_nodes)
-        fast_producer.start()
-        rand_consumer.start()
-        time.sleep(lb_stress_period
-                   )  # Let the system receive traffic for a set time period
-        rand_consumer.shutdown()
-        rand_consumer.wait()
-        fast_producer.wait()
+            soak_await_msgs = soak_await_bytes / repeater_msg_size
+            t1 = time.time()
+            initial_p, _ = repeater.total_messages()
+            try:
+                repeater.await_progress(
+                    soak_await_msgs, soak_await_bytes / scale.expect_bandwidth)
+            except TimeoutError:
+                t2 = time.time()
+                final_p, _ = repeater.total_messages()
+                bytes_sent = (final_p - initial_p) * repeater_msg_size
+                expect_mbps = scale.expect_bandwidth / (1024 * 1024.0)
+                actual_mbps = (bytes_sent / (t2 - t1)) / (1024 * 1024.0)
+                self.logger.error(
+                    f"Expected throughput {expect_mbps:.2f}, got throughput {actual_mbps:.2f}MB/s"
+                )
+                raise

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -34,10 +34,13 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             try:
                 r = f(self, *args, **kwargs)
             except:
+                self.redpanda.logger.exception(
+                    "Test failed, doing failure checks...")
                 self.redpanda.decode_backtraces()
                 self.redpanda.raise_on_crash()
                 raise
             else:
+                self.redpanda.logger.info("Test passed, doing log checks...")
                 if check_allowed_error_logs:
                     # Only do log inspections on tests that are otherwise
                     # successful.  This executes *before* the end-of-test

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -333,7 +333,10 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
                     self._status = ProduceStatus(data['Sent'], data['Acked'],
                                                  data['BadOffsets'],
                                                  data['Restarts'])
-                    self.logger.info(str(self._status))
+                    progress = (data['Sent'] / float(self._msg_count))
+                    self.logger.info(
+                        f"Producer progress: {progress*100:.2f}% {self._status}"
+                    )
                 else:
                     self.logger.debug(line)
 

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -154,8 +154,11 @@ class KgoRepeaterService(Service):
             else:
                 return True
 
-        self.logger.debug("Waiting for consumer group to be ready")
+        self.logger.debug(f"Waiting for group {self.group_name} to be ready")
+        t1 = time.time()
         wait_until(group_ready, timeout_sec=120, backoff_sec=10)
+        self.logger.debug(
+            f"Group {self.group_name} became ready in {time.time() - t1}s")
 
     def total_messages(self):
         """

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -1,0 +1,221 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import requests
+import json
+from typing import Optional, Callable
+from contextlib import contextmanager
+
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.tests.test import TestContext
+
+from rptest.services.redpanda import RedpandaService
+from rptest.clients.rpk import RpkTool
+
+
+class KgoRepeaterService(Service):
+    EXE = "kgo-repeater"
+    LOG_PATH = "/tmp/kgo-repeater.log"
+
+    logs = {"repeater_log": {"path": LOG_PATH, "collect_default": True}}
+
+    def __init__(self,
+                 context: TestContext,
+                 redpanda: RedpandaService,
+                 nodes: Optional[list[ClusterNode]],
+                 topic: str,
+                 msg_size: Optional[int],
+                 workers: int,
+                 key_count: int,
+                 group_name: str = "repeat01"):
+        # num_nodes=0 because we're asking it to not allocate any for us
+        super().__init__(context, num_nodes=0 if nodes else 1)
+
+        if nodes is not None:
+            assert len(nodes) > 0
+            self.nodes = nodes
+
+        self.redpanda = redpanda
+        self.topic = topic
+        self.msg_size = msg_size
+        self.workers = workers
+        self.group_name = group_name
+
+        # Note: using a port that happens to already be in test environment
+        # firewall rules from other use cases.  If changing this, update
+        # terraform for test clusters.
+        self.remote_port = 8080
+
+        self.key_count = key_count
+
+        self._stopped = False
+
+    def clean_node(self, node):
+        self.redpanda.logger.debug(f"{self.__class__.__name__}.clean_node")
+        node.account.kill_process(self.EXE, clean_shutdown=False)
+        if node.account.exists(self.LOG_PATH):
+            node.account.remove(self.LOG_PATH)
+
+    def start_node(self, node, clean=None):
+        mb_per_worker = 1
+        initial_data_mb = mb_per_worker * self.workers
+
+        cmd = (
+            "/opt/kgo-verifier/kgo-repeater "
+            f"-topic {self.topic} -brokers {self.redpanda.brokers()} "
+            f"-workers {self.workers} -initial-data-mb {initial_data_mb} "
+            f"-group {self.group_name} -remote -remote-port {self.remote_port} "
+        )
+
+        if self.msg_size is not None:
+            cmd += f" -payload-size={self.msg_size}"
+
+        if self.key_count is not None:
+            cmd += f" -keys={self.key_count}"
+
+        cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 &"
+
+        self.logger.info(f"start_node[{node.name}]: {cmd}")
+        node.account.ssh(cmd)
+
+    def stop(self, *args, **kwargs):
+        # On first call to stop, log status from the workers.
+        # (stop() may be called more than once during teardown)
+        if not self._stopped:
+            for node in self.nodes:
+                # This is only advisory, make errors non-fatal
+                try:
+                    r = requests.get(self._remote_url(node, "status"))
+                    self.logger.debug(
+                        f"kgo-repeater status on node {node.name}:")
+                    self.logger.debug(json.dumps(r.json(), indent=2))
+                except:
+                    self.logger.exception(
+                        f"Error getting pre-stop status on {node.name}")
+
+        self._stopped = True
+
+        super().stop(*args, **kwargs)
+
+    def stop_node(self, node):
+        node.account.kill_process(self.EXE,
+                                  allow_fail=False,
+                                  clean_shutdown=True)
+
+    def _remote_url(self, node, path):
+        return f"http://{node.account.hostname}:{self.remote_port}/{path}"
+
+    def remote_to_all(self, path):
+        for node in self.nodes:
+            self.logger.debug(f"Invoking remote path {path} on {node.name}")
+            r = requests.get(self._remote_url(node, path))
+            r.raise_for_status()
+
+    def prepare_and_activate(self):
+        """
+        Wait for all the processes to come up and the consumer group
+        to stabilize, then activate all their producers.
+        """
+        self.await_group_ready()
+
+        self.logger.debug("Activating producer loop")
+        self.remote_to_all("activate")
+
+    def await_group_ready(self):
+
+        expect_members = self.workers * len(self.nodes)
+
+        def group_ready():
+            rpk = RpkTool(self.redpanda)
+            group = rpk.group_describe(self.group_name, summary=True)
+            if group is None:
+                self.logger.debug(
+                    f"group_ready: {self.group_name} got None from describe")
+                return False
+            elif group.state != "Stable":
+                self.logger.debug(
+                    f"group_ready: waiting for stable, current state {group.state}"
+                )
+                return False
+            elif group.members != expect_members:
+                self.logger.debug(
+                    f"group_ready: waiting for node count ({group.members} != {expect_members})"
+                )
+                return False
+            else:
+                return True
+
+        self.logger.debug("Waiting for consumer group to be ready")
+        wait_until(group_ready, timeout_sec=120, backoff_sec=10)
+
+    def total_messages(self):
+        """
+        :return: 2-tuple of produced, consumed
+        """
+        produced = 0
+        consumed = 0
+        for node in self.nodes:
+            r = requests.get(self._remote_url(node, "status"))
+            r.raise_for_status()
+            node_status = r.json()
+            for worker_status in node_status:
+                produced += worker_status['produced']
+                consumed += worker_status['consumed']
+
+        return produced, consumed
+
+    def await_progress(self, msg_count, timeout_sec):
+        """
+        Call this in places you want to assert some progress
+        is really being made: say how many messages should be
+        produced+consumed & how long you expect it to take.
+        """
+        initial_p, initial_c = self.total_messages()
+
+        # Give it at least some chance to progress before we start checking
+        time.sleep(0.5)
+
+        def check():
+            p, c = self.total_messages()
+            pct = min(
+                float(p - initial_p) / (msg_count),
+                float(c - initial_c) / (msg_count)) * 100
+            self.logger.debug(
+                f"await_progress: {pct:.1f}% p={p} c={c}, initial_p={initial_p}, initial_c={initial_c}, await count {msg_count})"
+            )
+            return p >= initial_p + msg_count and c >= initial_c + msg_count
+
+        # Minimum window for checking for progress: otherwise when the bandwidth
+        # expection is high, we end up failing if we happen to check at a moment
+        # the system isn't at peak throughput (e.g. when it's just warming up)
+        timeout_sec = max(timeout_sec, 60)
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+
+
+@contextmanager
+def repeater_traffic(context, redpanda, *args, cleanup: Callable, **kwargs):
+    svc = KgoRepeaterService(context, redpanda, *args, **kwargs)
+    svc.start()
+    svc.prepare_and_activate()
+
+    try:
+        yield svc
+    except:
+        # Helpful to log the exception so that it appears before
+        # all the logs from our teardown and developer can jump
+        # straight to the point the error occurred.
+        redpanda.logger.exception("Exception during repeater_traffic region")
+        raise
+    finally:
+        svc.stop()
+        cleanup()

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -146,7 +146,11 @@ class KgoRepeaterService(Service):
                     f"group_ready: waiting for stable, current state {group.state}"
                 )
                 return False
-            elif group.members != expect_members:
+            elif group.members < expect_members / 2:
+                # FIXME: this should really require that all consumers are present, but
+                # in practice I see some a small minority of consumers drop out of the
+                # group sometimes when the cluster undergoes an all-node concurrent restart,
+                # and I don't want to stop the test for that.
                 self.logger.debug(
                     f"group_ready: waiting for node count ({group.members} != {expect_members})"
                 )

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import concurrent.futures
 import copy
 
 import time
@@ -625,8 +626,38 @@ class RedpandaService(Service):
             memory_kb = int(line.strip().split()[1])
             return memory_kb / 1024
 
-    def start(self, nodes=None, clean_nodes=True, start_si=True):
-        """Start the service on all nodes."""
+    def _for_nodes(self, nodes, cb: callable, *, parallel: bool):
+        if not parallel:
+            # Trivial case: just loop and call
+            for n in nodes:
+                cb(n)
+            return
+
+        node_futures = []
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(nodes)) as executor:
+            for node in nodes:
+                f = executor.submit(cb, node)
+                node_futures.append((node, f))
+
+            for node, f in node_futures:
+                f.result()
+
+    def start(self,
+              nodes=None,
+              clean_nodes=True,
+              start_si=True,
+              parallel: bool = False):
+        """
+        Start the service on all nodes.
+
+        By default, nodes are started in serial: this makes logs easier to
+        read and simplifies debugging.  For tests starting larger numbers of
+        nodes where serialized startup becomes annoying, pass parallel=True.
+
+        :param parallel: if true, run clean and start operations in parallel
+                         for the nodes being started.
+        """
         to_start = nodes if nodes is not None else self.nodes
         assert all((node in self.nodes for node in to_start))
         self.logger.info("%s: starting service" % self.who_am_i())
@@ -638,7 +669,8 @@ class RedpandaService(Service):
         self.logger.debug(
             self.who_am_i() +
             ": killing processes and attempting to clean up before starting")
-        for node in to_start:
+
+        def clean_one(node):
             try:
                 self.stop_node(node)
             except Exception:
@@ -658,13 +690,17 @@ class RedpandaService(Service):
                     f"Error cleaning node {node.account.hostname}:")
                 raise
 
+        self._for_nodes(to_start, clean_one, parallel=parallel)
+
         if first_start:
             self.write_tls_certs()
             self.write_bootstrap_cluster_config()
 
-        for node in to_start:
+        def start_one(node):
             self.logger.debug("%s: starting node" % self.who_am_i(node))
             self.start_node(node)
+
+        self._for_nodes(to_start, start_one, parallel=parallel)
 
         if self._start_duration_seconds < 0:
             self._start_duration_seconds = time.time() - self._start_time

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -155,7 +155,8 @@ class ResourceSettings:
                  num_cpus: Optional[int] = None,
                  memory_mb: Optional[int] = None,
                  bypass_fsync: Optional[bool] = None,
-                 nfiles: Optional[int] = None):
+                 nfiles: Optional[int] = None,
+                 reactor_stall_threshold: Optional[int] = None):
         self._num_cpus = num_cpus
         self._memory_mb = memory_mb
 
@@ -165,6 +166,7 @@ class ResourceSettings:
             self._bypass_fsync = bypass_fsync
 
         self._nfiles = nfiles
+        self._reactor_stall_threshold = reactor_stall_threshold
 
     @property
     def memory_mb(self):
@@ -200,6 +202,11 @@ class ResourceSettings:
             args.extend([
                 "--kernel-page-cache=true", "--overprovisioned ",
                 "--reserve-memory=0M"
+            ])
+
+        if self._reactor_stall_threshold is not None:
+            args.extend([
+                f"--blocked-reactor-notify-ms={self._reactor_stall_threshold}"
             ])
 
         if num_cpus is not None:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -855,6 +855,17 @@ class RedpandaService(Service):
         if self.coproc_enabled():
             self.start_wasm_engine(node)
 
+        if self.dedicated_nodes:
+            # When running on dedicated nodes, we should always be running on XFS.  If we
+            # aren't, it's probably an accident that can easily cause spurious failures
+            # and confusion, so be helpful and fail out early.
+            fs = node.account.ssh_output(
+                f"stat -f -c %T {self.PERSISTENT_ROOT}").strip()
+            if fs != b'xfs':
+                raise RuntimeError(
+                    f"Unexpected filesystem {fs} at {self.PERSISTENT_ROOT} on {node.name}"
+                )
+
         def is_status_ready():
             status = None
             try:

--- a/tests/rptest/services/templates/omb_workload.yaml
+++ b/tests/rptest/services/templates/omb_workload.yaml
@@ -2,8 +2,13 @@ name: {{name}}
 
 topics: {{topics}}
 partitionsPerTopic: {{partitions_per_topic}}
+{% if message_size is not none %}
+messageSize: {{message_size}}
+payloadFile: {{payload_file}}
+{% else %}
 messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
+{% endif %}
 subscriptionsPerTopic: {{subscriptions_per_topic}}
 producersPerTopic: {{producers_per_topic}}
 consumerPerSubscription: {{consumer_per_subscription}}

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -33,3 +33,6 @@ class NodeCrash(Exception):
         else:
             names = ",".join([c[0].name for c in self.crashes])
             return f"<NodeCrash ({names}) {example}>"
+
+    def __repr__(self):
+        return self.__str__()

--- a/tests/rptest/tests/prealloc_nodes.py
+++ b/tests/rptest/tests/prealloc_nodes.py
@@ -9,8 +9,8 @@
 
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.cluster.cluster_spec import ClusterSpec
-from ducktape.utils.util import wait_until
 from ducktape.tests.test import TestContext
+from rptest.util import wait_until
 
 
 class PreallocNodesTest(RedpandaTest):


### PR DESCRIPTION
## Cover letter

Updates to ManyPartitionsTest:
- Make it dynamically select size based on enviroment: this is useful for developers but also for running on different instance types without having to manually adjust things.
- Configure retention rules so that the test can run as long as it likes without filling disk.
- Add a compacted topic test
- Add a test that runs an OMB workload against a system with many partitions
- Use new kgo-repeater traffic generator

Other improvements:
- The KgoRepeaterService comes with a sweet python context manager for running part of a test with background traffic.
- Check for XFS on dedicated nodes: this saves developer time if they've accidentally broken a /var/lib/redpanda symlink to ephemeral storage
- Fix for NodeCrash printing
- Many fixes/improvements to test helpers.

Fixes https://github.com/redpanda-data/redpanda/issues/5389

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
