### PR TITLE
rpk: move logdirs command from debug to cluster

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -57,6 +57,7 @@ func NewClusterCommand(fs afero.Fs) *cobra.Command {
 	offsets.Use = "offsets"
 	command.AddCommand(
 		cluster.NewHealthOverviewCommand(fs),
+		cluster.NewLogdirsCommand(fs),
 		config.NewConfigCommand(fs),
 		license.NewLicenseCommand(fs),
 		maintenance.NewMaintenanceCommand(fs),

--- a/src/go/rpk/pkg/cli/cmd/cluster/logdirs.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/logdirs.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package debug
+package cluster
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	"github.com/twmb/types"
 )
 
-func newLogdirsCommand(fs afero.Fs) *cobra.Command {
+func NewLogdirsCommand(fs afero.Fs) *cobra.Command {
 	var (
 		configFile string
 

--- a/src/go/rpk/pkg/cli/cmd/debug/debug.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/debug.go
@@ -23,7 +23,6 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd.AddCommand(
 		newBundleCommand(fs),
 		NewInfoCommand(fs),
-		newLogdirsCommand(fs),
 	)
 
 	return cmd


### PR DESCRIPTION
## Cover letter

Move `rpk debug logdirs` to `rpk cluster logdirs`

## Backport Required
- [x] change of a command that's not released

## UX changes

* none

## Release notes
* none
