### PR TITLE
compat: add support for raft data types

### DIFF
--- a/src/v/compat/CMakeLists.txt
+++ b/src/v/compat/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     v::json
     v::cluster
     v::utils
-    v::raft)
+    v::raft
+    v::model_test_utils)
 
 add_subdirectory(tests)

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -145,6 +145,17 @@ inline void read_value(json::Value const& rd, model::ntp& obj) {
     read_member(rd, "partition", obj.tp.partition);
 }
 
+template<typename T>
+void read_value(json::Value const& v, ss::bool_class<T>& target) {
+    target = ss::bool_class<T>(v.GetBool());
+}
+
+template<typename T>
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const ss::bool_class<T>& b) {
+    rjson_serialize(w, bool(b));
+}
+
 #define json_write(_fname) json::write_member(wr, #_fname, obj._fname)
 #define json_read(_fname) json::read_member(rd, #_fname, obj._fname)
 

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -114,7 +114,8 @@ void read_member(json::Value const& v, char const* key, T& target) {
         read_value(it->value, target);
     } else {
         target = {};
-        std::cout << "key " << key << " not found, default initializing";
+        std::cout << "key " << key << " not found, default initializing"
+                  << std::endl;
     }
 }
 

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -427,4 +427,36 @@ struct compat_check<raft::vote_reply> {
     }
 };
 
+/*
+ * raft::heartbeat_request
+ */
+template<>
+struct compat_check<raft::heartbeat_request> {
+    static constexpr std::string_view name = "raft::heartbeat_request";
+
+    static std::vector<raft::heartbeat_request> create_test_cases() {
+        return generate_instances<raft::heartbeat_request>();
+    }
+
+    static void to_json(
+      const raft::heartbeat_request& obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(heartbeats);
+    }
+
+    static raft::heartbeat_request from_json(json::Value& rd) {
+        raft::heartbeat_request obj;
+        json_read(heartbeats);
+        return obj;
+    }
+
+    static std::vector<compat_binary> to_binary(raft::heartbeat_request obj) {
+        return compat_binary::serde_and_adl(std::move(obj));
+    }
+
+    static bool check(raft::heartbeat_request expected, compat_binary test) {
+        return verify_adl_or_serde(std::move(expected), std::move(test));
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -460,6 +460,46 @@ struct compat_check<raft::heartbeat_request> {
 };
 
 /*
+ * raft::heartbeat_reply
+ */
+template<>
+struct compat_check<raft::heartbeat_reply> {
+    static constexpr std::string_view name = "raft::heartbeat_reply";
+
+    static std::vector<raft::heartbeat_reply> create_test_cases() {
+        return generate_instances<raft::heartbeat_reply>();
+    }
+
+    static void to_json(
+      const raft::heartbeat_reply& obj, json::Writer<json::StringBuffer>& wr) {
+        // temporary workaround for serialization of append_entries_reply not
+        // needing the caller to start/end the object. will fix with a refactor.
+        wr.Key("meta");
+        wr.StartArray();
+        for (const auto& e : obj.meta) {
+            wr.StartObject();
+            rjson_serialize(wr, e);
+            wr.EndObject();
+        }
+        wr.EndArray();
+    }
+
+    static raft::heartbeat_reply from_json(json::Value& rd) {
+        raft::heartbeat_reply obj;
+        json_read(meta);
+        return obj;
+    }
+
+    static std::vector<compat_binary> to_binary(raft::heartbeat_reply obj) {
+        return compat_binary::serde_and_adl(std::move(obj));
+    }
+
+    static bool check(raft::heartbeat_reply expected, compat_binary test) {
+        return verify_adl_or_serde(std::move(expected), std::move(test));
+    }
+};
+
+/*
  * raft::append_entries_reply
  */
 template<>

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -459,4 +459,35 @@ struct compat_check<raft::heartbeat_request> {
     }
 };
 
+/*
+ * raft::append_entries_reply
+ */
+template<>
+struct compat_check<raft::append_entries_reply> {
+    static constexpr std::string_view name = "raft::append_entries_reply";
+
+    static std::vector<raft::append_entries_reply> create_test_cases() {
+        return generate_instances<raft::append_entries_reply>();
+    }
+
+    static void to_json(
+      raft::append_entries_reply obj, json::Writer<json::StringBuffer>& wr) {
+        rjson_serialize(wr, obj);
+    }
+
+    static raft::append_entries_reply from_json(json::Value& rd) {
+        raft::append_entries_reply obj;
+        read_value(rd, obj);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(raft::append_entries_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(raft::append_entries_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -323,4 +323,49 @@ struct instance_generator<raft::append_entries_reply> {
     static std::vector<raft::append_entries_reply> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<raft::heartbeat_reply> {
+    static raft::heartbeat_reply random() {
+        auto ret = raft::heartbeat_reply{{
+          instance_generator<raft::append_entries_reply>::random(),
+          instance_generator<raft::append_entries_reply>::random(),
+        }};
+
+        /*
+         * override node_id and target_node_id heartbeat_reply encoding assumes
+         * that the first node/target_node in the heartbeat set have the same
+         * node_id (revisions can be different).  that needs to be true here in
+         * the generated data otherwise we won't compare equal at after
+         * deserialization.
+         */
+        const auto node_id = tests::random_named_int<model::node_id>();
+        const auto target_node_id = tests::random_named_int<model::node_id>();
+
+        for (auto& r : ret.meta) {
+            r.target_node_id = raft::vnode{
+              target_node_id, r.target_node_id.revision()};
+            r.node_id = raft::vnode{node_id, r.target_node_id.revision()};
+        }
+
+        /*
+         * encoder will sort before serializing, so for equality test to work
+         * after deserializing we sort here first so that the json value we save
+         * has the same ordering.
+         */
+        struct sorter_fn {
+            constexpr bool operator()(
+              const raft::append_entries_reply& lhs,
+              const raft::append_entries_reply& rhs) const {
+                return lhs.last_flushed_log_index < rhs.last_flushed_log_index;
+            }
+        };
+
+        std::sort(ret.meta.begin(), ret.meta.end(), sorter_fn{});
+
+        return ret;
+    }
+
+    static std::vector<raft::heartbeat_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "compat/generator.h"
+#include "model/tests/random_batch.h"
 #include "raft/types.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"
@@ -299,6 +300,23 @@ struct instance_generator<raft::heartbeat_request> {
     }
 
     static std::vector<raft::heartbeat_request> limits() { return {}; }
+};
+
+template<>
+struct instance_generator<raft::append_entries_request> {
+    static raft::append_entries_request random() {
+        return raft::append_entries_request{
+          instance_generator<raft::vnode>::random(),
+          instance_generator<raft::vnode>::random(),
+          instance_generator<raft::protocol_metadata>::random(),
+          model::make_memory_record_batch_reader(
+            model::test::make_random_batches(model::offset(0), 3, false)),
+          raft::append_entries_request::flush_after_append(
+            tests::random_bool()),
+        };
+    }
+
+    static std::vector<raft::append_entries_request> limits() { return {}; }
 };
 
 template<>

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -301,4 +301,26 @@ struct instance_generator<raft::heartbeat_request> {
     static std::vector<raft::heartbeat_request> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<raft::append_entries_reply> {
+    static raft::append_entries_reply random() {
+        return {
+          .target_node_id = instance_generator<raft::vnode>::random(),
+          .node_id = instance_generator<raft::vnode>::random(),
+          .group = tests::random_named_int<raft::group_id>(),
+          .term = tests::random_named_int<model::term_id>(),
+          .last_flushed_log_index = tests::random_named_int<model::offset>(),
+          .last_dirty_log_index = tests::random_named_int<model::offset>(),
+          .last_term_base_offset = tests::random_named_int<model::offset>(),
+          .result = random_generators::random_choice(
+            {raft::append_entries_reply::status::success,
+             raft::append_entries_reply::status::failure,
+             raft::append_entries_reply::status::group_unavailable,
+             raft::append_entries_reply::status::timeout}),
+        };
+    }
+
+    static std::vector<raft::append_entries_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -82,4 +82,45 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
+inline void read_value(json::Value const& rd, raft::append_entries_reply& out) {
+    raft::append_entries_reply obj;
+    json_read(target_node_id);
+    json_read(node_id);
+    json_read(group);
+    json_read(term);
+    json_read(last_flushed_log_index);
+    json_read(last_dirty_log_index);
+    json_read(last_term_base_offset);
+    auto result = read_member_enum(rd, "result", obj.result);
+    switch (result) {
+    case 0:
+        obj.result = raft::append_entries_reply::status::success;
+        break;
+    case 1:
+        obj.result = raft::append_entries_reply::status::failure;
+        break;
+    case 2:
+        obj.result = raft::append_entries_reply::status::group_unavailable;
+        break;
+    case 3:
+        obj.result = raft::append_entries_reply::status::timeout;
+        break;
+    default:
+        vassert(false, "invalid result {}", result);
+    }
+    out = obj;
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& wr, const raft::append_entries_reply& obj) {
+    json_write(target_node_id);
+    json_write(node_id);
+    json_write(group);
+    json_write(term);
+    json_write(last_flushed_log_index);
+    json_write(last_dirty_log_index);
+    json_write(last_term_base_offset);
+    json_write(result);
+}
+
 } // namespace json

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -33,4 +33,53 @@ inline void read_value(json::Value const& rd, raft::vnode& obj) {
     obj = raft::vnode(node_id, revision);
 }
 
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const raft::protocol_metadata& v) {
+    w.StartObject();
+    w.Key("group");
+    rjson_serialize(w, v.group);
+    w.Key("commit_index");
+    rjson_serialize(w, v.commit_index);
+    w.Key("term");
+    rjson_serialize(w, v.term);
+    w.Key("prev_log_index");
+    rjson_serialize(w, v.prev_log_index);
+    w.Key("prev_log_term");
+    rjson_serialize(w, v.prev_log_term);
+    w.Key("last_visible_index");
+    rjson_serialize(w, v.last_visible_index);
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, raft::protocol_metadata& obj) {
+    raft::protocol_metadata tmp;
+    read_member(rd, "group", tmp.group);
+    read_member(rd, "commit_index", tmp.commit_index);
+    read_member(rd, "term", tmp.term);
+    read_member(rd, "prev_log_index", tmp.prev_log_index);
+    read_member(rd, "prev_log_term", tmp.prev_log_term);
+    read_member(rd, "last_visible_index", tmp.last_visible_index);
+    obj = tmp;
+}
+
+inline void read_value(json::Value const& rd, raft::heartbeat_metadata& obj) {
+    raft::heartbeat_metadata tmp;
+    read_member(rd, "meta", tmp.meta);
+    read_member(rd, "node_id", tmp.node_id);
+    read_member(rd, "target_node_id", tmp.target_node_id);
+    obj = tmp;
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const raft::heartbeat_metadata& v) {
+    w.StartObject();
+    w.Key("meta");
+    rjson_serialize(w, v.meta);
+    w.Key("node_id");
+    rjson_serialize(w, v.node_id);
+    w.Key("target_node_id");
+    rjson_serialize(w, v.target_node_id);
+    w.EndObject();
+}
+
 } // namespace json

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -39,6 +39,7 @@ using compat_checks = type_list<
   raft::vote_request,
   raft::vote_reply,
   raft::heartbeat_request,
+  raft::heartbeat_reply,
   raft::append_entries_reply,
   cluster::update_leadership_request,
   cluster::config_status,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -39,6 +39,7 @@ using compat_checks = type_list<
   raft::vote_request,
   raft::vote_reply,
   raft::heartbeat_request,
+  raft::append_entries_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -40,6 +40,7 @@ using compat_checks = type_list<
   raft::vote_reply,
   raft::heartbeat_request,
   raft::heartbeat_reply,
+  raft::append_entries_request,
   raft::append_entries_reply,
   cluster::update_leadership_request,
   cluster::config_status,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -225,10 +225,12 @@ ss::future<> write_corpus(const std::filesystem::path& dir) {
 
 ss::future<> check_type(const std::filesystem::path& file) {
     return read_fully_to_string(file).then([file](auto data) {
-        json::Document doc;
-        doc.Parse(data);
-        vassert(!doc.HasParseError(), "JSON {} has parse errors", file);
-        check(std::move(doc));
+        return ss::async([&] {
+            json::Document doc;
+            doc.Parse(data);
+            vassert(!doc.HasParseError(), "JSON {} has parse errors", file);
+            check(std::move(doc));
+        });
     });
 }
 

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -38,6 +38,7 @@ using compat_checks = type_list<
   raft::install_snapshot_reply,
   raft::vote_request,
   raft::vote_reply,
+  raft::heartbeat_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -91,4 +91,14 @@ void rjson_serialize(
     w.EndArray();
 }
 
+template<typename T, typename A>
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const ss::circular_buffer<T, A>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
 } // namespace json

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -197,7 +197,8 @@ std::ostream& operator<<(std::ostream& o, const consistency_level& l) {
 std::ostream& operator<<(std::ostream& o, const protocol_metadata& m) {
     return o << "{raft_group:" << m.group << ", commit_index:" << m.commit_index
              << ", term:" << m.term << ", prev_log_index:" << m.prev_log_index
-             << ", prev_log_term:" << m.prev_log_term << "}";
+             << ", prev_log_term:" << m.prev_log_term
+             << ", last_visible_index:" << m.last_visible_index << "}";
 }
 std::ostream& operator<<(std::ostream& o, const vote_reply& r) {
     return o << "{term:" << r.term << ", target_node_id" << r.target_node_id

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -259,6 +259,18 @@ struct append_entries_request
           req.flush);
     }
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const append_entries_request& r) {
+        fmt::print(
+          o,
+          "node_id {} target_node_id {} meta {} batches {}",
+          r.node_id,
+          r.target_node_id,
+          r.meta,
+          r._batches);
+        return o;
+    }
+
     ss::future<> serde_async_write(iobuf& out);
     ss::future<> serde_async_read(iobuf_parser&, const serde::header&);
 


### PR DESCRIPTION
## Cover letter

Integrates the remaining components of the raft rpc layer into the compat framework.

## Release notes

* None
