### PR TITLE
tests: make redpanda methods more thread-safe

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1141,7 +1141,7 @@ class RedpandaService(Service):
                 "Nodes report restart required but expect_restart is False")
 
     def monitor_log(self, node):
-        assert node in self._started
+        assert node in self.nodes
         return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
 
     def raise_on_crash(self):
@@ -1741,12 +1741,12 @@ class RedpandaService(Service):
         }
 
     def broker_address(self, node):
-        assert node in self._started
+        assert node in self.nodes
         cfg = self._node_configs[node]
         return f"{node.account.hostname}:{one_or_many(cfg['redpanda']['kafka_api'])['port']}"
 
     def admin_endpoint(self, node):
-        assert node in self._started
+        assert node in self.nodes
         return f"{node.account.hostname}:9644"
 
     def admin_endpoints_list(self):


### PR DESCRIPTION
## Cover letter

Several methods that run for a particular node check that the node is
started. This is somewhat reasonable as we typically expect to want to
run get info for just the started nodes. However, this doesn't play well
if calling any of these concurrently with a restart (removes from the
list of started nodes, then re-adds).

This commit makes the methods more thread-safe by checking the node is
in the immutable full set of nodes, rather than just the started nodes.
We do lose out on preventing some potential programmatic errors here,
but it seems worth the slightly improved thread safety.

Fixes https://github.com/redpanda-data/redpanda/issues/5827


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

