### PR TITLE
compat: add support for additional cluster:: types

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2122,6 +2122,12 @@ struct finish_reallocation_reply
       = default;
 
     auto serde_fields() { return std::tie(error); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const finish_reallocation_reply& r) {
+        fmt::print(o, "error {}", r.error);
+        return o;
+    }
 };
 
 struct set_maintenance_mode_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2141,6 +2141,12 @@ struct set_maintenance_mode_request
       = default;
 
     auto serde_fields() { return std::tie(id, enabled); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const set_maintenance_mode_request& r) {
+        fmt::print(o, "id {} enabled {}", r.id, r.enabled);
+        return o;
+    }
 };
 
 struct set_maintenance_mode_reply

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2054,6 +2054,12 @@ struct decommission_node_reply
       = default;
 
     auto serde_fields() { return std::tie(error); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const decommission_node_reply& r) {
+        fmt::print(o, "error {}", r.error);
+        return o;
+    }
 };
 
 struct recommission_node_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2159,6 +2159,12 @@ struct set_maintenance_mode_reply
       = default;
 
     auto serde_fields() { return std::tie(error); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const set_maintenance_mode_reply& r) {
+        fmt::print(o, "error {}", r.error);
+        return o;
+    }
 };
 
 struct config_status_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -921,6 +921,11 @@ struct join_request : serde::envelope<join_request, serde::version<0>> {
 
     friend bool operator==(const join_request&, const join_request&) = default;
 
+    friend std::ostream& operator<<(std::ostream& o, const join_request& r) {
+        fmt::print(o, "node {}", r.node);
+        return o;
+    }
+
     auto serde_fields() { return std::tie(node); }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1005,6 +1005,11 @@ struct join_node_reply : serde::envelope<join_node_reply, serde::version<0>> {
     friend bool operator==(const join_node_reply&, const join_node_reply&)
       = default;
 
+    friend std::ostream& operator<<(std::ostream& o, const join_node_reply& r) {
+        fmt::print(o, "success {} id {}", r.success, r.id);
+        return o;
+    }
+
     auto serde_fields() { return std::tie(success, id); }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2037,6 +2037,12 @@ struct decommission_node_request
       = default;
 
     auto serde_fields() { return std::tie(id); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const decommission_node_request& r) {
+        fmt::print(o, "id {}", r.id);
+        return o;
+    }
 };
 
 struct decommission_node_reply

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2071,6 +2071,12 @@ struct recommission_node_request
       = default;
 
     auto serde_fields() { return std::tie(id); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const recommission_node_request& r) {
+        fmt::print(o, "id {}", r.id);
+        return o;
+    }
 };
 
 struct recommission_node_reply

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -939,6 +939,11 @@ struct join_reply : serde::envelope<join_reply, serde::version<0>> {
 
     friend bool operator==(const join_reply&, const join_reply&) = default;
 
+    friend std::ostream& operator<<(std::ostream& o, const join_reply& r) {
+        fmt::print(o, "success {}", r.success);
+        return o;
+    }
+
     auto serde_fields() { return std::tie(success); }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -978,6 +978,17 @@ struct join_node_request
     friend bool operator==(const join_node_request&, const join_node_request&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const join_node_request& r) {
+        fmt::print(
+          o,
+          "logical_version {} node_uuid {} node {}",
+          r.logical_version,
+          r.node_uuid,
+          r.node);
+        return o;
+    }
+
     auto serde_fields() { return std::tie(logical_version, node_uuid, node); }
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2088,6 +2088,12 @@ struct recommission_node_reply
       = default;
 
     auto serde_fields() { return std::tie(error); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const recommission_node_reply& r) {
+        fmt::print(o, "error {}", r.error);
+        return o;
+    }
 };
 
 struct finish_reallocation_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2105,6 +2105,12 @@ struct finish_reallocation_request
       = default;
 
     auto serde_fields() { return std::tie(id); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const finish_reallocation_request& r) {
+        fmt::print(o, "id {}", r.id);
+        return o;
+    }
 };
 
 struct finish_reallocation_reply

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -157,4 +157,32 @@ bool verify_adl_or_serde(T expected, compat_binary test) {
     return true;
 }
 
+#define GEN_COMPAT_CHECK(Type, ToJson, FromJson)                               \
+    template<>                                                                 \
+    struct compat_check<Type> {                                                \
+        static constexpr std::string_view name = #Type;                        \
+                                                                               \
+        static std::vector<Type> create_test_cases() {                         \
+            return generate_instances<Type>();                                 \
+        }                                                                      \
+                                                                               \
+        static void to_json(Type obj, json::Writer<json::StringBuffer>& wr) {  \
+            ToJson;                                                            \
+        }                                                                      \
+                                                                               \
+        static Type from_json(json::Value& rd) {                               \
+            Type obj;                                                          \
+            FromJson;                                                          \
+            return obj;                                                        \
+        }                                                                      \
+                                                                               \
+        static std::vector<compat_binary> to_binary(Type obj) {                \
+            return compat_binary::serde_and_adl(obj);                          \
+        }                                                                      \
+                                                                               \
+        static bool check(Type obj, compat_binary test) {                      \
+            return verify_adl_or_serde(obj, std::move(test));                  \
+        }                                                                      \
+    };
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -173,4 +173,7 @@ GEN_COMPAT_CHECK(
   { json_write(error); },
   { json_read(error); })
 
+GEN_COMPAT_CHECK(
+  cluster::finish_reallocation_request, { json_write(id); }, { json_read(id); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -168,4 +168,9 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::recommission_node_request, { json_write(id); }, { json_read(id); })
 
+GEN_COMPAT_CHECK(
+  cluster::recommission_node_reply,
+  { json_write(error); },
+  { json_read(error); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -16,34 +16,6 @@
 #include "compat/cluster_json.h"
 #include "compat/json.h"
 
-#define GEN_COMPAT_CHECK(Type, ToJson, FromJson)                               \
-    template<>                                                                 \
-    struct compat_check<Type> {                                                \
-        static constexpr std::string_view name = #Type;                        \
-                                                                               \
-        static std::vector<Type> create_test_cases() {                         \
-            return generate_instances<Type>();                                 \
-        }                                                                      \
-                                                                               \
-        static void to_json(Type obj, json::Writer<json::StringBuffer>& wr) {  \
-            ToJson;                                                            \
-        }                                                                      \
-                                                                               \
-        static Type from_json(json::Value& rd) {                               \
-            Type obj;                                                          \
-            FromJson;                                                          \
-            return obj;                                                        \
-        }                                                                      \
-                                                                               \
-        static std::vector<compat_binary> to_binary(Type obj) {                \
-            return compat_binary::serde_and_adl(obj);                          \
-        }                                                                      \
-                                                                               \
-        static bool check(Type obj, compat_binary test) {                      \
-            return verify_adl_or_serde(obj, std::move(test));                  \
-        }                                                                      \
-    };
-
 namespace compat {
 
 GEN_COMPAT_CHECK(

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -160,4 +160,9 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::decommission_node_request, { json_write(id); }, { json_read(id); })
 
+GEN_COMPAT_CHECK(
+  cluster::decommission_node_reply,
+  { json_write(error); },
+  { json_read(error); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -192,4 +192,9 @@ GEN_COMPAT_CHECK(
       json_read(enabled);
   })
 
+GEN_COMPAT_CHECK(
+  cluster::set_maintenance_mode_reply,
+  { json_write(error); },
+  { json_read(error); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -127,4 +127,7 @@ GEN_COMPAT_CHECK(
       json_read(complete);
   });
 
+GEN_COMPAT_CHECK(
+  cluster::join_request, { json_write(node); }, { json_read(node); });
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -165,4 +165,7 @@ GEN_COMPAT_CHECK(
   { json_write(error); },
   { json_read(error); })
 
+GEN_COMPAT_CHECK(
+  cluster::recommission_node_request, { json_write(id); }, { json_read(id); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -133,4 +133,17 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::join_reply, { json_write(success); }, { json_read(success); });
 
+GEN_COMPAT_CHECK(
+  cluster::join_node_request,
+  {
+      json_write(logical_version);
+      json_write(node_uuid);
+      json_write(node);
+  },
+  {
+      json_read(logical_version);
+      json_read(node_uuid);
+      json_read(node);
+  });
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -176,4 +176,9 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::finish_reallocation_request, { json_write(id); }, { json_read(id); })
 
+GEN_COMPAT_CHECK(
+  cluster::finish_reallocation_reply,
+  { json_write(error); },
+  { json_read(error); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -157,4 +157,7 @@ GEN_COMPAT_CHECK(
       json_read(id);
   })
 
+GEN_COMPAT_CHECK(
+  cluster::decommission_node_request, { json_write(id); }, { json_read(id); })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -146,4 +146,15 @@ GEN_COMPAT_CHECK(
       json_read(node);
   });
 
+GEN_COMPAT_CHECK(
+  cluster::join_node_reply,
+  {
+      json_write(success);
+      json_write(id);
+  },
+  {
+      json_read(success);
+      json_read(id);
+  })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -181,4 +181,15 @@ GEN_COMPAT_CHECK(
   { json_write(error); },
   { json_read(error); })
 
+GEN_COMPAT_CHECK(
+  cluster::set_maintenance_mode_request,
+  {
+      json_write(id);
+      json_write(enabled);
+  },
+  {
+      json_read(id);
+      json_read(enabled);
+  })
+
 } // namespace compat

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -130,4 +130,7 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::join_request, { json_write(node); }, { json_read(node); });
 
+GEN_COMPAT_CHECK(
+  cluster::join_reply, { json_write(success); }, { json_read(success); });
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -312,4 +312,15 @@ struct instance_generator<cluster::recommission_node_reply> {
     static std::vector<cluster::recommission_node_reply> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::finish_reallocation_request> {
+    static cluster::finish_reallocation_request random() {
+        return {.id = tests::random_named_int<model::node_id>()};
+    }
+
+    static std::vector<cluster::finish_reallocation_request> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -283,4 +283,13 @@ struct instance_generator<cluster::decommission_node_request> {
     }
 };
 
+template<>
+struct instance_generator<cluster::decommission_node_reply> {
+    static cluster::decommission_node_reply random() {
+        return {.error = instance_generator<cluster::errc>::random()};
+    }
+
+    static std::vector<cluster::decommission_node_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -303,4 +303,13 @@ struct instance_generator<cluster::recommission_node_request> {
     }
 };
 
+template<>
+struct instance_generator<cluster::recommission_node_reply> {
+    static cluster::recommission_node_reply random() {
+        return {.error = instance_generator<cluster::errc>::random()};
+    }
+
+    static std::vector<cluster::recommission_node_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -323,4 +323,15 @@ struct instance_generator<cluster::finish_reallocation_request> {
     }
 };
 
+template<>
+struct instance_generator<cluster::finish_reallocation_reply> {
+    static cluster::finish_reallocation_reply random() {
+        return {.error = instance_generator<cluster::errc>::random()};
+    }
+
+    static std::vector<cluster::finish_reallocation_reply> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -334,4 +334,17 @@ struct instance_generator<cluster::finish_reallocation_reply> {
     }
 };
 
+template<>
+struct instance_generator<cluster::set_maintenance_mode_request> {
+    static cluster::set_maintenance_mode_request random() {
+        return {
+          .id = tests::random_named_int<model::node_id>(),
+          .enabled = tests::random_bool()};
+    }
+
+    static std::vector<cluster::set_maintenance_mode_request> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -262,4 +262,14 @@ struct instance_generator<cluster::join_node_request> {
     static std::vector<cluster::join_node_request> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::join_node_reply> {
+    static cluster::join_node_reply random() {
+        return cluster::join_node_reply{
+          tests::random_bool(), tests::random_named_int<model::node_id>()};
+    }
+
+    static std::vector<cluster::join_node_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -240,4 +240,13 @@ struct instance_generator<cluster::join_request> {
     static std::vector<cluster::join_request> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::join_reply> {
+    static cluster::join_reply random() {
+        return cluster::join_reply{tests::random_bool()};
+    }
+
+    static std::vector<cluster::join_reply> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -249,4 +249,17 @@ struct instance_generator<cluster::join_reply> {
     static std::vector<cluster::join_reply> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::join_node_request> {
+    static cluster::join_node_request random() {
+        return cluster::join_node_request{
+          tests::random_named_int<cluster::cluster_version>(),
+          tests::random_vector(
+            [] { return random_generators::get_int<uint8_t>(); }),
+          model::random_broker()};
+    }
+
+    static std::vector<cluster::join_node_request> limits() { return {}; }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -292,4 +292,15 @@ struct instance_generator<cluster::decommission_node_reply> {
     static std::vector<cluster::decommission_node_reply> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::recommission_node_request> {
+    static cluster::recommission_node_request random() {
+        return {.id = tests::random_named_int<model::node_id>()};
+    }
+
+    static std::vector<cluster::recommission_node_request> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -347,4 +347,15 @@ struct instance_generator<cluster::set_maintenance_mode_request> {
     }
 };
 
+template<>
+struct instance_generator<cluster::set_maintenance_mode_reply> {
+    static cluster::set_maintenance_mode_reply random() {
+        return {.error = instance_generator<cluster::errc>::random()};
+    }
+
+    static std::vector<cluster::set_maintenance_mode_reply> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -272,4 +272,15 @@ struct instance_generator<cluster::join_node_reply> {
     static std::vector<cluster::join_node_reply> limits() { return {}; }
 };
 
+template<>
+struct instance_generator<cluster::decommission_node_request> {
+    static cluster::decommission_node_request random() {
+        return {.id = tests::random_named_int<model::node_id>()};
+    }
+
+    static std::vector<cluster::decommission_node_request> limits() {
+        return {};
+    }
+};
+
 } // namespace compat

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -13,6 +13,7 @@
 #include "cluster/errc.h"
 #include "cluster/types.h"
 #include "compat/generator.h"
+#include "model/tests/randoms.h"
 #include "test_utils/randoms.h"
 
 namespace compat {
@@ -228,6 +229,15 @@ struct instance_generator<cluster::feature_barrier_response> {
     static std::vector<cluster::feature_barrier_response> limits() {
         return {};
     }
+};
+
+template<>
+struct instance_generator<cluster::join_request> {
+    static cluster::join_request random() {
+        return cluster::join_request{model::random_broker()};
+    }
+
+    static std::vector<cluster::join_request> limits() { return {}; }
 };
 
 } // namespace compat

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -13,6 +13,7 @@
 #include "json/document.h"
 #include "json/json.h"
 #include "model/fundamental.h"
+#include "net/unresolved_address.h"
 #include "utils/base64.h"
 
 namespace json {
@@ -163,10 +164,126 @@ void read_value(json::Value const& v, ss::bool_class<T>& target) {
     target = ss::bool_class<T>(v.GetBool());
 }
 
+template<typename T, typename V>
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const std::unordered_map<T, V>& m) {
+    w.StartArray();
+    for (const auto& e : m) {
+        w.StartObject();
+        w.Key("key");
+        rjson_serialize(w, e.first);
+        w.Key("value");
+        rjson_serialize(w, e.second);
+        w.EndObject();
+    }
+    w.EndArray();
+}
+
+template<typename T, typename V>
+inline void read_value(json::Value const& rd, std::unordered_map<T, V>& obj) {
+    for (const auto& e : rd.GetArray()) {
+        T key;
+        read_member(e, "key", key);
+        V value;
+        read_member(e, "value", value);
+        obj.emplace(std::move(key), std::move(value));
+    }
+}
+
 template<typename T>
 inline void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const ss::bool_class<T>& b) {
     rjson_serialize(w, bool(b));
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::broker_properties& b) {
+    w.StartObject();
+    w.Key("cores");
+    rjson_serialize(w, b.cores);
+    w.Key("available_memory_gb");
+    rjson_serialize(w, b.available_memory_gb);
+    w.Key("available_disk_gb");
+    rjson_serialize(w, b.available_disk_gb);
+    w.Key("mount_paths");
+    rjson_serialize(w, b.mount_paths);
+    w.Key("etc_props");
+    rjson_serialize(w, b.etc_props);
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, model::broker_properties& obj) {
+    read_member(rd, "cores", obj.cores);
+    read_member(rd, "available_memory_gb", obj.available_memory_gb);
+    read_member(rd, "available_disk_gb", obj.available_disk_gb);
+    read_member(rd, "mount_paths", obj.mount_paths);
+    read_member(rd, "etc_props", obj.etc_props);
+}
+
+inline void
+read_value(json::Value const& rd, ss::net::inet_address::family& obj) {
+    obj = static_cast<ss::net::inet_address::family>(rd.GetInt());
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const ss::net::inet_address::family& b) {
+    w.Int(static_cast<int>(b));
+}
+
+inline void read_value(json::Value const& rd, net::unresolved_address& obj) {
+    ss::sstring host;
+    uint16_t port{0};
+    read_member(rd, "address", host);
+    read_member(rd, "port", port);
+    obj = net::unresolved_address(std::move(host), port);
+}
+
+inline void read_value(json::Value const& rd, model::broker_endpoint& obj) {
+    ss::sstring host;
+    uint16_t port{0};
+
+    read_member(rd, "name", obj.name);
+    read_member(rd, "address", host);
+    read_member(rd, "port", port);
+
+    obj.address = net::unresolved_address(std::move(host), port);
+}
+
+inline void
+rjson_serialize(json::Writer<json::StringBuffer>& w, const model::broker& b) {
+    w.StartObject();
+    w.Key("id");
+    rjson_serialize(w, b.id());
+    w.Key("kafka_advertised_listeners");
+    rjson_serialize(w, b.kafka_advertised_listeners());
+    w.Key("rpc_address");
+    rjson_serialize(w, b.rpc_address());
+    w.Key("rack");
+    rjson_serialize(w, b.rack());
+    w.Key("properties");
+    rjson_serialize(w, b.properties());
+    w.EndObject();
+}
+
+inline void read_value(json::Value const& rd, model::broker& obj) {
+    model::node_id id;
+    std::vector<model::broker_endpoint> kafka_advertised_listeners;
+    net::unresolved_address rpc_address;
+    std::optional<model::rack_id> rack;
+    model::broker_properties properties;
+
+    read_member(rd, "id", id);
+    read_member(rd, "kafka_advertised_listeners", kafka_advertised_listeners);
+    read_member(rd, "rpc_address", rpc_address);
+    read_member(rd, "rack", rack);
+    read_member(rd, "properties", properties);
+
+    obj = model::broker(
+      id,
+      std::move(kafka_advertised_listeners),
+      std::move(rpc_address),
+      std::move(rack),
+      std::move(properties));
 }
 
 #define json_write(_fname) json::write_member(wr, #_fname, obj._fname)

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -48,6 +48,7 @@ using compat_checks = type_list<
   raft::append_entries_reply,
   cluster::join_request,
   cluster::join_reply,
+  cluster::join_node_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -55,6 +55,7 @@ using compat_checks = type_list<
   cluster::recommission_node_request,
   cluster::recommission_node_reply,
   cluster::finish_reallocation_request,
+  cluster::finish_reallocation_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -56,6 +56,7 @@ using compat_checks = type_list<
   cluster::recommission_node_reply,
   cluster::finish_reallocation_request,
   cluster::finish_reallocation_reply,
+  cluster::set_maintenance_mode_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -46,6 +46,7 @@ using compat_checks = type_list<
   raft::heartbeat_reply,
   raft::append_entries_request,
   raft::append_entries_reply,
+  cluster::join_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -49,6 +49,7 @@ using compat_checks = type_list<
   cluster::join_request,
   cluster::join_reply,
   cluster::join_node_request,
+  cluster::join_node_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -50,6 +50,7 @@ using compat_checks = type_list<
   cluster::join_reply,
   cluster::join_node_request,
   cluster::join_node_reply,
+  cluster::decommission_node_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -51,6 +51,7 @@ using compat_checks = type_list<
   cluster::join_node_request,
   cluster::join_node_reply,
   cluster::decommission_node_request,
+  cluster::decommission_node_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -52,6 +52,7 @@ using compat_checks = type_list<
   cluster::join_node_reply,
   cluster::decommission_node_request,
   cluster::decommission_node_reply,
+  cluster::recommission_node_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -111,7 +111,9 @@ struct corpus_helper {
 
         w.Key("binaries");
         w.StartArray();
-        for (auto& b : checker::to_binary(std::move(tb))) {
+        auto binaries = checker::to_binary(std::move(tb));
+        vassert(!binaries.empty(), "No binaries found for {}", checker::name);
+        for (auto& b : binaries) {
             w.StartObject();
             w.Key("name");
             w.String(b.name);
@@ -129,7 +131,9 @@ struct corpus_helper {
     static ss::future<> write(const std::filesystem::path& dir) {
         size_t instance = 0;
 
-        for (auto& test : checker::create_test_cases()) {
+        auto test_cases = checker::create_test_cases();
+        vassert(!test_cases.empty(), "No test cases for {}", checker::name);
+        for (auto& test : test_cases) {
             // json encoded test case
             auto buf = json::StringBuffer{};
             auto writer = json::Writer<json::StringBuffer>{buf};
@@ -164,6 +168,7 @@ struct corpus_helper {
         vassert(doc["binaries"].IsArray(), "binaries is not an array");
         auto binaries = doc["binaries"].GetArray();
 
+        vassert(!binaries.Empty(), "No binaries found for {}", checker::name);
         for (const auto& encoding : binaries) {
             vassert(encoding.IsObject(), "binaries entry is not an object");
             auto binary = encoding.GetObject();

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -54,6 +54,7 @@ using compat_checks = type_list<
   cluster::decommission_node_reply,
   cluster::recommission_node_request,
   cluster::recommission_node_reply,
+  cluster::finish_reallocation_request,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -47,6 +47,7 @@ using compat_checks = type_list<
   raft::append_entries_request,
   raft::append_entries_reply,
   cluster::join_request,
+  cluster::join_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -53,6 +53,7 @@ using compat_checks = type_list<
   cluster::decommission_node_request,
   cluster::decommission_node_reply,
   cluster::recommission_node_request,
+  cluster::recommission_node_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -57,6 +57,7 @@ using compat_checks = type_list<
   cluster::finish_reallocation_request,
   cluster::finish_reallocation_reply,
   cluster::set_maintenance_mode_request,
+  cluster::set_maintenance_mode_reply,
   cluster::update_leadership_request,
   cluster::config_status,
   cluster::cluster_property_kv,


### PR DESCRIPTION
## Cover letter

Adds support for various cluster:: types into the compat framework.

## Release notes

* None