### PR TITLE
compat: add support for some tx types

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -609,6 +609,22 @@ std::ostream& operator<<(std::ostream& o, const commit_tx_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const abort_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} pid {} tx_seq {} timeout {}}}",
+      r.ntp,
+      r.pid,
+      r.tx_seq,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const abort_tx_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -642,6 +642,24 @@ std::ostream& operator<<(std::ostream& o, const begin_group_tx_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const prepare_group_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} group_id {} etag {} pid {} tx_seq {} timeout {}}}",
+      r.ntp,
+      r.group_id,
+      r.etag,
+      r.pid,
+      r.tx_seq,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const prepare_group_tx_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -593,6 +593,22 @@ std::ostream& operator<<(
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const commit_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} pid {} tx_seq {} timeout {}}}",
+      r.ntp,
+      r.pid,
+      r.tx_seq,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const commit_tx_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -625,6 +625,23 @@ std::ostream& operator<<(std::ostream& o, const abort_tx_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const begin_group_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} group_id {} pid {} tx_seq {} timeout {}}}",
+      r.ntp,
+      r.group_id,
+      r.pid,
+      r.tx_seq,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const begin_group_tx_reply& r) {
+    fmt::print(o, "{{etag {} ec {}}}", r.etag, r.ec);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -676,6 +676,9 @@ struct begin_group_tx_request
         write(
           out, std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const begin_group_tx_request& r);
 };
 
 struct begin_group_tx_reply
@@ -697,6 +700,9 @@ struct begin_group_tx_reply
       = default;
 
     auto serde_fields() { return std::tie(etag, ec); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const begin_group_tx_reply& r);
 };
 
 struct prepare_group_tx_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -600,6 +600,7 @@ struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {
         write(
           out, std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
     }
+    friend std::ostream& operator<<(std::ostream& o, const abort_tx_request& r);
 };
 
 struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
@@ -614,6 +615,8 @@ struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
       = default;
 
     auto serde_fields() { return std::tie(ec); }
+
+    friend std::ostream& operator<<(std::ostream& o, const abort_tx_reply& r);
 };
 
 struct begin_group_tx_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -541,6 +541,9 @@ struct commit_tx_request
         write(
           out, std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const commit_tx_request& r);
 };
 
 struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
@@ -555,6 +558,8 @@ struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
       = default;
 
     auto serde_fields() { return std::tie(ec); }
+
+    friend std::ostream& operator<<(std::ostream& o, const commit_tx_reply& r);
 };
 
 struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -764,6 +764,9 @@ struct prepare_group_tx_request
         write(
           out, std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
     }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const prepare_group_tx_request& r);
 };
 
 struct prepare_group_tx_reply
@@ -780,6 +783,9 @@ struct prepare_group_tx_reply
       = default;
 
     auto serde_fields() { return std::tie(ec); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const prepare_group_tx_reply& r);
 };
 
 struct commit_group_tx_request

--- a/src/v/compat/abort_tx_compat.h
+++ b/src/v/compat/abort_tx_compat.h
@@ -20,64 +20,25 @@ namespace compat {
 /*
  * cluster::abort_tx_request
  */
-template<>
-struct compat_check<cluster::abort_tx_request> {
-    static constexpr std::string_view name = "cluster::abort_tx_request";
-
-    static std::vector<cluster::abort_tx_request> create_test_cases() {
-        return generate_instances<cluster::abort_tx_request>();
-    }
-
-    static void to_json(
-      cluster::abort_tx_request obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(ntp);
-        json_write(pid);
-        json_write(tx_seq);
-        json_write(timeout);
-    }
-
-    static cluster::abort_tx_request from_json(json::Value& rd) {
-        cluster::abort_tx_request obj;
-        json_read(ntp);
-        json_read(pid);
-        json_read(tx_seq);
-        json_read(timeout);
-        return obj;
-    }
-
-    static std::vector<compat_binary> to_binary(cluster::abort_tx_request obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-
-    static bool check(cluster::abort_tx_request obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::abort_tx_request,
+  {
+      json_write(ntp);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(timeout);
+  });
 
 /*
  * cluster::abort_tx_reply
  */
-template<>
-struct compat_check<cluster::abort_tx_reply> {
-    static constexpr std::string_view name = "cluster::abort_tx_reply";
-    static std::vector<cluster::abort_tx_reply> create_test_cases() {
-        return generate_instances<cluster::abort_tx_reply>();
-    }
-    static void
-    to_json(cluster::abort_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(ec);
-    }
-    static cluster::abort_tx_reply from_json(json::Value& rd) {
-        cluster::abort_tx_reply obj;
-        json_read(ec);
-        return obj;
-    }
-    static std::vector<compat_binary> to_binary(cluster::abort_tx_reply obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-    static bool check(cluster::abort_tx_reply obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::abort_tx_reply, { json_write(ec); }, { json_read(ec); });
 
 } // namespace compat

--- a/src/v/compat/abort_tx_compat.h
+++ b/src/v/compat/abort_tx_compat.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/abort_tx_generator.h"
+#include "compat/check.h"
+#include "compat/json.h"
+
+namespace compat {
+
+/*
+ * cluster::abort_tx_request
+ */
+template<>
+struct compat_check<cluster::abort_tx_request> {
+    static constexpr std::string_view name = "cluster::abort_tx_request";
+
+    static std::vector<cluster::abort_tx_request> create_test_cases() {
+        return generate_instances<cluster::abort_tx_request>();
+    }
+
+    static void to_json(
+      cluster::abort_tx_request obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(ntp);
+        json_write(pid);
+        json_write(tx_seq);
+        json_write(timeout);
+    }
+
+    static cluster::abort_tx_request from_json(json::Value& rd) {
+        cluster::abort_tx_request obj;
+        json_read(ntp);
+        json_read(pid);
+        json_read(tx_seq);
+        json_read(timeout);
+        return obj;
+    }
+
+    static std::vector<compat_binary> to_binary(cluster::abort_tx_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(cluster::abort_tx_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+/*
+ * cluster::abort_tx_reply
+ */
+template<>
+struct compat_check<cluster::abort_tx_reply> {
+    static constexpr std::string_view name = "cluster::abort_tx_reply";
+    static std::vector<cluster::abort_tx_reply> create_test_cases() {
+        return generate_instances<cluster::abort_tx_reply>();
+    }
+    static void
+    to_json(cluster::abort_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(ec);
+    }
+    static cluster::abort_tx_reply from_json(json::Value& rd) {
+        cluster::abort_tx_reply obj;
+        json_read(ec);
+        return obj;
+    }
+    static std::vector<compat_binary> to_binary(cluster::abort_tx_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+    static bool check(cluster::abort_tx_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/abort_tx_generator.h
+++ b/src/v/compat/abort_tx_generator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "compat/tx_gateway_generator.h"
+#include "model/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::abort_tx_request> {
+    static cluster::abort_tx_request random() {
+        return cluster::abort_tx_request(
+          model::random_ntp(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::abort_tx_request> limits() {
+        return {
+          cluster::abort_tx_request(
+            model::random_ntp(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::min()),
+            min_duration()),
+          cluster::abort_tx_request(
+            model::random_ntp(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::max()),
+            max_duration()),
+        };
+    }
+};
+
+template<>
+struct instance_generator<cluster::abort_tx_reply> {
+    static cluster::abort_tx_reply random() {
+        return cluster::abort_tx_reply(
+          instance_generator<cluster::tx_errc>::random());
+    }
+    static std::vector<cluster::abort_tx_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/begin_group_tx_compat.h
+++ b/src/v/compat/begin_group_tx_compat.h
@@ -20,71 +20,35 @@ namespace compat {
 /*
  * cluster::begin_group_tx_request
  */
-template<>
-struct compat_check<cluster::begin_group_tx_request> {
-    static constexpr std::string_view name = "cluster::begin_group_tx_request";
-
-    static std::vector<cluster::begin_group_tx_request> create_test_cases() {
-        return generate_instances<cluster::begin_group_tx_request>();
-    }
-
-    static void to_json(
-      cluster::begin_group_tx_request obj,
-      json::Writer<json::StringBuffer>& wr) {
-        json_write(ntp);
-        json_write(group_id);
-        json_write(pid);
-        json_write(tx_seq);
-        json_write(timeout);
-    }
-
-    static cluster::begin_group_tx_request from_json(json::Value& rd) {
-        cluster::begin_group_tx_request obj;
-        json_read(ntp);
-        json_read(group_id);
-        json_read(pid);
-        json_read(tx_seq);
-        json_read(timeout);
-        return obj;
-    }
-
-    static std::vector<compat_binary>
-    to_binary(cluster::begin_group_tx_request obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-
-    static bool check(cluster::begin_group_tx_request obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::begin_group_tx_request,
+  {
+      json_write(ntp);
+      json_write(group_id);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(group_id);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(timeout);
+  });
 
 /*
  * cluster::begin_group_tx_reply
  */
-template<>
-struct compat_check<cluster::begin_group_tx_reply> {
-    static constexpr std::string_view name = "cluster::begin_group_tx_reply";
-    static std::vector<cluster::begin_group_tx_reply> create_test_cases() {
-        return generate_instances<cluster::begin_group_tx_reply>();
-    }
-    static void to_json(
-      cluster::begin_group_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(etag);
-        json_write(ec);
-    }
-    static cluster::begin_group_tx_reply from_json(json::Value& rd) {
-        cluster::begin_group_tx_reply obj;
-        json_read(etag);
-        json_read(ec);
-        return obj;
-    }
-    static std::vector<compat_binary>
-    to_binary(cluster::begin_group_tx_reply obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-    static bool check(cluster::begin_group_tx_reply obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::begin_group_tx_reply,
+  {
+      json_write(etag);
+      json_write(ec);
+  },
+  {
+      json_read(etag);
+      json_read(ec);
+  });
 
 } // namespace compat

--- a/src/v/compat/begin_group_tx_compat.h
+++ b/src/v/compat/begin_group_tx_compat.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/begin_group_tx_generator.h"
+#include "compat/check.h"
+#include "compat/json.h"
+
+namespace compat {
+
+/*
+ * cluster::begin_group_tx_request
+ */
+template<>
+struct compat_check<cluster::begin_group_tx_request> {
+    static constexpr std::string_view name = "cluster::begin_group_tx_request";
+
+    static std::vector<cluster::begin_group_tx_request> create_test_cases() {
+        return generate_instances<cluster::begin_group_tx_request>();
+    }
+
+    static void to_json(
+      cluster::begin_group_tx_request obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(ntp);
+        json_write(group_id);
+        json_write(pid);
+        json_write(tx_seq);
+        json_write(timeout);
+    }
+
+    static cluster::begin_group_tx_request from_json(json::Value& rd) {
+        cluster::begin_group_tx_request obj;
+        json_read(ntp);
+        json_read(group_id);
+        json_read(pid);
+        json_read(tx_seq);
+        json_read(timeout);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::begin_group_tx_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(cluster::begin_group_tx_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+/*
+ * cluster::begin_group_tx_reply
+ */
+template<>
+struct compat_check<cluster::begin_group_tx_reply> {
+    static constexpr std::string_view name = "cluster::begin_group_tx_reply";
+    static std::vector<cluster::begin_group_tx_reply> create_test_cases() {
+        return generate_instances<cluster::begin_group_tx_reply>();
+    }
+    static void to_json(
+      cluster::begin_group_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(etag);
+        json_write(ec);
+    }
+    static cluster::begin_group_tx_reply from_json(json::Value& rd) {
+        cluster::begin_group_tx_reply obj;
+        json_read(etag);
+        json_read(ec);
+        return obj;
+    }
+    static std::vector<compat_binary>
+    to_binary(cluster::begin_group_tx_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+    static bool check(cluster::begin_group_tx_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/begin_group_tx_generator.h
+++ b/src/v/compat/begin_group_tx_generator.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "compat/tx_gateway_generator.h"
+#include "model/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::begin_group_tx_request> {
+    static cluster::begin_group_tx_request random() {
+        return cluster::begin_group_tx_request(
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::begin_group_tx_request> limits() {
+        return {
+          cluster::begin_group_tx_request(
+            model::random_ntp(),
+            tests::random_named_string<kafka::group_id>(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::min()),
+            min_duration()),
+          cluster::begin_group_tx_request(
+            model::random_ntp(),
+            tests::random_named_string<kafka::group_id>(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::max()),
+            max_duration()),
+        };
+    }
+};
+
+template<>
+struct instance_generator<cluster::begin_group_tx_reply> {
+    static cluster::begin_group_tx_reply random() {
+        return cluster::begin_group_tx_reply(
+          tests::random_named_int<model::term_id>(),
+          instance_generator<cluster::tx_errc>::random());
+    }
+    static std::vector<cluster::begin_group_tx_reply> limits() {
+        return {
+          cluster::begin_group_tx_reply(
+            model::term_id(std::numeric_limits<int64_t>::min()),
+            cluster::tx_errc::none),
+          cluster::begin_group_tx_reply(
+            model::term_id(std::numeric_limits<int64_t>::max()),
+            cluster::tx_errc::invalid_txn_state),
+        };
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/commit_tx_compat.h
+++ b/src/v/compat/commit_tx_compat.h
@@ -20,65 +20,25 @@ namespace compat {
 /*
  * cluster::commit_tx_request
  */
-template<>
-struct compat_check<cluster::commit_tx_request> {
-    static constexpr std::string_view name = "cluster::commit_tx_request";
-
-    static std::vector<cluster::commit_tx_request> create_test_cases() {
-        return generate_instances<cluster::commit_tx_request>();
-    }
-
-    static void to_json(
-      cluster::commit_tx_request obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(ntp);
-        json_write(pid);
-        json_write(tx_seq);
-        json_write(timeout);
-    }
-
-    static cluster::commit_tx_request from_json(json::Value& rd) {
-        cluster::commit_tx_request obj;
-        json_read(ntp);
-        json_read(pid);
-        json_read(tx_seq);
-        json_read(timeout);
-        return obj;
-    }
-
-    static std::vector<compat_binary>
-    to_binary(cluster::commit_tx_request obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-
-    static bool check(cluster::commit_tx_request obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::commit_tx_request,
+  {
+      json_write(ntp);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(timeout);
+  });
 
 /*
  * cluster::commit_tx_reply
  */
-template<>
-struct compat_check<cluster::commit_tx_reply> {
-    static constexpr std::string_view name = "cluster::commit_tx_reply";
-    static std::vector<cluster::commit_tx_reply> create_test_cases() {
-        return generate_instances<cluster::commit_tx_reply>();
-    }
-    static void to_json(
-      cluster::commit_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(ec);
-    }
-    static cluster::commit_tx_reply from_json(json::Value& rd) {
-        cluster::commit_tx_reply obj;
-        json_read(ec);
-        return obj;
-    }
-    static std::vector<compat_binary> to_binary(cluster::commit_tx_reply obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-    static bool check(cluster::commit_tx_reply obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::commit_tx_reply, { json_write(ec); }, { json_read(ec); });
 
 } // namespace compat

--- a/src/v/compat/commit_tx_compat.h
+++ b/src/v/compat/commit_tx_compat.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/commit_tx_generator.h"
+#include "compat/json.h"
+
+namespace compat {
+
+/*
+ * cluster::commit_tx_request
+ */
+template<>
+struct compat_check<cluster::commit_tx_request> {
+    static constexpr std::string_view name = "cluster::commit_tx_request";
+
+    static std::vector<cluster::commit_tx_request> create_test_cases() {
+        return generate_instances<cluster::commit_tx_request>();
+    }
+
+    static void to_json(
+      cluster::commit_tx_request obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(ntp);
+        json_write(pid);
+        json_write(tx_seq);
+        json_write(timeout);
+    }
+
+    static cluster::commit_tx_request from_json(json::Value& rd) {
+        cluster::commit_tx_request obj;
+        json_read(ntp);
+        json_read(pid);
+        json_read(tx_seq);
+        json_read(timeout);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::commit_tx_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool check(cluster::commit_tx_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+/*
+ * cluster::commit_tx_reply
+ */
+template<>
+struct compat_check<cluster::commit_tx_reply> {
+    static constexpr std::string_view name = "cluster::commit_tx_reply";
+    static std::vector<cluster::commit_tx_reply> create_test_cases() {
+        return generate_instances<cluster::commit_tx_reply>();
+    }
+    static void to_json(
+      cluster::commit_tx_reply obj, json::Writer<json::StringBuffer>& wr) {
+        json_write(ec);
+    }
+    static cluster::commit_tx_reply from_json(json::Value& rd) {
+        cluster::commit_tx_reply obj;
+        json_read(ec);
+        return obj;
+    }
+    static std::vector<compat_binary> to_binary(cluster::commit_tx_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+    static bool check(cluster::commit_tx_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/commit_tx_generator.h
+++ b/src/v/compat/commit_tx_generator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "compat/tx_gateway_generator.h"
+#include "model/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::commit_tx_request> {
+    static cluster::commit_tx_request random() {
+        return cluster::commit_tx_request(
+          model::random_ntp(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::commit_tx_request> limits() {
+        return {
+          cluster::commit_tx_request(
+            model::random_ntp(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::min()),
+            min_duration()),
+          cluster::commit_tx_request(
+            model::random_ntp(),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::max()),
+            max_duration()),
+        };
+    }
+};
+
+template<>
+struct instance_generator<cluster::commit_tx_reply> {
+    static cluster::commit_tx_reply random() {
+        return cluster::commit_tx_reply(
+          instance_generator<cluster::tx_errc>::random());
+    }
+    static std::vector<cluster::commit_tx_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/generator.h
+++ b/src/v/compat/generator.h
@@ -51,4 +51,15 @@ auto generate_instances(size_t randoms = 1) -> std::vector<T> {
     return res;
 }
 
+// NOTE: the bottom 10^6 is clamped.
+// This is so that roundtrip from ns->ms->ns will work as expected.
+inline model::timeout_clock::duration min_duration() {
+    constexpr auto min_chrono = std::chrono::milliseconds::min().count();
+    return model::timeout_clock::duration(min_chrono - (min_chrono % -1000000));
+}
+inline model::timeout_clock::duration max_duration() {
+    constexpr auto max_chrono = std::chrono::milliseconds::max().count();
+    return model::timeout_clock::duration(max_chrono - max_chrono % 1000000);
+}
+
 } // namespace compat

--- a/src/v/compat/id_allocator_generator.h
+++ b/src/v/compat/id_allocator_generator.h
@@ -35,8 +35,8 @@ struct instance_generator<cluster::allocate_id_request> {
     static std::vector<cluster::allocate_id_request> limits() {
         return {
           cluster::allocate_id_request{model::timeout_clock::duration(0)},
-          cluster::allocate_id_request{std::chrono::milliseconds::min()},
-          cluster::allocate_id_request{std::chrono::milliseconds::max()},
+          cluster::allocate_id_request{min_duration()},
+          cluster::allocate_id_request{max_duration()},
         };
     }
 };

--- a/src/v/compat/prepare_group_tx_compat.h
+++ b/src/v/compat/prepare_group_tx_compat.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/json.h"
+#include "compat/prepare_group_tx_generator.h"
+
+namespace compat {
+
+/*
+ * cluster::prepare_group_tx_request
+ */
+template<>
+struct compat_check<cluster::prepare_group_tx_request> {
+    static constexpr std::string_view name
+      = "cluster::prepare_group_tx_request";
+
+    static std::vector<cluster::prepare_group_tx_request> create_test_cases() {
+        return generate_instances<cluster::prepare_group_tx_request>();
+    }
+
+    static void to_json(
+      cluster::prepare_group_tx_request obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(ntp);
+        json_write(group_id);
+        json_write(etag);
+        json_write(pid);
+        json_write(tx_seq);
+        json_write(timeout);
+    }
+
+    static cluster::prepare_group_tx_request from_json(json::Value& rd) {
+        cluster::prepare_group_tx_request obj;
+        json_read(ntp);
+        json_read(group_id);
+        json_read(etag);
+        json_read(pid);
+        json_read(tx_seq);
+        json_read(timeout);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::prepare_group_tx_request obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static bool
+    check(cluster::prepare_group_tx_request obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+/*
+ * cluster::prepare_group_tx_reply
+ */
+template<>
+struct compat_check<cluster::prepare_group_tx_reply> {
+    static constexpr std::string_view name = "cluster::prepare_group_tx_reply";
+    static std::vector<cluster::prepare_group_tx_reply> create_test_cases() {
+        return generate_instances<cluster::prepare_group_tx_reply>();
+    }
+    static void to_json(
+      cluster::prepare_group_tx_reply obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(ec);
+    }
+    static cluster::prepare_group_tx_reply from_json(json::Value& rd) {
+        cluster::prepare_group_tx_reply obj;
+        json_read(ec);
+        return obj;
+    }
+    static std::vector<compat_binary>
+    to_binary(cluster::prepare_group_tx_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+    static bool check(cluster::prepare_group_tx_reply obj, compat_binary test) {
+        return verify_adl_or_serde(obj, std::move(test));
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/prepare_group_tx_compat.h
+++ b/src/v/compat/prepare_group_tx_compat.h
@@ -20,74 +20,29 @@ namespace compat {
 /*
  * cluster::prepare_group_tx_request
  */
-template<>
-struct compat_check<cluster::prepare_group_tx_request> {
-    static constexpr std::string_view name
-      = "cluster::prepare_group_tx_request";
-
-    static std::vector<cluster::prepare_group_tx_request> create_test_cases() {
-        return generate_instances<cluster::prepare_group_tx_request>();
-    }
-
-    static void to_json(
-      cluster::prepare_group_tx_request obj,
-      json::Writer<json::StringBuffer>& wr) {
-        json_write(ntp);
-        json_write(group_id);
-        json_write(etag);
-        json_write(pid);
-        json_write(tx_seq);
-        json_write(timeout);
-    }
-
-    static cluster::prepare_group_tx_request from_json(json::Value& rd) {
-        cluster::prepare_group_tx_request obj;
-        json_read(ntp);
-        json_read(group_id);
-        json_read(etag);
-        json_read(pid);
-        json_read(tx_seq);
-        json_read(timeout);
-        return obj;
-    }
-
-    static std::vector<compat_binary>
-    to_binary(cluster::prepare_group_tx_request obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-
-    static bool
-    check(cluster::prepare_group_tx_request obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::prepare_group_tx_request,
+  {
+      json_write(ntp);
+      json_write(group_id);
+      json_write(etag);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(group_id);
+      json_read(etag);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(timeout);
+  });
 
 /*
  * cluster::prepare_group_tx_reply
  */
-template<>
-struct compat_check<cluster::prepare_group_tx_reply> {
-    static constexpr std::string_view name = "cluster::prepare_group_tx_reply";
-    static std::vector<cluster::prepare_group_tx_reply> create_test_cases() {
-        return generate_instances<cluster::prepare_group_tx_reply>();
-    }
-    static void to_json(
-      cluster::prepare_group_tx_reply obj,
-      json::Writer<json::StringBuffer>& wr) {
-        json_write(ec);
-    }
-    static cluster::prepare_group_tx_reply from_json(json::Value& rd) {
-        cluster::prepare_group_tx_reply obj;
-        json_read(ec);
-        return obj;
-    }
-    static std::vector<compat_binary>
-    to_binary(cluster::prepare_group_tx_reply obj) {
-        return compat_binary::serde_and_adl(obj);
-    }
-    static bool check(cluster::prepare_group_tx_reply obj, compat_binary test) {
-        return verify_adl_or_serde(obj, std::move(test));
-    }
-};
+GEN_COMPAT_CHECK(
+  cluster::prepare_group_tx_reply, { json_write(ec); }, { json_read(ec); });
 
 } // namespace compat

--- a/src/v/compat/prepare_group_tx_generator.h
+++ b/src/v/compat/prepare_group_tx_generator.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "compat/tx_gateway_generator.h"
+#include "model/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::prepare_group_tx_request> {
+    static cluster::prepare_group_tx_request random() {
+        return cluster::prepare_group_tx_request(
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          tests::random_named_int<model::term_id>(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::prepare_group_tx_request> limits() {
+        return {
+          cluster::prepare_group_tx_request(
+            model::random_ntp(),
+            tests::random_named_string<kafka::group_id>(),
+            model::term_id(std::numeric_limits<int64_t>::min()),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::min()),
+            min_duration()),
+          cluster::prepare_group_tx_request(
+            model::random_ntp(),
+            tests::random_named_string<kafka::group_id>(),
+            model::term_id(std::numeric_limits<int64_t>::max()),
+            model::random_producer_identity(),
+            model::tx_seq(std::numeric_limits<int64_t>::max()),
+            max_duration()),
+        };
+    }
+};
+
+template<>
+struct instance_generator<cluster::prepare_group_tx_reply> {
+    static cluster::prepare_group_tx_reply random() {
+        return cluster::prepare_group_tx_reply(
+          instance_generator<cluster::tx_errc>::random());
+    }
+    static std::vector<cluster::prepare_group_tx_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -12,12 +12,16 @@
 
 #include "cluster/metadata_dissemination_types.h"
 #include "cluster/types.h"
+#include "compat/abort_tx_compat.h"
+#include "compat/begin_group_tx_compat.h"
 #include "compat/begin_tx_compat.h"
 #include "compat/check.h"
 #include "compat/cluster_compat.h"
+#include "compat/commit_tx_compat.h"
 #include "compat/id_allocator_compat.h"
 #include "compat/init_tm_tx_compat.h"
 #include "compat/metadata_dissemination_compat.h"
+#include "compat/prepare_group_tx_compat.h"
 #include "compat/prepare_tx_compat.h"
 #include "compat/raft_compat.h"
 #include "compat/try_abort_compat.h"
@@ -85,7 +89,15 @@ using compat_checks = type_list<
   cluster::update_leadership_request_v2,
   cluster::update_leadership_reply,
   cluster::get_leadership_request,
-  cluster::get_leadership_reply>;
+  cluster::get_leadership_reply,
+  cluster::abort_tx_request,
+  cluster::abort_tx_reply,
+  cluster::begin_group_tx_request,
+  cluster::begin_group_tx_reply,
+  cluster::prepare_group_tx_request,
+  cluster::prepare_group_tx_reply,
+  cluster::commit_tx_request,
+  cluster::commit_tx_reply>;
 
 struct compat_error final : public std::runtime_error {
 public:

--- a/src/v/compat/tx_gateway_generator.h
+++ b/src/v/compat/tx_gateway_generator.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "random/generators.h"
+
+#include <vector>
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::tx_errc> {
+    static cluster::tx_errc random() {
+        return random_generators::random_choice({
+          cluster::tx_errc::none,
+          cluster::tx_errc::leader_not_found,
+          cluster::tx_errc::shard_not_found,
+          cluster::tx_errc::partition_not_found,
+          cluster::tx_errc::stm_not_found,
+          cluster::tx_errc::partition_not_exists,
+          cluster::tx_errc::pid_not_found,
+          cluster::tx_errc::timeout,
+          cluster::tx_errc::conflict,
+          cluster::tx_errc::fenced,
+          cluster::tx_errc::stale,
+          cluster::tx_errc::not_coordinator,
+          cluster::tx_errc::coordinator_not_available,
+          cluster::tx_errc::preparing_rebalance,
+          cluster::tx_errc::rebalance_in_progress,
+          cluster::tx_errc::coordinator_load_in_progress,
+          cluster::tx_errc::unknown_server_error,
+          cluster::tx_errc::request_rejected,
+          cluster::tx_errc::invalid_producer_id_mapping,
+          cluster::tx_errc::invalid_txn_state,
+        });
+    }
+
+    static std::vector<raft::errc> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/tx_gateway_generator.h
+++ b/src/v/compat/tx_gateway_generator.h
@@ -48,4 +48,15 @@ struct instance_generator<cluster::tx_errc> {
     static std::vector<raft::errc> limits() { return {}; }
 };
 
+// NOTE: that the bottom 10^6 is removed.
+// This is so that roundtrip from ns->ms->ns will work as expected.
+inline model::timeout_clock::duration min_duration() {
+    constexpr auto min_chrono = std::chrono::milliseconds::min().count();
+    return model::timeout_clock::duration(min_chrono - (min_chrono % -1000000));
+}
+inline model::timeout_clock::duration max_duration() {
+    constexpr auto max_chrono = std::chrono::milliseconds::max().count();
+    return model::timeout_clock::duration(max_chrono - max_chrono % 1000000);
+}
+
 } // namespace compat

--- a/src/v/compat/tx_gateway_generator.h
+++ b/src/v/compat/tx_gateway_generator.h
@@ -48,15 +48,4 @@ struct instance_generator<cluster::tx_errc> {
     static std::vector<raft::errc> limits() { return {}; }
 };
 
-// NOTE: that the bottom 10^6 is removed.
-// This is so that roundtrip from ns->ms->ns will work as expected.
-inline model::timeout_clock::duration min_duration() {
-    constexpr auto min_chrono = std::chrono::milliseconds::min().count();
-    return model::timeout_clock::duration(min_chrono - (min_chrono % -1000000));
-}
-inline model::timeout_clock::duration max_duration() {
-    constexpr auto max_chrono = std::chrono::milliseconds::max().count();
-    return model::timeout_clock::duration(max_chrono - max_chrono % 1000000);
-}
-
 } // namespace compat


### PR DESCRIPTION
## Cover letter

Plugs some message types into the serde compat testing framework:
- cluster::commit_tx
- cluster::abort_tx
- cluster::begin_group_tx
- cluster::prepare_group_tx

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes


* none
