### PR TITLE
Partition autobalancer full disk test

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -370,6 +370,8 @@ ss::future<> controller::start() {
             config::shard_local_cfg()
               .partition_autobalancing_max_disk_usage_percent.bind(),
             config::shard_local_cfg()
+              .storage_space_alert_free_threshold_percent.bind(),
+            config::shard_local_cfg()
               .partition_autobalancing_tick_interval_ms.bind(),
             config::shard_local_cfg()
               .partition_autobalancing_movement_batch_size_bytes.bind());

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -83,6 +83,8 @@ private:
     // Injection points for unit tests
     ss::sstring _path_for_test;
     std::function<struct statvfs(const ss::sstring)> _statvfs_for_test;
+
+    std::optional<size_t> _disk_size_for_test;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -36,6 +36,7 @@ public:
       config::binding<model::partition_autobalancing_mode>&& mode,
       config::binding<std::chrono::seconds>&& availability_timeout,
       config::binding<unsigned>&& max_disk_usage_percent,
+      config::binding<unsigned>&& storage_space_alert_free_threshold_percent,
       config::binding<std::chrono::milliseconds>&& tick_interval,
       config::binding<size_t>&& movement_batch_size_bytes);
 
@@ -76,6 +77,7 @@ private:
     config::binding<model::partition_autobalancing_mode> _mode;
     config::binding<std::chrono::seconds> _availability_timeout;
     config::binding<unsigned> _max_disk_usage_percent;
+    config::binding<unsigned> _storage_space_alert_free_threshold_percent;
     config::binding<std::chrono::milliseconds> _tick_interval;
     config::binding<size_t> _movement_batch_size_bytes;
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -274,10 +274,11 @@ result<allocation_units> partition_balancer_planner::get_reallocation(
                     rrs.assigned_reallocation_sizes[r.node_id]
                       += partition_size;
                 }
+            }
+            for (const auto r : assignments.replicas) {
                 if (
-                  std::find(
-                    assignments.replicas.begin(), assignments.replicas.end(), r)
-                  == assignments.replicas.end()) {
+                  std::find(stable_replicas.begin(), stable_replicas.end(), r)
+                  == stable_replicas.end()) {
                     rrs.node_released_disk_size[r.node_id] += partition_size;
                 }
             }

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -224,7 +224,7 @@ result<allocation_units> partition_balancer_planner::get_reallocation(
     }
 
     rrs.moving_partitions.insert(ntp);
-    rrs.planned_movement_disk_size += partition_size;
+    rrs.planned_moves_size += partition_size;
     for (const auto r :
          reallocation.value().get_assignments().front().replicas) {
         if (
@@ -263,9 +263,7 @@ void partition_balancer_planner::get_unavailable_nodes_reassignments(
     for (const auto& t : _topic_table.topics_map()) {
         for (const auto& a : t.second.get_assignments()) {
             // End adding movements if batch is collected
-            if (
-              rrs.planned_movement_disk_size
-              >= _config.movement_disk_size_batch) {
+            if (rrs.planned_moves_size >= _config.movement_disk_size_batch) {
                 return;
             }
 
@@ -359,8 +357,7 @@ void partition_balancer_planner::get_full_node_reassignments(
     }
 
     for (const auto* node_disk : sorted_full_nodes) {
-        if (
-          rrs.planned_movement_disk_size >= _config.movement_disk_size_batch) {
+        if (rrs.planned_moves_size >= _config.movement_disk_size_batch) {
             return;
         }
 
@@ -377,9 +374,7 @@ void partition_balancer_planner::get_full_node_reassignments(
         auto ntp_size_it = ntp_on_node_sizes.begin();
         while (node_disk->final_used_ratio() > _config.soft_max_disk_usage_ratio
                && ntp_size_it != ntp_on_node_sizes.end()) {
-            if (
-              rrs.planned_movement_disk_size
-              >= _config.movement_disk_size_batch) {
+            if (rrs.planned_moves_size >= _config.movement_disk_size_batch) {
                 return;
             }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -18,6 +18,35 @@
 
 namespace cluster {
 
+namespace {
+
+hard_constraint_evaluator
+distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
+    class impl : public hard_constraint_evaluator::impl {
+    public:
+        explicit impl(const absl::flat_hash_set<model::node_id>& nodes)
+          : _nodes(nodes) {}
+
+        bool evaluate(const allocation_node& node) const final {
+            return !_nodes.contains(node.id());
+        }
+
+        void print(std::ostream& o) const final {
+            fmt::print(
+              o,
+              "distinct from nodes: {}",
+              std::vector(_nodes.begin(), _nodes.end()));
+        }
+
+    private:
+        const absl::flat_hash_set<model::node_id>& _nodes;
+    };
+
+    return hard_constraint_evaluator(std::make_unique<impl>(nodes));
+}
+
+} // namespace
+
 partition_balancer_planner::partition_balancer_planner(
   planner_config config,
   topic_table& topic_table,
@@ -38,8 +67,8 @@ void partition_balancer_planner::init_node_disk_reports_from_health_report(
             total += disk.total;
             free += disk.free;
         }
-        rrs.node_disk_reports.insert(
-          {node_report.id, node_disk_space(node_report.id, free, total)});
+        rrs.node_disk_reports.emplace(
+          node_report.id, node_disk_space(node_report.id, total, total - free));
     }
 }
 
@@ -60,10 +89,8 @@ void partition_balancer_planner::
   calculate_nodes_with_disk_constraints_violation(
     reallocation_request_state& rrs, plan_data& result) {
     for (const auto& n : rrs.node_disk_reports) {
-        double used_space_ratio = 1.0 - n.second.free_space_rate;
+        double used_space_ratio = n.second.original_used_ratio();
         if (used_space_ratio > _config.soft_max_disk_usage_ratio) {
-            rrs.nodes_with_disk_constraints_violation.insert(n.first);
-            rrs.full_nodes_disk_sizes.insert(n.second);
             result.violations.full_nodes.emplace_back(
               n.first, uint32_t(used_space_ratio * 100.0));
         }
@@ -103,58 +130,6 @@ bool partition_balancer_planner::all_reports_received(
     return true;
 }
 
-std::vector<model::broker_shard>
-partition_balancer_planner::get_stable_replicas(
-  const std::vector<model::broker_shard>& replicas,
-  const reallocation_request_state& rrs,
-  size_t full_nodes_leave_amount) {
-    std::vector<model::broker_shard> stable_replicas;
-    absl::flat_hash_map<model::node_id, uint32_t>
-      replicas_breaking_disk_constraints;
-
-    // add stable nodes
-    for (const auto& r : replicas) {
-        if (!rrs.unavailable_nodes.contains(r.node_id)) {
-            if (!rrs.nodes_with_disk_constraints_violation.contains(
-                  r.node_id)) {
-                stable_replicas.push_back(r);
-            } else {
-                replicas_breaking_disk_constraints[r.node_id] = r.shard;
-            }
-        }
-    }
-
-    // add 'full_nodes_leave_amount' of nodes with disk constraints violation
-    // ordered by free_space rate
-    for (auto node = rrs.full_nodes_disk_sizes.rbegin();
-         node != rrs.full_nodes_disk_sizes.rend();
-         node++) {
-        if (full_nodes_leave_amount == 0) {
-            return stable_replicas;
-        }
-        if (const auto& r = replicas_breaking_disk_constraints.find(
-              node->node_id);
-            r != replicas_breaking_disk_constraints.end()) {
-            stable_replicas.push_back(model::broker_shard{r->first, r->second});
-            full_nodes_leave_amount--;
-        }
-    }
-
-    return stable_replicas;
-}
-
-size_t partition_balancer_planner::get_full_nodes_amount(
-  const std::vector<model::broker_shard>& replicas,
-  const reallocation_request_state& rrs) {
-    size_t full_nodes_amount = 0;
-    for (const auto& r : replicas) {
-        if (rrs.nodes_with_disk_constraints_violation.contains(r.node_id)) {
-            full_nodes_amount += 1;
-        }
-    }
-    return full_nodes_amount;
-}
-
 bool partition_balancer_planner::is_partition_movement_possible(
   const std::vector<model::broker_shard>& current_replicas,
   const reallocation_request_state& rrs) {
@@ -187,105 +162,92 @@ std::optional<size_t> partition_balancer_planner::get_partition_size(
     return std::nullopt;
 }
 
-/*
- * Function tries to find max reallocation.
- * It tries to move ntp out of 'bad' nodes.
- * Initially it considers as 'bad' all unavailable nodes
- * and all nodes that are breaking max_disk_usage_ratio.
- * If reallocation request fails, it removes least filled node that
- * is available but is breaking max_disk_usage_ratio.
- * It repeats until it doesn't work out to calculate reallocation
- * or all nodes that are breaking max_disk_usage_ratio are removed out of 'bad'.
- */
-result<allocation_units> partition_balancer_planner::get_reallocation(
+partition_constraints partition_balancer_planner::get_partition_constraints(
   const partition_assignment& assignments,
   const topic_metadata& topic_metadata,
   size_t partition_size,
   double max_disk_usage_ratio,
-  reallocation_request_state& rrs) {
+  reallocation_request_state& rrs) const {
     allocation_constraints allocation_constraints;
 
     // Add constraint on least disk usage
     allocation_constraints.soft_constraints.push_back(
-      ss::make_lw_shared<soft_constraint_evaluator>(least_disk_filled(
-        max_disk_usage_ratio,
-        rrs.assigned_reallocation_sizes,
-        rrs.node_disk_reports)));
+      ss::make_lw_shared<soft_constraint_evaluator>(
+        least_disk_filled(max_disk_usage_ratio, rrs.node_disk_reports)));
 
     // Add constraint on partition max_disk_usage_ratio overfill
     allocation_constraints.hard_constraints.push_back(
       ss::make_lw_shared<hard_constraint_evaluator>(
         disk_not_overflowed_by_partition(
-          max_disk_usage_ratio,
-          partition_size,
-          rrs.assigned_reallocation_sizes,
-          rrs.node_disk_reports)));
+          max_disk_usage_ratio, partition_size, rrs.node_disk_reports)));
 
     // Add constraint on unavailable nodes
-    std::vector<model::broker_shard> unavailable_nodes;
-    unavailable_nodes.reserve(unavailable_nodes.size());
-    for (auto node_id : rrs.unavailable_nodes) {
-        unavailable_nodes.push_back(model::broker_shard{node_id, 0});
-    }
     allocation_constraints.hard_constraints.push_back(
       ss::make_lw_shared<hard_constraint_evaluator>(
-        distinct_from(unavailable_nodes)));
+        distinct_from(rrs.unavailable_nodes)));
 
-    auto constraints = partition_constraints(
+    return partition_constraints(
       assignments.id,
       topic_metadata.get_configuration().replication_factor,
-      allocation_constraints);
+      std::move(allocation_constraints));
+}
 
-    size_t full_node_amount = get_full_nodes_amount(assignments.replicas, rrs);
-    for (size_t i = 0; i <= full_node_amount; ++i) {
-        auto stable_replicas = get_stable_replicas(
-          assignments.replicas, rrs, i);
+result<allocation_units> partition_balancer_planner::get_reallocation(
+  const model::ntp& ntp,
+  const partition_assignment& assignments,
+  size_t partition_size,
+  partition_constraints constraints,
+  const std::vector<model::broker_shard>& stable_replicas,
+  reallocation_request_state& rrs) {
+    vlog(
+      clusterlog.debug,
+      "trying to find reallocation for ntp {} with stable_replicas: {}",
+      ntp,
+      stable_replicas);
 
-        if (stable_replicas.size() == assignments.replicas.size()) {
-            break;
-        }
+    auto stable_assigments = partition_assignment(
+      assignments.group, assignments.id, stable_replicas);
 
-        auto stable_assigments = partition_assignment(
-          assignments.group, assignments.id, stable_replicas);
+    auto reallocation = _partition_allocator.reallocate_partition(
+      std::move(constraints), stable_assigments);
 
-        auto reallocation = _partition_allocator.reallocate_partition(
-          constraints, stable_assigments);
+    if (!reallocation) {
+        vlog(
+          clusterlog.debug,
+          "attempt to find reallocation for ntp {} with "
+          "stable_replicas: {} failed, error: {}",
+          ntp,
+          stable_replicas,
+          reallocation.error().message());
 
-        auto ntp = model::ntp(
-          topic_metadata.get_configuration().tp_ns.ns,
-          topic_metadata.get_configuration().tp_ns.tp,
-          assignments.id);
-        if (reallocation.has_value()) {
-            rrs.moving_partitions.insert(ntp);
-            rrs.planned_movement_disk_size += partition_size;
-            for (const auto r :
-                 reallocation.value().get_assignments().front().replicas) {
-                if (
-                  std::find(stable_replicas.begin(), stable_replicas.end(), r)
-                  == stable_replicas.end()) {
-                    rrs.assigned_reallocation_sizes[r.node_id]
-                      += partition_size;
-                }
+        return reallocation;
+    }
+
+    rrs.moving_partitions.insert(ntp);
+    rrs.planned_movement_disk_size += partition_size;
+    for (const auto r :
+         reallocation.value().get_assignments().front().replicas) {
+        if (
+          std::find(stable_replicas.begin(), stable_replicas.end(), r)
+          == stable_replicas.end()) {
+            auto disk_it = rrs.node_disk_reports.find(r.node_id);
+            if (disk_it != rrs.node_disk_reports.end()) {
+                disk_it->second.assigned += partition_size;
             }
-            for (const auto r : assignments.replicas) {
-                if (
-                  std::find(stable_replicas.begin(), stable_replicas.end(), r)
-                  == stable_replicas.end()) {
-                    rrs.node_released_disk_size[r.node_id] += partition_size;
-                }
-            }
-            return reallocation;
-        } else {
-            vlog(
-              clusterlog.info,
-              "Can't find movement for ntp {} with stable_replicas: {}, "
-              "Error: {}",
-              ntp,
-              stable_replicas,
-              reallocation.error().message());
         }
     }
-    return errc::no_eligible_allocation_nodes;
+    for (const auto r : assignments.replicas) {
+        if (
+          std::find(stable_replicas.begin(), stable_replicas.end(), r)
+          == stable_replicas.end()) {
+            auto disk_it = rrs.node_disk_reports.find(r.node_id);
+            if (disk_it != rrs.node_disk_reports.end()) {
+                disk_it->second.released += partition_size;
+            }
+        }
+    }
+
+    return reallocation;
 }
 
 /*
@@ -294,44 +256,63 @@ result<allocation_units> partition_balancer_planner::get_reallocation(
  */
 void partition_balancer_planner::get_unavailable_nodes_reassignments(
   plan_data& result, reallocation_request_state& rrs) {
+    if (rrs.unavailable_nodes.empty()) {
+        return;
+    }
+
     for (const auto& t : _topic_table.topics_map()) {
         for (const auto& a : t.second.get_assignments()) {
-            auto ntp = model::ntp(t.first.ns, t.first.tp, a.id);
-            if (rrs.moving_partitions.contains(ntp)) {
-                continue;
-            }
-            // Get all available nodes
-            auto available_replicas = get_stable_replicas(
-              a.replicas, rrs, SIZE_MAX);
-            if (available_replicas.size() != a.replicas.size()) {
-                auto partition_size = get_partition_size(ntp, rrs);
-                if (
-                  !partition_size.has_value()
-                  || !is_partition_movement_possible(a.replicas, rrs)) {
-                    result.failed_reassignments_count += 1;
-                    continue;
-                }
-                auto new_allocation_units = get_reallocation(
-                  a,
-                  t.second.metadata,
-                  partition_size.value(),
-                  _config.hard_max_disk_usage_ratio,
-                  rrs);
-                if (new_allocation_units) {
-                    result.reassignments.emplace_back(ntp_reassignments{
-                      .ntp = ntp,
-                      .allocation_units = std::move(
-                        new_allocation_units.value())});
-                } else {
-                    result.failed_reassignments_count += 1;
-                }
-            }
-
             // End adding movements if batch is collected
             if (
               rrs.planned_movement_disk_size
               >= _config.movement_disk_size_batch) {
                 return;
+            }
+
+            auto ntp = model::ntp(t.first.ns, t.first.tp, a.id);
+            if (rrs.moving_partitions.contains(ntp)) {
+                continue;
+            }
+
+            std::vector<model::broker_shard> stable_replicas;
+            for (const auto& bs : a.replicas) {
+                if (!rrs.unavailable_nodes.contains(bs.node_id)) {
+                    stable_replicas.push_back(bs);
+                }
+            }
+
+            if (stable_replicas.size() == a.replicas.size()) {
+                continue;
+            }
+
+            auto partition_size = get_partition_size(ntp, rrs);
+            if (
+              !partition_size.has_value()
+              || !is_partition_movement_possible(a.replicas, rrs)) {
+                result.failed_reassignments_count += 1;
+                continue;
+            }
+
+            auto constraints = get_partition_constraints(
+              a,
+              t.second.metadata,
+              partition_size.value(),
+              _config.hard_max_disk_usage_ratio,
+              rrs);
+
+            auto new_allocation_units = get_reallocation(
+              ntp,
+              a,
+              partition_size.value(),
+              std::move(constraints),
+              stable_replicas,
+              rrs);
+            if (new_allocation_units) {
+                result.reassignments.emplace_back(ntp_reassignments{
+                  .ntp = ntp,
+                  .allocation_units = std::move(new_allocation_units.value())});
+            } else {
+                result.failed_reassignments_count += 1;
             }
         }
     }
@@ -339,12 +320,34 @@ void partition_balancer_planner::get_unavailable_nodes_reassignments(
 
 /*
  * Function is trying to move ntps out of node that are violating
- * soft_max_disk_usage_ratio. It takes nodes in free space rate order. For each
- * node it is trying to collect set of partitions to move. Partitions are
- * selected in ascending order of their size.
+ * soft_max_disk_usage_ratio. It takes nodes in reverse used space ratio order.
+ * For each node it is trying to collect set of partitions to move. Partitions
+ * are selected in ascending order of their size.
+ *
+ * If more than one replica in a group is on a node violating disk usage
+ * constraints, we try to reallocate all such replicas. But if a reallocation
+ * request fails, we retry while leaving some of these replicas intact.
  */
 void partition_balancer_planner::get_full_node_reassignments(
   plan_data& result, reallocation_request_state& rrs) {
+    std::vector<const node_disk_space*> sorted_full_nodes;
+    for (const auto& kv : rrs.node_disk_reports) {
+        const auto* node_disk = &kv.second;
+        if (node_disk->final_used_ratio() > _config.soft_max_disk_usage_ratio) {
+            sorted_full_nodes.push_back(node_disk);
+        }
+    }
+    std::sort(
+      sorted_full_nodes.begin(),
+      sorted_full_nodes.end(),
+      [](const auto* lhs, const auto* rhs) {
+          return lhs->final_used_ratio() > rhs->final_used_ratio();
+      });
+
+    if (sorted_full_nodes.empty()) {
+        return;
+    }
+
     absl::flat_hash_map<model::node_id, std::vector<model::ntp>> ntp_on_nodes;
     for (const auto& t : _topic_table.topics_map()) {
         for (const auto& a : t.second.get_assignments()) {
@@ -355,13 +358,14 @@ void partition_balancer_planner::get_full_node_reassignments(
         }
     }
 
-    for (const auto& node_disk_space : rrs.full_nodes_disk_sizes) {
+    for (const auto* node_disk : sorted_full_nodes) {
         if (
           rrs.planned_movement_disk_size >= _config.movement_disk_size_batch) {
             return;
         }
+
         absl::btree_multimap<size_t, model::ntp> ntp_on_node_sizes;
-        for (const auto& ntp : ntp_on_nodes[node_disk_space.node_id]) {
+        for (const auto& ntp : ntp_on_nodes[node_disk->node_id]) {
             auto partition_size_opt = get_partition_size(ntp, rrs);
             if (partition_size_opt.has_value()) {
                 ntp_on_node_sizes.emplace(partition_size_opt.value(), ntp);
@@ -369,13 +373,16 @@ void partition_balancer_planner::get_full_node_reassignments(
                 result.failed_reassignments_count += 1;
             }
         }
+
         auto ntp_size_it = ntp_on_node_sizes.begin();
-        while (double(
-                 rrs.node_released_disk_size[node_disk_space.node_id]
-                 + node_disk_space.free_space)
-                   / double(node_disk_space.total_space)
-                 < double(1) - _config.soft_max_disk_usage_ratio
+        while (node_disk->final_used_ratio() > _config.soft_max_disk_usage_ratio
                && ntp_size_it != ntp_on_node_sizes.end()) {
+            if (
+              rrs.planned_movement_disk_size
+              >= _config.movement_disk_size_batch) {
+                return;
+            }
+
             const auto& partition_to_move = ntp_size_it->second;
             if (rrs.moving_partitions.contains(partition_to_move)) {
                 ntp_size_it++;
@@ -387,31 +394,90 @@ void partition_balancer_planner::get_full_node_reassignments(
             const auto& current_assignments
               = topic_metadata.get_assignments().find(
                 partition_to_move.tp.partition);
+
             if (!is_partition_movement_possible(
                   current_assignments->replicas, rrs)) {
                 result.failed_reassignments_count += 1;
                 ntp_size_it++;
                 continue;
             }
-            auto new_allocation_units = get_reallocation(
+
+            auto constraints = get_partition_constraints(
               *current_assignments,
               topic_metadata.metadata,
               ntp_size_it->first,
               _config.soft_max_disk_usage_ratio,
               rrs);
-            if (new_allocation_units) {
-                result.reassignments.emplace_back(ntp_reassignments{
-                  .ntp = partition_to_move,
-                  .allocation_units = std::move(new_allocation_units.value())});
-            } else {
+
+            struct full_node_replica {
+                model::broker_shard bs;
+                node_disk_space disk;
+            };
+            std::vector<full_node_replica> full_node_replicas;
+            std::vector<model::broker_shard> stable_replicas;
+
+            for (const auto& r : current_assignments->replicas) {
+                if (rrs.unavailable_nodes.contains(r.node_id)) {
+                    continue;
+                }
+
+                auto disk_it = rrs.node_disk_reports.find(r.node_id);
+                vassert(
+                  disk_it != rrs.node_disk_reports.end(),
+                  "disk report for node {} must be present",
+                  r.node_id);
+                const auto& disk = disk_it->second;
+
+                if (
+                  disk.final_used_ratio() < _config.soft_max_disk_usage_ratio) {
+                    stable_replicas.push_back(r);
+                } else {
+                    full_node_replicas.push_back(full_node_replica{
+                      .bs = r,
+                      .disk = disk,
+                    });
+                }
+            }
+
+            // We start with a small set of stable replicas that are on "good"
+            // nodes and try to find a reallocation. If that fails, we add one
+            // replica from the set of full_node_replicas (starting from the
+            // least full) to stable replicas and retry until we get a valid
+            // reallocation.
+            std::sort(
+              full_node_replicas.begin(),
+              full_node_replicas.end(),
+              [](const auto& lhs, const auto& rhs) {
+                  return lhs.disk.final_used_ratio()
+                         < rhs.disk.final_used_ratio();
+              });
+
+            bool success = false;
+            for (const auto& replica : full_node_replicas) {
+                auto new_allocation_units = get_reallocation(
+                  partition_to_move,
+                  *current_assignments,
+                  ntp_size_it->first,
+                  constraints,
+                  stable_replicas,
+                  rrs);
+
+                if (new_allocation_units) {
+                    result.reassignments.emplace_back(ntp_reassignments{
+                      .ntp = partition_to_move,
+                      .allocation_units = std::move(
+                        new_allocation_units.value())});
+                    success = true;
+                    break;
+                } else {
+                    stable_replicas.push_back(replica.bs);
+                }
+            }
+            if (!success) {
                 result.failed_reassignments_count += 1;
             }
+
             ntp_size_it++;
-            if (
-              rrs.planned_movement_disk_size
-              >= _config.movement_disk_size_batch) {
-                return;
-            }
         }
     }
 }

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -63,7 +63,7 @@ public:
 
 private:
     struct reallocation_request_state {
-        uint64_t planned_movement_disk_size = 0;
+        uint64_t planned_moves_size = 0;
         absl::flat_hash_map<model::ntp, size_t> ntp_sizes;
         absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
         absl::flat_hash_set<model::node_id> unavailable_nodes;

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -67,23 +67,23 @@ private:
         absl::flat_hash_map<model::ntp, size_t> ntp_sizes;
         absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
         absl::flat_hash_set<model::node_id> unavailable_nodes;
-        absl::flat_hash_set<model::node_id>
-          nodes_with_disk_constraints_violation;
-        absl::btree_set<node_disk_space> full_nodes_disk_sizes;
         // Partitions that are planned to move in current planner request
         absl::flat_hash_set<model::ntp> moving_partitions;
-        // Size of partitions that are planned to move from node
-        absl::flat_hash_map<model::node_id, uint64_t> node_released_disk_size;
-        // Size of partitions that are planned to move on node
-        absl::flat_hash_map<model::node_id, uint64_t>
-          assigned_reallocation_sizes;
     };
 
-    result<allocation_units> get_reallocation(
+    partition_constraints get_partition_constraints(
       const partition_assignment& assignments,
       const topic_metadata& topic_metadata,
       size_t partition_size,
       double max_disk_usage_ratio,
+      reallocation_request_state&) const;
+
+    result<allocation_units> get_reallocation(
+      const model::ntp&,
+      const partition_assignment&,
+      size_t partition_size,
+      partition_constraints,
+      const std::vector<model::broker_shard>& stable_replicas,
       reallocation_request_state&);
 
     void get_unavailable_nodes_reassignments(
@@ -102,15 +102,6 @@ private:
       const std::vector<raft::follower_metrics>&,
       reallocation_request_state&,
       plan_data&);
-
-    size_t get_full_nodes_amount(
-      const std::vector<model::broker_shard>& replicas,
-      const reallocation_request_state& rrs);
-
-    std::vector<model::broker_shard> get_stable_replicas(
-      const std::vector<model::broker_shard>& replicas,
-      const reallocation_request_state&,
-      size_t full_nodes_leave_amount);
 
     bool is_partition_movement_possible(
       const std::vector<model::broker_shard>& current_replicas,

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -25,7 +25,12 @@ struct ntp_reassignments {
 };
 
 struct planner_config {
-    double max_disk_usage_ratio;
+    // If node disk usage goes over this ratio planner will actively move
+    // partitions away from the node.
+    double soft_max_disk_usage_ratio;
+    // Planner won't plan a move that will result in destination node(s) going
+    // over this ratio.
+    double hard_max_disk_usage_ratio;
     // Size of partitions that can be planned to move in one request
     size_t movement_disk_size_batch;
     std::chrono::seconds node_availability_timeout_sec;
@@ -78,7 +83,7 @@ private:
       const partition_assignment& assignments,
       const topic_metadata& topic_metadata,
       size_t partition_size,
-      bool use_max_disk_constraint,
+      double max_disk_usage_ratio,
       reallocation_request_state&);
 
     void get_unavailable_nodes_reassignments(

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -21,23 +21,25 @@ namespace cluster {
 
 struct node_disk_space {
     model::node_id node_id;
-    uint64_t free_space;
-    uint64_t total_space;
-    double free_space_rate;
+    uint64_t total = 0;
+    uint64_t used = 0;
+    // total size of partitions moved to this node
+    uint64_t assigned = 0;
+    // total size of partitions moved from this node
+    uint64_t released = 0;
 
     inline node_disk_space(
-      model::node_id node_id, uint64_t free_space, uint64_t total_space)
+      model::node_id node_id, uint64_t total, uint64_t used)
       : node_id(node_id)
-      , free_space(free_space)
-      , total_space(total_space)
-      , free_space_rate(double(free_space) / double(total_space)) {}
+      , total(total)
+      , used(used) {}
 
-    bool operator==(const node_disk_space& other) const {
-        return node_id == other.node_id;
-    }
+    double original_used_ratio() const { return double(used) / total; }
 
-    bool operator<(const node_disk_space& other) const {
-        return free_space_rate < other.free_space_rate;
+    double peak_used_ratio() const { return double(used + assigned) / total; }
+
+    double final_used_ratio() const {
+        return double(used + assigned - released) / total;
     }
 };
 

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -136,8 +136,6 @@ distinct_from(const std::vector<model::broker_shard>& current) {
 hard_constraint_evaluator disk_not_overflowed_by_partition(
   const double max_disk_usage_ratio,
   const size_t partition_size,
-  const absl::flat_hash_map<model::node_id, uint64_t>&
-    assigned_reallocation_sizes,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports) {
     class impl : public hard_constraint_evaluator::impl {
@@ -145,33 +143,22 @@ hard_constraint_evaluator disk_not_overflowed_by_partition(
         impl(
           const double max_disk_usage_ratio,
           const size_t partition_size,
-          const absl::flat_hash_map<model::node_id, uint64_t>&
-            assigned_reallocation_sizes,
           const absl::flat_hash_map<model::node_id, node_disk_space>&
             node_disk_reports)
           : _max_disk_usage_ratio(max_disk_usage_ratio)
           , _partition_size(partition_size)
-          , _assigned_reallocation_sizes(assigned_reallocation_sizes)
           , _node_disk_reports(node_disk_reports) {}
 
         bool evaluate(const allocation_node& node) const final {
-            auto node_disk_report = _node_disk_reports.find(node.id());
-            if (node_disk_report == _node_disk_reports.end()) {
+            auto disk_it = _node_disk_reports.find(node.id());
+            if (disk_it == _node_disk_reports.end()) {
                 return false;
             } else {
-                uint64_t assigned_reallocation_size = 0;
-                if (const auto& asigned_size
-                    = _assigned_reallocation_sizes.find(node.id());
-                    asigned_size != _assigned_reallocation_sizes.end()) {
-                    assigned_reallocation_size = asigned_size->second;
-                }
-                auto disk_usage = node_disk_report->second.total_space
-                                  - node_disk_report->second.free_space
-                                  + _partition_size
-                                  + assigned_reallocation_size;
-                return _max_disk_usage_ratio
-                         * double(node_disk_report->second.total_space)
-                       > double(disk_usage);
+                const auto& node_disk = disk_it->second;
+                auto peak_disk_usage = node_disk.used + node_disk.assigned
+                                       + _partition_size;
+                return peak_disk_usage
+                       < _max_disk_usage_ratio * node_disk.total;
             }
             return false;
         }
@@ -185,17 +172,12 @@ hard_constraint_evaluator disk_not_overflowed_by_partition(
 
         const double _max_disk_usage_ratio;
         const size_t _partition_size;
-        const absl::flat_hash_map<model::node_id, uint64_t>&
-          _assigned_reallocation_sizes;
         const absl::flat_hash_map<model::node_id, node_disk_space>&
           _node_disk_reports;
     };
 
     return hard_constraint_evaluator(std::make_unique<impl>(
-      max_disk_usage_ratio,
-      partition_size,
-      assigned_reallocation_sizes,
-      node_disk_reports));
+      max_disk_usage_ratio, partition_size, node_disk_reports));
 }
 
 soft_constraint_evaluator least_allocated() {
@@ -257,49 +239,34 @@ soft_constraint_evaluator distinct_rack(
 
 soft_constraint_evaluator least_disk_filled(
   const double max_disk_usage_ratio,
-  const absl::flat_hash_map<model::node_id, uint64_t>&
-    assigned_reallocation_sizes,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports) {
     class impl : public soft_constraint_evaluator::impl {
     public:
         impl(
           const double max_disk_usage_ratio,
-          const absl::flat_hash_map<model::node_id, uint64_t>&
-            assigned_reallocation_sizes,
           const absl::flat_hash_map<model::node_id, node_disk_space>&
             node_disk_reports)
           : _max_disk_usage_ratio(max_disk_usage_ratio)
-          , _assigned_reallocation_sizes(assigned_reallocation_sizes)
           , _node_disk_reports(node_disk_reports) {}
         uint64_t score(const allocation_node& node) const final {
             // we return 0 for node filled more or equal to max_disk_usage_ratio
             // and 10'000'000 for nodes empty disks
-            auto node_disk_report = _node_disk_reports.find(node.id());
-            if (node_disk_report == _node_disk_reports.end()) {
+            auto disk_it = _node_disk_reports.find(node.id());
+            if (disk_it == _node_disk_reports.end()) {
                 return 0;
             } else {
-                uint64_t assigned_reallocation_size = 0;
-                if (const auto& asigned_size
-                    = _assigned_reallocation_sizes.find(node.id());
-                    asigned_size != _assigned_reallocation_sizes.end()) {
-                    assigned_reallocation_size = asigned_size->second;
-                }
-                if (node_disk_report->second.total_space == 0) {
+                const auto& node_disk = disk_it->second;
+                if (node_disk.total == 0) {
                     return 0;
                 }
-                auto disk_free_space_rate
-                  = double(
-                      node_disk_report->second.free_space
-                      - assigned_reallocation_size)
-                    / double(node_disk_report->second.total_space);
-                auto min_disk_free_space = double(1) - _max_disk_usage_ratio;
-                if (disk_free_space_rate < min_disk_free_space) {
+                auto peak_disk_usage_ratio = node_disk.peak_used_ratio();
+                if (peak_disk_usage_ratio > _max_disk_usage_ratio) {
                     return 0;
                 } else {
                     return uint64_t(
                       soft_constraint_evaluator::max_score
-                      * ((disk_free_space_rate - min_disk_free_space) / _max_disk_usage_ratio));
+                      * ((_max_disk_usage_ratio - peak_disk_usage_ratio) / _max_disk_usage_ratio));
                 }
             }
             return 0;
@@ -310,14 +277,12 @@ soft_constraint_evaluator least_disk_filled(
         }
 
         const double _max_disk_usage_ratio;
-        const absl::flat_hash_map<model::node_id, uint64_t>&
-          _assigned_reallocation_sizes;
         const absl::flat_hash_map<model::node_id, node_disk_space>&
           _node_disk_reports;
     };
 
-    return soft_constraint_evaluator(std::make_unique<impl>(
-      max_disk_usage_ratio, assigned_reallocation_sizes, node_disk_reports));
+    return soft_constraint_evaluator(
+      std::make_unique<impl>(max_disk_usage_ratio, node_disk_reports));
 }
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -39,8 +39,6 @@ distinct_from(const std::vector<model::broker_shard>&);
 hard_constraint_evaluator disk_not_overflowed_by_partition(
   const double max_disk_usage_ratio,
   const size_t partition_size,
-  const absl::flat_hash_map<model::node_id, uint64_t>&
-    assigned_reallocation_sizes,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports);
 
@@ -53,8 +51,6 @@ soft_constraint_evaluator least_allocated();
  */
 soft_constraint_evaluator least_disk_filled(
   const double max_disk_usage_ratio,
-  const absl::flat_hash_map<model::node_id, uint64_t>&
-    assigned_reallocation_sizes,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports);
 

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -81,7 +81,8 @@ struct partition_balancer_planner_fixture {
     partition_balancer_planner_fixture()
       : planner(
         cluster::planner_config{
-          .max_disk_usage_ratio = 0.8,
+          .soft_max_disk_usage_ratio = 0.8,
+          .hard_max_disk_usage_ratio = 0.95,
           .movement_disk_size_batch = reallocation_batch_size,
           .node_availability_timeout_sec = std::chrono::minutes(1)},
         workers.table.local(),

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -348,6 +348,6 @@ class FranzGoVerifiableProducer(FranzGoVerifiableService):
 def await_minimum_produced_records(redpanda: RedpandaService,
                                    producer: FranzGoVerifiableProducer,
                                    min_acked: int = 0) -> None:
-    wait_until(lambda: producer.produce_status.acked > min_acked,
+    wait_until(lambda: producer.produce_status.acked >= min_acked,
                timeout_sec=300,
                backoff_sec=5)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -78,6 +78,7 @@ class EndToEndTest(Test):
                        num_nodes=1,
                        extra_rp_conf=None,
                        si_settings=None,
+                       environment=None,
                        install_opts: Optional[InstallOptions] = None):
         self.si_settings = si_settings
         if self.si_settings:
@@ -93,7 +94,8 @@ class EndToEndTest(Test):
                                         num_nodes,
                                         extra_rp_conf=self._extra_rp_conf,
                                         extra_node_conf=self._extra_node_conf,
-                                        si_settings=self.si_settings)
+                                        si_settings=self.si_settings,
+                                        environment=environment)
         version_to_install = None
         if install_opts:
             if install_opts.install_previous_version:


### PR DESCRIPTION
## Cover letter

Add a test for partition balancer full disk node handling with the following scenario:
* produce data and fill the cluster up to ~75%
* kill a node.
* partition balancer will move partitions to remaining nodes, causing remaining nodes to go over 80%
* start the killed node, check that partition balancer will balance partitions away from full nodes.

To make this test possible, we introduce an environment variable that forces redpanda to report mock disk size in the health monitor.

This test uncovered a bug in the partition balancer planner: because the planner tries to move all replicas in a set from "bad" nodes in one reallocation, if we don't take into account previous reallocations, we might think that some node is still full even if we have already planned several moves away from it. This lead to excessive movements being planned: when a full node became almost empty after executing a batch of reallocations. To fix this we use "final" node disk usage (after all reallocations are finished) where appropriate.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] v22.2.x

## UX changes
none

## Release notes
* none