### PR TITLE
archival: tweak description of connection limit

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -996,7 +996,8 @@ configuration::configuration()
   , cloud_storage_max_connections(
       *this,
       "cloud_storage_max_connections",
-      "Max number of simultaneous uploads to S3",
+      "Max number of simultaneous connections to S3 per shard (includes "
+      "connections used for both uploads and downloads)",
       {.visibility = visibility::user},
       20)
   , cloud_storage_disable_tls(


### PR DESCRIPTION
## Cover letter
Tweak the description of 'cloud_storage_max_connections' to reflect the
fact that it applies to both uploads and downloads.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none