### PR TITLE
rpk: add a method to deprecate child commands

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -22,6 +22,12 @@ https://redpanda.com/feedback`
 func Deprecated(newCmd *cobra.Command, newUse string) *cobra.Command {
 	newCmd.Deprecated = fmt.Sprintf("use %q instead", newUse)
 	newCmd.Hidden = true
+
+	if children := newCmd.Commands(); len(children) > 0 {
+		for _, child := range children {
+			Deprecated(child, newUse+" "+child.Name())
+		}
+	}
 	return newCmd
 }
 


### PR DESCRIPTION
## Cover letter

rpk now deprecates child commands of deprecated commands.

```
$ rpk config
# will print:
Command "config" is deprecated, use "rpk redpanda config" instead

# however, this won't appear in child commands:
$ rpk config set
... # normal output.
```

Now:
```
$ rpk config
Command "config" is deprecated, use "rpk redpanda config" instead

$ rpk config set
Command "set" is deprecated, use "rpk redpanda config set" instead

$ rpk redpanda config set
# normal output
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5529 

## Backport Required
- [x] papercut/not impactful enough to backport

## UX changes

Users will see deprecated messages in all the commands that are deprecated and not only in the root command.

## Release notes
* none