### PR TITLE
metrics: expose seastar runtime metric

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -317,7 +317,8 @@ void application::setup_metrics() {
     if (!config::shard_local_cfg().disable_public_metrics()) {
         seastar::metrics::replicate_metric_families(
           seastar::metrics::default_handle(),
-          {{"io_queue_total_read_ops", ssx::metrics::public_metrics_handle},
+          {{"scheduler_runtime_ms", ssx::metrics::public_metrics_handle},
+           {"io_queue_total_read_ops", ssx::metrics::public_metrics_handle},
            {"io_queue_total_write_ops", ssx::metrics::public_metrics_handle},
            {"memory_allocated_memory", ssx::metrics::public_metrics_handle},
            {"memory_free_memory", ssx::metrics::public_metrics_handle}})


### PR DESCRIPTION
## Cover letter
Expose the "scheduler_runtime_ms" metric on the "public_metrics" endpoint.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
