### PR TITLE
rpk: try download plugin directly from cloudsmith

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
@@ -2,12 +2,20 @@
 package plugin
 
 import (
+	"bytes"
+	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"runtime"
+	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -145,14 +153,17 @@ whether you have "shadowed" plugins (the same plugin specified multiple times).
 		},
 	}
 
-	cmd.Flags().BoolVarP(&local, "local", "l", false, "list locally installed plugins and shadowed plugins")
+	cmd.Flags().BoolVarP(&local, "local", "l", false, "List locally installed plugins and shadowed plugins")
 
 	return cmd
 }
 
 func newInstallCommand(fs afero.Fs) *cobra.Command {
-	var dir string
-	var update bool
+	var (
+		dir     string
+		update  bool
+		version string
+	)
 	cmd := &cobra.Command{
 		Use:     "install [PLUGIN]",
 		Aliases: []string{"download"},
@@ -166,67 +177,80 @@ be overridden by specifying the --bin-dir flag.
 		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			name := args[0]
+			var (
+				autoComplete bool
+				body         []byte
+				err          error
+			)
+			if len(version) > 0 {
+				body, err = tryDirectDownload(name, version)
+				if err != nil {
+					log.Debugf("unable to download: %v", err)
+				}
+			}
+			if body == nil {
+				fmt.Printf("Searching plugin manifest for %q...\n", name)
+				m, err := getManifest()
+				out.MaybeDieErr(err)
 
-			fmt.Printf("Searching plugin manifest for %q...\n", name)
-			m, err := getManifest()
-			out.MaybeDieErr(err)
+				p, err := m.FindEntry(name)
+				out.MaybeDieErr(err)
 
-			p, err := m.FindEntry(name)
-			out.MaybeDieErr(err)
+				_, remoteSha, err := p.PathShaForUser()
+				out.MaybeDieErr(err)
 
-			_, remoteSha, err := p.PathShaForUser()
-			out.MaybeDieErr(err)
+				var userAlreadyHas bool
+				installed := plugin.ListPlugins(fs, plugin.UserPaths())
+				for _, p := range installed {
+					if name == p.Name() {
+						sha, err := plugin.Sha256Path(fs, p.Path)
+						out.MaybeDieErr(err)
 
-			var userAlreadyHas bool
-			installed := plugin.ListPlugins(fs, plugin.UserPaths())
-			for _, p := range installed {
-				if name == p.Name() {
-					sha, err := plugin.Sha256Path(fs, p.Path)
-					out.MaybeDieErr(err)
+						if sha == remoteSha {
+							out.Exit("Plugin %q is already installed and up to date!", name)
+						}
 
-					if sha == remoteSha {
-						out.Exit("Plugin %q is already installed and up to date!", name)
-					}
-
-					msg := fmt.Sprintf(`Plugin %q is already installed, but is different from the remote plugin!
+						msg := fmt.Sprintf(`Plugin %q is already installed, but is different from the remote plugin!
 
  Local sha256: %s
 Remote sha256: %s
 
 `, name, sha, remoteSha)
-					if !update {
-						out.Exit(msg + "--update was not requested, exiting!")
+						if !update {
+							out.Exit(msg + "--update was not requested, exiting!")
+						}
+						fmt.Println(msg + "Downloading and validating updated plugin...")
+						userAlreadyHas = true
 					}
-					fmt.Println(msg + "Downloading and validating updated plugin...")
-					userAlreadyHas = true
 				}
-			}
-			if !userAlreadyHas {
-				fmt.Println("Found! Downloading and validating plugin...")
-			}
+				if !userAlreadyHas {
+					fmt.Println("Found! Downloading and validating plugin...")
+				}
 
-			body, err := p.DownloadForUser(urlBase)
-			out.MaybeDieErr(err)
+				body, err = p.DownloadForUser(urlBase)
+				out.MaybeDieErr(err)
+				autoComplete = p.HelpAutoComplete
+			}
 
 			fmt.Println("Downloaded! Writing plugin to disk...")
-			dst, err := plugin.WriteBinary(fs, p.Name, dir, body, p.HelpAutoComplete)
+			dst, err := plugin.WriteBinary(fs, name, dir, body, autoComplete)
 			out.MaybeDieErr(err)
 
-			fmt.Printf("Success! Plugin %q has been saved to %q and is now ready to use!\n", p.Name, dst)
+			fmt.Printf("Success! Plugin %q has been saved to %q and is now ready to use!\n", name, dst)
 
-			if p.HelpAutoComplete {
+			if autoComplete {
 				fmt.Printf(`
 This plugin supports autocompletion through rpk.
 
 If you enable rpk autocompletion, start a new terminal to tab complete your new
 command %q!
-`, p.Name)
+`, name)
 			} else {
 				fmt.Printf(`
 
 If you enable rpk autocompletion, start a new terminal to tab complete your new
 command %q!
-`, p.Name)
+`, name)
 			}
 		},
 	}
@@ -235,8 +259,10 @@ command %q!
 	dir, err = determineBinDir()
 	out.MaybeDieErr(err)
 
-	cmd.Flags().StringVar(&dir, "dir", dir, "destination directory to save the installed plugin (defaults to the first dir in $PATH)")
-	cmd.Flags().BoolVarP(&update, "update", "u", false, "update a locally installed plugin if it differs from the current remote version")
+	cmd.Flags().StringVar(&dir, "dir", dir, "Destination directory to save the installed plugin (defaults to the first dir in $PATH)")
+	cmd.Flags().BoolVarP(&update, "update", "u", false, "Update a locally installed plugin if it differs from the current remote version")
+	cmd.Flags().StringVar(&version, "version", "", "Version of the plugin you wish to download")
+	cmd.Flags().MarkHidden("version")
 
 	return cmd
 }
@@ -279,7 +305,7 @@ also removes all shadowed plugins of the same name.
 			}
 		},
 	}
-	cmd.Flags().BoolVar(&includeShadowed, "include-shadowed", false, "also remove shadowed plugins that have the same name")
+	cmd.Flags().BoolVar(&includeShadowed, "include-shadowed", false, "Also remove shadowed plugins that have the same name")
 	return cmd
 }
 
@@ -293,4 +319,48 @@ func determineBinDir() (string, error) {
 		return "", errors.New("unable to determine where to save plugin: PATH list is empty")
 	}
 	return paths[0], nil
+}
+
+func tryDirectDownload(name, version string) ([]byte, error) {
+	u := fmt.Sprintf("https://dl.redpanda.com/public/rpk-plugins/raw/names/%[1]s-%[2]s-%[3]s/versions/%[4]s/%[1]s.tgz", name, runtime.GOOS, runtime.GOARCH, version)
+	fmt.Printf("Searching for plugin %q in %s...\n", name, u)
+
+	client := &http.Client{Timeout: 100 * time.Second}
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		u,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request %s: %v", u, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to issue request to %s: %v", u, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("unsuccessful plugin response from %s, status: %s", u, http.StatusText(resp.StatusCode))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response from %s: %v", u, err)
+	}
+
+	gzr, err := gzip.NewReader(bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create gzip reader: %w", err)
+	}
+	if body, err = io.ReadAll(gzr); err != nil {
+		return nil, fmt.Errorf("unable to gzip decompress plugin: %w", err)
+	}
+	if err = gzr.Close(); err != nil {
+		return nil, fmt.Errorf("unable to close gzip reader: %w", err)
+	}
+
+	return body, nil
 }


### PR DESCRIPTION
## Cover letter

rpk plugin install <name> will try to download the plugin directly from Cloudsmith URL if hidden flag `--version` is passed:

```
URL: https://dl.redpanda.com/public/rpk-plugins/raw/names/[PLUGIN-NAME]-[OS]-[ARCH]/versions/[VERSION]/[PLUGIN-NAME].tgz.
```

Usage:
```yaml
$ rpk plugin install byoc --dir /home/rvasquez/go --version 0.0.1~alpha1

# Will download from

https://dl.redpanda.com/rpk-plugins/raw/names/byoc-linux-amd64/versions/0.0.1~alpha1/byoc.tgz
```
if an error occurs then it'll fall back to the old behavior of looking for the plugin in the S3 manifest.

Fixes #5785

## Backport Required
- [ ] v22.2.x

## UX changes

* none

## Release notes

* none