### PR TITLE
upgrade_test: reduce workload throughput

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -104,7 +104,11 @@ class UpgradeWithWorkloadTest(EndToEndTest):
         super(UpgradeWithWorkloadTest, self).setUp()
         # Start at a version that supports rolling restarts.
         self.initial_version = (22, 1, 3)
-        self.producer_msgs_per_sec = 200
+
+        # Use a relatively low throughput to give the restarted node a chance
+        # to catch up. If the node is particularly slow compared to the others
+        # (e.g. a locally-built debug binary), catching up can take a while.
+        self.producer_msgs_per_sec = 10
         install_opts = InstallOptions(version=self.initial_version)
         self.start_redpanda(num_nodes=3, install_opts=install_opts)
         self.installer = self.redpanda._installer


### PR DESCRIPTION
## Cover letter

Tests that run workloads through a rolling restart are susceptible to
flakiness when the node being restarted is knowingly slower than the
others. This can typically the case when running in mixed versions,
wherein one node is the locally-built debug binaries while the others
are downloaded release binaries. Upon returning from maintenance mode,
we attempt to wait for the number of recovering replicas to drop to
zero, but even the reduced workload we're running leads the test to be
flaky ~5% of the time when run locally.

This commit significantly reduces the workload sent, while still
ensuring progress is made through the rolling restart. I ran
UpgradeWithWorkloadTest.test_rolling_upgrade_with_rollback 100 times
with this reduced workload and saw no failures.

Fixes #5713
Fixed #5837

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes


* none
