### PR TITLE
config: increase storage min free bytes to 5 GiB

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1305,7 +1305,7 @@ configuration::configuration()
   , storage_min_free_bytes(
       *this,
       "storage_min_free_bytes",
-      "Threshold of minimim bytes free space before rejecting producers.",
+      "Threshold of minimum bytes free space before rejecting producers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB,
       {.min = 10_MiB})

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1307,7 +1307,7 @@ configuration::configuration()
       "storage_min_free_bytes",
       "Threshold of minimim bytes free space before rejecting producers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1_GiB,
+      5_GiB,
       {.min = 10_MiB})
   , enable_metrics_reporter(
       *this,


### PR DESCRIPTION
This is our best production default for now.

No backport required.

Fixes: #5853 
## UX changes

Default configuration value for storage_min_free_bytes has been increased from 1 to 5 GiB, which is the recommended starting point for production clusters.

## Release notes

* None
