### PR TITLE
tests: fixed incorrect assertion in movement upgrade test

### DIFF
--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -60,14 +60,21 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
 
     def verify(self):
         self.producer.wait()
+
         # wait for consumers to finish
-        wait_until(
-            lambda: self.consumer.consumer_status.valid_reads == self.producer.
-            produce_status.acked, 30)
+        def finished_consuming():
+            self.logger.debug(
+                f"verifying, producer acked: {self.producer.produce_status.acked}, "
+                f"consumer valid reads: {self.consumer.consumer_status.valid_reads}"
+            )
+            return self.consumer.consumer_status.valid_reads >= self.producer.produce_status.acked
+
+        # wait for consumers to finish
+        wait_until(finished_consuming, 90)
+
+        assert self.consumer.consumer_status.valid_reads >= self.producer.produce_status.acked
         self.consumer.shutdown()
         self.consumer.wait()
-
-        assert self.consumer.consumer_status.valid_reads == self.producer.produce_status.acked
 
     @cluster(num_nodes=6)
     @parametrize(replication_factor=1)


### PR DESCRIPTION
## Cover letter

Fixed assertion checking if the number of consumed messages is equal to
number of acked ones. Correct assertion should validate if number of
consumed messages is greater than equal to number of produced ones as
Kafka consumer groups leverage at least once delivery semantics.



<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5888
## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] v22.2.x
- [ ] v22.1.x
- [ ] papercut/not impactful enough to backport
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
