### PR TITLE
[v22.1.x] cmake: correct seastar SHA1 for public build

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -164,7 +164,7 @@ ExternalProject_Add(cryptopp
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 2a9504b3238cba4150be59353bf8d0b3a01fe39c
+  GIT_TAG 5531940ecd6fa6e5a30bbce8e0573db6f721d343
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
## Cover letter

This appears to have been incorrect since
22.1.1 was released.  Change it to the same SHA1 we use for internal builds.

Fixes https://github.com/redpanda-data/redpanda/issues/5860

## Backport Required

- [X] this is a backport

## UX changes

None

## Release notes

* none
