### PR TITLE
tests/services: fix false positive on 'SEGV' lines from aws IDs

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1024,6 +1024,10 @@ class RedpandaService(Service):
             for line in node.account.ssh_capture(
                     f"grep -e SEGV -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             ):
+                if 'SEGV' in line and 'x-amz-id' in line:
+                    # We log long encoded AWS headers that occasionally have 'SEGV' in them by chance
+                    continue
+
                 if "No such file or directory" not in line:
                     crash_log = line
                     break


### PR DESCRIPTION
## Cover letter

Occasionally, the "SEGV" string shows up inside an AWS ID.

A more nuanced regex might be good, but for the moment just suppress this case now that we've seen it.

## Backport Required

- [ ] not a bug fix
- [X] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
