### PR TITLE
Log unsupported version with warn level

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -72,6 +72,15 @@ ss::future<> connection_context::process_one_request() {
                       return ss::make_ready_future<>();
                   }
                   return dispatch_method_once(std::move(h.value()), s)
+                  .handle_exception_type(
+                    [this](const kafka_api_version_not_supported_exception& e) {
+                        vlog(
+                          klog.warn,
+                          "Error while processing request from {} - {}",
+                          _rs.conn->addr,
+                          e.what());
+                        _rs.conn->shutdown_input();
+                    })
                     .handle_exception_type([this](const std::bad_alloc&) {
                         // In general, dispatch_method_once does not throw,
                         // but bad_allocs are an exception.  Log it cleanly

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -31,6 +31,12 @@
 
 namespace kafka {
 
+class kafka_api_version_not_supported_exception : public std::runtime_error {
+public:
+    explicit kafka_api_version_not_supported_exception(const std::string& m)
+      : std::runtime_error(m) {}
+};
+
 /*
  * authz failures should be quiet or logged at a reduced severity level.
  */

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -98,7 +98,7 @@ process_result_stages process_generic(
     if (ctx.header().key != api_versions_api::key &&
       (ctx.header().version < handler->min_supported() ||
        ctx.header().version > handler->max_supported())) {
-        throw std::runtime_error(fmt::format(
+        throw kafka_api_version_not_supported_exception(fmt::format(
           "Unsupported version {} for {} API",
           ctx.header().version,
           handler->name()));

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -39,12 +39,6 @@ struct process_dispatch { // clang-format on
     }
 };
 
-class kafka_api_version_not_supported_exception : public std::runtime_error {
-public:
-    explicit kafka_api_version_not_supported_exception(const std::string& m)
-      : std::runtime_error(m) {}
-};
-
 template<typename Request>
 requires(KafkaApiHandler<Request> || KafkaApiTwoPhaseHandler<Request>)
   process_result_stages


### PR DESCRIPTION
## Cover letter

When client requests an unsupported API version it is not an unexpected
situation and should not be logged with ERROR severity. Introduced
separate exception handler for unsupported API version exceptions.

Fixes: #5868

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
