### PR TITLE
rpk partitions movement cancel

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -113,3 +113,8 @@ func (a *AdminAPI) DisableMaintenanceMode(ctx context.Context, nodeID int) error
 		nil,
 	)
 }
+
+func (a *AdminAPI) CancelNodePartitionsMovement(ctx context.Context, node int) ([]PartitionsMovementResult, error) {
+	var response []PartitionsMovementResult
+	return response, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%s/%d/cancel_partition_moves", brokersEndpoint, node), nil, &response)
+}

--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -23,7 +23,45 @@ type ClusterHealthOverview struct {
 	LeaderlessPartitions []string `json:"leaderless_partitions"`
 }
 
+// PartitionBalancerStatus is the status of the partition auto balancer.
+type PartitionBalancerStatus struct {
+	// Status is either off, ready, starting, in_progress or stalled.
+	//
+	//   off:          The balancer is disabled.
+	//   ready:        The balancer is active but there is nothing to do.
+	//   starting:     The balancer is starting but has not run yet.
+	//   in_progress:  The balancer is active and is in the process of
+	//                 scheduling partition movements.
+	//   stalled:      There are some violations, but for some reason, the
+	//                 balancer cannot make progress in mitigating them.
+	Status string `json:"status,omitempty"`
+	// Violations are the partition balancer violations.
+	Violations PartitionBalancerViolations `json:"violations,omitempty"`
+	// SecondsSinceLastTick is the last time the partition balancer ran.
+	SecondsSinceLastTick int `json:"seconds_since_last_tick,omitempty"`
+	// CurrentReassignmentsCount is the current number of partition
+	// reassignments in progress.
+	CurrentReassignmentsCount int `json:"current_reassignments_count,omitempty"`
+}
+
+// PartitionBalancerViolations describe the violations of the partition
+// auto balancer.
+type PartitionBalancerViolations struct {
+	// UnavailableNodes are the nodes that have been unavailable after a time
+	// set by 'partition_autobalancing_node_availability_timeout_sec' property.
+	UnavailableNodes []int `json:"unavailable_nodes,omitempty"`
+	// OverDiskLimitNodes are the nodes that surpassed the threshold of used
+	// disk percentage set by 'partition_autobalancing_max_disk_usage_percent'
+	// property.
+	OverDiskLimitNodes []int `json:"over_disk_limit_nodes,omitempty"`
+}
+
 func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview, error) {
 	var response ClusterHealthOverview
 	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/health_overview", nil, &response)
+}
+
+func (a *AdminAPI) GetPartitionStatus(ctx context.Context) (PartitionBalancerStatus, error) {
+	var response PartitionBalancerStatus
+	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/partition_balancer/status", nil, &response)
 }

--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -56,6 +56,15 @@ type PartitionBalancerViolations struct {
 	OverDiskLimitNodes []int `json:"over_disk_limit_nodes,omitempty"`
 }
 
+// PartitionsMovementResult is the information of the partitions movements that
+// were canceled.
+type PartitionsMovementResult struct {
+	Namespace string `json:"ns,omitempty"`
+	Topic     string `json:"topic,omitempty"`
+	Partition int    `json:"partition,omitempty"`
+	Result    string `json:"result,omitempty"`
+}
+
 func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview, error) {
 	var response ClusterHealthOverview
 	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/health_overview", nil, &response)
@@ -64,4 +73,9 @@ func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview
 func (a *AdminAPI) GetPartitionStatus(ctx context.Context) (PartitionBalancerStatus, error) {
 	var response PartitionBalancerStatus
 	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/partition_balancer/status", nil, &response)
+}
+
+func (a *AdminAPI) CancelAllPartitionsMovement(ctx context.Context) ([]PartitionsMovementResult, error) {
+	var response []PartitionsMovementResult
+	return response, a.sendAny(ctx, http.MethodPost, "/v1/cluster/cancel_reconfigurations", nil, &response)
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/license"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/maintenance"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/partitions"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	"github.com/spf13/afero"
@@ -61,6 +62,7 @@ func NewClusterCommand(fs afero.Fs) *cobra.Command {
 		config.NewConfigCommand(fs),
 		license.NewLicenseCommand(fs),
 		maintenance.NewMaintenanceCommand(fs),
+		partitions.NewPartitionsCommand(fs),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
@@ -1,0 +1,52 @@
+package partitions
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewMovementCancelCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "movement-cancel",
+		Short: "Cancel ongoing partitions reconfigurations",
+		Long:  `Cancel all ongoing partitions reconfigurations happening in the cluster`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			movements, err := cl.CancelAllPartitionsMovement(cmd.Context())
+			out.MaybeDie(err, "unable to cancel partitions movements: %v", err)
+
+			if len(movements) == 0 {
+				fmt.Println("There are no partitions movements ongoing to cancel")
+				return
+			}
+			printMovementsResult(movements)
+		},
+	}
+	return cmd
+}
+
+func printMovementsResult(movements []admin.PartitionsMovementResult) {
+	headers := []string{
+		"NAMESPACE",
+		"TOPIC",
+		"PARTITION",
+		"RESULT",
+	}
+	tw := out.NewTable(headers...)
+	defer tw.Flush()
+	for _, m := range movements {
+		tw.PrintStructFields(m)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
@@ -11,11 +11,28 @@ import (
 )
 
 func NewMovementCancelCommand(fs afero.Fs) *cobra.Command {
+	var (
+		node      int
+		noConfirm bool
+	)
 	cmd := &cobra.Command{
 		Use:   "movement-cancel",
 		Short: "Cancel ongoing partitions reconfigurations",
-		Long:  `Cancel all ongoing partitions reconfigurations happening in the cluster`,
-		Args:  cobra.ExactArgs(0),
+		Long: `Cancel ongoing partitions reconfigurations happening in the cluster
+
+By default, this command cancels all the partitions reconfiguration in the
+cluster, to ensure that you do not accidentally cancel all movements, this
+command prompts for confirmation before issuing the cancellation request to the
+cluster, you can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions movement-cancel --no-confirm
+
+If --node is set, this command will only stop the partitions happening in the
+specified node:
+
+    rpk cluster partitions movement-cancel --node 1
+`,
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
@@ -24,8 +41,28 @@ func NewMovementCancelCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			movements, err := cl.CancelAllPartitionsMovement(cmd.Context())
-			out.MaybeDie(err, "unable to cancel partitions movements: %v", err)
+			var movements []admin.PartitionsMovementResult
+			if node >= 0 {
+				if !noConfirm {
+					confirmed, err := out.Confirm("Confirm cancellation of partitions movement in node %v?", node)
+					out.MaybeDie(err, "unable to confirm partitions movements cancel: %v", err)
+					if !confirmed {
+						out.Exit("Command execution canceled.")
+					}
+				}
+				movements, err = cl.CancelNodePartitionsMovement(cmd.Context(), node)
+				out.MaybeDie(err, "unable to cancel partitions movements in node %v: %v", node, err)
+			} else {
+				if !noConfirm {
+					confirmed, err := out.Confirm("Confirm cancellation of all partitions movement in the cluster?")
+					out.MaybeDie(err, "unable to confirm partitions movements cancel: %v", err)
+					if !confirmed {
+						out.Exit("Command execution canceled.")
+					}
+				}
+				movements, err = cl.CancelAllPartitionsMovement(cmd.Context())
+				out.MaybeDie(err, "unable to cancel partitions movements: %v", err)
+			}
 
 			if len(movements) == 0 {
 				fmt.Println("There are no partitions movements ongoing to cancel")
@@ -34,6 +71,8 @@ func NewMovementCancelCommand(fs afero.Fs) *cobra.Command {
 			printMovementsResult(movements)
 		},
 	}
+	cmd.Flags().IntVar(&node, "node", -1, "ID of the node you wish to stop all the ongoing partitions reconfigurations")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
 }
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
@@ -1,0 +1,43 @@
+package partitions
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewPartitionsCommand(fs afero.Fs) *cobra.Command {
+	var (
+		adminURL       string
+		adminEnableTLS bool
+		adminCertFile  string
+		adminKeyFile   string
+		adminCAFile    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "partitions",
+		Args:  cobra.ExactArgs(0),
+		Short: "Manage cluster partitions",
+	}
+
+	common.AddAdminAPITLSFlags(cmd,
+		&adminEnableTLS,
+		&adminCertFile,
+		&adminKeyFile,
+		&adminCAFile,
+	)
+
+	cmd.AddCommand(
+		NewBalancerStatusCommand(fs),
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&adminURL,
+		config.FlagAdminHosts2,
+		"",
+		"Comma-separated list of admin API addresses (<IP>:<port>)")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
@@ -31,6 +31,7 @@ func NewPartitionsCommand(fs afero.Fs) *cobra.Command {
 
 	cmd.AddCommand(
 		NewBalancerStatusCommand(fs),
+		NewMovementCancelCommand(fs),
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/status.go
@@ -1,0 +1,102 @@
+package partitions
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewBalancerStatusCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "balancer-status",
+		Short: "Queries cluster for partition balancer status",
+		Long: `Queries cluster for partition balancer status:
+
+If continuous partition balancing is enabled, redpanda will continuously
+reassign partitions from both unavailable nodes and from nodes using more disk
+space than the configured limit.
+
+This command can be used to monitor the partition balancer status.
+
+FIELDS
+
+    Status:                        Either off, ready, starting, in progress, or
+                                   stalled.
+    Seconds Since Last Tick:       The last time the partition balancer ran.
+    Current Reassignments Count:   Current number of partition reassignments in
+                                   progress.
+    Unavailable Nodes:             The nodes that have been unavailable after a
+                                   time set by the
+                                   "partition_autobalancing_node_availability_timeout_sec"
+                                   cluster property.
+    Over Disk Limit Nodes:         The nodes that surpassed the threshold of
+                                   used disk percentage specified in the
+                                   "partition_autobalancing_max_disk_usage_percent"
+                                   cluster property.
+
+BALANCER STATUS
+
+    off:          The balancer is disabled.
+    ready:        The balancer is active but there is nothing to do.
+    starting:     The balancer is starting but has not run yet.
+    in_progress:  The balancer is active and is in the process of scheduling
+                  partition movements.
+    stalled:      Violations have been detected and the balancer cannot correct
+                  them.
+
+STALLED BALANCER
+
+A stalled balancer can occur for a few reasons and requires a bit of manual
+investigation. A few areas to investigate:
+
+* Are there are enough healthy nodes to which to move partitions? For example,
+  in a three node cluster, no movements are possible for partitions with three
+  replicas. You will see a stall every time there is a violation.
+
+* Does the cluster have sufficient space? If all nodes in the cluster are
+  utilizing more than 80% of their disk space, rebalancing cannot proceed.
+
+* Do all partitions have quorum? If the majority of a partition's replicas are
+  down, the partition cannot be moved.
+
+* Are any nodes in maintenance mode? Partitions are not moved if any node is in
+  maintenance mode.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			status, err := cl.GetPartitionStatus(cmd.Context())
+			out.MaybeDie(err, "unable to request balancer status: %v", err)
+
+			printBalancerStatus(status)
+		},
+	}
+
+	return cmd
+}
+
+func printBalancerStatus(pbs admin.PartitionBalancerStatus) {
+	const format = `Status:                       %v
+Seconds Since Last Tick:      %v
+Current Reassignment Count:   %v
+`
+	fmt.Printf(format, pbs.Status, pbs.SecondsSinceLastTick, pbs.CurrentReassignmentsCount)
+
+	v := pbs.Violations
+	if len(v.OverDiskLimitNodes) > 0 || len(v.UnavailableNodes) > 0 {
+		const vFormat = `Unavailable Nodes:            %v
+Over Disk Limit Nodes:        %v
+`
+		fmt.Printf(vFormat, v.UnavailableNodes, v.OverDiskLimitNodes)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -43,7 +43,7 @@ func AddKafkaFlags(
 		"brokers",
 		[]string{},
 		"Comma-separated list of broker ip:port pairs (e.g."+
-			" --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' )."+
+			" --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092')."+
 			" Alternatively, you may set the REDPANDA_BROKERS environment"+
 			" variable with the comma-separated list of broker addresses",
 	)


### PR DESCRIPTION
## Cover letter

This PR introduces the ability to cancel all partition movement happening in the cluster, its built upon the Admin API [`POST /v1/cluster/cancel_reconfigurations`](https://github.com/redpanda-data/redpanda/blob/72f43599961a4a67c65dfab7ad1bfe6ba19019b4/src/v/redpanda/admin/api-doc/cluster.json#L40-L54) and [`POST /v1/brokers/{id}/cancel_partition_moves`](https://github.com/redpanda-data/redpanda/blob/72f43599961a4a67c65dfab7ad1bfe6ba19019b4/src/v/redpanda/admin/api-doc/broker.json#L148-L169).

### Usage

By default, this command cancels all the partitions reconfiguration in the cluster, to ensure that you do not accidentally cancel all movements, this command prompts for confirmation before issuing the cancellation request to the cluster
```
$ rpk cluster partitions movement-cancel --api-urls '0.0.0.0:9645, 0.0.0.0:9646'

Confirm cancellation of all partitions movement in the cluster? (Y/n) Y

NAMESPACE    TOPIC    PARTITION    RESULT
kafka        foo      29           Success
kafka        foo      91           Partition configuration is not being updated
kafka        foo      82           Timeout occurred while processing request
```

If `--node` is set, this command will only stop the partitions happening in the specified node:

```
$ rpk cluster partitions movement-cancel --node 1 --no-confirm

NAMESPACE  TOPIC  PARTITION  RESULT
kafka      bar    444        Success
kafka      bar    434        Success
kafka      bar    437        Success
kafka      bar    441        Success
kafka      bar    456        Success
kafka      bar    439        Success
kafka      bar    416        Success
kafka      bar    427        Success
```

Fixes #5781 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] v22.2.x

## UX changes

This PR adds `rpk cluster partitions movement-cancel` which allows the user to cancel ongoing partitions movement in a cluster via rpk.

## Release notes
* Now you can cancel ongoing partitions movement in a cluster running `rpk cluster partitions movement-cancel` 
