### PR TITLE
Add additional types to compat

### DIFF
--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -138,6 +138,32 @@ std::ostream& operator<<(std::ostream& o, const partitions_filter& filter) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const get_node_health_request& r) {
+    fmt::print(
+      o, "{{filter: {}, current_version: {}}}", r.filter, r.current_version);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const get_node_health_reply& r) {
+    fmt::print(o, "{{error: {}, report: {}}}", r.error, r.report);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const get_cluster_health_request& r) {
+    fmt::print(
+      o,
+      "{{filter: {}, refresh: {}, decoded_version: {}}}",
+      r.filter,
+      r.refresh,
+      r.decoded_version);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const get_cluster_health_reply& r) {
+    fmt::print(o, "{{error: {}, report: {}}}", r.error, r.report);
+    return o;
+}
+
 } // namespace cluster
 namespace reflection {
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -274,6 +274,9 @@ struct get_node_health_request
     operator==(const get_node_health_request&, const get_node_health_request&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream&, const get_node_health_request&);
+
     auto serde_fields() { return std::tie(filter); }
 };
 
@@ -287,6 +290,9 @@ struct get_node_health_reply
     friend bool
     operator==(const get_node_health_reply&, const get_node_health_reply&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const get_node_health_reply&);
 
     auto serde_fields() { return std::tie(error, report); }
 };
@@ -310,6 +316,9 @@ struct get_cluster_health_request
     friend bool operator==(
       const get_cluster_health_request&, const get_cluster_health_request&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const get_cluster_health_request&);
 
     void serde_write(iobuf& out) {
         using serde::write;
@@ -339,6 +348,9 @@ struct get_cluster_health_reply
     friend bool
     operator==(const get_cluster_health_reply&, const get_cluster_health_reply&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const get_cluster_health_reply&);
 
     auto serde_fields() { return std::tie(error, report); }
 };

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/health_monitor_types.h"
+#include "model/tests/randoms.h"
+#include "random/generators.h"
+#include "storage/tests/randoms.h"
+#include "test_utils/randoms.h"
+
+namespace cluster::node {
+
+inline local_state random_local_state() {
+    return local_state{
+      {},
+      tests::random_named_string<application_version>(),
+      tests::random_named_int<cluster::cluster_version>(),
+      tests::random_duration<std::chrono::milliseconds>(),
+      tests::random_vector(storage::random_disk),
+      storage::disk_space_alert{
+        0} // TODO: replace with storage::random_disk_space_alert()
+    };
+}
+
+} // namespace cluster::node
+
+namespace cluster {
+
+inline errc random_failed_errc() {
+    return errc(random_generators::get_int<int16_t>(
+      static_cast<int16_t>(errc::notification_wait_timeout),
+      static_cast<int16_t>(errc::unknown_update_interruption_error)));
+}
+
+inline node_state random_node_state() {
+    return node_state{
+      {},
+      tests::random_named_int<model::node_id>(),
+      model::random_membership_state(),
+      cluster::alive(tests::random_bool())};
+}
+
+inline partition_status random_partition_status() {
+    return partition_status{
+      {},
+      tests::random_named_int<model::partition_id>(),
+      tests::random_named_int<model::term_id>(),
+      tests::random_optional(
+        [] { return tests::random_named_int<model::node_id>(); }),
+      tests::random_named_int<model::revision_id>(),
+      random_generators::get_int<size_t>()};
+}
+
+inline topic_status random_topic_status() {
+    return topic_status{
+      {},
+      model::random_topic_namespace(),
+      tests::random_vector(random_partition_status)};
+}
+
+inline drain_manager::drain_status random_drain_status() {
+    return drain_manager::drain_status{
+      {},
+      tests::random_bool(),
+      tests::random_bool(),
+      tests::random_optional(
+        [] { return random_generators::get_int<size_t>(); }),
+      tests::random_optional(
+        [] { return random_generators::get_int<size_t>(); }),
+      tests::random_optional(
+        [] { return random_generators::get_int<size_t>(); }),
+      tests::random_optional(
+        [] { return random_generators::get_int<size_t>(); })};
+}
+
+inline node_health_report random_node_health_report() {
+    auto random_ds = tests::random_optional(
+      [] { return random_drain_status(); });
+
+    return node_health_report{
+      {},
+      tests::random_named_int<model::node_id>(),
+      node::random_local_state(),
+      tests::random_vector(random_topic_status),
+      random_ds.has_value(),
+      random_ds};
+}
+
+inline cluster_health_report random_cluster_health_report() {
+    return cluster_health_report{
+      {},
+      tests::random_optional(
+        [] { return tests::random_named_int<model::node_id>(); }),
+      tests::random_vector(random_node_state),
+      tests::random_vector(random_node_health_report)};
+}
+
+inline partitions_filter random_partitions_filter() {
+    auto parition_set_gen = [] {
+        return tests::random_node_hash_set<model::partition_id>(
+          tests::random_named_int<model::partition_id>);
+    };
+    auto topic_kv_gen = [&] {
+        return std::pair{
+          tests::random_named_string<model::topic>(), parition_set_gen()};
+    };
+    auto topic_map_gen = [&] {
+        return tests::random_node_hash_map<
+          model::topic,
+          partitions_filter::partitions_set_t>(topic_kv_gen);
+    };
+    auto ns_kv_gen = [&] {
+        return std::pair{
+          tests::random_named_string<model::ns>(), topic_map_gen()};
+    };
+    auto ns_map_gen = [&] {
+        return tests::
+          random_node_hash_map<model::ns, partitions_filter::topic_map_t>(
+            ns_kv_gen);
+    };
+
+    return partitions_filter{{}, ns_map_gen()};
+}
+
+inline node_report_filter random_node_report_filter() {
+    return node_report_filter{
+      {},
+      include_partitions_info(tests::random_bool()),
+      random_partitions_filter()};
+}
+
+inline cluster_report_filter random_cluster_report_filter() {
+    return cluster_report_filter{
+      {}, random_node_report_filter(), tests::random_vector([] {
+          return tests::random_named_int<model::node_id>();
+      })};
+}
+
+} // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -717,6 +717,40 @@ std::ostream& operator<<(std::ostream& o, const prepare_group_tx_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const commit_group_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} pid {} tx_seq {} group_id {} timeout {}}}",
+      r.ntp,
+      r.pid,
+      r.tx_seq,
+      r.group_id,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const commit_group_tx_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const abort_group_tx_request& r) {
+    fmt::print(
+      o,
+      "{{ntp {} pid {} tx_seq {} group_id {} timeout {}}}",
+      r.ntp,
+      r.pid,
+      r.tx_seq,
+      r.group_id,
+      r.timeout);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const abort_group_tx_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -708,6 +708,9 @@ struct commit_group_tx_request
     operator==(const commit_group_tx_request&, const commit_group_tx_request&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const commit_group_tx_request& r);
+
     auto serde_fields() {
         return std::tie(ntp, pid, tx_seq, group_id, timeout);
     }
@@ -725,6 +728,9 @@ struct commit_group_tx_reply
     friend bool
     operator==(const commit_group_tx_reply&, const commit_group_tx_reply&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const commit_group_tx_reply& r);
 
     auto serde_fields() { return std::tie(ec); }
 };
@@ -767,6 +773,9 @@ struct abort_group_tx_request
     operator==(const abort_group_tx_request&, const abort_group_tx_request&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const abort_group_tx_request& r);
+
     auto serde_fields() {
         return std::tie(ntp, group_id, pid, tx_seq, timeout);
     }
@@ -784,6 +793,9 @@ struct abort_group_tx_reply
     friend bool
     operator==(const abort_group_tx_reply&, const abort_group_tx_reply&)
       = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const abort_group_tx_reply& r);
 
     auto serde_fields() { return std::tie(ec); }
 };

--- a/src/v/compat/abort_group_tx_compat.h
+++ b/src/v/compat/abort_group_tx_compat.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/abort_group_tx_generator.h"
+#include "compat/check.h"
+#include "compat/json.h"
+
+namespace compat {
+
+GEN_COMPAT_CHECK(
+  cluster::abort_group_tx_request,
+  {
+      json_write(ntp);
+      json_write(group_id);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(group_id);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(timeout);
+  });
+
+GEN_COMPAT_CHECK(
+  cluster::abort_group_tx_reply, { json_write(ec); }, { json_read(ec); });
+
+}; // namespace compat

--- a/src/v/compat/abort_group_tx_generator.h
+++ b/src/v/compat/abort_group_tx_generator.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "kafka/types.h"
+#include "model/tests/randoms.h"
+#include "model/timeout_clock.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::abort_group_tx_request> {
+    static cluster::abort_group_tx_request random() {
+        return cluster::abort_group_tx_request(
+          model::random_ntp(),
+          tests::random_named_string<kafka::group_id>(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::abort_group_tx_request> limits() { return {}; }
+};
+
+template<>
+struct instance_generator<cluster::abort_group_tx_reply> {
+    static cluster::abort_group_tx_reply random() {
+        return cluster::abort_group_tx_reply(
+          cluster::tx_errc(random_generators::get_int<int>(
+            static_cast<int>(cluster::tx_errc::none),
+            static_cast<int>(cluster::tx_errc::invalid_txn_state))));
+    }
+    static std::vector<cluster::abort_group_tx_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/commit_group_tx_compat.h
+++ b/src/v/compat/commit_group_tx_compat.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/commit_group_tx_generator.h"
+#include "compat/json.h"
+
+namespace compat {
+
+GEN_COMPAT_CHECK(
+  cluster::commit_group_tx_request,
+  {
+      json_write(ntp);
+      json_write(pid);
+      json_write(tx_seq);
+      json_write(group_id);
+      json_write(timeout);
+  },
+  {
+      json_read(ntp);
+      json_read(pid);
+      json_read(tx_seq);
+      json_read(group_id);
+      json_read(timeout);
+  });
+
+GEN_COMPAT_CHECK(
+  cluster::commit_group_tx_reply, { json_write(ec); }, { json_read(ec); });
+
+}; // namespace compat

--- a/src/v/compat/commit_group_tx_generator.h
+++ b/src/v/compat/commit_group_tx_generator.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "kafka/types.h"
+#include "model/timeout_clock.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::commit_group_tx_request> {
+    static cluster::commit_group_tx_request random() {
+        return cluster::commit_group_tx_request(
+          model::random_ntp(),
+          model::random_producer_identity(),
+          tests::random_named_int<model::tx_seq>(),
+          tests::random_named_string<kafka::group_id>(),
+          tests::random_duration<model::timeout_clock::duration>());
+    }
+    static std::vector<cluster::commit_group_tx_request> limits() { return {}; }
+};
+
+template<>
+struct instance_generator<cluster::commit_group_tx_reply> {
+    static cluster::commit_group_tx_reply random() {
+        return cluster::commit_group_tx_reply(
+          cluster::tx_errc(random_generators::get_int<int>(
+            static_cast<int>(cluster::tx_errc::none),
+            static_cast<int>(cluster::tx_errc::invalid_txn_state))));
+    }
+    static std::vector<cluster::commit_group_tx_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/get_cluster_health_compat.h
+++ b/src/v/compat/get_cluster_health_compat.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/get_cluster_health_generator.h"
+#include "compat/json.h"
+
+namespace compat {
+
+GEN_COMPAT_CHECK(
+  cluster::get_cluster_health_request,
+  {
+      json_write(filter);
+      json_write(refresh);
+      json_write(decoded_version);
+  },
+  {
+      json_read(filter);
+      json_read(refresh);
+      json_read(decoded_version);
+  });
+
+GEN_COMPAT_CHECK(
+  cluster::get_cluster_health_reply,
+  {
+      json_write(error);
+      json_write(report);
+  },
+  {
+      json_read(error);
+      json_read(report);
+  });
+
+}; // namespace compat

--- a/src/v/compat/get_cluster_health_generator.h
+++ b/src/v/compat/get_cluster_health_generator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/tests/randoms.h"
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "model/timeout_clock.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::get_cluster_health_request> {
+    static cluster::get_cluster_health_request random() {
+        return cluster::get_cluster_health_request{
+          {},
+          cluster::random_cluster_report_filter(),
+          cluster::force_refresh(tests::random_bool())};
+    }
+    static std::vector<cluster::get_cluster_health_request> limits() {
+        return {};
+    }
+};
+
+template<>
+struct instance_generator<cluster::get_cluster_health_reply> {
+    static cluster::get_cluster_health_reply random() {
+        return {
+          .error = instance_generator<cluster::errc>::random(),
+          .report = tests::random_optional(
+            cluster::random_cluster_health_report),
+        };
+    }
+    static std::vector<cluster::get_cluster_health_reply> limits() {
+        return {};
+    }
+};
+
+} // namespace compat

--- a/src/v/compat/get_node_health_compat.h
+++ b/src/v/compat/get_node_health_compat.h
@@ -1,0 +1,76 @@
+
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "compat/check.h"
+#include "compat/get_node_health_generator.h"
+#include "compat/json.h"
+
+namespace compat {
+
+GEN_COMPAT_CHECK(
+  cluster::get_node_health_request,
+  { json_write(filter); },
+  { json_read(filter); });
+
+template<>
+struct compat_check<cluster::get_node_health_reply> {
+    static constexpr std::string_view name = "cluster::get_node_health_reply";
+
+    static std::vector<cluster::get_node_health_reply> create_test_cases() {
+        return generate_instances<cluster::get_node_health_reply>();
+    }
+
+    static void to_json(
+      cluster::get_node_health_reply obj,
+      json::Writer<json::StringBuffer>& wr) {
+        json_write(error);
+        json_write(report);
+    }
+
+    static cluster::get_node_health_reply from_json(json::Value& rd) {
+        cluster::get_node_health_reply obj;
+        json_read(error);
+        json_read(report);
+        return obj;
+    }
+
+    static std::vector<compat_binary>
+    to_binary(cluster::get_node_health_reply obj) {
+        return compat_binary::serde_and_adl(obj);
+    }
+
+    static void
+    check(cluster::get_node_health_reply expected, compat_binary test) {
+        const auto name = test.name;
+        auto decoded = decode_adl_or_serde<cluster::get_node_health_reply>(
+          std::move(test));
+
+        /*
+         * adl encoding doesn't consider the error so we need to ignore that and
+         * only consider the report. serde encodes both error and report.
+         */
+        vassert(name == "serde" || name == "adl", "unexpected name {}", name);
+        const auto equal = name == "serde" ? expected == decoded
+                                           : expected.report == decoded.report;
+        if (!equal) {
+            throw compat_error(fmt::format(
+              "Verify of {{{}}} decoding failed:\nExpected: {}\nDecoded: {}",
+              name,
+              expected,
+              decoded));
+        }
+    }
+};
+
+}; // namespace compat

--- a/src/v/compat/get_node_health_generator.h
+++ b/src/v/compat/get_node_health_generator.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/tests/randoms.h"
+#include "cluster/types.h"
+#include "compat/generator.h"
+#include "model/timeout_clock.h"
+#include "test_utils/randoms.h"
+
+namespace compat {
+
+template<>
+struct instance_generator<cluster::get_node_health_request> {
+    static cluster::get_node_health_request random() {
+        return cluster::get_node_health_request{
+          {},
+          cluster::random_node_report_filter(),
+          random_generators::get_int<int8_t>()};
+    }
+    static std::vector<cluster::get_node_health_request> limits() { return {}; }
+};
+
+template<>
+struct instance_generator<cluster::get_node_health_reply> {
+    static cluster::get_node_health_reply random() {
+        return {
+          .error = instance_generator<cluster::errc>::random(),
+          .report = tests::random_optional(
+            [] { return cluster::random_node_health_report(); }),
+        };
+    }
+    static std::vector<cluster::get_node_health_reply> limits() { return {}; }
+};
+
+} // namespace compat

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -13,13 +13,17 @@
 #include "cluster/metadata_dissemination_types.h"
 #include "cluster/partition_balancer_types.h"
 #include "cluster/types.h"
+#include "compat/abort_group_tx_compat.h"
 #include "compat/abort_tx_compat.h"
 #include "compat/acls_compat.h"
 #include "compat/begin_group_tx_compat.h"
 #include "compat/begin_tx_compat.h"
 #include "compat/check.h"
 #include "compat/cluster_compat.h"
+#include "compat/commit_group_tx_compat.h"
 #include "compat/commit_tx_compat.h"
+#include "compat/get_cluster_health_compat.h"
+#include "compat/get_node_health_compat.h"
 #include "compat/id_allocator_compat.h"
 #include "compat/init_tm_tx_compat.h"
 #include "compat/metadata_dissemination_compat.h"
@@ -114,7 +118,15 @@ using compat_checks = type_list<
   cluster::partition_balancer_overview_request,
   cluster::partition_balancer_overview_reply,
   cluster::delete_acls_request,
-  cluster::delete_acls_reply>;
+  cluster::delete_acls_reply,
+  cluster::commit_group_tx_request,
+  cluster::commit_group_tx_reply,
+  cluster::abort_group_tx_request,
+  cluster::abort_group_tx_reply,
+  cluster::get_node_health_request,
+  cluster::get_node_health_reply,
+  cluster::get_cluster_health_request,
+  cluster::get_cluster_health_reply>;
 
 template<typename T>
 struct corpus_helper {

--- a/src/v/compat/storage_json.h
+++ b/src/v/compat/storage_json.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "compat/json.h"
+#include "storage/types.h"
+
+namespace json {
+
+inline void read_value(json::Value const& rd, storage::disk& obj) {
+    read_member(rd, "path", obj.path);
+    read_member(rd, "free", obj.free);
+    read_member(rd, "total", obj.total);
+}
+
+inline void
+rjson_serialize(json::Writer<json::StringBuffer>& w, const storage::disk& d) {
+    w.StartObject();
+    write_member(w, "path", d.path);
+    write_member(w, "free", d.free);
+    write_member(w, "total", d.total);
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -136,6 +136,12 @@ inline model::broker random_broker() {
     return random_broker(tests::random_named_int<model::node_id>());
 }
 
+inline model::membership_state random_membership_state() {
+    return membership_state(random_generators::get_int<int8_t>(
+      static_cast<int8_t>(model::membership_state::active),
+      static_cast<int8_t>(model::membership_state::removed)));
+}
+
 inline model::producer_identity random_producer_identity() {
     return {
       random_generators::get_int<int64_t>(),

--- a/src/v/storage/tests/randoms.h
+++ b/src/v/storage/tests/randoms.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/tests/randoms.h"
+#include "random/generators.h"
+#include "storage/types.h"
+#include "test_utils/randoms.h"
+
+namespace storage {
+
+inline storage::disk random_disk() {
+    return storage::disk{
+      {},
+      random_generators::gen_alphanum_string(20),
+      random_generators::get_int<uint64_t>(),
+      random_generators::get_int<uint64_t>()};
+}
+
+inline disk_space_alert random_disk_space_alert() {
+    return disk_space_alert(random_generators::get_int(
+      static_cast<int>(disk_space_alert::ok),
+      static_cast<int>(disk_space_alert::degraded)));
+}
+
+} // namespace storage

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -20,6 +20,7 @@
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
 
+#include <absl/container/node_hash_map.h>
 #include <bits/stdint-uintn.h>
 
 #include <limits>
@@ -89,6 +90,32 @@ inline std::chrono::milliseconds random_duration_ms() {
     auto rand = random_generators::get_int<int64_t>(0, max_ns);
     auto rand_ns = std::chrono::nanoseconds{rand};
     return std::chrono::duration_cast<std::chrono::milliseconds>(rand_ns);
+}
+
+template<typename Key, typename Value, typename Fn>
+inline absl::node_hash_map<Key, Value>
+random_node_hash_map(Fn&& gen, size_t size = 20) {
+    absl::node_hash_map<Key, Value> hm{};
+
+    for (size_t i = 0; i < size; i++) {
+        auto [k, v] = gen();
+        hm[k] = v;
+    }
+
+    return hm;
+}
+
+template<typename Value, typename Fn>
+inline absl::node_hash_set<Value>
+random_node_hash_set(Fn&& gen, size_t size = 20) {
+    absl::node_hash_set<Value> hs{};
+
+    for (size_t i = 0; i < size; i++) {
+        auto v = gen();
+        hs.insert(v);
+    }
+
+    return hs;
 }
 
 /*


### PR DESCRIPTION
## Cover letter

This PR adds the following types to compat;
- commit_group_tx_request
- commit_group_tx_reply
- abort_group_tx_request
- abort_group_tx_reply
- get_node_health_request
- get_node_health_reply
- get_cluster_health_request
- get_cluster_health_reply

## Release notes
* none