### PR TITLE
serde: add serde_direct_read

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -102,6 +102,12 @@ concept has_serde_direct_read
 };
 
 template<typename T>
+concept has_serde_async_direct_read
+  = requires(iobuf_parser& in, size_t bytes_left_limit) {
+    { T::serde_async_direct_read(in, bytes_left_limit) } -> seastar::Future;
+};
+
+template<typename T>
 concept is_absl_flat_hash_map
   = ::detail::is_specialization_of_v<T, absl::flat_hash_map>;
 
@@ -763,7 +769,10 @@ template<typename T>
 ss::future<std::decay_t<T>>
 read_async_nested(iobuf_parser& in, size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
-    if constexpr (has_serde_async_read<Type>) {
+    if constexpr (has_serde_async_direct_read<Type>) {
+        auto const h = read_header<Type>(in, bytes_left_limit);
+        return Type::serde_async_direct_read(in, h._bytes_left_limit);
+    } else if constexpr (has_serde_async_read<Type>) {
         auto const h = read_header<Type>(in, bytes_left_limit);
         return ss::do_with(Type{}, [&in, h](Type& t) {
             return t.serde_async_read(in, h).then(


### PR DESCRIPTION
## Cover letter

Introduce `serde[_async]_direct_read` so that default constructors aren't required.

## Backport Required

* [x] Not a bugfix

## UX changes

* none

## Release notes

* none
