### PR TITLE
Partition balancer: interaction with maintenance mode and node decommission

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -362,6 +362,7 @@ ss::future<> controller::start() {
             std::ref(_stm),
             std::ref(_tp_state),
             std::ref(_hm_frontend),
+            std::ref(_members_table),
             std::ref(_partition_allocator),
             std::ref(_tp_frontend),
             config::shard_local_cfg().partition_autobalancing_mode.bind(),

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -125,6 +125,16 @@ ss::future<> partition_balancer_backend::do_tick() {
       = co_await _health_monitor.get_current_cluster_health_snapshot(
         cluster_report_filter{});
 
+    auto follower_metrics = _raft0->get_follower_metrics();
+    for (auto& follower : follower_metrics) {
+        // patch last heartbeat time so that we don't get false positives for
+        // unavailable node detection for nodes that didn't respond to a
+        // heartbeat since we became leader (last_heartbeat would be -infinity
+        // for them).
+        follower.last_heartbeat = std::max(
+          follower.last_heartbeat, _raft0->became_leader_at());
+    }
+
     double soft_max_disk_usage_ratio = _max_disk_usage_percent() / 100.0;
     double hard_max_disk_usage_ratio
       = (100 - _storage_space_alert_free_threshold_percent()) / 100.0;
@@ -139,7 +149,7 @@ ss::future<> partition_balancer_backend::do_tick() {
           _topic_table,
           _members_table,
           _partition_allocator)
-          .plan_reassignments(health_report, _raft0->get_follower_metrics());
+          .plan_reassignments(health_report, follower_metrics);
 
     _last_leader_term = _raft0->term();
     _last_tick_time = ss::lowres_clock::now();

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -174,10 +174,12 @@ ss::future<> partition_balancer_backend::do_tick() {
           clusterlog.info,
           "last status: {}; "
           "violations: unavailable nodes: {}, full nodes: {}; "
+          "updates in progress: {}; "
           "reassignments planned: {}, cancelled: {}, failed: {}",
           _last_status,
           _last_violations.unavailable_nodes.size(),
           _last_violations.full_nodes.size(),
+          _topic_table.updates_in_progress().size(),
           plan_data.reassignments.size(),
           plan_data.cancellations.size(),
           plan_data.failed_reassignments_count);

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -151,7 +151,9 @@ ss::future<> partition_balancer_backend::do_tick() {
         _last_status = partition_balancer_status::in_progress;
     } else if (plan_data.status == planner_status::waiting_for_reports) {
         _last_status = partition_balancer_status::starting;
-    } else if (plan_data.failed_reassignments_count > 0) {
+    } else if (
+      plan_data.failed_reassignments_count > 0
+      || plan_data.status == planner_status::waiting_for_maintenance_end) {
         _last_status = partition_balancer_status::stalled;
     } else {
         _last_status = partition_balancer_status::ready;

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -31,6 +31,7 @@ public:
       ss::sharded<controller_stm>&,
       ss::sharded<topic_table>&,
       ss::sharded<health_monitor_frontend>&,
+      ss::sharded<members_table>&,
       ss::sharded<partition_allocator>&,
       ss::sharded<topics_frontend>&,
       config::binding<model::partition_autobalancing_mode>&& mode,
@@ -71,6 +72,7 @@ private:
     controller_stm& _controller_stm;
     topic_table& _topic_table;
     health_monitor_frontend& _health_monitor;
+    members_table& _members_table;
     partition_allocator& _partition_allocator;
     topics_frontend& _topics_frontend;
 

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -66,10 +66,11 @@ public:
 private:
     struct reallocation_request_state {
         std::vector<model::node_id> all_nodes;
-        absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
-        absl::flat_hash_set<model::node_id> unavailable_nodes;
+        absl::flat_hash_set<model::node_id> all_unavailable_nodes;
+        absl::flat_hash_set<model::node_id> timed_out_unavailable_nodes;
         size_t num_nodes_in_maintenance = 0;
         absl::flat_hash_set<model::node_id> decommissioning_nodes;
+        absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
 
         absl::flat_hash_map<model::ntp, size_t> ntp_sizes;
 

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -69,6 +69,7 @@ private:
         absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
         absl::flat_hash_set<model::node_id> unavailable_nodes;
         size_t num_nodes_in_maintenance = 0;
+        absl::flat_hash_set<model::node_id> decommissioning_nodes;
 
         absl::flat_hash_map<model::ntp, size_t> ntp_sizes;
 
@@ -104,8 +105,7 @@ private:
       plan_data&) const;
 
     void get_unavailable_node_movement_cancellations(
-      std::vector<model::ntp>& cancellations,
-      const reallocation_request_state&);
+      plan_data&, const reallocation_request_state&);
 
     bool is_partition_movement_possible(
       const std::vector<model::broker_shard>& current_replicas,

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -48,6 +48,7 @@ public:
         empty,
         movement_planned,
         cancellations_planned,
+        waiting_for_maintenance_end,
         waiting_for_reports,
     };
 
@@ -67,6 +68,7 @@ private:
         std::vector<model::node_id> all_nodes;
         absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
         absl::flat_hash_set<model::node_id> unavailable_nodes;
+        size_t num_nodes_in_maintenance = 0;
 
         absl::flat_hash_map<model::ntp, size_t> ntp_sizes;
 

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -189,11 +189,15 @@ struct partition_balancer_planner_fixture {
                 metrics.push_back(raft::follower_metrics{
                   .id = model::node_id(i),
                   .last_heartbeat = raft::clock_type::now()
-                                    - node_unavailable_timeout});
+                                    - node_unavailable_timeout,
+                  .is_live = false,
+                });
             } else {
                 metrics.push_back(raft::follower_metrics{
                   .id = model::node_id(i),
-                  .last_heartbeat = raft::clock_type::now()});
+                  .last_heartbeat = raft::clock_type::now(),
+                  .is_live = true,
+                });
             }
         }
         return metrics;

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -229,6 +229,16 @@ struct partition_balancer_planner_fixture {
         return health_report;
     }
 
+    void set_maintenance_mode(model::node_id id) {
+        workers.members.local().apply(
+          model::offset{}, cluster::maintenance_mode_cmd(id, true));
+        auto broker = workers.members.local().get_broker(id);
+        BOOST_REQUIRE(broker);
+        BOOST_REQUIRE(
+          broker.value()->get_maintenance_state()
+          == model::maintenance_state::active);
+    }
+
     controller_workers workers;
     cluster::partition_balancer_planner planner;
     int last_node_idx{};

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -761,3 +761,65 @@ FIXTURE_TEST(
       == cluster::partition_balancer_planner::status::
         waiting_for_maintenance_end);
 }
+
+/*
+ * 4 nodes; 1 topic; 1 node down; 1 decommissioning node
+ * Planner should not schedule any movements to the decommissioning node.
+ *   node_0: partitions: 1; down: True;
+ *   node_1: partitions: 1; down: False;
+ *   node_2: partitions: 1; down: False;
+ *   node_3: partitions: 0; down: False; decommissioning: True
+ */
+FIXTURE_TEST(
+  test_interaction_with_decommission_1, partition_balancer_planner_fixture) {
+    allocator_register_nodes(3);
+    create_topic("topic-1", 1, 3);
+    allocator_register_nodes(1);
+
+    std::set<size_t> unavailable_nodes{0};
+    auto hr = create_health_report();
+    auto fm = create_follower_metrics(unavailable_nodes);
+    set_decommissioning(model::node_id{3});
+
+    auto plan_data = planner.plan_reassignments(hr, fm);
+
+    check_violations(plan_data, unavailable_nodes, {});
+    BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
+    BOOST_REQUIRE_EQUAL(plan_data.failed_reassignments_count, 1);
+}
+
+/*
+ * 4 nodes; 1 topic; 1 node down; 1 decommissioning node
+ * Planner should not cancel any movements from the decommissioning node.
+ *   node_0: partitions: 1; down: False; decommissioning: True
+ *   node_1: partitions: 1; down: False;
+ *   node_2: partitions: 1; down: False;
+ *   node_3: partitions: 0; down: True;
+ *   movement in progress: (0, 1, 2) -> (1, 2, 3)
+ */
+FIXTURE_TEST(
+  test_interaction_with_decommission_2, partition_balancer_planner_fixture) {
+    allocator_register_nodes(3);
+    create_topic("topic-1", 1, 3);
+    allocator_register_nodes(1);
+
+    std::set<size_t> unavailable_nodes{3};
+    auto hr = create_health_report();
+    auto fm = create_follower_metrics(unavailable_nodes);
+
+    set_decommissioning(model::node_id{0});
+    move_partition_replicas(
+      model::ntp(test_ns, "topic-1", 0),
+      {
+        model::broker_shard{model::node_id{1}, 0},
+        model::broker_shard{model::node_id{2}, 0},
+        model::broker_shard{model::node_id{3}, 0},
+      });
+
+    auto plan_data = planner.plan_reassignments(hr, fm);
+
+    check_violations(plan_data, unavailable_nodes, {});
+    BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
+    BOOST_REQUIRE_EQUAL(plan_data.cancellations.size(), 0);
+    BOOST_REQUIRE_EQUAL(plan_data.failed_reassignments_count, 1);
+}

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -160,6 +160,9 @@ public:
     group_configuration config() const;
     const model::ntp& ntp() const { return _log.config().ntp(); }
     clock_type::time_point last_heartbeat() const { return _hbeat; };
+    clock_type::time_point became_leader_at() const {
+        return _became_leader_at;
+    };
 
     clock_type::time_point last_sent_append_entries_req_timesptamp(vnode);
     /**


### PR DESCRIPTION
## Cover letter

Fixes related to maintenance mode/decommissioning:
* If there is one node in maintenance mode, the balancer doesn't schedule any movements
* The balancer doesn't schedule any movements to decommissioning nodes
* The balancer doesn't cancel any movements from decommissioning nodes

Fixes #5572

Also a couple of unrelated fixes:
* A fix for a bug that manifested when controller leadership changed (all nodes became unavailable regardless of the time of the last ping).
* A fix for a bug when the balancer was in the "starting" state until an unavailable node timed out.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] v22.2.x

## UX changes
none

## Release notes
* none