### PR TITLE
Cache minor fixes backport to v22.1.x

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -69,7 +69,7 @@ public:
       ss::io_priority_class io_priority
       = priority_manager::local().shadow_indexing_priority(),
       size_t write_buffer_size = default_write_buffer_size,
-      unsigned int write_behind = default_write_buffer_size);
+      unsigned int write_behind = default_writebehind);
 
     /// \brief Checks if the value is cached
     ///


### PR DESCRIPTION
in v22.1.x we do not have access time tracker related code, so the only change to be backported is the writebehind fix.

partial backport of https://github.com/redpanda-data/redpanda/pull/5892