### PR TITLE
auth: Improvements for endpoint authentication

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -50,9 +50,10 @@ ss::future<> connection_context::process_one_request() {
            * 3. handshake was v0
            */
           if (unlikely(
-                sasl().state()
-                  == security::sasl_server::sasl_state::authenticate
-                && sasl().handshake_v0())) {
+                sasl()
+                && sasl()->state()
+                     == security::sasl_server::sasl_state::authenticate
+                && sasl()->handshake_v0())) {
               return handle_auth_v0(*sz).handle_exception(
                 [this](std::exception_ptr e) {
                     vlog(klog.info, "Detected error processing request: {}", e);
@@ -148,7 +149,8 @@ ss::future<> connection_context::handle_auth_v0(const size_t size) {
           response.data.error_message));
     }
 
-    if (sasl().state() == security::sasl_server::sasl_state::failed) {
+    if (
+      !sasl() || sasl()->state() == security::sasl_server::sasl_state::failed) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format, "Auth (handshake v0) failed with unknown error"));
     }

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -80,7 +80,7 @@ public:
     connection_context(
       protocol& p,
       net::server::resources&& r,
-      security::sasl_server sasl,
+      std::optional<security::sasl_server> sasl,
       bool enable_authorizer,
       std::optional<security::tls::mtls_state> mtls_state) noexcept
       : _proto(p)
@@ -100,7 +100,9 @@ public:
 
     protocol& server() { return _proto; }
     const ss::sstring& listener() const { return _rs.conn->name(); }
-    security::sasl_server& sasl() { return _sasl; }
+    security::sasl_server* sasl() {
+        return _sasl.has_value() ? &_sasl.value() : nullptr;
+    }
 
     template<typename T>
     bool authorized(
@@ -109,13 +111,16 @@ public:
         if (!_enable_authorizer) {
             return true;
         }
-        // mtls configured?
-        if (_mtls_state) {
-            return authorized_user(
-              _mtls_state->principal(), operation, name, quiet);
-        }
-        // use sasl
-        return authorized_user(sasl().principal(), operation, name, quiet);
+
+        auto get_principal = [this]() {
+            if (_mtls_state) {
+                return _mtls_state->principal();
+            } else if (_sasl) {
+                return _sasl->principal();
+            }
+            return ss::sstring{}; // anonymous user
+        };
+        return authorized_user(get_principal(), operation, name, quiet);
     }
 
     template<typename T>
@@ -131,26 +136,46 @@ public:
           name, operation, principal, security::acl_host(_client_addr));
 
         if (!authorized) {
-            if (quiet) {
-                vlog(
-                  _authlog.debug,
-                  "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
-                  "resource: {}",
-                  _proto.name(),
-                  security::sasl_state_to_str(_sasl.state()),
-                  operation,
-                  principal,
-                  name);
+            if (_sasl) {
+                if (quiet) {
+                    vlog(
+                      _authlog.debug,
+                      "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
+                      "resource: {}",
+                      _proto.name(),
+                      security::sasl_state_to_str(_sasl->state()),
+                      operation,
+                      principal,
+                      name);
+                } else {
+                    vlog(
+                      _authlog.info,
+                      "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
+                      "resource: {}",
+                      _proto.name(),
+                      security::sasl_state_to_str(_sasl->state()),
+                      operation,
+                      principal,
+                      name);
+                }
             } else {
-                vlog(
-                  _authlog.info,
-                  "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
-                  "resource: {}",
-                  _proto.name(),
-                  security::sasl_state_to_str(_sasl.state()),
-                  operation,
-                  principal,
-                  name);
+                if (quiet) {
+                    vlog(
+                      _authlog.debug,
+                      "proto: {}, acl op: {}, principal: {}, resource: {}",
+                      _proto.name(),
+                      operation,
+                      principal,
+                      name);
+                } else {
+                    vlog(
+                      _authlog.info,
+                      "proto: {}, acl op: {}, principal: {}, resource: {}",
+                      _proto.name(),
+                      operation,
+                      principal,
+                      name);
+                }
             }
         }
 
@@ -267,7 +292,7 @@ private:
     sequence_id _next_response;
     sequence_id _seq_idx;
     map_t _responses;
-    security::sasl_server _sasl;
+    std::optional<security::sasl_server> _sasl;
     const ss::net::inet_address _client_addr;
     const bool _enable_authorizer;
     ctx_log _authlog;

--- a/src/v/kafka/server/handlers/sasl_authenticate.cc
+++ b/src/v/kafka/server/handlers/sasl_authenticate.cc
@@ -23,7 +23,7 @@ ss::future<response_ptr> sasl_authenticate_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     vlog(klog.debug, "Received SASL_AUTHENTICATE {}", request);
 
-    auto result = ctx.sasl().authenticate(std::move(request.data.auth_bytes));
+    auto result = ctx.sasl()->authenticate(std::move(request.data.auth_bytes));
     if (likely(result)) {
         sasl_authenticate_response_data data{
           .error_code = error_code::none,

--- a/src/v/kafka/server/handlers/sasl_handshake.cc
+++ b/src/v/kafka/server/handlers/sasl_handshake.cc
@@ -33,13 +33,13 @@ ss::future<response_ptr> sasl_handshake_handler::handle(
     auto error = error_code::none;
 
     if (request.data.mechanism == security::scram_sha256_authenticator::name) {
-        ctx.sasl().set_mechanism(
+        ctx.sasl()->set_mechanism(
           std::make_unique<security::scram_sha256_authenticator::auth>(
             ctx.credentials()));
 
     } else if (
       request.data.mechanism == security::scram_sha512_authenticator::name) {
-        ctx.sasl().set_mechanism(
+        ctx.sasl()->set_mechanism(
           std::make_unique<security::scram_sha512_authenticator::auth>(
             ctx.credentials()));
 

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -170,10 +170,10 @@ ss::future<> protocol::apply(net::server::resources rs) {
      * if sasl authentication is not enabled then initialize the sasl state to
      * complete. this will cause auth to be skipped during request processing.
      */
-    security::sasl_server sasl(
-      authn_method == config::broker_authn_method::sasl
-        ? security::sasl_server::sasl_state::initial
-        : security::sasl_server::sasl_state::complete);
+    auto sasl = authn_method == config::broker_authn_method::sasl
+                  ? std::make_optional<security::sasl_server>(
+                    security::sasl_server::sasl_state::initial)
+                  : std::nullopt;
 
     std::optional<security::tls::mtls_state> mtls_state;
     if (authn_method == config::broker_authn_method::mtls_identity) {
@@ -187,9 +187,9 @@ ss::future<> protocol::apply(net::server::resources rs) {
     co_return co_await ss::do_until(
       [ctx] { return ctx->is_finished_parsing(); },
       [ctx] { return ctx->process_one_request(); })
-      .handle_exception([ctx](std::exception_ptr eptr) {
+      .handle_exception([ctx, authn_method](std::exception_ptr eptr) {
           auto disconnected = net::is_disconnect_exception(eptr);
-          if (config::shard_local_cfg().enable_sasl()) {
+          if (authn_method == config::broker_authn_method::sasl) {
               /*
                * This block is a 2x2 matrix of:
                * - sasl enabled or disabled
@@ -208,7 +208,7 @@ ss::future<> protocol::apply(net::server::resources rs) {
                     ctx->client_host(),
                     ctx->client_port(),
                     disconnected.value(),
-                    security::sasl_state_to_str(ctx->sasl().state()));
+                    security::sasl_state_to_str(ctx->sasl()->state()));
 
               } else {
                   vlog(
@@ -218,7 +218,7 @@ ss::future<> protocol::apply(net::server::resources rs) {
                     ctx->client_host(),
                     ctx->client_port(),
                     eptr,
-                    security::sasl_state_to_str(ctx->sasl().state()));
+                    security::sasl_state_to_str(ctx->sasl()->state()));
               }
           } else {
               if (disconnected) {

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -184,7 +184,7 @@ public:
     }
 
     const ss::sstring& listener() const { return _conn->listener(); }
-    security::sasl_server& sasl() { return _conn->sasl(); }
+    security::sasl_server* sasl() { return _conn->sasl(); }
     security::credential_store& credentials() {
         return _conn->server().credentials();
     }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1333,14 +1333,16 @@ class RedpandaService(Service):
             conf = yaml.dump(doc)
 
         if self._security.tls_provider:
-            tls_config = dict(
-                enabled=True,
-                require_client_auth=True,
-                name="dnslistener",
-                key_file=RedpandaService.TLS_SERVER_KEY_FILE,
-                cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
-                truststore_file=RedpandaService.TLS_CA_CRT_FILE,
-            )
+            tls_config = [
+                dict(
+                    enabled=True,
+                    require_client_auth=True,
+                    name=n,
+                    key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+                    cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+                    truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+                ) for n in ["dnslistener", "iplistener"]
+            ]
             doc = yaml.full_load(conf)
             doc["redpanda"].update(dict(kafka_api_tls=tls_config))
             conf = yaml.dump(doc)


### PR DESCRIPTION
## Cover letter

If neither `sasl` or `mtls_identity` are in use, then use the anonymous user.
`mtls_identity` requires tls and and client auth to be enabled.

This is undertested. Exhaustive tests are being worked on separately: https://github.com/redpanda-data/redpanda/compare/dev...BenPope:redpanda:redpanda-mtls-improvements

## Backport Required

- [x] fix for a feature that hasn't been released

## UX changes

* none

## Release notes

* none