### PR TITLE
tests: add assertions & logging to verifiable producer

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -234,8 +234,17 @@ class EndToEndTest(Test):
                                 consumer_timeout_sec=30,
                                 enable_idempotence=False) -> None:
         try:
-            self.await_consumed_offsets(self.producer.last_acked_offsets,
+            # Take copy of this dict in case a rogue VerifiableProducer
+            # thread modifies it.
+            # Related: https://github.com/redpanda-data/redpanda/issues/3450
+            last_acked_offsets = self.producer.last_acked_offsets.copy()
+
+            self.logger.info("Producer's offsets after stopping: %s" %\
+                         str(last_acked_offsets))
+
+            self.await_consumed_offsets(last_acked_offsets,
                                         consumer_timeout_sec)
+
             self.consumer.stop()
 
             self.validate(enable_idempotence)


### PR DESCRIPTION

## Cover letter

This is to narrow down a spooky failure seen when
the consumer is apparently not waiting for a high enough
offset, due to seeing a lower offset in await_consumed_offsets
than the VerifiableProducer had earlier reported.

Related: https://github.com/redpanda-data/redpanda/issues/3450

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* none
