### PR TITLE
archival: catch sem timeout in upload/sync loops

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -99,6 +99,13 @@ void ntp_archiver::run_sync_manifest_loop() {
           .handle_exception_type([](const ss::abort_requested_exception&) {})
           .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([this](const ss::semaphore_timed_out& e) {
+              vlog(
+                _rtclog.warn,
+                "Semaphore timed out in sync manifest loop: {}. This may be "
+                "due to the system being overloaded. The loop will restart.",
+                e);
+          })
           .handle_exception([this](std::exception_ptr e) {
               vlog(_rtclog.error, "sync manifest loop error: {}", e);
           })
@@ -122,6 +129,13 @@ void ntp_archiver::run_upload_loop() {
           .handle_exception_type([](const ss::abort_requested_exception&) {})
           .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([this](const ss::semaphore_timed_out& e) {
+              vlog(
+                _rtclog.warn,
+                "Semaphore timed out in the upload loop: {}. This may be "
+                "due to the system being overloaded. The loop will restart.",
+                e);
+          })
           .handle_exception([this](std::exception_ptr e) {
               vlog(_rtclog.error, "upload loop error: {}", e);
           })


### PR DESCRIPTION
## Cover Letter

Catch semaphore timeouts in the upload and sync manifest loops.
Semaphores are not used explicitly on those code paths, but other
synchronization primitives may use them and throw on timeout (see
segment_read_lock in 'ntp_archiver'.

Fixes #5895 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none