### PR TITLE
Refresh health monitor on leader

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -18,6 +18,7 @@
 #include "cluster/members_table.h"
 #include "config/configuration.h"
 #include "feature_table.h"
+#include "model/timeout_clock.h"
 #include "raft/group_manager.h"
 
 namespace cluster {
@@ -302,7 +303,8 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // This call in principle can be a network fetch, but in practice
     // we're only doing it immediately after cluster health has just
     // been updated, so do not expect it to go remote.
-    auto node_status_v = co_await _hm_frontend.local().get_nodes_status({});
+    auto node_status_v = co_await _hm_frontend.local().get_nodes_status(
+      model::timeout_clock::now() + 5s);
     if (node_status_v.has_error()) {
         // Raise exception to trigger backoff+retry
         throw std::runtime_error(fmt::format(

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -484,12 +484,6 @@ health_monitor_backend::maybe_refresh_cluster_health(
     co_return errc::success;
 }
 
-cluster_health_report
-health_monitor_backend::get_current_cluster_health_snapshot(
-  const cluster_report_filter& f) {
-    return build_cluster_report(f);
-}
-
 ss::future<result<node_health_report>>
 health_monitor_backend::collect_remote_node_health(model::node_id id) {
     const auto timeout = model::timeout_clock::now() + max_metadata_age();

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -429,7 +429,7 @@ health_monitor_backend::get_cluster_health(
   model::timeout_clock::time_point deadline) {
     vlog(
       clusterlog.debug,
-      "requesing cluster state report with filter: {}, force refresh: {}",
+      "requesting cluster state report with filter: {}, force refresh: {}",
       filter,
       refresh);
     auto ec = co_await maybe_refresh_cluster_health(refresh, deadline);

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -76,8 +76,6 @@ health_monitor_backend::health_monitor_backend(
       std::move(storage_min_bytes),
       storage_node_api,
       storage_api) {
-    _tick_timer.set_callback([this] { tick(); });
-    _tick_timer.arm(tick_interval());
     _leadership_notification_handle
       = _raft_manager.local().register_leadership_notification(
         [this](
@@ -124,7 +122,6 @@ ss::future<> health_monitor_backend::stop() {
     auto f = _gate.close();
     _refresh_mutex.broken();
     abort_current_refresh();
-    _tick_timer.cancel();
 
     if (_refresh_request) {
         _refresh_request.release();
@@ -278,23 +275,9 @@ health_monitor_backend::refresh_cluster_health_cache(force_refresh force) {
     auto holder = _gate.hold();
     auto leader_id = _raft0->get_leader_id();
 
-    // if we are a leader, do nothing
-    if (leader_id == _raft0->self().id()) {
-        co_return errc::success;
-    }
-
     // leadership change, abort old refresh request
     if (_refresh_request && leader_id != _refresh_request->leader_id) {
         abort_current_refresh();
-    }
-
-    // no leader controller
-    if (!leader_id) {
-        vlog(
-          clusterlog.debug,
-          "unable to refresh health metadata, no leader controller");
-        // TODO: maybe we should try to ping other members in this case ?
-        co_return errc::no_leader_controller;
     }
 
     auto units = co_await _refresh_mutex.get_units();
@@ -310,10 +293,6 @@ health_monitor_backend::refresh_cluster_health_cache(force_refresh force) {
         co_return errc::no_leader_controller;
     }
 
-    if (leader_id == _raft0->self().id()) {
-        co_return errc::success;
-    }
-
     // check under semaphore if we need to force refresh, otherwise we will just
     // skip refresh request since current state is 'fresh enough' i.e. not older
     // than max metadata age
@@ -326,13 +305,22 @@ health_monitor_backend::refresh_cluster_health_cache(force_refresh force) {
         co_return errc::success;
     }
 
-    vlog(clusterlog.debug, "refreshing health cache, leader id: {}", leader_id);
+    vlog(
+      clusterlog.debug,
+      "refreshing health cache, leader id: {} self: {}",
+      leader_id,
+      _raft0->self().id());
 
     _refresh_request = ss::make_lw_shared<abortable_refresh_request>(
       *leader_id, std::move(holder), std ::move(units));
 
-    co_return co_await _refresh_request->abortable_await(
-      dispatch_refresh_cluster_health_request(*leader_id));
+    // we either collect the cluster health reports while on raft0 leader or ask
+    // current leader for cluster health
+    auto f = leader_id == _raft0->self().id()
+               ? collect_cluster_health()
+               : dispatch_refresh_cluster_health_request(*leader_id);
+
+    co_return co_await _refresh_request->abortable_await(std::move(f));
 }
 
 ss::future<std::error_code>
@@ -396,7 +384,6 @@ health_monitor_backend::dispatch_refresh_cluster_health_request(
     }
 
     _reports_disk_health = cluster_disk_health;
-    _last_refresh = ss::lowres_clock::now();
     co_return make_error_code(errc::success);
 }
 
@@ -466,7 +453,7 @@ health_monitor_backend::maybe_refresh_cluster_health(
 
     // if current node is not the controller leader and we need a refresh we
     // refresh metadata cache
-    if (!_raft0->is_elected_leader() && need_refresh) {
+    if (need_refresh) {
         try {
             auto f = refresh_cluster_health_cache(refresh);
             auto err = co_await ss::with_timeout(deadline, std::move(f));
@@ -492,6 +479,7 @@ health_monitor_backend::maybe_refresh_cluster_health(
               "previous cluster health snapshot");
             co_return errc::timeout;
         }
+        _last_refresh = ss::lowres_clock::now();
     }
     co_return errc::success;
 }
@@ -500,29 +488,6 @@ cluster_health_report
 health_monitor_backend::get_current_cluster_health_snapshot(
   const cluster_report_filter& f) {
     return build_cluster_report(f);
-}
-
-void health_monitor_backend::tick() {
-    ssx::spawn_with_gate(_gate, [this]() -> ss::future<> {
-        co_await _local_monitor.update_state();
-        co_await tick_cluster_health();
-    });
-}
-
-ss::future<> health_monitor_backend::tick_cluster_health() {
-    if (!_raft0->is_elected_leader()) {
-        vlog(clusterlog.trace, "skipping tick, not leader");
-        _tick_timer.arm(tick_interval());
-        co_return;
-    }
-
-    // make sure that ticks will have fixed interval
-    auto next_tick = ss::lowres_clock::now() + tick_interval();
-    co_await collect_cluster_health().finally([this, next_tick] {
-        if (!_as.local().abort_requested()) {
-            _tick_timer.arm(next_tick);
-        }
-    });
 }
 
 ss::future<result<node_health_report>>
@@ -601,11 +566,11 @@ result<node_health_report> health_monitor_backend::process_node_reply(
     return res;
 }
 
-ss::future<> health_monitor_backend::collect_cluster_health() {
+ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     /**
      * We are collecting cluster health on raft 0 leader only
      */
-    vlog(clusterlog.trace, "collecting cluster health statistics");
+    vlog(clusterlog.info, "collecting cluster health statistics");
     // collect all reports
     auto ids = _members.local().all_broker_ids();
     auto reports = co_await ssx::async_transform(
@@ -653,6 +618,7 @@ ss::future<> health_monitor_backend::collect_cluster_health() {
         }
     }
     _reports_disk_health = cluster_disk_health;
+    co_return errc::success;
 }
 
 ss::future<result<node_health_report>>
@@ -772,10 +738,6 @@ health_monitor_backend::collect_topic_status(partitions_filter filters) {
     }
 
     co_return topics;
-}
-
-std::chrono::milliseconds health_monitor_backend::tick_interval() {
-    return config::shard_local_cfg().health_monitor_tick_interval();
 }
 
 std::chrono::milliseconds health_monitor_backend::max_metadata_age() {

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -117,8 +117,7 @@ private:
       = absl::node_hash_map<model::node_id, reply_status>;
 
     void tick();
-    ss::future<> tick_cluster_health();
-    ss::future<> collect_cluster_health();
+    ss::future<std::error_code> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);
     ss::future<std::error_code> maybe_refresh_cluster_health(
@@ -140,7 +139,6 @@ private:
     result<node_health_report>
       process_node_reply(model::node_id, result<get_node_health_reply>);
 
-    std::chrono::milliseconds tick_interval();
     std::chrono::milliseconds max_metadata_age();
     void abort_current_refresh();
 
@@ -166,7 +164,6 @@ private:
       = storage::disk_space_alert::ok;
     last_reply_cache_t _last_replies;
 
-    ss::timer<ss::lowres_clock> _tick_timer;
     ss::gate _gate;
     mutex _refresh_mutex;
     node::local_monitor _local_monitor;

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -65,9 +65,6 @@ public:
     ss::future<result<cluster_health_report>> get_cluster_health(
       cluster_report_filter, force_refresh, model::timeout_clock::time_point);
 
-    cluster_health_report
-    get_current_cluster_health_snapshot(const cluster_report_filter&);
-
     ss::future<storage::disk_space_alert> get_cluster_disk_health(
       force_refresh refresh, model::timeout_clock::time_point deadline);
 

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -54,14 +54,6 @@ storage::disk_space_alert health_monitor_frontend::get_cluster_disk_health() {
     return _cluster_disk_health;
 }
 
-ss::future<cluster_health_report>
-health_monitor_frontend::get_current_cluster_health_snapshot(
-  cluster_report_filter f) {
-    return dispatch_to_backend([f = std::move(f)](health_monitor_backend& be) {
-        return be.get_current_cluster_health_snapshot(f);
-    });
-}
-
 // Collcts and returns current node health report according to provided
 // filters list
 ss::future<result<node_health_report>>

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -53,10 +53,6 @@ public:
 
     storage::disk_space_alert get_cluster_disk_health();
 
-    // Returns currently available cluster health report snapshot
-    ss::future<cluster_health_report>
-      get_current_cluster_health_snapshot(cluster_report_filter);
-
     // Collcts and returns current node health report according to provided
     // filters list
     ss::future<result<node_health_report>>

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1288,7 +1288,8 @@ configuration::configuration()
       *this,
       "health_monitor_tick_interval",
       "How often health monitor refresh cluster state",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::deprecated},
       10s)
   , health_monitor_max_metadata_age(
       *this,

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -223,7 +223,9 @@ class EndToEndTest(Test):
             self.logger.info("Stopping producer after writing up to offsets %s" %\
                          str(self.producer.last_acked_offsets))
             self.producer.stop()
-            self.run_consumer_validation()
+            self.run_consumer_validation(
+                consumer_timeout_sec=consumer_timeout_sec,
+                enable_idempotence=enable_idempotence)
         except BaseException:
             self._collect_all_logs()
             raise

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -134,7 +134,7 @@ class WriteRejectTest(RedpandaTest):
 class FullDiskTest(EndToEndTest):
     def __init__(self, test_ctx):
         extra_rp_conf = {
-            "health_monitor_tick_interval": 1000,
+            "health_monitor_max_metadata_age": 1000,
             "metrics_reporter_tick_interval": 2000,
             "metrics_reporter_report_interval": 1000,
         }

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -27,7 +27,7 @@ class MetricsReporterTest(RedpandaTest):
             test_context=test_ctx,
             num_brokers=num_brokers,
             extra_rp_conf={
-                "health_monitor_tick_interval": 1000,
+                "health_monitor_max_metadata_age": 1000,
                 # report every two seconds
                 "metrics_reporter_tick_interval": 2000,
                 "metrics_reporter_report_interval": 1000,

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -407,7 +407,7 @@ class PartitionBalancerTest(EndToEndTest):
             extra_rp_conf={
                 "storage_min_free_bytes": 10 * 1024 * 1024,
                 "raft_learner_recovery_rate": 100_000_000,
-                "health_monitor_tick_interval": 3000
+                "health_monitor_max_metadata_age": 3000
             },
             environment={"__REDPANDA_TEST_DISK_SIZE": disk_size})
 


### PR DESCRIPTION
## Cover letter
  Changed the way how cluster health is refreshed on the `raft0` leader
  node. Currently the refresh will be triggered if controller leader
  health metadata is stale. Previously the refresh was timer base it might
  have happened that when leadership was change requester accessed a stale
  health metadata which were much older than `max_metadata_age`.

  Now every time the health report is requested we check the metadata age
  and if metadata is stale we dispatch an appropriate refresh request
  either contacting leader or gathering information from the cluster.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
