### PR TITLE
Partition list comparison made order independent

### DIFF
--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -225,7 +225,8 @@ class TestMirrorMakerService(EndToEndTest):
 
             self.logger.info(
                 f"source {source_group}, target_group: {target_group}")
-            return target_group.partitions == source_group.partitions and target_group.name == source_group.name
+            return sorted(target_group.partitions) == sorted(source_group.partitions) and \
+                target_group.name == source_group.name
 
         # wait for consumer group sync
         timeout = 600 if self.redpanda.dedicated_nodes else 60


### PR DESCRIPTION
## Cover letter

To properly check whether the lists of partitons in `rpk group describe` are the same, sort both partition lists first because the order of partitions is 1 - not guaranteed and 2 - not important.

Fixes #5762

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
