### PR TITLE
config: allow setting storage_min_free_bytes to zero

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1318,7 +1318,7 @@ configuration::configuration()
       "Threshold of minimum bytes free space before rejecting producers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB,
-      {.min = 10_MiB})
+      {.min = 0})
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",


### PR DESCRIPTION
Reasoning: CI and dev / test setups may wish to disable the threshold.

## Cover letter

* None

## Backport Required

- [x ] not a bug fix

## UX changes

Allow setting configuration for `storage_min_free_bytes` to zero, which disables behavior which block external producers from writing when space is low.

