### PR TITLE
rpk cluster partitions movement-cancel

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -113,3 +113,8 @@ func (a *AdminAPI) DisableMaintenanceMode(ctx context.Context, nodeID int) error
 		nil,
 	)
 }
+
+func (a *AdminAPI) CancelNodePartitionsMovement(ctx context.Context, node int) ([]PartitionsMovementResult, error) {
+	var response []PartitionsMovementResult
+	return response, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%s/%d/cancel_partition_moves", brokersEndpoint, node), nil, &response)
+}

--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -56,6 +56,15 @@ type PartitionBalancerViolations struct {
 	OverDiskLimitNodes []int `json:"over_disk_limit_nodes,omitempty"`
 }
 
+// PartitionsMovementResult is the information of the partitions movements that
+// were canceled.
+type PartitionsMovementResult struct {
+	Namespace string `json:"ns,omitempty"`
+	Topic     string `json:"topic,omitempty"`
+	Partition int    `json:"partition,omitempty"`
+	Result    string `json:"result,omitempty"`
+}
+
 func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview, error) {
 	var response ClusterHealthOverview
 	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/health_overview", nil, &response)
@@ -64,4 +73,9 @@ func (a *AdminAPI) GetHealthOverview(ctx context.Context) (ClusterHealthOverview
 func (a *AdminAPI) GetPartitionStatus(ctx context.Context) (PartitionBalancerStatus, error) {
 	var response PartitionBalancerStatus
 	return response, a.sendAny(ctx, http.MethodGet, "/v1/cluster/partition_balancer/status", nil, &response)
+}
+
+func (a *AdminAPI) CancelAllPartitionsMovement(ctx context.Context) ([]PartitionsMovementResult, error) {
+	var response []PartitionsMovementResult
+	return response, a.sendAny(ctx, http.MethodPost, "/v1/cluster/cancel_reconfigurations", nil, &response)
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/cancel.go
@@ -1,0 +1,52 @@
+package partitions
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewMovementCancelCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "movement-cancel",
+		Short: "Cancel ongoing partitions reconfigurations",
+		Long:  `Cancel all ongoing partitions reconfigurations happening in the cluster`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			movements, err := cl.CancelAllPartitionsMovement(cmd.Context())
+			out.MaybeDie(err, "unable to cancel partitions movements: %v", err)
+
+			if len(movements) == 0 {
+				fmt.Println("There are no partitions movements ongoing to cancel")
+				return
+			}
+			printMovementsResult(movements)
+		},
+	}
+	return cmd
+}
+
+func printMovementsResult(movements []admin.PartitionsMovementResult) {
+	headers := []string{
+		"NAMESPACE",
+		"TOPIC",
+		"PARTITION",
+		"RESULT",
+	}
+	tw := out.NewTable(headers...)
+	defer tw.Flush()
+	for _, m := range movements {
+		tw.PrintStructFields(m)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
@@ -30,8 +30,8 @@ func NewPartitionsCommand(fs afero.Fs) *cobra.Command {
 	)
 
 	cmd.AddCommand(
-		NewBalancerStatusCommand(fs),
-		NewMovementCancelCommand(fs),
+		newBalancerStatusCommand(fs),
+		newMovementCancelCommand(fs),
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/partitions.go
@@ -31,6 +31,7 @@ func NewPartitionsCommand(fs afero.Fs) *cobra.Command {
 
 	cmd.AddCommand(
 		NewBalancerStatusCommand(fs),
+		NewMovementCancelCommand(fs),
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/src/go/rpk/pkg/cli/cmd/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/partitions/status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewBalancerStatusCommand(fs afero.Fs) *cobra.Command {
+func newBalancerStatusCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "balancer-status",
 		Short: "Queries cluster for partition balancer status",


### PR DESCRIPTION
## Cover letter

This PR introduces the ability to cancel all partition movement happening in the cluster, its built upon the Admin API [`POST /v1/cluster/cancel_reconfigurations`](https://github.com/redpanda-data/redpanda/blob/72f43599961a4a67c65dfab7ad1bfe6ba19019b4/src/v/redpanda/admin/api-doc/cluster.json#L40-L54) and [`POST /v1/brokers/{id}/cancel_partition_moves`](https://github.com/redpanda-data/redpanda/blob/72f43599961a4a67c65dfab7ad1bfe6ba19019b4/src/v/redpanda/admin/api-doc/broker.json#L148-L169).

### Usage

By default, this command cancels all the partitions reconfiguration in the cluster, to ensure that you do not accidentally cancel all movements, this command prompts for confirmation before issuing the cancellation request to the cluster
```
$ rpk cluster partitions movement-cancel --api-urls '0.0.0.0:9645, 0.0.0.0:9646'

Confirm cancellation of all partitions movement in the cluster? (Y/n) Y

NAMESPACE    TOPIC    PARTITION    RESULT
kafka        foo      29           Success
kafka        foo      91           Partition configuration is not being updated
kafka        foo      82           Timeout occurred while processing request
```

If `--node` is set, this command will only stop the partitions happening in the specified node:

```
$ rpk cluster partitions movement-cancel --node 1 --no-confirm

NAMESPACE  TOPIC  PARTITION  RESULT
kafka      bar    444        Success
kafka      bar    434        Success
kafka      bar    437        Success
kafka      bar    441        Success
kafka      bar    456        Success
kafka      bar    439        Success
kafka      bar    416        Success
kafka      bar    427        Success
```

Fixes #5781 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] v22.2.x

## UX changes

This PR adds `rpk cluster partitions movement-cancel` which allows the user to cancel ongoing partitions movement in a cluster via rpk.

## Release notes
* Now you can cancel ongoing partitions movement in a cluster running `rpk cluster partitions movement-cancel` 

