### PR TITLE
rpk: sandbox mode: default and container mode

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "62bdc61185e7b81b8f96b400db98ed2f",
+			expectedHash:            "a3a81f47c734ebcd16ba339c77c7c4c0",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "979cb39eb1bebf515348713f4cd2d6da",
+			expectedHash: "cfc65ce54611c67feef7270e8c1d41ba",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "fad668348b9d5c88dae6f4db3ffe4041",
+			expectedHash: "791074a427c1b5006459bc466586d1a5",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -213,6 +213,7 @@ func TestSetCommand(t *testing.T) {
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 pandaproxy: {}
 schema_registry: {}
 `,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -15,6 +15,7 @@ package redpanda
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -37,7 +38,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
 )
 
 type prestartConfig struct {
@@ -131,7 +131,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 		installDirFlag  string
 		timeout         time.Duration
 		wellKnownIo     string
-		sandbox         bool
+		sandbox         string
 	)
 	sFlags := seastarFlags{}
 
@@ -150,6 +150,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			// for list flags, and since JSON often contains commas, it
 			// blows up when there's a JSON object.
 			configKvs, filteredArgs := parseConfigKvs(os.Args)
+			parseSandboxFlag(os.Args, &sandbox)
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			if err != nil {
@@ -162,22 +163,24 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			// Thus, we can ignore any env / flags that would come from rpk
 			// configuration itself.
 			cfg = cfg.FileOrDefaults()
-			clusterProperties := make(map[string]interface{})
-			if sandbox {
-				fmt.Fprintln(os.Stderr, "WARNING: This is a setup for development purposes only; in sandbox mode your clusters may run unrealistically fast and data can be corrupted any time your computer shuts down uncleanly.")
-				cfg.Redpanda.DeveloperMode = true
-				setDevModeFlags(cmd)
-				clusterProperties["topic_partitions_per_shard"] = 1000
-				clusterProperties["group_topic_partitions"] = 1
-				clusterProperties["auto_create_topics_enabled"] = true
+			if cfg.Redpanda.DeveloperMode && len(sandbox) == 0 {
+				sandbox = "default"
 			}
-			if cfg.Redpanda.DeveloperMode {
-				clusterProperties["storage_min_free_bytes"] = 0
-			}
-			if len(clusterProperties) > 0 {
-				err := setClusterProperties(fs, cfg.FileLocation(), clusterProperties)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "unable to set cluster properties: %v\n", err)
+			if len(sandbox) > 0 {
+				switch sandbox {
+				case "default", "container":
+					fmt.Fprintln(os.Stderr, "WARNING: This is a setup for development purposes only; in sandbox mode your clusters may run unrealistically fast and data can be corrupted any time your computer shuts down uncleanly.")
+					cfg.Redpanda.DeveloperMode = true
+					setDevModeFlags(cmd, sandbox)
+					err := setClusterProperties(fs, cfg.FileLocation(), sandbox)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "unable to set cluster properties: %v\n", err)
+					}
+				case "help":
+					fmt.Println(helpSandbox)
+					return nil
+				default:
+					return fmt.Errorf(`unrecognized sandbox type %q, use --sandbox=help for more info"`, sandbox)
 				}
 			}
 			if len(configKvs) > 0 {
@@ -505,7 +508,15 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 		"Enable overprovisioning",
 	)
 	command.Flags().BoolVar(&sFlags.unsafeBypassFsync, unsafeBypassFsyncFlag, false, "Enable unsafe-bypass-fsync")
-	command.Flags().BoolVar(&sandbox, sandboxFlag, false, "Sandbox mode, sets the following flags: --overprovisioned --smp 1 --node-id 0 --reserveMemory 0M --check=false --unsafe-bypass-fsync=true")
+	command.Flags().StringVar(
+		&sandbox,
+		sandboxFlag,
+		"",
+		"Sandbox mode, sets relevant properties for local development or test container usage; use --sandbox help for more info",
+	)
+	// --sandbox will be the same as --sandbox default:
+	command.Flags().Lookup(sandboxFlag).NoOptDefVal = "default"
+
 	command.Flags().DurationVar(
 		&timeout,
 		"timeout",
@@ -1068,13 +1079,22 @@ func mergeMaps(a, b map[string]string) map[string]string {
 }
 
 // setDevModeFlags sets flags bundled into --dev flag.
-func setDevModeFlags(cmd *cobra.Command) {
-	devMap := map[string]string{
-		overprovisionedFlag:   "true",
-		smpFlag:               "1",
-		reserveMemoryFlag:     "0M",
-		checkFlag:             "false",
-		unsafeBypassFsyncFlag: "true",
+func setDevModeFlags(cmd *cobra.Command, sandboxType string) {
+	var devMap map[string]string
+	if sandboxType == "default" {
+		devMap = map[string]string{
+			overprovisionedFlag: "true",
+			reserveMemoryFlag:   "0M",
+			checkFlag:           "false",
+		}
+	} else {
+		devMap = map[string]string{
+			overprovisionedFlag:   "true",
+			smpFlag:               "1",
+			reserveMemoryFlag:     "0M",
+			checkFlag:             "false",
+			unsafeBypassFsyncFlag: "true",
+		}
 	}
 	// We don't override the values set during command execution, e.g:
 	//   rpk redpanda start --dev --smp 2
@@ -1089,10 +1109,20 @@ func setDevModeFlags(cmd *cobra.Command) {
 // setClusterProperties generates a .bootstrap.yaml file in the same path as
 // the redpanda.yaml, this will be picked up by redpanda on first start and
 // set the passed properties.
-func setClusterProperties(fs afero.Fs, cfgFileLocation string, properties map[string]interface{}) (rerr error) {
-	props, err := yaml.Marshal(properties)
-	if err != nil {
-		return err
+func setClusterProperties(fs afero.Fs, cfgFileLocation string, sandboxType string) (rerr error) {
+	var props string
+	if sandboxType == "default" {
+		props = `auto_create_topics_enabled: true
+group_topic_partitions: 3
+storage_min_free_bytes: 10485760
+topic_partitions_per_shard: 1000
+`
+	} else {
+		props = `auto_create_topics_enabled: true
+group_topic_partitions: 1
+storage_min_free_bytes: 10485760
+topic_partitions_per_shard: 1000
+`
 	}
 	cfgDir := filepath.Dir(cfgFileLocation)
 
@@ -1103,7 +1133,7 @@ func setClusterProperties(fs afero.Fs, cfgFileLocation string, properties map[st
 
 	defer func() {
 		if rerr != nil {
-			suggestion := "you can run 'rpk cluster config set <key> <value>' to set the following properties: " + string(props)
+			suggestion := "you can run 'rpk cluster config set <key> <value>' to set the following properties: " + props
 			if removeErr := fs.Remove(tmp.Name()); removeErr != nil {
 				rerr = fmt.Errorf("%s, unable to remove temp file: %v; %s", rerr, removeErr, suggestion)
 			} else {
@@ -1112,7 +1142,7 @@ func setClusterProperties(fs afero.Fs, cfgFileLocation string, properties map[st
 		}
 	}()
 
-	err = afero.WriteFile(fs, tmp.Name(), props, 0o644)
+	_, err = io.WriteString(tmp, props)
 	tmp.Close()
 	if err != nil {
 		return fmt.Errorf("error writing to temporary file: %v", err)
@@ -1138,3 +1168,41 @@ func setClusterProperties(fs afero.Fs, cfgFileLocation string, properties map[st
 
 	return nil
 }
+
+func parseSandboxFlag(args []string, sandbox *string) {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--sandbox" && !strings.HasPrefix(args[i+1], "-") {
+			*sandbox = args[i+1]
+		}
+	}
+}
+
+const helpSandbox = `Sandbox mode sets relevant properties for  or test container usage.
+
+--sandbox
+    Flags:
+        * --overprovisioned                          > disables polling
+        * --reserve-memory 0M                        > disables reservation
+        * --check=false                              > disables filesystem checks
+    Cluster Properties:
+        * topic_partitions_per_shard: 1000           > lowers max limits of partitions
+        * group_topic_partitions: 3                  > minimizes group partitions
+        * auto_create_topics_enabled: true           > allows for tools like ksqldb to work
+        * storage_min_free_bytes: 10485760 (10Mb)    > removes disk safety pressure
+
+--sandbox container
+    Flags:
+        * --overprovisioned                          > disables polling
+        * --reserve-memory 0M                        > disables reservation
+        * --check=false                              > disables filesystem checks
+        * --smp 1                                    > limits execution to 1 core
+        * --unsafe-bypass-fsync                      > uses unsafe “flushing” for esoteric 
+                                                       filesystem support
+    Cluster Properties:
+        * topic_partitions_per_shard: 1000           > lowers max limits of partitions
+        * group_topic_partitions: 1                  > minimizes group partitions
+        * auto_create_topics_enabled: true           > allows for tools like ksqldb to work
+        * storage_min_free_bytes: 10485760 (10Mb)    > removes disk safety pressure
+
+After redpanda starts you can modify the cluster properties using:
+    rpk config set <key> <value>`

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -48,7 +48,8 @@ func Default() *Config {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 		// enable pandaproxy and schema_registry by default
 		Pandaproxy:     &Pandaproxy{},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -463,7 +463,8 @@ func TestDefault(t *testing.T) {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 	}
 	require.Exactly(t, expected, defaultConfig)

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -53,6 +53,7 @@ redpanda:
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 schema_registry: {}
 '''
 


### PR DESCRIPTION
## Cover letter
Introducing `--sandbox <mode>` mode options: `default` and `container`

For full context, see PRD: https://docs.google.com/document/d/1qC6K0xvC3i3JgI-LMAWCyWlxQZ8KvM8ABthujWFDQ74

### Usage
The user can either set `--sandbox` (alias for `--sandbox default`) or `--sandbox container`
```
# Default Mode:
$ rpk redpanda start --sandbox
$ rpk redpanda start --sandbox=default
$ rpk redpanda start --sandbox default

# Container Mode:
$ rpk redpanda start --sandbox=container
$ rpk redpanda start --sandbox container

# Mode Validation:
$ rpk redpanda start --sandbox foo
Error: unrecognized sandbox type "foo", use --sandbox=help for more info"
```
### Documentation 
```
$ rpk redpanda start --sandbox help
Sandbox mode sets relevant properties for  or test container usage.

--sandbox
    Flags:
        * --overprovisioned                          > disables polling
        * --reserve-memory 0M                        > disables reservation
        * --check=false                              > disables filesystem checks
    Cluster Properties:
        * topic_partitions_per_shard: 1000           > lowers max limits of partitions
        * group_topic_partitions: 3                  > minimizes group partitions
        * auto_create_topics_enabled: true           > allows for tools like ksqldb to work
        * storage_min_free_bytes: 10485760 (10Mb)    > removes disk safety pressure

--sandbox container
    Flags:
        * --overprovisioned                          > disables polling
        * --reserve-memory 0M                        > disables reservation
        * --check=false                              > disables filesystem checks
        * --smp 1                                    > limits execution to 1 core
        * --unsafe-bypass-fsync                      > uses unsafe “flushing” for esoteric 
                                                       filesystem support
    Cluster Properties:
        * topic_partitions_per_shard: 1000           > lowers max limits of partitions
        * group_topic_partitions: 1                  > minimizes group partitions
        * auto_create_topics_enabled: true           > allows for tools like ksqldb to work
        * storage_min_free_bytes: 10485760 (10Mb)    > removes disk safety pressure

After redpanda starts you can modify the cluster properties using:
    rpk config set <key> <value>
```

## Backport Required
- [x] v22.2.x

## UX changes

- overprovisioned is now enabled by default when `Redpanda.DeveloperMode` is enabled (`redpanda.developer_mode : true` in redpanda.yaml)

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
