### PR TITLE
rpk: sandbox mode: default and container mode

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "62bdc61185e7b81b8f96b400db98ed2f",
+			expectedHash:            "a3a81f47c734ebcd16ba339c77c7c4c0",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "979cb39eb1bebf515348713f4cd2d6da",
+			expectedHash: "cfc65ce54611c67feef7270e8c1d41ba",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "fad668348b9d5c88dae6f4db3ffe4041",
+			expectedHash: "791074a427c1b5006459bc466586d1a5",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -282,7 +282,7 @@ func CreateNode(
 		AdvertiseAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--advertise-rpc-addr",
 		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
-		"--smp 1 --memory 1G --reserve-memory 0M",
+		"--sandbox container",
 	}
 	containerConfig := container.Config{
 		Image:    image,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -213,6 +213,7 @@ func TestSetCommand(t *testing.T) {
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 pandaproxy: {}
 schema_registry: {}
 `,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -1385,6 +1385,24 @@ func TestStartCommand(t *testing.T) {
 			st *testing.T,
 		) {
 			require.Equal(st, "true", rpArgs.SeastarFlags["overprovisioned"])
+			require.Equal(st, "0M", rpArgs.SeastarFlags["reserve-memory"])
+			conf, err := new(config.Params).Load(fs)
+			require.NoError(st, err)
+			require.Equal(st, 0, conf.Redpanda.ID)
+			require.Equal(st, true, conf.Redpanda.DeveloperMode)
+		},
+	}, {
+		name: "--sandbox container flag set required bundle of flags",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--sandbox=container",
+		},
+		postCheck: func(
+			fs afero.Fs,
+			rpArgs *redpanda.RedpandaArgs,
+			st *testing.T,
+		) {
+			require.Equal(st, "true", rpArgs.SeastarFlags["overprovisioned"])
 			require.Equal(st, "1", rpArgs.SeastarFlags["smp"])
 			require.Equal(st, "0M", rpArgs.SeastarFlags["reserve-memory"])
 			require.Equal(st, "true", rpArgs.SeastarFlags["unsafe-bypass-fsync"])
@@ -1397,7 +1415,7 @@ func TestStartCommand(t *testing.T) {
 		name: "override values set by --sandbox",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
-			"--sandbox", "--smp", "2",
+			"--sandbox=container", "--smp", "2",
 		},
 		postCheck: func(
 			fs afero.Fs,
@@ -1414,6 +1432,50 @@ func TestStartCommand(t *testing.T) {
 			require.NoError(st, err)
 			require.Equal(st, 0, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
+		},
+	}, {
+		name: ".bootstrap.yaml created with --sandbox container",
+		before: func(fs afero.Fs) error {
+			// We also parse --sandbox flag "outside" of Cobra, directly from
+			// os.Args.
+			os.Args = append(
+				os.Args,
+				"--sandbox", "container",
+			)
+			return nil
+		},
+		after: func() {
+			for i, a := range os.Args {
+				if a == "--sandbox" {
+					os.Args = os.Args[:i]
+					return
+				}
+			}
+		},
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--sandbox=container",
+		},
+		postCheck: func(
+			fs afero.Fs,
+			_ *redpanda.RedpandaArgs,
+			st *testing.T,
+		) {
+			bFile := "/etc/redpanda/.bootstrap.yaml"
+			exists, err := afero.Exists(fs, bFile)
+			require.NoError(st, err)
+			require.True(st, exists)
+			file, err := afero.ReadFile(fs, bFile)
+			require.NoError(st, err)
+			require.Equal(
+				st,
+				`auto_create_topics_enabled: true
+group_topic_partitions: 1
+storage_min_free_bytes: 10485760
+topic_partitions_per_shard: 1000
+`,
+				string(file),
+			)
 		},
 	}, {
 		name: ".bootstrap.yaml created with --sandbox",
@@ -1435,8 +1497,8 @@ func TestStartCommand(t *testing.T) {
 			require.Equal(
 				st,
 				`auto_create_topics_enabled: true
-group_topic_partitions: 1
-storage_min_free_bytes: 0
+group_topic_partitions: 3
+storage_min_free_bytes: 10485760
 topic_partitions_per_shard: 1000
 `,
 				string(file),
@@ -1446,7 +1508,8 @@ topic_partitions_per_shard: 1000
 		name: ".bootstrap.yaml created with --sandbox in arbitrary path",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
-			"--sandbox", "--config", "/arbitrary/path/redpanda.yaml",
+			"--sandbox=container", "--config",
+			"/arbitrary/path/redpanda.yaml",
 		},
 		postCheck: func(
 			fs afero.Fs,
@@ -1463,14 +1526,14 @@ topic_partitions_per_shard: 1000
 				st,
 				`auto_create_topics_enabled: true
 group_topic_partitions: 1
-storage_min_free_bytes: 0
+storage_min_free_bytes: 10485760
 topic_partitions_per_shard: 1000
 `,
 				string(file),
 			)
 		},
 	}, {
-		name: ".bootstrap.yaml created with redpanda.developer_mode enabled",
+		name: "redpanda.developer_mode: true behaves like --sandbox default",
 		args: []string{"--install-dir", "/var/lib/redpanda"},
 		before: func(fs afero.Fs) error {
 			conf, _ := new(config.Params).Load(fs)
@@ -1479,9 +1542,20 @@ topic_partitions_per_shard: 1000
 		},
 		postCheck: func(
 			fs afero.Fs,
-			_ *redpanda.RedpandaArgs,
+			rpArgs *redpanda.RedpandaArgs,
 			st *testing.T,
 		) {
+			// Flags:
+			require.Equal(st, "true", rpArgs.SeastarFlags["overprovisioned"])
+			require.Equal(st, "0M", rpArgs.SeastarFlags["reserve-memory"])
+			conf, err := new(config.Params).Load(fs)
+			require.NoError(st, err)
+
+			// Config:
+			require.Equal(st, 0, conf.Redpanda.ID)
+			require.Equal(st, true, conf.Redpanda.DeveloperMode)
+
+			// Bootstrap Yaml
 			bFile := "/etc/redpanda/.bootstrap.yaml"
 			exists, err := afero.Exists(fs, bFile)
 			require.NoError(st, err)
@@ -1490,10 +1564,60 @@ topic_partitions_per_shard: 1000
 			require.NoError(st, err)
 			require.Equal(
 				st,
-				`storage_min_free_bytes: 0
+				`auto_create_topics_enabled: true
+group_topic_partitions: 3
+storage_min_free_bytes: 10485760
+topic_partitions_per_shard: 1000
 `,
 				string(file),
 			)
+		},
+	}, {
+		name: "Fails if unknown sandbox mode is passed",
+		before: func(fs afero.Fs) error {
+			// We also parse --sandbox flag "outside" of Cobra, directly from
+			// os.Args.
+			os.Args = append(
+				os.Args,
+				"--sandbox", "foo",
+			)
+			return nil
+		},
+		after: func() {
+			for i, a := range os.Args {
+				if a == "--sandbox" {
+					os.Args = os.Args[:i]
+					return
+				}
+			}
+		},
+		args:           []string{"--install-dir", "/var/lib/redpanda"},
+		expectedErrMsg: `unrecognized sandbox type "foo"`,
+	}, {
+		name: "--sandbox container can run along with additional redpanda args",
+		args: []string{"--install-dir", "/var/lib/redpanda", "additional-arg"},
+		before: func(fs afero.Fs) error {
+			os.Args = append(
+				os.Args,
+				"--sandbox", "container",
+			)
+			return nil
+		},
+		after: func() {
+			for i, a := range os.Args {
+				if a == "--sandbox" {
+					os.Args = os.Args[:i]
+					return
+				}
+			}
+		},
+		postCheck: func(
+			fs afero.Fs,
+			rpArgs *redpanda.RedpandaArgs,
+			st *testing.T,
+		) {
+			require.Contains(st, rpArgs.ExtraArgs, "additional-arg")
+			require.NotContains(st, rpArgs.ExtraArgs, "container")
 		},
 	}}
 

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -48,7 +48,8 @@ func Default() *Config {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 		// enable pandaproxy and schema_registry by default
 		Pandaproxy:     &Pandaproxy{},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -463,7 +463,8 @@ func TestDefault(t *testing.T) {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 	}
 	require.Exactly(t, expected, defaultConfig)

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -53,6 +53,7 @@ redpanda:
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 schema_registry: {}
 '''
 


### PR DESCRIPTION
## Cover letter
Introducing `--sandbox <mode>` mode options: `default` and `container`

For full context, see PRD: https://docs.google.com/document/d/1qC6K0xvC3i3JgI-LMAWCyWlxQZ8KvM8ABthujWFDQ74

### Usage
The user can either set `--sandbox` (alias for `--sandbox default`) or `--sandbox container`
```
# Default Mode:
$ rpk redpanda start --sandbox
$ rpk redpanda start --sandbox=default
$ rpk redpanda start --sandbox default

# Container Mode:
$ rpk redpanda start --sandbox=container
$ rpk redpanda start --sandbox container

# Mode Validation:
$ rpk redpanda start --sandbox foo
Error: unrecognized sandbox type "foo", use --sandbox=help for more info"
```
### Documentation 
```
$ rpk redpanda start --sandbox help
Sandbox mode sets relevant properties for local development or 
test container usage.

--sandbox
    Flags:
        * --overprovisioned
        * --reserve-memory 0M
        * --check=false
    Cluster Properties:
        * topic_partitions_per_shard: 1000
        * group_topic_partitions: 3
        * auto_create_topics_enabled: true
        * storage_min_free_bytes: 10485760 (10Mb)

--sandbox container
    Flags:
        * --overprovisioned
        * --reserve-memory 0M
        * --check=false
        * --smp 1
        * --unsafe-bypass-fsync
    Cluster Properties:
        * topic_partitions_per_shard: 1000
        * group_topic_partitions: 1
        * auto_create_topics_enabled: true
        * storage_min_free_bytes: 10485760 (10Mb)

After redpanda starts you can modify the cluster properties using:
    rpk config set <key> <value>
```

## Backport Required
- [x] v22.2.x

## UX changes

- overprovisioned is now enabled by default when `Redpanda.DeveloperMode` is enabled (`redpanda.developer_mode : true` in redpanda.yaml)

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
