### PR TITLE
cloud_storage: adjust condition to remove archiver

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -347,8 +347,8 @@ ss::future<> scheduler_service_impl::reconcile_archivers() {
     for (const auto& [ntp, archiver] : _archivers) {
         auto p = pm.get(ntp);
         if (
-          !p
-          || (archiver->upload_loop_stopped() && archiver->sync_manifest_loop_stopped())) {
+          !p || archiver->upload_loop_stopped()
+          || archiver->sync_manifest_loop_stopped()) {
             to_remove.push_back(ntp);
         }
     }

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -346,9 +346,7 @@ ss::future<> scheduler_service_impl::reconcile_archivers() {
     // find archivers that have already stopped
     for (const auto& [ntp, archiver] : _archivers) {
         auto p = pm.get(ntp);
-        if (
-          !p || archiver->upload_loop_stopped()
-          || archiver->sync_manifest_loop_stopped()) {
+        if (!p || archiver->is_loop_stopped()) {
             to_remove.push_back(ntp);
         }
     }


### PR DESCRIPTION
An archiver is removed in reconcile loop if it is considered to be stopped. The stop condition checks if the upload loop is stopped. with read replica there are two status variables which denote a stopped loop - one related to normal upload and other related to read replica. 

This change adjusts the condition such that any of these two variables being true marks the archiver as stopped, as the two conditions start out being false and they turn to true in mutually exclusive code paths.

The archiver must be removed in order for a stopped upload loop to restart later. This can happen in a condition where a node lost leadership, archiver is stopped and it immediately regained leadership. It is then necessary for the archiver to have been removed correctly earlier for it to start again. 

fixes #5928 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

None

