### PR TITLE
refactor: Global `recieve` -> `receive` replacements

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1052,7 +1052,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     }
 
     if (_mem_state.estimated.contains(bid.pid)) {
-        // we recieved second produce request while the first is still
+        // we received second produce request while the first is still
         // being processed. this is highly unlikely situation because
         // we replicate with ack=1 and it should be fast
         vlog(clusterlog.warn, "Too frequent produce with same pid:{}", bid.pid);

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -84,7 +84,7 @@ private:
                   if (!sz) {
                       return ss::make_exception_future<iobuf>(
                         kafka_request_disconnected_exception(
-                          "Request disconnected, no response recieved"));
+                          "Request disconnected, no response received"));
                   }
                   auto size = sz.value();
                   return _in.read_exactly(sizeof(correlation_id))

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -109,7 +109,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             lambda: self.mconsumer.total_consumed() >= limit,
             timeout_sec=timeout,
             err_msg=
-            "Timeout of after %ds while awaiting delivery of %d materialized records, recieved: %d"
+            "Timeout of after %ds while awaiting delivery of %d materialized records, received: %d"
             % (timeout, limit, self.mconsumer.total_consumed()))
         self.mconsumer.stop()
 

--- a/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
+++ b/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
@@ -39,7 +39,7 @@ class WasmRedpandaFailureRecoveryTest(WasmTest):
         self._one_traunch_observed = False
         self._num_records = num_records
 
-    def records_recieved(self, output_recieved):
+    def records_received(self, output_received):
         if self._one_traunch_observed is False:
             self.restart_redpanda(random.sample(self.redpanda.nodes, 1)[0])
             self._one_traunch_observed = True

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -177,7 +177,7 @@ class WasmTest(RedpandaTest):
                              self._output_consumer.results.num_records())
             batch_total = self._input_consumer.results.num_records()
             if batch_total > 0:
-                self.records_recieved(batch_total)
+                self.records_received(batch_total)
 
             return self._input_consumer.is_finished() \
                 and self._output_consumer.is_finished()
@@ -217,7 +217,7 @@ class WasmTest(RedpandaTest):
 
         return (self._input_consumer.results, self._output_consumer.results)
 
-    def records_recieved(self, output_recieved):
+    def records_received(self, output_received):
         """
         Called when a traunch of records has been returned from consumers
         """


### PR DESCRIPTION
## Cover letter

Code readability improvements replacing `recieved` -> `received` throughout the redpanda codebase.

## UX changes
Only one change could be visible to a user on this exception:
```c
                        kafka_request_disconnected_exception(
                          "Request disconnected, no response received"));
                  }
```

User will receive(Sorry, pun intended) the correct exception message in `src/v/kafka/client/transport.h` when raised.

## Release notes
* none

### Features

* Codebase readability improvements

### Improvements

global replace of `recieve`, making my high school grammar teacher very happy :)

This was placed into 3 commits in an attempt to separate logic/ownership in the merge. 

Feel free to cherry pick if lumping these in a single PR creates problems on merge:

- `src/v/cluster/rm_stm.cc` - comment change
- `src/v/kafka/client/transport.h` - exception change
- `tests/rptest/**/.py` - function/variable changes in test

Best,
Ryan