### PR TITLE
ducktape: adds decorator to skip test on debug mode

### DIFF
--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -22,6 +22,7 @@ from rptest.services.franz_go_verifiable_services import (
 )
 from rptest.services.redpanda import SISettings, RESTART_LOG_ALLOW_LIST
 from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class FranzGoVerifiableBase(PreallocNodesTest):
@@ -192,23 +193,13 @@ class FranzGoVerifiableWithSiTest(FranzGoVerifiableBase):
         assert self._rand_consumer.consumer_status.total_reads == self.RANDOM_READ_COUNT * self.RANDOM_READ_PARALLEL
         assert self._cg_consumer.consumer_status.valid_reads >= wrote_at_least
 
-    def no_debug(self, f):
-        def inner(*args, **kwargs):
-            if self.debug_mode:
-                self.logger.info(
-                    "Skipping test in debug mode (requires release build)")
-                return
-            return f(*args, **kwargs)
-
-        return inner
-
-    @no_debug
+    @skip_debug_mode
     def without_timeboxed(self):
         configs = {'log_segment_size': self.segment_size}
         self.redpanda.set_cluster_config(configs)
         self._workload(self.segment_size)
 
-    @no_debug
+    @skip_debug_mode
     def with_timeboxed(self):
         # Enabling timeboxed uploads causes a restart
         configs = {

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -1,0 +1,24 @@
+import functools
+
+
+def skip_debug_mode(func):
+    @functools.wraps(func)
+    def f(*args, **kwargs):
+        assert args, 'skip_debug_mode must be placed on a test class method'
+
+        caller = args[0]
+
+        assert hasattr(
+            caller, 'debug_mode'
+        ), 'skip_debug_mode called on object which does not have debug_mode attribute'
+        assert hasattr(
+            caller,
+            'logger'), 'skip_debug_mode called on object which has no logger'
+
+        if caller.debug_mode:
+            caller.logger.info(
+                "Skipping test in debug mode (requires release build)")
+            return None
+        return func(*args, **kwargs)
+
+    return f

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -1,10 +1,53 @@
 import functools
 
+from ducktape.cluster.cluster_spec import ClusterSpec
+
+
+def allocate_and_free(cluster, logger):
+    num_nodes = cluster.num_available_nodes()
+    logger.debug(f'skip_debug_mode:: allocating {num_nodes} nodes')
+    spec = ClusterSpec.simple_linux(num_nodes)
+    nodes = cluster.alloc(spec)
+    logger.debug(f'skip_debug_mode:: freeing up {num_nodes} nodes')
+    cluster.free_nodes(nodes)
+
+
+def cleanup_on_early_exit(caller):
+    """
+    Cleans up on early exit to avoid errors due to unused resources.
+
+    By default, the nodes we asked for are allocated and then freed,
+    but if a method called `early_exit_hook` is defined on the class
+    then it is called instead of the default action.
+    """
+    name = type(caller).__name__
+    if hook := getattr(caller, 'early_exit_hook', None):
+        assert callable(
+            hook
+        ), f'{name.early_exit_hook} should be a method which can be called to set up early exit from test'
+        hook()
+    else:
+        caller.logger.debug(
+            f'{name} does not define action to take when skipping test on debug mode. '
+            f'Cleaning up unused nodes.')
+
+        if test_context := getattr(caller, 'test_context', None):
+            allocate_and_free(test_context.cluster, caller.logger)
+
 
 def skip_debug_mode(func):
+    """
+    Decorator applied to a test class method. The property `debug_mode` should be present
+    on the object.
+
+    If set to true, the wrapped function call is skipped, and a cleanup action
+    is performed instead.
+
+    If set to false, the wrapped function (usually a test case) is called.
+    """
     @functools.wraps(func)
     def f(*args, **kwargs):
-        assert args, 'skip_debug_mode must be placed on a test class method'
+        assert args, 'skip_debug_mode must be placed on a test method in a class'
 
         caller = args[0]
 
@@ -14,10 +57,10 @@ def skip_debug_mode(func):
         assert hasattr(
             caller,
             'logger'), 'skip_debug_mode called on object which has no logger'
-
         if caller.debug_mode:
             caller.logger.info(
                 "Skipping test in debug mode (requires release build)")
+            cleanup_on_early_exit(caller)
             return None
         return func(*args, **kwargs)
 


### PR DESCRIPTION
## Cover letter

adds convenience decorator to skip test if the class owning the test has debug mode set.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

None
