### PR TITLE
rpk: introduce `rpk redpanda start --mode container`

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "62bdc61185e7b81b8f96b400db98ed2f",
+			expectedHash:            "a3a81f47c734ebcd16ba339c77c7c4c0",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "979cb39eb1bebf515348713f4cd2d6da",
+			expectedHash: "cfc65ce54611c67feef7270e8c1d41ba",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "fad668348b9d5c88dae6f4db3ffe4041",
+			expectedHash: "791074a427c1b5006459bc466586d1a5",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -282,7 +282,7 @@ func CreateNode(
 		AdvertiseAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--advertise-rpc-addr",
 		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
-		"--smp 1 --memory 1G --reserve-memory 0M",
+		"--mode container",
 	}
 	containerConfig := container.Config{
 		Image:    image,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -213,6 +213,7 @@ func TestSetCommand(t *testing.T) {
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 pandaproxy: {}
 schema_registry: {}
 `,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -48,7 +48,8 @@ func Default() *Config {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 		// enable pandaproxy and schema_registry by default
 		Pandaproxy:     &Pandaproxy{},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -463,7 +463,8 @@ func TestDefault(t *testing.T) {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+			CoredumpDir:     "/var/lib/redpanda/coredump",
+			Overprovisioned: true,
 		},
 	}
 	require.Exactly(t, expected, defaultConfig)

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -53,6 +53,7 @@ redpanda:
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump
+    overprovisioned: true
 schema_registry: {}
 '''
 


### PR DESCRIPTION
## Cover letter
Introducing `--mode container` for `rpk redpanda start`

For full context, see PRD: https://docs.google.com/document/d/1qC6K0xvC3i3JgI-LMAWCyWlxQZ8KvM8ABthujWFDQ74

### Usage
```
# Container Mode:
$ rpk redpanda start --mode container

# Mode Validation:
$ rpk redpanda start --mode foo
Error: unrecognized mode "foo", use --mode help for more info"
```
### Documentation 
```
$ rpk redpanda start --mode help
Mode uses well-known configuration properties for development or tests 
environments:

--mode container
    Bundled flags:
        * --overprovisioned
        * --reserve-memory 0M
        * --check=false
        * --unsafe-bypass-fsync
    Bundled cluster properties: 
        * auto_create_topics_enabled: true
        * group_topic_partitions: 3
        * storage_min_free_bytes: 10485760 (10MiB)
        * topic_partitions_per_shard: 1000

After redpanda starts you can modify the cluster properties using:
    rpk config set <key> <value>

```

## Backport Required
- [x] v22.2.x

## UX changes

- overprovisioned is now enabled by default when `Redpanda.DeveloperMode` is enabled (`redpanda.developer_mode : true` in redpanda.yaml)

- `rpk container start` will use `--mode container`.
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->

