### PR TITLE
tests/rptest: disable iam role tests for ec2

### DIFF
--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -12,4 +12,4 @@ ec2:
     - tests/wasm_topics_test.py # no wasm
     - tests/wasm_redpanda_failure_recovery_test.py # no wasm
     - tests/wasm_partition_movement_test.py # no wasm
-
+    - tests/e2e_iam_role_test.py # use static credentials


### PR DESCRIPTION
## Cover letter

IAM role tests use a bundled mock server script which has a fixed set of credentials which match our MinIO docker image.

These tests do not work with real S3 because it expects credentials which are supposed to be part of the test context. The tests can be made to work with S3 by passing the credentials from test context to the mock server script, but these should be disabled until that change is made. Fixes #5761 

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

None

