### PR TITLE
[v22.2.x] storage: add metrics clear to reader cache probe

### DIFF
--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -171,6 +171,12 @@ ss::future<> readers_cache::stop() {
     _readers.clear_and_dispose([](entry* e) {
         delete e; // NOLINT
     });
+    /**
+     * Stop and clear metrics as well or risk a double registrion on partition
+     * movements. For details see
+     * https://github.com/redpanda-data/redpanda/issues/5938
+     */
+    _probe.clear();
 }
 
 ss::future<readers_cache::range_lock_holder>

--- a/src/v/storage/readers_cache_probe.h
+++ b/src/v/storage/readers_cache_probe.h
@@ -14,6 +14,7 @@ public:
     void reader_evicted() { _readers_evicted++; }
     void cache_hit() { _cache_hits++; }
     void cache_miss() { _cache_misses++; }
+    void clear() { _metrics.clear(); }
 
     void setup_metrics(const model::ntp& ntp);
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5939.
Fixes https://github.com/redpanda-data/redpanda/issues/5961,