### PR TITLE
[v22.2.x] tests/rptest: disable iam role tests for ec2

### DIFF
--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -12,4 +12,4 @@ ec2:
     - tests/wasm_topics_test.py # no wasm
     - tests/wasm_redpanda_failure_recovery_test.py # no wasm
     - tests/wasm_partition_movement_test.py # no wasm
-
+    - tests/e2e_iam_role_test.py # use static credentials


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5953.
Fixes https://github.com/redpanda-data/redpanda/issues/5963,