### PR TITLE
cmake: bump seastar tag

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 79a3038e90c45195a0446a067f516f7ff0ada0be
+  GIT_TAG bdf4c58630f06aaffa02c98edc1192a2d8db2fe8
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
## Cover letter
Bump seastar tag to https://github.com/redpanda-data/seastar/commit/bdf4c58630f06aaffa02c98edc1192a2d8db2fe8.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
