### PR TITLE
rpc: Add unit tests for rpc evolution

### DIFF
--- a/src/v/rpc/test/CMakeLists.txt
+++ b/src/v/rpc/test/CMakeLists.txt
@@ -13,6 +13,13 @@ rpcgen(
   INCLUDES ${CMAKE_BINARY_DIR}/src/v
   )
 
+rpcgen(
+  TARGET echo_v2_gen
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/echo_v2_service.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/echo_v2_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+  )
+
 v_cc_library(
   NAME
     rpc_testing
@@ -20,6 +27,7 @@ v_cc_library(
     "test/rpc_integration_fixture.h"
   DEPS
     echo_gen
+    echo_v2_gen
     cycling_gen
   )
 

--- a/src/v/rpc/test/echo_v2_service.json
+++ b/src/v/rpc/test/echo_v2_service.json
@@ -1,0 +1,14 @@
+{
+    "namespace": "echo_v2",
+    "service_name": "echo",
+    "includes": [
+        "rpc/test/rpc_gen_types.h"
+    ],
+    "methods": [
+        {
+            "name": "echo_serde_only",
+            "input_type": "echo_req_serde_only",
+            "output_type": "echo_resp_serde_only"
+        }
+    ]
+}


### PR DESCRIPTION
The following tests, test our rpc services with an evolving client.