### PR TITLE
test: enable parallel redpanda startup by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -698,9 +698,10 @@ class RedpandaService(Service):
                 cb(n)
             return
 
-        node_futures = []
         with concurrent.futures.ThreadPoolExecutor(
                 max_workers=len(nodes)) as executor:
+            # The list() wrapper is to cause futures to be evaluated here+now
+            # (including throwing any exceptions) and not just spawned in background.
             list(executor.map(cb, nodes))
 
     def _startup_poll_interval(self, first_start):
@@ -1587,6 +1588,8 @@ class RedpandaService(Service):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         with concurrent.futures.ThreadPoolExecutor(
                 max_workers=len(nodes)) as executor:
+            # The list() wrapper is to cause futures to be evaluated here+now
+            # (including throwing any exceptions) and not just spawned in background.
             list(
                 executor.map(lambda n: self.stop_node(n, timeout=stop_timeout),
                              nodes))

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -707,7 +707,7 @@ class RedpandaService(Service):
               nodes=None,
               clean_nodes=True,
               start_si=True,
-              parallel: bool = False):
+              parallel: bool = True):
         """
         Start the service on all nodes.
 

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -114,19 +114,6 @@ class AccessControlListTest(RedpandaTest):
 
         admin = Admin(self.redpanda)
 
-        if self.security.mtls_identity_enabled():
-            feature_name = "mtls_authentication"
-            admin.put_feature(feature_name, {"state": "active"})
-
-            # wait for feature to be active so that tests don't have to retry
-            def check_feature_active():
-                for f in admin.get_features()["features"]:
-                    if f["name"] == feature_name and f["state"] == "active":
-                        return True
-                return False
-
-            wait_until(check_feature_active, timeout_sec=10, backoff_sec=1)
-
         # base case user is not a superuser and has no configured ACLs
         if self.security.sasl_enabled() or enable_authz:
             admin.create_user("base", self.password, self.algorithm)
@@ -138,23 +125,24 @@ class AccessControlListTest(RedpandaTest):
         client = self.get_super_client()
         client.acl_create_allow_cluster("cluster_describe", "describe")
 
-        # there is not a convenient interface for waiting for acls to propogate
-        # to all nodes so when we are using mtls only for identity we inject a
-        # sleep here to try to avoid any acl propogation races.
-        if self.security.mtls_identity_enabled():
-            time.sleep(5)
-            return
+        # Hack: create a user, so that we can watch for this user in order to
+        # confirm that all preceding controller log writes landed: this is
+        # an indirect way to check that ACLs (and users) have propagated
+        # to all nodes before we proceed.
+        checkpoint_user = "_test_checkpoint"
+        admin.create_user(checkpoint_user, "_password", self.algorithm)
 
         # wait for users to propagate to nodes
-        def users_propogated():
+        def auth_metadata_propagated():
             for node in self.redpanda.nodes:
                 users = admin.list_users(node=node)
-                if "base" not in users or "cluster_describe" not in users:
+                if checkpoint_user not in users:
                     return False
+                elif self.security.sasl_enabled() or enable_authz:
+                    assert "base" in users and "cluster_describe" in users
             return True
 
-        if self.security.sasl_enabled() or enable_authz:
-            wait_until(users_propogated, timeout_sec=10, backoff_sec=1)
+        wait_until(auth_metadata_propagated, timeout_sec=10, backoff_sec=1)
 
     def get_client(self, username):
         if self.security.mtls_identity_enabled(

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -140,6 +140,7 @@ class ClusterMetricsTest(RedpandaTest):
         level metrics at any given time.
         """
         # Assert metrics are reported once in a fresh, three node cluster
+        self._wait_until_controller_leader_is_stable()
         self._assert_reported_by_controller()
 
         # Restart the controller node and assert.
@@ -158,6 +159,7 @@ class ClusterMetricsTest(RedpandaTest):
         # This time the metrics should not be reported as a controller
         # couldn't be elected due to lack of quorum.
         self._stop_controller_node()
+        self._wait_until_controller_leader_is_stable()
         self._assert_reported_by_controller()
 
     @cluster(num_nodes=3)
@@ -166,6 +168,7 @@ class ClusterMetricsTest(RedpandaTest):
         Test that the cluster level metrics move in the expected way
         after creating a topic.
         """
+        self._wait_until_controller_leader_is_stable()
         self._assert_reported_by_controller()
 
         controller_node = self.redpanda.controller()
@@ -196,6 +199,7 @@ class ClusterMetricsTest(RedpandaTest):
         """
         # 'disable_public_metrics' defaults to false so cluster metrics
         # are expected
+        self._wait_until_controller_leader_is_stable()
         self._assert_reported_by_controller()
 
         self.redpanda.set_cluster_config({"disable_public_metrics": "true"},
@@ -204,5 +208,6 @@ class ClusterMetricsTest(RedpandaTest):
         # The 'public_metrics' endpoint that serves cluster level
         # metrics should not return anything when
         # 'disable_public_metrics' == true
+        self._wait_until_controller_leader_is_stable()
         cluster_metrics = self._get_cluster_metrics(self.redpanda.controller())
         assert cluster_metrics is None

--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -23,6 +23,10 @@ from rptest.tests.end_to_end import EndToEndTest
 ALLOWED_LOGS = [
     # e.g. cluster - controller_backend.cc:466 - exception while executing partition operation: {type: update_finished, ntp: {kafka/test-topic-1944-1639161306808363/1}, offset: 413, new_assignment: { id: 1, group_id: 65, replicas: {{node_id: 3, shard: 2}, {node_id: 4, shard: 2}, {node_id: 1, shard: 0}} }, previous_assignment: {nullopt}} - std::__1::__fs::filesystem::filesystem_error (error system:39, filesystem error: remove failed: Directory not empty [/var/lib/redpanda/data/kafka/test-topic-1944-1639161306808363])
     re.compile("cluster - .*Directory not empty"),
+
+    # <= 22.2 versions may log bare std::exception error
+    # (https://github.com/redpanda-data/redpanda/issues/5886)
+    re.compile("rpc - .*std::exception"),
 ]
 
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -660,7 +660,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             try:
                 partition_info = admin.get_partitions(topic, partition)
             except requests.exceptions.HTTPError as e:
-                if e.errno == 404:
+                if e.response.status_code == 404:
                     self.logger.info(
                         f"topic {topic}/{partition} not found, retrying")
                     return None

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -77,7 +77,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             **kwargs)
         self._ctx = ctx
 
-    @cluster(num_nodes=3, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @cluster(num_nodes=3,
+             log_allow_list=PREV_VERSION_LOG_ALLOW_LIST + ["FailureInjector"])
     @matrix(num_to_upgrade=[0, 2])
     def test_moving_not_fully_initialized_partition(self, num_to_upgrade):
         """


### PR DESCRIPTION
## Cover letter

This change should be functionally equivalent but provide a small per-test speedup.

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none