### PR TITLE
Fix for kafka request fuzzer never testing non-filled optional values

### DIFF
--- a/src/go/kreq-gen/go.mod
+++ b/src/go/kreq-gen/go.mod
@@ -2,4 +2,4 @@ module kafka-request-generator
 
 go 1.16
 
-require github.com/twmb/franz-go/pkg/kmsg v1.1.1-0.20220727195429-954ab1c15da1
+require github.com/twmb/franz-go/pkg/kmsg v1.2.0

--- a/src/go/kreq-gen/go.sum
+++ b/src/go/kreq-gen/go.sum
@@ -1,2 +1,2 @@
-github.com/twmb/franz-go/pkg/kmsg v1.1.1-0.20220727195429-954ab1c15da1 h1:2mQP5DUgCXFbLGmUDPCX61rflseMUx/YDgCLrGGbbos=
-github.com/twmb/franz-go/pkg/kmsg v1.1.1-0.20220727195429-954ab1c15da1/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kmsg v1.2.0 h1:jYWh2qFw5lDbNv5Gvu/sMKagzICxuA5L6m1W2Oe7XUo=
+github.com/twmb/franz-go/pkg/kmsg v1.2.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=

--- a/src/go/kreq-gen/kafka-request-generator.go
+++ b/src/go/kreq-gen/kafka-request-generator.go
@@ -145,10 +145,10 @@ func makeRandomKafkaData(version int16) []byte {
 func randomFill(v reflect.Value, version int16) {
 	switch v.Kind() {
 	case reflect.Ptr:
-		v.Set(reflect.New(v.Type().Elem()))
 		/// This conditional represents setting an nullable field to nil
 		/// happening 50% of the time
 		if makeRandomBool() {
+			v.Set(reflect.New(v.Type().Elem()))
 			randomFill(v.Elem(), version)
 		}
 	case reflect.Struct:

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -15,7 +15,7 @@
 
 #include <sstream>
 
-#define TEST_COMPAT_CHECK_NO_THROW(Source, Api, Version)                       \
+#define TEST_COMPAT_CHECK_NO_THROW(Source, Api, Version, IsRequest)            \
     try {                                                                      \
         Source;                                                                \
     } catch (const std::exception& ex) {                                       \
@@ -23,9 +23,10 @@
           false,                                                               \
           fmt::format(                                                         \
             "API protocol incompatability detected at api: {}, version: "      \
-            "{}, exception reported: {}",                                      \
+            "{}, IsRequest: {}, exception reported: {}",                       \
             Api,                                                               \
             Version,                                                           \
+            IsRequest,                                                         \
             ex.what()));                                                       \
     }
 
@@ -167,12 +168,14 @@ void check_proto_compat() {
           check_kafka_binary_format<typename H::api::request_type>(
             H::api::key, version, is_kafka_request::yes),
           H::api::key,
-          version);
+          version,
+          true);
         TEST_COMPAT_CHECK_NO_THROW(
           check_kafka_binary_format<typename H::api::response_type>(
             H::api::key, version, is_kafka_request::no),
           H::api::key,
-          version);
+          version,
+          false);
     }
 }
 


### PR DESCRIPTION
A few days ago @twmb found a bug in `franz-go` after performing a manual audit on the generated types. The bug was that `franz-go` had represented a field in `metadata_response` as `nullable` for all versions since `v0`. `redpanda`'s new `kafka-request-generator` should have crashed and detected this `franz-go` bug. The flow should have been:

1. `franz-go` generates null for a string
2. `redpanda` attempts to deserialize this null string as a normal one
3. `redpanda` throws after observing negative length string for an expected `non-nullable` string

Not detecting this crash was concerning. After debugging, it was observed that the `kafka-request-generator` was always filling optional fields, never testing these fields as null as it intended to half of the time.

With the fix in place, I observed the error in `franz-go`:
```
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 0, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 1, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 2, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 3, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 4, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 5, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 6, exception reported: Asked to read a negative byte string
/home/robert/workspace/redpanda/src/v/kafka/protocol/tests/protocol_test.cc(175): error: in "test_kafka_protocol_compat": API protocol incompatability detected at api: 3, version: 7, exception reported: Asked to read a negative byte string
```

Bumping `franz-go` to the [new latest version](https://github.com/twmb/franz-go/commit/da41bd3a8e61de7caa38e2e0337f5fdd810d3d12) fixes the issue, as this field is `nullable` but only starting in `metadata/v12`, a currently unsupported version of the metadata api for `redpanda`.