### PR TITLE
[v22.2.x] archival: catch sem timeout in upload/sync loops

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -104,6 +104,13 @@ void ntp_archiver::run_sync_manifest_loop() {
           .handle_exception_type([](const ss::abort_requested_exception&) {})
           .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([this](const ss::semaphore_timed_out& e) {
+              vlog(
+                _rtclog.warn,
+                "Semaphore timed out in sync manifest loop: {}. This may be "
+                "due to the system being overloaded. The loop will restart.",
+                e);
+          })
           .handle_exception([this](std::exception_ptr e) {
               vlog(_rtclog.error, "sync manifest loop error: {}", e);
           })
@@ -134,6 +141,13 @@ void ntp_archiver::run_upload_loop() {
           .handle_exception_type([](const ss::abort_requested_exception&) {})
           .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([this](const ss::semaphore_timed_out& e) {
+              vlog(
+                _rtclog.warn,
+                "Semaphore timed out in the upload loop: {}. This may be "
+                "due to the system being overloaded. The loop will restart.",
+                e);
+          })
           .handle_exception([this](std::exception_ptr e) {
               vlog(_rtclog.error, "upload loop error: {}", e);
           })


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5921.
Fixes https://github.com/redpanda-data/redpanda/issues/5977,