### PR TITLE
redpanda: fix whitespace

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -354,22 +354,22 @@ void application::setup_public_metrics() {
         })
       .get();
 
-    _public_metrics.invoke_on_all([](auto& public_metrics) {
-        public_metrics.groups.add_group(
-          "cpu",
-          {sm::make_gauge(
-            "busy_seconds_total",
-            [] {
-                return std::chrono::duration<double>(
-                         ss::engine().total_busy_time())
-                  .count();
-            },
-            sm::description("Total CPU busy time in seconds"))});
-    }).get();
+    _public_metrics
+      .invoke_on_all([](auto& public_metrics) {
+          public_metrics.groups.add_group(
+            "cpu",
+            {sm::make_gauge(
+              "busy_seconds_total",
+              [] {
+                  return std::chrono::duration<double>(
+                           ss::engine().total_busy_time())
+                    .count();
+              },
+              sm::description("Total CPU busy time in seconds"))});
+      })
+      .get();
 
-    _deferred.emplace_back([this] {
-        _public_metrics.stop().get();
-    });
+    _deferred.emplace_back([this] { _public_metrics.stop().get(); });
 }
 
 void application::setup_internal_metrics() {

--- a/src/v/resource_mgmt/scheduling_groups_probe.h
+++ b/src/v/resource_mgmt/scheduling_groups_probe.h
@@ -34,7 +34,8 @@ public:
                 "runtime_seconds_total",
                 [group_ref] {
                     auto runtime_duration = group_ref.get().get_stats().runtime;
-                    return std::chrono::duration<double>(runtime_duration).count();
+                    return std::chrono::duration<double>(runtime_duration)
+                      .count();
                 },
                 seastar::metrics::description(
                   "Accumulated runtime of task queue associated with this "


### PR DESCRIPTION
## Cover letter

In version 5c94d72e222361d31f8bd13649c1929c8a87d067 there was whitespace that earlier clang-format tolerated but clang format 14 (in the github action) rejects.

## Backport Required

- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
None
## Release notes

* none
