### PR TITLE
kafka/client: React to group coordinator changes

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -118,8 +118,18 @@ void consumer::start() {
                 *me,
                 e.error);
           })
+          .handle_exception_type([me](const broker_error& e) {
+              vlog(
+                kclog.debug,
+                "Consumer: {} heartbeat failed, broker_error: {}",
+                *me,
+                e.error);
+          })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
               vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
+          })
+          .handle_exception([me](std::exception_ptr ex) {
+              vlog(kclog.warn, "Generic exception caught: {}", ex);
           });
     });
     _heartbeat_timer.rearm_periodic(_config.consumer_heartbeat_interval());


### PR DESCRIPTION
This pull request modifies our client to react to group coordinator leader changes. If the leader changes `join_request`s will return `errc::not_leader` for which our client will not properly handle. This pull request has the client perform another `find_coordinator` request and potentially a metadata refresh (if needed) before attempting to issue another `join_reqeust`