### PR TITLE
Fixed truncation for compacted topics

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1798,13 +1798,15 @@ consensus::do_append_entries(append_entries_request&& r) {
               auto lstats = _log.offsets();
               if (unlikely(lstats.dirty_offset != r.meta.prev_log_index)) {
                   vlog(
-                    _ctxlog.error,
+                    _ctxlog.warn,
                     "Log truncation error, expected offset: {}, log "
                     "offsets: "
                     "{}, requested truncation at {}",
                     r.meta.prev_log_index,
                     lstats,
                     truncate_at);
+                  _flushed_offset = std::min(
+                    model::prev_offset(lstats.dirty_offset), _flushed_offset);
               }
               return do_append_entries(std::move(r));
           })

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -150,6 +150,7 @@ public:
     ss::future<> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }
+    void advance_generation() { _generation_id++; }
 
 private:
     void set_close();
@@ -192,6 +193,7 @@ private:
      * - segment is truncated
      * - batches are appended to the segment
      * - segment appender is flushed
+     * - segment is compacted
      */
     generation_id _generation_id{};
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -488,6 +488,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     s->force_set_commit_offset_from_index();
     s->release_batch_cache_index();
     co_await s->index().flush();
+    s->advance_generation();
     co_return s->size_bytes();
 }
 

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -55,7 +55,9 @@ ss::future<compaction_result> self_compact_segment(
  * segment, and upper range offsets (e.g. stable_offset) taken from the last
  * segment in the input range.
  */
-ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
+ss::future<
+  std::tuple<ss::lw_shared_ptr<segment>, std::vector<segment::generation_id>>>
+make_concatenated_segment(
   std::filesystem::path,
   std::vector<ss::lw_shared_ptr<segment>>,
   compaction_config,


### PR DESCRIPTION
## Cover letter

Fixed two issues in Redpanda truncation handling during compaction

### Compaction overlapping with segment mutations

A `segment::generation_id` is a counter that is incremented every time a
segment is modified (flushed, written to, truncated). When segment is
being compacted we must know if it was truncated as the copy of segment
which is compacted was not affected by mutation.

Using `segment::generation_id` to detect situations in which staging
compacted segment and compacting it interleaved with mutation operation.

When segment is mutated when being compacted we need to drop the
compaction result not to override the mutated segment.

### Truncation offset requested in the middle of gap

When truncating segment in the middle we use
`offset_to_filepos_consumer` to establish the physical position in a
file that reflects the offset. The physical position is then used to
truncate the file on disk.

Previously we required for the requested offset to be equal to the batch
base_offset and only then returned position in the file. When segment is
a compacted segment the requested offset may not exists as it might have
been deleted during compaction process. In this situation we should
return last offset and end position of a batch preceding the gap.

Fixes: #5979

Signed-off-by: Michal Maslanka <michal@redpanda.com>

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
