### PR TITLE
cluster: Lower log level for health stats collection

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -564,7 +564,7 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     /**
      * We are collecting cluster health on raft 0 leader only
      */
-    vlog(clusterlog.info, "collecting cluster health statistics");
+    vlog(clusterlog.debug, "collecting cluster health statistics");
     // collect all reports
     auto ids = _members.local().all_broker_ids();
     auto reports = co_await ssx::async_transform(


### PR DESCRIPTION
## Cover letter

Make the default logging less noisy - this runs every 10s.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
