### PR TITLE
kafka/server: Log details on unexpected EOF fail

### DIFF
--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -63,7 +63,10 @@ parse_header(ss::input_stream<char>& src) {
     buf = co_await src.read_exactly(client_id_size);
 
     if (src.eof()) {
-        throw std::runtime_error(fmt::format("Unexpected EOF for client ID"));
+        throw std::runtime_error(fmt::format(
+          "Unexpected EOF for client ID, client_id_size: {}, header: {}",
+          client_id_size,
+          header));
     }
     header.client_id_buffer = std::move(buf);
     header.client_id = std::string_view(


### PR DESCRIPTION
- The most common cause of this error path is a non-kafka client that has hit port 9092 with at least `request_header_size` bytes in the request buffer.

- This commit logs additional information in the exception thrown so that when debugging, it can be immediately confirmed if the request was made by a kafka client or not. For example observing a value for `header.key` that is not API compliant.
