### PR TITLE
cloud_storage: Fix transactions e2e test

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -449,7 +449,7 @@ model::offset remote_partition::first_uploaded_offset() {
     try {
         auto it = _manifest.begin();
         auto off = get_kafka_base_offset(it->second);
-        vlog(_ctxlog.debug, "remote partition first_uploaded_offset: {}", off);
+        vlog(_ctxlog.trace, "remote partition first_uploaded_offset: {}", off);
         return off;
     } catch (...) {
         vlog(

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -39,7 +39,9 @@ ss::future<> tx_range_manifest::update(ss::input_stream<char> is) {
     using namespace rapidjson;
     iobuf result;
     auto os = make_iobuf_ref_output_stream(result);
-    co_await ss::copy(is, os);
+    co_await ss::copy(is, os).finally([&is, &os]() mutable {
+        return is.close().finally([&os]() mutable { return os.close(); });
+    });
     iobuf_istreambuf ibuf(result);
     std::istream stream(&ibuf);
     Document m;

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -287,8 +287,12 @@ class Producer:
 
     def reconnect(self):
         self.producer = confluent_kafka.Producer({
-            'bootstrap.servers': self.brokers,
-            'transactional.id': self.name,
+            'bootstrap.servers':
+            self.brokers,
+            'transactional.id':
+            self.name,
+            'transaction.timeout.ms':
+            5000,
         })
         self.producer.init_transactions()
 


### PR DESCRIPTION
## Cover letter

Fix  test_restore_with_aborted_tx test failure on CI.

Use `transactions.timeout.ms` in kafka producer and add delay before reconnect.
Fix segment hydration logic `remote_segment`. Currently, the tx-manifest is never saved to SI cache. This PR fixes this so the materialization of transactional metadata could be done from cache instead of S3.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

none

## Release notes

* none

### Features

* none

### Improvements

* Improve transaction metadata handling in Shadow Indexing

