### PR TITLE
cluster: Use bucket passed via `redpanda.remote.readreplica` in read-replica mode 

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -46,7 +46,8 @@ public:
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
-      ss::sharded<feature_table>&);
+      ss::sharded<feature_table>&,
+      std::optional<remote_partition_properties> rtp);
 
     raft::group_id group() const { return _raft->group(); }
     ss::future<> start();
@@ -222,6 +223,10 @@ public:
         return cfg.is_read_replica_mode_enabled();
     }
 
+    s3::bucket_name get_read_replica_bucket() const {
+        return _read_replica_bucket.value();
+    }
+
     /// Return true if shadow indexing is enabled for the partition
     bool is_remote_fetch_enabled() const {
         const auto& cfg = _raft->log_config();
@@ -319,6 +324,7 @@ private:
     bool _is_idempotence_enabled{false};
     ss::lw_shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
+    std::optional<s3::bucket_name> _read_replica_bucket{std::nullopt};
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -17,6 +17,8 @@
 #include "cluster/feature_table.h"
 #include "cluster/ntp_callbacks.h"
 #include "cluster/partition.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/group_manager.h"
@@ -78,7 +80,7 @@ public:
       storage::ntp_config,
       raft::group_id,
       std::vector<model::broker>,
-      std::optional<cluster::remote_topic_properties> = std::nullopt);
+      std::optional<remote_partition_properties> = std::nullopt);
 
     ss::future<> shutdown(const model::ntp& ntp);
     ss::future<> remove(const model::ntp& ntp);
@@ -177,7 +179,7 @@ private:
     /// \return true if the recovery was invoked, false otherwise
     ss::future<cloud_storage::log_recovery_result> maybe_download_log(
       storage::ntp_config& ntp_cfg,
-      std::optional<cluster::remote_topic_properties> rtp);
+      std::optional<remote_partition_properties> rtp);
 
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1003,6 +1003,11 @@ struct remote_topic_properties
     operator<<(std::ostream&, const remote_topic_properties&);
 };
 
+struct remote_partition_properties {
+    s3::bucket_name bucket;
+    remote_topic_properties rtp;
+};
+
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -13,6 +13,7 @@
 #include "cluster/errc.h"
 #include "cluster/types.h"
 #include "compat/model_generator.h"
+#include "model/fundamental.h"
 #include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -35,6 +35,12 @@ using offset = named_type<int64_t, struct kafka_offset_type>;
 
 } // namespace kafka
 
+namespace s3 {
+
+using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
+
+} // namespace s3
+
 namespace model {
 
 // Named after Kafka cleanup.policy topic property

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -12,6 +12,7 @@
 
 #include "cloud_roles/apply_credentials.h"
 #include "http/client.h"
+#include "model/fundamental.h"
 #include "net/transport.h"
 #include "net/types.h"
 #include "outcome.h"
@@ -33,7 +34,6 @@
 namespace s3 {
 
 using access_point_uri = named_type<ss::sstring, struct s3_access_point_uri>;
-using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
 using object_key = named_type<std::filesystem::path, struct s3_object_key>;
 using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
 using ca_trust_file


### PR DESCRIPTION
## Cover letter

Currently, read replica topic uses bucket from the configuration. This PR adds new fields to `remote_topic_properites` and propagates it. The `cloud_storage::remote_partition` and `archival::ntp_archiver_service` are using this value in read-replica mode.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

none

## Release notes

* none


### Features

* none

### Improvements

* none