### PR TITLE
[v22.1.x] cloud_storage/tests: wait for partition metadata during topic recovery tests

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -493,7 +493,7 @@ class RpkTool:
             p.kill()
             raise RpkException(f"command {' '.join(cmd)} timed out")
 
-        self._redpanda.logger.debug(output)
+        self._redpanda.logger.debug(f'\n{output}')
 
         if p.returncode:
             self._redpanda.logger.error(error)


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5757.
Fixes https://github.com/redpanda-data/redpanda/issues/6014,