### PR TITLE
Fix data loss consistency violation

### DIFF
--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -73,7 +73,9 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
+    BOOST_REQUIRE_EQUAL(
+      stm.add_partitions(tx_id, partitions).get0(),
+      cluster::tm_stm::op_status::success);
     BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
     auto tx2 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx2.id, tx_id);
@@ -128,7 +130,9 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
+    BOOST_REQUIRE_EQUAL(
+      stm.add_partitions(tx_id, partitions).get0(),
+      cluster::tm_stm::op_status::success);
     auto tx3 = expect_tx(stm.get_tx(tx_id));
     auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
     auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
@@ -167,7 +171,9 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
     auto tx2 = stm.reset_tx_ongoing(tx_id, c->term());
-    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
+    BOOST_REQUIRE_EQUAL(
+      stm.add_partitions(tx_id, partitions).get0(),
+      cluster::tm_stm::op_status::success);
     auto tx3 = expect_tx(stm.get_tx(tx_id));
     auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
     auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -149,9 +149,10 @@ public:
     // reset_xxx: updates a transaction and an etag
     checked<tm_transaction, tm_stm::op_status>
       reset_tx_ongoing(kafka::transactional_id, model::term_id);
-    bool add_partitions(
+    ss::future<tm_stm::op_status> add_partitions(
       kafka::transactional_id, std::vector<tm_transaction::tx_partition>);
-    bool add_group(kafka::transactional_id, kafka::group_id, model::term_id);
+    ss::future<tm_stm::op_status>
+      add_group(kafka::transactional_id, kafka::group_id, model::term_id);
     bool is_actual_term(model::term_id term) { return _insync_term == term; }
     std::optional<kafka::transactional_id>
     get_id_by_pid(model::producer_identity pid) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -929,8 +929,8 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
         response.results.push_back(res_topic);
     }
 
-    return when_all_succeed(bfs.begin(), bfs.end())
-      .then([response, tx, stm](std::vector<begin_tx_reply> brs) mutable {
+    auto brs = co_await when_all_succeed(bfs.begin(), bfs.end());
+
           std::vector<tm_transaction::tx_partition> partitions;
           for (auto& br : brs) {
               auto topic_it = std::find_if(
@@ -984,8 +984,7 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
               }
               topic_it->results.push_back(res_partition);
           }
-          return response;
-      });
+          co_return response;
 }
 
 ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -219,6 +219,9 @@ class Batch:
             return Batch(index, header, data)
         assert len(data) == 0
 
+    def __len__(self):
+        return self.header.record_count
+
     def __iter__(self):
         return RecordIter(self.header.record_count, self.records)
 

--- a/tools/offline_log_viewer/tx_coordinator.py
+++ b/tools/offline_log_viewer/tx_coordinator.py
@@ -1,0 +1,87 @@
+from storage import Segment
+from enum import Enum
+from io import BytesIO
+from reader import Reader
+import struct
+
+
+class TxStatus(Enum):
+    ongoing = 0
+    preparing = 1
+    prepared = 2
+    aborting = 3
+    killed = 4
+    ready = 5
+    tombstone = 6
+
+
+class TxLog:
+    def __init__(self, ntp):
+        self.ntp = ntp
+
+    def decode(self):
+        for batch in self.batches():
+            header = batch.header_dict()
+            records = batch
+            if header["type_name"] == "tm_update":
+                assert len(records) == 1
+            header["records"] = []
+            for record in records:
+                record_dict = record.kv_dict()
+                if header["type_name"] == "tm_update":
+                    rdr = Reader(BytesIO(record.key))
+                    record_dict["key"] = {}
+                    record_dict["key"]["raw"] = record_dict["k"]
+                    del record_dict["k"]
+                    record_dict["key"]["type"] = rdr.read_int8()
+                    record_dict["key"]["pid.id"] = rdr.read_int64()
+                    record_dict["key"]["tx.id"] = rdr.read_string()
+
+                    rdr = Reader(BytesIO(record.value))
+                    record_dict["value"] = {}
+                    record_dict["value"]["raw"] = record_dict["v"]
+                    del record_dict["v"]
+                    record_dict["value"]["version"] = rdr.read_int8()
+                    record_dict["value"]["tx.id"] = rdr.read_string()
+                    record_dict["value"]["pid"] = {}
+                    record_dict["value"]["pid"]["id"] = rdr.read_int64()
+                    record_dict["value"]["pid"]["epoch"] = rdr.read_int16()
+                    record_dict["value"]["tx_seq"] = rdr.read_int64()
+                    record_dict["value"]["etag"] = rdr.read_int64()
+                    record_dict["value"]["status"] = TxStatus(
+                        rdr.read_int32()).name
+                    record_dict["value"]["timeout_ms"] = rdr.read_int64()
+                    record_dict["value"]["last_update_ts"] = rdr.read_int64()
+                    record_dict["value"]["partitions"] = []
+                    record_dict["value"]["groups"] = []
+                    p_size = rdr.read_int32()
+                    for i in range(p_size):
+                        partition = {}
+                        partition["ntp"] = {}
+                        partition["ntp"]["ns"] = rdr.read_string()
+                        partition["ntp"]["tp"] = {}
+                        partition["ntp"]["tp"]["topic"] = rdr.read_string()
+                        partition["ntp"]["tp"]["partition"] = rdr.read_int32()
+                        partition["etag"] = rdr.read_int64()
+                        record_dict["value"]["partitions"].append(partition)
+
+                    g_size = rdr.read_int32()
+                    for i in range(g_size):
+                        group = {}
+                        group["id"] = rdr.read_string()
+                        group["etag"] = rdr.read_int64()
+                        record_dict["value"]["groups"].append(group)
+                elif header["type_name"] == "raft_configuration":
+                    pass
+                elif header["type_name"] == "checkpoint":
+                    pass
+                else:
+                    raise Exception(header["type_name"])
+                header["records"].append(record_dict)
+                yield header
+
+    def batches(self):
+        for path in self.ntp.segments:
+            s = Segment(path)
+            for batch in s:
+                yield batch


### PR DESCRIPTION
## Cover letter

Kafka API doesn't have explicit begin txn API, when a transaction coordinator recieves first add_partition or add_group it starts a transaction. Also Redpanda defers disk flushes to the commit moment. Combinations of those thing caues a problem:

1. a client issues add_partition to txn coordinator
2. txn coordinator starts a transaction (this is in memory state)
3. the client writes a message to data partition
4. redpanda treats the write as acks=1 and acks the request before the replication is finished (it's safe to do it because on commit redpanda checks that all pending replication is done)
5. txn coordinator & data partition experience re-election and the in memory state is lost
6. the client issues add_group to txn coordinator
7. txn coordinator is unaware about the ongoing txn and starts new transaction
8. the client commits the txn and only the consumer group change is written

Since the data record was written with acks=1 just before re-election it gets lost and the client hasn't figured out that there was something wrong with transaction.

Fixes #6018

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

## Release notes

* fixes consistency violation caused by split-brain of the txn coordinator