### PR TITLE
rpc: retain correlation idx across transport resets

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -80,7 +80,11 @@ ss::future<> transport::connect(clock_type::duration connection_timeout) {
 }
 
 void transport::reset_state() {
-    _correlation_idx = 0;
+    /*
+     * the _correlation_idx is explicitly not reset as a pragmatic approach to
+     * dealing with an apparent race condition in which two requests with the
+     * same correlation id are in flight shortly after a reset.
+     */
     _last_seq = sequence_t{0};
     _seq = sequence_t{0};
     _version = transport_version::v1;


### PR DESCRIPTION
## Cover letter

The rpc client transport works as an unordered stream of requests and
responses. In order to match a response to a request each request
contains a unique correlation id which the server includes the header of
a response. The client tracks inflight requests by correlation id and
matches the response using an index.

Recently we have been observing a protocol violation
https://github.com/redpanda-data/redpanda/issues/5608. One explanation
for this would be that the client matched a response with the wrong
request.

The correlation id is a unique integer that is incremented for each request. So
how could this happen? One explanation is that a concurrency bug exists with
the transport reset logic in which the correlation id is reset to 0. In fact,
there is some evidence, but not definitive evidence, that something like this
is happening. Shown in https://github.com/redpanda-data/redpanda/issues/6005
are the following two trace logs that were logged 1ms apart.

```
TRACE 2022-08-12 19:43:02,647 [shard 1] rpc - transport.cc:216 - xxxxx[0x618000016890]: sending to {host: docker-rp-10, port: 33145} gen 9 header {version:1, header_checksum:0, compression:0, payload_size:0, meta:1699244518, correlation_id:2, payload_checksum:0}
TRACE 2022-08-12 19:43:02,646 [shard 1] rpc - transport.cc:216 - xxxxx[0x618000016890]: sending to {host: docker-rp-10, port: 33145} gen 9 header {version:2, header_checksum:0, compression:0, payload_size:0, meta:1699244518, correlation_id:2, payload_checksum:0}
```

Notice that both have the same correlation id (2) but different transport
versions (1 and 2). The leading theory is that a transport reset occurs between
these two message sends _and_ a concurreny bug exists which is not properly
cancelling inflight requests / responses from the previous "generation" of the
transport, leading to a mismatched request/response and the protocol violation.
So far analysis of code paths hasn't lead to explanation, but the analysis is
complicated.

This patch takes a pragmatic approach to avoiding this situation. When a
transport is reset the correlation id is _not_ reset. This ensure that unique
correlation ids continue to be generated. The result is that there may still be
a race with cleaning up in flight requests/responses but that no mistakes in
request/response matching via the correlation id should occur.

### Testing

Prior to this patch I was able to trigger the protocol violation between 1/100 and 1/50
test runs (see https://github.com/redpanda-data/redpanda/pull/5931 for historical runs).
With this patch the violation has not triggered in approximately 600 runs.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* None