### PR TITLE
[v22.2.x] rpc: retain correlation idx across transport resets

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -80,7 +80,11 @@ ss::future<> transport::connect(clock_type::duration connection_timeout) {
 }
 
 void transport::reset_state() {
-    _correlation_idx = 0;
+    /*
+     * the _correlation_idx is explicitly not reset as a pragmatic approach to
+     * dealing with an apparent race condition in which two requests with the
+     * same correlation id are in flight shortly after a reset.
+     */
     _last_seq = sequence_t{0};
     _seq = sequence_t{0};
     _version = transport_version::v1;


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6021.
