### PR TITLE
cluster: Remove remote_partition_properties

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -47,7 +47,7 @@ public:
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
       ss::sharded<feature_table>&,
-      std::optional<remote_partition_properties> rtp);
+      std::optional<s3::bucket_name> read_replica_bucket = std::nullopt);
 
     raft::group_id group() const { return _raft->group(); }
     ss::future<> start();

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -75,9 +75,10 @@ ss::future<consensus_ptr> partition_manager::manage(
   storage::ntp_config ntp_cfg,
   raft::group_id group,
   std::vector<model::broker> initial_nodes,
-  std::optional<remote_partition_properties> rpp) {
+  std::optional<remote_topic_properties> rtp,
+  std::optional<s3::bucket_name> read_replica_bucket) {
     gate_guard guard(_gate);
-    auto dl_result = co_await maybe_download_log(ntp_cfg, rpp);
+    auto dl_result = co_await maybe_download_log(ntp_cfg, rtp);
     auto [logs_recovered, min_kafka_offset, max_kafka_offset, manifest]
       = dl_result;
     if (logs_recovered) {
@@ -152,7 +153,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _cloud_storage_api,
       _cloud_storage_cache,
       _feature_table,
-      rpp);
+      read_replica_bucket);
 
     _ntp_table.emplace(log.config().ntp(), p);
     _raft_table.emplace(group, p);
@@ -178,11 +179,10 @@ ss::future<consensus_ptr> partition_manager::manage(
 
 ss::future<cloud_storage::log_recovery_result>
 partition_manager::maybe_download_log(
-  storage::ntp_config& ntp_cfg,
-  std::optional<remote_partition_properties> rpp) {
-    if (rpp.has_value() && _partition_recovery_mgr.local_is_initialized()) {
+  storage::ntp_config& ntp_cfg, std::optional<remote_topic_properties> rtp) {
+    if (rtp.has_value() && _partition_recovery_mgr.local_is_initialized()) {
         auto res = co_await _partition_recovery_mgr.local().download_log(
-          ntp_cfg, rpp->rtp);
+          ntp_cfg, *rtp);
         co_return res;
     }
     vlog(

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -80,7 +80,8 @@ public:
       storage::ntp_config,
       raft::group_id,
       std::vector<model::broker>,
-      std::optional<remote_partition_properties> = std::nullopt);
+      std::optional<remote_topic_properties> = std::nullopt,
+      std::optional<s3::bucket_name> = std::nullopt);
 
     ss::future<> shutdown(const model::ntp& ntp);
     ss::future<> remove(const model::ntp& ntp);
@@ -178,8 +179,7 @@ private:
     /// \param ntp_cfg is an ntp_config instance to recover
     /// \return true if the recovery was invoked, false otherwise
     ss::future<cloud_storage::log_recovery_result> maybe_download_log(
-      storage::ntp_config& ntp_cfg,
-      std::optional<remote_partition_properties> rtp);
+      storage::ntp_config& ntp_cfg, std::optional<remote_topic_properties> rtp);
 
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1003,11 +1003,6 @@ struct remote_topic_properties
     operator<<(std::ostream&, const remote_topic_properties&);
 };
 
-struct remote_partition_properties {
-    s3::bucket_name bucket;
-    remote_topic_properties rtp;
-};
-
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -13,7 +13,6 @@
 #include "cluster/errc.h"
 #include "cluster/types.h"
 #include "compat/model_generator.h"
-#include "model/fundamental.h"
 #include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"


### PR DESCRIPTION
## Cover letter

Followup PR for #6006. Remove `remote_partition_properties` struct and pass bucket name for read replica and `remote_topic_properties` separately.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

none

## Release notes

* none

### Features

* none
* 
### Improvements

* none