### PR TITLE
security: add missing dependency to fix linking.

### DIFF
--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     license.cc
   DEPS
     v::bytes
+    v::utils
     absl::flat_hash_map
     absl::flat_hash_set
     cryptopp


### PR DESCRIPTION
v::utils is missing while building v::security, and ld complains:

> /usr/bin/ld: lib/libv_v_security.a(license.cc.o): in function `security::make_license(seastar::basic_sstring<char, unsigned int, 15u, true> const&)':
> license.cc:(.text+0x32b): undefined reference to `base64_to_string(std::basic_string_view<char, std::char_traits<char> >)'
> /usr/bin/ld: license.cc:(.text+0x439): undefined reference to `base64_to_string(std::basic_string_view<char, std::char_traits<char> >)'

Signed-off-by: Jianyong Chen <baluschch@gmail.com>