### PR TITLE
operator: add a flag to disable clearing of seeds servers in configur…

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -42,6 +42,7 @@ const (
 	externalConnectivityAddressTypeEnvVar = "EXTERNAL_CONNECTIVITY_ADDRESS_TYPE"
 	hostPortEnvVar                        = "HOST_PORT"
 	proxyHostPortEnvVar                   = "PROXY_HOST_PORT"
+	skipClusterSeedInitEnvVar             = "SKIP_CLUSTER_SEED_INIT"
 )
 
 type brokerID int
@@ -58,6 +59,7 @@ type configuratorConfig struct {
 	redpandaRPCPort                 int
 	hostPort                        int
 	proxyHostPort                   int
+	skipClusterSeedInit             bool
 }
 
 func (c *configuratorConfig) String() string {
@@ -131,9 +133,9 @@ func main() {
 
 	cfg.Redpanda.Id = int(hostIndex)
 
-	// First Redpanda node need to have cleared seed servers in order
-	// to form raft group 0
-	if hostIndex == 0 {
+	// Unless the cluster is configured to skip this phase, the first Redpanda node
+	// needs to have seed servers cleared in order to form raft group 0.
+	if !c.skipClusterSeedInit && hostIndex == 0 {
 		cfg.Redpanda.SeedServers = []config.SeedServer{}
 	}
 
@@ -288,6 +290,7 @@ func getExternalIP(node *corev1.Node) string {
 	return ""
 }
 
+// nolint:funlen // this lists all envs
 func checkEnvVars() (configuratorConfig, error) {
 	var result error
 	var extCon string
@@ -378,6 +381,15 @@ func checkEnvVars() (configuratorConfig, error) {
 		c.proxyHostPort, err = strconv.Atoi(proxyHostPort)
 		if err != nil {
 			result = multierror.Append(result, fmt.Errorf("unable to convert proxy host port from string to int: %w", err))
+		}
+	}
+
+	// Existing cluster env var is optional
+	skipInit, exist := os.LookupEnv(skipClusterSeedInitEnvVar)
+	if exist && skipInit != "" {
+		c.skipClusterSeedInit, err = strconv.ParseBool(skipInit)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("unable to convert the skip cluster seed init flag (%q) from string to bool: %w", skipInit, err))
 		}
 	}
 

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -69,6 +69,17 @@ func TestEnsure(t *testing.T) {
 	// Remove shadow-indexing-cache from the volume claim templates
 	stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates = stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates[:1]
 
+	skipInitCluster := cluster.DeepCopy()
+	if skipInitCluster.Annotations == nil {
+		skipInitCluster.Annotations = make(map[string]string)
+	}
+	skipInitCluster.Annotations["redpanda.vectorized.io/skip-cluster-seed-init"] = "true"
+	skipInitSts := stsFromCluster(skipInitCluster)
+	skipInitSts.Spec.Template.Spec.InitContainers[0].Env = append(skipInitSts.Spec.Template.Spec.InitContainers[0].Env, corev1.EnvVar{
+		Name:  "SKIP_CLUSTER_SEED_INIT",
+		Value: "true",
+	})
+
 	tests := []struct {
 		name           string
 		existingObject client.Object
@@ -81,6 +92,7 @@ func TestEnsure(t *testing.T) {
 		{"update redpanda resources", stsResource, resourcesUpdatedRedpandaCluster, resourcesUpdatedSts},
 		{"disabled sidecar", nil, noSidecarCluster, noSidecarSts},
 		{"cluster without shadow index cache dir", stsResource, withoutShadowIndexCacheDirectory, stsWithoutSecondPersistentVolume},
+		{"skip seed init cluster", nil, skipInitCluster, skipInitSts},
 	}
 
 	for _, tt := range tests {
@@ -152,8 +164,27 @@ func TestEnsure(t *testing.T) {
 				actual.Spec.VolumeClaimTemplates[i].Labels = nil
 			}
 			assert.Equal(t, tt.expectedObject.Spec.VolumeClaimTemplates, actual.Spec.VolumeClaimTemplates)
+
+			assert.Equal(t, len(tt.expectedObject.Spec.Template.Spec.InitContainers), len(actual.Spec.Template.Spec.InitContainers))
+			for i := range tt.expectedObject.Spec.Template.Spec.InitContainers {
+				expEnv := envAsMap(tt.expectedObject.Spec.Template.Spec.InitContainers[i].Env)
+				actEnv := envAsMap(actual.Spec.Template.Spec.InitContainers[i].Env)
+				// assert that the subset of expected envs matches
+				for k, v := range expEnv {
+					assert.Equal(t, v, actEnv[k])
+				}
+			}
 		})
 	}
+}
+
+func envAsMap(envs []corev1.EnvVar) map[string]string {
+	m := make(map[string]string, len(envs))
+	for _, e := range envs {
+		// Ignoring value from for the tests
+		m[e.Name] = e.Value
+	}
+	return m
 }
 
 func stsFromCluster(pandaCluster *redpandav1alpha1.Cluster) *v1.StatefulSet {

--- a/src/go/k8s/tests/e2e/additional-configuration/02-update-config.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/02-update-config.yaml
@@ -3,6 +3,9 @@ kind: Cluster
 metadata:
   name: additional-configuration
   namespace: default
+  annotations:
+    # We also check that the cluster starts correctly when using the annotation
+    redpanda.vectorized.io/skip-cluster-seed-init: "true"
 spec:
   additionalConfiguration:
     redpanda.enable_idempotence: "true"


### PR DESCRIPTION
…ator image.

Setting annotation `redpanda.vectorized.io/skip-cluster-seed-init=true` on a cluster will disable the default behavior that let node 0 have an empty seeds servers list (initially created to allow it to create a new cluster upon initialization).

When a cluster is already existing, node 0 does not need to create a new cluster and must always join other nodes.

## Cover letter

This is an attempt to solve the split-brain issue occurring when node 0 loses the data dir. This problem is solved in 22.2.x but the fix is linked to downscaling and cannot be easily backported.
This is meant to be an alternative, that can be backported easily to older versions.

When doing operations that can cause the datadir to be lost, like moving clusters to other sets of nodes, the cluster needs to:
- Have the operator updated to a version with this fix
- Be annotated with `redpanda.vectorized.io/skip-cluster-seed-init=true`

... before executing the migration procedure.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x (initially here)
- [x] v21.11.x (maybe)

## Release notes

### Improvements

* Added flag that prevents split brain when performing operations that can cause loss of data dir on existing clusters
