### PR TITLE
rptest: Improve read replica test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -234,24 +234,26 @@ class SISettings:
     GLOBAL_S3_REGION_KEY = "s3_region"
 
     def __init__(
-        self,
-        *,
-        log_segment_size: int = 16 * 1000000,
-        cloud_storage_access_key: str = 'panda-user',
-        cloud_storage_secret_key: str = 'panda-secret',
-        cloud_storage_region: str = 'panda-region',
-        cloud_storage_bucket: Optional[str] = None,
-        cloud_storage_api_endpoint: str = 'minio-s3',
-        cloud_storage_api_endpoint_port: int = 9000,
-        cloud_storage_cache_size: int = 160 * 1000000,
-        cloud_storage_enable_remote_read: bool = True,
-        cloud_storage_enable_remote_write: bool = True,
-        cloud_storage_reconciliation_interval_ms: Optional[int] = None,
-        cloud_storage_max_connections: Optional[int] = None,
-        cloud_storage_disable_tls: bool = True,
-        cloud_storage_segment_max_upload_interval_sec: Optional[int] = None,
-        cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
-            int] = None):
+            self,
+            *,
+            log_segment_size: int = 16 * 1000000,
+            cloud_storage_access_key: str = 'panda-user',
+            cloud_storage_secret_key: str = 'panda-secret',
+            cloud_storage_region: str = 'panda-region',
+            cloud_storage_bucket: Optional[str] = None,
+            cloud_storage_api_endpoint: str = 'minio-s3',
+            cloud_storage_api_endpoint_port: int = 9000,
+            cloud_storage_cache_size: int = 160 * 1000000,
+            cloud_storage_enable_remote_read: bool = True,
+            cloud_storage_enable_remote_write: bool = True,
+            cloud_storage_reconciliation_interval_ms: Optional[int] = None,
+            cloud_storage_max_connections: Optional[int] = None,
+            cloud_storage_disable_tls: bool = True,
+            cloud_storage_segment_max_upload_interval_sec: Optional[
+                int] = None,
+            cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
+                int] = None,
+            bypass_bucket_creation: bool = False):
         self.log_segment_size = log_segment_size
         self.cloud_storage_access_key = cloud_storage_access_key
         self.cloud_storage_secret_key = cloud_storage_secret_key
@@ -268,6 +270,7 @@ class SISettings:
         self.cloud_storage_segment_max_upload_interval_sec = cloud_storage_segment_max_upload_interval_sec
         self.cloud_storage_readreplica_manifest_sync_timeout_ms = cloud_storage_readreplica_manifest_sync_timeout_ms
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
+        self.bypass_bucket_creation = bypass_bucket_creation
 
     def load_context(self, logger, test_context):
         """
@@ -1083,7 +1086,9 @@ class RedpandaService(Service):
 
         self.logger.debug(
             f"Creating S3 bucket: {self._si_settings.cloud_storage_bucket}")
-        self.s3_client.create_bucket(self._si_settings.cloud_storage_bucket)
+        if not self._si_settings.bypass_bucket_creation:
+            self.s3_client.create_bucket(
+                self._si_settings.cloud_storage_bucket)
 
     def list_buckets(self) -> dict[str, Union[list, dict]]:
         assert self.s3_client is not None

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -45,8 +45,12 @@ class TestReadReplicaService(EndToEndTest):
         cloud_storage_readreplica_manifest_sync_timeout_ms=500,
         cloud_storage_segment_max_upload_interval_sec=5)
 
-    # Read reaplica should have a different bucket
+    # Read reaplica shouldn't have it's own bucket.
+    # We're adding 'none' as a bucket name without creating
+    # an actual bucket with such name.
     rr_settings = SISettings(
+        cloud_storage_bucket='none',
+        bypass_bucket_creation=True,
         cloud_storage_reconciliation_interval_ms=500,
         cloud_storage_max_connections=5,
         log_segment_size=log_segment_size,


### PR DESCRIPTION
## Cover letter

Verify that the read replica cluster can work without setting a bucket.
Use 'none' as a bucket name for read replica cluster. Do not create a bucket with such name for read replica cluster.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes


* none


### Features

* none

### Improvements

* none