### PR TITLE
http/client: overrides fmt formatter for request to hide sensitive info

### DIFF
--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -378,8 +378,7 @@ std::error_code signature_v4::sign_header(
       canonical_headers.value().signed_headers,
       hexdigest(digest));
     header.set(boost::beast::http::field::authorization, auth_header);
-    vlog(
-      clrl_log.trace, "\n[signed-header]\n\n{}", http::redacted_header(header));
+    vlog(clrl_log.trace, "\n[signed-header]\n\n{}", header);
     return {};
 }
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -86,7 +86,7 @@ ss::future<client::request_response_t> client::make_request(
     auto target = header.target();
     ss::sstring target_str(target.data(), target.size());
     prefix_logger ctxlog(http_log, ssx::sformat("[{}]", target_str));
-    vlog(ctxlog.trace, "client.make_request {}", redacted_header(header));
+    vlog(ctxlog.trace, "client.make_request {}", header);
 
     auto req = ss::make_shared<request_stream>(this, std::move(header));
     auto res = ss::make_shared<response_stream>(this, verb, target_str);

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -258,3 +258,20 @@ inline ss::future<> client::forward(client* client, BufferSeq&& seq) {
     return client->send(std::move(scattered));
 }
 } // namespace http
+
+template<>
+struct fmt::formatter<http::client::request_header> {
+    constexpr auto parse(fmt::format_parse_context& ctx)
+      -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const http::client::request_header& h, FormatContext& ctx)
+      -> decltype(ctx.out()) {
+        auto redacted = http::redacted_header(h);
+        std::stringstream s;
+        s << redacted;
+        return fmt::format_to(ctx.out(), "{}", s.str());
+    }
+};

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -855,8 +855,7 @@ SEASTAR_THREAD_TEST_CASE(test_header_redacted) {
     request_header.set(boost::beast::http::field::authorization, "password");
     request_header.set("x-amz-content-sha256", "pigeon");
     request_header.set("x-amz-security-token", "capetown");
-    auto redacted = http::redacted_header(request_header);
-    auto s = fmt::format("{}", redacted);
+    auto s = fmt::format("{}", request_header);
     BOOST_REQUIRE(s.find("password") == std::string::npos);
     BOOST_REQUIRE(s.find("pigeon") == std::string::npos);
     BOOST_REQUIRE(s.find("capetown") == std::string::npos);

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -287,7 +287,7 @@ request_creator::make_list_objects_v2_request(
     }
 
     auto ec = _apply_credentials->add_auth(header);
-    vlog(s3_log.trace, "ListObjectsV2:\n {}", http::redacted_header(header));
+    vlog(s3_log.trace, "ListObjectsV2:\n {}", header);
     if (ec) {
         return ec;
     }
@@ -492,10 +492,7 @@ ss::future<http::client::response_stream_ref> client::get_object(
         return ss::make_exception_future<http::client::response_stream_ref>(
           std::system_error(header.error()));
     }
-    vlog(
-      s3_log.trace,
-      "send https request:\n{}",
-      http::redacted_header(header.value()));
+    vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
       .then([](http::client::response_stream_ref&& ref) {
           // here we didn't receive any bytes from the socket and
@@ -532,10 +529,7 @@ ss::future<client::head_object_result> client::head_object(
         return ss::make_exception_future<client::head_object_result>(
           std::system_error(header.error()));
     }
-    vlog(
-      s3_log.trace,
-      "send https request:\n{}",
-      http::redacted_header(header.value()));
+    vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
       .then(
         [key](const http::client::response_stream_ref& ref)
@@ -582,10 +576,7 @@ ss::future<> client::put_object(
     if (!header) {
         return ss::make_exception_future<>(std::system_error(header.error()));
     }
-    vlog(
-      s3_log.trace,
-      "send https request:\n{}",
-      http::redacted_header(header.value()));
+    vlog(s3_log.trace, "send https request:\n{}", header.value());
     return ss::do_with(
       std::move(body),
       [this, timeout, header = std::move(header)](
@@ -626,10 +617,7 @@ ss::future<client::list_bucket_result> client::list_objects_v2(
         return ss::make_exception_future<list_bucket_result>(
           std::system_error(header.error()));
     }
-    vlog(
-      s3_log.trace,
-      "send https request:\n{}",
-      http::redacted_header(header.value()));
+    vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
       .then([](const http::client::response_stream_ref& resp) mutable {
           // chunked encoding is used so we don't know output size in
@@ -672,10 +660,7 @@ ss::future<> client::delete_object(
     if (!header) {
         return ss::make_exception_future<>(std::system_error(header.error()));
     }
-    vlog(
-      s3_log.trace,
-      "send https request:\n{}",
-      http::redacted_header(header.value()));
+    vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
       .then([](const http::client::response_stream_ref& ref) {
           return drain_response_stream(ref).then([ref](iobuf&& res) {


### PR DESCRIPTION
## Cover letter

An http request can contain headers which have sensitive information such as authorization. We redact these fields right now using a special function which creates a copy of the request with sensitive fields removed. This has the downside of making the developer remember to call the function each time the request is printed.

The changes here override the fmtlib formatter for request so that any objects logged via fmt are automatically redacted. It is not possible to override the ostream operator without subclassing the request class and using that subclass everywhere, using the fmt API is less intrusive to the code base.

fixes #5011

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

A backport is not explicitly required because the current group of sensitive headers is already handled in the code base. 

## UX changes

None

## Release notes

None

