### PR TITLE
Fixed truncation during adjacent segments compaction 

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1396,10 +1396,16 @@ void disk_log_impl::wrote_stm_bytes(size_t byte_size) {
 storage_resources& disk_log_impl::resources() { return _manager.resources(); }
 
 std::ostream& disk_log_impl::print(std::ostream& o) const {
-    return o << "{offsets:" << offsets()
-             << ", max_collectible_offset: " << _max_collectible_offset
-             << ", closed:" << _closed << ", config:" << config()
-             << ", logs:" << _segs << "}";
+    fmt::print(
+      o,
+      "{{offsets: {}, max_collectible_offset: {}, is_closed: {}, segments: "
+      "[{}], config: {}}}",
+      offsets(),
+      _max_collectible_offset,
+      _closed,
+      _segs,
+      config());
+    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const disk_log_impl& d) {

--- a/src/v/storage/offset_to_filepos_consumer.h
+++ b/src/v/storage/offset_to_filepos_consumer.h
@@ -26,69 +26,41 @@ namespace storage::internal {
 class offset_to_filepos_consumer {
 public:
     using type = std::optional<std::pair<model::offset, size_t>>;
-    offset_to_filepos_consumer(model::offset target, size_t initial)
+    offset_to_filepos_consumer(
+      model::offset log_start_offset, model::offset target, size_t initial)
       : _target_last_offset(target)
+      , _prev_batch_last_offset(model::prev_offset(log_start_offset))
       , _accumulator(initial)
       , _prev(initial) {}
     ss::future<ss::stop_iteration> operator()(::model::record_batch batch) {
         _prev = _accumulator;
         _accumulator += batch.size_bytes();
-        if (_target_last_offset == batch.base_offset()) {
-            _filepos = {batch.base_offset() - model::offset(1), _prev};
-            return ss::make_ready_future<ss::stop_iteration>(
-              ss::stop_iteration::yes);
-        }
-        // if we are in the middle of an actual batch, throw an exception to
-        // preserve previous semantics
 
+        if (_target_last_offset <= batch.base_offset()) {
+            _filepos = {_prev_batch_last_offset, _prev};
+            co_return ss::stop_iteration::yes;
+        }
         if (
           _target_last_offset > batch.base_offset()
-          && _target_last_offset < batch.last_offset()) {
-            _filepos = std::nullopt;
-            return ss::make_exception_future<ss::stop_iteration>(
-              std::runtime_error{fmt::format(
-                "offset_to_filepos_consumer can only translate base_offsets. "
-                "Current batch's {}-{}. Requested offset {} is in a middle of "
-                "curren batch.",
-                batch.base_offset(),
-                batch.last_offset(),
-                _target_last_offset)});
+          && _target_last_offset <= batch.last_offset()) {
+            throw std::runtime_error(fmt::format(
+              "Offset to file position consumer isn't able to translate "
+              "offsets other than batch base offset or offset being in the "
+              "gap. Requested offset: {}, current batch offsets: [{},{}]",
+              _target_last_offset,
+              batch.base_offset(),
+              batch.last_offset()));
         }
-        if (_target_last_offset == batch.last_offset()) {
-            return ss::make_exception_future<ss::stop_iteration>(
-              std::runtime_error{fmt::format(
-                "offset_to_filepos_consumer can only translate base_offsets. "
-                "Current batch's {}-{}. last_offset matches target offset:{}. "
-                "accumulated bytes:{}",
-                batch.base_offset(),
-                batch.last_offset(),
-                _target_last_offset,
-                _accumulator)});
-        }
-        if (batch.base_offset() > _target_last_offset) {
-            return ss::make_exception_future<ss::stop_iteration>(
-              std::runtime_error{fmt::format(
-                "offset_to_filepos_consumer can only translate base_offsets. "
-                "Current batch's {}-{}, exceeds target offset:{}. accumulated "
-                "bytes:{}",
-                batch.base_offset(),
-                batch.last_offset(),
-                _target_last_offset,
-                _accumulator)});
-        }
-        /**
-         * We update _filepos here in case we hit a gap, if so we need to return
-         * an offset and end position of a last batch preceding the gap.
-         */
-        _filepos = {batch.last_offset(), _accumulator};
-        return ss::make_ready_future<ss::stop_iteration>(
-          ss::stop_iteration::no);
+
+        _prev_batch_last_offset = batch.last_offset();
+        co_return ss::stop_iteration::no;
     }
     type end_of_stream() { return _filepos; }
 
 private:
     type _filepos;
     model::offset _target_last_offset;
+    model::offset _prev_batch_last_offset;
     size_t _accumulator;
     size_t _prev;
 };

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <iterator>
 #include <numeric>
+#include <optional>
 
 storage::disk_log_impl* get_disk_log(storage::log log) {
     return dynamic_cast<storage::disk_log_impl*>(log.get_impl());
@@ -2428,3 +2429,131 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
     truncate.get();
     info("truncate_done");
 };
+
+FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
+    auto cfg = default_log_config(test_dir);
+    cfg.stype = storage::log_config::storage_type::disk;
+    cfg.cache = storage::with_cache::no;
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
+    storage::ntp_config::default_overrides overrides;
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    auto ntp = model::ntp("default", "test", 0);
+
+    auto log = mgr
+                 .manage(storage::ntp_config(
+                   ntp,
+                   mgr.config().base_dir,
+                   std::make_unique<storage::ntp_config::default_overrides>(
+                     overrides)))
+                 .get0();
+
+    auto large_batch = [](int key) {
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+
+        builder.add_raw_kv(
+          reflection::to_iobuf(ssx::sformat("key-{}", key)),
+          bytes_to_iobuf(random_generators::get_bytes(33_KiB)));
+        return std::move(builder).build();
+    };
+
+    auto write_and_compact =
+      [&](ss::circular_buffer<model::record_batch> batches) {
+          auto reader = model::make_memory_record_batch_reader(
+            std::move(batches));
+
+          storage::log_append_config appender_cfg{
+            .should_fsync = storage::log_append_config::fsync::no,
+            .io_priority = ss::default_priority_class(),
+            .timeout = model::no_timeout,
+          };
+
+          std::move(reader)
+            .for_each_ref(log.make_appender(appender_cfg), model::no_timeout)
+            .discard_result()
+            .then([&log] { return log.flush(); })
+            .get();
+
+          log
+            .compact(storage::compaction_config(
+              model::timestamp::min(),
+              std::nullopt,
+              ss::default_priority_class(),
+              as))
+            .get();
+      };
+    {
+        /**
+         * Truncate with dirty offset being preceeded by a gap
+         *
+         * segment: [[batch (base_offset: 0)][gap][batch (base_offset: 10)]]
+         *
+         */
+        ss::circular_buffer<model::record_batch> batches;
+
+        // first batch
+        batches.push_back(large_batch(1));
+        // 10 batches with the same key
+        for (int i = 0; i < 10; ++i) {
+            batches.push_back(large_batch(2));
+        }
+        // roll segment with new term append
+        auto b = large_batch(1);
+        b.set_term(model::term_id(10));
+        batches.push_back(std::move(b));
+
+        write_and_compact(std::move(batches));
+
+        model::offset truncate_offset(10);
+
+        log
+          .truncate(storage::truncate_config(
+            truncate_offset, ss::default_priority_class()))
+          .get();
+        info("truncated at: {}, offsets: {}", truncate_offset, log.offsets());
+        BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(0));
+    }
+
+    {
+        /**
+         * Truncate with the first offset available in the log
+         * segment: [batch: (base_offset: 11)]
+         *
+         */
+        ss::circular_buffer<model::record_batch> batches;
+
+        // first batch
+        batches.push_back(large_batch(1));
+        // 10 batches with the same key
+        for (int i = 0; i < 10; ++i) {
+            batches.push_back(large_batch(2));
+        }
+        // roll segment with new term append
+        for (auto i = 1; i < 10; ++i) {
+            auto b = large_batch(i + 20);
+            b.set_term(model::term_id(10));
+            batches.push_back(std::move(b));
+        }
+
+        write_and_compact(std::move(batches));
+
+        model::offset truncate_offset(11);
+        log
+          .truncate_prefix(storage::truncate_prefix_config(
+            truncate_offset, ss::default_priority_class()))
+          .get();
+
+        log
+          .truncate(storage::truncate_config(
+            truncate_offset, ss::default_priority_class()))
+          .get();
+        info("truncated at: {}, offsets: {}", truncate_offset, log.offsets());
+        // empty log have a dirty offset equal to (start_offset - 1)
+        BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(10));
+    }
+}


### PR DESCRIPTION
## Cover letter

This PR includes two fixes for truncation of compacted log segments:

### Incorrect calculation of physical offsets when it lands in a gap

When start offset and truncation offset both were in the gap the
`storage::offset_to_filepos_consumer` was unable to translate the offset
to physical position in a file causing the test to fail.

Changed implementation to let the consumer decide on when to stop
iterating over the set of batches. Previously the stop point was based
on the reader configuration. Now the consumer validates target offset
against the batch offsets and decide whether it should stop iteration
and return physical position. Current implementation retained validation
of requested offset i.e. it is only allowed to request physical position
of batch base offset or offset must be in a gap.

### Truncating swapped segment with physical offset of previous one

Truncation of a segment is a two step process in a first step we use
`offset_to_filepos_consumer` to determine a position in a file where the
truncation should happen. The consumer returns a physical offset in a
file. After that the file is truncated. Since both of those operations
are executed as asynchorous actions it may happen that the segment will
be swapped in between the two steps (as a result of adjacent segment
compaction). Added checking of segment generation before the segment
file is truncated to make sure that is wasn't swapped with other
segment. If the swap took place we retry truncation with the same base
offset it will determine a new physical position in a file and truncate it.



<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6063 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

- fixes a need for retrying truncation of compacted topic partition when it failed
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
