### PR TITLE
tests: bump ducktape version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@7ba83f32d5f265aad955a31096dcc0c97d96c0ce',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@c81a6cfe46abbf18d8521d8a3b8fbabc45811e9c',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',


### PR DESCRIPTION
## Cover letter

Pulls in
https://github.com/redpanda-data/ducktape/commit/c81a6cfe46abbf18d8521d8a3b8fbabc45811e9c,
a change that makes ducktape use a relativized path for the target of
its 'latest` symlink. The link now looks like:

drwxr-xr-x   3 root   root      4096 Aug 17 12:03 2022-08-17--008
drwxr-xr-x   3 root   root      4096 Aug 17 12:05 2022-08-17--009
lrwxrwxrwx   1 root   root        15 Aug 17 12:05 latest -> 2022-08-17--009


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none
