### PR TITLE
tests: rpk redpanda start tests

### DIFF
--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -53,6 +53,13 @@ class RpkRemoteTool:
     def mode_set(self, mode):
         return self._execute([self._rpk_binary(), 'redpanda', 'mode', mode])
 
+    def redpanda_start(self, additional_args="", env_vars="", log_file=""):
+        return self._execute([
+            env_vars,
+            self._rpk_binary(), "redpanda", "start", "-v", additional_args,
+            ">>", log_file, "2>&1", "&"
+        ])
+
     def _run_config(self, cmd, path=None, timeout=30):
         cmd = [self._rpk_binary(), 'redpanda', 'config'] + cmd
 

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -53,7 +53,7 @@ class RpkRemoteTool:
     def mode_set(self, mode):
         return self._execute([self._rpk_binary(), 'redpanda', 'mode', mode])
 
-    def redpanda_start(self, additional_args="", env_vars="", log_file=""):
+    def redpanda_start(self, log_file, additional_args="", env_vars=""):
         return self._execute([
             env_vars,
             self._rpk_binary(), "redpanda", "start", "-v", additional_args,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -37,6 +37,7 @@ from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.admin import Admin
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rolling_restarter import RollingRestarter
+from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.utils import BadLogLines, NodeCrash
 from rptest.clients.python_librdkafka import PythonLibrdkafka
@@ -948,6 +949,28 @@ class RedpandaService(Service):
             else:
                 yield filename
 
+    def __is_status_ready(self, node):
+        """
+        Calls Admin API's v1/status/ready endpoint to verify if the node
+        is ready
+        """
+        status = None
+        try:
+            status = Admin.ready(node).get("status")
+        except requests.exceptions.ConnectionError:
+            self.logger.debug(
+                f"node {node.name} not yet accepting connections")
+            return False
+        except:
+            self.logger.exception(
+                f"error on getting status from {node.account.hostname}")
+            raise
+        if status != "ready":
+            self.logger.debug(
+                f"status of {node.account.hostname} isn't ready: {status}")
+            return False
+        return True
+
     def start_node(self,
                    node,
                    override_cfg_params=None,
@@ -984,24 +1007,6 @@ class RedpandaService(Service):
                     f"Non-XFS filesystem {fs} at {self.PERSISTENT_ROOT} on {node.name}"
                 )
 
-        def is_status_ready():
-            status = None
-            try:
-                status = Admin.ready(node).get("status")
-            except requests.exceptions.ConnectionError:
-                self.logger.debug(
-                    f"node {node.name} not yet accepting connections")
-                return False
-            except:
-                self.logger.exception(
-                    f"error on getting status from {node.account.hostname}")
-                raise
-            if status != "ready":
-                self.logger.debug(
-                    f"status of {node.account.hostname} isn't ready: {status}")
-                return False
-            return True
-
         def start_rp():
             self.start_redpanda(node)
 
@@ -1015,7 +1020,7 @@ class RedpandaService(Service):
                 )
             else:
                 wait_until(
-                    is_status_ready,
+                    lambda: self.__is_status_ready(node),
                     timeout_sec=timeout,
                     backoff_sec=self._startup_poll_interval(first_start),
                     err_msg=
@@ -1026,6 +1031,35 @@ class RedpandaService(Service):
         self.start_service(node, start_rp)
         if not expect_fail:
             self._started.append(node)
+
+    def start_node_with_rpk(self, node, additional_args=""):
+        """
+        Start a single instance of redpanda using rpk. similar to start_node, 
+        this function will not return until redpanda appears to have started 
+        successfully.
+        """
+        node.account.mkdirs(RedpandaService.DATA_DIR)
+        node.account.mkdirs(os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+        env_vars = " ".join(
+            [f"{k}={v}" for (k, v) in self._environment.items()])
+        rpk = RpkRemoteTool(self, node)
+
+        def start_rp():
+            rpk.redpanda_start(additional_args, env_vars,
+                               RedpandaService.STDOUT_STDERR_CAPTURE)
+
+            wait_until(
+                lambda: self.__is_status_ready(node),
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg=
+                f"Redpanda service {node.account.hostname} failed to start within 60 sec using rpk",
+                retry_on_exc=True)
+
+        self.logger.debug(f"Node status prior to redpanda startup:")
+        self.start_service(node, start_rp)
+        self._started.append(node)
 
     def _log_node_process_state(self, node):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1046,8 +1046,8 @@ class RedpandaService(Service):
         rpk = RpkRemoteTool(self, node)
 
         def start_rp():
-            rpk.redpanda_start(additional_args, env_vars,
-                               RedpandaService.STDOUT_STDERR_CAPTURE)
+            rpk.redpanda_start(RedpandaService.STDOUT_STDERR_CAPTURE,
+                               additional_args, env_vars)
 
             wait_until(
                 lambda: self.__is_status_ready(node),

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -1,0 +1,102 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk_remote import RpkRemoteTool
+from rptest.services.redpanda import RedpandaService
+
+import os
+import yaml
+import tempfile
+
+
+class RpkRedpandaStartTest(RedpandaTest):
+    def __init__(self, ctx):
+        super(RpkRedpandaStartTest, self).__init__(test_context=ctx)
+        self._ctx = ctx
+        self.rpk = RpkTool(self.redpanda)
+
+    def setUp(self):
+        # Skip starting redpanda, so that test can explicitly start it
+        pass
+
+    @cluster(num_nodes=1)
+    def test_simple_start(self):
+        """
+        Validate simple start using rpk, no additional flags.
+        """
+        node = self.redpanda.nodes[0]
+        self.redpanda.start_node_with_rpk(node)
+
+        # By default we start with developer_mode: true.
+        assert self.redpanda.search_log(
+            "WARNING: This is a setup for development purposes only")
+
+    @cluster(num_nodes=1)
+    def test_container_mode(self):
+        """
+        Verify that when using flag --mode dev-container we succesfully
+        set some cluster properties. We verify this using rpk instead
+        of using admin endpoint directly.
+        """
+        node = self.redpanda.nodes[0]
+        self.redpanda.start_node_with_rpk(node, "--mode dev-container")
+
+        expected_cluster_properties = {
+            "auto_create_topics_enabled": "true",
+            "group_topic_partitions": "3",
+            # RPK returns scientific notation for large int values.
+            # https://github.com/redpanda-data/redpanda/issues/6070
+            "storage_min_free_bytes": "1.048576e+07",
+            "topic_partitions_per_shard": "1000"
+        }
+
+        for p in expected_cluster_properties:
+            cli_readback = self.rpk.cluster_config_get(p)
+            if cli_readback != expected_cluster_properties[p]:
+                self.logger.error(
+                    f"Unexpected value for {p}, expected {expected_cluster_properties[p]}, got {cli_readback}"
+                )
+            assert cli_readback == expected_cluster_properties[p]
+
+        assert self.redpanda.search_log(
+            "WARNING: This is a setup for development purposes only")
+
+    @cluster(num_nodes=1)
+    def test_production_mode(self):
+        """
+        Test will set production mode, start redpanda, and verify
+        that we are executing the checks.
+        """
+        node = self.redpanda.nodes[0]
+        node.account.mkdirs(os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+        self.redpanda.clean_node(node)
+        rpk = RpkRemoteTool(self.redpanda, node)
+        rpk.mode_set("production")
+
+        self.redpanda.start_node_with_rpk(node)
+
+        # First we check that we don't modify redpanda.developer_mode
+        # on the first start.
+        with tempfile.TemporaryDirectory() as d:
+            node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
+            with open(os.path.join(d, 'redpanda.yaml')) as f:
+                actual_config = yaml.full_load(f.read())
+                assert 'developer_mode' not in actual_config['redpanda']
+
+        # This is production, just checking that we are not setting
+        # anything that makes rpk think that is a dev environment.
+        assert not self.redpanda.search_log(
+            "WARNING: This is a setup for development purposes only")
+
+        # We execute checks when starting redpanda if production mode is enabled
+        assert self.redpanda.search_log("System check - PASSED")

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -100,3 +100,18 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # We execute checks when starting redpanda if production mode is enabled
         assert self.redpanda.search_log("System check - PASSED")
+
+    @cluster(num_nodes=1)
+    def test_seastar_flag(self):
+        """
+        Reproduce: https://github.com/redpanda-data/redpanda/issues/4778
+        Verify that rpk doesn't transforms additional arguments. 
+        """
+        node = self.redpanda.nodes[0]
+        node.account.mkdirs(os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+        self.redpanda.start_node_with_rpk(node, "--abort-on-seastar-bad-alloc")
+
+        # This was the original issue:
+        assert not self.redpanda.search_log(
+            f"\-\-abort-on-seastar-bad-alloc=true")


### PR DESCRIPTION
## Cover letter

This PR introduces 4 small checks for `rpk redpanda start`:

1. Someone installs redpanda and starts it the first time.
2. Someone follows our guide, sets production mode, and starts redpanda.
3. Our new feature: `--mode dev-container`.
4. Passing a seastar flag

Fixes #5519

## Backport Required

- [x] not a bug fix

## UX changes
* none

## Release notes
* none
