### PR TITLE
Added compacted topic to some tests using verifiable consumer/producer pair

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -69,6 +69,9 @@ log_manager::log_manager(
     _config.compaction_interval.watch([this]() {
         _jitter = simple_time_jitter<ss::lowres_clock>{
           _config.compaction_interval()};
+        if (_compaction_timer.cancel()) {
+            _compaction_timer.rearm(_jitter());
+        }
     });
 }
 void log_manager::trigger_housekeeping() {

--- a/tests/rptest/services/verifiable_producer.py
+++ b/tests/rptest/services/verifiable_producer.py
@@ -220,15 +220,17 @@ class VerifiableProducer(BackgroundThreadService):
                 with self.lock:
                     if data["name"] == "producer_send_error":
                         data["node"] = idx
-                        self.not_acked_values.append(
-                            self.message_validator(data["value"]))
+                        value = self.message_validator(data["value"])
+                        key = data["key"]
+                        self.not_acked_values.append((key, value))
                         self.produced_count[idx] += 1
 
                     elif data["name"] == "producer_send_success":
                         partition = TopicPartition(data["topic"],
                                                    data["partition"])
                         value = self.message_validator(data["value"])
-                        self.acked_values.append(value)
+                        key = data["key"]
+                        self.acked_values.append((key, value))
 
                         if partition not in self.acked_values_by_partition:
                             self.acked_values_by_partition[partition] = []

--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -1,0 +1,121 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.services.cluster import cluster
+from rptest.util import segments_count
+
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.utils.mode_checks import cleanup_on_early_exit
+
+
+class CompactionEndToEndTest(EndToEndTest):
+    def setUp(self):
+        super(CompactionEndToEndTest, self).setUp()
+
+        self.throughput = 100000 if not self.debug_mode else 10000
+        self.segment_size = 5 * 1024 * 1024 if not self.debug_mode else 1024 * 1024
+        # we use small partition count to make the segment count grow faster
+        self.partition_count = 2
+
+        # setup redpanda to speed up compaction
+        self.start_redpanda(num_nodes=3)
+
+    def start_workload(self, key_set_cardinality, initial_cleanup_policy):
+        # create topic with deletion policy
+        spec = TopicSpec(partition_count=self.partition_count,
+                         replication_factor=3,
+                         segment_bytes=self.segment_size,
+                         cleanup_policy=initial_cleanup_policy)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(num_nodes=1,
+                            throughput=self.throughput,
+                            repeating_keys=key_set_cardinality)
+
+    def topic_segments(self):
+        storage = self.redpanda.node_storage(self.redpanda.nodes[0])
+        topic_partitions = storage.partitions("kafka", self.topic)
+
+        return [len(p.segments) for p in topic_partitions]
+
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(key_set_cardinality=[10, 1000, 10000],
+            initial_cleanup_policy=[
+                TopicSpec.CLEANUP_COMPACT, TopicSpec.CLEANUP_DELETE
+            ])
+    def test_basic_compaction(self, key_set_cardinality,
+                              initial_cleanup_policy):
+        '''
+        Basic end to end compaction logic test. The test verifies if last value 
+        consumed for each key matches the last produced value for the same key. 
+        The test waits for the compaction to merge some adjacent segments.
+
+        The test is parametrized with initial cleanup policy parameter. 
+        This way the test validates both recovery and inflight generation 
+        of compaction indices.
+        '''
+        # skip debug mode tests for keys with high cardinality
+        if key_set_cardinality > 10 and self.debug_mode:
+            cleanup_on_early_exit(self)
+            return
+
+        self.start_workload(key_set_cardinality, initial_cleanup_policy)
+        rpk = RpkTool(self.redpanda)
+        cfgs = rpk.describe_topic_configs(self.topic)
+        self.logger.debug(f"Initial topic {self.topic} configuration: {cfgs}")
+
+        # make sure that segments will not be compacted when we populate
+        # topic partitions with data
+        rpk.cluster_config_set("log_compaction_interval_ms", str(3600 * 1000))
+
+        def segment_number_matches(predicate):
+            segments_per_partition = self.topic_segments()
+            self.logger.debug(
+                f"Topic {self.topic} segments per partition: {segments_per_partition}"
+            )
+
+            return all([predicate(n) for n in segments_per_partition])
+
+        # wait for multiple segments to appear in topic partitions
+        wait_until(lambda: segment_number_matches(lambda s: s >= 5),
+                   timeout_sec=180,
+                   backoff_sec=2)
+
+        # enable compaction, if topic isn't compacted
+        if initial_cleanup_policy == TopicSpec.CLEANUP_DELETE:
+            rpk.alter_topic_config(self.topic,
+                                   set_key="cleanup.policy",
+                                   set_value=TopicSpec.CLEANUP_COMPACT)
+        # stop producer
+        self.logger.info("Stopping producer after writing up to offsets %s" %\
+                         str(self.producer.last_acked_offsets))
+        self.producer.stop()
+        current_segments_per_partition = self.topic_segments()
+        self.logger.info(
+            f"Stopped producer, segments per partition: {current_segments_per_partition}"
+        )
+        # make compaction frequent
+        rpk.cluster_config_set("log_compaction_interval_ms", str(3000))
+
+        # wait for compaction to merge some adjacent segments
+        wait_until(lambda: segment_number_matches(lambda s: s < 5),
+                   timeout_sec=180,
+                   backoff_sec=2)
+
+        # enable consumer and validate consumed records
+        self.start_consumer(num_nodes=1)
+
+        self.run_validation(enable_compaction=True)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -18,7 +18,7 @@
 # - Replaced dependency on Kafka with Redpanda
 # - Imported annotate_missing_msgs helper from kafka test suite
 
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from typing import Optional
 import os
 from typing import Optional
@@ -145,7 +145,10 @@ class EndToEndTest(Test):
         """
         return os.environ.get('BUILD_TYPE', None) == 'debug'
 
-    def start_consumer(self, num_nodes=1, group_id="test_group"):
+    def start_consumer(self,
+                       num_nodes=1,
+                       group_id="test_group",
+                       verify_offsets=True):
         assert self.redpanda
         assert self.topic
         self.consumer = VerifiableConsumer(
@@ -154,10 +157,15 @@ class EndToEndTest(Test):
             redpanda=self.redpanda,
             topic=self.topic,
             group_id=group_id,
-            on_record_consumed=self.on_record_consumed)
+            on_record_consumed=self.on_record_consumed,
+            verify_offsets=verify_offsets)
         self.consumer.start()
 
-    def start_producer(self, num_nodes=1, throughput=1000):
+    def start_producer(self,
+                       num_nodes=1,
+                       throughput=1000,
+                       repeating_keys=None,
+                       enable_idempotence=False):
         assert self.redpanda
         assert self.topic
         self.producer = VerifiableProducer(
@@ -166,15 +174,18 @@ class EndToEndTest(Test):
             redpanda=self.redpanda,
             topic=self.topic,
             throughput=throughput,
-            message_validator=is_int_with_prefix)
+            message_validator=is_int_with_prefix,
+            repeating_keys=repeating_keys,
+            enable_idempotence=enable_idempotence)
         self.producer.start()
 
     def on_record_consumed(self, record, node):
         partition = TopicPartition(record["topic"], record["partition"])
+        key = record["key"]
         record_id = record["value"]
         offset = record["offset"]
         self.last_consumed_offsets[partition] = offset
-        self.records_consumed.append(record_id)
+        self.records_consumed.append((key, record_id))
 
     def await_consumed_offsets(self, last_acked_offsets, timeout_sec):
         def has_finished_consuming():
@@ -226,7 +237,8 @@ class EndToEndTest(Test):
                        min_records=5000,
                        producer_timeout_sec=30,
                        consumer_timeout_sec=30,
-                       enable_idempotence=False):
+                       enable_idempotence=False,
+                       enable_compaction=False):
         try:
             self.await_num_produced(min_records, producer_timeout_sec)
 
@@ -235,14 +247,16 @@ class EndToEndTest(Test):
             self.producer.stop()
             self.run_consumer_validation(
                 consumer_timeout_sec=consumer_timeout_sec,
-                enable_idempotence=enable_idempotence)
+                enable_idempotence=enable_idempotence,
+                enable_compaction=enable_compaction)
         except BaseException:
             self._collect_all_logs()
             raise
 
     def run_consumer_validation(self,
                                 consumer_timeout_sec=30,
-                                enable_idempotence=False) -> None:
+                                enable_idempotence=False,
+                                enable_compaction=False) -> None:
         try:
             # Take copy of this dict in case a rogue VerifiableProducer
             # thread modifies it.
@@ -257,12 +271,67 @@ class EndToEndTest(Test):
 
             self.consumer.stop()
 
-            self.validate(enable_idempotence)
+            self.validate(enable_idempotence, enable_compaction)
         except BaseException:
             self._collect_all_logs()
             raise
 
-    def validate(self, enable_idempotence):
+    def validate_compacted(self):
+
+        consumer_state = {}
+
+        acked_producer_state = {}
+        not_acked_producer_state = defaultdict(set)
+
+        for k, v in self.producer.acked:
+            acked_producer_state[k] = v
+
+        # some of the not acked records may have been received and persisted,
+        # we need to store all of them and check if consumer result is one of them
+        for k, v in self.producer.not_acked:
+            not_acked_producer_state[k].add(v)
+
+        for k, v in self.records_consumed:
+            consumer_state[k] = v
+
+        msg = ""
+        success = True
+        errors = []
+
+        for consumed_key, consumed_value in consumer_state.items():
+            # invalid key consumed
+            if consumed_key not in acked_producer_state and consumed_key not in not_acked_producer_state:
+                return False, f"key {consumed_key} was consumed but it is missing in produced state"
+
+            # success case, simply continue
+            if acked_producer_state[consumed_key] == consumed_value:
+                continue
+
+            # we must check not acked state as it might have been caused
+            # by request timeout and a message might still have been consumed by consumer
+            self.logger.debug(
+                f"Checking not acked produced messages for key: {k}, previous acked value: {acked_producer_state[consumed_key]}, consumed value: {v}"
+            )
+            # consumed value is one of the not acked produced values
+            if consumed_key in not_acked_producer_state and consumed_value in not_acked_producer_state[
+                    consumed_key]:
+                continue
+
+            # consumed value is not equal to last acked produced value and any of not acked value, error out
+            success = False
+            errors.append((consumed_key, consumed_value,
+                           acked_producer_state.get(consumed_key, None),
+                           not_acked_producer_state.get(consumed_key, None)))
+
+        if not success:
+            msg += "Invalid value detected for consumed compacted topic records. errors: ["
+            for key, consumed_value, produced_acked, producer_not_acked in errors:
+                msg += f"key: {k} consumed value: {consumed_value}, produced values: (acked: {produced_acked}, not_acked: {producer_not_acked}) "
+            msg += "]"
+
+        return success, msg
+
+    def validate(self, enable_idempotence, enable_compaction):
         self.logger.info("Number of acked records: %d" %
                          len(self.producer.acked))
         self.logger.info("Number of consumed records: %d" %
@@ -270,26 +339,29 @@ class EndToEndTest(Test):
 
         success = True
         msg = ""
+        if enable_compaction:
+            success, msg = self.validate_compacted()
+        else:
+            # Correctness of the set difference operation depends on using equivalent
+            # message_validators in producer and consumer
+            missing = set(self.producer.acked) - set(self.records_consumed)
 
-        # Correctness of the set difference operation depends on using equivalent
-        # message_validators in producer and consumer
-        missing = set(self.producer.acked) - set(self.records_consumed)
-
-        if len(missing) > 0:
-            success = False
-            msg = annotate_missing_msgs(missing, self.producer.acked,
-                                        self.records_consumed, msg)
-
-        # Are there duplicates?
-        if len(set(self.records_consumed)) != len(self.records_consumed):
-            num_duplicates = abs(
-                len(set(self.records_consumed)) - len(self.records_consumed))
-
-            if enable_idempotence:
+            if len(missing) > 0:
                 success = False
-                msg += "Detected %d duplicates even though idempotence was enabled.\n" % num_duplicates
-            else:
-                msg += "(There are also %d duplicate messages in the log - but that is an acceptable outcome)\n" % num_duplicates
+                msg = annotate_missing_msgs(missing, self.producer.acked,
+                                            self.records_consumed, msg)
+
+            # Are there duplicates?
+            if len(set(self.records_consumed)) != len(self.records_consumed):
+                num_duplicates = abs(
+                    len(set(self.records_consumed)) -
+                    len(self.records_consumed))
+
+                if enable_idempotence:
+                    success = False
+                    msg += "Detected %d duplicates even though idempotence was enabled.\n" % num_duplicates
+                else:
+                    msg += "(There are also %d duplicate messages in the log - but that is an acceptable outcome)\n" % num_duplicates
 
         # Collect all logs if validation fails
         if not success:


### PR DESCRIPTION
## Cover letter

Added support for compacted topics in `end_to_end_test`. Using compacted topics in partition move interruption test and node operations fuzzy test.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
