### PR TITLE
cloud_storage/tests: filter out segments missing in manifest when accumulating non-data batch sizes

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -1,16 +1,17 @@
 import collections
+import json
+import pprint
+import random
 import struct
 from collections import defaultdict, namedtuple
 from typing import Sequence
 
+import confluent_kafka
 import xxhash
 
-from rptest.archival.s3_client import S3ObjectMetadata
+from rptest.archival.s3_client import S3ObjectMetadata, S3Client
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-
-import confluent_kafka
-import random
 
 EMPTY_SEGMENT_SIZE = 4096
 
@@ -321,3 +322,64 @@ class Producer:
         else:
             self.producer.commit_transaction()
             self.keys.extend(keys)
+
+
+class S3View:
+    def __init__(self, expected_topics: Sequence[TopicSpec], client: S3Client,
+                 bucket: str, logger):
+        self.logger = logger
+        self.bucket = bucket
+        self.client = client
+        self.expected_topics = expected_topics
+        self.path_matcher = PathMatcher(self.expected_topics)
+        self.objects = self.client.list_objects(self.bucket)
+        self.partition_manifests = {}
+        for o in self.objects:
+            if self.path_matcher.is_partition_manifest(o):
+                manifest_path = parse_s3_manifest_path(o.Key)
+                data = self.client.get_object_data(self.bucket, o.Key)
+                self.partition_manifests[manifest_path.ntp] = json.loads(data)
+                self.logger.debug(
+                    f'registered partition manifest for {manifest_path.ntp}: '
+                    f'{pprint.pformat(self.partition_manifests[manifest_path.ntp], indent=2)}'
+                )
+
+    def is_segment_part_of_a_manifest(self, o: S3ObjectMetadata) -> bool:
+        """
+        Queries that given object is a segment, and is a part of one of the test partition manifests
+        with a matching archiver term
+        """
+        try:
+            if not self.path_matcher.is_segment(o):
+                return False
+
+            segment_path = parse_s3_segment_path(o.Key)
+            partition_manifest = self.partition_manifests.get(segment_path.ntp)
+            if not partition_manifest:
+                self.logger.warn(f'no manifest found for {segment_path.ntp}')
+                return False
+            segments_in_manifest = partition_manifest['segments']
+
+            # Filename for segment contains the archiver term, eg:
+            # 4886-1-v1.log.2 -> 4886-1-v1.log and 2
+            base_name, archiver_term = segment_path.name.rsplit('.', 1)
+            segment_entry = segments_in_manifest.get(base_name)
+            if not segment_entry:
+                self.logger.warn(
+                    f'no entry found for segment path {base_name} '
+                    f'in manifest: {pprint.pformat(segments_in_manifest, indent=2)}'
+                )
+                return False
+
+            # Archiver term should match the value in partition manifest
+            manifest_archiver_term = str(segment_entry['archiver_term'])
+            if archiver_term == manifest_archiver_term:
+                return True
+
+            self.logger.warn(
+                f'{segment_path} has archiver term {archiver_term} '
+                f'which does not match manifest term {manifest_archiver_term}')
+            return False
+        except Exception as e:
+            self.logger.info(f'error {e} while checking if {o} is a segment')
+            return False


### PR DESCRIPTION
## Cover letter

When comparing size of restored partition with size on s3, we adjust the original partition size by deducting non data batches, because these are not restored to disk.

When computing the size of non data batches we iterate over all segments and add up all non data batches in them. This sometimes results in adding up batches from segments which were not part of the partition manifest (because of a lower archiver term than the one in manifest) and therefore are not going to be restored.

The end result is that the baseline gets deducted by an inaccurate (too large) amount and the assertion fails indicating that the restored partition is larger than original.

This change introduces an S3 view utility which allows to query if a segment is part of manifest, by matching the path and the archiver term. Only segments which qualify are scanned for non data batches.

The view can be extended to provide more query functions as needed.

fixes #4520 

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

None
