### PR TITLE
[transaction] Fix group_*_tx events compaction

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/record.h"
+#include "model/timestamp.h"
 #include "seastarx.h"
 #include "utils/mutex.h"
 
@@ -746,6 +747,15 @@ private:
 
         return false;
     }
+
+    void update_store_offset_builder(
+      cluster::simple_batch_builder& builder,
+      const model::topic& name,
+      model::partition_id partition,
+      model::offset commited_offset,
+      leader_epoch commited_leader_epoch,
+      const ss::sstring& metadata,
+      model::timestamp commited_timestemp);
 
     kafka::group_id _id;
     group_state _state;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -199,10 +199,7 @@ struct clean_segment_value
 inline bool is_compactible(const model::record_batch& b) {
     return !(
       b.header().type == model::record_batch_type::raft_configuration
-      || b.header().type == model::record_batch_type::archival_metadata
-      || b.header().type == model::record_batch_type::group_abort_tx
-      || b.header().type == model::record_batch_type::group_commit_tx
-      || b.header().type == model::record_batch_type::group_prepare_tx);
+      || b.header().type == model::record_batch_type::archival_metadata);
 }
 
 } // namespace storage::internal


### PR DESCRIPTION
## Cover letter

Problem is group_*_tx contains only producer_id in key, so compaction save only last records for this events.
We need only save in logs consumed offset after commit_txs. For this we can write store_offset event together with group_commit_tx.

New Problem: this 2 events contains different record batch type. So we can not put it in one batch and write on disk atomically. But it is not a problem, because client got ok for commit_request (see tx_gateway_frontend). So redpanda will eventually finish commit and complete write for both this events.

Fixes #5163

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes
### Improvements

* Enable compaction for group_*_tx log records