### PR TITLE
tests: make FeaturesMultiNodeTest more robust

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -385,8 +385,8 @@ class Admin:
     def get_node_config(self):
         return self._request("GET", "node_config").json()
 
-    def get_features(self):
-        return self._request("GET", "features").json()
+    def get_features(self, node=None):
+        return self._request("GET", "features", node=node).json()
 
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)


### PR DESCRIPTION
## Cover letter

This was relying on fast propagation of controller
writes between nodes, relative to the execution of
the test.

Fixes https://github.com/redpanda-data/redpanda/issues/6011

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
