### PR TITLE
[WIP] Rest auth poc

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -428,6 +428,8 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::
                            is_same_v<type, model::cloud_credentials_source>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, config::authentication_method>) {
+        return "authentication_method";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/config/rest_authn_endpoint.h
+++ b/src/v/config/rest_authn_endpoint.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <cctype>
+
+namespace config {
+struct authentication_method {
+    model::broker_endpoint endpoint;
+    ss::sstring authentication_type;
+
+    static bool is_supported_authn_type(ss::sstring authn_type) {
+        ss::sstring type{authn_type};
+        // Standardize the format to lower case
+        std::transform(
+          authn_type.cbegin(), authn_type.cend(), type.begin(), ::tolower);
+        return type == "null" || type == "http_basic" || type == "mtls";
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const authentication_method& cfg) {
+        fmt::print(o, "{{type: {}}}", cfg.authentication_type);
+        return o;
+    }
+
+    bool operator==(authentication_method const& rhs) const = default;
+
+    static std::optional<ss::sstring>
+    validate(const authentication_method& cfg) {
+        if (!is_supported_authn_type(cfg.authentication_type)) {
+            return "Unsupported authentication type";
+        }
+
+        return std::nullopt;
+    }
+};
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::authentication_method> {
+    using rhs_type = config::authentication_method;
+    static Node encode(const rhs_type& rhs) {
+        Node node;
+        node["authentication_type"] = rhs.authentication_type;
+        return node;
+    }
+
+    static bool decode(const Node& node, rhs_type& rhs) {
+        ss::sstring authentication_type;
+        if (node["authentication_type"]) {
+            authentication_type = node["authentication_type"].as<ss::sstring>();
+        } else {
+            return false;
+        }
+
+        rhs = config::authentication_method{
+          .authentication_type = authentication_type};
+
+        return true;
+    }
+};
+} // namespace YAML

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -80,6 +80,16 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::authentication_method& v) {
+    w.StartObject();
+
+    w.Key("authentication_type");
+    w.String(v.authentication_type.c_str());
+
+    w.EndObject();
+}
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const custom_aggregate& v) {
     w.StartObject();
 

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -13,6 +13,7 @@
 
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
+#include "config/rest_authn_endpoint.h"
 #include "config/seed_server.h"
 #include "config/tests/custom_aggregate.h"
 #include "config/tls_config.h"
@@ -40,6 +41,9 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const std::vector<config::seed_server>& v);
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::authentication_method& v);
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const custom_aggregate& v);

--- a/src/v/pandaproxy/fwd.h
+++ b/src/v/pandaproxy/fwd.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace pandaproxy {
+
+class kafka_client_cache;
+class sharded_client_cache;
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -74,7 +74,10 @@ public:
       model::timestamp::type keep_alive = 30)
       : _config{cfg}
       , _cache_size{size}
-      , _keep_alive{keep_alive} {}
+      , _keep_alive{keep_alive} {
+        // Need to specify type or else bad any_cast runtime error
+        _config.sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
+    }
 
     ~kafka_client_cache() = default;
 
@@ -97,9 +100,10 @@ public:
         return it->second->second;
     }
 
-    client_ptr make_client() {
-        // TODO(@NyaliaLui): Add SASL/SCRAM creds by incorporating
-        // the user credentials
+    client_ptr make_client(credential_t user) {
+        _config.scram_username.set_value(user.first);
+        _config.scram_password.set_value(user.second);
+
         return ss::make_lw_shared<timestamped_client>(
           to_yaml(_config, config::redact_secrets::no), model::new_timestamp());
     }

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -14,16 +14,21 @@
 #include "hashing/xx.h"
 #include "kafka/client/client.h"
 #include "kafka/protocol/errors.h"
+#include "model/timestamp.h"
 #include "pandaproxy/logger.h"
 #include "security/credential_store.h"
-#include "utils/mutex.h"
+#include "ssx/future-util.h"
 
+#include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <fmt/format.h>
 
 #include <chrono>
+#include <list>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
@@ -31,6 +36,16 @@
 namespace pandaproxy {
 
 namespace {
+struct timestamped_client {
+    kafka::client::client real;
+    model::timestamp creation_time;
+
+    timestamped_client(YAML::Node const& cfg, model::timestamp t)
+      : real{cfg}
+      , creation_time{t} {}
+};
+using client_ptr = ss::lw_shared_ptr<timestamped_client>;
+
 // First is username, Second is password
 using credential_t = std::pair<ss::sstring, ss::sstring>;
 
@@ -41,70 +56,127 @@ ss::shard_id user_shard(const ss::sstring& name) {
 
 } // namespace
 
+// A LRU cache implemented with a doubly-linked list and an
+// unordered map. The list tracks frequency where the most
+// recently used client is at the front. When the cache is full
+// remove the client from the end of the list. The map is for
+// constant time look-ups of the kafka clients.
 class kafka_client_cache {
 public:
-    using client_ptr = ss::lw_shared_ptr<kafka::client::client>;
-    using client_map = absl::flat_hash_map<ss::sstring, client_ptr>;
+    using user_client_pair = std::pair<ss::sstring, client_ptr>;
+    using user_client_list_it = std::list<user_client_pair>::iterator;
+    using user_client_map
+      = absl::flat_hash_map<ss::sstring, user_client_list_it>;
 
-    kafka_client_cache(YAML::Node const& cfg, int32_t size)
+    kafka_client_cache(
+      YAML::Node const& cfg,
+      size_t size,
+      model::timestamp::type keep_alive = 30)
       : _config{cfg}
-      , _cache_size{size} {}
+      , _cache_size{size}
+      , _keep_alive{keep_alive} {}
 
     ~kafka_client_cache() = default;
 
-    client_map::iterator find(credential_t user) {
-        return _client_map.find(user.first);
+    client_ptr fetch(credential_t user) {
+        auto it = _user_client_map.find(user.first);
+
+        // User not found
+        if (it == _user_client_map.end()) {
+            throw std::out_of_range(
+              fmt::format("User {} not found", user.first));
+        }
+
+        // Otherwise user found. Move it to the begginng
+        // of the frequency list. Splice will shift the items
+        // over.
+        _user_client_list.splice(
+          _user_client_list.begin(), _user_client_list, it->second);
+
+        // The client is at the second of the iterator.
+        return it->second->second;
     }
 
-    ss::future<client_ptr> make_client(credential_t user) {
-        client_ptr client = ss::make_lw_shared<kafka::client::client>(
-          to_yaml(_config, config::redact_secrets::no));
-        _client_map[user.first] = client;
-        return ss::make_ready_future<client_ptr>(client);
+    client_ptr make_client() {
+        // TODO(@NyaliaLui): Add SASL/SCRAM creds by incorporating
+        // the user credentials
+        return ss::make_lw_shared<timestamped_client>(
+          to_yaml(_config, config::redact_secrets::no), model::new_timestamp());
     }
 
-    client_map::iterator end() { return _client_map.end(); }
+    void insert(credential_t user, client_ptr client) {
+        // First remove the last used client if the
+        // cache is full.
+        if (_user_client_map.size() > _cache_size) {
+            auto lru = _user_client_list.end();
+            --lru; // Last item is back one step
+            _user_client_map.erase(lru->first);
+            _user_client_list.pop_back();
+        }
 
-    int32_t cache_size() const { return _cache_size; }
+        // See if the user already has a client.
+        // If yes, remove that client from our containers
+        // because we're about to insert a new one.
+        auto it = _user_client_map.find(user.first);
+        if (it != _user_client_map.end()) {
+            _user_client_list.erase(it->second);
+            _user_client_map.erase(it);
+        }
+
+        // Now we can insert the client
+        // Add the user-client pair to front of frequency
+        // list since it will become recently "used"
+        _user_client_list.push_front(user_client_pair{user.first, client});
+
+        // Add the user-client iterator to the map so we
+        // can do a constant time lookup later. The iterator
+        // is already at the front of the list.
+        _user_client_map[user.first] = _user_client_list.begin();
+    }
+
+    size_t cache_size() const { return _cache_size; }
+    model::timestamp::type keep_alive_time() const { return _keep_alive; }
+    std::list<user_client_pair>& get_list() { return _user_client_list; }
+    user_client_map& get_map() { return _user_client_map; }
 
 private:
     kafka::client::configuration _config;
-    int32_t _cache_size;
-    client_map _client_map;
+    size_t _cache_size;
+    model::timestamp::type _keep_alive;
+    std::list<user_client_pair> _user_client_list;
+    user_client_map _user_client_map;
 };
 
 class sharded_client_cache {
 public:
-    using client_ptr = kafka_client_cache::client_ptr;
-    using client_map = kafka_client_cache::client_map;
-
     ss::future<>
-    start(ss::smp_service_group sg, YAML::Node const& cfg, int32_t size) {
+    start(ss::smp_service_group sg, YAML::Node const& cfg, size_t size) {
         _smp_opts = ss::smp_submit_to_options{sg};
         return _cache.start(cfg, size);
     }
 
     ss::future<> stop() { return _cache.stop(); }
 
-    ss::future<client_ptr> find_or_create(credential_t user) {
+    ss::future<client_ptr> fetch_client(credential_t user) {
         // Access the cache on the appropriate
         // shard please.
         auto u_shard{user_shard(user.first)};
         return _cache.invoke_on(
           u_shard, _smp_opts, [&user](kafka_client_cache& cache) {
-              auto search = cache.find(user);
-
-              // Return the client if the user already
-              // has one
-              if (search != cache.end()) {
+              client_ptr client{nullptr};
+              try {
+                  // Return the client if the user already
+                  // has one
+                  client = cache.fetch(user);
                   vlog(plog.debug, "Reuse client for user {}", user.first);
-                  return ss::make_ready_future<client_ptr>(search->second);
-              } else {
-                  // Otherwise create a client for the user.
-                  // The client is automatically stored in
-                  // the cache.
+                  return ss::make_ready_future<client_ptr>(client);
+              } catch (std::out_of_range& ex) {
+                  // Otherwise create a client for the user,
+                  // insert it to the cache, then return.
                   vlog(plog.debug, "Make client for user {}", user.first);
-                  return cache.make_client(user);
+                  client = cache.make_client(user);
+                  cache.insert(user, client);
+                  return ss::make_ready_future<client_ptr>(client);
               }
           });
     }
@@ -112,5 +184,6 @@ public:
 private:
     ss::smp_submit_to_options _smp_opts;
     ss::sharded<kafka_client_cache> _cache;
+    ss::gate _gate;
 };
 } // namespace pandaproxy

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "hashing/jump_consistent_hash.h"
+#include "hashing/xx.h"
+#include "kafka/client/client.h"
+#include "kafka/protocol/errors.h"
+#include "pandaproxy/logger.h"
+#include "security/credential_store.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace pandaproxy {
+
+namespace {
+// First is username, Second is password
+using credential_t = std::pair<ss::sstring, ss::sstring>;
+
+ss::shard_id user_shard(const ss::sstring& name) {
+    auto hash = xxhash_64(name.data(), name.length());
+    return jump_consistent_hash(hash, ss::smp::count);
+}
+
+} // namespace
+
+class kafka_client_cache {
+public:
+    using client_ptr = ss::lw_shared_ptr<kafka::client::client>;
+    using client_map = absl::flat_hash_map<ss::sstring, client_ptr>;
+
+    kafka_client_cache(YAML::Node const& cfg, int32_t size)
+      : _config{cfg}
+      , _cache_size{size} {}
+
+    ~kafka_client_cache() = default;
+
+    client_map::iterator find(credential_t user) {
+        return _client_map.find(user.first);
+    }
+
+    ss::future<client_ptr> make_client(credential_t user) {
+        client_ptr client = ss::make_lw_shared<kafka::client::client>(
+          to_yaml(_config, config::redact_secrets::no));
+        _client_map[user.first] = client;
+        return ss::make_ready_future<client_ptr>(client);
+    }
+
+    client_map::iterator end() { return _client_map.end(); }
+
+    int32_t cache_size() const { return _cache_size; }
+
+private:
+    kafka::client::configuration _config;
+    int32_t _cache_size;
+    client_map _client_map;
+};
+
+class sharded_client_cache {
+public:
+    using client_ptr = kafka_client_cache::client_ptr;
+    using client_map = kafka_client_cache::client_map;
+
+    ss::future<>
+    start(ss::smp_service_group sg, YAML::Node const& cfg, int32_t size) {
+        _smp_opts = ss::smp_submit_to_options{sg};
+        return _cache.start(cfg, size);
+    }
+
+    ss::future<> stop() { return _cache.stop(); }
+
+    ss::future<client_ptr> find_or_create(credential_t user) {
+        // Access the cache on the appropriate
+        // shard please.
+        auto u_shard{user_shard(user.first)};
+        return _cache.invoke_on(
+          u_shard, _smp_opts, [&user](kafka_client_cache& cache) {
+              auto search = cache.find(user);
+
+              // Return the client if the user already
+              // has one
+              if (search != cache.end()) {
+                  vlog(plog.debug, "Reuse client for user {}", user.first);
+                  return ss::make_ready_future<client_ptr>(search->second);
+              } else {
+                  // Otherwise create a client for the user.
+                  // The client is automatically stored in
+                  // the cache.
+                  vlog(plog.debug, "Make client for user {}", user.first);
+                  return cache.make_client(user);
+              }
+          });
+    }
+
+private:
+    ss::smp_submit_to_options _smp_opts;
+    ss::sharded<kafka_client_cache> _cache;
+};
+} // namespace pandaproxy

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -54,6 +54,12 @@ configuration::configuration()
       "consumer_instance_timeout_ms",
       "How long to wait for an idle consumer before removing it",
       {},
-      std::chrono::minutes{5}) {}
+      std::chrono::minutes{5})
+  , client_cache_size(
+      *this,
+      "client_cache_size",
+      "Size of the internal kafka client cache. Default 10.",
+      {},
+      10) {}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -60,6 +60,12 @@ configuration::configuration()
       "client_cache_size",
       "Size of the internal kafka client cache. Default 10.",
       {},
-      10) {}
+      10)
+  , authentication_method(
+      *this,
+      "authentication_method",
+      "Authentication method for REST requests. Default null.",
+      {},
+      config::authentication_method{.authentication_type{"null"}}) {}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/config_store.h"
 #include "config/property.h"
+#include "config/rest_authn_endpoint.h"
 #include "config/tls_config.h"
 #include "model/metadata.h"
 
@@ -34,6 +35,7 @@ struct configuration final : public config::config_store {
     config::property<ss::sstring> api_doc_dir;
     config::property<std::chrono::milliseconds> consumer_instance_timeout;
     config::property<int32_t> client_cache_size;
+    config::property<config::authentication_method> authentication_method;
 
     configuration();
     explicit configuration(const YAML::Node& cfg);

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -34,7 +34,7 @@ struct configuration final : public config::config_store {
       advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
     config::property<std::chrono::milliseconds> consumer_instance_timeout;
-    config::property<int32_t> client_cache_size;
+    config::property<size_t> client_cache_size;
     config::property<config::authentication_method> authentication_method;
 
     configuration();

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -33,6 +33,7 @@ struct configuration final : public config::config_store {
       advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
     config::property<std::chrono::milliseconds> consumer_instance_timeout;
+    config::property<int32_t> client_cache_size;
 
     configuration();
     explicit configuration(const YAML::Node& cfg);

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -125,7 +125,6 @@ credential_t do_authenticate(
         throw ss::httpd::bad_request_exception(
           "Unsupported Authorization method");
     } else {
-        // No Authorization header: user is anonymous
         throw ss::httpd::bad_request_exception("Missing Authorization header");
     }
 }
@@ -145,7 +144,12 @@ credential_t authenticate(server::request_t& rq) {
 
 ss::future<server::reply_t>
 get_brokers(server::request_t rq, server::reply_t rp) {
-    credential_t user = authenticate(rq);
+    credential_t user{"ANON", "ANON"};
+    if (
+      rq.service().config().authentication_method().authentication_type
+      == "http_basic") {
+        user = authenticate(rq);
+    }
 
     auto res_fmt = parse::accept_header(
       *rq.req,

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -161,10 +161,10 @@ get_brokers(server::request_t rq, server::reply_t rp) {
         return kafka::metadata_request{.list_all_topics = false};
     };
 
-    return rq.service().client_cache().find_or_create(user).then(
+    return rq.service().client_cache().fetch_client(user).then(
       [res_fmt, &make_metadata_req, rp = std::move(rp)](
-        kafka_client_cache::client_ptr client) mutable {
-          return client->dispatch(make_metadata_req)
+        client_ptr client) mutable {
+          return client->real.dispatch(make_metadata_req)
             .then(
               [res_fmt, rp = std::move(rp)](
                 kafka::metadata_request::api_type::response_type res) mutable {

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -63,10 +63,14 @@ proxy::proxy(
   const YAML::Node& config,
   ss::smp_service_group smp_sg,
   size_t max_memory,
-  ss::sharded<kafka::client::client>& client)
+  ss::sharded<kafka::client::client>& client,
+  sharded_client_cache& client_cache,
+  cluster::controller* controller)
   : _config(config)
   , _mem_sem(max_memory, "pproxy/mem")
   , _client(client)
+  , _client_cache(client_cache)
+  , _controller(controller)
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(
       "pandaproxy",

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -11,7 +11,8 @@
 
 #pragma once
 
-#include "kafka/client/client.h"
+#include "cluster/controller.h"
+#include "pandaproxy/kafka_client_cache.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/server.h"
 #include "seastarx.h"
@@ -31,7 +32,9 @@ public:
       const YAML::Node& config,
       ss::smp_service_group smp_sg,
       size_t max_memory,
-      ss::sharded<kafka::client::client>& client);
+      ss::sharded<kafka::client::client>& client,
+      sharded_client_cache& client_cache,
+      cluster::controller* controller);
 
     ss::future<> start();
     ss::future<> stop();
@@ -39,11 +42,15 @@ public:
     configuration& config();
     kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
+    sharded_client_cache& client_cache() { return _client_cache; }
+    cluster::controller* controller() { return _controller; }
 
 private:
     configuration _config;
     ssx::semaphore _mem_sem;
     ss::sharded<kafka::client::client>& _client;
+    sharded_client_cache& _client_cache;
+    cluster::controller* _controller;
     ctx_server<proxy>::context_t _ctx;
     ctx_server<proxy> _server;
 };

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -12,8 +12,8 @@
 #pragma once
 
 #include "config/config_store.h"
-#include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/kafka_client_cache.h"
 #include "seastarx.h"
 
 #include <seastar/core/abort_source.hh>

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -22,6 +22,7 @@
 #include "kafka/server/fwd.h"
 #include "net/conn_quota.h"
 #include "net/fwd.h"
+#include "pandaproxy/fwd.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/configuration.h"
@@ -172,6 +173,7 @@ private:
     ss::sharded<net::conn_quota> _kafka_conn_quotas;
     ss::sharded<net::server> _kafka_server;
     ss::sharded<kafka::client::client> _proxy_client;
+    std::unique_ptr<pandaproxy::sharded_client_cache> _proxy_client_cache;
     ss::sharded<pandaproxy::rest::proxy> _proxy;
     std::unique_ptr<pandaproxy::schema_registry::api> _schema_registry;
     ss::sharded<storage::compaction_controller> _compaction_controller;


### PR DESCRIPTION
## Cover letter

A WIP for adding HTTP Basic Auth header to PP and SR.

Must do goals:
- [x] Create a cache that holds kafka clients and a cache size config (**Completed Aug 29**)
- [x] Add methods for client creation and lookup (**Completed Aug 29**)
- [x] Add procedures for shard lookup (**Completed Aug 30**)
- [ ] Add config for enable basic authentication
- [x] Add basic authentication which will remove standalone mode. Base64 encoding not supported in this PoC (**Completed Aug 30**) 
- [x] Pass appropriate user creds to the kafka client so ACLs are enforced via the client
- [x] Incorporate LRU replacement policy for client cleanup (**Completed Sept 1**)
- [ ] Incorporate timestamps to clients so stale clients may be removed as well

Nice-to-haves:
- [ ] Unit tests
- [ ] Integration tests (ducktape)