### PR TITLE
tests: back-to-back upgrades test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1602,13 +1602,15 @@ class RedpandaService(Service):
                               nodes,
                               override_cfg_params=None,
                               start_timeout=None,
-                              stop_timeout=None):
+                              stop_timeout=None,
+                              use_maintenance_mode=True):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         restarter = RollingRestarter(self)
         restarter.restart_nodes(nodes,
                                 override_cfg_params=override_cfg_params,
                                 start_timeout=start_timeout,
-                                stop_timeout=stop_timeout)
+                                stop_timeout=stop_timeout,
+                                use_maintenance_mode=use_maintenance_mode)
 
     def registered(self, node):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1911,7 +1911,10 @@ class RedpandaService(Service):
         """
         counts = {self.idx(node): None for node in self.nodes}
         for node in self.nodes:
-            metrics = self.metrics(node)
+            try:
+                metrics = self.metrics(node)
+            except:
+                return False
             idx = self.idx(node)
             for family in metrics:
                 for sample in family.samples:


### PR DESCRIPTION
## Cover letter

This commit adds a test that performs two upgrades while running some
workloads concurrently.

It's worth noting that, as of writing, two versions ago (v21.11) we
didn't support maintenance mode (or more broadly, rolling restarts), so
if the initial version is on this version, the test will stop the
produce workload before performing upgrades.

I've also parameterized the test to also exercise a single version
upgrade, optionally replacing the first upgrade with a simple rolling
restart.

Fixes #5920

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes

* none
