### PR TITLE
chore: fix unused capture warnings in clang-tidy

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -115,7 +115,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
 
     wait_for_partition_leadership(manifest_ntp);
     auto part = app.partition_manager.local().get(manifest_ntp);
-    tests::cooperative_spin_wait_with_timeout(10s, [this, part]() mutable {
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
         return part->high_watermark() >= model::offset(1);
     }).get();
 
@@ -323,7 +323,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     init_storage_api_local(segments);
     wait_for_partition_leadership(manifest_ntp);
     auto part = app.partition_manager.local().get(manifest_ntp);
-    tests::cooperative_spin_wait_with_timeout(10s, [this, part]() mutable {
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
         return part->high_watermark() >= model::offset(1);
     }).get();
 

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -251,8 +251,7 @@ FIXTURE_TEST(test_download_segment_timeout, s3_imposter_fixture) { // NOLINT
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
 
-    iobuf downloaded;
-    auto try_consume = [&downloaded](uint64_t, ss::input_stream<char>) {
+    auto try_consume = [](uint64_t, ss::input_stream<char>) {
         return ss::make_ready_future<uint64_t>(0);
     };
 

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -57,7 +57,7 @@ FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
       .get();
 
     // wait for reconciliation to be finished
-    tests::cooperative_spin_wait_with_timeout(2s, [this, &n2, &test_ntp] {
+    tests::cooperative_spin_wait_with_timeout(2s, [&n2, &test_ntp] {
         return n2->controller->get_api()
           .local()
           .get_reconciliation_state(test_ntp)

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -33,7 +33,7 @@ wait_for_leaders_updates(int id, cluster::metadata_cache& cache) {
     std::vector<model::node_id> leaders;
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
-      [&cache, &leaders, id] {
+      [&cache, &leaders] {
           leaders.clear();
           const model::topic_namespace tn(
             model::ns("default"), model::topic("test_1"));

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -373,7 +373,7 @@ public:
           replicas,
           [this, ntp, &reference_batches, max_offset](model::broker_shard bs) {
               return read_replica_batches(bs, ntp, max_offset)
-                .then([this, ntp, &reference_batches, bs](
+                .then([ntp, &reference_batches, bs](
                         foreign_batches_t batches) {
                     vlog(
                       logger.info,

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -373,8 +373,7 @@ public:
           replicas,
           [this, ntp, &reference_batches, max_offset](model::broker_shard bs) {
               return read_replica_batches(bs, ntp, max_offset)
-                .then([ntp, &reference_batches, bs](
-                        foreign_batches_t batches) {
+                .then([ntp, &reference_batches, bs](foreign_batches_t batches) {
                     vlog(
                       logger.info,
                       "Comparing {} {} batches {} {}",

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -49,7 +49,7 @@ public:
         // wait for cluster to be stable
         tests::cooperative_spin_wait_with_timeout(60s, [this, node_count] {
             return std::all_of(
-              apps.cbegin(), apps.cend(), [this, node_count](auto c) {
+              apps.cbegin(), apps.cend(), [node_count](auto c) {
                   return c.second->controller->get_members_table()
                            .local()
                            .all_broker_ids()

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
@@ -33,7 +33,7 @@ coproc_cluster_fixture::enable_coprocessors(std::vector<deploy> copros) {
     co_await ss::parallel_for_each(
       node_ids, [this, ids](const model::node_id& node_id) {
           application* app = get_node_application(node_id);
-          return ss::parallel_for_each(ids, [this, app](coproc::script_id id) {
+          return ss::parallel_for_each(ids, [app](coproc::script_id id) {
               return coproc::wasm::wait_for_copro(
                 app->coprocessing->get_pacemaker(), id);
           });

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -59,15 +59,14 @@ do_verify_partition(storage::log log, model::ntp ntp, std::size_t n) {
 
 ss::future<> fiber_mock_fixture::verify_results(expected_t expected) {
     return _state.invoke_on_all([this, expected](state&) mutable {
-        return ss::do_with(
-          std::move(expected), [this](expected_t& expected) {
-              return ss::parallel_for_each(
-                expected, [this](expected_t::value_type& p) {
-                    auto log = app.storage.local().log_mgr().get(p.first);
-                    return log ? do_verify_partition(*log, p.first, p.second)
-                               : ss::now();
-                });
-          });
+        return ss::do_with(std::move(expected), [this](expected_t& expected) {
+            return ss::parallel_for_each(
+              expected, [this](expected_t::value_type& p) {
+                  auto log = app.storage.local().log_mgr().get(p.first);
+                  return log ? do_verify_partition(*log, p.first, p.second)
+                             : ss::now();
+              });
+        });
     });
 }
 

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -58,9 +58,9 @@ do_verify_partition(storage::log log, model::ntp ntp, std::size_t n) {
 }
 
 ss::future<> fiber_mock_fixture::verify_results(expected_t expected) {
-    return _state.invoke_on_all([this, expected](state& s) mutable {
+    return _state.invoke_on_all([this, expected](state&) mutable {
         return ss::do_with(
-          std::move(expected), [this, &s](expected_t& expected) {
+          std::move(expected), [this](expected_t& expected) {
               return ss::parallel_for_each(
                 expected, [this](expected_t::value_type& p) {
                     auto log = app.storage.local().log_mgr().get(p.first);

--- a/src/v/coproc/tests/offset_storage_utils_tests.cc
+++ b/src/v/coproc/tests/offset_storage_utils_tests.cc
@@ -112,7 +112,7 @@ FIXTURE_TEST(offset_keeper_saved_offsets, offset_keeper_fixture) {
       .get();
 
     /// Wait until at-least one attempt to write offsets to disk was made
-    tests::cooperative_spin_wait_with_timeout(5s, [this]() {
+    tests::cooperative_spin_wait_with_timeout(5s, []() {
         return ss::file_exists(coproc::offsets_snapshot_path().string());
     }).get();
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -259,7 +259,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_GET_streaming_roundtrip) {
       std::move(header),
       std::nullopt,
       skip_bytes,
-      [skip_bytes](http::client::response_header const& header, iobuf&& body) {
+      [](http::client::response_header const& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
           iobuf_parser parser(std::move(body));

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -149,19 +149,16 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
 
     info("Waiting for group coordinator");
     kafka::describe_groups_response desc_res{};
-    tests::cooperative_spin_wait_with_timeout(
-      10s,
-      [&client, &desc_res] {
-          return client.dispatch(describe_group_request_builder())
-            .then([&desc_res](kafka::describe_groups_response res) {
-                desc_res = std::move(res);
-                info("Describe group res: {}", desc_res);
-                return desc_res.data.groups.size() == 1
-                       && desc_res.data.groups[0].error_code
-                            != kafka::error_code::not_coordinator;
-            });
-      })
-      .get();
+    tests::cooperative_spin_wait_with_timeout(10s, [&client, &desc_res] {
+        return client.dispatch(describe_group_request_builder())
+          .then([&desc_res](kafka::describe_groups_response res) {
+              desc_res = std::move(res);
+              info("Describe group res: {}", desc_res);
+              return desc_res.data.groups.size() == 1
+                     && desc_res.data.groups[0].error_code
+                          != kafka::error_code::not_coordinator;
+          });
+    }).get();
 
     auto check_group_response = [](
                                   const kafka::describe_groups_response& res,

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -151,7 +151,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
     kafka::describe_groups_response desc_res{};
     tests::cooperative_spin_wait_with_timeout(
       10s,
-      [this, &group_id, &client, &desc_res] {
+      [&client, &desc_res] {
           return client.dispatch(describe_group_request_builder())
             .then([&desc_res](kafka::describe_groups_response res) {
                 desc_res = std::move(res);

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -22,7 +22,7 @@ public:
     void restart() {
         shutdown();
         app_signal = std::make_unique<::stop_signal>();
-        ss::smp::invoke_on_all([this] {
+        ss::smp::invoke_on_all([] {
             auto& config = config::shard_local_cfg();
             config.get("disable_metrics").set_value(false);
         }).get0();

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1040,8 +1040,8 @@ if ({{ cond }}) {
 {%- else %}
 {{ writer }}.write_array({{ fname }}, [version]({{ field.value_type }}& v, response_writer& writer) {
 {%- endif %}
-    (void)version;
 {%- endif %}
+    (void)version;
 {%- if field.type().value_type().is_struct %}
 {{- struct_serde(field.type().value_type(), methods, "v") | indent }}
 {%- else %}
@@ -1075,8 +1075,8 @@ if ({{ cond }}) {
 {%- else %}
 {{ fname }} = reader.read_array([version](request_reader& reader) {
 {%- endif %}
-    (void)version;
 {%- endif %}
+    (void)version;
 {%- if field.type().value_type().is_struct %}
     {{ field.type().value_type().name }} v;
 {{- struct_serde(field.type().value_type(), methods, "v") | indent }}

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -41,7 +41,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
     app.partition_manager
       .invoke_on(
         *shard,
-        [ntp, this](cluster::partition_manager& mgr) {
+        [ntp](cluster::partition_manager& mgr) {
             info("Manager:{} - log:{}", mgr, *mgr.get(ntp));
         })
       .get();

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -124,7 +124,7 @@ public:
     void restart() {
         shutdown();
         app_signal = std::make_unique<::stop_signal>();
-        ss::smp::invoke_on_all([this] {
+        ss::smp::invoke_on_all([] {
             auto& config = config::shard_local_cfg();
             config.get("disable_metrics").set_value(false);
         }).get0();

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -104,13 +104,13 @@ struct conn_quota_fixture {
     }
 
     void drop_on_shard(
-      ss::shard_id shard, ss::net::inet_address addr, uint32_t take_units) {
+      ss::shard_id shard, uint32_t take_units) {
         assert(shard_units[shard].size() >= take_units);
 
         scq
           .invoke_on(
             shard,
-            [shard, this, take_units, addr](conn_quota& cq) {
+            [shard, this, take_units](conn_quota& cq) {
                 for (size_t i = 0; i < take_units; ++i) {
                     shard_units[shard].pop_back();
                 }
@@ -574,7 +574,7 @@ FIXTURE_TEST(test_overlaps, conn_quota_fixture) {
     // First take all the tokens on shard 1 and drop them
     // again, this puts all the borrowed tokens here
     take_on_shard(1, addr1, 10);
-    drop_on_shard(1, addr1, 10);
+    drop_on_shard(1, 10);
 
     // Now take tokens from each shard
     for (int i = 0; i < 5; ++i) {

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -103,8 +103,7 @@ struct conn_quota_fixture {
           .get();
     }
 
-    void drop_on_shard(
-      ss::shard_id shard, uint32_t take_units) {
+    void drop_on_shard(ss::shard_id shard, uint32_t take_units) {
         assert(shard_units[shard].size() >= take_units);
 
         scq

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -177,7 +177,7 @@ private:
             seastar::default_priority_class()),
           std::chrono::seconds(1),
           _consensus_client_protocol,
-          [this](raft::leadership_status st) {
+          [](raft::leadership_status st) {
               if (!st.current_leader) {
                   vlog(kvelldblog.info, "No leader in group {}", st.group);
                   return;
@@ -222,7 +222,7 @@ static void initialize_connection_cache_in_thread(
         auto [node, cfg] = extract_peer(i);
         for (ss::shard_id i = 0; i < ss::smp::count; ++i) {
             auto shard = rpc::connection_cache::shard_for(self, i, node);
-            ss::smp::submit_to(shard, [&cache, shard, n = node, config = cfg] {
+            ss::smp::submit_to(shard, [&cache, n = node, config = cfg] {
                 return cache.local().emplace(
                   n,
                   config,

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -50,7 +50,7 @@ FIXTURE_TEST(test_replicate_multiple_entries_single_node, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "State is consistent after replication");
 };
 
@@ -70,7 +70,7 @@ FIXTURE_TEST(
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "State is consistent after replication");
     auto& n = gr.get_member(model::node_id(0));
     auto last_visible = n.consensus->last_visible_index();
@@ -91,7 +91,7 @@ FIXTURE_TEST(test_replicate_multiple_entries, raft_test_fixture) {
     validate_logs_replication(gr);
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "State is consistent");
     validate_offset_translation(gr);
 };
@@ -189,7 +189,7 @@ FIXTURE_TEST(test_single_node_recovery, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
 
     validate_logs_replication(gr);
@@ -223,7 +223,7 @@ FIXTURE_TEST(test_empty_node_recovery, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
     validate_offset_translation(gr);
 };
@@ -256,7 +256,7 @@ FIXTURE_TEST(test_empty_node_recovery_relaxed_consistency, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "After recovery state is consistent");
     validate_offset_translation(gr);
 };
@@ -296,7 +296,7 @@ FIXTURE_TEST(test_single_node_recovery_multi_terms, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "State is conistent after recovery");
     validate_offset_translation(gr);
 };
@@ -355,7 +355,7 @@ FIXTURE_TEST(test_recovery_of_crashed_leader_truncation, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state should be consistent");
     validate_offset_translation(gr);
 };
@@ -373,7 +373,7 @@ FIXTURE_TEST(test_append_entries_with_relaxed_consistency, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "After recovery state is consistent");
 
     validate_offset_translation(gr);
@@ -391,12 +391,12 @@ FIXTURE_TEST(
 
     wait_for(
       1s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "After recovery state is consistent");
 
     wait_for(
       1s,
-      [this, &gr] {
+      [&gr] {
           auto& node = gr.get_members().begin()->second;
           auto lstats = node.log->offsets();
           return node.consensus->last_visible_index() == lstats.dirty_offset;
@@ -484,7 +484,7 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
 
     wait_for(
       3s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
 
     validate_logs_replication(gr);
@@ -560,7 +560,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
 
     validate_logs_replication(gr);
@@ -607,7 +607,7 @@ FIXTURE_TEST(test_snapshot_recovery, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
 
     validate_logs_replication(gr);
@@ -658,7 +658,7 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_commit_indexes_the_same(gr); },
+      [&gr] { return are_all_commit_indexes_the_same(gr); },
       "After recovery state is consistent");
 
     validate_logs_replication(gr);
@@ -702,7 +702,7 @@ FIXTURE_TEST(test_last_visible_offset_relaxed_consistency, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "After recovery state is consistent");
     auto updated_last_visible = leader_raft->last_visible_index();
     BOOST_REQUIRE_GT(updated_last_visible, last_visible);
@@ -724,7 +724,7 @@ FIXTURE_TEST(test_mixed_consisteny_levels, raft_test_fixture) {
 
     wait_for(
       10s,
-      [this, &gr] { return are_all_consumable_offsets_are_the_same(gr); },
+      [&gr] { return are_all_consumable_offsets_are_the_same(gr); },
       "After recovery state is consistent");
     validate_offset_translation(gr);
 };

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -86,8 +86,7 @@ struct mux_state_machine_fixture {
                       auto group = raft::group_id(0);
                       return _group_mgr.local()
                         .create_group(group, {self_broker()}, log)
-                        .then([log](
-                                ss::lw_shared_ptr<raft::consensus> c) {
+                        .then([log](ss::lw_shared_ptr<raft::consensus> c) {
                             return c->start().then([c] { return c; });
                         });
                   })

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -86,7 +86,7 @@ struct mux_state_machine_fixture {
                       auto group = raft::group_id(0);
                       return _group_mgr.local()
                         .create_group(group, {self_broker()}, log)
-                        .then([this, log, group](
+                        .then([log](
                                 ss::lw_shared_ptr<raft::consensus> c) {
                             return c->start().then([c] { return c; });
                         });

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -321,7 +321,7 @@ struct raft_node {
             cache
               .invoke_on(
                 sh,
-                [&broker, this](rpc::connection_cache& c) {
+                [&broker](rpc::connection_cache& c) {
                     if (c.contains(broker.id())) {
                         return seastar::make_ready_future<>();
                     }

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -664,7 +664,7 @@ public:
     ss::future<> apply(net::server::resources rs) final {
         return ss::do_until(
           [rs] { return rs.conn->input().eof() || rs.abort_requested(); },
-          [this, rs]() mutable {
+          [rs]() mutable {
               return ss::make_exception_future<>(
                 erroneous_protocol_exception());
           });

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -126,7 +126,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
 
     std::vector<size_t> random_ntp_removal_sequence;
     std::generate_n(
-      std::back_inserter(random_ntp_removal_sequence), ntp_count, [ntp_count] {
+      std::back_inserter(random_ntp_removal_sequence), ntp_count, [] {
           // generate *inclusive* indices
           return random_generators::get_int<size_t>(0, ntp_count - 1);
       });

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -691,7 +691,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     };
 
     auto append =
-      [log, &_sem, &as, batches_per_append, &last_append_offset]() mutable {
+      [log, &_sem, batches_per_append, &last_append_offset]() mutable {
           return ss::with_semaphore(
             _sem, 1, [log, batches_per_append, &last_append_offset]() mutable {
                 return ss::sleep(10ms).then(
@@ -2292,7 +2292,7 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
               return log
                 .truncate(storage::truncate_config(
                   offset.dirty_offset, ss::default_priority_class()))
-                .finally([start, o = offset.dirty_offset] {
+                .finally([start] {
                     // assert that truncation took less than 5 seconds
                     BOOST_REQUIRE_LT(
                       (ss::steady_clock_type::now() - start) / 1ms, 5000);


### PR DESCRIPTION
## Cover letter

Fixes unused lambda capture warnings.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* None