### PR TITLE
s/disk_log_impl: check if segments are empty in do_truncate

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1170,6 +1170,12 @@ ss::future<> disk_log_impl::do_truncate(truncate_config cfg) {
       internal::offset_to_filepos_consumer(
         start, cfg.base_offset, initial_size),
       model::no_timeout);
+
+    // all segments were deleted, return
+    if (_segs.empty()) {
+        co_return;
+    }
+
     auto last_ptr = _segs.back();
 
     if (initial_generation_id != last_ptr->get_generation_id()) {


### PR DESCRIPTION
## Cover letter

We need to recheck if segment set is empty after truncation physical
offset has been establish. Since reading segment is a scheduling point
it may be the case that all segments were removed right after the read.



<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
