### PR TITLE
Raft: recovery throttle available units metric

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -892,6 +892,9 @@ struct raft_test_fixture {
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
             config::shard_local_cfg()
+              .get("disable_public_metrics")
+              .set_value(true);
+            config::shard_local_cfg()
               .get("raft_heartbeat_disconnect_failures")
               .set_value((size_t)0);
         }).get();


### PR DESCRIPTION
## Cover letter

Add recovery throttle metric that shows current available units in recovery semaphore.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* New metric for partition movement available bandwidth

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
