### PR TITLE
cloud_storage: limit segment readers per partition

### DIFF
--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -244,6 +244,7 @@ private:
         /// In either case return a reader.
         std::unique_ptr<remote_segment_batch_reader> borrow_reader(
           const storage::log_reader_config& cfg,
+          ssx::semaphore&,
           retry_chain_logger& ctxlog,
           partition_probe& probe);
 
@@ -331,6 +332,12 @@ private:
       materialized_segment_state,
       &materialized_segment_state::_hook>
       _materialized;
+
+    // Limit the number of readers of materialized segments that may exist.
+    // This also implicitly limits the number of materialized segments that may
+    // exist, since each materialized segment should have at least one reader.
+    ssx::semaphore _readers_limit;
+
     ss::condition_variable _cvar;
     /// Timer use to periodically evict stale readers
     ss::timer<ss::lowres_clock> _stm_timer;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -895,6 +895,7 @@ private:
 remote_segment_batch_reader::remote_segment_batch_reader(
   ss::lw_shared_ptr<remote_segment> s,
   const storage::log_reader_config& config,
+  ssx::semaphore_units units,
   partition_probe& probe) noexcept
   : _seg(std::move(s))
   , _config(config)
@@ -902,7 +903,8 @@ remote_segment_batch_reader::remote_segment_batch_reader(
   , _rtc(_seg->get_retry_chain_node())
   , _ctxlog(cst_log, _rtc, _seg->get_ntp().path())
   , _cur_rp_offset(_seg->get_base_rp_offset())
-  , _cur_delta(_seg->get_base_offset_delta()) {
+  , _cur_delta(_seg->get_base_offset_delta())
+  , _units(std::move(units)) {
     _probe.segment_reader_created();
 }
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -208,6 +208,7 @@ public:
     remote_segment_batch_reader(
       ss::lw_shared_ptr<remote_segment>,
       const storage::log_reader_config& config,
+      ssx::semaphore_units,
       partition_probe& probe) noexcept;
 
     remote_segment_batch_reader(
@@ -261,6 +262,9 @@ private:
     size_t _bytes_consumed{0};
     ss::gate _gate;
     bool _stopped{false};
+
+    // Units frorm the partition's readers_limit semaphore
+    ssx::semaphore_units _units;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -185,7 +185,8 @@ FIXTURE_TEST(
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, cache.local(), bucket, m, key, fib);
     partition_probe probe(manifest_ntp);
-    remote_segment_batch_reader reader(segment, reader_config, probe);
+    remote_segment_batch_reader reader(
+      segment, reader_config, ssx::semaphore_units(), probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 
     auto s = reader.read_some(model::no_timeout, ot_state).get();
@@ -276,7 +277,8 @@ void test_remote_segment_batch_reader(
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, fixture.cache.local(), bucket, m, key, fib);
     partition_probe probe(manifest_ntp);
-    remote_segment_batch_reader reader(segment, reader_config, probe);
+    remote_segment_batch_reader reader(
+      segment, reader_config, ssx::semaphore_units(), probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 
     size_t batch_ix = 0;
@@ -388,6 +390,7 @@ FIXTURE_TEST(
         headers.at(0).base_offset,
         headers.at(0).last_offset(),
         ss::default_priority_class()),
+      ssx::semaphore_units(),
       probe);
     storage::offset_translator_state ot_state(m.get_ntp());
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1112,6 +1112,12 @@ configuration::configuration()
       "Timeout to check if cache eviction should be triggered",
       {.visibility = visibility::tunable},
       30s)
+  , cloud_storage_readers_per_partition(
+      *this,
+      "cloud_storage_readers_per_partition",
+      "Maximum concurrent readers of cloud storage data per partition",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      4)
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -238,6 +238,7 @@ struct configuration final : public config_store {
     // Archival cache
     property<size_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
+    property<size_t> cloud_storage_readers_per_partition;
 
     one_or_many_property<ss::sstring> superusers;
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -277,7 +277,6 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
     def __init__(self, test_context: TestContext):
         si_settings = SISettings(log_segment_size=self.segment_size,
                                  cloud_storage_cache_size=20 * 2**30,
-                                 cloud_storage_bucket='while-busy-bucket',
                                  cloud_storage_enable_remote_read=False,
                                  cloud_storage_enable_remote_write=False)
 


### PR DESCRIPTION
## Cover letter

Many readers may be created as a result of concurrent readers.  `remote_segment` instances also keep a cache of recently used readers, which can grow to an unbounded length if consumers exhibit random read behavior.  Because there is a per-reader resource overhead (file descriptiors and memory), we must limit the number of readers to avoid exhausting memory under random read workloads.

The limit is applied at the partition level rather than the shard level for two reasons:
- Simplicity: if we limited readers per-shard, then we would need a mechanism for one partition to prompt other partitions to release some readers if the limit was reached.
- Fairness: if we had a global reader count limit, then some partitions subject to random reads would tend to degrade the read performance of other partitions doing nice sequential reads.

The main downside of this change is that if someone did have a workload with large numbers of consumers targeting each partition, they will see a performance degradation as segment readers are destroyed and created more frequently.  However, it was already the case that reading S3 data was an "all bets are off" level of performance (segments can be evicted any time + reads may experience delays waiting for hydration).

Fixes: #6111 

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

See release notes.

## Release notes

### Improvements

* Improved stability when tiered storage is in use and consumers exhibit random-style access patterns.
* A new cluster configuration property `cloud_storage_readers_per_partition` is added.  This should not usually require changing.  It controls the number of internal reader objects that may be created concurrently per partition, when reading from segments in cloud storage.
