### PR TITLE
[v22.2.x] Raft: recovery throttle available units metric

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -892,6 +892,9 @@ struct raft_test_fixture {
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
             config::shard_local_cfg()
+              .get("disable_public_metrics")
+              .set_value(true);
+            config::shard_local_cfg()
               .get("raft_heartbeat_disconnect_failures")
               .set_value((size_t)0);
         }).get();


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6110.
