### PR TITLE
gha/rpk: notify on darwin sign failure

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -121,6 +121,20 @@ jobs:
     outputs:
       upload_url: ${{ needs.create-release.outputs.upload_url }}
 
+  notify-sign-failure:
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs: [sign-darwin]
+    steps:
+      - name: Notify sign failed
+        id: notify_sign_failure
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          channel-id: ${{ secrets.INTERNAL_RELEASES_SLACK_CHANNEL }}
+          slack-message: "ERROR: signing darwin binaries for `${{ github.ref_name }}` failed in ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.VBOTBUILDOVICH_SLACK_BOT_TOKEN }}
+
   create-release:
     name: Create release
     needs: [build]


### PR DESCRIPTION
## Cover letter

Send slack message to `INTERNAL_RELEASES_SLACK_CHANNEL` on failure to sign darwin binaries during release.

Example slack message:
> ERROR: signing darwin binaries for `v22.2.12-rc11` failed in https://github.com/andrewhsu/redpanda/actions/runs/2922624807

Address issue: https://github.com/redpanda-data/devprod/issues/341

## Backport Required

needs backport to supported branches:
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none