### PR TITLE
tests: tolerate out of order acks in VerifiableProducer

### DIFF
--- a/tests/rptest/services/verifiable_producer.py
+++ b/tests/rptest/services/verifiable_producer.py
@@ -168,38 +168,6 @@ class VerifiableProducer(BackgroundThreadService):
                 compression_index]
         return prop_file
 
-    def _update_offsets_strict(self, node, partition, data):
-        """
-        Update self._last_acked_offsets with some strict consistency checking,
-        must only be used on single-producer instances of this service.
-        :return:
-        """
-
-        # These assertions are aimed at finding an apparent rare issue
-        # where the verification in EndToEndTest can go wrong.
-        # Related: https://github.com/redpanda-data/redpanda/issues/3450
-        try:
-            assert data["offset"] > self._last_acked_offsets.get(partition, -1)
-
-            self._last_acked_offsets[partition] = data["offset"]
-
-            # Greater-equal because offsets may advance from failed/retried produce
-            assert sum(o + 1
-                       for o in self._last_acked_offsets.values()) >= len(
-                           self.acked_values)
-
-            assert sum(pc for pc in self.produced_count.values()) == len(
-                self.acked_values) + len(self.not_acked_values)
-        except AssertionError:
-            self.logger.error(
-                f"Assertion failed on node {node.name}, message {data}")
-            self.logger.error(f"last_acked_offsets {self._last_acked_offsets}")
-            self.logger.error(f"len(acked_values) {len(self.acked_values)}")
-            self.logger.error(
-                f"len(not_acked_values) {len(self.not_acked_values)}")
-            self.logger.error(f"produced_count: {self.produced_count}")
-            raise
-
     def _worker(self, idx, node):
         node.account.ssh("mkdir -p %s" % VerifiableProducer.PERSISTENT_ROOT,
                          allow_fail=False)
@@ -268,15 +236,12 @@ class VerifiableProducer(BackgroundThreadService):
 
                         self.produced_count[idx] += 1
 
-                        if len(self.nodes) > 1:
-                            # With multiple producers, we have to decide whose
-                            # offset to use for our state.  Take the highest value
-                            # we have seen
-                            self._last_acked_offsets[partition] = max(
-                                data["offset"],
-                                self._last_acked_offsets.get(partition, 0))
-                        else:
-                            self._update_offsets_strict(node, partition, data)
+                        # Completions are not guaranteed to be called in-order wrt offsets,
+                        # even if there is only one producer, so we must handle situation
+                        # where we see an offset lower than what we already recorded as highest.
+                        self._last_acked_offsets[partition] = max(
+                            data["offset"],
+                            self._last_acked_offsets.get(partition, 0))
 
                         # Log information if there is a large gap between successively acknowledged messages
                         t = time.time()


### PR DESCRIPTION
## Cover letter

The end to end test logic had a built in assumption that verifiableproducer's last_acked dictionary always moved forward, and could get badly confused (#3450) if that was violated.

Recently assertions and logging were added to detect cases where this assumption was violated, and fortunately they've confirmed that the test was simply wrong to expect monotonic offsets in the acks for a partition.

This PR removes the strict assertions and updates the offset tracking code to do a max() on the offsets it sees.

Fixes https://github.com/redpanda-data/redpanda/issues/6122
Fixes https://github.com/redpanda-data/redpanda/issues/6121
Fixes https://github.com/redpanda-data/redpanda/issues/3450

## Backport Required

- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
