### PR TITLE
tests: fix TxAbortSnapshotTest

### DIFF
--- a/tests/rptest/tests/tx_abort_index_test.py
+++ b/tests/rptest/tests/tx_abort_index_test.py
@@ -131,6 +131,13 @@ class TxAbortSnapshotTest(RedpandaTest):
         wait_until(segments_gone, timeout_sec=60, backoff_sec=1)
 
         self.redpanda.restart_nodes(self.redpanda.nodes)
-        current_idx = self.find_indexes(self.topics[0].name)
-        for node in self.redpanda.nodes:
-            assert len(current_idx[node.account.hostname]) == 0
+
+        def indices_gone():
+            current_idx = self.find_indexes(self.topics[0].name)
+            for node in self.redpanda.nodes:
+                if len(current_idx[node.account.hostname]) != 0:
+                    return False
+
+            return True
+
+        wait_until(indices_gone, timeout_sec=30, backoff_sec=1)


### PR DESCRIPTION
## Cover letter

The success condition is not synchronously
true after a node restart: it can take some
time.

Fixes https://github.com/redpanda-data/redpanda/issues/6134

## Backport Required

- [x] test doesn't exist in old branches
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
