### PR TITLE
build: fix outstanding warnings and enable -Wall

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+add_compile_options(-Wall)
+
 # libraries
 add_subdirectory(test_utils)
 add_subdirectory(ssx)

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -300,7 +300,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     // made.
     // The manifest that this test generates contains a segment definition
     // that clashes with the partial upload.
-    model::offset lso = model::offset::max();
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1)},
       {manifest_ntp, model::offset(1000), model::term_id(4)},

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -51,21 +51,6 @@ static storage::ntp_config get_ntp_conf() {
     return storage::ntp_config(manifest_ntp, "base-dir");
 }
 
-/// Compare two json objects logically by parsing them first and then going
-/// through fields
-static bool
-compare_json_objects(const std::string_view& lhs, const std::string_view& rhs) {
-    using namespace rapidjson;
-    Document lhsd, rhsd;
-    lhsd.Parse({lhs.data(), lhs.size()});
-    rhsd.Parse({rhs.data(), rhs.size()});
-    if (lhsd != rhsd) {
-        vlog(
-          test_log.trace, "Json objects are not equal:\n{}and\n{}", lhs, rhs);
-    }
-    return lhsd == rhsd;
-}
-
 static void log_segment(const storage::segment& s) {
     vlog(
       test_log.info,

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -241,8 +241,6 @@ void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
     vlog(fixt_log.trace, "waiting for partition {}", ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, ntp] {
         auto& table = app.controller->get_partition_leaders().local();
-        model::node_id node(0);
-        int cnt = 0;
         auto self = app.controller->self();
         ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
         return table.wait_for_leader(ntp, deadline, {}).get0() == self

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -160,8 +160,6 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
     std::string manifest_path = fmt::format(
       "/{:08x}/meta/{}/manifest.json", hash, manifest_ntp_path);
 
-    const char* topic_url
-      = "/00000000/meta/test-namespace/topic_3/topic_manifest.json";
     archival::segment_name seg000{"0-0-v1.log"};
     archival::segment_name seg100{"100-0-v1.log"};
     set_expectations_and_listen({});

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -469,7 +469,6 @@ FIXTURE_TEST(
   test_remote_partition_scan_full_truncated_segments, cloud_storage_fixture) {
     constexpr int batches_per_segment = 10;
     constexpr int num_segments = 3;
-    constexpr int total_batches = batches_per_segment * num_segments;
 
     auto segments = setup_s3_imposter(*this, 3, 10, /*truncate_segments=*/true);
     auto base = segments[0].base_offset;
@@ -585,7 +584,6 @@ FIXTURE_TEST(test_remote_partition_scan_middle, cloud_storage_fixture) {
 FIXTURE_TEST(test_remote_partition_scan_off, cloud_storage_fixture) {
     constexpr int batches_per_segment = 10;
     constexpr int num_segments = 3;
-    constexpr int total_batches = batches_per_segment * num_segments;
 
     auto segments = setup_s3_imposter(*this, 3, 10);
     auto base = segments[2].max_offset + model::offset(10);
@@ -720,7 +718,6 @@ FIXTURE_TEST(
   test_remote_partition_scan_translate_full_4, cloud_storage_fixture) {
     constexpr int batches_per_segment = 10;
     constexpr int num_segments = 3;
-    constexpr int total_batches = batches_per_segment * num_segments;
     batch_t data = {
       .num_records = 10, .type = model::record_batch_type::raft_data};
     batch_t conf = {
@@ -979,8 +976,6 @@ SEASTAR_THREAD_TEST_CASE(test_btree_iterator_range_scan) {
         BOOST_REQUIRE_EQUAL(i->second, 2 * cnt);
         cnt++;
     }
-
-    auto it = iter_t(map);
 }
 
 FIXTURE_TEST(test_remote_partition_read_cached_index, cloud_storage_fixture) {

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -467,7 +467,6 @@ FIXTURE_TEST(test_remote_partition_scan_full, cloud_storage_fixture) {
 /// This test scans the entire range of offsets
 FIXTURE_TEST(
   test_remote_partition_scan_full_truncated_segments, cloud_storage_fixture) {
-    constexpr int batches_per_segment = 10;
     constexpr int num_segments = 3;
 
     auto segments = setup_s3_imposter(*this, 3, 10, /*truncate_segments=*/true);
@@ -582,9 +581,6 @@ FIXTURE_TEST(test_remote_partition_scan_middle, cloud_storage_fixture) {
 
 /// This test scans batches in the middle
 FIXTURE_TEST(test_remote_partition_scan_off, cloud_storage_fixture) {
-    constexpr int batches_per_segment = 10;
-    constexpr int num_segments = 3;
-
     auto segments = setup_s3_imposter(*this, 3, 10);
     auto base = segments[2].max_offset + model::offset(10);
     auto max = base + model::offset(10);

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -124,7 +124,7 @@ FIXTURE_TEST(test_autocreate_on_non_leader, cluster_test_fixture) {
 
     // first controller
     auto app_0 = create_node_application(n_1);
-    auto app_1 = create_node_application(n_2);
+    create_node_application(n_2);
 
     wait_for_controller_leadership(n_1).get();
 

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -19,7 +19,7 @@ using namespace std::chrono_literals; // NOLINT
 
 FIXTURE_TEST(test_join_single_node, cluster_test_fixture) {
     model::node_id id{0};
-    auto app = create_node_application(id);
+    create_node_application(id);
     wait_for_controller_leadership(id).get();
 
     wait_for_all_members(3s).get();
@@ -32,16 +32,16 @@ FIXTURE_TEST(test_join_single_node, cluster_test_fixture) {
 }
 
 FIXTURE_TEST(test_two_node_cluster, cluster_test_fixture) {
-    auto n1 = create_node_application(model::node_id{0});
-    auto n2 = create_node_application(model::node_id{1});
+    create_node_application(model::node_id{0});
+    create_node_application(model::node_id{1});
     // Check if all brokers were registered
     wait_for_all_members(3s).get();
 }
 
 FIXTURE_TEST(test_three_node_cluster, cluster_test_fixture) {
-    auto n1 = create_node_application(model::node_id{0});
-    auto n2 = create_node_application(model::node_id{1});
-    auto n3 = create_node_application(model::node_id{2});
+    create_node_application(model::node_id{0});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
 
     wait_for_all_members(3s).get();
 }

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -26,9 +26,9 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
     model::node_id node_0(0);
     model::node_id node_1(1);
     model::node_id node_2(2);
-    auto node_app_0 = create_node_application(node_0);
+    create_node_application(node_0);
     wait_for_controller_leadership(node_0).get();
-    auto node_app_1 = create_node_application(node_1);
+    create_node_application(node_1);
     [[maybe_unused]] auto node_app_2 = create_node_application(node_2);
 
     // wait for cluster to be stable

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -24,7 +24,6 @@ using namespace std::chrono_literals; // NOLINT
 FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
     auto n1 = create_node_application(model::node_id{0});
     auto n2 = create_node_application(model::node_id{1});
-    auto n3 = create_node_application(model::node_id{2});
     model::ntp test_ntp(test_ns, model::topic("tp"), model::partition_id(0));
     wait_for_all_members(3s).get();
 

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -39,8 +39,8 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
     // add three nodes
     auto node_0 = create_node_application(model::node_id{0});
     wait_for_controller_leadership(node_0->controller->self()).get();
-    auto node_1 = create_node_application(model::node_id{1});
-    auto node_2 = create_node_application(model::node_id{2});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
 
     // wait for cluster to be stable
     tests::cooperative_spin_wait_with_timeout(5s, [this] {

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -176,8 +176,8 @@ model::ntp ntp(model::ns ns, ss::sstring tp, int pid) {
 
 FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
     auto n1 = create_node_application(model::node_id{0});
-    auto n2 = create_node_application(model::node_id{1});
-    auto n3 = create_node_application(model::node_id{2});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
 
     wait_for_all_members(3s).get();
     // wait for disk space report to be present
@@ -304,8 +304,8 @@ FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
 
 FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
     auto n1 = create_node_application(model::node_id{0});
-    auto n2 = create_node_application(model::node_id{1});
-    auto n3 = create_node_application(model::node_id{2});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
 
     wait_for_all_members(3s).get();
     // wait for disk space report to be present

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -143,8 +143,6 @@ void local_monitor_fixture::assert_space_alert(
   size_t free,
   disk_space_alert expected) {
     static const size_t block_size = 1024;
-    size_t min_percent_blocks = percent_alert_bytes / block_size;
-    size_t min_bytes_blocks = bytes_alert / block_size;
 
     unsigned percent = (percent_alert_bytes * 100) / volume;
     set_config_free_thresholds(percent, bytes_alert, min_bytes);

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -64,8 +64,8 @@ FIXTURE_TEST(
     model::node_id n_2(1);
     model::node_id n_3(2);
     auto cntrl_0 = create_node_application(n_1);
-    auto cntrl_1 = create_node_application(n_2);
-    auto cntrl_2 = create_node_application(n_3);
+    create_node_application(n_2);
+    create_node_application(n_3);
 
     auto& cache_0 = get_local_cache(n_1);
     auto& cache_1 = get_local_cache(n_2);
@@ -106,7 +106,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     model::node_id n_1(0);
     model::node_id n_2(1);
     auto cntrl_0 = create_node_application(n_1);
-    auto cntrl_1 = create_node_application(n_2);
+    create_node_application(n_2);
 
     auto& cache_0 = get_local_cache(n_1);
     auto& cache_1 = get_local_cache(n_2);
@@ -130,7 +130,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
       .get0();
 
     // Add new now to the cluster
-    auto cntrl_2 = create_node_application(model::node_id{2});
+    create_node_application(model::node_id{2});
     auto& cache_2 = get_local_cache(model::node_id{2});
     // Wait for node to join the cluster
     tests::cooperative_spin_wait_with_timeout(

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -87,8 +87,7 @@ struct partition_balancer_planner_fixture {
           .node_availability_timeout_sec = std::chrono::minutes(1)},
         workers.table.local(),
         workers.members.local(),
-        workers.allocator.local())
-      , workers() {}
+        workers.allocator.local()) {}
 
     cluster::topic_configuration_assignment make_tp_configuration(
       const ss::sstring& topic, int partitions, int16_t replication_factor) {

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -310,7 +310,6 @@ public:
         }).get0();
 
         auto retries = 10;
-        bool stop = false;
         foreign_batches_t ret;
         auto single_retry = [count, ntp](cluster::partition_manager& pm) {
             auto batches = model::test::make_random_batches(

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -155,7 +155,6 @@ public:
         }).get0();
 
         auto retries = 10;
-        bool stop = false;
         foreign_batches_t ret;
         auto single_retry = [count, ntp](cluster::partition_manager& pm) {
             auto batches = model::test::make_random_batches(

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -450,7 +450,7 @@ struct adl<partition_status_v0> {
     }
 
     partition_status_v0 from(iobuf_parser& p) {
-        auto version = adl<int8_t>{}.from(p);
+        adl<int8_t>{}.from(p); // version
         auto id = adl<model::partition_id>{}.from(p);
         auto term = adl<model::term_id>{}.from(p);
         auto leader = adl<std::optional<model::node_id>>{}.from(p);

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -20,7 +20,7 @@
 #include "test_utils/fixture.h"
 #include "units.h"
 
-static void validate_delta(
+inline void validate_delta(
   const std::vector<cluster::topic_table::delta>& d,
   int new_partitions,
   int removed_partitions) {

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -46,17 +46,17 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     // discard create delta
     table.local().wait_for_changes(as).get0();
     table.local()
-                   .apply(
-                     cluster::delete_topic_cmd(
-                       make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")),
-                     model::offset(0))
-                   .get0();
+      .apply(
+        cluster::delete_topic_cmd(
+          make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")),
+        model::offset(0))
+      .get0();
     table.local()
-                   .apply(
-                     cluster::delete_topic_cmd(
-                       make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")),
-                     model::offset(0))
-                   .get0();
+      .apply(
+        cluster::delete_topic_cmd(
+          make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")),
+        model::offset(0))
+      .get0();
 
     auto md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
@@ -152,11 +152,10 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
       std::move(cfg), std::move(p_as));
 
     table.local()
-                   .apply(
-                     cluster::create_partition_cmd(
-                       make_tp_ns("test_tp_2"), std::move(pca)),
-                     model::offset(0))
-                   .get0();
+      .apply(
+        cluster::create_partition_cmd(make_tp_ns("test_tp_2"), std::move(pca)),
+        model::offset(0))
+      .get0();
 
     auto md = table.local().get_topic_metadata(make_tp_ns("test_tp_2"));
 

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -45,13 +45,13 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     create_topics();
     // discard create delta
     table.local().wait_for_changes(as).get0();
-    auto res_1 = table.local()
+    table.local()
                    .apply(
                      cluster::delete_topic_cmd(
                        make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")),
                      model::offset(0))
                    .get0();
-    auto res_2 = table.local()
+    table.local()
                    .apply(
                      cluster::delete_topic_cmd(
                        make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")),
@@ -151,7 +151,7 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     cluster::create_partitions_configuration_assignment pca(
       std::move(cfg), std::move(p_as));
 
-    auto res_1 = table.local()
+    table.local()
                    .apply(
                      cluster::create_partition_cmd(
                        make_tp_ns("test_tp_2"), std::move(pca)),

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -115,13 +115,13 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_dispatching_happy_path_delete, topic_table_updates_dispatcher_fixture) {
     create_topics();
-    auto res_1 = dispatcher
+    dispatcher
                    .apply_update(serialize_cmd(cluster::delete_topic_cmd(
                                                  make_tp_ns("test_tp_2"),
                                                  make_tp_ns("test_tp_2")))
                                    .get0())
                    .get0();
-    auto res_2 = dispatcher
+    dispatcher
                    .apply_update(serialize_cmd(cluster::delete_topic_cmd(
                                                  make_tp_ns("test_tp_3"),
                                                  make_tp_ns("test_tp_3")))

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -116,17 +116,17 @@ FIXTURE_TEST(
   test_dispatching_happy_path_delete, topic_table_updates_dispatcher_fixture) {
     create_topics();
     dispatcher
-                   .apply_update(serialize_cmd(cluster::delete_topic_cmd(
-                                                 make_tp_ns("test_tp_2"),
-                                                 make_tp_ns("test_tp_2")))
-                                   .get0())
-                   .get0();
+      .apply_update(
+        serialize_cmd(cluster::delete_topic_cmd(
+                        make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")))
+          .get0())
+      .get0();
     dispatcher
-                   .apply_update(serialize_cmd(cluster::delete_topic_cmd(
-                                                 make_tp_ns("test_tp_3"),
-                                                 make_tp_ns("test_tp_3")))
-                                   .get0())
-                   .get0();
+      .apply_update(
+        serialize_cmd(cluster::delete_topic_cmd(
+                        make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")))
+          .get0())
+      .get0();
 
     auto md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);

--- a/src/v/cluster/tests/utils.h
+++ b/src/v/cluster/tests/utils.h
@@ -18,7 +18,7 @@
 
 static const model::ns test_ns = model::ns("test-namespace");
 
-static cluster::partition_assignment create_test_assignment(
+inline cluster::partition_assignment create_test_assignment(
   const ss::sstring& topic,
   int partition_id,
   std::vector<std::pair<uint32_t, uint32_t>> shards_assignment,
@@ -44,7 +44,7 @@ using batches_t = ss::circular_buffer<model::record_batch>;
 using batches_ptr_t = ss::lw_shared_ptr<batches_t>;
 using foreign_batches_t = ss::foreign_ptr<batches_ptr_t>;
 
-static void wait_for_metadata(
+inline void wait_for_metadata(
   cluster::topic_table& topic_table,
   const std::vector<cluster::topic_result>& results,
   std::chrono::milliseconds tout = std::chrono::seconds(5)) {

--- a/src/v/kafka/client/test/retry_with_mitigation.cc
+++ b/src/v/kafka/client/test/retry_with_mitigation.cc
@@ -81,7 +81,7 @@ SEASTAR_THREAD_TEST_CASE(test_retry_fail_2) {
 SEASTAR_THREAD_TEST_CASE(test_retry_fail_all) {
     context ctx = {true, true, true};
     size_t errors{};
-    auto res = kc::retry_with_mitigation(ctx.retries(), 0ms, std::ref(ctx), ctx)
+    kc::retry_with_mitigation(ctx.retries(), 0ms, std::ref(ctx), ctx)
                  .handle_exception_type(
                    [&errors](const counted_error& ex) { errors = ex.count; })
                  .get();

--- a/src/v/kafka/client/test/retry_with_mitigation.cc
+++ b/src/v/kafka/client/test/retry_with_mitigation.cc
@@ -82,9 +82,9 @@ SEASTAR_THREAD_TEST_CASE(test_retry_fail_all) {
     context ctx = {true, true, true};
     size_t errors{};
     kc::retry_with_mitigation(ctx.retries(), 0ms, std::ref(ctx), ctx)
-                 .handle_exception_type(
-                   [&errors](const counted_error& ex) { errors = ex.count; })
-                 .get();
+      .handle_exception_type(
+        [&errors](const counted_error& ex) { errors = ex.count; })
+      .get();
     BOOST_REQUIRE_EQUAL(ctx.calls(), 3);
     BOOST_REQUIRE_EQUAL(errors, 3);
 }

--- a/src/v/kafka/protocol/CMakeLists.txt
+++ b/src/v/kafka/protocol/CMakeLists.txt
@@ -28,8 +28,6 @@ v_cc_library(
     logger.cc
     flex_versions.cc
     ${message_srcs}
-  COPTS
-    "-Wno-unused-lambda-capture"
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/kafka/protocol/tests/batch_reader_test.cc
+++ b/src/v/kafka/protocol/tests/batch_reader_test.cc
@@ -128,7 +128,6 @@ SEASTAR_THREAD_TEST_CASE(consumer_records_consume_batch_fail_magic) {
 
     auto crs = kafka::batch_reader(std::move(ctx.record_set));
 
-    model::offset last_offset{};
     auto kba = crs.consume_batch();
     BOOST_REQUIRE(!kba.v2_format);
 }
@@ -140,7 +139,6 @@ SEASTAR_THREAD_TEST_CASE(consumer_records_consume_batch_fail_crc) {
 
     auto crs = kafka::batch_reader(std::move(ctx.record_set));
 
-    model::offset last_offset{};
     auto kba = crs.consume_batch();
     BOOST_REQUIRE(!kba.valid_crc);
 }

--- a/src/v/kafka/protocol/tests/field_parser_test.cc
+++ b/src/v/kafka/protocol/tests/field_parser_test.cc
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(serde_tags) {
 
     /// Serialize the random tags into an iobuf
     kafka::response_writer writer(buf);
-    writer.write_tags(std::move(copy_tags(tags)));
+    writer.write_tags(copy_tags(tags));
 
     /// Copy the result to use for a later comparison
     iobuf copy = buf.copy();
@@ -155,7 +155,7 @@ T serde_flex(T& type) {
 SEASTAR_THREAD_TEST_CASE(serde_flex_types) {
     auto gen_random_string = []() {
         const auto str_len = random_generators::get_int(0, 20);
-        return random_generators::gen_alphanum_string(15);
+        return random_generators::gen_alphanum_string(str_len);
     };
     {
         /// uuid

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -338,7 +338,6 @@ FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
     // create a topic partition with some data
     model::topic topic("foo");
     model::partition_id pid(0);
-    model::offset offset(0);
     auto ntp = make_default_ntp(topic, pid);
     auto log_config = make_default_config();
     wait_for_controller_leadership().get0();
@@ -372,7 +371,6 @@ FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
 FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
     // create a topic partition with some data
     model::topic topic("foo");
-    model::partition_id pid(0);
     model::offset offset(0);
 
     wait_for_controller_leadership().get0();
@@ -409,7 +407,7 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
         model::partition_id partition_id(i);
         auto ntp = make_default_ntp(topic, partition_id);
         auto shard = app.shard_table.local().shard_for(ntp);
-        auto r = app.partition_manager
+        app.partition_manager
                    .invoke_on(
                      *shard,
                      [ntp](cluster::partition_manager& mgr) {
@@ -423,6 +421,7 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
                            raft::replicate_options(
                              raft::consistency_level::quorum_ack));
                      })
+                   .discard_result()
                    .get0();
     }
     auto resp = fresp.get0();
@@ -474,7 +473,7 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     client.connect().get();
     auto fresp = client.dispatch(req, kafka::api_version(4));
     auto shard = app.shard_table.local().shard_for(ntp);
-    auto r = app.partition_manager
+    app.partition_manager
                .invoke_on(
                  *shard,
                  [ntp](cluster::partition_manager& mgr) {
@@ -488,6 +487,7 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
                        raft::replicate_options(
                          raft::consistency_level::quorum_ack));
                  })
+               .discard_result()
                .get0();
 
     auto resp = fresp.get0();
@@ -554,7 +554,7 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     // add date to all partitions
     for (auto& ntp : ntps) {
         auto shard = app.shard_table.local().shard_for(ntp);
-        auto r = app.partition_manager
+        app.partition_manager
                    .invoke_on(
                      *shard,
                      [ntp](cluster::partition_manager& mgr) {
@@ -568,6 +568,7 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
                            raft::replicate_options(
                              raft::consistency_level::quorum_ack));
                      })
+                   .discard_result()
                    .get0();
     }
 
@@ -597,7 +598,6 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
 FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
     model::topic topic("foo");
     model::partition_id pid(0);
-    model::offset offset(0);
     auto ntp = make_default_ntp(topic, pid);
 
     wait_for_controller_leadership().get0();

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -408,21 +408,20 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
         auto ntp = make_default_ntp(topic, partition_id);
         auto shard = app.shard_table.local().shard_for(ntp);
         app.partition_manager
-                   .invoke_on(
-                     *shard,
-                     [ntp](cluster::partition_manager& mgr) {
-                         auto partition = mgr.get(ntp);
-                         auto batches = model::test::make_random_batches(
-                           model::offset(0), 5);
-                         auto rdr = model::make_memory_record_batch_reader(
-                           std::move(batches));
-                         return partition->raft()->replicate(
-                           std::move(rdr),
-                           raft::replicate_options(
-                             raft::consistency_level::quorum_ack));
-                     })
-                   .discard_result()
-                   .get0();
+          .invoke_on(
+            *shard,
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+                auto batches = model::test::make_random_batches(
+                  model::offset(0), 5);
+                auto rdr = model::make_memory_record_batch_reader(
+                  std::move(batches));
+                return partition->raft()->replicate(
+                  std::move(rdr),
+                  raft::replicate_options(raft::consistency_level::quorum_ack));
+            })
+          .discard_result()
+          .get0();
     }
     auto resp = fresp.get0();
     client.stop().then([&client] { client.shutdown(); }).get();
@@ -474,21 +473,20 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     auto fresp = client.dispatch(req, kafka::api_version(4));
     auto shard = app.shard_table.local().shard_for(ntp);
     app.partition_manager
-               .invoke_on(
-                 *shard,
-                 [ntp](cluster::partition_manager& mgr) {
-                     auto partition = mgr.get(ntp);
-                     auto batches = model::test::make_random_batches(
-                       model::offset(0), 5);
-                     auto rdr = model::make_memory_record_batch_reader(
-                       std::move(batches));
-                     return partition->raft()->replicate(
-                       std::move(rdr),
-                       raft::replicate_options(
-                         raft::consistency_level::quorum_ack));
-                 })
-               .discard_result()
-               .get0();
+      .invoke_on(
+        *shard,
+        [ntp](cluster::partition_manager& mgr) {
+            auto partition = mgr.get(ntp);
+            auto batches = model::test::make_random_batches(
+              model::offset(0), 5);
+            auto rdr = model::make_memory_record_batch_reader(
+              std::move(batches));
+            return partition->raft()->replicate(
+              std::move(rdr),
+              raft::replicate_options(raft::consistency_level::quorum_ack));
+        })
+      .discard_result()
+      .get0();
 
     auto resp = fresp.get0();
     client.stop().then([&client] { client.shutdown(); }).get();
@@ -555,21 +553,20 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     for (auto& ntp : ntps) {
         auto shard = app.shard_table.local().shard_for(ntp);
         app.partition_manager
-                   .invoke_on(
-                     *shard,
-                     [ntp](cluster::partition_manager& mgr) {
-                         auto partition = mgr.get(ntp);
-                         auto batches = model::test::make_random_batches(
-                           model::offset(0), 5);
-                         auto rdr = model::make_memory_record_batch_reader(
-                           std::move(batches));
-                         return partition->raft()->replicate(
-                           std::move(rdr),
-                           raft::replicate_options(
-                             raft::consistency_level::quorum_ack));
-                     })
-                   .discard_result()
-                   .get0();
+          .invoke_on(
+            *shard,
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+                auto batches = model::test::make_random_batches(
+                  model::offset(0), 5);
+                auto rdr = model::make_memory_record_batch_reader(
+                  std::move(batches));
+                return partition->raft()->replicate(
+                  std::move(rdr),
+                  raft::replicate_options(raft::consistency_level::quorum_ack));
+            })
+          .discard_result()
+          .get0();
     }
 
     auto resp = client.dispatch(req, kafka::api_version(4)).get0();

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -99,7 +99,8 @@ FIXTURE_TEST(metadata_rt_test, fixture) {
     group_md.protocol = random_optional<kafka::protocol_name>();
     group_md.leader = random_optional<kafka::member_id>();
     group_md.state_timestamp = model::timestamp::now();
-    for ([[maybe_unused]] auto i : boost::irange(0, random_generators::get_int(0, 10))) {
+    for ([[maybe_unused]] auto i :
+         boost::irange(0, random_generators::get_int(0, 10))) {
         group_md.members.push_back(random_member_state());
     }
 
@@ -312,8 +313,7 @@ FIXTURE_TEST(test_backward_compatible_serializer_metadata_type, fixture) {
         };
         auto batch = to_record_batch(std::move(key), std::optional<iobuf>());
         // old -> new type
-        serializer.get_metadata_type(
-          batch.copy_records().back().share_key());
+        serializer.get_metadata_type(batch.copy_records().back().share_key());
     }
 }
 
@@ -340,7 +340,8 @@ FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
     group_md.protocol = random_optional<kafka::protocol_name>();
     group_md.leader = random_optional<kafka::member_id>();
     group_md.state_timestamp = model::timestamp::now();
-    for ([[maybe_unused]] auto i : boost::irange(0, random_generators::get_int(0, 10))) {
+    for ([[maybe_unused]] auto i :
+         boost::irange(0, random_generators::get_int(0, 10))) {
         group_md.members.push_back(random_member_state());
     }
     auto group_kv = serializer.to_kv(kafka::group_metadata_kv{

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -99,7 +99,7 @@ FIXTURE_TEST(metadata_rt_test, fixture) {
     group_md.protocol = random_optional<kafka::protocol_name>();
     group_md.leader = random_optional<kafka::member_id>();
     group_md.state_timestamp = model::timestamp::now();
-    for (auto i : boost::irange(0, random_generators::get_int(0, 10))) {
+    for ([[maybe_unused]] auto i : boost::irange(0, random_generators::get_int(0, 10))) {
         group_md.members.push_back(random_member_state());
     }
 
@@ -312,7 +312,7 @@ FIXTURE_TEST(test_backward_compatible_serializer_metadata_type, fixture) {
         };
         auto batch = to_record_batch(std::move(key), std::optional<iobuf>());
         // old -> new type
-        auto type = serializer.get_metadata_type(
+        serializer.get_metadata_type(
           batch.copy_records().back().share_key());
     }
 }
@@ -340,7 +340,7 @@ FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
     group_md.protocol = random_optional<kafka::protocol_name>();
     group_md.leader = random_optional<kafka::member_id>();
     group_md.state_timestamp = model::timestamp::now();
-    for (auto i : boost::irange(0, random_generators::get_int(0, 10))) {
+    for ([[maybe_unused]] auto i : boost::irange(0, random_generators::get_int(0, 10))) {
         group_md.members.push_back(random_member_state());
     }
     auto group_kv = serializer.to_kv(kafka::group_metadata_kv{

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -31,7 +31,7 @@ static auto split_member_id(const ss::sstring& m) {
 static bool is_uuid(const ss::sstring& uuid) {
     try {
         boost::uuids::string_generator g;
-        auto _ = g(uuid.c_str());
+        g(uuid.c_str());
         return true;
     } catch (...) {
         return false;

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -108,7 +108,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
               }
               auto& part = *resp.data.topics.begin();
 
-              for (auto& r : part.partitions) {
+              for ([[maybe_unused]] auto& r : part.partitions) {
                   const auto& data = part.partitions.begin()->records;
                   if (data && !data->empty()) {
                       // update next fetch offset the same way as Kafka clients

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -27,9 +27,6 @@
 
 namespace pps = pandaproxy::schema_registry;
 
-constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
-constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
-
 inline model::record_batch make_record_batch(
   std::string_view key, std::string_view val, model::offset base_offset) {
     storage::record_batch_builder rb{
@@ -86,9 +83,6 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
 
     auto c = pps::consume_to_store(s, seq.local());
-
-    auto sequence = model::offset{0};
-    const auto node_id = model::node_id{123};
 
     model::offset base_offset{0};
     BOOST_REQUIRE_NO_THROW(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -80,7 +80,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     simple_sharded_store store;
 
     auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
-    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    store.insert(schema1, pps::schema_version{1});
     auto valid_simple
       = pps::make_protobuf_schema_definition(store.store, schema1).get();
 }
@@ -90,7 +90,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
 
     // imported depends on simple, which han't been inserted
     auto schema1 = pps::canonical_schema{pps::subject{"imported"}, imported};
-    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    store.insert(schema1, pps::schema_version{1});
     BOOST_REQUIRE_EXCEPTION(
       pps::make_protobuf_schema_definition(store.store, schema1).get(),
       pps::exception,
@@ -105,7 +105,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
     auto schema2 = pps::canonical_schema{pps::subject{"imported"}, imported};
 
-    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    store.insert(schema1, pps::schema_version{1});
 
     auto valid_simple
       = pps::make_protobuf_schema_definition(store.store, schema1).get();
@@ -130,9 +130,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
       imported_again,
       {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
 
-    auto sch1 = store.insert(schema1, pps::schema_version{1});
-    auto sch2 = store.insert(schema2, pps::schema_version{1});
-    auto sch3 = store.insert(schema3, pps::schema_version{1});
+    store.insert(schema1, pps::schema_version{1});
+    store.insert(schema2, pps::schema_version{1});
+    store.insert(schema3, pps::schema_version{1});
 
     auto valid_simple
       = pps::make_protobuf_schema_definition(store.store, schema1).get();
@@ -154,8 +154,8 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
       pps::canonical_schema_definition{
         R"(syntax =  "proto3"; package google.protobuf; message Timestamp { int64 seconds = 1;  int32 nanos = 2; })",
         pps::schema_type::protobuf}};
-    auto sch1 = store.insert(schema1, pps::schema_version{1});
-    auto sch2 = store.insert(schema2, pps::schema_version{1});
+    store.insert(schema1, pps::schema_version{1});
+    store.insert(schema2, pps::schema_version{1});
 
     auto valid_empty
       = pps::make_protobuf_schema_definition(store.store, schema1).get();

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -60,7 +60,7 @@ bool check_compatible(
   std::string_view writer) {
     simple_sharded_store store;
     store.store.set_compatibility(lvl).get();
-    auto sch1 = store.insert(
+    store.insert(
       pandaproxy::schema_registry::canonical_schema{
         pps::subject{"sub"},
         pps::canonical_schema_definition{writer, pps::schema_type::protobuf},

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -31,7 +31,6 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
 
     s.set_compatibility(pps::compatibility_level::backward).get();
     auto sub = pps::subject{"sub"};
-    auto avro = pps::schema_type::avro;
     s.upsert(
        dummy_marker,
        {sub, pps::canonical_schema_definition{schema1}},

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -33,17 +33,14 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     auto referenced_schema = pps::canonical_schema{
       pps::subject{"simple.proto"}, simple};
     store
-                  .upsert(
-                    pps::seq_marker{
-                      std::nullopt,
-                      std::nullopt,
-                      ver1,
-                      pps::seq_marker_key_type::schema},
-                    referenced_schema,
-                    pps::schema_id{1},
-                    ver1,
-                    pps::is_deleted::no)
-                  .get();
+      .upsert(
+        pps::seq_marker{
+          std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema},
+        referenced_schema,
+        pps::schema_id{1},
+        ver1,
+        pps::is_deleted::no)
+      .get();
 
     // Insert referenced
     auto importing_schema = pps::canonical_schema{
@@ -52,17 +49,14 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       {{"simple", pps::subject{"simple.proto"}, ver1}}};
 
     store
-                  .upsert(
-                    pps::seq_marker{
-                      std::nullopt,
-                      std::nullopt,
-                      ver1,
-                      pps::seq_marker_key_type::schema},
-                    importing_schema,
-                    pps::schema_id{2},
-                    ver1,
-                    pps::is_deleted::no)
-                  .get();
+      .upsert(
+        pps::seq_marker{
+          std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema},
+        importing_schema,
+        pps::schema_id{2},
+        ver1,
+        pps::is_deleted::no)
+      .get();
 
     auto referenced_by
       = store.referenced_by(referenced_schema.sub(), ver1).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -32,7 +32,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     // Insert simple
     auto referenced_schema = pps::canonical_schema{
       pps::subject{"simple.proto"}, simple};
-    auto sch1 = store
+    store
                   .upsert(
                     pps::seq_marker{
                       std::nullopt,
@@ -51,7 +51,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       imported,
       {{"simple", pps::subject{"simple.proto"}, ver1}}};
 
-    auto sch2 = store
+    store
                   .upsert(
                     pps::seq_marker{
                       std::nullopt,

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -323,12 +323,12 @@ FIXTURE_TEST(test_recovery_of_crashed_leader_truncation, raft_test_fixture) {
     leader_raft.release();
     // since replicate doesn't accept timeout client have to deal with it.
     ss::with_timeout(model::timeout_clock::now() + 1s, std::move(f))
-               .handle_exception_type([](const ss::timed_out_error&) {
-                   return result<raft::replicate_result>(
-                     rpc::errc::client_request_timeout);
-               })
-               .discard_result()
-               .get0();
+      .handle_exception_type([](const ss::timed_out_error&) {
+          return result<raft::replicate_result>(
+            rpc::errc::client_request_timeout);
+      })
+      .discard_result()
+      .get0();
 
     // shut down the leader
     info("shutting down leader {}", first_leader_id);

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -182,7 +182,6 @@ FIXTURE_TEST(sharing_one_reader, foreign_entry_fixture) {
 }
 
 FIXTURE_TEST(sharing_correcteness_test, foreign_entry_fixture) {
-    auto copies = 5;
     auto batches = model::test::make_random_batches(model::offset(0), 50, true);
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
     auto refs = raft::details::share_n(std::move(rdr), 2).get0();

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -38,7 +38,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
     }
 
     void prepare_raft_group() {
-        auto leader_id = wait_for_group_leader(gr);
+        wait_for_group_leader(gr);
         ss::abort_source as;
 
         auto first_ts = model::timestamp::now();

--- a/src/v/raft/tests/membership_test.cc
+++ b/src/v/raft/tests/membership_test.cc
@@ -260,7 +260,6 @@ FIXTURE_TEST(replace_whole_group, raft_test_fixture) {
     new_members.push_back(raft::broker_revision{
       .broker = gr.get_member(model::node_id(5)).broker,
       .rev = model::revision_id(0)});
-    bool success = false;
     info("replacing configuration");
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
               return leader.consensus
@@ -431,7 +430,6 @@ FIXTURE_TEST(revert_configuration_change, raft_test_fixture) {
     new_members.push_back(raft::broker_revision{
       .broker = gr.get_member(model::node_id(5)).broker,
       .rev = model::revision_id(0)});
-    bool success = false;
     info("replacing configuration");
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
               return leader.consensus

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -355,7 +355,7 @@ struct raft_node {
     ss::abort_source _as;
 };
 
-static model::ntp node_ntp(raft::group_id gr_id, model::node_id n_id) {
+inline model::ntp node_ntp(raft::group_id gr_id, model::node_id n_id) {
     return model::ntp(
       model::kafka_namespace,
       model::topic(ssx::sformat("group_{}", gr_id())),
@@ -542,7 +542,7 @@ private:
     size_t _segment_size;
 };
 
-static model::record_batch_reader random_batches_reader(int max_batches) {
+inline model::record_batch_reader random_batches_reader(int max_batches) {
     auto batches = model::test::make_random_batches(
       model::test::record_batch_spec{
         .offset = model::offset(0),
@@ -551,7 +551,7 @@ static model::record_batch_reader random_batches_reader(int max_batches) {
     return model::make_memory_record_batch_reader(std::move(batches));
 }
 
-static model::record_batch_reader
+inline model::record_batch_reader
 random_batch_reader(model::test::record_batch_spec spec) {
     auto batch = model::test::make_random_batch(spec);
     ss::circular_buffer<model::record_batch> batches;
@@ -561,14 +561,14 @@ random_batch_reader(model::test::record_batch_spec spec) {
     return model::make_memory_record_batch_reader(std::move(batches));
 }
 
-static model::record_batch_reader
+inline model::record_batch_reader
 random_batches_reader(model::test::record_batch_spec spec) {
     auto batches = model::test::make_random_batches(spec);
     return model::make_memory_record_batch_reader(std::move(batches));
 }
 
 template<typename Rep, typename Period, typename Pred>
-static void wait_for(
+inline void wait_for(
   std::chrono::duration<Rep, Period> timeout, Pred&& p, ss::sstring msg) {
     using clock_t = std::chrono::system_clock;
     auto start = clock_t::now();
@@ -584,7 +584,7 @@ static void wait_for(
     }
 }
 
-static void assert_at_most_one_leader(raft_group& gr) {
+inline void assert_at_most_one_leader(raft_group& gr) {
     std::unordered_map<long, int> leaders_per_term;
     for (auto& [_, m] : gr.get_members()) {
         auto term = static_cast<long>(m.consensus->term());
@@ -600,7 +600,7 @@ static void assert_at_most_one_leader(raft_group& gr) {
     }
 }
 
-static bool are_logs_the_same_length(const raft_group::logs_t& logs) {
+inline bool are_logs_the_same_length(const raft_group::logs_t& logs) {
     // if one of the logs is empty all of them have to be empty
     auto empty = std::all_of(
       logs.cbegin(), logs.cend(), [](const raft_group::logs_t::value_type& p) {
@@ -621,7 +621,7 @@ static bool are_logs_the_same_length(const raft_group::logs_t& logs) {
     });
 }
 
-static bool are_all_commit_indexes_the_same(raft_group& gr) {
+inline bool are_all_commit_indexes_the_same(raft_group& gr) {
     auto c_idx = gr.get_members().begin()->second.consensus->committed_offset();
     return std::all_of(
       gr.get_members().begin(),
@@ -633,7 +633,7 @@ static bool are_all_commit_indexes_the_same(raft_group& gr) {
       });
 }
 
-static bool are_all_consumable_offsets_are_the_same(raft_group& gr) {
+inline bool are_all_consumable_offsets_are_the_same(raft_group& gr) {
     auto c_idx
       = gr.get_members().begin()->second.consensus->last_visible_index();
     return std::all_of(
@@ -647,7 +647,7 @@ static bool are_all_consumable_offsets_are_the_same(raft_group& gr) {
       });
 }
 
-static bool are_logs_equivalent(
+inline bool are_logs_equivalent(
   const std::vector<model::record_batch>& a,
   const std::vector<model::record_batch>& b) {
     // both logs are empty - this is ok
@@ -664,7 +664,7 @@ static bool are_logs_equivalent(
     return a_it == a.rbegin() || b_it == b.rbegin();
 }
 
-static bool assert_all_logs_are_the_same(const raft_group::logs_t& logs) {
+inline bool assert_all_logs_are_the_same(const raft_group::logs_t& logs) {
     auto it = logs.begin();
     auto& reference = logs.begin()->second;
 
@@ -676,7 +676,7 @@ static bool assert_all_logs_are_the_same(const raft_group::logs_t& logs) {
       });
 }
 
-static void validate_logs_replication(raft_group& gr) {
+inline void validate_logs_replication(raft_group& gr) {
     auto logs = gr.read_all_logs();
     wait_for(
       10s,
@@ -690,17 +690,17 @@ static void validate_logs_replication(raft_group& gr) {
 }
 
 template<typename T>
-static model::timeout_clock::time_point timeout(std::chrono::duration<T> d) {
+model::timeout_clock::time_point timeout(std::chrono::duration<T> d) {
     return model::timeout_clock::now() + d;
 }
 
-static model::node_id wait_for_group_leader(raft_group& gr) {
+inline model::node_id wait_for_group_leader(raft_group& gr) {
     auto leader_id = gr.wait_for_leader().get0();
     assert_at_most_one_leader(gr);
     return leader_id;
 }
 
-static void
+inline void
 assert_stable_leadership(const raft_group& gr, int number_of_intervals = 5) {
     auto before = gr.get_elections_count();
     ss::sleep(heartbeat_interval * number_of_intervals).get0();
@@ -760,7 +760,7 @@ ss::future<bool> retry_with_leader(
       .then([meta] { return meta->success; });
 }
 
-static ss::future<bool> replicate_random_batches(
+inline ss::future<bool> replicate_random_batches(
   raft_group& gr,
   int count,
   raft::consistency_level c_lvl = raft::consistency_level::quorum_ack,
@@ -780,7 +780,7 @@ static ss::future<bool> replicate_random_batches(
       });
 }
 
-static ss::future<bool> replicate_random_batches(
+inline ss::future<bool> replicate_random_batches(
   model::term_id expected_term,
   raft_group& gr,
   int count,
@@ -805,7 +805,7 @@ static ss::future<bool> replicate_random_batches(
 /**
  * Makes compactible batches, having one record per batch
  */
-static model::record_batch_reader
+inline model::record_batch_reader
 make_compactible_batches(int keys, size_t batches, model::timestamp ts) {
     ss::circular_buffer<model::record_batch> ret;
     for (size_t b = 0; b < batches; b++) {
@@ -828,7 +828,7 @@ make_compactible_batches(int keys, size_t batches, model::timestamp ts) {
     return model::make_memory_record_batch_reader(std::move(ret));
 }
 
-static ss::future<bool> replicate_compactible_batches(
+inline ss::future<bool> replicate_compactible_batches(
   raft_group& gr,
   model::timestamp ts,
   model::timeout_clock::duration tout = 1s) {
@@ -846,7 +846,7 @@ static ss::future<bool> replicate_compactible_batches(
     });
 }
 
-static void validate_offset_translation(raft_group& gr) {
+inline void validate_offset_translation(raft_group& gr) {
     // build reference map
     if (gr.get_members().size() == 1) {
         return;

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -665,7 +665,6 @@ inline bool are_logs_equivalent(
 }
 
 inline bool assert_all_logs_are_the_same(const raft_group::logs_t& logs) {
-    auto it = logs.begin();
     auto& reference = logs.begin()->second;
 
     return std::all_of(

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -96,7 +96,6 @@ bool ser_deser_verify(T type) {
     // Serialize
     iobuf out;
     reflection::async_adl<T>{}.to(out, type).get();
-    const auto originals_hash = std::hash<iobuf>{}(out);
 
     // Deserialize
     iobuf_parser in(std::move(out));

--- a/src/v/rpc/test/roundtrip_tests.cc
+++ b/src/v/rpc/test/roundtrip_tests.cc
@@ -30,7 +30,6 @@ SEASTAR_THREAD_TEST_CASE(roundtrip_with_fragmented_buffer) {
         src.oi.append(ss::temporary_buffer<char>(55));
         reflection::serialize(b, std::move(src));
     }
-    const size_t src_size = b.size_bytes();
     auto expected = reflection::adl<complex_custom>{}.from(std::move(b));
     BOOST_REQUIRE_EQUAL(55, expected.oi.size_bytes());
 }

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -334,6 +334,7 @@ FIXTURE_TEST(client_muxing, rpc_integration_fixture) {
                    cycling::san_francisco{66},
                    rpc::client_opts(rpc::no_timeout))
                  .get0();
+    BOOST_REQUIRE(ret.has_value());
     info("Calling echo method");
     auto echo_resp = client
                        .suffix_echo(
@@ -341,6 +342,7 @@ FIXTURE_TEST(client_muxing, rpc_integration_fixture) {
                          rpc::client_opts(rpc::no_timeout))
                        .get0();
     client.stop().get();
+    BOOST_REQUIRE(echo_resp.has_value());
 
     BOOST_REQUIRE_EQUAL(echo_resp.value().data.str, "testing..._suffix");
 }

--- a/src/v/serde/test/fuzz.cc
+++ b/src/v/serde/test/fuzz.cc
@@ -202,8 +202,6 @@ bool test_version_upgrade(
 
 void fuzz_serde(uint8_t const* data, size_t size) {
     constexpr auto const gen1 = std::make_index_sequence<1>();
-    constexpr auto const gen12 = std::make_index_sequence<2>();
-    constexpr auto const gen123 = std::make_index_sequence<3>();
 
     try {
         test_success(types_21{}, {data, size}, gen1);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -284,7 +284,6 @@ FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     std::vector<model::record_batch_header> headers;
-    model::offset current_offset = model::offset{0};
     ss::circular_buffer<model::record_batch> batches;
     std::vector<size_t> term_batches_counts;
     for (auto i = 0; i < 5; i++) {
@@ -304,7 +303,7 @@ FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
       ss::default_priority_class(),
       model::no_timeout};
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
-    auto res = std::move(reader)
+    std::move(reader)
                  .for_each_ref(
                    log.make_appender(append_cfg), append_cfg.timeout)
                  .get0();
@@ -675,7 +674,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
 
-    auto result = append_exactly(log, 10, 100).get0();
+    append_exactly(log, 10, 100).get0();
     BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(9));
 
     std::vector<ss::future<>> futures;
@@ -812,7 +811,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
       model::test::make_random_batch(model::offset(0), 1, false));
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    auto ret = rdr.for_each_ref(std::move(appender), model::no_timeout).get0();
+    rdr.for_each_ref(std::move(appender), model::no_timeout).get0();
 
     // we truncate at {6} so we expect dirty offset equal {5}
     BOOST_REQUIRE_EQUAL(offsets_after_recovery.dirty_offset, model::offset(5));
@@ -887,7 +886,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       model::test::make_random_batch(model::offset(0), 1, false));
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    auto ret = std::move(rdr)
+    std::move(rdr)
                  .for_each_ref(std::move(appender), model::no_timeout)
                  .get0();
 
@@ -1191,7 +1190,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     static constexpr size_t batch_size_ondisk = 1033; // Size internally
     static constexpr size_t input_batch_count = 100;
 
-    auto result = append_exactly(log, input_batch_count, batch_size, "key")
+    append_exactly(log, input_batch_count, batch_size, "key")
                     .get0(); // 100*1_KiB
 
     // Test becomes non-deterministic if we allow flush in background: flush
@@ -1219,7 +1218,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     for (int i = 0; i < 10; ++i) {
         log.compact(ccfg).get0();
     }
-    auto sz_after = get_disk_log(log)->get_probe().partition_size();
+    get_disk_log(log)->get_probe().partition_size();
 
     as.request_abort();
     auto lstats_after = log.offsets();
@@ -1265,7 +1264,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
         auto ntp = model::ntp("default", ssx::sformat("test-{}", i), 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
         auto log = mgr.manage(std::move(ntp_cfg)).get0();
-        auto result = append_exactly(log, 1000, 100).get0();
+        append_exactly(log, 1000, 100).get0();
         logs.push_back(log);
     }
     std::vector<size_t> sizes;
@@ -1776,7 +1775,6 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
       std::nullopt,
       std::nullopt);
 
-    model::offset next_to_read;
     auto truncate_f = ss::now();
     {
         auto reader = log.make_reader(reader_cfg).get();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -304,9 +304,8 @@ FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
       model::no_timeout};
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     std::move(reader)
-                 .for_each_ref(
-                   log.make_appender(append_cfg), append_cfg.timeout)
-                 .get0();
+      .for_each_ref(log.make_appender(append_cfg), append_cfg.timeout)
+      .get0();
     log.flush().get();
 
     auto read_batches = read_and_validate_all_batches(log);
@@ -886,9 +885,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       model::test::make_random_batch(model::offset(0), 1, false));
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    std::move(rdr)
-                 .for_each_ref(std::move(appender), model::no_timeout)
-                 .get0();
+    std::move(rdr).for_each_ref(std::move(appender), model::no_timeout).get0();
 
     // before append offsets should be equal to {1}, as we stopped there
     BOOST_REQUIRE_EQUAL(offsets_after_recovery.dirty_offset, model::offset(1));
@@ -1191,7 +1188,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     static constexpr size_t input_batch_count = 100;
 
     append_exactly(log, input_batch_count, batch_size, "key")
-                    .get0(); // 100*1_KiB
+      .get0(); // 100*1_KiB
 
     // Test becomes non-deterministic if we allow flush in background: flush
     // explicitly instead.

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -158,7 +158,7 @@ public:
 
         // do multiple append calls
 
-        for (auto append : boost::irange(0, appends)) {
+        for ([[maybe_unused]] auto append : boost::irange(0, appends)) {
             auto batches = batch_generator();
             // Collect batches offsets
             for (auto& b : batches) {

--- a/src/v/utils/tests/input_stream_fanout_test.cc
+++ b/src/v/utils/tests/input_stream_fanout_test.cc
@@ -82,7 +82,6 @@ void test_async_read(
     auto is = make_iobuf_input_stream(std::move(input));
     auto streams = input_stream_fanout<N>(std::move(is), readahead, limit);
     ss::gate g;
-    int cnt_a = 0;
     auto dispatch_bg_read = [&g, &copy](auto sa) mutable {
         auto cnt = ss::make_lw_shared<int>(0);
         (void)ss::with_gate(g, [&copy, cnt, sa = std::move(sa)]() mutable {

--- a/src/v/utils/tests/retry_chain_node_test.cc
+++ b/src/v/utils/tests/retry_chain_node_test.cc
@@ -154,7 +154,6 @@ SEASTAR_THREAD_TEST_CASE(check_abort_requested_fail) {
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_1) {
     retry_chain_node n1;
     retry_chain_node n2(1000ms, 100ms, &n1);
-    auto now = ss::lowres_clock::now();
     BOOST_REQUIRE(n1.get_timeout() == 0ms);
     BOOST_REQUIRE(n2.get_timeout() == 1000ms);
 }
@@ -162,7 +161,6 @@ SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_1) {
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_2) {
     retry_chain_node n1(1000ms, 100ms);
     retry_chain_node n2(500ms, 100ms, &n1);
-    auto now = ss::lowres_clock::now();
     BOOST_REQUIRE(n1.get_timeout() == 1000ms);
     BOOST_REQUIRE(n2.get_timeout() == 500ms);
 }
@@ -170,7 +168,6 @@ SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_2) {
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_3) {
     retry_chain_node n1(500ms, 100ms);
     retry_chain_node n2(1000ms, 100ms, &n1);
-    auto now = ss::lowres_clock::now();
     BOOST_REQUIRE(n1.get_timeout() == 500ms);
     BOOST_REQUIRE(n2.get_timeout() == 500ms);
 }


### PR DESCRIPTION
## Cover letter

Enables -Wall for the build and fixes outstanding warnings, mostly in tests.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* None