### PR TITLE
build, go/kreq-gen: let cmake find the path to "go" executable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,8 +22,6 @@ ccache -p # print the config
 ccache -s # print the stats before reusing
 ccache -z # zero the stats
 
-go=$(which go)
-
 # Change Debug via  -DCMAKE_BUILD_TYPE=Debug
 cmake -DCMAKE_BUILD_TYPE=Release \
   -B$root/build \
@@ -31,7 +29,6 @@ cmake -DCMAKE_BUILD_TYPE=Release \
   -GNinja \
   -DCMAKE_C_COMPILER=$CC \
   -DCMAKE_CXX_COMPILER=$CXX \
-  -DCMAKE_GO_BINARY=$(go) \
   -DDEPOT_TOOLS_DIR=$DEPOT_TOOLS_DIR \
   "$@"
 

--- a/src/go/kreq-gen/CMakeLists.txt
+++ b/src/go/kreq-gen/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_program(GO_EXECUTABLE go)
-set(CMAKE_GO_BINARY "${GO_EXECUTABLE}" CACHE PATH "path to go executable")
 if(NOT GO_EXECUTABLE)
   message(FATAL_ERROR "Can't find go executable. Is golang installed?")
 endif()
@@ -10,7 +9,7 @@ function(add_go_dependency NAME MAIN_SRC)
   get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
   add_custom_target(${NAME})
   add_custom_command(TARGET ${NAME}
-                    COMMAND env GOPATH=${GOPATH} ${CMAKE_GO_BINARY} build
+                    COMMAND env GOPATH=${GOPATH} ${GO_EXECUTABLE} build
                     -modcacherw -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}"
                     ${CMAKE_GO_FLAGS} ${MAIN_SRC}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/src/go/kreq-gen/CMakeLists.txt
+++ b/src/go/kreq-gen/CMakeLists.txt
@@ -1,3 +1,9 @@
+find_program(GO_EXECUTABLE go)
+set(CMAKE_GO_BINARY "${GO_EXECUTABLE}" CACHE PATH "path to go executable")
+if(NOT GO_EXECUTABLE)
+  message(FATAL_ERROR "Can't find go executable. Is golang installed?")
+endif()
+
 set(GOPATH ${CMAKE_CURRENT_BINARY_DIR})
 
 function(add_go_dependency NAME MAIN_SRC)


### PR DESCRIPTION
## Cover letter

this allows developer to build the tree without relying on build.sh.
cmake script is supposed to be self-contained in the sense that it
should be able to detect the dependencies, and fail whe generating
the building system if any of the dependencies is not satisified.
so, in this change, a cached variable is added to store the path to
"go" compiler. this allows us to build the tree with cmake, and
to override the path by passing `-DCMAKE_GO_BINARY=/path/to/go`.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.



Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
