### PR TITLE
ducktape: test_cancelling_partition_move_x_core wait movement starts before cancelling

### DIFF
--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -214,6 +214,7 @@ class PartitionMovementMixin():
         """
         Request partition movement to interrupt and validates resulting cancellation against previous assignment
         """
+        self._wait_for_move_in_progress(topic, partition)
         admin = Admin(self.redpanda)
         try:
             if unclean_abort:


### PR DESCRIPTION
## Cover letter

Add wait until movement starts before cancelling it.
Error was described in linked issue

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6009

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
