### PR TITLE
tests: increase timeout in FeaturesNodeJoinTest

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -370,6 +370,9 @@ class FeaturesNodeJoinTest(RedpandaTest):
         # Restart it with a sufficiently recent version and join should succeed
         self.installer.install([old_node], RedpandaInstaller.HEAD)
         self.redpanda.restart_nodes([old_node])
+
+        # Timeout long enough for join retries & health monitor tick (registered
+        # requires `is_alive`)
         wait_until(lambda: self.redpanda.registered(old_node),
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=1)


### PR DESCRIPTION
## Cover letter

This prepares it for the change to wait_until
that removes the post-wait sleep.

Fixes https://github.com/redpanda-data/redpanda/issues/6145

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
