### PR TITLE
tests: make test_leader_transfers_recovery more robust

### DIFF
--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -29,6 +29,7 @@ class RpkProducer(BackgroundThreadService):
         self._printable = printable
         self._stopping = Event()
         self._quiet = quiet
+        self._output_line_count = 0
 
         if produce_timeout is None:
             produce_timeout = 10
@@ -61,6 +62,7 @@ class RpkProducer(BackgroundThreadService):
             for line in node.account.ssh_capture(
                     cmd, timeout_sec=self._produce_timeout):
                 self.logger.debug(line.rstrip())
+                self._output_line_count += 1
         except RemoteCommandError:
             if self._stopping.is_set():
                 pass
@@ -69,6 +71,10 @@ class RpkProducer(BackgroundThreadService):
 
         self._redpanda.logger.debug(
             f"Finished sending {self._msg_count} messages")
+
+    @property
+    def output_line_count(self):
+        return self._output_line_count
 
     def stop_node(self, node):
         self._stopping.set()


### PR DESCRIPTION
## Cover letter

    tests: make test_leader_transfers_recovery more robust
    
    If leader transfers are done in quick succession, this
    can cause a client to stall out for some period of time
    long enough to time out the SSH session in RpkProducer.
    
    Avoid this by not starting the next leadership transfer
    until we see some producer progress after the previous
    one.
    
    Fixes https://github.com/redpanda-data/redpanda/issues/6150


## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none