### PR TITLE
Schema Registry: Explicitly set compression to none for _schemas

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -159,7 +159,9 @@ ss::future<> service::create_internal_topic() {
           .assignments{},
           .configs{
             {.name{ss::sstring{kafka::topic_property_cleanup_policy}},
-             .value{"compact"}}}};
+             .value{"compact"}},
+            {.name{ss::sstring{kafka::topic_property_compression}},
+             .value{ssx::sformat("{}", model::compression::none)}}}};
     };
     auto res = co_await _client.local().create_topic(make_internal_topic());
     if (res.data.topics.size() != 1) {


### PR DESCRIPTION
## Cover letter

kafka/client doesn't yet support compressed batches #3062

Disable compression on the `_schemas` topic so that a client
producing to the topic (e.g., rpk) doesn't compress the batches.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

If a kafka client produces to the `_schemas` topic, it may be tempted to use the default compression policy, which, by default, is producer. Compression isn't supported; explicitly set the compression to none to better support manually creating schema.

## Release notes

### Improvements

* Schema Registry: Disable compression on the `_schemas` topic to better support manually creating schema.
