### PR TITLE
[v21.11.x] test: disable leader balancer in RecreateTopicMetadataTest

### DIFF
--- a/tests/rptest/tests/recreate_topic_metadata_test.py
+++ b/tests/rptest/tests/recreate_topic_metadata_test.py
@@ -21,10 +21,14 @@ from rptest.tests.redpanda_test import RedpandaTest
 class RecreateTopicMetadataTest(RedpandaTest):
     def __init__(self, test_context):
 
-        super(RecreateTopicMetadataTest,
-              self).__init__(test_context=test_context,
-                             num_brokers=5,
-                             extra_rp_conf={})
+        super(RecreateTopicMetadataTest, self).__init__(
+            test_context=test_context,
+            num_brokers=5,
+            extra_rp_conf={
+                # Test does explicit leadership movements
+                # that the balancer would interfere with.
+                'enable_leader_balancer': False
+            })
 
     @cluster(num_nodes=5)
     @parametrize(replication_factor=3)


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/4042.
