### PR TITLE
Fix 6132: retry topic creation on missing controller leader

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -13,6 +13,7 @@ import typing
 import time
 from typing import Optional
 from ducktape.cluster.cluster import ClusterNode
+from rptest.util import wait_until_result
 from rptest.services import tls
 
 DEFAULT_TIMEOUT = 30
@@ -120,17 +121,28 @@ class RpkTool:
         self._tls_cert = tls_cert
 
     def create_topic(self, topic, partitions=1, replicas=None, config=None):
-        cmd = ["create", topic]
-        cmd += ["--partitions", str(partitions)]
-        if replicas is not None:
-            cmd += ["--replicas", str(replicas)]
-        if config is not None:
-            cfg = [f"{k}:{v}" for k, v in config.items()]
-            for it in cfg:
-                cmd += ["--topic-config", it]
-        output = self._run_topic(cmd)
-        self._check_stdout_success(output)
-        return output
+        def create_topic():
+            try:
+                cmd = ["create", topic]
+                cmd += ["--partitions", str(partitions)]
+                if replicas is not None:
+                    cmd += ["--replicas", str(replicas)]
+                if config is not None:
+                    cfg = [f"{k}:{v}" for k, v in config.items()]
+                    for it in cfg:
+                        cmd += ["--topic-config", it]
+                output = self._run_topic(cmd)
+                self._check_stdout_success(output)
+                return (True, output)
+            except RpkException as e:
+                if "Kafka replied that the controller broker is -1" in str(e):
+                    return False
+                raise e
+
+        wait_until_result(create_topic,
+                          10,
+                          0.1,
+                          err_msg="Can't create a topic within 10s")
 
     def add_partitions(self, topic, partitions):
         cmd = ["add-partitions", topic, "-n", str(partitions)]

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -31,6 +31,8 @@ from rptest.clients.default import DefaultClient
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
 from rptest.archival.s3_client import S3Client
+from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -124,6 +126,11 @@ class EndToEndTest(Test):
             self.redpanda.restart_nodes(nodes_to_upgrade)
 
         self._client = DefaultClient(self.redpanda)
+        self._rpk_client = RpkTool(self.redpanda)
+
+    def rpk_client(self):
+        assert self._rpk_client is not None
+        return self._rpk_client
 
     def client(self):
         assert self._client is not None

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -602,8 +602,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         # create a single topic with replication factor of 1
         topic = 'test-topic'
-        rpk = RpkTool(self.redpanda)
-        rpk.create_topic(topic, 1, 1)
+        self.rpk_client().create_topic(topic, 1, 1)
         partition = 0
         num_records = 1000
 
@@ -673,12 +672,12 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         wait_until(lambda: get_status() == 'in_progress', 10, 1)
         # delete the topic
-        rpk.delete_topic(topic)
+        self.rpk_client().delete_topic(topic)
 
         # start the node back up
         self.redpanda.start_node(node)
         # create topic again
-        rpk.create_topic(topic, 1, 1)
+        self.rpk_client().create_topic(topic, 1, 1)
         wait_until(lambda: get_status() == 'done', 10, 1)
 
     @cluster(num_nodes=5)


### PR DESCRIPTION
## Cover letter

Retry topic creation on missing controller leader (pr-blocker fix);

Fixes #6132 

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none