### PR TITLE
rpk: send cluster config updates to leader

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -106,7 +106,7 @@ func (a *AdminAPI) PatchClusterConfig(
 	}
 
 	var result ClusterConfigWriteResult
-	err := a.sendAny(ctx, http.MethodPut, "/v1/cluster_config", body, &result)
+	err := a.sendToLeader(ctx, http.MethodPut, "/v1/cluster_config", body, &result)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION

## Cover letter

...rather than to any node, and relying on
forwarding to leader.

This gets a more deterministic result in the edge
case of no-op changes where rpk cannot determine
client-side that it is a no-op, and relies on
the admin API code to do that.

Because this check is done on in the admin API handler,
it happens on whichever node the request lands on, which
could be an out of date follower, in which case we might
write a (harmless, redundant) additional config version to
the controller log.

That can trip up an automated test.

Fixes https://github.com/redpanda-data/redpanda/issues/6163

## Backport Required

- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none