### PR TITLE
cloud_storage: Segment prefetching

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -18,6 +18,7 @@ v_cc_library(
     remote_partition.cc
     remote_segment_index.cc
     tx_range_manifest.cc
+    prefetch_tracker.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "model/fundamental.h"
+#include "utils/hdr_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -32,6 +33,8 @@ public:
     void segment_reader_created() { ++_cur_segment_readers; }
     void segment_reader_destroyed() { --_cur_segment_readers; }
 
+    std::unique_ptr<hdr_hist::measurement> auto_segment_wait_measurement();
+
 private:
     uint64_t _bytes_read = 0;
     uint64_t _records_read = 0;
@@ -41,6 +44,9 @@ private:
 
     int32_t _cur_readers = 0;
     int32_t _cur_segment_readers = 0;
+
+    /// Time reader spends waiting for segment download
+    hdr_hist _reader_segment_wait;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/cloud_storage/prefetch_tracker.cc
+++ b/src/v/cloud_storage/prefetch_tracker.cc
@@ -1,0 +1,72 @@
+#include "cloud_storage/prefetch_tracker.h"
+
+#include "cloud_storage/logger.h"
+#include "config/configuration.h"
+
+namespace cloud_storage {
+
+prefetch_tracker::prefetch_tracker()
+  : _enabled(config::shard_local_cfg().cloud_storage_prefetch_enable.value())
+  , _prefetch_threshold(
+      config::shard_local_cfg().cloud_storage_prefetch_threshold.value())
+  , _prefetch_size(
+      config::shard_local_cfg().cloud_storage_prefetch_size_trigger.value()) {}
+
+prefetch_tracker::prefetch_tracker(
+  bool enabled, size_t threshold, size_t limit) noexcept
+  : _enabled(enabled)
+  , _prefetch_threshold(threshold)
+  , _prefetch_size(limit) {}
+
+void prefetch_tracker::on_new_segment() {
+    _segment_ready = false;
+    _segment_bytes = 0;
+    _segment_size = 0;
+}
+
+void prefetch_tracker::set_segment_size(size_t sz) { _segment_size = sz; }
+
+void prefetch_tracker::on_bytes_consumed(size_t sz) {
+    _total_bytes += sz;
+    _segment_bytes += sz;
+}
+
+bool prefetch_tracker::operator()() {
+    if (!_enabled) {
+        return false;
+    }
+    if (_total_bytes < _prefetch_threshold) {
+        vlog(
+          cst_log.trace,
+          "prefetch_tracker: prefetch disabled, {} is less than threshold {}",
+          _total_bytes,
+          _prefetch_threshold);
+        return false;
+    }
+    auto bytes_remains = _segment_size - _segment_bytes;
+    if (
+      !_segment_ready && _segment_size >= _prefetch_size
+      && bytes_remains <= _prefetch_size) {
+        vlog(
+          cst_log.debug,
+          "prefetch_tracker: prefetch enabled, segment bytes {} is less than "
+          "prefetch limit {}",
+          _segment_bytes,
+          _prefetch_size);
+        _segment_ready = true;
+        return true;
+    }
+    vlog(
+      cst_log.trace,
+      "prefetch_tracker: prefetch disabled, segment bytes {} is greater than "
+      "prefetch limit {} or segment ready is {}",
+      _segment_bytes,
+      _prefetch_size,
+      _segment_ready);
+    return false;
+}
+
+const prefetch_tracker prefetch_tracker::disabled = prefetch_tracker(
+  false, 0, 0);
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/prefetch_tracker.h
+++ b/src/v/cloud_storage/prefetch_tracker.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+#include "config/property.h"
+
+namespace cloud_storage {
+
+/** Prefetch tracker for partition_record_batch_reader_impl.
+ * The object of this class is created per reader. It is passed
+ * to every remote_segment_batch_reader instance that partition
+ * reader uses. When the partition is destroyed the instance of
+ * the prefetch_tracker can still be stored inside the cached
+ * remote_segment_batch_reader instance. Once the segment reader is completed
+ * the partition reader have to extract the tracker out of it and
+ * add it to the next segment reader.
+ */
+class prefetch_tracker {
+public:
+    static const prefetch_tracker disabled;
+    /// Default c-tor will bind to config::shard_local_cfg()
+    /// properties.
+    prefetch_tracker();
+    /// This c-tor can be used to pass custom bindings
+    /// that could bind to something other than config::shard_local_cfg()
+    prefetch_tracker(bool enabled, size_t threshold, size_t limit) noexcept;
+
+    void on_new_segment();
+    void set_segment_size(size_t sz);
+    void on_bytes_consumed(size_t sz);
+    bool operator()();
+
+private:
+    bool _segment_ready{false};
+    size_t _segment_bytes{0};
+    size_t _segment_size{0};
+    size_t _total_bytes{0};
+    bool _enabled;
+    size_t _prefetch_threshold;
+    size_t _prefetch_size;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -95,6 +95,14 @@ remote_probe::remote_probe(
               "bytes_received",
               [this] { return _cnt_bytes_received; },
               sm::description("Number of bytes received from cloud storage")),
+            sm::make_histogram(
+              "segment_hydration_latency",
+              sm::description("Segment hydration latency"),
+              [this] {
+                  return ssx::metrics::report_default_histogram(
+                    _segment_hydration);
+              })
+              .aggregate({sm::shard_label}),
           });
     }
 
@@ -121,6 +129,11 @@ remote_probe::remote_probe(
              {direction_label("rx")})
              .aggregate({sm::shard_label})});
     }
+}
+
+std::unique_ptr<hdr_hist::measurement>
+remote_probe::auto_hydration_measurement() {
+    return _segment_hydration.auto_measure();
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -13,9 +13,11 @@
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "utils/hdr_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 
+#include <chrono>
 #include <cstdint>
 
 namespace cloud_storage {
@@ -149,6 +151,8 @@ public:
 
     void register_download_size(size_t n) { _cnt_bytes_received += n; }
 
+    std::unique_ptr<hdr_hist::measurement> auto_hydration_measurement();
+
 private:
     /// Number of topic manifest uploads
     uint64_t _cnt_topic_manifest_uploads{0};
@@ -186,6 +190,8 @@ private:
     uint64_t _cnt_tx_manifest_uploads{0};
     /// Number of tx-range manifest downloads
     uint64_t _cnt_tx_manifest_downloads{0};
+    /// Hydration latency
+    hdr_hist _segment_hydration;
 
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -471,6 +471,7 @@ ss::future<download_result> remote::download_segment(
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Download segment {}", path);
     std::optional<download_result> result;
+    auto latency_probe = _probe.auto_hydration_measurement();
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         std::exception_ptr eptr = nullptr;
         try {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -314,6 +314,8 @@ private:
     iterator end();
     iterator upper_bound(model::offset);
 
+    void bg_prefetch_segment(iterator it);
+
     using segment_map_t = absl::btree_map<model::offset, segment_state>;
 
     using evicted_resource_t = std::variant<

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -198,6 +198,8 @@ remote_segment::data_stream(size_t pos, ss::io_priority_class io_priority) {
     co_return storage::segment_reader_handle(std::move(data_stream));
 }
 
+size_t remote_segment::get_segment_size_bytes() const { return _segment_size; }
+
 ss::future<remote_segment::input_stream_with_offsets>
 remote_segment::offset_data_stream(
   model::offset kafka_offset, ss::io_priority_class io_priority) {
@@ -291,6 +293,7 @@ ss::future<> remote_segment::do_hydrate_segment() {
             co_await _cache.put(_path().native() + ".index", index_stream);
             _index = std::move(tmpidx);
         }
+        _segment_size = size_bytes;
         co_return size_bytes;
     };
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -948,6 +948,10 @@ remote_segment_batch_reader::read_some(
               _cur_rp_offset,
               _bytes_consumed));
         }
+        if (new_bytes_consumed.value() > _bytes_consumed) {
+            _prefetch.on_bytes_consumed(
+              new_bytes_consumed.value() - _bytes_consumed);
+        }
         _bytes_consumed = new_bytes_consumed.value();
     }
     _total_size = 0;
@@ -969,6 +973,7 @@ remote_segment_batch_reader::init_parser() {
       storage::segment_reader_handle(std::move(stream_off.stream)));
     _cur_rp_offset = stream_off.rp_offset;
     _cur_delta = stream_off.rp_offset - stream_off.kafka_offset;
+    _prefetch.set_segment_size(_seg->get_segment_size_bytes());
     co_return parser;
 }
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -126,6 +126,9 @@ public:
     ss::future<std::vector<cluster::rm_stm::tx_range>>
     aborted_transactions(model::offset from, model::offset to);
 
+    /// Size of the segment in bytes
+    size_t get_segment_size_bytes() const;
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available
@@ -181,6 +184,8 @@ private:
 
     using tx_range_vec = fragmented_vector<cluster::rm_stm::tx_range>;
     std::optional<tx_range_vec> _tx_range;
+
+    size_t _segment_size{0};
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ rp_test(
     remote_segment_test.cc
     remote_partition_test.cc
     remote_segment_index_test.cc 
+    prefetch_tracker_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/prefetch_tracker_test.cc
+++ b/src/v/cloud_storage/tests/prefetch_tracker_test.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/prefetch_tracker.h"
+#include "cloud_storage/types.h"
+#include "config/base_property.h"
+#include "config/configuration.h"
+#include "config/property.h"
+#include "redpanda/tests/fixture.h"
+#include "seastarx.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace cloud_storage;
+
+SEASTAR_THREAD_TEST_CASE(test_prefetch_tracker) { // NOLINT
+    prefetch_tracker tracker(true, 100, 10);
+
+    tracker.on_new_segment();
+    tracker.set_segment_size(200);
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(10); // consumed 10 bytes, 190 bytes remains
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(100); // consumed 110 bytes, 90 bytes remains
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(80); // consumed 190 bytes, 10 bytes remains
+    BOOST_REQUIRE(tracker());
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(10); // consumed 200 bytes, 0 bytes remains
+    BOOST_REQUIRE(!tracker());
+    tracker.on_new_segment();
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(
+      10); // consumed 10 bytes, segment size not known yet
+    BOOST_REQUIRE(!tracker());
+    tracker.set_segment_size(200);
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(100); // consumed 100 bytes, 90 bytes remains
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(80); // consumed 100 bytes, 0 bytes remains
+    BOOST_REQUIRE(tracker());
+    BOOST_REQUIRE(!tracker());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_prefetch_tracker_small_segments) { // NOLINT
+    // Validate that prefetching is not utilized for small segments
+    prefetch_tracker tracker(true, 0, 100);
+
+    tracker.on_new_segment();
+    tracker.set_segment_size(50);
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(10);
+    BOOST_REQUIRE(!tracker());
+    tracker.on_bytes_consumed(40);
+    BOOST_REQUIRE(!tracker());
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1115,6 +1115,27 @@ configuration::configuration()
       "Timeout to check if cache eviction should be triggered",
       {.visibility = visibility::tunable},
       30s)
+  , cloud_storage_prefetch_enable(
+      *this,
+      "cloud_storage_prefetch_enable",
+      "Enable prefetch in shadow indexing",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
+  , cloud_storage_prefetch_size_trigger(
+      *this,
+      "cloud_storage_prefetch_size_trigger",
+      "The prefetching of the next segment should be triggered when this "
+      "number or fewer bytes remain to be consumed by the reader from the "
+      "segment",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      32_MiB)
+  , cloud_storage_prefetch_threshold(
+      *this,
+      "cloud_storage_prefetch_threshold",
+      "Prefetch is used only for sequential readers that consumed at least "
+      "this number of bytes",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_GiB)
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -238,6 +238,11 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
 
+    // SI prefetch control
+    property<bool> cloud_storage_prefetch_enable;
+    property<size_t> cloud_storage_prefetch_size_trigger;
+    property<size_t> cloud_storage_prefetch_threshold;
+
     one_or_many_property<ss::sstring> superusers;
 
     // kakfa queue depth control: latency ewma


### PR DESCRIPTION
## Cover letter

Implement prefetching of segments.
The prefetching is controlled by three parameters in the config:
- `cloud_storage_prefetch_enabled` is a flag that enables or disables prefetching
- `cloud_storage_prefetch_threshold` is a number of bytes that consumer has to consume before prefetching will be enabled for it
- `cloud_storage_prefetch_size_limit` number of bytes left to be consumed in the segment when the prefetching can kick in

By default the feature is enabled and the threshold is set to 1GiB. So it will only be used for readers that were able to read more than one GiB. The next segment download will be started only when there is only 32MiB left to read in a current segment.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* Three new configuration parameters are introduced to control segment prefetching in shadow indexing. `cloud_storage_prefetch_enabled`, `cloud_storage_prefetch_threshold`, and `cloud_storage_prefetch_size_limit`.

## Release notes

* Segment prefetching for Shadow Indexing is implemented

### Features

* none

### Improvements

* none