### PR TITLE
tests: Retry group describe on NOT_COORDINATOR error

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -415,6 +415,9 @@ class RpkTool:
                 if "COORDINATOR_NOT_AVAILABLE" in e.msg:
                     # Transient, return None to retry
                     return None
+                elif "NOT_COORDINATOR" in e.msg:
+                    # Transient, retry
+                    return None
                 elif "Kafka replied that group" in e.msg:
                     # Transient, return None to retry
                     # e.g. Kafka replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list


### PR DESCRIPTION
## Cover letter

`NOT_COORDINATOR: This is not the correct coordinator`

is a retry-able transient error. Let the wrapper retry.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6173

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none