### PR TITLE
[v21.11.x] tests: shrink client port range to protect 33145

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       nofile:
         soft: 131072
         hard: 131072
+    sysctls:
+      net.ipv4.ip_local_port_range: 34000 60999
     depends_on: 
     - minio
     volumes:

--- a/tests/rptest/tests/configuration_update_test.py
+++ b/tests/rptest/tests/configuration_update_test.py
@@ -15,6 +15,11 @@ from rptest.services.redpanda import RedpandaService
 
 from rptest.tests.redpanda_test import RedpandaTest
 
+# Choose ports _below_ the default 33145, because test environment
+# is configured to only use emphemeral ports above 34000: this avoids
+# port collisions.
+ALTERNATIVE_RPC_PORTS = [12345, 20001]
+
 
 class ConfigurationUpdateTest(RedpandaTest):
     """
@@ -31,10 +36,10 @@ class ConfigurationUpdateTest(RedpandaTest):
         self.redpanda.stop_node(node_1)
         self.redpanda.stop_node(node_2)
         # change both ports
-        altered_port_cfg_1 = dict(
-            rpc_server=dict(address="{}".format(node_1.name), port=12345))
-        altered_port_cfg_2 = dict(
-            rpc_server=dict(address="{}".format(node_2.name), port=54321))
+        altered_port_cfg_1 = dict(rpc_server=dict(
+            address="{}".format(node_1.name), port=ALTERNATIVE_RPC_PORTS[0]))
+        altered_port_cfg_2 = dict(rpc_server=dict(
+            address="{}".format(node_2.name), port=ALTERNATIVE_RPC_PORTS[1]))
 
         # start both nodes
         self.redpanda.start_node(node_1, altered_port_cfg_1)
@@ -130,7 +135,8 @@ class ConfigurationUpdateTest(RedpandaTest):
 
         # change rpc port & kafka advertised address
         altered_port_cfg_1 = dict(
-            rpc_server=dict(address="{}".format(node.name), port=54321),
+            rpc_server=dict(address="{}".format(node.name),
+                            port=ALTERNATIVE_RPC_PORTS[1]),
             kafka_api=make_new_address(node, 10091),
             advertised_kafka_api=make_new_address(node, 10091))
         # remove node data folder


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/3954.
Fixes https://github.com/redpanda-data/redpanda/issues/6177,