### PR TITLE
Made `offset_for_leader_epoch_archival` more robust

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -157,8 +157,9 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
                    timeout_sec=120,
                    backoff_sec=5,
                    err_msg="Segments were not removed")
-    except:
+    except Exception as e:
         # On errors, dump listing of the storage location
+        redpanda.logger.error(f"Error waiting for segments removal: {e}")
         for node in redpanda.nodes:
             redpanda.logger.error(f"Storage listing on {node.name}:")
             for line in node.account.ssh_capture(f"find {redpanda.DATA_DIR}"):


### PR DESCRIPTION
## Cover letter

Made `offset_for_leader_epoch_archival` more robust by retrying setting a topic retention when it failed.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6170 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
