### PR TITLE
Validate under replicated metric after consumer is done

### DIFF
--- a/tests/rptest/tests/cluster_metadata_test.py
+++ b/tests/rptest/tests/cluster_metadata_test.py
@@ -79,4 +79,4 @@ class MetadataTest(RedpandaTest):
                 returned_ids = [n.id for n in nodes]
                 return len(nodes) == 2 and node_id not in returned_ids
 
-            wait_until(contains_only_alive_nodes, 30, 1)
+            wait_until(contains_only_alive_nodes, 60)

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -107,13 +107,13 @@ class FullNodeRecoveryTest(EndToEndTest):
                 f"under replicated partitions: {list(under_replicated)}")
             return len(under_replicated) == 0
 
-        # wait for prepopulated topic to recover
-        wait_until(all_topics_recovered, 60, 1)
-
         self.run_validation(min_records=20000,
                             enable_idempotence=False,
                             producer_timeout_sec=60,
                             consumer_timeout_sec=180)
+
+        # wait for prepopulated topic to recover
+        wait_until(all_topics_recovered, 60, 1)
 
         # validate prepopulated topic offsets
         assert offsets == list_offsets()


### PR DESCRIPTION
## Cover letter

Change the order of validation in full node recovery test. Now we first
wait for all the messages to be consumed and only then check if recovery
has finished. The change does not change the invariants validated in
test but allow it to finish earlier.

Fixes: #6151

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
