### PR TITLE
[v22.2.x] ducktape: test_cancelling_partition_move_x_core wait movement starts before cancelling

### DIFF
--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -214,6 +214,7 @@ class PartitionMovementMixin():
         """
         Request partition movement to interrupt and validates resulting cancellation against previous assignment
         """
+        self._wait_for_move_in_progress(topic, partition)
         admin = Admin(self.redpanda)
         try:
             if unclean_abort:


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6152.
Fixes https://github.com/redpanda-data/redpanda/issues/6189,