### PR TITLE
[v22.2.x]  cloud_storage: interrupt downloading segment

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -66,7 +66,7 @@ ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
         return storage::batch_consumer::consume_result::accept_batch;
     };
     auto len = co_await storage::transform_stream(
-      std::move(src), std::move(dst), pred);
+      std::move(src), std::move(dst), pred, _as);
     if (len.has_error()) {
         throw std::system_error(len.error());
     }

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -12,6 +12,7 @@
 
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
+#include "storage/types.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/iostream.hh>
@@ -26,8 +27,11 @@ namespace cloud_storage {
 /// It consumes information stored in the manifest.
 class offset_translator final {
 public:
-    explicit offset_translator(model::offset initial_delta)
-      : _initial_delta(initial_delta) {}
+    offset_translator(
+      model::offset initial_delta,
+      storage::opt_abort_source_t as = std::nullopt)
+      : _initial_delta(initial_delta)
+      , _as(as) {}
 
     struct stream_stats {
         model::offset min_offset;
@@ -52,6 +56,7 @@ public:
 
 private:
     model::offset _initial_delta;
+    storage::opt_abort_source_t _as;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -83,7 +83,11 @@ partition_recovery_manager::~partition_recovery_manager() {
     vassert(_gate.is_closed(), "S3 downloader is not stopped properly");
 }
 
-ss::future<> partition_recovery_manager::stop() { co_await _gate.close(); }
+ss::future<> partition_recovery_manager::stop() {
+    vlog(cst_log.debug, "Stopping partition_recovery_manager");
+    _as.request_abort();
+    return _gate.close();
+}
 
 ss::future<log_recovery_result> partition_recovery_manager::download_log(
   const storage::ntp_config& ntp_cfg, cluster::remote_topic_properties rtp) {
@@ -101,7 +105,7 @@ ss::future<log_recovery_result> partition_recovery_manager::download_log(
         co_return log_recovery_result{};
     }
     partition_downloader downloader(
-      ntp_cfg, &_remote.local(), rtp, _bucket, _gate, _root);
+      ntp_cfg, &_remote.local(), rtp, _bucket, _gate, _root, _as);
     co_return co_await downloader.download_log();
 }
 
@@ -111,7 +115,8 @@ partition_downloader::partition_downloader(
   cluster::remote_topic_properties rtp,
   s3::bucket_name bucket,
   ss::gate& gate_root,
-  retry_chain_node& parent)
+  retry_chain_node& parent,
+  storage::opt_abort_source_t as)
   : _ntpc(ntpc)
   , _bucket(std::move(bucket))
   , _remote(remote)
@@ -121,7 +126,8 @@ partition_downloader::partition_downloader(
   , _ctxlog(
       cst_log,
       _rtcnode,
-      ssx::sformat("[{}, rev: {}]", ntpc.ntp().path(), ntpc.get_revision())) {}
+      ssx::sformat("[{}, rev: {}]", ntpc.ntp().path(), ntpc.get_revision()))
+  , _as(as) {}
 
 ss::future<log_recovery_result> partition_downloader::download_log() {
     vlog(_ctxlog.debug, "Check conditions for S3 recovery for {}", _ntpc);
@@ -556,7 +562,7 @@ partition_downloader::download_segment_file(
       segm.meta.size_bytes,
       part.part_prefix.string());
 
-    offset_translator otl{segm.meta.delta_offset};
+    offset_translator otl{segm.meta.delta_offset, _as};
 
     auto localpath = part.part_prefix
                      / std::string{otl.get_adjusted_segment_name(

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -79,6 +79,7 @@ private:
     ss::sharded<remote>& _remote;
     ss::gate _gate;
     retry_chain_node _root;
+    ss::abort_source _as;
 };
 
 /// Topic downloader is used to download topic segments from S3 (or compatible
@@ -93,7 +94,8 @@ public:
       cluster::remote_topic_properties rtp,
       s3::bucket_name bucket,
       ss::gate& gate_root,
-      retry_chain_node& parent);
+      retry_chain_node& parent,
+      storage::opt_abort_source_t as);
 
     partition_downloader(const partition_downloader&) = delete;
     partition_downloader(partition_downloader&&) = delete;
@@ -195,6 +197,7 @@ private:
     ss::gate& _gate;
     retry_chain_node _rtcnode;
     retry_chain_logger _ctxlog;
+    storage::opt_abort_source_t _as;
 };
 
 } // namespace cloud_storage

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -298,10 +298,12 @@ public:
     explicit copy_helper(
       ss::input_stream<char> input,
       ss::output_stream<char> output,
-      record_batch_transform_predicate pred)
+      record_batch_transform_predicate pred,
+      opt_abort_source_t as)
       : _input(std::move(input))
       , _output(std::move(output))
-      , _pred(std::move(pred)) {}
+      , _pred(std::move(pred))
+      , _as(as) {}
 
     ss::future<result<model::record_batch_header>> read_header() {
         return read_header_impl(_input, ss::sstring("copy_helper"));
@@ -312,7 +314,8 @@ public:
     ss::future<result<size_t>> run() {
         size_t consumed = 0;
         bool stop = false;
-        while (!stop) {
+        while (!stop
+               && (!_as.has_value() || !_as.value().get().abort_requested())) {
             auto r = co_await read_header();
             if (!r) {
                 if (r.error() == parser_errc::end_of_stream) {
@@ -386,13 +389,15 @@ public:
     ss::output_stream<char> _output;
     record_batch_transform_predicate _pred;
     model::record_batch_header _header{};
+    opt_abort_source_t _as;
 };
 
 ss::future<result<size_t>> transform_stream(
   ss::input_stream<char> in,
   ss::output_stream<char> out,
-  record_batch_transform_predicate pred) {
-    copy_helper helper(std::move(in), std::move(out), std::move(pred));
+  record_batch_transform_predicate pred,
+  opt_abort_source_t as) {
+    copy_helper helper(std::move(in), std::move(out), std::move(pred), as);
     co_return co_await helper.run().finally(
       [&helper] { return helper.close(); });
 }

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -160,6 +160,7 @@ using record_batch_transform_predicate = ss::noncopyable_function<
 ss::future<result<size_t>> transform_stream(
   ss::input_stream<char> in,
   ss::output_stream<char> out,
-  record_batch_transform_predicate pred);
+  record_batch_transform_predicate pred,
+  opt_abort_source_t as = std::nullopt);
 
 } // namespace storage


### PR DESCRIPTION
Backport of #5847

cloud_storage::remote may download a big segment and redpanda will not
be stopped until the segment is fully downloaded. This commit adds an
abort source that is passed to the offset_translator.
partition_recovery_manager may interrupt segment download with this
abort source.

(cherry picked from commit af30270f16604ec0b90d3ba497edea94b6110456)
