### PR TITLE
build: allow disabling just git hash

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -37,23 +37,43 @@ add_subdirectory(compat)
 add_subdirectory(rp_util)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
+
+# If enabled, the git hash is included in the Redpanda binary, which will
+# require relinking of at least the `redpanda` binary each time the hash
+# changes (switching branches, creating a new commit, etc).
+# Cannot be used when ENABLE_GIT_VERSION=off.
+option(ENABLE_GIT_HASH "Build with Git hash in metadata" OFF)
+
 if(${ENABLE_GIT_VERSION})
-include(GetGitRevisionDescription)
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-git_local_changes(GIT_CLEAN_DIRTY)
-if("${GIT_CLEAN_DIRTY}" STREQUAL "DIRTY")
-  set(GIT_CLEAN_DIRTY "-dirty")
+  include(GetGitRevisionDescription)
+  if(${ENABLE_GIT_HASH})
+    git_describe(GIT_VER --always)
+  else()
+    # If displaying a version, make sure it also doesn't display a hash.
+    git_describe(GIT_VER --always --abbrev=0)
+  endif()
 else()
-  set(GIT_CLEAN_DIRTY "")
-endif()
-git_describe(GIT_VER --always)
-else(${ENABLE_GIT_VERSION})
+  if(${ENABLE_GIT_HASH})
+    message(FATAL_ERROR "ENABLE_GIT_HASH cannot be 'on' when ENABLE_GIT_VERSION is 'off'")
+  endif()
   set(GIT_VER "no_version")
+endif()
+
+if(${ENABLE_GIT_HASH})
+  include(GetGitRevisionDescription)
+  get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+  git_local_changes(GIT_CLEAN_DIRTY)
+  if("${GIT_CLEAN_DIRTY}" STREQUAL "DIRTY")
+    set(GIT_CLEAN_DIRTY "-dirty")
+  else()
+    set(GIT_CLEAN_DIRTY "")
+  endif()
+else()
   set(GIT_SHA1 "000")
   set(GIT_CLEAN_DIRTY "-dev")
-endif(${ENABLE_GIT_VERSION})
-configure_file(version.h.in version.h @ONLY)
+endif()
 
+configure_file(version.h.in version.h @ONLY)
 # main executables
 add_subdirectory(redpanda)
 


### PR DESCRIPTION
## Cover letter

Developers commonly use ENABLE_GIT_VERSION=off to force the version
string to be entirely independent of git:

```
$ ./bin/redpanda --version
no_version - 000-dev
```

...resulting in a faster build because we don't have to rebuild/relink
anything that may depend on the version.

This does not play well with upgrade tests, which expect the version to
be of the format v1.2.3. In particular, we need to be able to figure out
the numeric version for certain tests, to ensure we pull the correct
version when testing upgrades from the previous version. While test-only
solutions might exist for the `dev` branch (e.g. treating "no_version"
as the highest released version), they don't work generally for all
branches (e.g. consider running an upgrade test on an older branch for a
patch release).

This commit adds an option to still include a version, but not add the
git hash, which changes on every commit. This reduces the time required
to run after, e.g. changing a Python test file that doesn't change any
C++ code.

Current default after a dummy commit without ENABLE_GIT_VERSION=on:

```
$ time task rp:run-ducktape-tests  REDPANDA_LOG_LEVEL=trace BUILD_TYPE=debug DUCKTAPE_ARGS="tests/rptest/tests/redpanda_binary_test.py"
...
real    1m53.801s
user    3m6.894s
sys     0m21.730s
```

With ENABLE_GIT_HASH=off after dummy commit:

```
real    0m26.811s
user    0m46.296s
sys     0m13.880s
```

Note that this doesn't completely get rid of work caused by a spurious
git commit when running tests, since we still end up needing to re-run
cmake when the git HEAD changes by virtue of calling functions that
depend on git. Further changes could be made here to get rid of the
dependency on git altogether for versioning (e.g. using
CMAKE_PROJECT_VERSION to define the version instead of relying on git
tags), but I opted to go for lower hanging fruit.

This helps mitigate https://github.com/redpanda-data/redpanda/issues/5485 a bit, but there's certainly room for improvement, likely requiring broader discussion since it could potentially impact to release process, e.g. if we start using a version file.

Will be followed up with a corresponding change to the internal tooling repo.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none

