### PR TITLE
redpanda: Log exceptions from admin_server

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -349,6 +349,45 @@ void admin_server::log_request(
       req.get_url());
 }
 
+void admin_server::log_exception(
+  const ss::sstring& url,
+  const request_auth_result& auth_state,
+  std::exception_ptr eptr) const {
+    using http_status = ss::httpd::reply::status_type;
+    using http_status_ut = std::underlying_type_t<http_status>;
+    const auto log_ex = [&](
+                          std::optional<http_status_ut> status = std::nullopt) {
+        std::stringstream os;
+        const auto username
+          = (auth_state.get_username().size() > 0 ? auth_state.get_username() : "_anonymous");
+        /// Strip URL of query parameters in the case sensitive information
+        /// might have been passed
+        fmt::print(
+          os,
+          "[{}] exception intercepted - url: [{}]",
+          username,
+          url.substr(0, url.find('?')));
+        if (status) {
+            fmt::print(os, " http_return_status[{}]", *status);
+        }
+        fmt::print(os, " reason - {}", eptr);
+        return os.str();
+    };
+
+    try {
+        std::rethrow_exception(eptr);
+    } catch (ss::httpd::base_exception& ex) {
+        const auto status = static_cast<http_status_ut>(ex.status());
+        if (ex.status() == http_status::internal_server_error) {
+            vlog(logger.error, "{}", log_ex(status));
+        } else if (status >= 400) {
+            vlog(logger.warn, "{}", log_ex(status));
+        }
+    } catch (...) {
+        vlog(logger.error, "{}", log_ex());
+    }
+}
+
 void admin_server::rearm_log_level_timer() {
     _log_level_timer.cancel();
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -724,7 +724,12 @@ ss::future<> admin_server::throw_on_error(
               "can not update broker {} state, invalid state transition "
               "requested",
               id));
+        case cluster::errc::timeout:
+            throw ss::httpd::base_exception(
+              fmt::format("Timeout: {}", ec.message()),
+              ss::httpd::reply::status_type::gateway_timeout);
         case cluster::errc::update_in_progress:
+        case cluster::errc::leadership_changed:
         case cluster::errc::waiting_for_recovery:
         case cluster::errc::no_leader_controller:
             throw ss::httpd::base_exception(

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -192,12 +192,12 @@ static void parse_data_section(license& lc, const json::Document& doc) {
 }
 
 license make_license(const ss::sstring& raw_license) {
-    license lc;
-    auto components = parse_license(raw_license);
-    if (!crypto::verify_license(components.data, components.signature)) {
-        throw license_verifcation_exception("RSA signature invalid");
-    }
     try {
+        license lc;
+        auto components = parse_license(raw_license);
+        if (!crypto::verify_license(components.data, components.signature)) {
+            throw license_verifcation_exception("RSA signature invalid");
+        }
         auto decoded_data = base64_to_string(components.data);
         json::Document doc;
         doc.Parse(decoded_data);

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -244,7 +244,7 @@ class RpkClusterTest(RedpandaTest):
             return
 
         with expect_exception(RpkException,
-                              lambda e: "Internal Server Error" in str(e)):
+                              lambda e: "License is malformed" in str(e)):
             with tempfile.NamedTemporaryFile() as tf:
                 tf.write(bytes(license + 'r', 'UTF-8'))
                 tf.seek(0)

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -15,7 +15,13 @@ from rptest.services.admin import Admin
 import confluent_kafka as ck
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import DEFAULT_LOG_ALLOW_LIST
+import re
 import requests
+
+NON_EXISTENT_TID_LOG_ALLOW_LIST = [
+    re.compile(r".*Unexpected tx_error error: Unknown server error.*")
+]
 
 
 class TxAdminTest(RedpandaTest):
@@ -392,7 +398,9 @@ class TxAdminTest(RedpandaTest):
 
         producer.commit_transaction()
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3,
+             log_allow_list=DEFAULT_LOG_ALLOW_LIST +
+             NON_EXISTENT_TID_LOG_ALLOW_LIST)
     def test_delete_non_existent_tid(self):
         tx_id = "0"
         producer = ck.Producer({


### PR DESCRIPTION
This patch introduces a change to have the admin server log encountered exceptions at the appropriate log level, example:

## Release notes
* Exceptions thrown from the admin server will now be logged at the debug level

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/04c7597b81444a2f8fdba156dbf481db2a9b63c4..0492659c1bdcc653c0e2e8e6550e559985f6d360)
- Instead of logging all exceptions at the debug level, log them at warn or error based on the http reply type

Change in [force-push](https://github.com/redpanda-data/redpanda/compare/0492659c1bdcc653c0e2e8e6550e559985f6d360..a3b22e9d576db862668d1914119de502003c9221)
- Log additional details such as client addr, url, and auth username
- Modified implementation to accomplish the above

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/a062b163ef5e7987b1fbc0ba9527c4992c744dc5..ba5ef0594a7ccf573205457b941cf5dd4aaab2a6)
- Ducktape changes to handle new exemptions to introduce, i.e. newly logged errors from admin server that must be exempt from the bad log line checker 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/ba5ef0594a7ccf573205457b941cf5dd4aaab2a6..2dbede709e94432809479becd5c8a3fe680e56fb)
- Rebase dev to grab newly added tests that were failing CI runs due to modifications 

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2dbede709e94432809479becd5c8a3fe680e56fb..8fe8ba754449564ef364f45e8880db29160c6527)
- Map `cluster::errc` to http 503 error codes, previously they were unhandled resulting in 500's being returned, failing ducktape tests due to bad log line excs

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/8fe8ba754449564ef364f45e8880db29160c6527..c3a6d036b4676c0bdd38e4222491b4cc3ee30d0c)
- Implemented Alex's feedback to not log url query params

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/c3a6d036b4676c0bdd38e4222491b4cc3ee30d0c..facd22b94e5b02aee40a20cb43cba96452587c34)
- Rebase dev

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/facd22b94e5b02aee40a20cb43cba96452587c34..d8e3fe537aa5027cc594b8799e84b9bdc13adeec)
- Fixed a test that had a missing import