### PR TITLE
tests: wait until license feature is fully supported

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -400,7 +400,9 @@ class Admin:
             features_resp = None
             try:
                 features_resp = self.get_features(node=node)
-            except RequestException:
+            except RequestException as e:
+                self.redpanda.logger.debug(
+                    f"Could not get features on {node.account.hostname}: {e}")
                 return False
             features_dict = dict(
                 (f["name"], f) for f in features_resp["features"])

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -388,6 +388,29 @@ class Admin:
     def get_features(self, node=None):
         return self._request("GET", "features", node=node).json()
 
+    def supports_feature(self, feature_name: str, nodes=None):
+        """
+        Returns true whether all nodes in 'nodes' support the given feature. If
+        no nodes are supplied, uses all nodes in the cluster.
+        """
+        if not nodes:
+            nodes = self.redpanda.nodes
+
+        def node_supports_feature(node):
+            features_resp = None
+            try:
+                features_resp = self.get_features(node=node)
+            except RequestException:
+                return False
+            features_dict = dict(
+                (f["name"], f) for f in features_resp["features"])
+            return features_dict[feature_name]["state"] == "active"
+
+        for node in nodes:
+            if not node_supports_feature(node):
+                return False
+        return True
+
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -92,6 +92,12 @@ class UpgradeToLicenseChecks(RedpandaTest):
             [self.redpanda.nodes[1], self.redpanda.nodes[2]])
         _ = wait_for_num_versions(self.redpanda, 1)
 
+        wait_until(
+            lambda: self.admin.supports_feature("license"),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for cluster to support 'license' feature")
+
         # Assert that the log was found
         wait_until(
             lambda: self.redpanda.search_log("Enterprise feature(s).*"),


### PR DESCRIPTION
## Cover letter

We may start logging the nag message on a node that has activated the
`license` while there are others in the cluster that have not yet
activated the feature. This patch updates the behavior so we wait for
the feature to be active on all nodes before proceeding.

Without the fix, when applying #6003, I saw 1/10 failures of this test.
With it, I ran the test with 50/50 successful runs.

Fixes https://github.com/redpanda-data/redpanda/issues/6143

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes

* none
