### PR TITLE
Fix kubebuilder project

### DIFF
--- a/src/go/k8s/PROJECT
+++ b/src/go/k8s/PROJECT
@@ -1,14 +1,19 @@
 domain: vectorized.io
-layout: go.kubebuilder.io/v3
+layout:
+- go.kubebuilder.io/v3
 multigroup: true
 projectName: redpanda-operator
 repo: github.com/redpanda-data/redpanda/src/go/k8s
 resources:
 - api:
     crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: vectorized.io
   group: redpanda
   kind: Cluster
+  path: github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1
   version: v1alpha1
   webhooks:
     webhookVersion: v1
-version: 3-alpha
+version: "3"

--- a/src/go/k8s/apis/redpanda/v1alpha1/webhook_suite_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/webhook_suite_test.go
@@ -21,8 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-
+	admissionv1beta1 "k8s.io/api/admission/v1beta1" // nolint:goimports // crlfmt
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -158,8 +158,13 @@ var _ = BeforeEach(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// kube-apiserver hanging during cleanup
+	// REF https://book.kubebuilder.io/reference/envtest.html#kubernetes-120-and-121-binary-issues
+	timeout := 30 * time.Second
+	poll := 5 * time.Second
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, timeout, poll).ShouldNot(HaveOccurred())
 })
 
 type mockAdminAPI struct {

--- a/src/go/k8s/hack/boilerplate.go.txt
+++ b/src/go/k8s/hack/boilerplate.go.txt
@@ -1,0 +1,8 @@
+// Copyright 2021 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -615,9 +615,7 @@ func (r *StatefulSetResource) composeCURLMaintenanceCommand(
 
 // setVolumes manipulates v1.StatefulSet object in order to add cloud storage and
 // Redpanda data volume
-func setVolumes(
-	ss *appsv1.StatefulSet, cluster *redpandav1alpha1.Cluster,
-) {
+func setVolumes(ss *appsv1.StatefulSet, cluster *redpandav1alpha1.Cluster) {
 	pvcDataDir := preparePVCResource(datadirName, cluster.Namespace, cluster.Spec.Storage, ss.Labels)
 	ss.Spec.VolumeClaimTemplates = append(ss.Spec.VolumeClaimTemplates, pvcDataDir)
 	vol := corev1.Volume{


### PR DESCRIPTION
## Cover letter

Fixes kubebuilder project:

- Running `go test ./...` for envtests hangs during cleanup [REF](https://github.com/kubernetes-sigs/controller-runtime/issues/1571)
- Update PROJECT config to be compatible with latest kubebuilder v3.6.0 and fixes scaffolding of API/Webhook
- CRLFMTs code to avoid diff when running `make test`

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

None
