### PR TITLE
Serde direct read ben

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1989,7 +1989,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     {
-        raft::heartbeat_request data;
+        std::vector<raft::heartbeat_metadata> heartbeats;
 
         // heartbeat request uses the first node/target_node for all of the
         // heartbeat meatdata entries. so here we arrange for that to be true in
@@ -2013,8 +2013,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
               .target_node_id = raft::
                 vnode{target_node_id, tests::random_named_int<model::revision_id>()},
             };
-            data.heartbeats.push_back(hm);
+            heartbeats.push_back(hm);
         }
+
+        raft::heartbeat_request data(std::move(heartbeats));
 
         // encoder will sort automatically. so for equality to work as expected
         // we use the same sorting for the input as the expected output.

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -447,9 +447,9 @@ struct compat_check<raft::heartbeat_request> {
     }
 
     static raft::heartbeat_request from_json(json::Value& rd) {
-        raft::heartbeat_request obj;
-        json_read(heartbeats);
-        return obj;
+        std::vector<raft::heartbeat_metadata> hb;
+        json::read_value(rd, hb);
+        return raft::heartbeat_request{std::move(hb)};
     }
 
     static std::vector<compat_binary> to_binary(raft::heartbeat_request obj) {

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -120,8 +120,7 @@ model::broker create_test_broker() {
 
 SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
     static constexpr int64_t one_k = 1'000;
-    raft::heartbeat_request req;
-    req.heartbeats = std::vector<raft::heartbeat_metadata>(one_k);
+    raft::heartbeat_request req{std::vector<raft::heartbeat_metadata>(one_k)};
     for (int64_t i = 0; i < one_k; ++i) {
         req.heartbeats[i].node_id = raft::vnode(
           model::node_id(one_k), model::revision_id(i));
@@ -166,9 +165,7 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
 }
 SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip_with_negative) {
     static constexpr int64_t one_k = 10;
-    raft::heartbeat_request req;
-
-    req.heartbeats = std::vector<raft::heartbeat_metadata>(one_k);
+    raft::heartbeat_request req{std::vector<raft::heartbeat_metadata>(one_k)};
     for (int64_t i = 0; i < one_k; ++i) {
         req.heartbeats[i].target_node_id = raft::vnode(
           model::node_id(0), model::revision_id(-i - 100));

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -196,12 +196,6 @@ struct append_entries_request
   : serde::envelope<append_entries_request, serde::version<0>> {
     using flush_after_append = ss::bool_class<struct flush_after_append_tag>;
 
-    /*
-     * default initialize with no record batch reader. default construction
-     * should only be used by serialization frameworks.
-     */
-    append_entries_request() noexcept = default;
-
     // required for the cases where we will set the target node id before
     // sending request to the node
     append_entries_request(
@@ -272,7 +266,8 @@ struct append_entries_request
     }
 
     ss::future<> serde_async_write(iobuf& out);
-    ss::future<> serde_async_read(iobuf_parser&, const serde::header&);
+    static ss::future<append_entries_request>
+    serde_async_direct_read(iobuf_parser& in, size_t bytes_left_limit);
 
 private:
     /*

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -354,7 +354,6 @@ struct heartbeat_request
   : serde::envelope<heartbeat_request, serde::version<0>> {
     std::vector<heartbeat_metadata> heartbeats;
 
-    heartbeat_request() noexcept = default;
     explicit heartbeat_request(std::vector<heartbeat_metadata> heartbeats)
       : heartbeats(std::move(heartbeats)) {}
 
@@ -365,7 +364,8 @@ struct heartbeat_request
       = default;
 
     ss::future<> serde_async_write(iobuf& out);
-    void serde_read(iobuf_parser&, const serde::header&);
+    static heartbeat_request
+    serde_direct_read(iobuf_parser& in, size_t bytes_left_limit);
 };
 
 struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>> {


### PR DESCRIPTION
## Cover letter

Remove (2 of the) default constructors added specifically for `serde`, prior to https://github.com/redpanda-data/redpanda/pull/5891. This PR is just an example of using `serde_[async_]direct_read`

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
