### PR TITLE
.github: add an option to backport reason list

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
 
 <!-- Specify which branches this should be backported to, e.g.: -->
 - [ ] not a bug fix
+- [ ] issue does not exist in previous branches
 - [ ] papercut/not impactful enough to backport
 - [ ] v22.2.x
 - [ ] v22.1.x


### PR DESCRIPTION


## Cover letter

As we go into next tranche of development projects,
we'll increasingly have issues that only affect new
code in `dev` and do not require backport for that
reason.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none