### PR TITLE
[v22.2.x] tests: back-to-back upgrades test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1681,13 +1681,15 @@ class RedpandaService(Service):
                               nodes,
                               override_cfg_params=None,
                               start_timeout=None,
-                              stop_timeout=None):
+                              stop_timeout=None,
+                              use_maintenance_mode=True):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         restarter = RollingRestarter(self)
         restarter.restart_nodes(nodes,
                                 override_cfg_params=override_cfg_params,
                                 start_timeout=start_timeout,
-                                stop_timeout=stop_timeout)
+                                stop_timeout=stop_timeout,
+                                use_maintenance_mode=use_maintenance_mode)
 
     def registered(self, node):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1994,7 +1994,10 @@ class RedpandaService(Service):
         """
         counts = {self.idx(node): None for node in self.nodes}
         for node in self.nodes:
-            metrics = self.metrics(node)
+            try:
+                metrics = self.metrics(node)
+            except:
+                return False
             idx = self.idx(node)
             for family in metrics:
                 for sample in family.samples:

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -61,11 +61,21 @@ class InstallOptions:
     """
     def __init__(self,
                  install_previous_version=False,
+                 install_prev_prev_version=False,
                  version=None,
                  num_to_upgrade=0):
         # If true, install the highest version of the prior feature version
         # before HEAD.
         self.install_previous_version = install_previous_version
+
+        # HACK: this is a part of a backport that requires new test infra to
+        # start Redpanda from two versions ago in EndToEndTest. Other test
+        # harnesses can just use the RedpandaInstaller directly to deduce and
+        # install the proper version.
+
+        # If true, install the highest version of the feature version two
+        # versions before HEAD.
+        self.install_prev_prev_version = install_prev_prev_version
 
         # Either RedpandaInstaller.HEAD or a numeric tuple representing the
         # version to install (e.g. (22, 1, 3)).

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -106,6 +106,11 @@ class EndToEndTest(Test):
             if install_opts.install_previous_version:
                 version_to_install = \
                     self.redpanda._installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+            if install_opts.install_prev_prev_version:
+                prev_version = \
+                    self.redpanda._installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+                version_to_install = \
+                    self.redpanda._installer.highest_from_prior_feature_version(prev_version)
             if install_opts.version:
                 version_to_install = install_opts.version
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6094.
Fixes https://github.com/redpanda-data/redpanda/issues/6216,