### PR TITLE
controller_upgrade_test: add message to allowed list

### DIFF
--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -24,13 +24,18 @@ ALLOWED_LOGS = [
     # e.g. cluster - controller_backend.cc:466 - exception while executing partition operation: {type: update_finished, ntp: {kafka/test-topic-1944-1639161306808363/1}, offset: 413, new_assignment: { id: 1, group_id: 65, replicas: {{node_id: 3, shard: 2}, {node_id: 4, shard: 2}, {node_id: 1, shard: 0}} }, previous_assignment: {nullopt}} - std::__1::__fs::filesystem::filesystem_error (error system:39, filesystem error: remove failed: Directory not empty [/var/lib/redpanda/data/kafka/test-topic-1944-1639161306808363])
     re.compile("cluster - .*Directory not empty"),
 
-    # <= 22.2 versions may log bare std::exception error
+    # < 22.2 versions may log bare std::exception error
     # (https://github.com/redpanda-data/redpanda/issues/5886)
     re.compile("rpc - .*std::exception"),
+
     #  <= 22.2 versions may log bare seastar::condition_variable_timed_out error
     re.compile(
         "rpc - Service handler threw an exception: seastar::condition_variable_timed_out"
     ),
+
+    # < 22.2 versions may log a "cannot find consensus group" error message
+    # (https://github.com/redpanda-data/redpanda/pull/5742)
+    re.compile("r/heartbeat - .*cannot find consensus group"),
 ]
 
 


### PR DESCRIPTION
## Cover letter

The underlying issue was addressed in
https://github.com/redpanda-data/redpanda/pull/5742. The log may still
show up in upgrade tests.

Fixes #5378

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes


* none

