### PR TITLE
Fix make docker-build

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -90,18 +90,18 @@ certmanager-install: kind-create
 	./hack/install-cert-manager.sh
 
 prepare-dockerfile:
-	echo "ARG BUILDPLATFORM" > Dockerfile
-	cat Dockerfile.in >> Dockerfile
+	echo "ARG BUILDPLATFORM" > Dockerfile.out
+	cat Dockerfile >> Dockerfile.out
 
 # Build the docker image
 docker-build: prepare-dockerfile
 	echo "~~~ Building operator image :docker:"
-	docker build --build-arg BUILDPLATFORM='linux/${TARGETARCH}' --build-arg TARGETARCH=${TARGETARCH} --target=manager -f Dockerfile -t ${OPERATOR_IMG_LATEST} ../
+	docker build --build-arg BUILDPLATFORM='linux/${TARGETARCH}' --build-arg TARGETARCH=${TARGETARCH} --target=manager -f Dockerfile.out -t ${OPERATOR_IMG_LATEST} ../
 
 # Build the docker image
 docker-build-configurator: prepare-dockerfile
 	echo "~~~ Building configurator image :docker:"
-	docker build --build-arg BUILDPLATFORM='linux/${TARGETARCH}' --build-arg TARGETARCH=${TARGETARCH} --target=configurator -f Dockerfile -t ${CONFIGURATOR_IMG_LATEST} ../
+	docker build --build-arg BUILDPLATFORM='linux/${TARGETARCH}' --build-arg TARGETARCH=${TARGETARCH} --target=configurator -f Dockerfile.out -t ${CONFIGURATOR_IMG_LATEST} ../
 
 # Preload controller image to kind cluster
 push-to-kind: kind-create certmanager-install


### PR DESCRIPTION
## Cover letter

Dockerfile.in is missing and breaks docker-build [REF](https://github.com/redpanda-data/redpanda/commit/412a7344532679f863fc081e1b70fad6491744f1)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

none

## Release notes

none