### PR TITLE
Mark known recently triggered ci-failures with ok_to_fail

### DIFF
--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -11,6 +11,7 @@ from ducktape.mark.resource import cluster
 from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.mark import ok_to_fail
 
 import os
 import time
@@ -113,6 +114,8 @@ class ConnectionRateLimitTest(PreallocNodesTest):
 
         return sum(deltas) / len(deltas)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5276
+    # https://github.com/redpanda-data/redpanda/issues/6074
     @cluster(num_nodes=8)
     def connection_rate_test(self):
         self._producer.start(clean=False)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -258,6 +258,7 @@ class ConsumerGroupTest(RedpandaTest):
             c.wait()
             c.free()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5952
     @cluster(num_nodes=6)
     @parametrize(static_members=True)
     @parametrize(static_members=False)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -108,6 +108,7 @@ class ConsumerGroupTest(RedpandaTest):
                                     self.topic_spec.name, 128, 5000, -1)
         self.producer.start()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5885
     @cluster(num_nodes=6)
     @parametrize(static_members=True)
     @parametrize(static_members=False)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -19,6 +19,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.utils.util import wait_until
 from ducktape.mark import parametrize
+from ducktape.mark import ok_to_fail
 
 
 class ConsumerGroupTest(RedpandaTest):
@@ -305,6 +306,7 @@ class ConsumerGroupTest(RedpandaTest):
             c.wait()
             c.free()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5079
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(static_members=True)
     @parametrize(static_members=False)

--- a/tests/rptest/tests/consumer_offsets_migration_test.py
+++ b/tests/rptest/tests/consumer_offsets_migration_test.py
@@ -19,9 +19,10 @@ from rptest.services.failure_injector import FailureInjector, FailureSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST, RedpandaService, ResourceSettings
 from rptest.clients.default import DefaultClient
-from ducktape.utils.util import wait_until
 
+from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
+from ducktape.mark import ok_to_fail
 
 
 class ConsumerOffsetsMigrationTest(EndToEndTest):
@@ -29,6 +30,9 @@ class ConsumerOffsetsMigrationTest(EndToEndTest):
     min_inter_failure_time_sec = 30
     max_inter_failure_time_sec = 60
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5261
+    # https://github.com/redpanda-data/redpanda/issues/5324
+    # https://github.com/redpanda-data/redpanda/issues/5358
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @matrix(failures=[True, False], cpus=[1, 3])
     def test_migrating_consume_offsets(self, failures, cpus):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -177,6 +177,9 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         rpk.alter_topic_config(self.topic, 'retention.bytes',
                                str(self.segment_size))
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6054
+    # https://github.com/redpanda-data/redpanda/issues/6061
+    # https://github.com/redpanda-data/redpanda/issues/6111
     @cluster(num_nodes=8)
     def test_create_or_delete_topics_while_busy(self):
         self.logger.info(f"Environment: {os.environ}")

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -12,6 +12,7 @@ import random
 
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
@@ -111,6 +112,8 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                              'default_topic_replications': self.num_brokers,
                          })
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4639
+    # https://github.com/redpanda-data/redpanda/issues/5390
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_write_with_node_failures(self):
         self.start_producer()

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -655,6 +655,7 @@ class PandaProxyTest(RedpandaTest):
         assert sc_res.status_code == requests.codes.not_found
         assert sc_res.json()["error_code"] == 40403
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5638
     @cluster(num_nodes=3)
     def test_remove_consumer_validation(self):
         """

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -24,6 +24,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool, RpkException
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.mark import matrix
+from ducktape.mark import ok_to_fail
 
 # We inject failures which might cause consumer groups
 # to re-negotiate, so it is necessary to have a longer
@@ -316,6 +317,9 @@ class PartitionBalancerTest(EndToEndTest):
             ns.make_available()
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5154
+    # https://github.com/redpanda-data/redpanda/issues/6075
+    # https://github.com/redpanda-data/redpanda/issues/5836
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -377,6 +377,8 @@ class PartitionBalancerTest(EndToEndTest):
             ns.make_available()
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5884
+    # https://github.com/redpanda-data/redpanda/issues/5980
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_full_nodes(self):
         """

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -64,6 +64,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.redpanda.set_cluster_config(
             {"raft_learner_recovery_rate": str(new_value)})
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5887
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(replication_factor=[1, 3],
             unclean_abort=[True, False],

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -5,7 +5,10 @@ from numpy import partition
 
 import requests
 from rptest.services.cluster import cluster
+
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
+from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -13,7 +16,6 @@ from rptest.services.verifiable_producer import TopicPartition
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.tests.partition_movement import PartitionMovementMixin
-from ducktape.mark import matrix, parametrize
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
 
 NO_RECOVERY = "no_recovery"
@@ -106,6 +108,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
                                 consumer_timeout_sec=45,
                                 min_records=self.min_records)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5608
+    # https://github.com/redpanda-data/redpanda/issues/6020
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(replication_factor=[1, 3],
             unclean_abort=[True, False],

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -708,6 +708,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             consumer_timeout_sec=45,
                             min_records=records)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6087
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_availability_when_one_node_down(self):
         """

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -18,7 +18,9 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+
 from rptest.util import wait_until
+from ducktape.mark import ok_to_fail
 
 
 class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):
@@ -99,6 +101,8 @@ class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):
 
         self.move_worker.join()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5827
+    # https://github.com/redpanda-data/redpanda/issues/5868
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_basic_upgrade(self):
         topic = TopicSpec(partition_count=16, replication_factor=3)

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -7,9 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import matrix
 from rptest.services.cluster import cluster
+
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -173,6 +175,7 @@ class PrefixTruncateRecoveryUpgradeTest(PrefixTruncateRecoveryTestBase):
                                          self.initial_version)
         super(PrefixTruncateRecoveryUpgradeTest, self).setUp()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5589
     @cluster(num_nodes=3,
              log_allow_list=LOG_ALLOW_LIST +
              MixedVersionWorkloadRunner.ALLOWED_LOGS)

--- a/tests/rptest/tests/rack_aware_replica_placement_test.py
+++ b/tests/rptest/tests/rack_aware_replica_placement_test.py
@@ -9,6 +9,7 @@
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
+from ducktape.mark import ok_to_fail
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
@@ -75,6 +76,7 @@ class RackAwarePlacementTest(RedpandaTest):
             )
             assert len(set(racks)) == min(num_racks, num_replicas)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4885
     @cluster(num_nodes=6)
     @matrix(rack_layout_str=['ABCDEF', 'xxYYzz', 'ooooFF'],
             num_partitions=[50, 400],

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -15,8 +15,10 @@ from rptest.services.redpanda import SISettings
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.util import expect_exception
+
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
+from ducktape.mark import ok_to_fail
 
 import json
 
@@ -172,6 +174,7 @@ class TestReadReplicaService(EndToEndTest):
         else:
             return None
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6073
     @cluster(num_nodes=6)
     @matrix(partition_count=[10])
     def test_produce_is_forbidden(self, partition_count: int) -> None:
@@ -184,6 +187,7 @@ class TestReadReplicaService(EndToEndTest):
                 in str(e)):
             second_rpk.produce(self.topic_name, "", "test payload")
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6073
     @cluster(num_nodes=9)
     @matrix(partition_count=[10], min_records=[10000])
     def test_simple_end_to_end(self, partition_count: int,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -9,7 +9,6 @@
 
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings
-from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -19,6 +18,9 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 from rptest.utils.si_utils import Producer
+
+from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
 
 import confluent_kafka as ck
 
@@ -57,6 +59,7 @@ class ShadowIndexingTxTest(RedpandaTest):
             rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
             rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5651
     @cluster(num_nodes=3)
     def test_shadow_indexing_aborted_txs(self):
         """Check that messages belonging to aborted transaction are not seen by clients

--- a/tests/rptest/trim_results.py
+++ b/tests/rptest/trim_results.py
@@ -39,7 +39,7 @@ class Trimmer:
             results_dir = os.path.join(self.result_path,
                                        r['relative_results_dir'])
 
-            if r['test_status'] == "PASS":
+            if r['test_status'] == "PASS" or r['test_status'] == "OPASS":
                 for service in r['services']:
                     service_logs = {
                         "RedpandaService": "redpanda.log",


### PR DESCRIPTION
## Cover letter

Marking existing recently triggered ci-failures with `ok_to_fail` before disabling merging with failures.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes

* none