### PR TITLE
Fixed logging abort_requested_exception with error severity

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -690,6 +690,9 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
         } catch (ss::sleep_aborted const&) {
             stop = true;
             continue;
+        } catch (ss::abort_requested_exception const&) {
+            stop = true;
+            continue;
         } catch (...) {
             vlog(
               clusterlog.error,

--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -37,6 +37,9 @@ ALLOWED_REPLICATION = [1, 3]
 V22_1_CHAOS_ALLOW_LOGS = [
     re.compile("storage - Could not parse header"),
     re.compile("storage - Cannot continue parsing"),
+    re.compile(
+        ".*controller_backend.*exception while executing partition operation:.*"
+    )
 ]
 
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -91,10 +91,7 @@ CHAOS_LOG_ALLOW_LIST = [
     re.compile("rpc - Service handler threw an exception: std"),
 
     # rpc - Service handler threw an exception: seastar::broken_promise (broken promise)"
-    re.compile("rpc - Service handler threw an exception: seastar"),
-    re.compile(
-        "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
-    ),
+    re.compile("rpc - Service handler threw an exception: seastar")
 ]
 
 


### PR DESCRIPTION
## Cover letter

When redpanda is shutting down the `abort_requested_exception` may be thrown from partition operation reconciliation loop. This situation is perfectly valid and should not trigger an `ERROR` log entry to be emitted.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #5654

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
