### PR TITLE
rpc/simple_protocol: disambiguate condition variable timeout exception

### DIFF
--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -27,6 +27,10 @@ ALLOWED_LOGS = [
     # <= 22.2 versions may log bare std::exception error
     # (https://github.com/redpanda-data/redpanda/issues/5886)
     re.compile("rpc - .*std::exception"),
+    #  <= 22.2 versions may log bare seastar::condition_variable_timed_out error
+    re.compile(
+        "rpc - Service handler threw an exception: seastar::condition_variable_timed_out"
+    ),
 ]
 
 


### PR DESCRIPTION
## Cover letter

When `ss::condition_variable_timeout_exception` is thrown from service
handler it should not be treated as generic error but result in timeout
being returned to the client.

Fixes: #6201

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
