### PR TITLE
tests: fix raise_on_bad_logs

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1242,7 +1242,7 @@ class RedpandaService(Service):
                 self.logger.info(
                     f"{RedpandaService.STDOUT_STDERR_CAPTURE} not found on {node.account.hostname}. Skipping log scan."
                 )
-                return
+                continue
 
             self.logger.info(
                 f"Scanning node {node.account.hostname} log for errors...")


### PR DESCRIPTION

## Cover letter

This was added in bf0488dd61 -- it drops out of
log scans when it sees a node with no log.  It should
just skip the node with no log, and proceed to scan
logs of other nodes.

This issue appears to have resulted in https://github.com/redpanda-data/redpanda/pull/5059 showing a passing run on the PR even though it would in general cause failures from log errors.

Related: https://github.com/redpanda-data/redpanda/issues/6221

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none