### PR TITLE
rptest: Enable SI for SIPartitionMovementTest

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -791,6 +791,8 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,
             log_segment_size=10240,  # 10KiB
+            cloud_storage_enable_remote_read=True,
+            cloud_storage_enable_remote_write=True,
         )
         super(SIPartitionMovementTest, self).__init__(
             ctx,


### PR DESCRIPTION
## Cover letter

SI wasn't enabled properly for the test so the log was truncated causing all sorts of trouble.

Fixes #6147 #6131

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes


* none

### Features

* none

### Improvements

* none

