### PR TITLE
Feature: offline_log_viewer updates

### DIFF
--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -251,7 +251,7 @@ def decode_topic_command_adl(k_rdr: Reader, rdr: Reader):
 
 
 def decode_topic_command(record):
-    rdr = Reader(BufferedReader(BytesIO(record.value)))
+    rdr = Reader(BytesIO(record.value))
     k_rdr = Reader(BytesIO(record.key))
     either_ald_or_serde = rdr.peek_int8()
     assert either_ald_or_serde >= -1, "unsupported serialization format"

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -438,9 +438,42 @@ def read_config_kv(reader):
     return (k, v)
 
 
-def decode_config_command(record):
-    rdr = Reader(BytesIO(record.value))
-    k_rdr = Reader(BytesIO(record.key))
+def decode_config_command_serde(k_rdr: Reader, rdr: Reader):
+    cmd = {}
+    cmd['type'] = rdr.read_int8()
+    if cmd['type'] == 0:
+        cmd['type_name'] = 'config_delta'
+        cmd['version'] = k_rdr.read_int64()
+        cmd |= rdr.read_envelope(
+            lambda rdr, _: {
+                'upsert':
+                rdr.read_serde_vector(lambda rdr: rdr.read_envelope(
+                    lambda rdr, _: {
+                        'k': rdr.read_string(),
+                        'v': rdr.read_string()
+                    })),
+                'remove':
+                rdr.read_serde_vector(Reader.read_string),
+            })
+    elif cmd['type'] == 1:
+        cmd['type_name'] = 'config_status'
+        cmd['node_id'] = k_rdr.read_int32()
+        cmd |= rdr.read_envelope(
+            lambda rdr, _: {
+                'status':
+                rdr.read_envelope(
+                    lambda rdr, _: {
+                        'node': rdr.read_int32(),
+                        'version': rdr.read_int64(),
+                        'restart': rdr.read_bool(),
+                        'unknown': rdr.read_serde_vector(Reader.read_string),
+                        'invalid': rdr.read_serde_vector(Reader.read_string),
+                    }),
+            })
+    return cmd
+
+
+def decode_config_command_adl(k_rdr: Reader, rdr: Reader):
     cmd = {}
     cmd['type'] = rdr.read_int8()
     if cmd['type'] == 0:
@@ -527,7 +560,8 @@ def decode_record(batch, record):
         ret['data'] = decode_adl_or_serde(record, decode_acl_command_adl,
                                           decode_acl_command_serde)
     if batch.type == BatchType.cluster_config_cmd:
-        ret['data'] = decode_config_command(record)
+        ret['data'] = decode_adl_or_serde(record, decode_config_command_adl,
+                                          decode_config_command_serde)
     if batch.type == BatchType.feature_update:
         ret['data'] = decode_feature_command(record)
     return ret

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -1,10 +1,12 @@
 import logging
-from io import BufferedReader, BytesIO
+from io import BytesIO
 from model import *
 from reader import Reader
-from storage import Batch, Segment
+from storage import Segment
 from storage import BatchType
 import datetime
+
+logger = logging.getLogger('controller')
 
 
 def read_topic_properties_serde(rdr: Reader, version):
@@ -263,8 +265,7 @@ def decode_topic_command(record):
         return decode_topic_command_adl(k_rdr, rdr)
 
 
-def decode_config(record):
-    rdr = Reader(BytesIO(record.value))
+def decode_config(k_rdr: Reader, rdr: Reader):
     return read_raft_config(rdr)
 
 
@@ -551,14 +552,7 @@ def decode_feature_command_adl(k_rdr: Reader, rdr: Reader):
     return cmd
 
 
-def decode_node_management_command(record):
-    rdr = Reader(BufferedReader(BytesIO(record.value)))
-    k_rdr = Reader(BytesIO(record.key))
-    either_adl_or_serde = rdr.peek_int8()
-    assert either_adl_or_serde >= -1, "unsupported serialization format"
-    if either_adl_or_serde == -1:
-        # serde encoding flag, consume it and proceed
-        rdr.skip(1)
+def decode_node_management_command(k_rdr: Reader, rdr: Reader):
     cmd = {'type': rdr.read_int8()}
     if cmd['type'] == 0:
         cmd |= {
@@ -584,9 +578,7 @@ def decode_node_management_command(record):
     return cmd
 
 
-def decode_adl_or_serde(record, adl_fn, serde_fn):
-    rdr = Reader(BufferedReader(BytesIO(record.value)))
-    k_rdr = Reader(BytesIO(record.key))
+def decode_adl_or_serde(k_rdr: Reader, rdr: Reader, adl_fn, serde_fn):
     either_adl_or_serde = rdr.peek_int8()
     assert either_adl_or_serde >= -1, "unsupported serialization format"
     if either_adl_or_serde == -1:
@@ -607,25 +599,38 @@ def decode_record(batch, record):
         header.first_ts / 1000.0).strftime('%Y-%m-%d %H:%M:%S')
     ret['data'] = None
 
+    rdr = Reader(BytesIO(record.value))
+    k_rdr = Reader(BytesIO(record.key))
+
     if batch.type == BatchType.raft_configuration:
-        ret['data'] = decode_config(record)
+        ret['data'] = decode_config(k_rdr, rdr)
     if batch.type == BatchType.topic_management_cmd:
-        ret['data'] = decode_adl_or_serde(record, decode_topic_command_adl,
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr, decode_topic_command_adl,
                                           decode_topic_command_serde)
     if batch.type == BatchType.user_management_cmd:
-        ret['data'] = decode_adl_or_serde(record, decode_user_command_adl,
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr, decode_user_command_adl,
                                           decode_user_command_serde)
     if batch.type == BatchType.acl_management_cmd:
-        ret['data'] = decode_adl_or_serde(record, decode_acl_command_adl,
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr, decode_acl_command_adl,
                                           decode_acl_command_serde)
     if batch.type == BatchType.cluster_config_cmd:
-        ret['data'] = decode_adl_or_serde(record, decode_config_command_adl,
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr,
+                                          decode_config_command_adl,
                                           decode_config_command_serde)
     if batch.type == BatchType.feature_update:
-        ret['data'] = decode_adl_or_serde(record, decode_feature_command_adl,
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr,
+                                          decode_feature_command_adl,
                                           decode_feature_command_serde)
     if batch.type == BatchType.node_management_cmd:
-        ret['data'] = decode_node_management_command(record)
+        ret['data'] = decode_adl_or_serde(k_rdr, rdr,
+                                          decode_node_management_command,
+                                          decode_node_management_command)
+
+    k_unread = k_rdr.remaining()
+    v_unread = rdr.remaining()
+    if k_unread != 0 or v_unread != 0:
+        ret['unread'] = {'key': k_unread, 'value': v_unread}
+        logger.error(f"@{ret['type']} unread bytes. k:{k_unread} v:{v_unread}")
 
     return ret
 

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -192,9 +192,9 @@ def decode_record(batch, record):
         ret['data'] = decode_user_command(record)
     if batch.type == BatchType.acl_management_cmd:
         ret['data'] = decode_acl_command(record)
-    if header.type == BatchType.cluster_config_cmd:
+    if batch.type == BatchType.cluster_config_cmd:
         ret['data'] = decode_config_command(record)
-    if header.type == BatchType.feature_update:
+    if batch.type == BatchType.feature_update:
         ret['data'] = decode_feature_command(record)
     return ret
 

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -311,9 +311,115 @@ def decode_user_command_adl(k_rdr: Reader, rdr: Reader):
     return cmd
 
 
-def decode_acl_command(record):
-    rdr = Reader(BytesIO(record.value))
-    k_rdr = Reader(BytesIO(record.key))
+def read_acl_binding_serde(k_rdr: Reader):
+    return k_rdr.read_envelope(
+        lambda k_rdr, _: {
+            'pattern':
+            k_rdr.read_envelope(
+                lambda k_rdr, _: {
+                    'resource': decode_acl_resource(k_rdr.read_serde_enum()),
+                    'name': k_rdr.read_string(),
+                    'pattern': decode_acl_pattern_type(k_rdr.read_serde_enum())
+                }),
+            'entry':
+            k_rdr.read_envelope(
+                lambda k_rdr, _: {
+                    'principal':
+                    k_rdr.read_envelope(
+                        lambda k_rdr, _: {
+                            'type':
+                            decode_acl_principal_type(k_rdr.read_serde_enum()),
+                            'name':
+                            k_rdr.read_string()
+                        }),
+                    'host':
+                    k_rdr.read_envelope(
+                        lambda k_rdr, _: {
+                            'addr':
+                            k_rdr.read_optional(
+                                lambda k_rdr: {
+                                    'ipv4': k_rdr.read_bool(),
+                                    'data': k_rdr.read_iobuf().hex()
+                                })
+                        }),
+                    'operation':
+                    decode_acl_operation(k_rdr.read_serde_enum()),
+                    'permission':
+                    decode_acl_permission(k_rdr.read_serde_enum()),
+                }),
+        })
+
+
+def decode_serialized_pattern_type(v):
+    if 0 <= v <= 2:
+        return ['literal', 'prefixed', 'match'][v]
+    return 'error'
+
+
+def read_acl_binding_filter_serde(k_rdr: Reader):
+    # pattern class does not really use serde
+    return k_rdr.read_envelope(
+        lambda k_rdr, _: {
+            'pattern': {
+                'resource':
+                k_rdr.read_optional(lambda k_rdr: decode_acl_resource(
+                    k_rdr.read_serde_enum())),
+                'name':
+                k_rdr.read_envelope(Reader.read_string),
+                'pattern':
+                k_rdr.read_optional(lambda k_rdr:
+                                    decode_serialized_pattern_type(
+                                        k_rdr.read_serde_enum())),
+            },
+            'acl':
+            k_rdr.read_envelope(
+                lambda k_rdr, _: {
+                    'principal':
+                    k_rdr.read_optional(lambda k_rdr: k_rdr.read_envelope(
+                        lambda k_rdr, _: {
+                            'type':
+                            decode_acl_principal_type(k_rdr.read_serde_enum()),
+                            'name':
+                            k_rdr.read_string()
+                        })),
+                    'host':
+                    k_rdr.read_optional(lambda k_rdr: k_rdr.read_envelope(
+                        lambda k_rdr, _: {
+                            'addr':
+                            k_rdr.read_optional(
+                                lambda k_rdr: {
+                                    'ipv4': k_rdr.read_bool(),
+                                    'data': k_rdr.read_iobuf().hex()
+                                })
+                        })),
+                    'operation':
+                    k_rdr.read_optional(lambda k_rdr: decode_acl_operation(
+                        k_rdr.read_serde_enum())),
+                    'permission':
+                    k_rdr.read_optional(lambda k_rdr: decode_acl_permission(
+                        k_rdr.read_serde_enum())),
+                }),
+        })
+
+
+def decode_acl_command_serde(k_rdr: Reader, rdr: Reader):
+    cmd = {}
+    cmd['type'] = rdr.read_int8()
+    cmd['str_type'] = decode_acls_cmd_type(cmd['type'])
+    if cmd['type'] == 8:
+        cmd['acls'] = k_rdr.read_envelope(
+            lambda k_rdr, _:
+            {'bindings': k_rdr.read_serde_vector(read_acl_binding_serde)})
+    elif cmd['type'] == 9:
+        cmd |= k_rdr.read_envelope(lambda k_rdr, _: {
+            'filters':
+            k_rdr.read_serde_vector(read_acl_binding_filter_serde)
+        })
+
+    return cmd
+
+
+def decode_acl_command_adl(k_rdr: Reader, rdr: Reader):
     cmd = {}
     cmd['type'] = rdr.read_int8()
     cmd['str_type'] = decode_acls_cmd_type(cmd['type'])
@@ -418,7 +524,8 @@ def decode_record(batch, record):
         ret['data'] = decode_adl_or_serde(record, decode_user_command_adl,
                                           decode_user_command_serde)
     if batch.type == BatchType.acl_management_cmd:
-        ret['data'] = decode_acl_command(record)
+        ret['data'] = decode_adl_or_serde(record, decode_acl_command_adl,
+                                          decode_acl_command_serde)
     if batch.type == BatchType.cluster_config_cmd:
         ret['data'] = decode_config_command(record)
     if batch.type == BatchType.feature_update:

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -268,9 +268,27 @@ def decode_config(record):
     return read_raft_config(rdr)
 
 
-def decode_user_command(record):
-    rdr = Reader(BytesIO(record.value))
-    k_rdr = Reader(BytesIO(record.key))
+def decode_user_command_serde(k_rdr: Reader, rdr: Reader):
+    cmd = {'type': rdr.read_int8()}
+    cmd['str_type'] = decode_user_cmd_type(cmd['type'])
+
+    if cmd['type'] == 5 or cmd['type'] == 7:
+        cmd['user'] = k_rdr.read_string()
+        cmd['cred'] = rdr.read_envelope(
+            lambda rdr, _: {
+                # obfuscate secrets
+                'salt': obfuscate_secret(rdr.read_iobuf().hex()),
+                'server_key': obfuscate_secret(rdr.read_iobuf().hex()),
+                'stored_key': obfuscate_secret(rdr.read_iobuf().hex()),
+                'iterations': rdr.read_int32(),
+            })
+    elif cmd['type'] == 6:
+        cmd['user'] = k_rdr.read_string()
+
+    return cmd
+
+
+def decode_user_command_adl(k_rdr: Reader, rdr: Reader):
     cmd = {}
     cmd['type'] = rdr.read_int8()
     cmd['str_type'] = decode_user_cmd_type(cmd['type'])
@@ -397,7 +415,8 @@ def decode_record(batch, record):
         ret['data'] = decode_adl_or_serde(record, decode_topic_command_adl,
                                           decode_topic_command_serde)
     if batch.type == BatchType.user_management_cmd:
-        ret['data'] = decode_user_command(record)
+        ret['data'] = decode_adl_or_serde(record, decode_user_command_adl,
+                                          decode_user_command_serde)
     if batch.type == BatchType.acl_management_cmd:
         ret['data'] = decode_acl_command(record)
     if batch.type == BatchType.cluster_config_cmd:

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -1,3 +1,4 @@
+import logging
 from io import BufferedReader, BytesIO
 from model import *
 from reader import Reader
@@ -6,9 +7,190 @@ from storage import BatchType
 import datetime
 
 
-def decode_topic_command(record):
-    rdr = Reader(BufferedReader(BytesIO(record.value)))
-    k_rdr = Reader(BytesIO(record.key))
+def read_topic_properties_serde(rdr: Reader, version):
+    assert 0 <= version <= 1
+    topic_properties = {
+        'compression': rdr.read_optional(Reader.read_serde_enum),
+        'cleanup_policy_bitflags': rdr.read_optional(Reader.read_serde_enum),
+        'compaction_strategy': rdr.read_optional(Reader.read_serde_enum),
+        'timestamp_type': rdr.read_optional(Reader.read_serde_enum),
+        'segment_size': rdr.read_optional(Reader.read_uint64),
+        'retention_bytes': rdr.read_tristate(Reader.read_uint64),
+        'retention_duration': rdr.read_tristate(Reader.read_uint64),
+        'recovery': rdr.read_optional(Reader.read_bool),
+        'shadow_indexing': rdr.read_optional(Reader.read_serde_enum),
+    }
+
+    # introduced for remote read replicas
+    if version == 1:
+        topic_properties |= {
+            'read_replica':
+            rdr.read_optional(Reader.read_bool),
+            'read_replica_bucket':
+            rdr.read_optional(Reader.read_string),
+            'remote_topic_properties':
+            rdr.read_optional(
+                lambda r: {
+                    'remote_revision': r.read_int64(),
+                    'remote_partition_count': r.read_int32()
+                }),
+        }
+    return topic_properties
+
+
+def read_topic_assignment_serde(rdr: Reader):
+    return rdr.read_envelope(
+        lambda rdr, _: {
+            'cfg':
+            rdr.read_envelope(
+                lambda rdr, _: {
+                    'namespace':
+                    rdr.read_string(),
+                    'topic':
+                    rdr.read_string(),
+                    'partitions':
+                    rdr.read_int32(),
+                    'replication_factor':
+                    rdr.read_int16(),
+                    'properties':
+                    rdr.read_envelope(read_topic_properties_serde,
+                                      max_version=1),
+                }),
+            'assignments':
+            rdr.read_serde_vector(lambda r: r.read_envelope(
+                lambda r, _: {
+                    'group':
+                    r.read_int64(),
+                    'id':
+                    r.read_int32(),
+                    'replicas':
+                    r.read_serde_vector(lambda r: {
+                        'node_id': r.read_int32(),
+                        'shard': r.read_uint32(),
+                    }),
+                })),
+        })
+
+
+def read_inc_update_op_serde(rdr: Reader):
+    v = rdr.read_serde_enum()
+    if -1 < v < 3:
+        return ['none', 'set', 'remove'][v]
+    return 'error'
+
+
+def read_property_update_serde(rdr: Reader, type_reader):
+    return rdr.read_envelope(lambda rdr, _: {
+        'value': type_reader(rdr),
+        'op': read_inc_update_op_serde(rdr),
+    })
+
+
+def read_incremental_topic_update_serde(rdr: Reader):
+    return rdr.read_envelope(
+        lambda rdr, _: {
+            'compression':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+            'cleanup_policy_bitflags':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+            'compaction_strategy':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+            'timestamp_type':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+            'segment_size':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_uint64)),
+            'retention_bytes':
+            read_property_update_serde(
+                rdr, lambda r: r.read_tristate(Reader.read_uint64)),
+            'retention_duration':
+            read_property_update_serde(
+                rdr, lambda r: r.read_tristate(Reader.read_int64)),
+            'shadow_indexing':
+            read_property_update_serde(
+                rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+        })
+
+
+def read_create_partitions_serde(rdr: Reader):
+    return rdr.read_envelope(
+        lambda rdr, _: {
+            'cfg':
+            rdr.read_envelope(
+                lambda rdr, _: {
+                    'namespace':
+                    rdr.read_string(),
+                    'topic':
+                    rdr.read_string(),
+                    'new_total_partition_count':
+                    rdr.read_int32(),
+                    'custom_assignments':
+                    rdr.read_serde_vector(lambda r: r.read_serde_vector(
+                        Reader.read_int32)),
+                }),
+            'assignments':
+            rdr.read_serde_vector(lambda r: r.read_envelope(
+                lambda rdr, _: {
+                    'group': rdr.read_int64(),
+                    'id': rdr.read_int32(),
+                    'replicas': rdr.read_serde_vector(read_broker_shard),
+                })),
+        })
+
+
+def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
+    cmd = {}
+    cmd['type'] = rdr.read_int8()
+    if cmd['type'] == 0:
+        cmd['type_string'] = 'create_topic'
+        cmd |= read_topic_assignment_serde(rdr)
+    elif cmd['type'] == 1:
+        cmd['type_string'] = 'delete_topic'
+        cmd['namespace'] = rdr.read_string()
+        cmd['topic'] = rdr.read_string()
+    elif cmd['type'] == 2:
+        cmd['type_string'] = 'update_partitions'
+        cmd['namespace'] = k_rdr.read_string()
+        cmd['topic'] = k_rdr.read_string()
+        cmd['partition'] = k_rdr.read_int32()
+        cmd['replicas'] = rdr.read_serde_vector(read_broker_shard)
+    elif cmd['type'] == 3:
+        cmd['type_string'] = 'finish_partitions_update'
+        cmd['topic'] = k_rdr.read_string()
+        cmd['partition'] = k_rdr.read_int32()
+        cmd['replicas'] = rdr.read_serde_vector(read_broker_shard)
+    elif cmd['type'] == 4:
+        cmd['type_string'] = 'update_topic_properties'
+        cmd['namespace'] = k_rdr.read_string()
+        cmd['topic'] = k_rdr.read_string()
+        cmd['update'] = read_incremental_topic_update_serde(rdr)
+    elif cmd['type'] == 5:
+        cmd['type_string'] = 'create_partitions'
+        cmd |= read_create_partitions_serde(rdr)
+    elif cmd['type'] == 6:
+        cmd['type_string'] = 'create_non_replicable_topic'
+        cmd['topic'] = k_rdr.read_envelope(
+            lambda k_rdr, _: {
+                'source': {
+                    'namespace': k_rdr.read_string(),
+                    'topic': k_rdr.read_string(),
+                },
+                'name': {
+                    'namespace': k_rdr.read_string(),
+                    'topic': k_rdr.read_string(),
+                },
+            })
+    elif cmd['type'] == 7:
+        cmd['type_string'] = 'cancel_moving_partition_replicas'
+        cmd |= rdr.read_envelope(lambda rdr, _: {'force': rdr.read_bool()})
+    return cmd
+
+
+def decode_topic_command_adl(k_rdr: Reader, rdr: Reader):
     cmd = {}
     cmd['type'] = rdr.read_int8()
     if cmd['type'] == 0:
@@ -68,6 +250,19 @@ def decode_topic_command(record):
     return cmd
 
 
+def decode_topic_command(record):
+    rdr = Reader(BufferedReader(BytesIO(record.value)))
+    k_rdr = Reader(BytesIO(record.key))
+    either_ald_or_serde = rdr.peek_int8()
+    assert either_ald_or_serde >= -1, "unsupported serialization format"
+    if either_ald_or_serde == -1:
+        # serde encoding flag, consume it and proceed
+        rdr.skip(1)
+        return decode_topic_command_serde(k_rdr, rdr)
+    else:
+        return decode_topic_command_adl(k_rdr, rdr)
+
+
 def decode_config(record):
     rdr = Reader(BytesIO(record.value))
     return read_raft_config(rdr)
@@ -114,7 +309,6 @@ def decode_acl_command(record):
 
 
 def read_config_kv(reader):
-
     k = reader.read_string()
     v = reader.read_string()
     return (k, v)
@@ -200,7 +394,8 @@ def decode_record(batch, record):
     if batch.type == BatchType.raft_configuration:
         ret['data'] = decode_config(record)
     if batch.type == BatchType.topic_management_cmd:
-        ret['data'] = decode_topic_command(record)
+        ret['data'] = decode_adl_or_serde(record, decode_topic_command_adl,
+                                          decode_topic_command_serde)
     if batch.type == BatchType.user_management_cmd:
         ret['data'] = decode_user_command(record)
     if batch.type == BatchType.acl_management_cmd:

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -496,16 +496,51 @@ def decode_config_command_adl(k_rdr: Reader, rdr: Reader):
     return cmd
 
 
-def decode_feature_command(record):
+def decode_action_t(v):
+    if 1 <= v <= 3:
+        return ['', 'complete_preparing', 'activate', 'deactivate'][v]
+    return v
+
+
+def decode_feature_command_serde(k_rdr: Reader, rdr: Reader):
+    cmd = {'type': rdr.read_int8()}
+    if cmd['type'] == 0:
+        cmd['type_name'] = 'feature_update'
+        cmd |= k_rdr.read_envelope(
+            lambda k_rdr, _: {
+                'cluster_version':
+                k_rdr.read_int64(),
+                'actions':
+                k_rdr.read_serde_vector(lambda k_rdr: k_rdr.read_envelope(
+                    lambda k_rdr, _: {
+                        'feature_name': k_rdr.read_string(),
+                        'action': decode_action_t(k_rdr.read_serde_enum()),
+                    }))
+            })
+    elif cmd['type'] == 1:
+        cmd['type_name'] = 'license_update'
+        cmd |= k_rdr.read_envelope(
+            lambda k_rdr, _: {
+                'redpanda_license':
+                k_rdr.read_envelope(
+                    lambda k_rdr, _: {
+                        'format_version': k_rdr.read_uint8(),
+                        'type': k_rdr.read_serde_enum(),
+                        'organization': k_rdr.read_string(),
+                        'expiry': k_rdr.read_int64(),
+                    })
+            })
+    return cmd
+
+
+def decode_feature_command_adl(k_rdr: Reader, rdr: Reader):
     def decode_feature_update_action(r):
         action = {}
         action['v'] = r.read_int8()
         action['feature_name'] = r.read_string()
-        action['action'] = r.read_int16()
+        action['action'] = decode_action_t(r.read_int16())
         return action
 
-    rdr = Reader(BytesIO(record.value))
-    k_rdr = Reader(BytesIO(record.key))
     cmd = {}
     cmd['type'] = rdr.read_int8()
     if cmd['type'] == 0:
@@ -513,15 +548,39 @@ def decode_feature_command(record):
         cmd['v'] = k_rdr.read_int8()
         cmd['cluster_version'] = k_rdr.read_int64()
         cmd['actions'] = k_rdr.read_vector(decode_feature_update_action)
+    return cmd
+
+
+def decode_node_management_command(record):
+    rdr = Reader(BufferedReader(BytesIO(record.value)))
+    k_rdr = Reader(BytesIO(record.key))
+    either_adl_or_serde = rdr.peek_int8()
+    assert either_adl_or_serde >= -1, "unsupported serialization format"
+    if either_adl_or_serde == -1:
+        # serde encoding flag, consume it and proceed
+        rdr.skip(1)
+    cmd = {'type': rdr.read_int8()}
+    if cmd['type'] == 0:
+        cmd |= {
+            'type_string': 'decommission_node',
+            'node_id': k_rdr.read_int32()
+        }
     elif cmd['type'] == 1:
-        cmd['type_name'] = 'license_update'
-        k_rdr.read_envelope()
-        cmd['format_v'] = k_rdr.read_uint8()
-        cmd['license_type'] = k_rdr.read_uint8()
-        cmd['org'] = k_rdr.read_string()
-        cmd['expiry'] = k_rdr.read_string()
-    else:
-        cmd['type_name'] = 'unknown'
+        cmd |= {
+            'type_string': 'recommission_node',
+            'node_id': k_rdr.read_int32()
+        }
+    elif cmd['type'] == 2:
+        cmd |= {
+            'type_string': 'finish_reallocations',
+            'node_id': k_rdr.read_int32()
+        }
+    elif cmd['type'] == 3:
+        cmd |= {
+            'type_string': 'maintenance_mode',
+            'node_id': k_rdr.read_int32(),
+            'enabled': rdr.read_bool()
+        }
     return cmd
 
 
@@ -563,7 +622,11 @@ def decode_record(batch, record):
         ret['data'] = decode_adl_or_serde(record, decode_config_command_adl,
                                           decode_config_command_serde)
     if batch.type == BatchType.feature_update:
-        ret['data'] = decode_feature_command(record)
+        ret['data'] = decode_adl_or_serde(record, decode_feature_command_adl,
+                                          decode_feature_command_serde)
+    if batch.type == BatchType.node_management_cmd:
+        ret['data'] = decode_node_management_command(record)
+
     return ret
 
 

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -149,6 +149,8 @@ def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
     cmd['type'] = rdr.read_int8()
     if cmd['type'] == 0:
         cmd['type_string'] = 'create_topic'
+        cmd['namespace'] = k_rdr.read_string()
+        cmd['topic'] = k_rdr.read_string()
         cmd |= read_topic_assignment_serde(rdr)
     elif cmd['type'] == 1:
         cmd['type_string'] = 'delete_topic'
@@ -174,6 +176,7 @@ def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
         cmd['type_string'] = 'create_partitions'
         cmd |= read_create_partitions_serde(rdr)
     elif cmd['type'] == 6:
+        rdr.skip(1)  #unused
         cmd['type_string'] = 'create_non_replicable_topic'
         cmd['topic'] = k_rdr.read_envelope(
             lambda k_rdr, _: {
@@ -271,7 +274,7 @@ def decode_config(k_rdr: Reader, rdr: Reader):
 
 def decode_user_command_serde(k_rdr: Reader, rdr: Reader):
     cmd = {'type': rdr.read_int8()}
-    cmd['str_type'] = decode_user_cmd_type(cmd['type'])
+    cmd['type_string'] = decode_user_cmd_type(cmd['type'])
 
     if cmd['type'] == 5 or cmd['type'] == 7:
         cmd['user'] = k_rdr.read_string()
@@ -284,6 +287,7 @@ def decode_user_command_serde(k_rdr: Reader, rdr: Reader):
                 'iterations': rdr.read_int32(),
             })
     elif cmd['type'] == 6:
+        rdr.skip(1)  # unused
         cmd['user'] = k_rdr.read_string()
 
     return cmd
@@ -408,10 +412,12 @@ def decode_acl_command_serde(k_rdr: Reader, rdr: Reader):
     cmd['type'] = rdr.read_int8()
     cmd['str_type'] = decode_acls_cmd_type(cmd['type'])
     if cmd['type'] == 8:
+        rdr.skip(1)  # unused
         cmd['acls'] = k_rdr.read_envelope(
             lambda k_rdr, _:
             {'bindings': k_rdr.read_serde_vector(read_acl_binding_serde)})
     elif cmd['type'] == 9:
+        rdr.skip(1)  # unused
         cmd |= k_rdr.read_envelope(lambda k_rdr, _: {
             'filters':
             k_rdr.read_serde_vector(read_acl_binding_filter_serde)
@@ -506,6 +512,7 @@ def decode_action_t(v):
 def decode_feature_command_serde(k_rdr: Reader, rdr: Reader):
     cmd = {'type': rdr.read_int8()}
     if cmd['type'] == 0:
+        rdr.skip(1)  # value unused
         cmd['type_name'] = 'feature_update'
         cmd |= k_rdr.read_envelope(
             lambda k_rdr, _: {
@@ -519,6 +526,7 @@ def decode_feature_command_serde(k_rdr: Reader, rdr: Reader):
                     }))
             })
     elif cmd['type'] == 1:
+        rdr.skip(1)  # value unused
         cmd['type_name'] = 'license_update'
         cmd |= k_rdr.read_envelope(
             lambda k_rdr, _: {
@@ -544,6 +552,7 @@ def decode_feature_command_adl(k_rdr: Reader, rdr: Reader):
 
     cmd = {}
     cmd['type'] = rdr.read_int8()
+    rdr.skip(1)  #value unused
     if cmd['type'] == 0:
         cmd['type_name'] = 'feature_update'
         cmd['v'] = k_rdr.read_int8()
@@ -555,16 +564,19 @@ def decode_feature_command_adl(k_rdr: Reader, rdr: Reader):
 def decode_node_management_command(k_rdr: Reader, rdr: Reader):
     cmd = {'type': rdr.read_int8()}
     if cmd['type'] == 0:
+        rdr.skip(1)
         cmd |= {
             'type_string': 'decommission_node',
             'node_id': k_rdr.read_int32()
         }
     elif cmd['type'] == 1:
+        rdr.skip(1)
         cmd |= {
             'type_string': 'recommission_node',
             'node_id': k_rdr.read_int32()
         }
     elif cmd['type'] == 2:
+        rdr.skip(1)
         cmd |= {
             'type_string': 'finish_reallocations',
             'node_id': k_rdr.read_int32()

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -174,6 +174,19 @@ def decode_feature_command(record):
     return cmd
 
 
+def decode_adl_or_serde(record, adl_fn, serde_fn):
+    rdr = Reader(BufferedReader(BytesIO(record.value)))
+    k_rdr = Reader(BytesIO(record.key))
+    either_adl_or_serde = rdr.peek_int8()
+    assert either_adl_or_serde >= -1, "unsupported serialization format"
+    if either_adl_or_serde == -1:
+        # serde encoding flag, consume it and proceed
+        rdr.skip(1)
+        return serde_fn(k_rdr, rdr)
+    else:
+        return adl_fn(k_rdr, rdr)
+
+
 def decode_record(batch, record):
     ret = {}
     header = batch.header

--- a/tools/offline_log_viewer/reader.py
+++ b/tools/offline_log_viewer/reader.py
@@ -1,5 +1,6 @@
 import struct
 import collections
+from io import BufferedReader, BytesIO
 
 SERDE_ENVELOPE_FORMAT = "<BBI"
 SERDE_ENVELOPE_SIZE = struct.calcsize(SERDE_ENVELOPE_FORMAT)
@@ -9,8 +10,9 @@ SerdeEnvelope = collections.namedtuple('SerdeEnvelope',
 
 
 class Reader:
-    def __init__(self, stream):
-        self.stream = stream
+    def __init__(self, stream: BytesIO):
+        # BytesIO provides .getBuffer(), BufferedReader peek()
+        self.stream = BufferedReader(stream)
 
     @staticmethod
     def _decode_zig_zag(v):
@@ -128,3 +130,6 @@ class Reader:
 
     def skip(self, length):
         self.stream.read(length)
+
+    def remaining(self):
+        return len(self.stream.raw.getbuffer()) - self.stream.tell()


### PR DESCRIPTION
## Cover letter

These changes add a first support in tools/offlile_log_viewer for serde-encoded controller messages.

running 

    python viewer.py --type controller --path [redpanda data path]

will decode logs produced by v22.2 and earlier. serde commands start with a field 'envelope' that contains 
```[version, compat_version, encoded_size]```.

Partially fixes #5293,

implements:
- [x] serde decode of controller commands:
    - [x] decode_topic_command
    - [x] decode_user_command
    - [x] decode_acl_command
    - [x] decode_config_command
    - [x] decode_feature_command
    - [x] decode_node_management 
- [ ] gold master and coverage testing
- [ ] ductape integration
    - [ ] test that new version of redpanda can be completely decoded with this tool
    - [ ] add means to run this tool as a part of a ductape test

open questions:
- should there be a check (with a message) that all the bytes are processed?
- should the structure of the json reflect more closely the cpp class hierarchies (some hierarchies are flattened)?
- should the names of the fields match the one used in the cpp source (some names are abbreviated or de-abbreviated)?

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

messages are decoded in a stream of json files. the schema for adl encoded files is unchanged, but the schema for serde - encoded message is different in some places than the corresponding adl-one, reflecting more the hierarchical data organization. 

## Release notes

* none
