### PR TITLE
[v22.1.x] rptest: Enable SI for SIPartitionMovementTest

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -591,6 +591,8 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,
             log_segment_size=10240,  # 10KiB
+            cloud_storage_enable_remote_read=True,
+            cloud_storage_enable_remote_write=True,
         )
         super(SIPartitionMovementTest, self).__init__(
             ctx,


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6229.
Fixes https://github.com/redpanda-data/redpanda/issues/6239,