### PR TITLE
tests: fixes for scale_tests/

### DIFF
--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -25,11 +25,20 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
                          *args,
                          **kwargs)
 
-        self._partitions = 32
-        self._message_size = 1280
-        self._message_cnt = 500000
-        self._consumers = 8
-        self._number_of_moves = 50
+        if not self.redpanda.dedicated_nodes:
+            # Mini mode, for developers working on the test on their workstation.
+            # (not for use in CI)
+            self._partitions = 16
+            self._message_size = 16384
+            self._message_cnt = 64000
+            self._consumers = 1
+            self._number_of_moves = 2
+        else:
+            self._partitions = 32
+            self._message_size = 1280
+            self._message_cnt = 500000
+            self._consumers = 8
+            self._number_of_moves = 50
 
     def _start_producer(self, topic_name):
         self.producer = KgoVerifierProducer(

--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -35,6 +35,9 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
             self._number_of_moves = 2
         else:
             self._partitions = 32
+            # FIXME: this is not enough data to keep up a background load through
+            # the test.
+            # https://github.com/redpanda-data/redpanda/issues/6245
             self._message_size = 1280
             self._message_cnt = 500000
             self._consumers = 8
@@ -55,7 +58,6 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
                    backoff_sec=1)
 
     def _start_consumer(self, topic_name):
-
         self.consumer = KgoVerifierConsumerGroupConsumer(
             self.test_context,
             self.redpanda,
@@ -65,21 +67,17 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
             nodes=self.preallocated_nodes)
         self.consumer.start(clean=False)
 
-    def verify(self):
+    def verify(self, topic_name):
         self.producer.wait()
 
-        # wait for consumers to finish
-        def finished_consuming():
-            self.logger.debug(
-                f"verifying, producer acked: {self.producer.produce_status.acked}, "
-                f"consumer valid reads: {self.consumer.consumer_status.validator.valid_reads}"
-            )
-            return self.consumer.consumer_status.validator.valid_reads >= self.producer.produce_status.acked
-
-        # wait for consumers to finish
-        wait_until(finished_consuming, 90)
-
         self.consumer.wait()
+        assert self.consumer.consumer_status.validator.invalid_reads == 0
+        del self.consumer
+
+        # Create a fresh consumer to read the quiescent state from start to finish
+        self._start_consumer(topic_name)
+        self.consumer.wait()
+
         assert self.consumer.consumer_status.validator.valid_reads >= self.producer.produce_status.acked
         assert self.consumer.consumer_status.validator.invalid_reads == 0
 
@@ -97,11 +95,11 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
         for _ in range(20):
             # choose a random topic-partition
             metadata = self.client().describe_topics()
-            topic, partition = self._random_partition(metadata)
-            self.logger.info(f"selected partition: {topic}/{partition}")
-            self._do_move_and_verify(topic, partition, 360)
+            t, partition = self._random_partition(metadata)
+            self.logger.info(f"selected partition: {t}/{partition}")
+            self._do_move_and_verify(t, partition, 360)
 
-        self.verify()
+        self.verify(topic.name)
 
     def _random_move_and_cancel(self, topic, partition):
         previous_assignment, _ = self._dispatch_random_partition_move(
@@ -127,7 +125,9 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
         for _ in range(self._number_of_moves):
             # choose a random topic-partition
             metadata = self.client().describe_topics()
-            topic, partition = self._random_partition(metadata)
-            self.logger.info(f"selected partition: {topic}/{partition}")
+            t, partition = self._random_partition(metadata)
+            self.logger.info(f"selected partition: {t}/{partition}")
 
-            self._random_move_and_cancel(topic, partition)
+            self._random_move_and_cancel(t, partition)
+
+        self.verify(topic.name)

--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -72,16 +72,16 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest,
         def finished_consuming():
             self.logger.debug(
                 f"verifying, producer acked: {self.producer.produce_status.acked}, "
-                f"consumer valid reads: {self.consumer.consumer_status.valid_reads}"
+                f"consumer valid reads: {self.consumer.consumer_status.validator.valid_reads}"
             )
-            return self.consumer.consumer_status.valid_reads >= self.producer.produce_status.acked
+            return self.consumer.consumer_status.validator.valid_reads >= self.producer.produce_status.acked
 
         # wait for consumers to finish
         wait_until(finished_consuming, 90)
 
-        assert self.consumer.consumer_status.valid_reads >= self.producer.produce_status.acked
-        self.consumer.shutdown()
         self.consumer.wait()
+        assert self.consumer.consumer_status.validator.valid_reads >= self.producer.produce_status.acked
+        assert self.consumer.consumer_status.validator.invalid_reads == 0
 
     @cluster(num_nodes=6)
     @parametrize(replication_factor=1)

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -804,6 +804,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                               topic=topic_names[0],
                               msg_size=repeater_msg_size,
                               workers=workers,
+                              max_buffered_records=64,
                               cleanup=lambda: self.free_preallocated_nodes(),
                               **repeater_kwargs) as repeater:
             repeater_await_bytes = 1E9

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -123,7 +123,7 @@ class ScaleParameters:
             # bandwidth.  Divide by 2 to give comfortable room for variation.
             # This is total bandwidth from a group of producers.
             self.expect_bandwidth = (node_count / replication_factor) * (
-                self.node_cpus / 24.0) * 1E9
+                self.node_cpus / 24.0) * 1E9 * 0.5
 
             # Single-producer tests are slower, bottlenecked on the
             # client side.

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -67,12 +67,12 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
         self.producer.wait()
         # wait for consumers to finish
         wait_until(
-            lambda: self.consumer.consumer_status.valid_reads == self.producer.
-            produce_status.acked, 300)
-        self.consumer.shutdown()
+            lambda: self.consumer.consumer_status.validator.valid_reads >= self
+            .producer.produce_status.acked, 300)
         self.consumer.wait()
 
-        assert self.consumer.consumer_status.valid_reads == self.producer.produce_status.acked
+        assert self.consumer.consumer_status.validator.valid_reads >= self.producer.produce_status.acked
+        assert self.consumer.consumer_status.validator.invalid_reads == 0
 
     def node_replicas(self, topics, node_id):
         topic_descriptions = self.client().describe_topics(topics)

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -91,7 +91,14 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
     @parametrize(type=BIG_PARTITIONS)
     def test_partition_balancer_with_many_partitions(self, type):
         replication_factor = 3
-        if type == self.MANY_PARTITIONS:
+        if not self.redpanda.dedicated_nodes:
+            # Mini mode, for developers working on the test on their workstation.
+            # (not for use in CI)
+            message_size = 16384
+            message_cnt = 64000
+            consumers = 1
+            partitions_count = 16
+        elif type == self.MANY_PARTITIONS:
             # in total the test produces 250GB of data
             message_size = 128 * (2 ^ 10)
             message_cnt = 2000000

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -37,7 +37,9 @@ class KgoRepeaterService(Service):
                  msg_size: Optional[int],
                  workers: int,
                  key_count: Optional[int] = None,
-                 group_name: str = "repeat01"):
+                 group_name: str = "repeat01",
+                 max_buffered_records: Optional[int] = None,
+                 mb_per_worker: Optional[int] = None):
         # num_nodes=0 because we're asking it to not allocate any for us
         super().__init__(context, num_nodes=0 if nodes else 1)
 
@@ -57,6 +59,12 @@ class KgoRepeaterService(Service):
         self.remote_port = 8080
 
         self.key_count = key_count
+        self.max_buffered_records = max_buffered_records
+
+        if mb_per_worker is None:
+            mb_per_worker = 4
+
+        self.mb_per_worker = mb_per_worker
 
         self._stopped = False
 
@@ -67,8 +75,7 @@ class KgoRepeaterService(Service):
             node.account.remove(self.LOG_PATH)
 
     def start_node(self, node, clean=None):
-        mb_per_worker = 1
-        initial_data_mb = mb_per_worker * self.workers
+        initial_data_mb = self.mb_per_worker * self.workers
 
         cmd = (
             "/opt/kgo-verifier/kgo-repeater "
@@ -82,6 +89,9 @@ class KgoRepeaterService(Service):
 
         if self.key_count is not None:
             cmd += f" -keys={self.key_count}"
+
+        if self.max_buffered_records is not None:
+            cmd += f" -max-buffered-records={self.max_buffered_records}"
 
         cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 &"
 

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -258,7 +258,7 @@ class StatusThread(threading.Thread):
             progress = (worker_statuses[0]['sent'] /
                         float(self._parent._msg_count))
             self.logger.info(
-                f"Producer {self.who_am_i} progress: {progress*100:.2f}% {self._parent._status}"
+                f"Producer {self.who_am_i} progress: {progress*100:.2f}% {reduced}"
             )
         else:
             self.logger.info(f"Worker {self.who_am_i} status: {reduced}")

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -98,7 +98,9 @@ class KgoVerifierService(Service):
         wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} > {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
         pid_str = node.account.ssh_output(wrapped_cmd)
-        self.logger.debug(f"spawned {self.who_am_i()} pid={pid_str}")
+        self.logger.debug(
+            f"spawned {self.who_am_i()} node={node.name} pid={pid_str} port={self._remote_port}"
+        )
         pid = int(pid_str.strip())
         self._pid = pid
 
@@ -126,6 +128,12 @@ class KgoVerifierService(Service):
         node.account.remove("valid_offsets*json", True)
         node.account.remove(f"/tmp/{self.__class__.__name__}*")
 
+    def _remote(self, node, action):
+        url = self._remote_url(node, action)
+        self._redpanda.logger.info(f"{self.who_am_i()} remote call: {url}")
+        r = requests.get(url)
+        r.raise_for_status()
+
     def wait_node(self, node, timeout_sec=None):
         """
         Wait for the remote process to gracefully finish: if it is a one-shot
@@ -146,8 +154,7 @@ class KgoVerifierService(Service):
 
         # If this is a looping worker, tell it to end after the current loop
         self.logger.debug(f"wait_node {self.who_am_i()}: requesting last_pass")
-        r = requests.get(self._remote_url(node, "last_pass"))
-        r.raise_for_status()
+        self._remote(node, "last_pass")
 
         # Let the worker fall through to the end of its current iteration
         self.logger.debug(
@@ -165,13 +172,17 @@ class KgoVerifierService(Service):
 
         # Permit the subprocess to exit, and wait for it to do so
         self.logger.debug(f"wait_node {self.who_am_i()}: requesting shutdown")
-        r = requests.get(self._remote_url(node, "shutdown"))
-        r.raise_for_status()
+        self._remote(node, "shutdown")
         self.logger.debug(
-            f"wait_node {self.who_am_i()}: waiting for process to terminate")
+            f"wait_node {self.who_am_i()}: waiting node={node.name} pid={self._pid} to terminate"
+        )
         wait_until(lambda: not node.account.exists(f"/proc/{self._pid}"),
                    timeout_sec=10,
                    backoff_sec=0.5)
+
+        self.logger.debug(
+            f"wait_node {self.who_am_i()}: node={node.name} pid={self._pid} terminated"
+        )
 
         self._release_port()
 
@@ -489,7 +500,6 @@ class KgoVerifierProducer(KgoVerifierService):
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes
-        self._remote_port = None
 
     @property
     def produce_status(self):

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -56,8 +56,26 @@ class KgoVerifierService(Service):
         self._remote_port = None
 
         for node in self.nodes:
-            if not hasattr(node, "kgo_verifier_next_port"):
-                node.kgo_verifier_next_port = REMOTE_PORT_BASE
+            if not hasattr(node, "kgo_verifier_ports"):
+                node.kgo_verifier_ports = {}
+
+    def __del__(self):
+        self._release_port()
+
+    def _release_port(self):
+        for node in self.nodes:
+            port_map = getattr(node, "kgo_verifier_ports", dict())
+            if self.who_am_i() in port_map:
+                del port_map[self.who_am_i()]
+
+    def _select_port(self, node):
+        ports_in_use = set(node.kgo_verifier_ports.values())
+        i = REMOTE_PORT_BASE
+        while i in ports_in_use:
+            i = i + 1
+
+        node.kgo_verifier_ports[self.who_am_i()] = i
+        return i
 
     @property
     def log_path(self):
@@ -75,11 +93,9 @@ class KgoVerifierService(Service):
     def spawn(self, cmd, node):
         assert self._pid is None
 
-        port = node.kgo_verifier_next_port
-        node.kgo_verifier_next_port += 1
-        self._remote_port = port
+        self._remote_port = self._select_port(node)
 
-        wrapped_cmd = f"nohup {cmd} --remote --remote-port {port} > {self.log_path} 2>&1 & echo $!"
+        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} > {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
         pid_str = node.account.ssh_output(wrapped_cmd)
         self.logger.debug(f"spawned {self.who_am_i()} pid={pid_str}")
@@ -101,6 +117,8 @@ class KgoVerifierService(Service):
         except RemoteCommandError as e:
             if b"No such process" not in e.msg:
                 raise
+
+        self._release_port()
 
     def clean_node(self, node):
         self._redpanda.logger.info(f"{self.__class__.__name__}.clean_node")
@@ -154,6 +172,8 @@ class KgoVerifierService(Service):
         wait_until(lambda: not node.account.exists(f"/proc/{self._pid}"),
                    timeout_sec=10,
                    backoff_sec=0.5)
+
+        self._release_port()
 
         return True
 


### PR DESCRIPTION
## Cover letter

- Make KgoRepeaterService use fewer ports (so that we don't end up bumping against the limit of the range in https://github.com/redpanda-data/vtools/pull/910 later)
- Update HighThroughputPartitionMovementTest/PartitionBalancerScaleTest for some name changes in the kgo-verifier refactor that got missed at the time.
- Mitigate races in HighThroughputPartitionMovementTest/PartitionBalancerScaleTest where they relied on producing a small enough amount of data that it was all done by the time the first produce status was read  This doesn't fix the underlying issue of insufficient produced data (https://github.com/redpanda-data/redpanda/issues/6245)
- Adjust the target bandwidth in ManyPartitionsTest to better match throughput on i3en.xlarge instances.  This was already scaled dynamically be instance size, but the throughput was more deterministic on the larger instance types.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none