### PR TITLE
tests: wait for 'maintenance_mode' in rolling restart

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -186,16 +186,9 @@ class UpgradeBackToBackTest(PreallocNodesTest):
             self._producer.wait()
             assert self._producer.produce_status.acked == self.PRODUCE_COUNT
 
-        def has_maintenance_supprt():
-            features_resp = self.redpanda._admin.get_features()
-            features_dict = dict(
-                (f["name"], f) for f in features_resp["features"])
-            return features_dict["maintenance_mode"]["state"] == "active"
-
         produce_during_upgrade = self.initial_version >= (22, 1, 0)
         if produce_during_upgrade:
             # Give ample time to restart, given the running workload.
-            wait_until(has_maintenance_supprt, 30, 1)
             self.installer.install(self.redpanda.nodes,
                                    self.intermediate_version)
             self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
@@ -229,7 +222,6 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                        timeout_sec=90,
                        backoff_sec=3)
 
-        wait_until(has_maintenance_supprt, 30, 1)
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
         self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
                                             start_timeout=90,


### PR DESCRIPTION
## Cover letter

We need to wait for `maintenance_mode` feature activation on all nodes for all
tests that undergo a rolling restart. This patch pulls in a wait to the
`rolling_restarter`, using the newly introduced `Admin.supports_feature()`
method that does just this.

Without this, we could see the following in tests:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 135, in run
    data = self.run_test()
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 227, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.10/dist-packages/ducktape/mark/_mark.py", line 476, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/root/tests/rptest/services/cluster.py", line 35, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/upgrade_test.py", line 234, in test_upgrade_with_all_workloads
    self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
  File "/root/tests/rptest/services/redpanda.py", line 1634, in rolling_restart_nodes
    restarter.restart_nodes(nodes,
  File "/root/tests/rptest/services/rolling_restarter.py", line 74, in restart_nodes
    admin.maintenance_stop(node)
  File "/root/tests/rptest/services/admin.py", line 683, in maintenance_stop
    return self._request("delete", url)
  File "/root/tests/rptest/services/admin.py", line 334, in _request
    r.raise_for_status()
  File "/usr/local/lib/python3.10/dist-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://docker-rp-16:9644/v1/brokers/3/maintenance
```

Fixes [the issue reported by Rob in CI here](https://github.com/redpanda-data/redpanda/pull/6235#issuecomment-1228512692)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes


* none