### PR TITLE
transactions: Support transaction coordinator leadership transfer

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -141,6 +141,8 @@ public:
     transfer_leadership(std::optional<model::node_id> target) {
         if (_rm_stm) {
             return _rm_stm->transfer_leadership(target);
+        } else if (_tm_stm) {
+            return _tm_stm->transfer_leadership(target);
         } else {
             return _raft->do_transfer_leadership(target);
         }

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -41,11 +41,6 @@ using op_status = cluster::tm_stm::op_status;
 using tm_transaction = cluster::tm_transaction;
 using tx_status = cluster::tm_transaction::tx_status;
 
-static tm_transaction expect_tx(std::optional<tm_transaction> maybe_tx) {
-    BOOST_REQUIRE((bool)maybe_tx);
-    return maybe_tx.value();
-}
-
 static tm_transaction expect_tx(checked<tm_transaction, op_status> maybe_tx) {
     BOOST_REQUIRE(maybe_tx.has_value());
     return maybe_tx.value();

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -72,12 +72,12 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
                        c->term(), tx_id, std::chrono::milliseconds(0), pid)
                      .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id));
+    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
     BOOST_REQUIRE_EQUAL(tx1.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx1.pid, pid);
     BOOST_REQUIRE_EQUAL(tx1.status, tx_status::ready);
     BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
-    expect_tx(stm.mark_tx_ongoing(tx_id));
+    expect_tx(stm.mark_tx_ongoing(tx_id).get0());
     std::vector<tm_transaction::tx_partition> partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
@@ -87,7 +87,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
       stm.add_partitions(tx_id, partitions).get0(),
       cluster::tm_stm::op_status::success);
     BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
-    auto tx2 = expect_tx(stm.get_tx(tx_id));
+    auto tx2 = expect_tx(stm.get_tx(tx_id).get0());
     BOOST_REQUIRE_EQUAL(tx2.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx2.pid, pid);
     BOOST_REQUIRE_EQUAL(tx2.status, tx_status::ongoing);
@@ -105,7 +105,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(tx4.status, tx_status::prepared);
     BOOST_REQUIRE_EQUAL(tx4.tx_seq, tx2.tx_seq);
     BOOST_REQUIRE_EQUAL(tx4.partitions.size(), 2);
-    auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id));
+    auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id).get0());
     BOOST_REQUIRE_EQUAL(tx5.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx5.pid, pid);
     BOOST_REQUIRE_EQUAL(tx5.status, tx_status::ongoing);
@@ -134,8 +134,8 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
                        c->term(), tx_id, std::chrono::milliseconds(0), pid)
                      .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id));
-    auto tx2 = stm.reset_tx_ongoing(tx_id, c->term());
+    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
+    auto tx2 = stm.reset_tx_ongoing(tx_id, c->term()).get0();
     std::vector<tm_transaction::tx_partition> partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
@@ -144,10 +144,10 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(
       stm.add_partitions(tx_id, partitions).get0(),
       cluster::tm_stm::op_status::success);
-    auto tx3 = expect_tx(stm.get_tx(tx_id));
+    auto tx3 = expect_tx(stm.get_tx(tx_id).get0());
     auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
     auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
+    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id).get0());
     BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx6.pid, pid);
     BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ongoing);
@@ -176,20 +176,20 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
                        c->term(), tx_id, std::chrono::milliseconds(0), pid1)
                      .get0();
     BOOST_REQUIRE(op_code == op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id));
+    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
     std::vector<tm_transaction::tx_partition> partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    auto tx2 = stm.reset_tx_ongoing(tx_id, c->term());
+    auto tx2 = stm.reset_tx_ongoing(tx_id, c->term()).get0();
     BOOST_REQUIRE_EQUAL(
       stm.add_partitions(tx_id, partitions).get0(),
       cluster::tm_stm::op_status::success);
-    auto tx3 = expect_tx(stm.get_tx(tx_id));
+    auto tx3 = expect_tx(stm.get_tx(tx_id).get0());
     auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
     auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
+    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id).get0());
 
     auto pid2 = model::producer_identity{1, 1};
     auto expected_pid = model::producer_identity(3, 5);
@@ -199,7 +199,7 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
             c->term(), tx_id, std::chrono::milliseconds(0), pid2, expected_pid)
           .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx7 = expect_tx(stm.get_tx(tx_id));
+    auto tx7 = expect_tx(stm.get_tx(tx_id).get0());
     BOOST_REQUIRE_EQUAL(tx7.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx7.pid, pid2);
     BOOST_REQUIRE_EQUAL(tx7.status, tx_status::ready);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -131,6 +131,10 @@ std::optional<tm_transaction> tm_stm::do_get_tx(kafka::transactional_id tx_id) {
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::get_tx(kafka::transactional_id tx_id) {
+    auto r = co_await sync(_sync_timeout);
+    if (!r.has_value()) {
+        co_return r.error();
+    }
     auto tx_it = _mem_txes.find(tx_id);
     if (tx_it != _mem_txes.end()) {
         co_return tx_it->second;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -167,9 +167,13 @@ ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::do_barrier() {
         });
 }
 
+ss::future<> tm_stm::checkpoint_ongoing_txs() { return ss::now(); }
+
 ss::future<std::error_code>
 tm_stm::transfer_leadership(std::optional<model::node_id> target) {
-    return _c->do_transfer_leadership(target);
+    auto units = co_await _state_lock.hold_write_lock();
+    co_await checkpoint_ongoing_txs();
+    co_return co_await _c->do_transfer_leadership(target);
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>>

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -167,6 +167,11 @@ ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::do_barrier() {
         });
 }
 
+ss::future<std::error_code>
+tm_stm::transfer_leadership(std::optional<model::node_id> target) {
+    return _c->do_transfer_leadership(target);
+}
+
 ss::future<checked<model::term_id, tm_stm::op_status>>
 tm_stm::sync(model::timeout_clock::duration timeout) {
     return ss::with_gate(_gate, [this, timeout] { return do_sync(timeout); });

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -166,7 +166,8 @@ public:
 
     ss::gate& gate() { return _gate; }
 
-    ss::future<std::optional<tm_transaction>> get_tx(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
+      get_tx(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_ongoing(kafka::transactional_id);
     // mark_xxx: updates a transaction if the term matches etag
@@ -283,6 +284,7 @@ private:
       std::chrono::milliseconds,
       model::producer_identity);
     ss::future<stm_snapshot> do_take_snapshot();
+    std::optional<tm_transaction> do_get_tx(kafka::transactional_id);
 
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       update_tx(tm_transaction, model::term_id);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -166,12 +166,12 @@ public:
 
     ss::gate& gate() { return _gate; }
 
-    std::optional<tm_transaction> get_tx(kafka::transactional_id);
-    checked<tm_transaction, tm_stm::op_status>
+    ss::future<std::optional<tm_transaction>> get_tx(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_ongoing(kafka::transactional_id);
     // mark_xxx: updates a transaction if the term matches etag
     // reset_xxx: updates a transaction and an etag
-    checked<tm_transaction, tm_stm::op_status>
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
       reset_tx_ongoing(kafka::transactional_id, model::term_id);
     ss::future<tm_stm::op_status> add_partitions(
       kafka::transactional_id, std::vector<tm_transaction::tx_partition>);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -186,6 +186,8 @@ public:
         return _state_lock.hold_read_lock();
     }
 
+    ss::future<> checkpoint_ongoing_txs();
+
     ss::future<std::error_code>
       transfer_leadership(std::optional<model::node_id>);
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -186,6 +186,9 @@ public:
         return _state_lock.hold_read_lock();
     }
 
+    ss::future<std::error_code>
+      transfer_leadership(std::optional<model::node_id>);
+
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       reset_tx_ready(model::term_id, kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -38,8 +38,11 @@ namespace cluster {
 using use_tx_version_with_last_pid_bool
   = ss::bool_class<struct use_tx_version_with_last_pid_tag>;
 
+// Update this if your patch bumps the version.
+// Current version of transaction record (v2).
+// Includes all changes for transactions GA.
+// + last_pid field - KIP-360 support
 struct tm_transaction {
-    // Version 2 added last_pid field to tx log records
     static constexpr uint8_t version = 2;
 
     enum tx_status {
@@ -293,8 +296,9 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
 };
 
-// Version 1 added last_update_ts to tx lod record. And new status tombstone to
-// tx_status
+// Updates in v1.
+//  + last_update_ts - tracks last updated ts for transactions expiration
+//  + tx_status::tombstone - Removes all txn related state upon apply.
 struct tm_transaction_v1 {
     static constexpr uint8_t version = 1;
 


### PR DESCRIPTION
## Cover letter

The patch supports graceful leadership transfer scenario for transaction coordinator (tm_stm). High level approach is as follows.

* Adds a `transferring` flag to `tm_transaction` state. Defaults to false but is true for transfer-in-progress txns.
* Upon receiving a leadership transfer request, flip this flag and flush ongoing txns to log
* New leader applies them in-memory and lazily resets the flag upon access _but_ before updating their state.
* If the flag is set and the term does not match, new leader expires them so that we don't read any dirty uncommitted txns.

A side effect of this refactoring is that the transactions can now appear in log/mem state, so the patch refactors to lookup in both places wherever needed.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6214

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Improvements

* Transactions can now span leadership changes of transaction coordinator.
