### PR TITLE
s/disk_log_impl: advance segment generation after adjacent compaction

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -49,9 +49,11 @@ segment::segment(
   segment_appender_ptr a,
   std::optional<compacted_index_writer> ci,
   std::optional<batch_cache_index> c,
-  storage_resources& resources) noexcept
+  storage_resources& resources,
+  segment::generation_id gen) noexcept
   : _resources(resources)
   , _appender_callbacks(this)
+  , _generation_id(gen)
   , _tracker(tkr)
   , _reader(std::move(r))
   , _idx(std::move(i))

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -72,7 +72,8 @@ public:
       segment_appender_ptr,
       std::optional<compacted_index_writer>,
       std::optional<batch_cache_index>,
-      storage_resources&) noexcept;
+      storage_resources&,
+      generation_id = generation_id{}) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -195,7 +196,7 @@ private:
      * - segment appender is flushed
      * - segment is compacted
      */
-    generation_id _generation_id{};
+    generation_id _generation_id;
 
     offset_tracker _tracker;
     segment_reader _reader;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -662,7 +662,8 @@ make_concatenated_segment(
         nullptr,
         std::nullopt,
         std::nullopt,
-        resources),
+        resources,
+        segments.front()->get_generation_id() + segment::generation_id(1)),
       std::move(generations));
 }
 


### PR DESCRIPTION
## Cover letter

When adjacent segments are compacted we must advance resulting segment
generation. It was previously observed that the segment which was
a result of adjacent segments compaction had exactly the same generation
as the segment from before compaction. This may lead to incorrect
truncation of a segment as physical offset valid for the segment from
before adjacent compaction is most likely invalid for the segment after
adjacent compaction.

Fixes: #6253 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
