### PR TITLE
Do not describe replication factor and partition count in describe configs result

### DIFF
--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -458,22 +458,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 result.error_code = error_code::topic_authorization_failed;
                 continue;
             }
-            /**
-             * Redpanda extensions
-             */
-            add_config_if_requested(
-              resource,
-              result,
-              "partition_count",
-              topic_config->partition_count,
-              describe_configs_source::topic);
 
-            add_config_if_requested(
-              resource,
-              result,
-              "replication_factor",
-              topic_config->replication_factor,
-              describe_configs_source::topic);
             /**
              * Kafka properties
              */

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -337,8 +337,6 @@ FIXTURE_TEST(
     std::vector<ss::sstring> all_properties = {
       "retention.ms",
       "retention.bytes",
-      "replication_factor",
-      "partition_count",
       "segment.bytes",
       "cleanup.policy",
       "compression.type",
@@ -373,8 +371,6 @@ FIXTURE_TEST(
     std::vector<ss::sstring> first_group_config_properties = {
       "retention.ms",
       "retention.bytes",
-      "replication_factor",
-      "partition_count",
       "segment.bytes",
       "redpanda.remote.read",
       "redpanda.remote.write"};

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -35,9 +35,9 @@ class DescribeTopicsTest(RedpandaTest):
             # bulk describe
             output = client.describe_topics()
             for topic in topics:
-                if f"partition_count={topic.partition_count}" not in output:
+                if f"PartitionCount: {topic.partition_count}" not in output:
                     return False
-                if f"replication_factor={topic.replication_factor}" not in output:
+                if f"ReplicationFactor: {topic.replication_factor}" not in output:
                     return False
             # and targetted topic describe
             topics_described = [


### PR DESCRIPTION
## Cover letter

Not reporting `partition_count` and `replication_factor` in `DescribeTopicsResponse`


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2176 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
