### PR TITLE
rpk: avoid rewriting nil arrays in cluster config

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -83,7 +83,7 @@ func exportConfig(
 		if meta.Type == "array" {
 			switch x := curValue.(type) {
 			case nil:
-				fmt.Fprintf(&sb, "%s: []", name)
+				fmt.Fprintf(&sb, "%s:", name)
 			case []interface{}:
 				if len(x) > 0 {
 					fmt.Fprintf(&sb, "%s:\n", name)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -665,6 +665,18 @@ class ClusterConfigTest(RedpandaTest):
 
         return version, text
 
+    def _noop_export_import(self):
+        # Intentionally enabling --all flag to test all properties
+        text = self._export(True)
+
+        # Validate that RPK gives us valid yaml
+        _ = yaml.full_load(text)
+
+        with tempfile.NamedTemporaryFile('w') as file:
+            file.write(text)
+            file.flush()
+            return self.rpk.cluster_config_import(file.name, True)
+
     @cluster(num_nodes=3)
     def test_rpk_export_import(self):
         """
@@ -672,6 +684,9 @@ class ClusterConfigTest(RedpandaTest):
         also `edit` (which is just an export/import cycle with
         a text editor run in the middle)
         """
+        # A no-op export & import check:
+        assert "No changes were made." in self._noop_export_import()
+
         # An arbitrary tunable for checking --all
         tunable_property = 'kafka_qdc_depth_alpha'
 


### PR DESCRIPTION
## Cover letter

Every time we exported a cluster config via rpk,
we treated nil arrays as empty arrays, e.g:

```
PROPERTY                            PRIOR  NEW
kafka_mtls_principal_mapping_rules  <nil>  []
```
Fixes #6188

## Backport Required
- [x] v22.2.x

## UX changes

* Bugfix: rpk no longer will treat nil array properties as empty arrays when executing `rpk cluster config edit/export`

## Release notes
* Bugfix: rpk no longer will treat nil array properties as empty arrays when executing `rpk cluster config edit/export`

