### PR TITLE
[v22.2.x] rpk: avoid rewriting nil arrays in cluster config

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -83,7 +83,7 @@ func exportConfig(
 		if meta.Type == "array" {
 			switch x := curValue.(type) {
 			case nil:
-				fmt.Fprintf(&sb, "%s: []", name)
+				fmt.Fprintf(&sb, "%s:", name)
 			case []interface{}:
 				if len(x) > 0 {
 					fmt.Fprintf(&sb, "%s:\n", name)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -646,6 +646,18 @@ class ClusterConfigTest(RedpandaTest):
 
         return version, text
 
+    def _noop_export_import(self):
+        # Intentionally enabling --all flag to test all properties
+        text = self._export(True)
+
+        # Validate that RPK gives us valid yaml
+        _ = yaml.full_load(text)
+
+        with tempfile.NamedTemporaryFile('w') as file:
+            file.write(text)
+            file.flush()
+            return self.rpk.cluster_config_import(file.name, True)
+
     @cluster(num_nodes=3)
     def test_rpk_export_import(self):
         """
@@ -653,6 +665,9 @@ class ClusterConfigTest(RedpandaTest):
         also `edit` (which is just an export/import cycle with
         a text editor run in the middle)
         """
+        # A no-op export & import check:
+        assert "No changes were made." in self._noop_export_import()
+
         # An arbitrary tunable for checking --all
         tunable_property = 'kafka_qdc_depth_alpha'
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6262.
Fixes https://github.com/redpanda-data/redpanda/issues/6268,