### PR TITLE
rpk: add confirmation prompt to iotune to force execution

### DIFF
--- a/src/go/rpk/pkg/tuners/iotune.go
+++ b/src/go/rpk/pkg/tuners/iotune.go
@@ -19,41 +19,43 @@ import (
 	"github.com/spf13/afero"
 )
 
+type ioTuner struct {
+	duration        time.Duration
+	evalDirectories []string
+	fs              afero.Fs
+	ioConfigFile    string
+	timeout         time.Duration
+}
+
 func NewIoTuneTuner(
 	fs afero.Fs,
 	evalDirectories []string,
 	ioConfigFile string,
 	duration, timeout time.Duration,
 ) Tunable {
-	return NewCheckedTunable(
-		NewIOConfigFileExistanceChecker(fs, ioConfigFile),
-		func() TuneResult {
-			return tune(evalDirectories, ioConfigFile, duration, timeout)
-		},
-		func() (bool, string) {
-			return checkIfIoTuneIsSupported(fs)
-		},
-		false)
+	return &ioTuner{
+		duration:        duration,
+		evalDirectories: evalDirectories,
+		fs:              fs,
+		ioConfigFile:    ioConfigFile,
+		timeout:         timeout,
+	}
 }
 
-func checkIfIoTuneIsSupported(fs afero.Fs) (bool, string) {
-	if exists, _ := afero.Exists(fs, iotune.Bin); !exists {
+func (tuner *ioTuner) CheckIfSupported() (bool, string) {
+	if exists, _ := afero.Exists(tuner.fs, iotune.Bin); !exists {
 		return false, fmt.Sprintf("'%s' not found in PATH", iotune.Bin)
 	}
 	return true, ""
 }
 
-func tune(
-	evalDirectories []string,
-	ioConfigFile string,
-	duration, timeout time.Duration,
-) TuneResult {
-	ioTune := iotune.NewIoTune(os.NewProc(), timeout)
+func (tuner *ioTuner) Tune() TuneResult {
+	ioTune := iotune.NewIoTune(os.NewProc(), tuner.timeout)
 	args := iotune.IoTuneArgs{
-		Dirs:           evalDirectories,
+		Dirs:           tuner.evalDirectories,
 		Format:         iotune.Seastar,
-		PropertiesFile: ioConfigFile,
-		Duration:       duration,
+		PropertiesFile: tuner.ioConfigFile,
+		Duration:       tuner.duration,
 		FsCheck:        false,
 	}
 	output, err := ioTune.Run(args)


### PR DESCRIPTION
## Cover letter

iotune tuner checked if the io-config file was already present before executing, which means if the user wanted to rerun iotune (after a fix or a mount change), it would have to delete the file manually.                                                                
                                                                         
Now the user will have to confirm via a CLI prompt if they want to proceed with an Iotune execution and we warn them that this will delete previous iotune results.                                                
                                                                         
In the future, we should change this overwriting approach in the redpanda-iotune binary to something like appending each test result to a list. 

Part of #6149, the rest of the ticket should be handled in redpanda-iotune.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x

## UX changes
Assuming that we already ran iotune once and still have the `/etc/redpanda/io-config.yaml`:

Before:
```
# This won't execute iotune, just skip it without telling the user what's going on
$ rpk iotune
Starting iotune...
IO configuration file stored as '/etc/redpanda/io-config.yaml'
```

Now:
```
$ rpk iotune
? IO config file detected, do you want to continue? doing this will overwrite previous results. No
IO tune canceled.

$ rpk iotune
? IO config file detected, do you want to continue? doing this will overwrite previous results. Yes
Starting iotune...
...
```

and this will force the iotune execution without prompt.
```
$ rpk iotune --no-confirm
```

## Release notes
### Improvements

* rpk now will prompt the user for confirmation when executing iotune multiple times.
