### PR TITLE
Console for Redpanda with Kafka mTLS

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -807,6 +807,15 @@ func (r *Cluster) KafkaTLSListeners() []ListenerWithName {
 	return res
 }
 
+// KafkaListener returns a KafkaAPI listener
+// It returns internal listener if available
+func (r *Cluster) KafkaListener() *KafkaAPI {
+	if l := r.InternalListener(); l != nil {
+		return l
+	}
+	return r.ExternalListener()
+}
+
 // AdminAPIInternal returns internal admin listener
 func (r *Cluster) AdminAPIInternal() *AdminAPI {
 	for _, el := range r.Spec.Configuration.AdminAPI {
@@ -1001,6 +1010,13 @@ func (k KafkaAPI) GetTLS() *TLSConfig {
 //nolint:gocritic // TODO KafkaAPI is now 81 bytes, consider a pointer
 func (k KafkaAPI) GetExternal() *ExternalConnectivityConfig {
 	return &k.External
+}
+
+// IsMutualTLSEnabled returns true if API requires client aut
+//
+//nolint:gocritic // TODO KafkaAPI is now 81 bytes, consider a pointer
+func (k KafkaAPI) IsMutualTLSEnabled() bool {
+	return k.TLS.Enabled && k.TLS.RequireClientAuth
 }
 
 // Admin API

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -172,7 +172,7 @@ func (r *Reconciling) Do(
 
 	applyResources := []resources.Resource{
 		consolepkg.NewKafkaSA(r.Client, r.Scheme, console, cluster, r.clusterDomain, r.AdminAPIClientFactory, log),
-		consolepkg.NewKafkaACL(r.Client, r.Scheme, console, cluster, r.KafkaAdminClientFactory, log),
+		consolepkg.NewKafkaACL(r.Client, r.Scheme, console, cluster, r.KafkaAdminClientFactory, r.Store, log),
 		configmapResource,
 		consolepkg.NewDeployment(r.Client, r.Scheme, console, cluster, r.Store, log),
 		consolepkg.NewService(r.Client, r.Scheme, console, r.clusterDomain, log),
@@ -220,7 +220,7 @@ func (r *Deleting) Do(
 ) (ctrl.Result, error) {
 	applyResources := []resources.ManagedResource{
 		consolepkg.NewKafkaSA(r.Client, r.Scheme, console, cluster, r.clusterDomain, r.AdminAPIClientFactory, log),
-		consolepkg.NewKafkaACL(r.Client, r.Scheme, console, cluster, r.KafkaAdminClientFactory, log),
+		consolepkg.NewKafkaACL(r.Client, r.Scheme, console, cluster, r.KafkaAdminClientFactory, r.Store, log),
 	}
 
 	for _, each := range applyResources {

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -109,7 +109,7 @@ var _ = BeforeSuite(func(done Done) {
 		}
 		return testAdminAPI, nil
 	}
-	testStore = consolepkg.NewStore(k8sManager.GetClient())
+	testStore = consolepkg.NewStore(k8sManager.GetClient(), k8sManager.GetScheme())
 	testKafkaAdmin = &mockKafkaAdmin{}
 	testKafkaAdminFactory = func(context.Context, client.Client, *redpandav1alpha1.Cluster) (consolepkg.KafkaAdminClient, error) {
 		return testKafkaAdmin, nil

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	testStore = consolepkg.NewStore(k8sManager.GetClient(), k8sManager.GetScheme())
 	testKafkaAdmin = &mockKafkaAdmin{}
-	testKafkaAdminFactory = func(context.Context, client.Client, *redpandav1alpha1.Cluster) (consolepkg.KafkaAdminClient, error) {
+	testKafkaAdminFactory = func(context.Context, client.Client, *redpandav1alpha1.Cluster, *consolepkg.Store) (consolepkg.KafkaAdminClient, error) {
 		return testKafkaAdmin, nil
 	}
 

--- a/src/go/k8s/main.go
+++ b/src/go/k8s/main.go
@@ -153,7 +153,7 @@ func main() {
 		Scheme:                  mgr.GetScheme(),
 		Log:                     ctrl.Log.WithName("controllers").WithName("redpanda").WithName("Console"),
 		AdminAPIClientFactory:   adminutils.NewInternalAdminAPI,
-		Store:                   consolepkg.NewStore(mgr.GetClient()),
+		Store:                   consolepkg.NewStore(mgr.GetClient(), mgr.GetScheme()),
 		EventRecorder:           mgr.GetEventRecorderFor("Console"),
 		KafkaAdminClientFactory: consolepkg.NewKafkaAdmin,
 	}).WithClusterDomain(clusterDomain).SetupWithManager(mgr); err != nil {

--- a/src/go/k8s/pkg/console/admin.go
+++ b/src/go/k8s/pkg/console/admin.go
@@ -2,6 +2,9 @@ package console
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -14,7 +17,6 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -54,31 +56,121 @@ func NewAdminAPI(
 
 // NewKafkaAdmin create a franz-go admin client
 func NewKafkaAdmin(
-	ctx context.Context, cl client.Client, cluster *redpandav1alpha1.Cluster,
+	ctx context.Context, cl client.Client, cluster *redpandav1alpha1.Cluster, store *Store,
 ) (KafkaAdminClient, error) {
 	opts := []kgo.Opt{kgo.SeedBrokers(getBrokers(cluster)...)}
 	if cluster.Spec.EnableSASL {
-		// Use Cluster superuser to manage Kafka
-		// Console Kafka Service Account can't add ACLs to itself
-		clusterSu := types.NamespacedName{
-			Namespace: cluster.GetNamespace(),
-			Name:      fmt.Sprintf("%s-superuser", cluster.GetName()),
+		sasl, err := getSASLOpt(ctx, cl, cluster)
+		if err != nil {
+			return nil, err
 		}
-		secret := corev1.Secret{}
-		if err := cl.Get(ctx, clusterSu, &secret); err != nil {
-			return nil, fmt.Errorf("getting Cluster superuser Secret: %w", err)
+		opts = append(opts, sasl)
+	}
+	if cluster.KafkaListener().IsMutualTLSEnabled() {
+		tlsconfig, err := getTLSConfigOpt(cluster, store)
+		if err != nil {
+			return nil, err
 		}
-		mech := scram.Auth{
-			User: string(secret.Data[corev1.BasicAuthUsernameKey]),
-			Pass: string(secret.Data[corev1.BasicAuthPasswordKey]),
-		}
-		opts = append(opts, kgo.SASL(mech.AsSha256Mechanism()))
+		opts = append(opts, tlsconfig)
 	}
 
 	kclient, err := kgo.NewClient(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating kafka client: %w", err)
 	}
-
 	return kadm.NewClient(kclient), nil
+}
+
+func getSASLOpt(ctx context.Context, cl client.Client, cluster *redpandav1alpha1.Cluster) (kgo.Opt, error) {
+	// Use Cluster superuser to manage Kafka
+	// Console Kafka Service Account can't add ACLs to itself
+	su := redpandav1alpha1.SecretKeyRef{
+		Namespace: cluster.GetNamespace(),
+		Name:      fmt.Sprintf("%s-superuser", cluster.GetName()),
+	}
+
+	secret, err := su.GetSecret(ctx, cl)
+	if err != nil {
+		return nil, err
+	}
+	user, err := su.GetValue(secret, corev1.BasicAuthUsernameKey)
+	if err != nil {
+		return nil, err
+	}
+	pass, err := su.GetValue(secret, corev1.BasicAuthPasswordKey)
+	if err != nil {
+		return nil, err
+	}
+
+	mech := scram.Auth{User: string(user), Pass: string(pass)}
+	return kgo.SASL(mech.AsSha256Mechanism()), nil
+}
+
+func getTLSConfigOpt(cluster *redpandav1alpha1.Cluster, store *Store) (kgo.Opt, error) {
+	keypair, err := clientCert(cluster, store)
+	if err != nil {
+		return nil, fmt.Errorf("getting client certificate: %w", err)
+	}
+
+	config := &tls.Config{
+		Certificates: keypair,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	ca := &SecretTLSCa{NodeSecretRef: cluster.KafkaListener().TLS.NodeSecretRef}
+	if ca.useCaCert() {
+		rootca, err := caCert(cluster, store)
+		if err != nil {
+			return nil, fmt.Errorf("getting root certificate: %w", err)
+		}
+		config.RootCAs = rootca
+	}
+
+	return kgo.DialTLSConfig(config), nil
+}
+
+func clientCert(cluster *redpandav1alpha1.Cluster, store *Store) ([]tls.Certificate, error) {
+	clientcert := redpandav1alpha1.SecretKeyRef{}
+	secret, exists := store.GetKafkaClientCert(cluster)
+	if !exists {
+		return nil, fmt.Errorf("not in store") //nolint:goerr113 // no need to declare new error type
+	}
+
+	cert, err := clientcert.GetValue(secret, corev1.TLSCertKey)
+	if err != nil {
+		return nil, err
+	}
+	key, err := clientcert.GetValue(secret, corev1.TLSPrivateKeyKey)
+	if err != nil {
+		return nil, err
+	}
+
+	keypair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %w", err)
+	}
+	return []tls.Certificate{keypair}, nil
+}
+
+func caCert(cluster *redpandav1alpha1.Cluster, store *Store) (*x509.CertPool, error) {
+	rootca := redpandav1alpha1.SecretKeyRef{}
+	secret, exists := store.GetKafkaNodeCert(cluster)
+	if !exists {
+		return nil, fmt.Errorf("not in store") //nolint:goerr113 // no need to declare new error type
+	}
+
+	caRaw, err := rootca.GetValue(secret, corev1.ServiceAccountRootCAKey)
+	if err != nil {
+		return nil, err
+	}
+	caBlock, _ := pem.Decode(caRaw)
+	ca, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	return pool, nil
 }

--- a/src/go/k8s/pkg/console/configmap.go
+++ b/src/go/k8s/pkg/console/configmap.go
@@ -345,21 +345,22 @@ var (
 	KafkaTLSKeyFilePath  = fmt.Sprintf("%s/%s", KafkaTLSDir, corev1.TLSPrivateKeyKey)
 )
 
-// SchemaRegistryTLSCa handles mounting CA cert
-type SchemaRegistryTLSCa struct {
-	NodeSecretRef *corev1.ObjectReference
+// SecretTLSCa handles mounting CA cert
+type SecretTLSCa struct {
+	NodeSecretRef  *corev1.ObjectReference
+	UsePublicCerts bool
 }
 
 // FilePath returns the CA filepath mount
-func (s *SchemaRegistryTLSCa) FilePath() string {
+func (s *SecretTLSCa) FilePath(defaultCaCert string) string {
 	if s.useCaCert() {
-		return SchemaRegistryTLSCaFilePath
+		return defaultCaCert
 	}
 	return DefaultCaFilePath
 }
 
 // Volume returns mount Volume definition
-func (s *SchemaRegistryTLSCa) Volume(name string) *corev1.Volume {
+func (s *SecretTLSCa) Volume(name string) *corev1.Volume {
 	if s.useCaCert() {
 		return &corev1.Volume{
 			Name: name,
@@ -375,8 +376,8 @@ func (s *SchemaRegistryTLSCa) Volume(name string) *corev1.Volume {
 }
 
 // useCaCert checks if the CA certificate referenced by NodeSecretRef should be used
-func (s *SchemaRegistryTLSCa) useCaCert() bool {
-	return !UsePublicCerts && s.NodeSecretRef != nil
+func (s *SecretTLSCa) useCaCert() bool {
+	return !s.UsePublicCerts && s.NodeSecretRef != nil
 }
 
 func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
@@ -389,13 +390,13 @@ func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
 	if y := cm.consoleobj.Spec.SchemaRegistry.Enabled; y {
 		tls := schema.TLSConfig{Enabled: false}
 		if yy := cm.clusterobj.IsSchemaRegistryTLSEnabled(); yy {
-			ca := &SchemaRegistryTLSCa{
-				// SchemaRegistryAPITLS cannot be nil
-				cm.clusterobj.SchemaRegistryAPITLS().TLS.NodeSecretRef,
+			ca := &SecretTLSCa{
+				NodeSecretRef:  cm.clusterobj.SchemaRegistryAPITLS().TLS.NodeSecretRef,
+				UsePublicCerts: UsePublicCerts,
 			}
 			tls = schema.TLSConfig{
 				Enabled:    y,
-				CaFilepath: ca.FilePath(),
+				CaFilepath: ca.FilePath(SchemaRegistryTLSCaFilePath),
 			}
 			if cm.clusterobj.IsSchemaRegistryMutualTLSEnabled() {
 				tls.CertFilepath = SchemaRegistryTLSCertFilePath
@@ -408,9 +409,10 @@ func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
 
 	tls := kafka.TLSConfig{Enabled: false}
 	if l := cm.clusterobj.KafkaListener(); l.IsMutualTLSEnabled() {
+		ca := &SecretTLSCa{NodeSecretRef: l.TLS.NodeSecretRef}
 		tls = kafka.TLSConfig{
 			Enabled:      true,
-			CaFilepath:   DefaultCaFilePath,
+			CaFilepath:   ca.FilePath(KafkaTLSCaFilePath),
 			CertFilepath: KafkaTLSCertFilePath,
 			KeyFilepath:  KafkaTLSKeyFilePath,
 		}

--- a/src/go/k8s/pkg/console/deployment.go
+++ b/src/go/k8s/pkg/console/deployment.go
@@ -260,6 +260,7 @@ const (
 
 	tlsSchemaRegistryMountName = "tls-schema-registry"
 	tlsConnectMountName        = "tls-connect-%s"
+	tlsKafkaMountName          = "tls-kafka"
 
 	schemaRegistryClientCertSuffix = "schema-registry-client"
 
@@ -333,6 +334,17 @@ func (d *Deployment) getVolumes(ss string) []corev1.Volume {
 		})
 	}
 
+	if d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
+		volumes = append(volumes, corev1.Volume{
+			Name: tlsKafkaMountName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: fmt.Sprintf("%s-operator-client", d.clusterobj.GetName()),
+				},
+			},
+		})
+	}
+
 	return volumes
 }
 
@@ -380,6 +392,14 @@ func (d *Deployment) getContainers(ss string) []corev1.Container {
 			Name:      enterpriseGoogleSAMountName,
 			ReadOnly:  true,
 			MountPath: enterpriseGoogleSAMountPath,
+		})
+	}
+
+	if d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      tlsKafkaMountName,
+			ReadOnly:  true,
+			MountPath: KafkaTLSDir,
 		})
 	}
 

--- a/src/go/k8s/pkg/console/deployment.go
+++ b/src/go/k8s/pkg/console/deployment.go
@@ -55,7 +55,7 @@ func (d *Deployment) Ensure(ctx context.Context) error {
 		return err
 	}
 
-	ss, err := d.ensureSyncedSecrets(ctx)
+	ss, err := d.ensureSyncedSecrets()
 	if err != nil {
 		return err
 	}
@@ -174,79 +174,58 @@ func (d *Deployment) ensureServiceAccount(ctx context.Context) (string, error) {
 
 // ensureSyncedSecrets ensures that Secrets required by Deployment are available
 // These Secrets are synced across different namespace via the Store
-func (d *Deployment) ensureSyncedSecrets(ctx context.Context) (string, error) {
-	// Currently only copying Schema Registry certificates
-	// Nothing to do if TLS is disabled
-	if !d.clusterobj.IsSchemaRegistryTLSEnabled() {
-		return "", nil
+func (d *Deployment) ensureSyncedSecrets() (map[string]string, error) {
+	syncedSecrets := map[string]map[string][]byte{}
+
+	if d.clusterobj.IsSchemaRegistryTLSEnabled() { //nolint:nestif // secret syncing is complex
+		data := map[string][]byte{}
+		if d.clusterobj.IsSchemaRegistryMutualTLSEnabled() {
+			clientCert, exists := d.store.GetSchemaRegistryClientCert(d.clusterobj)
+			if !exists {
+				return nil, fmt.Errorf("get schema registry client certificate: %s", "not found") //nolint:goerr113 // no need to declare new error type
+			}
+			certfile := getOrEmpty(corev1.TLSCertKey, clientCert.Data)
+			keyfile := getOrEmpty(corev1.TLSPrivateKeyKey, clientCert.Data)
+			data[corev1.TLSCertKey] = []byte(certfile)
+			data[corev1.TLSPrivateKeyKey] = []byte(keyfile)
+		}
+
+		// Only write CA cert if not using DefaultCaFilePath
+		ca := &SchemaRegistryTLSCa{d.clusterobj.SchemaRegistryAPITLS().TLS.NodeSecretRef}
+		if ca.useCaCert() {
+			caCert, exists := d.store.GetSchemaRegistryNodeCert(d.clusterobj)
+			if !exists {
+				return nil, fmt.Errorf("get schema registry node certificate: %s", "not found") //nolint:goerr113 // no need to declare new error type
+			}
+			cafile := getOrEmpty("ca.crt", caCert.Data)
+			data["ca.crt"] = []byte(cafile)
+		}
+		syncedSecrets[schemaRegistrySyncedSecretKey] = data
 	}
 
-	// Write the synced certs to secret
-	data := map[string][]byte{}
-
-	if d.clusterobj.IsSchemaRegistryMutualTLSEnabled() {
-		clientCert, exists := d.store.GetSchemaRegistryClientCert(d.clusterobj)
+	if d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
+		data := map[string][]byte{}
+		clientCert, exists := d.store.GetKafkaClientCert(d.clusterobj)
 		if !exists {
-			return "", fmt.Errorf("get schema registry client certificate: %s", "not found") //nolint:goerr113 // no need to declare new error type
+			return nil, fmt.Errorf("get kafka client certificate: %s", "not found") //nolint:goerr113 // no need to declare new error type
 		}
-		certfile := getOrEmpty("tls.crt", clientCert.Data)
-		keyfile := getOrEmpty("tls.key", clientCert.Data)
-		data["tls.crt"] = []byte(certfile)
-		data["tls.key"] = []byte(keyfile)
+		certfile := getOrEmpty(corev1.TLSCertKey, clientCert.Data)
+		keyfile := getOrEmpty(corev1.TLSPrivateKeyKey, clientCert.Data)
+		data[corev1.TLSCertKey] = []byte(certfile)
+		data[corev1.TLSPrivateKeyKey] = []byte(keyfile)
+		syncedSecrets[kafkaSyncedSecretKey] = data
 	}
 
-	// Only write CA cert if not using DefaultCaFilePath
-	ca := &SchemaRegistryTLSCa{d.clusterobj.SchemaRegistryAPITLS().TLS.NodeSecretRef}
-	if ca.useCaCert() {
-		caCert, exists := d.store.GetSchemaRegistryNodeCert(d.clusterobj)
-		if !exists {
-			return "", fmt.Errorf("get schema registry node certificate: %s", "not found") //nolint:goerr113 // no need to declare new error type
-		}
-		cafile := getOrEmpty("ca.crt", caCert.Data)
-		data["ca.crt"] = []byte(cafile)
-	}
-
-	// Nothing to do if synced certs is empty
-	if len(data) == 0 {
-		return "", nil
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", d.consoleobj.GetName(), resources.SchemaRegistrySuffix),
-			Namespace: d.consoleobj.GetNamespace(),
-			Labels:    labels.ForConsole(d.consoleobj),
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		Data: data,
-	}
-
-	err := controllerutil.SetControllerReference(d.consoleobj, secret, d.scheme)
-	if err != nil {
-		return "", err
-	}
-
-	created, err := resources.CreateIfNotExists(ctx, d.Client, secret, d.log)
-	if err != nil {
-		return "", fmt.Errorf("creating Console synced secret: %w", err)
-	}
-
-	if !created {
-		var current corev1.Secret
-		err = d.Get(ctx, types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}, &current)
+	secretNames := map[string]string{}
+	for key, ss := range syncedSecrets {
+		name, err := d.store.CreateSyncedSecret(d.consoleobj, ss, key, d.log)
 		if err != nil {
-			return "", fmt.Errorf("fetching Console synced secret: %w", err)
+			return nil, err
 		}
-		_, err = resources.Update(ctx, &current, secret, d.Client, d.log)
-		if err != nil {
-			return "", fmt.Errorf("updating Console synced secret: %w", err)
-		}
+		secretNames[key] = name
 	}
 
-	return secret.GetName(), nil
+	return secretNames, nil
 }
 
 func getGracePeriod(period time.Duration) *int64 {
@@ -263,6 +242,7 @@ const (
 	tlsKafkaMountName          = "tls-kafka"
 
 	schemaRegistryClientCertSuffix = "schema-registry-client"
+	kafkaClientCertSuffix          = "operator-client"
 
 	enterpriseRBACMountName     = "enterprise-rbac"
 	enterpriseRBACMountPath     = "/etc/console/enterprise/rbac"
@@ -272,7 +252,7 @@ const (
 	prometheusBasicAuthPassowrdEnvVar = "CLOUD_PROMETHEUSENDPOINT_BASICAUTH_PASSWORD"
 )
 
-func (d *Deployment) getVolumes(ss string) []corev1.Volume {
+func (d *Deployment) getVolumes(ss map[string]string) []corev1.Volume {
 	volumes := []corev1.Volume{
 		{
 			Name: configMountName,
@@ -286,12 +266,12 @@ func (d *Deployment) getVolumes(ss string) []corev1.Volume {
 		},
 	}
 
-	if d.clusterobj.IsSchemaRegistryTLSEnabled() && ss != "" {
+	if secretName, ok := ss[schemaRegistrySyncedSecretKey]; ok && d.clusterobj.IsSchemaRegistryTLSEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: tlsSchemaRegistryMountName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: ss,
+					SecretName: secretName,
 				},
 			},
 		})
@@ -334,12 +314,12 @@ func (d *Deployment) getVolumes(ss string) []corev1.Volume {
 		})
 	}
 
-	if d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
+	if secretName, ok := ss[kafkaSyncedSecretKey]; ok && d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: tlsKafkaMountName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: fmt.Sprintf("%s-operator-client", d.clusterobj.GetName()),
+					SecretName: secretName,
 				},
 			},
 		})
@@ -351,7 +331,7 @@ func (d *Deployment) getVolumes(ss string) []corev1.Volume {
 // ConsoleContainerName is the Console container name
 var ConsoleContainerName = "console"
 
-func (d *Deployment) getContainers(ss string) []corev1.Container {
+func (d *Deployment) getContainers(ss map[string]string) []corev1.Container {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      configMountName,
@@ -368,7 +348,7 @@ func (d *Deployment) getContainers(ss string) []corev1.Container {
 		})
 	}
 
-	if d.clusterobj.IsSchemaRegistryTLSEnabled() && ss != "" {
+	if _, ok := ss[schemaRegistrySyncedSecretKey]; ok && d.clusterobj.IsSchemaRegistryTLSEnabled() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      tlsSchemaRegistryMountName,
 			ReadOnly:  true,
@@ -395,7 +375,7 @@ func (d *Deployment) getContainers(ss string) []corev1.Container {
 		})
 	}
 
-	if d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
+	if _, ok := ss[kafkaSyncedSecretKey]; ok && d.clusterobj.KafkaListener().IsMutualTLSEnabled() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      tlsKafkaMountName,
 			ReadOnly:  true,

--- a/src/go/k8s/pkg/console/sasl.go
+++ b/src/go/k8s/pkg/console/sasl.go
@@ -68,7 +68,7 @@ type (
 	}
 
 	// KafkaAdminClientFactory returns a KafkaAdminClient
-	KafkaAdminClientFactory func(context.Context, client.Client, *redpandav1alpha1.Cluster) (KafkaAdminClient, error)
+	KafkaAdminClientFactory func(context.Context, client.Client, *redpandav1alpha1.Cluster, *Store) (KafkaAdminClient, error)
 )
 
 // GenerateSASLUsername returns username used for Kafka SASL config
@@ -157,6 +157,7 @@ type KafkaACL struct {
 	consoleobj *redpandav1alpha1.Console
 	clusterobj *redpandav1alpha1.Cluster
 	kafkaAdmin KafkaAdminClientFactory
+	store      *Store
 	log        logr.Logger
 }
 
@@ -167,6 +168,7 @@ func NewKafkaACL(
 	consoleobj *redpandav1alpha1.Console,
 	clusterobj *redpandav1alpha1.Cluster,
 	kafkaAdmin KafkaAdminClientFactory,
+	store *Store,
 	log logr.Logger,
 ) *KafkaACL {
 	return &KafkaACL{
@@ -175,6 +177,7 @@ func NewKafkaACL(
 		consoleobj: consoleobj,
 		clusterobj: clusterobj,
 		kafkaAdmin: kafkaAdmin,
+		store:      store,
 		log:        log,
 	}
 }
@@ -191,7 +194,7 @@ func (k *KafkaACL) Ensure(ctx context.Context) error {
 	}
 	b.PrefixUserExcept()
 
-	kadmclient, err := k.kafkaAdmin(ctx, k.Client, k.clusterobj)
+	kadmclient, err := k.kafkaAdmin(ctx, k.Client, k.clusterobj, k.store)
 	if err != nil {
 		return fmt.Errorf("creating kafka admin client: %w", err)
 	}
@@ -244,7 +247,7 @@ func (k *KafkaACL) Cleanup(ctx context.Context) error {
 	}
 	b.PrefixUserExcept()
 
-	kadmclient, err := k.kafkaAdmin(ctx, k.Client, k.clusterobj)
+	kadmclient, err := k.kafkaAdmin(ctx, k.Client, k.clusterobj, k.store)
 	if err != nil {
 		return fmt.Errorf("creating kafka admin client: %w", err)
 	}

--- a/src/go/k8s/pkg/console/store.go
+++ b/src/go/k8s/pkg/console/store.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	labels "github.com/redpanda-data/redpanda/src/go/k8s/pkg/labels"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // By default, Console can only be created with the same namespace as the referenced Cluster.
@@ -23,14 +29,21 @@ type Store struct {
 
 	context context.Context
 	client  client.Client
+	scheme  *runtime.Scheme
 }
 
+var (
+	schemaRegistrySyncedSecretKey = "schema-registry"
+	kafkaSyncedSecretKey          = "kafka"
+)
+
 // NewStore creates a new store
-func NewStore(cl client.Client) *Store {
+func NewStore(cl client.Client, scheme *runtime.Scheme) *Store {
 	return &Store{
 		ThreadSafeStore: cache.NewThreadSafeStore(cache.Indexers{}, cache.Indices{}),
 		context:         context.Background(),
 		client:          cl,
+		scheme:          scheme,
 	}
 }
 
@@ -38,7 +51,7 @@ func NewStore(cl client.Client) *Store {
 func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 	if cluster.IsSchemaRegistryTLSEnabled() { //nolint:nestif // sync is complex
 		if cluster.IsSchemaRegistryMutualTLSEnabled() {
-			schemaRegistryClientCert, err := syncSchemaRegistryCert(
+			schemaRegistryClientCert, err := syncCert(
 				s.context,
 				s.client,
 				client.ObjectKeyFromObject(cluster),
@@ -55,7 +68,7 @@ func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 		ca := &SchemaRegistryTLSCa{cluster.SchemaRegistryAPITLS().TLS.NodeSecretRef}
 		if ca.useCaCert() {
 			nodeSecretRef := cluster.SchemaRegistryAPITLS().TLS.NodeSecretRef
-			schemaRegistryNodeCert, err := syncSchemaRegistryCert(
+			schemaRegistryNodeCert, err := syncCert(
 				s.context,
 				s.client,
 				types.NamespacedName{Namespace: nodeSecretRef.Namespace, Name: nodeSecretRef.Name},
@@ -68,10 +81,24 @@ func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 		}
 	}
 
+	if cluster.KafkaListener().IsMutualTLSEnabled() {
+		kafkaClientCert, err := syncCert(
+			s.context,
+			s.client,
+			client.ObjectKeyFromObject(cluster),
+			fmt.Sprintf("%s-%s", cluster.GetName(), kafkaClientCertSuffix),
+		)
+		if err != nil {
+			return fmt.Errorf("sync kafka client certificate: %w", err)
+		}
+		// same as Update()
+		s.Add(s.getKafkaClientCertKey(cluster), kafkaClientCert)
+	}
+
 	return nil
 }
 
-func syncSchemaRegistryCert(
+func syncCert(
 	ctx context.Context, cl client.Client, nsn client.ObjectKey, name string,
 ) (client.Object, error) {
 	secret := corev1.Secret{}
@@ -89,6 +116,12 @@ func (s *Store) getSchemaRegistryClientCertKey(
 	cluster *redpandav1alpha1.Cluster,
 ) string {
 	return fmt.Sprintf("%s-%s-%s", cluster.GetNamespace(), cluster.GetName(), schemaRegistryClientCertSuffix)
+}
+
+func (s *Store) getKafkaClientCertKey(
+	cluster *redpandav1alpha1.Cluster,
+) string {
+	return fmt.Sprintf("%s-%s-%s", cluster.GetNamespace(), cluster.GetName(), kafkaClientCertSuffix)
 }
 
 func (s *Store) getSchemaRegistryNodeCertKey(
@@ -115,4 +148,59 @@ func (s *Store) GetSchemaRegistryNodeCert(
 		return secret.(*corev1.Secret), true
 	}
 	return nil, false
+}
+
+// GetKafkaClientCert gets the Kafka client cert and returns Secret object
+func (s *Store) GetKafkaClientCert(
+	cluster *redpandav1alpha1.Cluster,
+) (*corev1.Secret, bool) {
+	if secret, exists := s.Get(s.getKafkaClientCertKey(cluster)); exists {
+		return secret.(*corev1.Secret), true
+	}
+	return nil, false
+}
+
+// CreateSyncedSecret creates the synced Secret in Console namespace
+func (s *Store) CreateSyncedSecret(
+	console *redpandav1alpha1.Console,
+	data map[string][]byte,
+	secretNameSuffix string,
+	log logr.Logger,
+) (string, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", console.GetName(), secretNameSuffix),
+			Namespace: console.GetNamespace(),
+			Labels:    labels.ForConsole(console),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		Data: data,
+	}
+
+	err := controllerutil.SetControllerReference(console, secret, s.scheme)
+	if err != nil {
+		return "", err
+	}
+
+	created, err := resources.CreateIfNotExists(s.context, s.client, secret, log)
+	if err != nil {
+		return "", fmt.Errorf("creating Console synced secret %s: %w", secret, err)
+	}
+
+	if !created {
+		var current corev1.Secret
+		err = s.client.Get(s.context, types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}, &current)
+		if err != nil {
+			return "", fmt.Errorf("fetching Console synced secret %s: %w", secret, err)
+		}
+		_, err = resources.Update(s.context, &current, secret, s.client, log)
+		if err != nil {
+			return "", fmt.Errorf("updating Console synced secret %s: %w", secret, err)
+		}
+	}
+
+	return secret.GetName(), nil
 }

--- a/src/go/k8s/pkg/console/store.go
+++ b/src/go/k8s/pkg/console/store.go
@@ -65,7 +65,10 @@ func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 		}
 
 		// Only sync CA cert if not using DefaultCaFilePath
-		ca := &SchemaRegistryTLSCa{cluster.SchemaRegistryAPITLS().TLS.NodeSecretRef}
+		ca := &SecretTLSCa{
+			NodeSecretRef:  cluster.SchemaRegistryAPITLS().TLS.NodeSecretRef,
+			UsePublicCerts: UsePublicCerts,
+		}
 		if ca.useCaCert() {
 			nodeSecretRef := cluster.SchemaRegistryAPITLS().TLS.NodeSecretRef
 			schemaRegistryNodeCert, err := syncCert(
@@ -81,7 +84,7 @@ func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 		}
 	}
 
-	if cluster.KafkaListener().IsMutualTLSEnabled() {
+	if l := cluster.KafkaListener(); l.IsMutualTLSEnabled() {
 		kafkaClientCert, err := syncCert(
 			s.context,
 			s.client,
@@ -93,6 +96,22 @@ func (s *Store) Sync(cluster *redpandav1alpha1.Cluster) error {
 		}
 		// same as Update()
 		s.Add(s.getKafkaClientCertKey(cluster), kafkaClientCert)
+
+		// Only sync CA cert if not using DefaultCaFilePath
+		nodeSecretRef := l.TLS.NodeSecretRef
+		ca := &SecretTLSCa{NodeSecretRef: nodeSecretRef}
+		if ca.useCaCert() {
+			kafkaNodeCert, err := syncCert(
+				s.context,
+				s.client,
+				types.NamespacedName{Namespace: nodeSecretRef.Namespace, Name: nodeSecretRef.Name},
+				nodeSecretRef.Name,
+			)
+			if err != nil {
+				return fmt.Errorf("sync kafka node certificate: %w", err)
+			}
+			s.Add(s.getKafkaNodeCertKey(cluster), kafkaNodeCert)
+		}
 	}
 
 	return nil
@@ -130,6 +149,10 @@ func (s *Store) getSchemaRegistryNodeCertKey(
 	return fmt.Sprintf("%s-%s-%s", cluster.GetNamespace(), cluster.GetName(), "schema-registry-node")
 }
 
+func (s *Store) getKafkaNodeCertKey(cluster *redpandav1alpha1.Cluster) string {
+	return fmt.Sprintf("%s-%s-%s", cluster.GetNamespace(), cluster.GetName(), "kafka-node")
+}
+
 // GetSchemaRegistryClientCert gets the Schema Registry client cert and returns Secret object
 func (s *Store) GetSchemaRegistryClientCert(
 	cluster *redpandav1alpha1.Cluster,
@@ -155,6 +178,16 @@ func (s *Store) GetKafkaClientCert(
 	cluster *redpandav1alpha1.Cluster,
 ) (*corev1.Secret, bool) {
 	if secret, exists := s.Get(s.getKafkaClientCertKey(cluster)); exists {
+		return secret.(*corev1.Secret), true
+	}
+	return nil, false
+}
+
+// GetKafkaNodeCert gets the Kafka node cert and returns Secret object
+func (s *Store) GetKafkaNodeCert(
+	cluster *redpandav1alpha1.Cluster,
+) (*corev1.Secret, bool) {
+	if secret, exists := s.Get(s.getKafkaNodeCertKey(cluster)); exists {
 		return secret.(*corev1.Secret), true
 	}
 	return nil, false

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/00-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: console-kafka-mtls

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/00-create-ns.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/00-create-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: console-kafka-mtls

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/01-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-tls-secret-node-certificate
+  namespace: console-kafka-mtls

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/01-create-certificate.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/01-create-certificate.yaml
@@ -1,0 +1,49 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cluster-tls-secret-selfsigned-issuer
+  namespace: console-kafka-mtls
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-tls-secret-root-certificate
+  namespace: console-kafka-mtls
+spec:
+  isCA: true
+  commonName: root-common-name
+  issuerRef:
+    kind: Issuer
+    name: cluster-tls-secret-selfsigned-issuer
+  secretName: cluster-tls-secret-root-certificate
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cluster-tls-secret-root-issuer
+  namespace: console-kafka-mtls
+spec:
+  ca:
+    secretName: cluster-tls-secret-root-certificate
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-tls-secret-node-certificate
+  namespace: console-kafka-mtls
+spec:
+  dnsNames:
+    # Kakfa API
+    - "*.cluster.console-kafka-mtls.svc.cluster.local"
+  issuerRef:
+    kind: Issuer
+    name: cluster-tls-secret-root-issuer
+  secretName: cluster-tls-secret-node-certificate

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/02-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+  namespace: console-kafka-mtls
+status:
+  replicas: 2
+  restarting: false
+  conditions:
+    - type: ClusterConfigured
+      status: "True"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: app.kubernetes.io/name=redpanda
+    tail: -1
+  - type: pod
+    namespace: redpanda-system
+    selector: control-plane=controller-manager
+    tail: -1
+  - type: command
+    command: kubectl get clusters -o jsonpath={@} -n console-kafka-mtls
+  - type: command
+    command: kubectl get pods -o jsonpath={@} -n console-kafka-mtls

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/02-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/02-redpanda-cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+  namespace: console-kafka-mtls
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+      tls:
+        enabled: true
+        requireClientAuth: true
+        nodeSecretRef:
+          name: cluster-tls-secret-node-certificate
+          namespace: console-kafka-mtls
+    adminApi:
+    - port: 9644
+    schemaRegistry:
+      port: 8081
+    pandaproxyApi:
+     - port: 8082
+    developerMode: true
+  additionalConfiguration:
+    redpanda.append_chunk_size: "40960"
+    redpanda.segment_appender_flush_timeout_ms: "1003"

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/03-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  namespace: console-kafka-mtls
+status:
+  readyReplicas: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda-console
+  tail: -1
+- type: pod
+  namespace: redpanda-system
+  selector: control-plane=controller-manager
+  tail: -1

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/03-console.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/03-console.yaml
@@ -1,0 +1,17 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Console
+metadata:
+  name: console
+  namespace: console-kafka-mtls
+spec:
+  server:
+    listenPort: 8080
+  schema:
+    enabled: false
+  clusterRef:
+    name: cluster
+    namespace: console-kafka-mtls
+  deployment:
+    image: vectorized/console:master-173596f
+  connect:
+    enabled: false

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/04-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-console
+  namespace: console-kafka-mtls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda-console
+  tail: -1

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/04-call-console.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/04-call-console.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-console
+  namespace: console-kafka-mtls
+spec:
+  template:
+    spec:
+      containers:
+        - name: curl
+          image: curlimages/curl:latest
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - curl http://console.$POD_NAMESPACE.svc.cluster.local:8080/admin/health -v
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/05-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/05-cleanup.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: redpanda.vectorized.io/v1alpha1
+  kind: Console
+  name: console
+  namespace: console-kafka-mtls
+- apiVersion: v1
+  kind: Namespace
+  name: console-kafka-mtls


### PR DESCRIPTION
## Cover letter

Support installing Console in Redpanda cluster with Kafka mTLS enabled.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes [#2761](https://app.zenhub.com/workspaces/cloud-62684e2c6635e100149514fd/issues/redpanda-data/cloud/2761)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

User will be able to install Console from the operator with Redpanda cluster that has mTLS auth in the Kafka API.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Features

* Install Console from the operator that connects to Redpanda Kafka API via mTLS.

