### PR TITLE
Message max size

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -816,6 +816,12 @@ configuration::configuration()
       "Timeout for executing node management operations",
       {.visibility = visibility::tunable},
       5s)
+  , kafka_request_max_bytes(
+      *this,
+      "kafka_request_max_bytes",
+      "Maximum size of a single request processed via Kafka API",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100_MiB)
   , compaction_ctrl_update_interval_ms(
       *this,
       "compaction_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -178,6 +178,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;
+    property<uint32_t> kafka_request_max_bytes;
     // Compaction controller
     property<std::chrono::milliseconds> compaction_ctrl_update_interval_ms;
     property<double> compaction_ctrl_p_coeff;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "config/property.h"
 #include "kafka/server/protocol.h"
 #include "kafka/server/response.h"
 #include "kafka/types.h"
@@ -88,7 +89,8 @@ public:
       net::server::resources&& r,
       std::optional<security::sasl_server> sasl,
       bool enable_authorizer,
-      std::optional<security::tls::mtls_state> mtls_state) noexcept
+      std::optional<security::tls::mtls_state> mtls_state,
+      config::binding<uint32_t> max_request_size) noexcept
       : _proto(p)
       , _rs(std::move(r))
       , _sasl(std::move(sasl))
@@ -96,7 +98,8 @@ public:
       , _client_addr(_rs.conn ? _rs.conn->addr.addr() : ss::net::inet_address{})
       , _enable_authorizer(enable_authorizer)
       , _authlog(_client_addr, client_port())
-      , _mtls_state(std::move(mtls_state)) {}
+      , _mtls_state(std::move(mtls_state))
+      , _max_request_size(std::move(max_request_size)) {}
 
     ~connection_context() noexcept = default;
     connection_context(const connection_context&) = delete;
@@ -301,6 +304,7 @@ private:
     const bool _enable_authorizer;
     ctx_log _authlog;
     std::optional<security::tls::mtls_state> _mtls_state;
+    config::binding<uint32_t> _max_request_size;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -406,7 +406,7 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
             continue;
         }
 
-        // an error occured handling legacy messages (magic 0 or 1)
+        // an error occurred handling legacy messages (magic 0 or 1)
         if (unlikely(part.records->adapter.legacy_error)) {
             partitions_dispatched.push_back(ss::now());
             partitions_produced.push_back(
@@ -502,7 +502,7 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
           ctx.respond(request.make_full_disk_response()));
     }
 
-    // determine if the request has transactional / idemponent batches
+    // determine if the request has transactional / idempotent batches
     for (auto& topic : request.data.topics) {
         for (auto& part : topic.partitions) {
             if (part.records) {
@@ -609,7 +609,7 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
                               }
                           }
 
-                          // in the absense of errors, acks = 0 results in the
+                          // in the absence of errors, acks = 0 results in the
                           // response being dropped, as the client does not
                           // expect a response. here we mark the response as
                           // noop, but let it flow back so that it can be

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -180,7 +180,12 @@ ss::future<> protocol::apply(net::server::resources rs) {
     }
 
     auto ctx = ss::make_lw_shared<connection_context>(
-      *this, std::move(rs), std::move(sasl), authz_enabled, mtls_state);
+      *this,
+      std::move(rs),
+      std::move(sasl),
+      authz_enabled,
+      mtls_state,
+      config::shard_local_cfg().kafka_request_max_bytes.bind());
 
     co_return co_await ss::do_until(
       [ctx] { return ctx->is_finished_parsing(); },

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -9,6 +9,7 @@
 
 #include "net/connection.h"
 
+#include "net/exceptions.h"
 #include "rpc/service.h"
 
 namespace net {
@@ -40,6 +41,8 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         // Happens on unclean client disconnect, typically wrapping
         // an out_of_range
         return "parse error";
+    } catch (const invalid_request_error& e) {
+        return "invalid request";
     } catch (...) {
         // Global catch-all prevents stranded/non-handled exceptional futures.
         // In all other non-explicity handled cases, the exception will not be

--- a/src/v/net/exceptions.h
+++ b/src/v/net/exceptions.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <fmt/core.h>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace net {
+
+struct invalid_request_error final : public std::runtime_error {
+public:
+    explicit invalid_request_error(std::string_view msg)
+      : std::runtime_error(msg.data()) {}
+};
+
+} // namespace net

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -20,6 +20,7 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "config/broker_authn_endpoint.h"
+#include "config/mock_property.h"
 #include "config/node_config.h"
 #include "coproc/api.h"
 #include "kafka/client/transport.h"
@@ -414,7 +415,8 @@ public:
           net::server::resources(nullptr, nullptr),
           std::move(sasl),
           false,
-          std::nullopt);
+          std::nullopt,
+          config::mock_property<uint32_t>(100_MiB).bind());
 
         kafka::request_header header;
         auto encoder_context = kafka::request_context(

--- a/tests/rptest/tests/limits_test.py
+++ b/tests/rptest/tests/limits_test.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.services import redpanda
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+import string
+
+from rptest.util import wait_until
+
+
+class LimitsTest(RedpandaTest):
+    def _rand_string(sz):
+        return ''.join(
+            random.choice(string.ascii_letters + string.digits)
+            for _ in range(sz))
+
+    @cluster(num_nodes=3)
+    def test_kafka_request_max_size(self):
+        topic = TopicSpec(partition_count=1)
+        # create topic
+        DefaultClient(self.redpanda).create_topic(topic)
+        rpk = RpkTool(self.redpanda)
+        # produce 512KB message
+        rpk.produce(topic=topic.name,
+                    key="test",
+                    msg=LimitsTest._rand_string(512 * 1024))
+        # set request max bytes to 50KB
+        new_limit = 50 * 1024
+        rpk.cluster_config_set("kafka_request_max_bytes", str(new_limit))
+
+        def produce_error():
+            try:
+                rpk.produce(topic=topic.name,
+                            key="test",
+                            msg=LimitsTest._rand_string(512 * 1024))
+            except RpkException as e:
+                return "timed out" in e.msg
+
+            return False
+
+        wait_until(produce_error, 30, 1)


### PR DESCRIPTION
## Cover letter

Added support for message max bytes. When any of the Kafka API requests size is larger than the configured `kafka_request_max_bytes` the connection is dropped and request is not being processed.

This is a limit that we should map to kafka socket.request.max.bytes. For the max.message.bytes i have another PR open.


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* Added new property `kafka_request_max_bytes` to control the maximum size of a request processed by server.
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
