### PR TITLE
tests: reinstate exact consumer count checks in KgoRepeaterService

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -444,6 +444,10 @@ class RpkTool:
                     # Transient, return None to retry
                     # e.g. Kafka replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list
                     return None
+                elif "connection refused" in e.msg:
+                    # Metadata directed us to a broker that is uncontactable, perhaps
+                    # it was just stopped.  Retry should succeed once metadata updates.
+                    return None
                 else:
                     raise
 


### PR DESCRIPTION
## Cover letter

**This is cleanup for when https://github.com/twmb/franz-go/issues/198 is resolved and we pull an updated kgo-verifier that includes the fix.**

This check had been made permissive to work around a franz-go
bug.

Reinstate it, and keep some debug code which was added to make
any failures here specifically say which workers disappeared.

Fixes https://github.com/redpanda-data/redpanda/issues/5959

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none