### PR TITLE
cloud_storage: Add DeleteObject S3 API support

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -600,6 +600,76 @@ ss::future<download_result> remote::segment_exists(
     co_return *result;
 }
 
+ss::future<upload_result> remote::delete_segment(
+  const s3::bucket_name& bucket,
+  const remote_segment_path& segment_path,
+  retry_chain_node& parent) {
+    ss::gate::holder gh{_gate};
+    retry_chain_node fib(&parent);
+    retry_chain_logger ctxlog(cst_log, fib);
+    auto path = s3::object_key(segment_path());
+    auto [client, deleter] = co_await _pool.acquire();
+    auto permit = fib.retry();
+    vlog(ctxlog.debug, "Delete segment {}", path);
+    std::optional<upload_result> result;
+    while (!_gate.is_closed() && permit.is_allowed && !result) {
+        std::exception_ptr eptr = nullptr;
+        try {
+            // NOTE: DeleteObject in S3 doesn't return an error
+            // if the object doesn't exist. Because of that we're
+            // using 'upload_result' type as a return type. No need
+            // to handle NoSuchKey error. The 'upload_result' represents
+            // any mutable operation.
+            co_await client->delete_object(bucket, path, fib.get_timeout());
+            vlog(ctxlog.debug, "Receive OK DeleteObject {} response", path);
+            co_return upload_result::success;
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+        co_await client->shutdown();
+        auto outcome = categorize_error(eptr, fib, bucket, path);
+        switch (outcome) {
+        case error_outcome::retry_slowdown:
+            [[fallthrough]];
+        case error_outcome::retry:
+            vlog(
+              ctxlog.debug,
+              "DeleteObject {}, {} backoff required",
+              bucket,
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                permit.delay));
+            co_await ss::sleep_abortable(permit.delay, _as);
+            permit = fib.retry();
+            break;
+        case error_outcome::fail:
+            result = upload_result::failed;
+            break;
+        case error_outcome::notfound:
+            vassert(
+              false,
+              "Unexpected NoSuchKey error response from DeleteObject {}",
+              path);
+            break;
+        }
+    }
+    if (!result) {
+        vlog(
+          ctxlog.warn,
+          "DeleteObject {}, {}, backoff quota exceded, segment not deleted",
+          path,
+          bucket);
+        result = upload_result::timedout;
+    } else {
+        vlog(
+          ctxlog.warn,
+          "DeleteObject {}, {}, segment not deleted, error: {}",
+          path,
+          bucket,
+          *result);
+    }
+    co_return *result;
+}
+
 ss::sstring lazy_abort_source::abort_reason() const { return _abort_reason; }
 
 bool lazy_abort_source::abort_requested() { return _predicate(*this); }

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -207,6 +207,17 @@ public:
       const remote_segment_path& path,
       retry_chain_node& parent);
 
+    /// \brief Delete segment from S3
+    ///
+    /// The method deletes the segment. It can retry after some errors.
+    ///
+    /// \param segment_path is a segment's name in S3
+    /// \param bucket is a name of the S3 bucket
+    ss::future<upload_result> delete_segment(
+      const s3::bucket_name& bucket,
+      const remote_segment_path& segment_path,
+      retry_chain_node& parent);
+
 private:
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);
     s3::client_pool _pool;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -305,3 +305,37 @@ FIXTURE_TEST(test_segment_exists_timeout, s3_imposter_fixture) { // NOLINT
     auto expect_timeout = remote.segment_exists(bucket, path, fib).get();
     BOOST_REQUIRE(expect_timeout == download_result::timedout);
 }
+
+FIXTURE_TEST(test_segment_delete, s3_imposter_fixture) { // NOLINT
+    set_expectations_and_listen({});
+    auto conf = get_configuration();
+    auto bucket = s3::bucket_name("bucket");
+    remote remote(s3_connection_limit(10), conf, config_file);
+    auto name = segment_name("0-1-v1.log");
+    auto path = generate_remote_segment_path(
+      manifest_ntp, manifest_revision, name, model::term_id{1});
+
+    retry_chain_node fib(100ms, 20ms);
+    uint64_t clen = manifest_payload.size();
+    auto action = ss::defer([&remote] { remote.stop().get(); });
+    auto reset_stream = []() -> ss::future<storage::segment_reader_handle> {
+        iobuf out;
+        out.append(manifest_payload.data(), manifest_payload.size());
+        co_return storage::segment_reader_handle(
+          make_iobuf_input_stream(std::move(out)));
+    };
+    auto upl_res = remote
+                     .upload_segment(
+                       bucket, path, clen, reset_stream, fib, always_continue)
+                     .get();
+    BOOST_REQUIRE(upl_res == upload_result::success);
+
+    // NOTE: we have to upload something as segment in order for the mock to
+    // work correctly.
+
+    auto expected_success = remote.delete_segment(bucket, path, fib).get();
+    BOOST_REQUIRE(expected_success == upload_result::success);
+
+    auto expected_notfound = remote.segment_exists(bucket, path, fib).get();
+    BOOST_REQUIRE(expected_notfound == download_result::notfound);
+}


### PR DESCRIPTION
## Cover letter

This is a part of the cloud retention project.

Add `DeleteObject` call to S3 client and to the `cloud_storage::remote`.
The `cloud_storage::remote` is guaranteed to never return `not_found` error since AWS S3 api never returns `NoSuchKey` error from the `DeleteObject` request.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none

