### PR TITLE
gha/lint: run lint check on push to any branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,13 @@
 name: Lint all codez
 on:
   push:
-    tags: 'v2**'
     branches:
-      - dev
-      - release
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     branches:
-      - main
-      - dev
+      - '**'
 
 jobs:
   go:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,13 +25,18 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.8
-      id: go
+
+    - name: lint rpk
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.45.2
+        working-directory: src/go/rpk/
 
     - name: install gofumpt
       working-directory: src/go/rpk
@@ -43,12 +48,6 @@ jobs:
       run: |
         find . -name *.go -type f | xargs -n1 gofumpt -w -lang=1.17
         git diff --exit-code
-
-    - name: lint rpk
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.45.2
-        working-directory: src/go/rpk/
 
   js:
     name: Lint js files


### PR DESCRIPTION
## Cover letter

Without this fix, the lint checks won't run on PRs to the release branches or on merge of PRs to the release branches. They currently run on PRs to [dev](https://github.com/redpanda-data/redpanda/tree/dev) branch and on merge of PR to dev branch as well as on tag push.

This PR will change the workflow so lint checks run on push to any branch, including the release branches. Also, no need to run the lint checks again on push of tag because the lint check will have already run on a git commit that is tagged.

Partially addresses issue https://github.com/redpanda-data/devprod/issues/349

## Backport Required

needs backport to the supported branches:
- [ ] [v22.2.x](https://github.com/redpanda-data/redpanda/tree/v22.2.x)
- [ ] [v22.1.x](https://github.com/redpanda-data/redpanda/tree/v22.1.x)
- [ ] [v21.11.x](https://github.com/redpanda-data/redpanda/tree/v21.11.x)

## UX changes

* none

## Release notes

* none