### PR TITLE
cluster, schema_registry: improve handling of internal topic replication factors

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -469,4 +469,23 @@ ss::future<> controller::cluster_creation_hook() {
       "creation");
 }
 
+/**
+ * Helper for subsystems that create internal topics, to discover
+ * how many replicas they should use.
+ */
+int16_t controller::internal_topic_replication() const {
+    auto replication_factor
+      = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
+    if (
+      replication_factor
+      > (int16_t)_members_table.local().all_brokers().size()) {
+        // Fall back to r=1 if we do not have sufficient nodes
+        return 1;
+    } else {
+        // Respect `internal_topic_replication_factor` if enough
+        // nodes were available.
+        return replication_factor;
+    }
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -112,6 +112,8 @@ public:
         return _raft0->is_elected_leader();
     }
 
+    int16_t internal_topic_replication() const;
+
     ss::future<> wire_up();
 
     ss::future<> start();

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -208,6 +208,13 @@ void health_manager::tick() {
                     ok = co_await ensure_topic_replication(
                       model::tx_manager_nt);
                 }
+
+                if (ok) {
+                    const model::topic_namespace schema_registry_nt{
+                      model::kafka_namespace,
+                      model::schema_registry_internal_tp.topic};
+                    ok = co_await ensure_topic_replication(schema_registry_nt);
+                }
             }
 
             _timer.arm(_tick_interval);

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -12,6 +12,7 @@
 #include "cluster/controller.h"
 #include "cluster/id_allocator_service.h"
 #include "cluster/logger.h"
+#include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
@@ -148,7 +149,7 @@ id_allocator_frontend::dispatch_allocate_id_to_leader(
               vlog(
                 clusterlog.warn,
                 "got error {} on remote allocate_id",
-                r.error());
+                r.error().message());
               return allocate_id_reply{0, errc::timeout};
           }
           return r.value();
@@ -221,7 +222,7 @@ ss::future<bool> id_allocator_frontend::try_create_id_allocator_topic() {
       model::kafka_internal_namespace,
       model::id_allocator_topic,
       1,
-      config::shard_local_cfg().id_allocator_replication()};
+      _controller->internal_topic_replication()};
 
     topic.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::none;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1768,7 +1768,7 @@ ss::future<bool> tx_gateway_frontend::try_create_tx_topic() {
       model::kafka_internal_namespace,
       model::tx_manager_topic,
       1,
-      config::shard_local_cfg().transaction_coordinator_replication()};
+      _controller->internal_topic_replication()};
 
     topic.properties.segment_size
       = config::shard_local_cfg().transaction_coordinator_log_segment_size;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -484,17 +484,8 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
   , transaction_coordinator_replication(
-      *this,
-      "transaction_coordinator_replication",
-      "Replication factor for a transaction coordinator topic",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1)
-  , id_allocator_replication(
-      *this,
-      "id_allocator_replication",
-      "Replication factor for an id allocator topic",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1)
+      *this, "transaction_coordinator_replication")
+  , id_allocator_replication(*this, "id_allocator_replication")
   , transaction_coordinator_cleanup_policy(
       *this,
       "transaction_coordinator_cleanup_policy",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -120,8 +120,8 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
     property<int16_t> default_topic_replication;
-    property<int16_t> transaction_coordinator_replication;
-    property<int16_t> id_allocator_replication;
+    deprecated_property transaction_coordinator_replication;
+    deprecated_property id_allocator_replication;
     property<model::cleanup_policy_bitflags>
       transaction_coordinator_cleanup_policy;
     property<std::chrono::milliseconds>

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -28,12 +28,14 @@ api::api(
   ss::smp_service_group sg,
   size_t max_memory,
   kafka::client::configuration& client_cfg,
-  configuration& cfg) noexcept
+  configuration& cfg,
+  std::unique_ptr<cluster::controller>& c) noexcept
   : _node_id{node_id}
   , _sg{sg}
   , _max_memory{max_memory}
   , _client_cfg{client_cfg}
-  , _cfg{cfg} {}
+  , _cfg{cfg}
+  , _controller(c) {}
 
 api::~api() noexcept = default;
 
@@ -50,7 +52,8 @@ ss::future<> api::start() {
       _max_memory,
       std::ref(_client),
       std::ref(*_store),
-      std::ref(_sequencer));
+      std::ref(_sequencer),
+      std::ref(_controller));
 
     co_await _service.invoke_on_all(&service::start);
 }

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/controller_api.h"
 #include "kafka/client/fwd.h"
 #include "model/metadata.h"
 #include "pandaproxy/schema_registry/fwd.h"
@@ -22,6 +23,10 @@ namespace YAML {
 class Node;
 }
 
+namespace cluster {
+class controller;
+}
+
 namespace pandaproxy::schema_registry {
 
 class api {
@@ -31,7 +36,8 @@ public:
       ss::smp_service_group sg,
       size_t max_memory,
       kafka::client::configuration& client_cfg,
-      configuration& cfg) noexcept;
+      configuration& cfg,
+      std::unique_ptr<cluster::controller>&) noexcept;
     ~api() noexcept;
 
     ss::future<> start();
@@ -43,6 +49,7 @@ private:
     size_t _max_memory;
     kafka::client::configuration& _client_cfg;
     configuration& _cfg;
+    std::unique_ptr<cluster::controller>& _controller;
 
     ss::sharded<kafka::client::client> _client;
     std::unique_ptr<pandaproxy::schema_registry::sharded_store> _store;

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -210,7 +210,8 @@ service::service(
   size_t max_memory,
   ss::sharded<kafka::client::client>& client,
   sharded_store& store,
-  ss::sharded<seq_writer>& sequencer)
+  ss::sharded<seq_writer>& sequencer,
+  std::unique_ptr<cluster::controller>& controller)
   : _config(config)
   , _mem_sem(max_memory, "pproxy/schema-svc")
   , _client(client)
@@ -225,6 +226,7 @@ service::service(
       json::serialization_format::schema_registry_v1_json)
   , _store(store)
   , _writer(sequencer)
+  , _controller(controller)
   , _ensure_started{[this]() { return do_start(); }} {}
 
 ss::future<> service::start() {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -9,6 +9,7 @@
 
 #include "pandaproxy/schema_registry/service.h"
 
+#include "cluster/controller.h"
 #include "kafka/client/client_fetch_batch_reader.h"
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/errors.h"
@@ -144,7 +145,7 @@ ss::future<> service::create_internal_topic() {
     // for the schema registry chooses to override it.
     int16_t replication_factor
       = _config.schema_registry_replication_factor().value_or(
-        config::shard_local_cfg().default_topic_replication());
+        _controller->internal_topic_replication());
 
     vlog(
       plog.debug,

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -26,6 +26,10 @@
 
 #include <vector>
 
+namespace cluster {
+class controller;
+}
+
 namespace pandaproxy::schema_registry {
 
 class service {
@@ -36,7 +40,8 @@ public:
       size_t max_memory,
       ss::sharded<kafka::client::client>& client,
       sharded_store& store,
-      ss::sharded<seq_writer>& sequencer);
+      ss::sharded<seq_writer>& sequencer,
+      std::unique_ptr<cluster::controller>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -59,6 +64,7 @@ private:
     ctx_server<service> _server;
     sharded_store& _store;
     ss::sharded<seq_writer>& _writer;
+    std::unique_ptr<cluster::controller>& _controller;
 
     one_shot _ensure_started;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -680,7 +680,8 @@ void application::wire_up_services() {
           // https://github.com/redpanda-data/redpanda/issues/1392
           memory_groups::kafka_total_memory(),
           *_schema_reg_client_config,
-          *_schema_reg_config);
+          *_schema_reg_config,
+          std::reference_wrapper(controller));
     }
 }
 


### PR DESCRIPTION
## Cover letter

There was a lack of consistency in how we decided how many replicas to create in our internal topics, and between the configuration used in creation and that later applied in health_manager.

This PR simplifies matters:
- `internal_topic_replication_factor` controls all the internal topics, and is 3 by default
- When choosing a replication factor, the members_table is consulted to check we have enough nodes, if we don't then the topics are created with r=1
- `internal_topic_replication_factor` continues to be applied continuously by health_manager to fix up any topics that were created when the cluster was smaller, or on old versions of redpanda.

The removal of the per-topic configuration properties for id_allocator and tx_coordinator is partly for simplification, but mainly to correct the bug that these properties weren't respected in practice anyway: if you set them to 1, then health_manager will just come along and increase it to 3 anyway.

The issue #4490 also mentions coproc, but it wasn't obvious to me where that's created & we don't support it, so I'm passing it by.

Fixes: https://github.com/redpanda-data/redpanda/issues/4490

## Backport Required

I'm calling this "not a bug fix" because it's a behavioral change, we are treating the config differently than we used to, so it's not appropriate to backport.

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

See release notes.

## Release notes

### Improvements

* Internal topics are created with an appropriate replication factor more reliably on clusters with at least 3 nodes, whereas previously in some cirtcumstances they could exist in a single-replica state for a period of time before being upgraded to a replicated state.
* Configuration property `id_allocator_replication` is deprecated in favor of 
* Configuration property `transaction_coordinator_replication` is deprecated in favor of `internal_topic_replication_factor`
* The Schema Registry topic's default replication factor is now controlled by `internal_topic_replication_factor` rather than `default_topic_replication`.

