### PR TITLE
tests: update kgo-verifier

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 1a5caf0 && \
+    cd /opt/kgo-verifier && git reset --hard d68b2cd && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients


### PR DESCRIPTION
## Cover letter

This includes bug fixes for franz-go and
performance/logging improvements.

Related: redpanda-data/kgo-verifier#8

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none