### PR TITLE
[transaction] Do not write preparing state on disk

### DIFF
--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -83,24 +83,18 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(tx2.status, tx_status::ongoing);
     BOOST_REQUIRE_GT(tx2.tx_seq, tx1.tx_seq);
     BOOST_REQUIRE_EQUAL(tx2.partitions.size(), 2);
-    auto tx3 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
+    auto tx3 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
     BOOST_REQUIRE_EQUAL(tx3.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx3.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx3.status, tx_status::preparing);
+    BOOST_REQUIRE_EQUAL(tx3.status, tx_status::prepared);
     BOOST_REQUIRE_EQUAL(tx3.tx_seq, tx2.tx_seq);
     BOOST_REQUIRE_EQUAL(tx3.partitions.size(), 2);
-    auto tx4 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
+    auto tx4 = expect_tx(stm.mark_tx_ongoing(tx_id));
     BOOST_REQUIRE_EQUAL(tx4.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx4.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx4.status, tx_status::prepared);
-    BOOST_REQUIRE_EQUAL(tx4.tx_seq, tx2.tx_seq);
-    BOOST_REQUIRE_EQUAL(tx4.partitions.size(), 2);
-    auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id));
-    BOOST_REQUIRE_EQUAL(tx5.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx5.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx5.status, tx_status::ongoing);
-    BOOST_REQUIRE_GT(tx5.tx_seq, tx2.tx_seq);
-    BOOST_REQUIRE_EQUAL(tx5.partitions.size(), 0);
+    BOOST_REQUIRE_EQUAL(tx4.status, tx_status::ongoing);
+    BOOST_REQUIRE_GT(tx4.tx_seq, tx2.tx_seq);
+    BOOST_REQUIRE_EQUAL(tx4.partitions.size(), 0);
 }
 
 FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
@@ -134,14 +128,13 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
       stm.add_partitions(tx_id, partitions).get0(),
       cluster::tm_stm::op_status::success);
     auto tx3 = expect_tx(stm.get_tx(tx_id));
-    auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
-    auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
-    BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx6.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ongoing);
-    BOOST_REQUIRE_EQUAL(tx6.partitions.size(), 0);
-    BOOST_REQUIRE_NE(tx6.tx_seq, tx1.tx_seq);
+    auto tx4 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
+    auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id));
+    BOOST_REQUIRE_EQUAL(tx5.id, tx_id);
+    BOOST_REQUIRE_EQUAL(tx5.pid, pid);
+    BOOST_REQUIRE_EQUAL(tx5.status, tx_status::ongoing);
+    BOOST_REQUIRE_EQUAL(tx5.partitions.size(), 0);
+    BOOST_REQUIRE_NE(tx5.tx_seq, tx1.tx_seq);
 }
 
 FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
@@ -175,9 +168,8 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
       stm.add_partitions(tx_id, partitions).get0(),
       cluster::tm_stm::op_status::success);
     auto tx3 = expect_tx(stm.get_tx(tx_id));
-    auto tx4 = expect_tx(stm.mark_tx_preparing(c->term(), tx_id).get());
-    auto tx5 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
+    auto tx4 = expect_tx(stm.mark_tx_prepared(c->term(), tx_id).get());
+    auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id));
 
     auto pid2 = model::producer_identity{1, 1};
     op_code = stm
@@ -185,9 +177,9 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
                   c->term(), tx_id, std::chrono::milliseconds(0), pid2)
                 .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx7 = expect_tx(stm.get_tx(tx_id));
-    BOOST_REQUIRE_EQUAL(tx7.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx7.pid, pid2);
-    BOOST_REQUIRE_EQUAL(tx7.status, tx_status::ready);
-    BOOST_REQUIRE_EQUAL(tx7.partitions.size(), 0);
+    auto tx6 = expect_tx(stm.get_tx(tx_id));
+    BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
+    BOOST_REQUIRE_EQUAL(tx6.pid, pid2);
+    BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ready);
+    BOOST_REQUIRE_EQUAL(tx6.partitions.size(), 0);
 }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -145,22 +145,6 @@ tm_stm::update_tx(tm_transaction tx, model::term_id term) {
     co_return tx_opt.value();
 }
 
-ss::future<checked<tm_transaction, tm_stm::op_status>>
-tm_stm::mark_tx_preparing(
-  model::term_id expected_term, kafka::transactional_id tx_id) {
-    auto ptx = _mem_txes.find(tx_id);
-    if (ptx == _mem_txes.end()) {
-        co_return tm_stm::op_status::not_found;
-    }
-    auto tx = ptx->second;
-    if (tx.status != tm_transaction::tx_status::ongoing) {
-        co_return tm_stm::op_status::conflict;
-    }
-    tx.status = cluster::tm_transaction::tx_status::preparing;
-    tx.last_update_ts = clock_type::now();
-    co_return co_await update_tx(std::move(tx), expected_term);
-}
-
 ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::mark_tx_aborting(
   model::term_id expected_term, kafka::transactional_id tx_id) {
     auto ptx = _mem_txes.find(tx_id);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -183,7 +183,7 @@ ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::mark_tx_prepared(
         co_return tm_stm::op_status::not_found;
     }
     auto tx = tx_opt.value();
-    if (tx.status != tm_transaction::tx_status::preparing) {
+    if (tx.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::conflict;
     }
     tx.status = cluster::tm_transaction::tx_status::prepared;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -180,8 +180,6 @@ public:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       reset_tx_ready(model::term_id, kafka::transactional_id, model::term_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
-      mark_tx_preparing(model::term_id, kafka::transactional_id);
-    ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_aborting(model::term_id, kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       mark_tx_prepared(model::term_id, kafka::transactional_id);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1530,19 +1530,7 @@ tx_gateway_frontend::do_commit_tm_tx(
               group.group_id, group.etag, tx.pid, tx.tx_seq, timeout));
         }
 
-        if (tx.status == tm_transaction::tx_status::ongoing) {
-            auto preparing_tx = co_await stm->mark_tx_preparing(
-              expected_term, tx.id);
-            if (!preparing_tx.has_value()) {
-                if (preparing_tx.error() == tm_stm::op_status::not_leader) {
-                    outcome->set_value(tx_errc::not_coordinator);
-                    co_return tx_errc::not_coordinator;
-                }
-                outcome->set_value(tx_errc::unknown_server_error);
-                co_return tx_errc::unknown_server_error;
-            }
-            tx = preparing_tx.value();
-        }
+        // TODO: Do it under feature for transaction GA
 
         auto ok = true;
         auto rejected = false;
@@ -1578,7 +1566,6 @@ tx_gateway_frontend::do_commit_tm_tx(
         outcome->set_value(tx_errc::unknown_server_error);
         throw;
     }
-    outcome->set_value(tx_errc::none);
 
     auto changed_tx = co_await stm->mark_tx_prepared(expected_term, tx.id);
     if (!changed_tx.has_value()) {
@@ -1587,6 +1574,14 @@ tx_gateway_frontend::do_commit_tm_tx(
         }
         co_return tx_errc::unknown_server_error;
     }
+
+    // We can reduce the number of disk operation if we will not write preparing
+    // state on disk. But after it we should ans to client when we sure that tx
+    // will be recommited after fail. We can garanie it only if we ans after
+    // marking tx prepared. Becase after fail tx will be recommited again and
+    // client will see expected bechavior.
+    outcome->set_value(tx_errc::none);
+
     tx = changed_tx.value();
 
     std::vector<ss::future<commit_group_tx_reply>> gfs;


### PR DESCRIPTION
## Cover letter

We can reduce the number of disk operation if we will not write preparing
state on disk. But after it we should ans to client when we sure that tx
will be recommited after fail. We can garanie it only if we ans after
marking tx prepared. Becase after fail tx will be recommited again and
client will see expected bechavior.

Fixes #4829

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
