### PR TITLE
tests: apply a timeout to arroyo test execution + fix output capture

### DIFF
--- a/tests/rptest/tests/compatibility/arroyo_test.py
+++ b/tests/rptest/tests/compatibility/arroyo_test.py
@@ -43,7 +43,8 @@ class ArroyoTest(PreallocNodesTest):
                 f"{env_preamble} "
                 f"python3 -m pytest {ArroyoTest.TEST_SUITE_PATH} "
                 "-k KafkaStreamsTestCase -rf",
-                combine_stderr=True)
+                combine_stderr=True,
+                timeout_sec=120)
 
             pytest_output = list(capture)
             for log_line in pytest_output:


### PR DESCRIPTION
## Cover letter

Anecdotally, I have twice seen test runs fail with a hang in this test (e.g. https://buildkite.com/redpanda/vtools/builds/3465#0182fde7-5f27-4f4c-bf26-6a5631f7618d)

It's not obvious, because the test hangs the ducktape TestRunner rather than timing out (I use pandaresults to tell me which test started but didn't finish).  We don't get any output from the underlying test suite because its output isn't written until the SSH remote command completes successfully.

This PR doesn't fix any actual failure, but it should create a situation where the next time it happens we get an explicit test failure & some logs from the remote process to see what was up.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none