### PR TITLE
[v21.11.x] fix lint on v21.11.x branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,13 @@
 name: Lint all codez
 on:
   push:
-    tags: 'v2**'
     branches:
-      - dev
-      - release
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     branches:
-      - main
-      - dev
+      - '**'
 
 jobs:
   go:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,22 +82,14 @@ jobs:
   cpp:
     name: Lint files with clang-format
     runs-on: ubuntu-20.04
-    # Use ubuntu:hirsute explicitly as it is the first version to have
-    # clang-format 12 available
-    container: ubuntu:hirsute
     steps:
-
-    - name: Fetch clang-format
-      run: apt-get update && apt-get install -y git clang-format
-      env:
-        DEBIAN_FRONTEND: noninteractive
 
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Run clang fmt
       run: |
-        find . -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format -i -style=file -fallback-style=none
+        find . -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-12 -i -style=file -fallback-style=none
         git diff --exit-code
 
   sh:

--- a/src/go/rpk/pkg/api/api.go
+++ b/src/go/rpk/pkg/api/api.go
@@ -94,10 +94,7 @@ func SendMetrics(p MetricsPayload, conf config.Config) error {
 }
 
 func SendEnvironment(
-	fs afero.Fs,
-	env EnvironmentPayload,
-	conf config.Config,
-	skipCloudCheck bool,
+	fs afero.Fs, env EnvironmentPayload, conf config.Config, skipCloudCheck bool,
 ) error {
 	cloudVendor := "N/A"
 	vmType := "N/A"

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -927,7 +927,13 @@ func parseNamedAddress(
 	}, nil
 }
 
-func sendEnv(fs afero.Fs, env api.EnvironmentPayload, conf *config.Config, skipChecks bool, err error) {
+func sendEnv(
+	fs afero.Fs,
+	env api.EnvironmentPayload,
+	conf *config.Config,
+	skipChecks bool,
+	err error,
+) {
 	if err != nil {
 		env.ErrorMsg = err.Error()
 	}

--- a/tests/rptest/tests/cluster_view_test.py
+++ b/tests/rptest/tests/cluster_view_test.py
@@ -24,7 +24,6 @@ from rptest.tests.end_to_end import EndToEndTest
 
 
 class ClusterViewTest(EndToEndTest):
-
     @cluster(num_nodes=3)
     def test_view_changes_on_add(self):
         self.redpanda = RedpandaService(self.test_context, 3, KafkaCliTools)


### PR DESCRIPTION
## Cover letter

Currently, lint checks are not run on PRs to [v21.11.x](https://github.com/redpanda-data/redpanda/tree/v21.11.x) branch. This PR will change the workflow so lint checks run on PRs to the v21.11.x branch as well as pushes to v21.11.x branch. Also, the lint checks won't be run on push of tag because the lint check will have already run on a git commit that is tagged.

This PR includes backport of PR #6294 (cherry-pick clean), only needed to take faf05af:
```
bash$ git cherry-pick -x faf05afb13193c70d5ba19b7b640cb3a748d902a
Auto-merging .github/workflows/lint.yml
[fix-lint-v21.11.x 126e534d6] gha/lint: run lint check on push to any branch
 Date: Thu Sep 1 03:57:20 2022 +0000
 1 file changed, 4 insertions(+), 5 deletions(-)
```

## Backport Required

* none

## UX changes

* none

## Release notes

* none