### PR TITLE
Fix init_producer_id crash (unblocks chaos tests)

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -163,11 +163,11 @@ tm_stm::mark_tx_preparing(
 
 ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::mark_tx_aborting(
   model::term_id expected_term, kafka::transactional_id tx_id) {
-    auto ptx = _mem_txes.find(tx_id);
-    if (ptx == _mem_txes.end()) {
+    auto ptx = get_tx(tx_id);
+    if (!ptx.has_value()) {
         co_return tm_stm::op_status::not_found;
     }
-    auto tx = ptx->second;
+    auto tx = ptx.value();
     if (tx.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::conflict;
     }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1447,10 +1447,6 @@ tx_gateway_frontend::do_abort_tm_tx(
     }
 
     if (tx.status == tm_transaction::tx_status::ongoing) {
-        if (expected_term != tx.etag) {
-            // making sure we're canceling a tx started within current term
-            co_return tx_errc::invalid_txn_state;
-        }
         auto changed_tx = co_await stm->mark_tx_aborting(expected_term, tx.id);
         if (!changed_tx.has_value()) {
             if (changed_tx.error() == tm_stm::op_status::not_leader) {


### PR DESCRIPTION
## Cover letter

The split-brain fix 1a301657 started persisting the first add partition call which caused a tx with ongoing status make it to the log and survive re-election. Some of the txn coordinator logic wasn't ready and it blocked txn processing

Fixes https://github.com/redpanda-data/redpanda/issues/6311
Fixes https://github.com/redpanda-data/redpanda-jepsen/issues/16

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## Release notes

* fix  init_producer_id's timeouts