### PR TITLE
redpanda: print timestamp along with version at startup

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -210,17 +210,17 @@ int application::run(int ac, char** av) {
     }
     // use endl for explicit flushing
     std::cout << community_msg << std::endl;
-    vlog(_log.info, "Redpanda {}", redpanda_version());
-    struct ::utsname buf;
-    ::uname(&buf);
-    vlog(
-      _log.info,
-      "kernel={}, nodename={}, machine={}",
-      buf.release,
-      buf.nodename,
-      buf.machine);
 
     return app.run(ac, av, [this, &app] {
+        vlog(_log.info, "Redpanda {}", redpanda_version());
+        struct ::utsname buf;
+        ::uname(&buf);
+        vlog(
+          _log.info,
+          "kernel={}, nodename={}, machine={}",
+          buf.release,
+          buf.nodename,
+          buf.machine);
         auto& cfg = app.configuration();
         log_system_resources(_log, cfg);
         // NOTE: we validate required args here instead of above because run()


### PR DESCRIPTION
## Cover letter

Fixes https://github.com/redpanda-data/redpanda/issues/6295. 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

This commit adds the timestamp along with the version info at startup.

```
INFO  2022-09-06 18:02:50,578 [shard 0] redpanda::main - application.cc:215 - Redpanda v22.1.1-rc1 - 000-dev
INFO  2022-09-06 18:02:50,578 [shard 0] redpanda::main - application.cc:223 - kernel=5.15.0-46-generic, nodename=daisuke-Redpanda, machine=x86_64
```

### Improvements

Improves supportability when troubleshooting Redpanda issue.