### PR TITLE
rptest: Set timeout in transactional producer

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -277,13 +277,14 @@ class PathMatcher:
 
 
 class Producer:
-    def __init__(self, brokers, name, logger):
+    def __init__(self, brokers, name, logger, timeout_sec: float = 60.0):
         self.keys = []
         self.cur_offset = 0
         self.brokers = brokers
         self.logger = logger
         self.num_aborted = 0
         self.name = name
+        self.timeout_sec = timeout_sec
         self.reconnect()
 
     def reconnect(self):
@@ -295,7 +296,7 @@ class Producer:
             'transaction.timeout.ms':
             5000,
         })
-        self.producer.init_transactions()
+        self.producer.init_transactions(self.timeout_sec)
 
     def produce(self, topic):
         """produce some messages inside a transaction with increasing keys


### PR DESCRIPTION
## Cover letter

The timeout parameter which is passed to the init_transactions is eventually passed to rd_kafka_init_transactions. The default value that python wrapper is using is -1. This commit allows to set the timeout value explicitly. The default value is set to 120 seconds.

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes #6336

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none
