### PR TITLE
pp: add basic auth to /brokers

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME config
   SRCS
+    rest_authn_endpoint.cc
     broker_authn_endpoint.cc
     configuration.cc
     node_config.cc

--- a/src/v/config/from_string_view.h
+++ b/src/v/config/from_string_view.h
@@ -1,0 +1,22 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <type_traits>
+
+namespace config {
+
+template<typename E>
+std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
+  from_string_view(std::string_view);
+
+} // namespace config

--- a/src/v/config/rest_authn_endpoint.cc
+++ b/src/v/config/rest_authn_endpoint.cc
@@ -1,0 +1,107 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/rest_authn_endpoint.h"
+
+#include "kafka/client/exceptions.h"
+#include "model/metadata.h"
+#include "utils/string_switch.h"
+
+namespace config {
+
+constexpr inline std::string_view to_string_view(rest_authn_type m) {
+    switch (m) {
+    case rest_authn_type::none:
+        return "none";
+    case rest_authn_type::http_basic:
+        return "http_basic";
+    default:
+        return "invalid";
+    }
+}
+
+template<>
+std::optional<rest_authn_type>
+from_string_view<rest_authn_type>(std::string_view sv) {
+    return string_switch<std::optional<rest_authn_type>>(sv)
+      .match("none", rest_authn_type::none)
+      .match("http_basic", rest_authn_type::http_basic)
+      .default_match(std::nullopt);
+}
+
+std::ostream& operator<<(std::ostream& os, const rest_authn_endpoint& ep) {
+    fmt::print(os, "{{{}:{}:{}}}", ep.name, ep.address, ep.authn_type);
+    return os;
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::rest_authn_endpoint>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["address"] = rhs.address.host();
+    node["port"] = rhs.address.port();
+    if (rhs.authn_type) {
+        node["authentication_method"]["authentication_type"] = ss::sstring(
+          to_string_view(*rhs.authn_type));
+    }
+    return node;
+}
+
+bool convert<config::rest_authn_endpoint>::decode(const Node& node, type& rhs) {
+    for (auto s : {"address", "port"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+    ss::sstring name;
+    if (node["name"]) {
+        name = node["name"].as<ss::sstring>();
+    }
+    auto address = node["address"].as<ss::sstring>();
+    auto port = node["port"].as<uint16_t>();
+    auto addr = net::unresolved_address(std::move(address), port);
+    std::optional<config::rest_authn_type> authn_type{};
+
+    if (node["authentication_method"] && node["authentication_method"]["authentication_type"]) {
+        auto n = node["authentication_method"]["authentication_type"];
+        authn_type = config::from_string_view<config::rest_authn_type>(n.as<ss::sstring>());
+    }
+    rhs = config::rest_authn_endpoint{
+      .name = std::move(name),
+      .address = std::move(addr),
+      .authn_type = authn_type};
+    return true;
+}
+
+} // namespace YAML
+
+void json::rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::rest_authn_endpoint& ep) {
+    w.StartObject();
+    w.Key("name");
+    w.String(ep.name);
+    w.Key("address");
+    w.String(ep.address.host());
+    w.Key("port");
+    w.Uint(ep.address.port());
+    // If Authn type exists, then a
+    // nested object is created.
+    if (ep.authn_type) {
+        w.Key("authentication_method");
+        w.StartObject();
+        w.Key("authentication_type");
+        auto authn_type = to_string_view(*ep.authn_type);
+        w.String(authn_type.begin(), authn_type.length());
+        w.EndObject();
+    }
+    w.EndObject();
+}

--- a/src/v/config/rest_authn_endpoint.h
+++ b/src/v/config/rest_authn_endpoint.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Redpanda Data, Inc.
+// Copyright 2022 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -27,36 +27,35 @@
 
 namespace config {
 
-enum class broker_authn_method {
+enum class rest_authn_type {
     none = 0,
-    sasl,
-    mtls_identity,
+    http_basic,
 };
 
-std::string_view to_string_view(broker_authn_method m);
+constexpr inline std::string_view to_string_view(rest_authn_type m);
 
 template<>
-std::optional<broker_authn_method>
-from_string_view<broker_authn_method>(std::string_view sv);
+std::optional<rest_authn_type>
+from_string_view<rest_authn_type>(std::string_view sv);
 
-struct broker_authn_endpoint {
+struct rest_authn_endpoint {
     ss::sstring name;
     net::unresolved_address address;
-    std::optional<broker_authn_method> authn_method;
+    std::optional<rest_authn_type> authn_type;
 
     friend bool
-    operator==(const broker_authn_endpoint&, const broker_authn_endpoint&)
+    operator==(const rest_authn_endpoint&, const rest_authn_endpoint&)
       = default;
 
     friend std::ostream&
-    operator<<(std::ostream& os, const broker_authn_endpoint& ep);
+    operator<<(std::ostream& os, const rest_authn_endpoint& ep);
 };
 
 namespace detail {
 
 template<>
-consteval std::string_view property_type_name<broker_authn_endpoint>() {
-    return "config::broker_auth_endpoint";
+consteval std::string_view property_type_name<rest_authn_endpoint>() {
+    return "config::rest_authn_endpoint";
 }
 
 } // namespace detail
@@ -66,8 +65,8 @@ consteval std::string_view property_type_name<broker_authn_endpoint>() {
 namespace YAML {
 
 template<>
-struct convert<config::broker_authn_endpoint> {
-    using type = config::broker_authn_endpoint;
+struct convert<config::rest_authn_endpoint> {
+    using type = config::rest_authn_endpoint;
     static Node encode(const type& rhs);
     static bool decode(const Node& node, type& rhs);
 };
@@ -77,6 +76,6 @@ struct convert<config::broker_authn_endpoint> {
 namespace json {
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const config::broker_authn_endpoint& ep);
+  json::Writer<json::StringBuffer>& w, const config::rest_authn_endpoint& ep);
 
 }

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -5,6 +5,8 @@ v_cc_library(
     logger.cc
     probe.cc
     server.cc
+    kafka_client_cache.cc
+    sharded_client_cache.cc
   DEPS
     v::pandaproxy_parsing
     v::pandaproxy_json

--- a/src/v/pandaproxy/client_cache_error.h
+++ b/src/v/pandaproxy/client_cache_error.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace pandaproxy {
+
+struct client_cache_error : std::exception {
+    client_cache_error(std::string_view msg)
+      : std::exception{}
+      , msg{msg} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    std::string msg;
+};
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/fwd.h
+++ b/src/v/pandaproxy/fwd.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace pandaproxy {
+
+class kafka_client_cache;
+class sharded_client_cache;
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/kafka_client_cache.h"
+
+#include "pandaproxy/client_cache_error.h"
+#include "pandaproxy/logger.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace pandaproxy {
+
+static constexpr auto clean_timer_period = 10s;
+
+kafka_client_cache::kafka_client_cache(
+  YAML::Node const& cfg,
+  size_t max_size,
+  std::vector<config::broker_authn_endpoint> kafka_api,
+  model::timestamp::type keep_alive)
+  : _config{cfg}
+  , _cache_max_size{max_size}
+  , _kafka_has_sasl{false}
+  , _keep_alive{keep_alive} {
+    // Is there a Kafka listener with SASL enabled?
+    auto ep_it = std::find_if(
+      kafka_api.begin(),
+      kafka_api.end(),
+      [](const config::broker_authn_endpoint& ep) {
+          return ep.authn_method == config::broker_authn_method::sasl;
+      });
+
+    _kafka_has_sasl = ep_it != kafka_api.end();
+
+    _clean_timer.set_callback([this] {
+        // Do not need a gate since there are limited items
+        // in the cache. Therefore, relative to other design,
+        // garbage collection is inexpensive here.
+        clean_stale_clients();
+    });
+    _clean_timer.arm_periodic(clean_timer_period);
+}
+
+kafka_client_cache::~kafka_client_cache() {
+    _clean_timer.cancel();
+}
+
+client_ptr kafka_client_cache::fetch(credential_t user) {
+    auto& inner_hash = _cache.get<underlying_hash>();
+    auto it_hash = inner_hash.find(user.name);
+
+    if (it_hash == inner_hash.end()) {
+        return nullptr;
+    }
+
+    // Otherwise user-client found.
+
+    // Convert the hash iterator to list iterator
+    auto it_list = _cache.project<underlying_list>(it_hash);
+    auto& inner_list = _cache.get<underlying_list>();
+
+    // Extract the item. This is OK because elements are
+    // not copied or moved. Instead internal pointers
+    // are simply re-balanced and no allocations are made.
+    auto node = inner_list.extract(it_list);
+    
+    // Update the timestamp and put it to the front
+    node.value().client->last_used = model::timestamp::now();
+    inner_list.push_front(node.value());
+
+    return node.value().client;
+}
+
+client_ptr kafka_client_cache::make_client(
+  credential_t user, config::rest_authn_type authn_type) {
+    kafka::client::configuration cfg{to_yaml(_config, config::redact_secrets::no)};
+    
+    // Set the principal when there is a Kafka listener with SASL
+    // enabled and the incoming request is using HTTP Basic AuthN
+    if (_kafka_has_sasl && authn_type == config::rest_authn_type::http_basic) {
+        // Need to specify type or else bad any_cast runtime error
+        cfg.sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
+        cfg.scram_username.set_value(user.name);
+        cfg.scram_password.set_value(user.pass);
+    }
+
+    return ss::make_lw_shared<timestamped_client>(to_yaml(cfg, config::redact_secrets::no), model::new_timestamp());
+}
+
+void kafka_client_cache::insert(credential_t user, client_ptr client) {
+    // Warn the user and do nothing if the 
+    // max size is 0
+    if (_cache_max_size == 0) {
+        throw client_cache_error("Failed to insert client. Max cache size is 0.");
+    }
+
+    auto& inner_list = _cache.get<underlying_list>();
+
+    // First remove the last used client if the
+    // cache is full.
+    if (_cache.size() >= _cache_max_size) {
+        if (_cache.size() != 0) {
+            inner_list.pop_back();
+        }
+    }
+
+    user_client_pair pair{.username = user.name, .client = client};
+
+    // Add the user-client pair to front of frequency
+    // list since it will become recently "used"
+    // NOTE: push_front will silently fail if a duplicate
+    // already exists.
+    inner_list.push_front(pair);
+}
+
+client_ptr kafka_client_cache::fetch_or_insert(credential_t user, config::rest_authn_type authn_type) {
+  client_ptr client{fetch(user)};
+
+  // Make a client and insert
+  // if the fetch failed
+  if (client == client_ptr{nullptr}) {
+    client = make_client(user, authn_type);
+    insert(user, client);
+    vlog(plog.debug, "Made client for user {}", user.name);
+  } else {
+    vlog(plog.debug, "Reuse client for user {}", user.name);
+  }
+
+  return client;
+}
+
+void kafka_client_cache::clean_stale_clients() {
+    auto& inner_list = _cache.get<underlying_list>();
+    inner_list.remove_if([this](const user_client_pair& item) {
+        auto live = (model::new_timestamp()() - item.client->last_used());
+
+        if (live >= _keep_alive) {
+            vlog(plog.debug, "Removed {} from cache", item.username);
+            return true;
+        }
+        return false;  
+    });
+}
+
+size_t kafka_client_cache::size() const { return _cache.size(); }
+size_t kafka_client_cache::max_size() const { return _cache_max_size; }
+std::chrono::milliseconds kafka_client_cache::clean_timer() { return clean_timer_period; }
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "config/broker_authn_endpoint.h"
+#include "config/rest_authn_endpoint.h"
+#include "pandaproxy/types.h"
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timer.hh>
+
+#include <utility>
+#include <vector>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace bmi = boost::multi_index;
+
+namespace pandaproxy {
+
+class sharded_client_cache;
+
+// A LRU cache implemented with a doubly-linked list and a
+// hash using boost multi container. The list tracks
+// frequency where the most recently used client is at the front.
+// When the cache is full remove the client from the end of the
+// list. The hash is for constant time look-ups of the kafka clients.
+class kafka_client_cache {
+public:
+    struct user_client_pair {
+        ss::sstring username;
+        client_ptr client;
+    };
+
+    // Tags used for indexing
+    struct underlying_list {};
+    struct underlying_hash {};
+
+    using underlying_t = bmi::multi_index_container<
+      user_client_pair,
+      bmi::indexed_by<
+        bmi::sequenced<bmi::tag<underlying_list>>,
+        bmi::hashed_unique<
+          bmi::tag<underlying_hash>,
+          bmi::
+            member<user_client_pair, ss::sstring, &user_client_pair::username>,
+          std::hash<ss::sstring>,
+          std::equal_to<>>>>;
+
+    kafka_client_cache(
+      YAML::Node const& cfg,
+      size_t max_size,
+      std::vector<config::broker_authn_endpoint> kafka_api,
+      model::timestamp::type keep_alive);
+
+    ~kafka_client_cache();
+
+    kafka_client_cache(const kafka_client_cache&) = delete;
+    kafka_client_cache& operator=(const kafka_client_cache&) = delete;
+
+    client_ptr fetch_or_insert(credential_t user, config::rest_authn_type authn_type);
+
+    size_t size() const;
+    size_t max_size() const;
+    static std::chrono::milliseconds clean_timer();
+
+private:
+    friend class test_client_cache;
+    client_ptr fetch(credential_t user);
+    void insert(credential_t user, client_ptr client);
+    client_ptr
+    make_client(credential_t user, config::rest_authn_type authn_type);
+    void clean_stale_clients();
+
+    kafka::client::configuration _config;
+    size_t _cache_max_size;
+    bool _kafka_has_sasl;
+    model::timestamp::type _keep_alive;
+    underlying_t _cache;
+    ss::timer<ss::lowres_clock> _clean_timer;
+};
+} // namespace pandaproxy

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/exceptions.h"
 #include "kafka/protocol/exceptions.h"
+#include "pandaproxy/client_cache_error.h"
 #include "pandaproxy/error.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/rjson_util.h"
@@ -105,6 +106,8 @@ inline std::unique_ptr<ss::httpd::reply> exception_reply(std::exception_ptr e) {
         return errored_body(e.code(), e.message());
     } catch (const seastar::httpd::base_exception& e) {
         return errored_body(reply_error_code::kafka_bad_request, e.what());
+    } catch(const client_cache_error& e) {
+        return errored_body(reply_error_code::internal_server_error, e.what());
     } catch (...) {
         vlog(plog.error, "exception_reply: {}", std::current_exception());
         auto ise = make_error_condition(

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -15,6 +15,7 @@
 #include "model/metadata.h"
 #include "units.h"
 
+#include <algorithm>
 #include <chrono>
 
 namespace pandaproxy::rest {
@@ -31,7 +32,9 @@ configuration::configuration()
     "pandaproxy_api",
     "Rest API listen address and port",
     {},
-    {model::broker_endpoint(net::unresolved_address("0.0.0.0", 8082))})
+    {config::rest_authn_endpoint{
+      .address = net::unresolved_address("0.0.0.0", 8082),
+      .authn_type = std::nullopt}})
   , pandaproxy_api_tls(
       *this,
       "pandaproxy_api_tls",
@@ -54,6 +57,35 @@ configuration::configuration()
       "consumer_instance_timeout_ms",
       "How long to wait for an idle consumer before removing it",
       {},
-      std::chrono::minutes{5}) {}
+      std::chrono::minutes{5})
+  , client_cache_max_size(
+      *this,
+      "client_cache_max_size",
+      "The maximum number of kafka clients in the LRU cache",
+      {.needs_restart = config::needs_restart::no},
+      10)
+  , client_keep_alive(
+      *this,
+      "client_keep_alive",
+      "Time in milliseconds that an idle connection may remain open",
+      {.needs_restart = config::needs_restart::no, .example = "30000"},
+      (30000ms).count()) {}
+
+config::rest_authn_type
+configuration::authn_type(net::unresolved_address& address) {
+    auto pp_api = pandaproxy_api.value();
+    auto it = std::find_if(
+      pp_api.begin(),
+      pp_api.end(),
+      [&address](const config::rest_authn_endpoint& ep) {
+          return ep.address == address;
+      });
+
+    if (it != pp_api.end()) {
+        return it->authn_type.value_or(config::rest_authn_type::none);
+    } else {
+        return config::rest_authn_type::none;
+    }
+}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -12,8 +12,10 @@
 #pragma once
 #include "config/config_store.h"
 #include "config/property.h"
+#include "config/rest_authn_endpoint.h"
 #include "config/tls_config.h"
 #include "model/metadata.h"
+#include "model/timestamp.h"
 
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
@@ -26,16 +28,24 @@ namespace pandaproxy::rest {
 /// All application modules depend on configuration. The configuration module
 /// can not depend on any other module to prevent cyclic dependencies.
 struct configuration final : public config::config_store {
-    config::one_or_many_property<model::broker_endpoint> pandaproxy_api;
+    config::one_or_many_property<config::rest_authn_endpoint> pandaproxy_api;
     config::one_or_many_property<config::endpoint_tls_config>
       pandaproxy_api_tls;
     config::one_or_many_property<model::broker_endpoint>
       advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
     config::property<std::chrono::milliseconds> consumer_instance_timeout;
+    config::property<int64_t> client_cache_max_size;
+    config::property<int64_t> client_keep_alive;
 
     configuration();
     explicit configuration(const YAML::Node& cfg);
+
+    // A helper method that searches for the address within
+    // list of pandaproxy_api endpoints.
+    // Returns the authn type if the address is found.
+    // Returns none type otherwise
+    config::rest_authn_type authn_type(net::unresolved_address& address);
 };
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -9,52 +9,115 @@
 
 #include "pandaproxy/rest/proxy.h"
 
+#include "config/property.h"
+#include "config/rest_authn_endpoint.h"
+#include "net/unresolved_address.h"
 #include "pandaproxy/api/api-doc/rest.json.h"
 #include "pandaproxy/logger.h"
+#include "pandaproxy/parsing/exceptions.h"
+#include "pandaproxy/parsing/from_chars.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/handlers.h"
+#include "pandaproxy/types.h"
+#include "redpanda/request_auth.h"
+#include "utils/gate_guard.h"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/memory.hh>
+#include <seastar/core/temporary_buffer.hh>
 #include <seastar/http/api_docs.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/http/request_parser.hh>
+
+#include <algorithm>
+#include <string>
 
 namespace pandaproxy::rest {
 
+namespace {
+net::unresolved_address address_from_host(ss::sstring host_and_port) {
+    auto colon = host_and_port.find_last_of(':');
+    ss::sstring host{host_and_port.substr(0, colon)};
+    ss::sstring port_str{host_and_port.substr(colon+1)};
+
+    auto res = parse::from_chars<uint16_t>{}(port_str);
+    if (res.has_error()) {
+        throw parse::error(
+          parse::error_code::not_acceptable, "INT conversion fail");
+    }
+
+    return net::unresolved_address{host, res.value()};
+}
+} // namespace
+
 using server = ctx_server<proxy>;
 
-server::routes_t get_proxy_routes() {
+template<typename Handler>
+auto wrap(configuration& cfg, Handler h) {
+    return [&cfg, h{std::move(h)}](
+             server::request_t rq,
+             server::reply_t rp) -> ss::future<server::reply_t> {
+        net::unresolved_address req_address{address_from_host(rq.req->get_header("Host"))};
+        rq.ctx.authn_type = rq.service().config().authn_type(req_address);
+
+        if (rq.ctx.authn_type == config::rest_authn_type::http_basic) {
+            config::property<bool> require_auth{
+              cfg,
+              "",
+              "",
+              {.needs_restart = config::needs_restart::no,
+               .visibility = config::visibility::user},
+              true};
+            request_authenticator auth{
+              require_auth.bind(), rq.service().controller()};
+
+            // Will throw if auth fails
+            // The catch statements in reply.h will do error handling
+            auto auth_result = auth.authenticate(*rq.req);
+            auth_result.pass();
+            rq.ctx.user = credential_t{
+              auth_result.get_username(), auth_result.get_password()};
+        }
+
+        co_return co_await h(std::move(rq), std::move(rp));
+    };
+}
+
+server::routes_t get_proxy_routes(configuration& cfg) {
     server::routes_t routes;
     routes.api = ss::httpd::rest_json::name;
 
-    routes.routes.emplace_back(
-      server::route_t{ss::httpd::rest_json::get_brokers, get_brokers});
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::rest_json::get_brokers, wrap(cfg, get_brokers)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::get_topics_names, get_topics_names});
+      ss::httpd::rest_json::get_topics_names, wrap(cfg, get_topics_names)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::get_topics_records, get_topics_records});
+      ss::httpd::rest_json::get_topics_records, wrap(cfg, get_topics_records)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::post_topics_name, post_topics_name});
-
-    routes.routes.emplace_back(
-      server::route_t{ss::httpd::rest_json::create_consumer, create_consumer});
-
-    routes.routes.emplace_back(
-      server::route_t{ss::httpd::rest_json::remove_consumer, remove_consumer});
+      ss::httpd::rest_json::post_topics_name, wrap(cfg, post_topics_name)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::subscribe_consumer, subscribe_consumer});
-
-    routes.routes.emplace_back(
-      server::route_t{ss::httpd::rest_json::consumer_fetch, consumer_fetch});
+      ss::httpd::rest_json::create_consumer, wrap(cfg, create_consumer)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::get_consumer_offsets, get_consumer_offsets});
+      ss::httpd::rest_json::remove_consumer, wrap(cfg, remove_consumer)});
 
     routes.routes.emplace_back(server::route_t{
-      ss::httpd::rest_json::post_consumer_offsets, post_consumer_offsets});
+      ss::httpd::rest_json::subscribe_consumer, wrap(cfg, subscribe_consumer)});
+
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::rest_json::consumer_fetch, wrap(cfg, consumer_fetch)});
+
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::rest_json::get_consumer_offsets,
+      wrap(cfg, get_consumer_offsets)});
+
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::rest_json::post_consumer_offsets,
+      wrap(cfg, post_consumer_offsets)});
 
     return routes;
 }
@@ -63,10 +126,14 @@ proxy::proxy(
   const YAML::Node& config,
   ss::smp_service_group smp_sg,
   size_t max_memory,
-  ss::sharded<kafka::client::client>& client)
+  ss::sharded<kafka::client::client>& client,
+  sharded_client_cache& client_cache,
+  cluster::controller* controller)
   : _config(config)
   , _mem_sem(max_memory, "pproxy/mem")
   , _client(client)
+  , _client_cache(client_cache)
+  , _controller(controller)
   , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
   , _server(
       "pandaproxy",
@@ -78,7 +145,7 @@ proxy::proxy(
       json::serialization_format::application_json) {}
 
 ss::future<> proxy::start() {
-    _server.routes(get_proxy_routes());
+    _server.routes(get_proxy_routes(_config));
     return _server.start(
       _config.pandaproxy_api(),
       _config.pandaproxy_api_tls(),

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -11,9 +11,10 @@
 
 #pragma once
 
-#include "kafka/client/client.h"
+#include "cluster/fwd.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/server.h"
+#include "pandaproxy/sharded_client_cache.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -31,7 +32,9 @@ public:
       const YAML::Node& config,
       ss::smp_service_group smp_sg,
       size_t max_memory,
-      ss::sharded<kafka::client::client>& client);
+      ss::sharded<kafka::client::client>& client,
+      sharded_client_cache& client_cache,
+      cluster::controller* controller);
 
     ss::future<> start();
     ss::future<> stop();
@@ -39,11 +42,15 @@ public:
     configuration& config();
     kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
+    sharded_client_cache& client_cache() { return _client_cache; }
+    cluster::controller* controller() { return _controller; }
 
 private:
     configuration _config;
     ssx::semaphore _mem_sem;
     ss::sharded<kafka::client::client>& _client;
+    sharded_client_cache& _client_cache;
+    cluster::controller* _controller;
     ctx_server<proxy>::context_t _ctx;
     ctx_server<proxy> _server;
 };

--- a/src/v/pandaproxy/rest/test/fetch.cc
+++ b/src/v/pandaproxy/rest/test/fetch.cc
@@ -64,6 +64,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics//partitions/0/"
           "records?max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -82,6 +83,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics//partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -100,6 +102,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t/partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -126,6 +129,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         body.append(batch_1_body.data(), batch_1_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,
@@ -143,6 +147,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t/partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -163,6 +168,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         body.append(batch_2_body.data(), batch_2_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,
@@ -179,6 +185,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         info("Fetch offset 3 - expect offset 3");
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t/partitions/0/"
           "records?offset=3&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -196,6 +203,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         info("Fetch offset 2 - expect offsets 0-3");
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t/partitions/0/"
           "records?offset=2&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
@@ -249,6 +257,7 @@ FIXTURE_TEST(pandaproxy_fetch_json_v2, pandaproxy_test_fixture) {
         body.append(batch_body.data(), batch_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,
@@ -265,6 +274,7 @@ FIXTURE_TEST(pandaproxy_fetch_json_v2, pandaproxy_test_fixture) {
         info("Fetch offset 1 as json - expect offsets 0-1");
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t/partitions/0/"
           "records?offset=1&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,

--- a/src/v/pandaproxy/rest/test/list_topics.cc
+++ b/src/v/pandaproxy/rest/test/list_topics.cc
@@ -29,7 +29,7 @@ FIXTURE_TEST(pandaproxy_list_topics, pandaproxy_test_fixture) {
 
     {
         info("List no topics");
-        auto res = http_request(client, "/topics");
+        auto res = http_request(client, proxy_ep.address, "/topics");
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"([])");
@@ -45,7 +45,7 @@ FIXTURE_TEST(pandaproxy_list_topics, pandaproxy_test_fixture) {
 
     {
         info("List known topics");
-        auto res = http_request(client, "/topics");
+        auto res = http_request(client, proxy_ep.address, "/topics");
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"(["t"])");

--- a/src/v/pandaproxy/rest/test/produce.cc
+++ b/src/v/pandaproxy/rest/test/produce.cc
@@ -73,6 +73,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         body.append(produce_binary_body.data(), produce_binary_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,
@@ -102,6 +103,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         body.append(produce_binary_body.data(), produce_binary_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,
@@ -121,6 +123,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         body.append(produce_json_body.data(), produce_json_body.size());
         auto res = http_request(
           client,
+          proxy_ep.address,
           "/topics/t",
           std::move(body),
           boost::beast::http::verb::post,

--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -22,7 +22,9 @@ configuration::configuration()
     "schema_registry_api",
     "Schema Registry API listen address and port",
     {},
-    {model::broker_endpoint(net::unresolved_address("0.0.0.0", 8081))})
+    {config::rest_authn_endpoint{
+      .address = net::unresolved_address("0.0.0.0", 8081),
+      .authn_type = std::nullopt}})
   , schema_registry_api_tls(
       *this,
       "schema_registry_api_tls",

--- a/src/v/pandaproxy/schema_registry/configuration.h
+++ b/src/v/pandaproxy/schema_registry/configuration.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/config_store.h"
 #include "config/configuration.h"
+#include "config/rest_authn_endpoint.h"
 #include "config/tls_config.h"
 #include "model/metadata.h"
 
@@ -23,7 +24,8 @@ struct configuration final : public config::config_store {
     configuration();
     explicit configuration(const YAML::Node& cfg);
 
-    config::one_or_many_property<model::broker_endpoint> schema_registry_api;
+    config::one_or_many_property<config::rest_authn_endpoint>
+      schema_registry_api;
     config::one_or_many_property<config::endpoint_tls_config>
       schema_registry_api_tls;
     config::property<std::optional<int16_t>> schema_registry_replication_factor;

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -33,9 +33,10 @@ inline iobuf make_body(const ss::sstring& body) {
 }
 
 inline auto post_schema(
-  http::client& client, const pps::subject& sub, const ss::sstring& payload) {
+  http::client& client, net::unresolved_address& host, const pps::subject& sub, const ss::sstring& payload) {
     return http_request(
       client,
+      host,
       fmt::format("/subjects/{}/versions", sub()),
       make_body(payload),
       boost::beast::http::verb::post,
@@ -45,10 +46,12 @@ inline auto post_schema(
 
 inline auto delete_subject(
   http::client& client,
+  net::unresolved_address& host,
   const pps::subject& sub,
   pps::permanent_delete del = {}) {
     return http_request(
       client,
+      host,
       fmt::format("/subjects/{}?permanent={}", sub(), del),
       boost::beast::http::verb::delete_,
       ppj::serialization_format::schema_registry_v1_json,
@@ -57,11 +60,13 @@ inline auto delete_subject(
 
 inline auto delete_subject_version(
   http::client& client,
+  net::unresolved_address& host,
   const pps::subject& sub,
   pps::schema_version ver,
   pps::permanent_delete del = {}) {
     return http_request(
       client,
+      host,
       fmt::format("/subjects/{}/versions/{}?permanent={}", sub(), ver(), del),
       boost::beast::http::verb::delete_,
       ppj::serialization_format::schema_registry_v1_json,
@@ -70,10 +75,12 @@ inline auto delete_subject_version(
 
 inline auto get_subject_versions(
   http::client& client,
+  net::unresolved_address& host,
   const pps::subject& sub,
   pps::include_deleted del = {}) {
     return http_request(
       client,
+      host,
       fmt::format("/subjects/{}/versions?deleted={}", sub(), del),
       boost::beast::http::verb::get,
       ppj::serialization_format::schema_registry_v1_json,

--- a/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
+++ b/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
@@ -30,14 +30,14 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Post a schema as key");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(client, schema_reg_ep.address, pps::subject{"test-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -49,14 +49,14 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Delete version 1");
         auto res = delete_subject_version(
-          client, pps::subject{"test-key"}, pps::schema_version{1});
+          client, schema_reg_ep.address, pps::subject{"test-key"}, pps::schema_version{1});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect subject not_found");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(client, schema_reg_ep.address, pps::subject{"test-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }
@@ -64,7 +64,7 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Expect deleted version 1");
         auto res = get_subject_versions(
-          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, pps::include_deleted::yes);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -76,7 +76,7 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Hard delete version 1");
         auto res = delete_subject_version(
-          client,
+          client, schema_reg_ep.address,
           pps::subject{"test-key"},
           pps::schema_version{1},
           pps::permanent_delete::yes);
@@ -87,7 +87,7 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Expect sub not found");
         auto res = get_subject_versions(
-          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, pps::include_deleted::yes);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }
@@ -95,14 +95,14 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Repost a schema as key");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(client, schema_reg_ep.address, pps::subject{"test-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -113,7 +113,7 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject");
-        auto res = delete_subject(client, pps::subject{"test-key"});
+        auto res = delete_subject(client, schema_reg_ep.address, pps::subject{"test-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
@@ -128,14 +128,14 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     {
         info("Post a schema as key");
         auto res = post_schema(
-          client, pps::subject{"int-key"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"int-key"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"int-key"});
+        auto res = get_subject_versions(client, schema_reg_ep.address, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -148,6 +148,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
         info("Post a schema as key, which references the first");
         auto res = post_schema(
           client,
+          schema_reg_ep.address,
           pps::subject{"reference-key"},
           ss::sstring{
             R"(
@@ -169,7 +170,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     {
         info("Delete version 1, expect failure 42206");
         auto res = delete_subject_version(
-          client, pps::subject{"int-key"}, pps::schema_version{1});
+          client, schema_reg_ep.address, pps::subject{"int-key"}, pps::schema_version{1});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
           boost::beast::http::status::unprocessable_entity);
@@ -178,7 +179,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject int-key, expect failure 42206");
-        auto res = delete_subject(client, pps::subject{"int-key"});
+        auto res = delete_subject(client, schema_reg_ep.address, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
           boost::beast::http::status::unprocessable_entity);
@@ -187,14 +188,14 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject reference-key");
-        auto res = delete_subject(client, pps::subject{"reference-key"});
+        auto res = delete_subject(client, schema_reg_ep.address, pps::subject{"reference-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Delete subject int-key");
-        auto res = delete_subject(client, pps::subject{"int-key"});
+        auto res = delete_subject(client, schema_reg_ep.address, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
           boost::beast::http::status::unprocessable_entity);
@@ -204,14 +205,14 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     {
         info("Permanantly delete subject reference-key");
         auto res = delete_subject(
-          client, pps::subject{"reference-key"}, pps::permanent_delete::yes);
+          client, schema_reg_ep.address, pps::subject{"reference-key"}, pps::permanent_delete::yes);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Delete subject int-key");
-        auto res = delete_subject(client, pps::subject{"int-key"});
+        auto res = delete_subject(client, schema_reg_ep.address, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }

--- a/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
+++ b/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
@@ -27,7 +27,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
 
     {
         info("List schema types (no headers)");
-        auto res = http_request(client, "/schemas/types");
+        auto res = http_request(client, schema_reg_ep.address, "/schemas/types");
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"(["PROTOBUF","AVRO"])");
@@ -40,6 +40,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
         info("List schema types (accept schema_registry_json)");
         auto res = http_request(
           client,
+          schema_reg_ep.address,
           "/schemas/types",
           boost::beast::http::verb::get,
           ppj::serialization_format::schema_registry_json,

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -59,7 +59,7 @@ FIXTURE_TEST(
     {
         info("Post a schema as key (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
@@ -71,7 +71,7 @@ FIXTURE_TEST(
     {
         info("Repost a schema as key (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
@@ -83,7 +83,7 @@ FIXTURE_TEST(
     {
         info("Repost a schema as value (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-value"}, avro_int_payload);
+          client, schema_reg_ep.address, pps::subject{"test-value"}, avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
@@ -95,7 +95,7 @@ FIXTURE_TEST(
     {
         info("Post a new schema as key (expect schema_id=2)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_long_payload);
+          client, schema_reg_ep.address, pps::subject{"test-key"}, avro_long_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
@@ -115,7 +115,7 @@ FIXTURE_TEST(
 
     {
         info("Post an invalid payload");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(client, schema_reg_ep.address, pps::subject{"test-key"}, R"(
 {
   "schema": "\"int\"",
   "InvalidField": "AVRO"
@@ -139,7 +139,7 @@ FIXTURE_TEST(
 
     {
         info("Post an invalid schema");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(client, schema_reg_ep.address, pps::subject{"test-key"}, R"(
 {
   "schema": "not_json",
   "schemaType": "AVRO"
@@ -163,7 +163,7 @@ FIXTURE_TEST(
 
     for (auto i = 0; i < 10; ++i) {
         info("Post a schema as key (expect schema_id=1)");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(client, schema_reg_ep.address, pps::subject{"test-key"}, R"(
 {
   "schema": "syntax = \"proto3\"; message Simple { string i = 1; }",
   "schemaType": "PROTOBUF"
@@ -234,7 +234,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post company schema (expect schema_id=1)");
     auto res = post_schema(
-      client, company_req.schema.sub(), ppj::rjson_serialize(company_req));
+      client, schema_reg_ep.address, company_req.schema.sub(), ppj::rjson_serialize(company_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),
@@ -242,7 +242,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post employee schema (expect schema_id=2)");
     res = post_schema(
-      client, employee_req.schema.sub(), ppj::rjson_serialize(employee_req));
+      client, schema_reg_ep.address, employee_req.schema.sub(), ppj::rjson_serialize(employee_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -165,7 +165,7 @@ void server::routes(server::routes_t&& rts) {
 }
 
 ss::future<> server::start(
-  const std::vector<model::broker_endpoint>& endpoints,
+  const std::vector<config::rest_authn_endpoint>& endpoints,
   const std::vector<config::endpoint_tls_config>& endpoints_tls,
   const std::vector<model::broker_endpoint>& advertised) {
     _server._routes.register_exeption_handler(

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -12,8 +12,10 @@
 #pragma once
 
 #include "config/config_store.h"
+#include "config/rest_authn_endpoint.h"
 #include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/types.h"
 #include "seastarx.h"
 
 #include <seastar/core/abort_source.hh>
@@ -44,6 +46,8 @@ public:
         ssx::semaphore& mem_sem;
         ss::abort_source as;
         ss::smp_service_group smp_sg;
+        credential_t user;
+        config::rest_authn_type authn_type;
     };
 
     struct request_t {
@@ -91,7 +95,7 @@ public:
     void routes(routes_t&& routes);
 
     ss::future<> start(
-      const std::vector<model::broker_endpoint>& endpoints,
+      const std::vector<config::rest_authn_endpoint>& endpoints,
       const std::vector<config::endpoint_tls_config>& endpoints_tls,
       const std::vector<model::broker_endpoint>& advertised);
     ss::future<> stop();

--- a/src/v/pandaproxy/sharded_client_cache.cc
+++ b/src/v/pandaproxy/sharded_client_cache.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/sharded_client_cache.h"
+
+#include "hashing/jump_consistent_hash.h"
+#include "hashing/xx.h"
+#include "pandaproxy/kafka_client_cache.h"
+#include "ssx/future-util.h"
+
+namespace pandaproxy {
+
+ss::shard_id user_shard(const ss::sstring& name) {
+    auto hash = xxhash_64(name.data(), name.length());
+    return jump_consistent_hash(hash, ss::smp::count);
+}
+
+ss::future<> sharded_client_cache::start(
+  ss::smp_service_group sg,
+  YAML::Node const& cfg,
+  size_t max_size,
+  std::vector<config::broker_authn_endpoint> kafka_api,
+  model::timestamp::type keep_alive) {
+    _smp_opts = ss::smp_submit_to_options{sg};
+    return _cache.start(cfg, max_size, std::move(kafka_api), keep_alive);
+}
+
+ss::future<> sharded_client_cache::stop() { 
+  return _gate.close().then([this] {
+     return _cache.stop();
+  });
+}
+
+ss::future<client_ptr> sharded_client_cache::fetch_client(
+  credential_t user, config::rest_authn_type authn_type) {
+
+    return ss::with_gate(_gate, [this, user, authn_type] {
+      // Access the cache on the appropriate
+      // shard please.
+      auto u_shard{user_shard(user.name)};
+      return _cache.invoke_on(u_shard, _smp_opts, [user, authn_type](kafka_client_cache& cache) {
+          client_ptr client{cache.fetch_or_insert(user, authn_type)};
+          return ss::make_ready_future<client_ptr>(client);
+      });
+    });
+}
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/sharded_client_cache.h
+++ b/src/v/pandaproxy/sharded_client_cache.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "config/broker_authn_endpoint.h"
+#include "config/rest_authn_endpoint.h"
+#include "pandaproxy/types.h"
+#include "pandaproxy/logger.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <vector>
+
+namespace pandaproxy {
+
+class kafka_client_cache;
+
+class sharded_client_cache {
+public:
+    ss::future<> start(
+      ss::smp_service_group sg,
+      YAML::Node const& cfg,
+      size_t max_size,
+      std::vector<config::broker_authn_endpoint> kafka_api,
+      model::timestamp::type keep_alive);
+
+    ss::future<> stop();
+
+    ss::future<client_ptr>
+    fetch_client(credential_t user, config::rest_authn_type authn_type);
+
+private:
+    ss::smp_submit_to_options _smp_opts;
+    ss::gate _gate;
+    ss::sharded<kafka_client_cache> _cache;
+};
+} // namespace pandaproxy

--- a/src/v/pandaproxy/test/CMakeLists.txt
+++ b/src/v/pandaproxy/test/CMakeLists.txt
@@ -7,3 +7,15 @@ rp_test(
   LIBRARIES Boost::unit_test_framework v::pandaproxy_common v::kafka_protocol
   LABELS pandaproxy
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_single_thread
+  SOURCES
+    sharded_client_cache.cc
+    kafka_client_cache.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::rphashing v::http v::pandaproxy_common v::kafka_protocol
+  ARGS "-- -c 1"
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/test/kafka_client_cache.cc
+++ b/src/v/pandaproxy/test/kafka_client_cache.cc
@@ -1,0 +1,128 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/kafka_client_cache.h"
+
+#include "config/node_config.h"
+#include "config/rest_authn_endpoint.h"
+#include "kafka/client/configuration.h"
+#include "pandaproxy/client_cache_error.h"
+#include "pandaproxy/types.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace pandaproxy {
+class test_client_cache : public kafka_client_cache {
+public:
+    test_client_cache(size_t max_size, std::vector<config::broker_authn_endpoint> kafka_api)
+      : kafka_client_cache(to_yaml(kafka::client::configuration{}, config::redact_secrets::no), max_size, std::move(kafka_api), (1000ms).count()) {}
+
+    test_client_cache(size_t max_size)
+      : test_client_cache(max_size, std::move(config::node().kafka_api.value())) {}
+
+    client_ptr fetch(credential_t user) {
+      return kafka_client_cache::fetch(user);
+    }
+
+    void insert(credential_t user, client_ptr client) {
+      kafka_client_cache::insert(user, client);
+    }
+
+    client_ptr
+    make_client(credential_t user, config::rest_authn_type authn_type) {
+      return kafka_client_cache::make_client(user, authn_type);
+    }
+};
+} // namespace pandaproxy
+
+namespace pp = pandaproxy;
+
+SEASTAR_THREAD_TEST_CASE(test_cache_make_client) {
+  size_t max_size{10};
+  auto kafka_api = std::move(config::node().kafka_api.value());
+  kafka_api.clear();
+  kafka_api.push_back(config::broker_authn_endpoint{.address = net::unresolved_address("127.0.0.1", 9092), .authn_method = config::broker_authn_method::sasl});
+  pp::test_client_cache client_cache{max_size, std::move(kafka_api)};
+
+  {
+    // Creating a client with no authn type results in a kafka
+    // client without a principal
+    pp::client_ptr client = client_cache.make_client(pp::credential_t{}, config::rest_authn_type::none);
+    BOOST_TEST(client->real.config().sasl_mechanism.value() == "");
+    BOOST_TEST(client->real.config().scram_username.value() == "");
+    BOOST_TEST(client->real.config().scram_password.value() == "");
+  }
+
+  {
+    // Creating a client with http_basic authn type results
+    // in a kafka client with a principal
+    pp::credential_t user{"red", "panda"};
+    pp::client_ptr client = client_cache.make_client(user, config::rest_authn_type::http_basic);
+    BOOST_TEST(client->real.config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client->real.config().scram_username.value() == user.name);
+    BOOST_TEST(client->real.config().scram_password.value() == user.pass);
+  }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_cache_insert_and_fetch_client) {
+  {
+    pp::credential_t user1;
+    size_t max_size{1};
+    pp::test_client_cache client_cache{max_size};
+    BOOST_TEST(client_cache.size() == 0);
+
+    pp::client_ptr client1 = client_cache.make_client(user1, config::rest_authn_type::none);
+
+    // First insert should pass without problems
+    client_cache.insert(user1, client1);
+
+    // Create a new client with a different user
+    // and insert.
+    pp::credential_t user2{"red", "panda"};
+    pp::client_ptr client2 = client_cache.make_client(user2, config::rest_authn_type::none);
+    client_cache.insert(user2, client2);
+
+    // The LRU replacement should have triggered so
+    // the cache size should still be 1 and a fetch on the
+    // first user should fail with nullptr.
+    BOOST_TEST(client_cache.size() == 1);
+    BOOST_TEST(client_cache.max_size() == max_size);
+    pp::client_ptr temp1 = client_cache.fetch(user1);
+    BOOST_CHECK(temp1 == pp::client_ptr(nullptr));
+
+    // A fetch on the second user should succeed
+    // and it should have the latest timestamp.
+    // Also do a short sleep so the timestamps are different.
+    ss::sleep(ss::lowres_clock::duration(1ms)).get();
+    model::timestamp original_t = client2->last_used;
+    pp::client_ptr temp2 = client_cache.fetch(user2);
+    BOOST_CHECK(&temp2->real == &client2->real);
+    BOOST_TEST(temp2->last_used() > original_t());
+  }
+
+  {
+    size_t max_size{0};
+    pp::test_client_cache client_cache{max_size};
+
+    // Insert with max size 0 should fail
+    try {
+      client_cache.insert(pp::credential_t{}, nullptr);
+    } catch (const pp::client_cache_error &ex) {
+      BOOST_TEST(ex.what() == "Failed to insert client. Max cache size is 0.");
+    }
+  }
+}

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -32,15 +32,13 @@ public:
 
     http::client make_proxy_client() {
         net::base_transport::configuration transport_cfg;
-        transport_cfg.server_addr = net::unresolved_address{
-          "localhost", proxy_port};
+        transport_cfg.server_addr = proxy_ep.address;
         return http::client(transport_cfg);
     }
 
     http::client make_schema_reg_client() {
         net::base_transport::configuration transport_cfg;
-        transport_cfg.server_addr = net::unresolved_address{
-          "localhost", schema_reg_port};
+        transport_cfg.server_addr = schema_reg_ep.address;
         return http::client(transport_cfg);
     }
 

--- a/src/v/pandaproxy/test/sharded_client_cache.cc
+++ b/src/v/pandaproxy/test/sharded_client_cache.cc
@@ -1,0 +1,126 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/sharded_client_cache.h"
+
+#include "config/node_config.h"
+#include "config/rest_authn_endpoint.h"
+#include "kafka/client/configuration.h"
+#include "pandaproxy/types.h"
+#include "pandaproxy/kafka_client_cache.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace pp = pandaproxy;
+
+SEASTAR_THREAD_TEST_CASE(test_sharded_client_cache) {
+    pp::credential_t user;
+    size_t cache_max_size = 10;
+    std::chrono::milliseconds keep_alive{1000ms};
+
+    kafka::client::configuration cfg;
+    cfg.sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
+    cfg.scram_username.set_value(user.name);
+    cfg.scram_password.set_value(user.pass);
+    BOOST_REQUIRE_EQUAL(cfg.scram_username.value(), user.name);
+    BOOST_REQUIRE_EQUAL(cfg.scram_password.value(), user.pass);
+
+    pp::sharded_client_cache client_cache;
+    client_cache
+      .start(
+        ss::default_smp_service_group(),
+        to_yaml(cfg, config::redact_secrets::no),
+        cache_max_size,
+        config::node().kafka_api.value(),
+        keep_alive.count())
+      .get();
+    auto stop_client_cache = ss::defer(
+      [&client_cache]() { client_cache.stop().get(); });
+
+    pp::client_ptr client1 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+    pp::client_ptr client2 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+    BOOST_CHECK(&client1->real == &client2->real);
+    BOOST_TEST(client1->last_used() == client2->last_used());
+
+    ss::sleep(ss::lowres_clock::duration(keep_alive + pp::kafka_client_cache::clean_timer())).get();
+    pp::client_ptr client3 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+    BOOST_CHECK(&client1->real != &client3->real);
+    BOOST_TEST(client1->last_used() != client3->last_used());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_keep_alive) {
+    pp::credential_t user;
+    size_t cache_max_size = 10;
+
+    kafka::client::configuration cfg;
+    cfg.sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
+    cfg.scram_username.set_value(user.name);
+    cfg.scram_password.set_value(user.pass);
+    BOOST_REQUIRE_EQUAL(cfg.scram_username.value(), user.name);
+    BOOST_REQUIRE_EQUAL(cfg.scram_password.value(), user.pass);
+
+    {
+      // A negative keep alive means that idle clients should
+      // be immediately removed when garbage collection
+      // kicks in. Note that garbage collection occurs
+      // on a 10s interval.
+      std::chrono::milliseconds keep_alive{-1000ms};
+
+      pp::sharded_client_cache client_cache;
+      client_cache
+        .start(
+          ss::default_smp_service_group(),
+          to_yaml(cfg, config::redact_secrets::no),
+          cache_max_size,
+          config::node().kafka_api.value(),
+          keep_alive.count())
+        .get();
+      auto stop_client_cache = ss::defer(
+        [&client_cache]() { client_cache.stop().get(); });
+
+      pp::client_ptr client1 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+      ss::sleep(ss::lowres_clock::duration(pp::kafka_client_cache::clean_timer())).get();
+      pp::client_ptr client2 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+      BOOST_CHECK(&client1->real != &client2->real);
+      BOOST_TEST(client1->last_used() != client2->last_used());
+    }
+
+    {
+      // A zero keep alive means the same thing as the
+      // negative version. Regardless we should explictly
+      // test that scenario.
+      std::chrono::milliseconds keep_alive{0ms};
+    
+      pp::sharded_client_cache client_cache;
+      client_cache
+        .start(
+          ss::default_smp_service_group(),
+          to_yaml(cfg, config::redact_secrets::no),
+          cache_max_size,
+          config::node().kafka_api.value(),
+          keep_alive.count())
+        .get();
+      auto stop_client_cache = ss::defer(
+        [&client_cache]() { client_cache.stop().get(); });
+
+      pp::client_ptr client1 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+      ss::sleep(ss::lowres_clock::duration(pp::kafka_client_cache::clean_timer())).get();
+      pp::client_ptr client2 = client_cache.fetch_client(user, config::rest_authn_type::none).get();
+      BOOST_CHECK(&client1->real != &client2->real);
+      BOOST_TEST(client1->last_used() != client2->last_used());
+    }
+}

--- a/src/v/pandaproxy/types.h
+++ b/src/v/pandaproxy/types.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "kafka/client/client.h"
+#include "kafka/protocol/errors.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <chrono>
+
+namespace pandaproxy {
+
+struct timestamped_client {
+    kafka::client::client real;
+    model::timestamp last_used;
+
+    timestamped_client(YAML::Node const& cfg, model::timestamp t)
+      : real{cfg}
+      , last_used{t} {}
+};
+using client_ptr = ss::lw_shared_ptr<timestamped_client>;
+
+struct credential_t {
+    ss::sstring name;
+    ss::sstring pass;
+
+    credential_t() = default;
+    credential_t(ss::sstring n, ss::sstring p)
+      : name{std::move(n)}
+      , pass{std::move(p)} {}
+};
+
+} // namespace pandaproxy

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -22,6 +22,7 @@
 #include "kafka/server/fwd.h"
 #include "net/conn_quota.h"
 #include "net/fwd.h"
+#include "pandaproxy/fwd.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/configuration.h"
@@ -172,6 +173,7 @@ private:
     ss::sharded<net::conn_quota> _kafka_conn_quotas;
     ss::sharded<net::server> _kafka_server;
     ss::sharded<kafka::client::client> _proxy_client;
+    std::unique_ptr<pandaproxy::sharded_client_cache> _proxy_client_cache;
     ss::sharded<pandaproxy::rest::proxy> _proxy;
     std::unique_ptr<pandaproxy::schema_registry::api> _schema_registry;
     ss::sharded<storage::compaction_controller> _compaction_controller;

--- a/src/v/redpanda/request_auth.cc
+++ b/src/v/redpanda/request_auth.cc
@@ -95,7 +95,7 @@ request_auth_result request_authenticator::do_authenticate(
               "Malformed Authorization header");
         }
         username = security::credential_user{decoded_bytes.substr(0, colon)};
-        auto password = ss::sstring(decoded_bytes.substr(colon + 1));
+        security::credential_password password{decoded_bytes.substr(colon + 1)};
 
         const auto cred_opt = cred_store.get<security::scram_credential>(
           username);
@@ -129,7 +129,9 @@ request_auth_result request_authenticator::do_authenticate(
                   superusers.begin(), superusers.end(), username);
                 bool superuser = (found != superusers.end()) || (!require_auth);
                 return request_auth_result(
-                  username, request_auth_result::superuser(superuser));
+                  username,
+                  password,
+                  request_auth_result::superuser(superuser));
             }
         }
     } else if (!auth_hdr.empty()) {

--- a/src/v/redpanda/request_auth.h
+++ b/src/v/redpanda/request_auth.h
@@ -41,8 +41,11 @@ public:
      * @param is_superuser
      */
     request_auth_result(
-      security::credential_user username, superuser is_superuser)
+      security::credential_user username,
+      security::credential_password password,
+      superuser is_superuser)
       : _username(username)
+      , _password(password)
       , _authenticated(true)
       , _superuser(is_superuser){};
 
@@ -73,9 +76,11 @@ public:
     void pass();
 
     ss::sstring const& get_username() const { return _username; }
+    ss::sstring const& get_password() const { return _password; }
 
 private:
     security::credential_user _username;
+    security::credential_password _password;
     bool _authenticated{false};
     bool _superuser{false};
     bool _checked{false};

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -25,6 +25,8 @@ namespace security {
  * consistent for the duration of that process.
  */
 using credential_user = named_type<ss::sstring, struct credential_user_type>;
+using credential_password
+  = named_type<ss::sstring, struct credential_password_type>;
 
 class credential_store {
 public:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -370,6 +370,7 @@ class SecurityConfig:
         self.endpoint_authn_method: Optional[str] = None
         self.tls_provider: Optional[TLSProvider] = None
         self.require_client_auth: bool = True
+        self.pp_authn_type: Optional[str] = None
 
         # The rules to extract principal from mtls
         self.principal_mapping_rules = self.__DEFAULT_PRINCIPAL_MAPPING_RULES
@@ -611,6 +612,9 @@ class RedpandaService(Service):
 
     def endpoint_authn_method(self):
         return self._security.endpoint_authn_method
+
+    def pp_authn_type(self):
+        return self._security.pp_authn_type
 
     def require_client_auth(self):
         return self._security.require_client_auth
@@ -1540,7 +1544,8 @@ class RedpandaService(Service):
                            enable_sr=self._enable_sr,
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
-                           endpoint_authn_method=self.endpoint_authn_method())
+                           endpoint_authn_method=self.endpoint_authn_method(),
+                           pp_authn_type=self.pp_authn_type())
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -53,6 +53,12 @@ pandaproxy:
   pandaproxy_api:
     address: "0.0.0.0"
     port: 8082
+    {% if pp_authn_type %}
+    authentication_method:
+      authentication_type: {{ pp_authn_type }}
+    {% endif %}
+
+  client_cache_size: 20
 
   advertised_pandaproxy_api:
     address: "{{node.account.hostname}}"


### PR DESCRIPTION
## Cover letter

At Redpanda there is an effort to improve security by support HTTP Basic Authentication to our RESTful services (e.g., Pandaproxy and Schema Registry). The Pandaproxy will need to account for multiple authenticated connections on top of validating user credentials from the Basic Auth header.

This PR adds a function wrapper to all Pandaproxy route handlers where basic authentication support is within the wrapper. Inside the wrapper is where credentials are taken from the auth header and then validated against the shared credential store.

This PR adds support for multiple authenticated connections by creating a Kafka client cache. The cache is designed as a sharded service, it has a LRU replacement policy, and all clients are destroyed after 30s of liveness. The cache is added to the brokers route only in this patch.

The new configuration options to enable basic auth are attached to the listener in pandaproxy_api:
```yaml
authentication_method: object
  authentication_type: string
    Optional values: null, http_basic, mTLS
    Default value: null
```

Examples for the new authn config:
```yaml
pandaproxy:
  pandaproxy_api:
  - address: localhost
    port: 8082
    authentication_method:
      authentication_type: none
```

```yaml
pandaproxy:
  pandaproxy_api:
  - address: localhost
    port: 8082
    authentication_method:
      authentication_type: mtls
```

```yaml
pandaproxy:
  pandaproxy_api:
  - address: localhost
    port: 8082
    authentication_method:
      authentication_type: http_basic
```
After this PR, the leftover tasks are:
- Add support for multiple authenticated connections to the remaining Pandaproxy routes `/topic` and `/consumers`
- Add Basic Auth to Schema Registry routes `/config`, `/mode`, `/schemas`, `/subjects`, `/compatibility`
- Create upgrade, scale, and feature tests in ducktape
- Manual tests on cloud infra

Changes from force-push `e75e886` and `4c63f28`:
- Cosmetic changes
- Updated pre-existing auth wrapper to capture passwords
- Removed custom `rest_request_authenticator` class
- Placed authentication in a central location, `wrap()`
- Changed credential type to be a struct
- Capturing kafka api configuration in the client cache
- Update client cache to assign a principal when the Kafka subsystem has SASL enabled
- Check if the incoming request is for a connection with Basic Auth enabled

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Adds HTTP Basic Auth to /brokers on the Pandaproxy