### PR TITLE
operator: add a health, ready checker for the webhook server

### DIFF
--- a/src/go/k8s/main.go
+++ b/src/go/k8s/main.go
@@ -167,6 +167,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	if webhookEnabled {
+		hookServer := mgr.GetWebhookServer()
+		if err := mgr.AddReadyzCheck("webhook", hookServer.StartedChecker()); err != nil {
+			setupLog.Error(err, "unable to create ready check")
+			os.Exit(1)
+		}
+
+		if err := mgr.AddHealthzCheck("webhook", hookServer.StartedChecker()); err != nil {
+			setupLog.Error(err, "unable to create health check")
+			os.Exit(1)
+		}
+	}
 	setupLog.Info("Starting manager")
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
## Cover letter

The Redpanda operator provides a webhook for validation and mutation. However, there's a case where the operator appears as Ready whereas the webhook server isn't yet, leading to cluster deployment errors.

This PR takes advantage of an addition in the controller-runtime (`StartedChecker()`) that adds a webhook health check. The operator will now appear as Ready only once the webhook is ready to serve. If webhooks are disabled, this health check is skipped.