### PR TITLE
Fixes 6329: heap-use-after-free in TxFeatureFlagTest.test_disabling_transactions_after_they_being_used

### DIFF
--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -242,6 +242,18 @@ private:
       _tx_locks;
     ss::future<> apply(model::record_batch b) override;
 
+    ss::future<checked<model::term_id, tm_stm::op_status>> do_barrier();
+    ss::future<checked<model::term_id, tm_stm::op_status>>
+      do_sync(model::timeout_clock::duration);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
+      do_update_tx(tm_transaction, model::term_id);
+    ss::future<tm_stm::op_status> do_register_new_producer(
+      model::term_id,
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::producer_identity);
+    ss::future<stm_snapshot> do_take_snapshot();
+
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       update_tx(tm_transaction, model::term_id);
     ss::future<result<raft::replicate_result>>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1098,7 +1098,10 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
       _ssg,
       [request = std::move(request),
        timeout](tx_gateway_frontend& self) mutable {
-          return self.do_end_txn(std::move(request), timeout);
+          return ss::with_gate(
+            self._gate, [request = std::move(request), timeout, &self] {
+                return self.do_end_txn(std::move(request), timeout);
+            });
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -579,7 +579,11 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
       shard.value(),
       _ssg,
       [tx_id, transaction_timeout_ms, timeout](tx_gateway_frontend& self) {
-          return self.do_init_tm_tx(tx_id, transaction_timeout_ms, timeout);
+          return ss::with_gate(
+            self._gate, [tx_id, transaction_timeout_ms, timeout, &self] {
+                return self.do_init_tm_tx(
+                  tx_id, transaction_timeout_ms, timeout);
+            });
       });
 
     vlog(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -141,9 +141,11 @@ void tx_gateway_frontend::start_expire_timer() {
 }
 
 ss::future<> tx_gateway_frontend::stop() {
+    vlog(txlog.debug, "Asked to stop tx coordinator");
     _expire_timer.cancel();
     _as.request_abort();
-    return _gate.close();
+    return _gate.close().then(
+      [] { vlog(txlog.debug, "Tx coordinator is stopped"); });
 }
 
 ss::future<std::optional<model::node_id>> tx_gateway_frontend::get_tx_broker() {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -814,7 +814,10 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
       _ssg,
       [request = std::move(request),
        timeout](tx_gateway_frontend& self) mutable {
-          return self.do_add_partition_to_tx(request, timeout);
+          return ss::with_gate(
+            self._gate, [request = std::move(request), timeout, &self] {
+                return self.do_add_partition_to_tx(request, timeout);
+            });
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -990,7 +990,10 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
       _ssg,
       [request = std::move(request),
        timeout](tx_gateway_frontend& self) mutable {
-          return self.do_add_offsets_to_tx(request, timeout);
+          return ss::with_gate(
+            self._gate, [request = std::move(request), timeout, &self] {
+                return self.do_add_offsets_to_tx(request, timeout);
+            });
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -274,7 +274,9 @@ ss::future<try_abort_reply> tx_gateway_frontend::try_abort_locally(
       shard.value(),
       _ssg,
       [tm, pid, tx_seq, timeout](tx_gateway_frontend& self) {
-          return self.do_try_abort(tm, pid, tx_seq, timeout);
+          return ss::with_gate(self._gate, [tm, pid, tx_seq, timeout, &self] {
+              return self.do_try_abort(tm, pid, tx_seq, timeout);
+          });
       });
 
     vlog(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1179,140 +1179,6 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
       });
 }
 
-ss::future<tx_gateway_frontend::return_all_txs_res>
-tx_gateway_frontend::get_all_transactions() {
-    auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
-
-    if (!shard.has_value()) {
-        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
-        co_return tx_errc::shard_not_found;
-    }
-
-    co_return co_await container().invoke_on(
-      *shard,
-      _ssg,
-      [](tx_gateway_frontend& self)
-        -> ss::future<tx_gateway_frontend::return_all_txs_res> {
-          auto partition = self._partition_manager.local().get(
-            model::tx_manager_ntp);
-          if (!partition) {
-              vlog(
-                txlog.warn,
-                "can't get partition by {} ntp",
-                model::tx_manager_ntp);
-              co_return tx_errc::partition_not_found;
-          }
-
-          auto stm = partition->tm_stm();
-
-          if (!stm) {
-              vlog(
-                txlog.error,
-                "can't get tm stm of the {}' partition",
-                model::tx_manager_ntp);
-              co_return tx_errc::unknown_server_error;
-          }
-
-          auto gate_lock = gate_guard(self._gate);
-          auto read_lock = co_await stm->read_lock();
-
-          auto res = co_await stm->get_all_transactions();
-          if (!res.has_value()) {
-              if (res.error() == tm_stm::op_status::not_leader) {
-                  co_return tx_errc::not_coordinator;
-              }
-              co_return tx_errc::unknown_server_error;
-          }
-
-          co_return res.value();
-      });
-}
-
-ss::future<tx_errc> tx_gateway_frontend::delete_partition_from_tx(
-  kafka::transactional_id tid, tm_transaction::tx_partition ntp) {
-    auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
-
-    if (shard == std::nullopt) {
-        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
-        co_return tx_errc::shard_not_found;
-    }
-
-    co_return co_await container().invoke_on(
-      *shard,
-      _ssg,
-      [tid, ntp](tx_gateway_frontend& self) -> ss::future<tx_errc> {
-          auto partition = self._partition_manager.local().get(
-            model::tx_manager_ntp);
-          if (!partition) {
-              vlog(
-                txlog.warn,
-                "can't get partition by {} ntp",
-                model::tx_manager_ntp);
-              co_return tx_errc::invalid_txn_state;
-          }
-
-          auto stm = partition->tm_stm();
-
-          if (!stm) {
-              vlog(
-                txlog.warn,
-                "can't get tm stm of the {}' partition",
-                model::tx_manager_ntp);
-              co_return tx_errc::invalid_txn_state;
-          }
-
-          co_return co_await stm->read_lock().then(
-            [&self, stm, tid, ntp](ss::basic_rwlock<>::holder unit) {
-                return with(
-                         stm,
-                         tid,
-                         "delete_partition_from_tx",
-                         [&self, stm, tid, ntp]() {
-                             return self.do_delete_partition_from_tx(
-                               stm, tid, ntp);
-                         })
-                  .finally([u = std::move(unit)] {});
-            });
-      });
-}
-
-ss::future<tx_errc> tx_gateway_frontend::do_delete_partition_from_tx(
-  ss::shared_ptr<tm_stm> stm,
-  kafka::transactional_id tid,
-  tm_transaction::tx_partition ntp) {
-    checked<model::term_id, tm_stm::op_status> term_opt
-      = tm_stm::op_status::unknown;
-    try {
-        term_opt = co_await stm->sync();
-    } catch (...) {
-        co_return tx_errc::invalid_txn_state;
-    }
-    if (!term_opt.has_value()) {
-        if (term_opt.error() == tm_stm::op_status::not_leader) {
-            co_return tx_errc::not_coordinator;
-        }
-        co_return tx_errc::invalid_txn_state;
-    }
-    auto term = term_opt.value();
-
-    auto res = co_await stm->delete_partition_from_tx(term, tid, ntp);
-
-    if (res.has_error()) {
-        switch (res.error()) {
-        case tm_stm::op_status::not_leader:
-            co_return tx_errc::leader_not_found;
-        case tm_stm::op_status::partition_not_found:
-            co_return tx_errc::partition_not_found;
-        case tm_stm::op_status::conflict:
-            co_return tx_errc::conflict;
-        default:
-            co_return tx_errc::unknown_server_error;
-        }
-    }
-
-    co_return tx_errc::none;
-}
-
 ss::future<checked<cluster::tm_transaction, tx_errc>>
 tx_gateway_frontend::do_end_txn(
   end_tx_request request,
@@ -1910,6 +1776,140 @@ ss::future<> tx_gateway_frontend::do_expire_old_tx(
     }
 
     co_await stm->expire_tx(tx_id);
+}
+
+ss::future<tx_gateway_frontend::return_all_txs_res>
+tx_gateway_frontend::get_all_transactions() {
+    auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
+
+    if (!shard.has_value()) {
+        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
+        co_return tx_errc::shard_not_found;
+    }
+
+    co_return co_await container().invoke_on(
+      *shard,
+      _ssg,
+      [](tx_gateway_frontend& self)
+        -> ss::future<tx_gateway_frontend::return_all_txs_res> {
+          auto partition = self._partition_manager.local().get(
+            model::tx_manager_ntp);
+          if (!partition) {
+              vlog(
+                txlog.warn,
+                "can't get partition by {} ntp",
+                model::tx_manager_ntp);
+              co_return tx_errc::partition_not_found;
+          }
+
+          auto stm = partition->tm_stm();
+
+          if (!stm) {
+              vlog(
+                txlog.error,
+                "can't get tm stm of the {}' partition",
+                model::tx_manager_ntp);
+              co_return tx_errc::unknown_server_error;
+          }
+
+          auto gate_lock = gate_guard(self._gate);
+          auto read_lock = co_await stm->read_lock();
+
+          auto res = co_await stm->get_all_transactions();
+          if (!res.has_value()) {
+              if (res.error() == tm_stm::op_status::not_leader) {
+                  co_return tx_errc::not_coordinator;
+              }
+              co_return tx_errc::unknown_server_error;
+          }
+
+          co_return res.value();
+      });
+}
+
+ss::future<tx_errc> tx_gateway_frontend::delete_partition_from_tx(
+  kafka::transactional_id tid, tm_transaction::tx_partition ntp) {
+    auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
+
+    if (shard == std::nullopt) {
+        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
+        co_return tx_errc::shard_not_found;
+    }
+
+    co_return co_await container().invoke_on(
+      *shard,
+      _ssg,
+      [tid, ntp](tx_gateway_frontend& self) -> ss::future<tx_errc> {
+          auto partition = self._partition_manager.local().get(
+            model::tx_manager_ntp);
+          if (!partition) {
+              vlog(
+                txlog.warn,
+                "can't get partition by {} ntp",
+                model::tx_manager_ntp);
+              co_return tx_errc::invalid_txn_state;
+          }
+
+          auto stm = partition->tm_stm();
+
+          if (!stm) {
+              vlog(
+                txlog.warn,
+                "can't get tm stm of the {}' partition",
+                model::tx_manager_ntp);
+              co_return tx_errc::invalid_txn_state;
+          }
+
+          co_return co_await stm->read_lock().then(
+            [&self, stm, tid, ntp](ss::basic_rwlock<>::holder unit) {
+                return with(
+                         stm,
+                         tid,
+                         "delete_partition_from_tx",
+                         [&self, stm, tid, ntp]() {
+                             return self.do_delete_partition_from_tx(
+                               stm, tid, ntp);
+                         })
+                  .finally([u = std::move(unit)] {});
+            });
+      });
+}
+
+ss::future<tx_errc> tx_gateway_frontend::do_delete_partition_from_tx(
+  ss::shared_ptr<tm_stm> stm,
+  kafka::transactional_id tid,
+  tm_transaction::tx_partition ntp) {
+    checked<model::term_id, tm_stm::op_status> term_opt
+      = tm_stm::op_status::unknown;
+    try {
+        term_opt = co_await stm->sync();
+    } catch (...) {
+        co_return tx_errc::invalid_txn_state;
+    }
+    if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
+            co_return tx_errc::not_coordinator;
+        }
+        co_return tx_errc::invalid_txn_state;
+    }
+    auto term = term_opt.value();
+
+    auto res = co_await stm->delete_partition_from_tx(term, tid, ntp);
+
+    if (res.has_error()) {
+        switch (res.error()) {
+        case tm_stm::op_status::not_leader:
+            co_return tx_errc::leader_not_found;
+        case tm_stm::op_status::partition_not_found:
+            co_return tx_errc::partition_not_found;
+        case tm_stm::op_status::conflict:
+            co_return tx_errc::conflict;
+        default:
+            co_return tx_errc::unknown_server_error;
+        }
+    }
+
+    co_return tx_errc::none;
 }
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -179,6 +179,8 @@ private:
       add_paritions_tx_request,
       model::timeout_clock::duration);
     ss::future<add_offsets_tx_reply> do_add_offsets_to_tx(
+      add_offsets_tx_request, model::timeout_clock::duration);
+    ss::future<add_offsets_tx_reply> do_add_offsets_to_tx(
       ss::shared_ptr<tm_stm>,
       add_offsets_tx_request,
       model::timeout_clock::duration);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -136,7 +136,6 @@ private:
       std::chrono::milliseconds,
       model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
-      ss::shard_id,
       kafka::transactional_id,
       std::chrono::milliseconds,
       model::timeout_clock::duration);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -118,7 +118,6 @@ private:
       model::tx_seq,
       model::timeout_clock::duration);
     ss::future<try_abort_reply> do_try_abort(
-      ss::shard_id,
       model::partition_id,
       model::producer_identity,
       model::tx_seq,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -173,11 +173,8 @@ private:
       reabort_tm_tx(tm_transaction, model::timeout_clock::duration);
 
     ss::future<add_paritions_tx_reply> do_add_partition_to_tx(
-      ss::shared_ptr<tm_stm>,
-      add_paritions_tx_request,
-      model::timeout_clock::duration);
+      add_paritions_tx_request, model::timeout_clock::duration);
     ss::future<add_paritions_tx_reply> do_add_partition_to_tx(
-      tm_transaction,
       ss::shared_ptr<tm_stm>,
       add_paritions_tx_request,
       model::timeout_clock::duration);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -145,6 +145,8 @@ private:
       std::chrono::milliseconds,
       model::timeout_clock::duration);
 
+    ss::future<end_tx_reply>
+      do_end_txn(end_tx_request, model::timeout_clock::duration);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_end_txn(
       end_tx_request,
       ss::shared_ptr<cluster::tm_stm>,

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -45,9 +45,11 @@ ss::future<> state_machine::handle_eviction() {
 }
 
 ss::future<> state_machine::stop() {
+    vlog(_log.debug, "Asked to stop state_machine");
     _waiters.stop();
     _as.request_abort();
-    return _gate.close();
+    return _gate.close().then(
+      [this] { vlog(_log.debug, "state_machine is stopped"); });
 }
 
 ss::future<> state_machine::wait(


### PR DESCRIPTION
## Cover letter

The shutdown was interrupting an ongoing tx and it lead to heap-use-after-free. Wrapped the txn methods with _gate to prevent it.

Fixes: #6329

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none