### PR TITLE
[v22.2.x] rptest: Set timeout in transactional producer

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -277,13 +277,14 @@ class PathMatcher:
 
 
 class Producer:
-    def __init__(self, brokers, name, logger):
+    def __init__(self, brokers, name, logger, timeout_sec: float = 60.0):
         self.keys = []
         self.cur_offset = 0
         self.brokers = brokers
         self.logger = logger
         self.num_aborted = 0
         self.name = name
+        self.timeout_sec = timeout_sec
         self.reconnect()
 
     def reconnect(self):
@@ -291,7 +292,7 @@ class Producer:
             'bootstrap.servers': self.brokers,
             'transactional.id': self.name,
         })
-        self.producer.init_transactions()
+        self.producer.init_transactions(self.timeout_sec)
 
     def produce(self, topic):
         """produce some messages inside a transaction with increasing keys


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6337.
Fixes https://github.com/redpanda-data/redpanda/issues/6345,