### PR TITLE
[v22.2.x] Heal network failures in the end of EndToEndFinjectorTest

### DIFF
--- a/tests/rptest/tests/e2e_finjector.py
+++ b/tests/rptest/tests/e2e_finjector.py
@@ -62,14 +62,6 @@ class EndToEndFinjectorTest(EndToEndTest):
         self.finjector_thread.daemon = True
         self.finjector_thread.start()
 
-    def disable_failures(self):
-        self.enable_failures = False
-        self.finjector_thread.join()
-
-    def enable_failures(self):
-        self.enable_failures = True
-        self.start_finjector()
-
     def random_failure_spec(self):
         f_type = random.choice(self.allowed_failures)
         length = self.failure_length_provider(f_type)

--- a/tests/rptest/tests/e2e_finjector.py
+++ b/tests/rptest/tests/e2e_finjector.py
@@ -89,3 +89,9 @@ class EndToEndFinjectorTest(EndToEndTest):
             self.redpanda.logger.info(
                 f"waiting {delay} seconds before next failure")
             time.sleep(delay)
+
+    def teardown(self):
+        self.enable_failures = False
+        if self.finjector_thread:
+            self.finjector_thread.join()
+        FailureInjector(self.redpanda)._heal_all()


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6342.
Fixes https://github.com/redpanda-data/redpanda/issues/6347,