### PR TITLE
Remove ok_to_fail from fixed tests

### DIFF
--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -34,7 +34,6 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3450
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
         self.redpanda = RedpandaService(self.test_context,

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -716,7 +716,6 @@ class PandaProxyTest(RedpandaTest):
             })
         assert sc_res.status_code == requests.codes.no_content
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3454
     @cluster(num_nodes=3)
     def test_consumer_group_binary_v2(self):
         """

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -101,8 +101,7 @@ class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):
 
         self.move_worker.join()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5827
-    # https://github.com/redpanda-data/redpanda/issues/5868
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5868
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_basic_upgrade(self):
         topic = TopicSpec(partition_count=16, replication_factor=3)


### PR DESCRIPTION
## Cover letter

Remove `ok_to_fail` from fixed tests.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none