### PR TITLE
Remove ok_to_fail from fixed tests

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -174,7 +174,6 @@ class TestReadReplicaService(EndToEndTest):
         else:
             return None
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6073
     @cluster(num_nodes=6)
     @matrix(partition_count=[10])
     def test_produce_is_forbidden(self, partition_count: int) -> None:
@@ -187,7 +186,6 @@ class TestReadReplicaService(EndToEndTest):
                 in str(e)):
             second_rpk.produce(self.topic_name, "", "test payload")
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6073
     @cluster(num_nodes=9)
     @matrix(partition_count=[10], min_records=[10000])
     def test_simple_end_to_end(self, partition_count: int,


### PR DESCRIPTION
## Cover letter

Remove `ok_to_fail` from fixed tests.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none