### PR TITLE
tests: fix a rare failure during shutdown of kgo-verifier.

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -172,7 +172,14 @@ class KgoVerifierService(Service):
 
         # Permit the subprocess to exit, and wait for it to do so
         self.logger.debug(f"wait_node {self.who_am_i()}: requesting shutdown")
-        self._remote(node, "shutdown")
+        try:
+            self._remote(node, "shutdown")
+        except requests.exceptions.ConnectionError:
+            # It is permitted for the remote process to abort connection and fail
+            # to send a response, as it does not wait for HTTP response to flush
+            # before shutting down.
+            pass
+
         self.logger.debug(
             f"wait_node {self.who_am_i()}: waiting node={node.name} pid={self._pid} to terminate"
         )


### PR DESCRIPTION
## Cover letter

Test could fail if kgo-verifier process terminates before it has sent response to the /shutdown HTTP request.

I saw this happen only once (https://buildkite.com/redpanda/vtools/builds/3494#01832034-6062-4422-97f7-d1d2822f3ecf) but let's make it robust.

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
None
## Release notes

* none
