### PR TITLE
raft: coordinated recovery

### DIFF
--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -335,7 +335,7 @@ struct instance_generator<raft::append_entries_reply> {
              raft::append_entries_reply::status::failure,
              raft::append_entries_reply::status::group_unavailable,
              raft::append_entries_reply::status::timeout}),
-        };
+          .may_recover = tests::random_bool()};
     }
 
     static std::vector<raft::append_entries_reply> limits() { return {}; }

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -108,6 +108,7 @@ inline void read_value(json::Value const& rd, raft::append_entries_reply& out) {
     default:
         vassert(false, "invalid result {}", result);
     }
+    json_read(may_recover);
     out = obj;
 }
 
@@ -130,6 +131,7 @@ inline void rjson_serialize(
     json_write(last_dirty_log_index);
     json_write(last_term_base_offset);
     json_write(result);
+    json_write(may_recover);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -229,6 +229,24 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       512_KiB,
       {.min = 128, .max = 5_MiB})
+  , raft_recovery_concurrent_per_shard(
+      *this,
+      "raft_recovery_concurrent_per_shard",
+      "How many partitions may simultaneously recover data to a particular "
+      "shard.  This is limited to avoid overwhelming nodes when they come back "
+      "online after an outage.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      128,
+      {.min = 1, .max = 16384})
+  , raft_recovery_grace_ms(
+      *this,
+      "raft_recovery_grace_ms",
+      "How long to wait before starting the first recovery to a node after"
+      "it starts.  This is to accumulate enough recovering topics to make"
+      "a determination of which partitions to recovery first.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5000ms,
+      {.min = 1ms, .max = 600s})
   , use_scheduling_groups(*this, "use_scheduling_groups")
   , enable_admin_api(*this, "enable_admin_api")
   , default_num_windows(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -76,6 +76,8 @@ struct configuration final : public config_store {
     deprecated_property max_version;
     bounded_property<std::optional<size_t>> raft_max_recovery_memory;
     bounded_property<size_t> raft_recovery_default_read_size;
+    bounded_property<size_t> raft_recovery_concurrent_per_shard;
+    bounded_property<std::chrono::milliseconds> raft_recovery_grace_ms;
     // Kafka
     deprecated_property use_scheduling_groups;
     deprecated_property enable_admin_api;

--- a/src/v/config/mock_property.h
+++ b/src/v/config/mock_property.h
@@ -33,6 +33,8 @@ public:
         _property.set_value(value);
     }
 
+    const T& operator()() { return _property(); }
+
     void update(T&& value) { _property.update_value(std::move(value)); }
 
     binding<T> bind() { return _property.bind(); }

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -34,6 +34,7 @@ v_cc_library(
     follower_queue.cc
     offset_translator.cc
     recovery_memory_quota.cc
+    recovery_coordinator.cc
   DEPS
     v::storage
     raft_rpc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -96,6 +96,7 @@ consensus::consensus(
   storage::api& storage,
   std::optional<std::reference_wrapper<recovery_throttle>> recovery_throttle,
   recovery_memory_quota& recovery_mem_quota,
+  recovery_coordinator& recovery_coordinator,
   features::feature_table& ft,
   std::optional<voter_priority> voter_priority_override)
   : _self(nid, initial_cfg.revision_id())
@@ -127,6 +128,7 @@ consensus::consensus(
   , _storage(storage)
   , _recovery_throttle(recovery_throttle)
   , _recovery_mem_quota(recovery_mem_quota)
+  , _recovery_coordinator(recovery_coordinator)
   , _features(ft)
   , _snapshot_mgr(
       std::filesystem::path(_log.config().work_directory()),

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -196,7 +196,7 @@ void consensus::do_step_down(std::string_view ctx) {
           _term,
           _log.offsets().dirty_offset);
     }
-    _vstate = vote_state::follower;
+    set_vstate(vote_state::follower);
 }
 
 void consensus::maybe_step_down() {
@@ -1684,7 +1684,7 @@ consensus::do_append_entries(append_entries_request&& r) {
 
     // raft.pdf:If AppendEntries RPC received from new leader: convert to
     // follower (§5.2)
-    _vstate = vote_state::follower;
+    set_vstate(vote_state::follower);
     if (unlikely(_leader_id != r.node_id)) {
         _leader_id = r.node_id;
         _follower_reply.broadcast();
@@ -3311,5 +3311,7 @@ consensus::timequery(storage::timequery_config cfg) {
           return res;
       });
 }
+
+void consensus::set_vstate(vote_state vs) { _vstate = vs; }
 
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -27,6 +27,7 @@
 #include "raft/offset_translator.h"
 #include "raft/prevote_stm.h"
 #include "raft/probe.h"
+#include "raft/recovery_coordinator.h"
 #include "raft/recovery_memory_quota.h"
 #include "raft/recovery_throttle.h"
 #include "raft/replicate_batcher.h"
@@ -97,6 +98,7 @@ public:
       storage::api&,
       std::optional<std::reference_wrapper<recovery_throttle>>,
       recovery_memory_quota&,
+      recovery_coordinator&,
       features::feature_table&,
       std::optional<voter_priority> = std::nullopt);
 
@@ -655,6 +657,7 @@ private:
     storage::api& _storage;
     std::optional<std::reference_wrapper<recovery_throttle>> _recovery_throttle;
     recovery_memory_quota& _recovery_mem_quota;
+    recovery_coordinator& _recovery_coordinator;
     features::feature_table& _features;
     storage::simple_snapshot_manager _snapshot_mgr;
     std::optional<storage::snapshot_writer> _snapshot_writer;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -588,6 +588,12 @@ private:
         }
         return false;
     }
+
+    void enter_follower_recovery(
+      model::offset current_offset,
+      model::offset hwm,
+      bool already_recovering = false);
+
     // args
     vnode _self;
     raft::group_id _group;
@@ -680,6 +686,14 @@ private:
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _follower_reply;
     append_entries_buffer _append_requests_buffer;
+
+    /**
+     * If a follower notices that it requires recovery, it starts tracking
+     * that via this object, which holds a place in the recovery_coordinator
+     * queue to regulate how many raft groups can go into recovery concurrently.
+     */
+    std::optional<follower_recovery_state> _follower_recovery_state;
+
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -146,6 +146,9 @@ public:
     std::optional<model::node_id> get_leader_id() const {
         return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;
     }
+
+    void set_vstate(vote_state);
+
     /**
      * Sends a round of heartbeats to followers, when majority of followers
      * replied with success to either this of any following request all reads up

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -82,6 +82,10 @@ public:
 
     consensus_client_protocol raft_client() const { return _client; }
 
+    const recovery_status& get_recovery_status() {
+        return _recovery_coordinator.get_status();
+    }
+
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -14,6 +14,7 @@
 #include "model/metadata.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"
+#include "raft/recovery_coordinator.h"
 #include "raft/recovery_memory_quota.h"
 #include "raft/types.h"
 #include "rpc/fwd.h"
@@ -98,6 +99,7 @@ private:
     storage::api& _storage;
     recovery_throttle& _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
+    recovery_coordinator _recovery_coordinator;
     features::feature_table& _feature_table;
     bool _is_ready;
 };

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -136,7 +136,7 @@ ss::future<bool> prevote_stm::prevote(bool leadership_transfer) {
     return _ptr->_op_lock
       .with([this, leadership_transfer] {
           // 5.2.1 mark node as candidate, and update leader id
-          _ptr->_vstate = consensus::vote_state::candidate;
+          _ptr->set_vstate(consensus::vote_state::candidate);
           //  only trigger notification when we had a leader previosly
           if (_ptr->_leader_id) {
               _ptr->_leader_id = std::nullopt;

--- a/src/v/raft/recovery_coordinator.cc
+++ b/src/v/raft/recovery_coordinator.cc
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "recovery_coordinator.h"
+
+#include "seastar/core/coroutine.hh"
+#include "vassert.h"
+
+namespace raft {
+
+recovery_coordinator_base::recovery_coordinator_base(
+  config::binding<size_t> rps)
+  // TODO: use something like adjustable_allowance to handle changes to this
+  // binding
+  : _concurrent_recoveries(rps(), "concurrent_recoveries") {}
+
+recovery_coordinator_base::~recovery_coordinator_base() {
+    for (auto s : _states) {
+        s->detach();
+    }
+    _states.clear();
+}
+
+static bool is_internal(const model::ntp& ntp) {
+    return ntp.ns == model::redpanda_ns
+           || ntp.ns == model::kafka_internal_namespace
+           || (ntp.ns == model::kafka_namespace && ntp.tp.topic == model::kafka_consumer_offsets_topic);
+}
+
+/**
+ * Called when a follower_recovery_state is constructed or moved
+ */
+void recovery_coordinator_base::register_follower(
+  follower_recovery_state* frs) {
+    vlog(
+      raftlog.debug,
+      "register_follower: {} ({}) ({} states)",
+      *frs,
+      fmt::ptr(frs),
+      _states.size());
+    _states.push_back(frs);
+
+    // Special case for newly created partitions:
+    // proceed to "recover" immediately.  This is not necessary for
+    // correctness, we do it because:
+    //  - improved observability, where "recovery means recovery" rather than
+    //    "recovery" stats also spiking up when a partition is created.
+    //  - exploit our knowledge that a newly created partition will almost
+    //    always just have a single config event in the log.
+    //  - simplify testing, so that tests don't have to filter out
+    //    spurious "recovery" events that occur during partition creation
+    if (frs->last_offset == model::offset{-1} && frs->hwm == model::offset{0}) {
+        frs->recovering = true;
+    }
+
+    // If we register a follower that is _already_ recovering, it means the
+    // leader sent is a recovery message without us asking: perhaps this node
+    // restarted while the leader already had a recovery_stm constructed and
+    // running.
+    // To avoid exceeding our concurrency limit, subtract from our semaphore
+    // to account for this partition already being in recovery.
+    if (frs->recovering) {
+        vlog(
+          raftlog.debug,
+          "register_follower: {} already in recovery, updating accounting",
+          *frs);
+        frs->start_recovery(ss::consume_units(_concurrent_recoveries, 1));
+        _status.offsets_pending += frs->offset_count();
+        _status.offsets_hwm = std::max(
+          _status.offsets_pending, _status.offsets_hwm);
+        _status.partitions_active += 1;
+
+        return;
+    }
+
+    bool fast_dispatch = is_internal(frs->ntp)
+                         && _concurrent_recoveries.current() > 0;
+
+    if (fast_dispatch) {
+        // If there are units available, dispatch
+        // their recovery immediately rather than waiting for the next tick.
+        vlog(
+          raftlog.debug, "register_follower: fast-start recovery for {}", *frs);
+        start_one(frs);
+        _status.offsets_pending += frs->offset_count();
+        _status.offsets_hwm = std::max(
+          _status.offsets_pending, _status.offsets_hwm);
+        _status.partitions_active += 1;
+    } else {
+        // In general, registering a follower for recovery does not start it
+        // immediately, but waits til the next tick to group the followers
+        // together & prioritize.
+        maybe_advance(frs->ntp, false);
+    }
+}
+
+/**
+ * Called when a follower_recovery_state is destroyed or moved.
+ */
+void recovery_coordinator_base::unregister_follower(
+  follower_recovery_state* frs) {
+    vlog(
+      raftlog.debug,
+      "unregister_follower: {} ({}) ({} states)",
+      *frs,
+      fmt::ptr(frs),
+      _states.size());
+
+    std::erase_if(
+      _states, [frs](follower_recovery_state* i) { return i == frs; });
+
+    maybe_advance(frs->ntp, false);
+}
+
+void recovery_coordinator_base::start_one(follower_recovery_state* st) {
+    vlog(
+      raftlog.debug,
+      "Starting recovery of partition {} ({}) from {} to {}",
+      st->ntp,
+      fmt::ptr(st),
+      st->last_offset,
+      st->hwm);
+    st->start_recovery(ss::consume_units(_concurrent_recoveries, 1));
+}
+
+void recovery_coordinator_base::sort() {
+    class sorter {
+    public:
+        sorter(const std::vector<follower_recovery_state*>& states) {
+            for (const auto& s : states) {
+                if (is_internal(s->ntp)) {
+                    continue;
+                }
+
+                auto remaining = std::max(
+                  s->hwm - s->last_offset, model::offset{0});
+                topic_offset_counts[s->ntp.tp.topic] += remaining;
+            }
+        }
+
+        bool
+        operator()(follower_recovery_state* a, follower_recovery_state* b) {
+            // Anything already recovering stays at the front of the queue
+            bool a_recovering = a->recovering;
+            bool b_recovering = b->recovering;
+            if (a_recovering != b_recovering) {
+                return a_recovering > b_recovering;
+            }
+
+            // Internal topics are the highest priority
+            bool a_internal = is_internal(a->ntp);
+            bool b_internal = is_internal(b->ntp);
+            if (a_internal != b_internal) {
+                return a_internal > b_internal;
+            }
+
+            // For other topics, put the topic with the lowest outstanding
+            // offsets first.
+            auto a_count = topic_offset_counts[a->ntp.tp.topic];
+            auto b_count = topic_offset_counts[b->ntp.tp.topic];
+            return a_count < b_count;
+        }
+
+    private:
+        std::map<model::topic, model::offset> topic_offset_counts;
+    };
+
+    auto s = sorter(_states);
+    std::sort(_states.begin(), _states.end(), s);
+}
+
+ss::future<> recovery_coordinator_base::tick() {
+    auto gate_guard = _gate.hold();
+
+    vlog(
+      raftlog.debug,
+      "tick: units available {}, queue {}",
+      _concurrent_recoveries.current(),
+      _states.size());
+
+    if (_followers_dirty) {
+        _followers_dirty = false;
+
+        if (_concurrent_recoveries.current() > 0) {
+            // We have some units to hand out: sort the list before
+            // doing so.  Otherwise sorting is a waste of time.
+            sort();
+        }
+
+        if (_states.empty()) {
+            vlog(raftlog.debug, "No followers awaiting recovery.");
+        } else {
+            vlog(raftlog.trace, "Current groups awaiting recovery:");
+            for (const auto& s : _states) {
+                vlog(raftlog.trace, "  {}", *s);
+            }
+        }
+
+        for (const auto st : _states) {
+            if (_concurrent_recoveries.current() <= 0) {
+                break;
+            }
+
+            if (st->recovering == false) {
+                start_one(st);
+            }
+        }
+    } else {
+        vlog(raftlog.trace, "Updating stats (no changes to follower list)");
+    }
+
+    // Update status summary
+    _status.offsets_pending = 0;
+    _status.partitions_pending = 0;
+    _status.partitions_active = 0;
+    for (const auto st : _states) {
+        if (st->recovering) {
+            _status.partitions_active += 1;
+        } else {
+            _status.partitions_pending += 1;
+        }
+
+        _status.offsets_pending += st->offset_count();
+    }
+    _status.offsets_hwm = std::max(
+      _status.offsets_pending, _status.offsets_hwm);
+
+    vlog(
+      raftlog.trace,
+      "Updated stats ({} active, {} total)",
+      _status.partitions_active,
+      _states.size());
+
+    co_return;
+}
+
+const recovery_status& recovery_coordinator_base::get_status() {
+    return _status;
+}
+
+} // namespace raft
+
+template<>
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<raft::follower_recovery_state, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  raft::follower_recovery_state const& frs,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
+    return fmt::format_to(
+      ctx.out(),
+      "follower({}, {}, {}-{})",
+      frs.ntp,
+      frs.recovering,
+      frs.last_offset,
+      frs.hwm);
+}

--- a/src/v/raft/recovery_coordinator.h
+++ b/src/v/raft/recovery_coordinator.h
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "raft/logger.h"
+#include "seastar/core/gate.hh"
+#include "seastar/core/lowres_clock.hh"
+#include "seastar/core/timer.hh"
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+
+#include <fmt/core.h>
+
+#include <vector>
+
+namespace raft {
+
+class follower_recovery_state;
+
+/**
+ * Summarized state of a recovery_coordinator.  Use merge()
+ * across statuses from all shards to get a total node state.
+ *
+ * Suitable for use in admin API, statistics, etc.
+ */
+struct recovery_status {
+    uint64_t partitions_pending{0};
+    uint64_t partitions_active{0};
+    uint64_t offsets_pending{0};
+    uint64_t offsets_hwm{0};
+
+    void merge(recovery_status const& rhs) {
+        partitions_pending += rhs.partitions_pending;
+        partitions_active += rhs.partitions_active;
+        offsets_pending += rhs.offsets_pending;
+        offsets_hwm += rhs.offsets_hwm;
+    }
+};
+
+/**
+ * Although each raft group's recovery can proceed independently, it is
+ * not desirable to run all of them in parallel, because it leads to
+ * an excess of concurrent I/Os to a node coming back online after an outage.
+ *
+ * This class is responsible for limiting the number of recoveries
+ * done to a single node at once, and prioritizing them to recover
+ * important metadata before bulk data.
+ *
+ * It is split into a "base" class that contains most of the logic, and
+ * then specialized into a subclass that contains timing code, so that the
+ * latter part can easily be switched out for unit testing with manual_clock.
+ */
+class recovery_coordinator_base {
+public:
+    recovery_coordinator_base(config::binding<size_t> rps);
+    ~recovery_coordinator_base();
+
+    void register_follower(follower_recovery_state*);
+    void unregister_follower(follower_recovery_state*);
+
+    const recovery_status& get_status();
+
+    /**
+     * Signal to the coordinator that something has changed, and it
+     * should wake up and make scheduling decisions (if stats_only
+     * is false), and update status.
+     */
+    virtual void maybe_advance(const model::ntp&, bool stats_only) = 0;
+
+protected:
+    ss::gate _gate;
+
+    ss::future<> tick();
+    void sort();
+
+    void start_one(follower_recovery_state* frs);
+
+    // TODO: define more efficient data structure for sorting + lookup
+    // on register/deregister
+    // All partitions on this shard which are currently waiting to
+    // recover or in the process of recovering.
+    std::vector<follower_recovery_state*> _states;
+
+    // This structure is updated in tick() to enable other classes
+    // (mainly the admin server) to look up the total recovery status.
+    recovery_status _status;
+
+    // Limit how many recoveries may proceed concurrently on this shard.
+    ssx::named_semaphore<> _concurrent_recoveries;
+
+    // Followers have registered or deregistered, so we may need to
+    // make some new scheduling decisions.  If we tick and this is false,
+    // that means we only need to update status.
+    bool _followers_dirty{false};
+};
+
+/**
+ * The 'ticker' is the concrete implementation of recovery_coordinator,
+ * templated on a particular clock type to use.
+ */
+template<typename Clock>
+class recovery_coordinator_ticker : public recovery_coordinator_base {
+public:
+    recovery_coordinator_ticker(
+      config::binding<size_t> rps,
+      config::binding<std::chrono::milliseconds> period,
+      config::binding<std::chrono::milliseconds> grace_period)
+      : recovery_coordinator_base(std::move(rps))
+      , _timer([this] { return tick(); })
+      , _period(std::move(period))
+      , _grace_period(std::move(grace_period)) {}
+
+    ss::future<> start() { co_return; }
+
+    ss::future<> stop() {
+        _timer.cancel();
+        return _gate.close();
+    }
+
+    void maybe_advance(const model::ntp& ntp, bool stats_only) override {
+        using namespace std::chrono_literals;
+
+        if (!stats_only) {
+            _followers_dirty = true;
+        }
+
+        // Q: Why don't we check that some units are available before scheduling
+        //    a tick, to avoid doing it if it won't be able to start anything?
+        // A: Because we may be killed while a follower_recovery_state is
+        //    unregistering itself, while it still holds semaphore units which
+        //    it will release afterward.
+
+        // Q: Why do we tick even if _states is empty?
+        // A: Because we might have just unregistered the last follower state,
+        //    and need to do a round of updates to the status structure to
+        //    make out final status visible via the admin API.
+        if (!_timer.armed()) {
+            // This time period is meant to be long enough to accumulate a round
+            // of heartbeats and then prioritize them in a batch.
+
+            // Grace period
+            // TODO: pre-empt grace period if the system has fewer partitions
+            // than the limit.
+            if (_grace) {
+                _timer.arm(Clock::now() + _grace_period());
+
+                // Do not exit grace mode when we see the controller NTP
+                // come up, because this happens so much earlier than the
+                // rest of the system.
+                if (ntp != model::controller_ntp) {
+                    _grace = false;
+                }
+            } else {
+                _timer.arm(Clock::now() + _period());
+            }
+        }
+    }
+
+private:
+    // This timer is armed after a follower registers or unregisters, to
+    // prompt a call to tick().  The timer's delay provides nagling of
+    // the sorting of _states and updates to _status.
+    seastar::timer<Clock> _timer;
+
+    // How long to accumulate registrations for before making the next
+    // decision about which partitions to start recovering.
+    config::binding<std::chrono::milliseconds> _period;
+
+    // How long to wait after the first partition registers for recovery,
+    // before ticking for the first time.  Allows accumulating enough
+    // follower_recovery_states to make a reasonable prioritization decision,
+    // rather than ending up with a "first come first served" behavior.
+    config::binding<std::chrono::milliseconds> _grace_period;
+
+    // If true, wait longer before scheduling recoveries to give all the
+    // partitions a chance to report in on startup.
+    bool _grace{true};
+};
+
+using recovery_coordinator = recovery_coordinator_ticker<ss::lowres_clock>;
+
+/**
+ * If a `consensus` object is ready for recovery or currently recovering,
+ * it instantiates one of these.
+ *
+ * In most cases, the purpose is to register that the follower requires
+ * recovery, to enable recovery_coordinator to start considering this
+ * as a candidate for kicking off recovery.  However, this can also be
+ * constructed in an already-recovering state for situations where recovery
+ * has been initiated by the leader & not via recovery_coordinator.
+ */
+class follower_recovery_state {
+public:
+    follower_recovery_state(
+      recovery_coordinator_base* rc,
+      model::ntp n,
+      model::offset current,
+      model::offset hwm,
+      bool already_recovering)
+      : recovering(already_recovering)
+      , ntp(n)
+      , last_offset(current)
+      , hwm(hwm)
+      , _coordinator(rc) {
+        if (_coordinator) {
+            _coordinator->register_follower(this);
+        }
+    }
+
+    follower_recovery_state(follower_recovery_state&& rhs) noexcept
+      : _coordinator(rhs._coordinator)
+      , _units(std::move(rhs._units)) {
+        if (_coordinator) {
+            _coordinator->unregister_follower(&rhs);
+            _coordinator->register_follower(this);
+        }
+    }
+
+    follower_recovery_state(const follower_recovery_state& rhs) = delete;
+    follower_recovery_state& operator=(const follower_recovery_state&) = delete;
+
+    ~follower_recovery_state() {
+        if (_coordinator) {
+            _coordinator->unregister_follower(this);
+        }
+    }
+
+    void update(model::offset latest) {
+        if (latest > last_offset) {
+            last_offset = latest;
+        }
+        hwm = std::max(hwm, last_offset + model::offset{1});
+        _coordinator->maybe_advance(ntp, true);
+    }
+
+    /**
+     * When recovering is true, we advertise may_recover in append_entries_reply
+     */
+    bool recovering{false};
+
+    // Copy of the NTP for the partition we refer to.
+    model::ntp ntp;
+
+    // The last offset we recovered
+    model::offset last_offset{0};
+
+    // The highest offset we've seen, we use this for indicating progress
+    // of our recovery
+    model::offset hwm{0};
+
+    void detach() {
+        _units = ssx::semaphore_units();
+        _coordinator = nullptr;
+    }
+
+    void start_recovery(ssx::semaphore_units&& units) {
+        _units = std::move(units);
+        recovering = true;
+    }
+
+    model::offset offset_count() {
+        return std::max(hwm - last_offset, model::offset{0});
+    }
+
+private:
+    recovery_coordinator_base* _coordinator;
+
+    ssx::semaphore_units _units;
+};
+
+} // namespace raft
+
+template<>
+struct fmt::formatter<raft::follower_recovery_state> {
+    using type = raft::follower_recovery_state;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -408,7 +408,8 @@ ss::future<> recovery_stm::replicate(
         .prev_log_term = prev_log_term,
         .last_visible_index = last_visible_idx},
       std::move(reader),
-      flush);
+      flush,
+      true);
     auto meta = get_follower_meta();
 
     if (!meta) {

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -93,6 +93,20 @@ ss::future<result<append_entries_reply>>
 replicate_entries_stm::send_append_entries_request(
   vnode n, append_entries_request req) {
     _ptr->update_node_append_timestamp(n);
+
+    auto fs = _ptr->_fstats.find(n);
+    if (fs != _ptr->_fstats.end()) {
+        // In general, replicate_entries_stm and recovery_stm don't send to
+        // the same node at the same time, but there is a small window at
+        // the end of recovery where our follower skip check passes because
+        // their offset is high enough, but recovery_stm is still following
+        // and sending data to the follower.
+        // To avoid flapping the recovery_coordinator state on the follower,
+        // we mark our append_entries_request as is_recovery=true, as if it
+        // had come from the recovery_stm.
+        req.is_recovery = fs->second.is_recovering;
+    }
+
     vlog(_ctxlog.trace, "Sending append entries request {} to {}", req.meta, n);
 
     req.target_node_id = n;

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(srcs
     mutex_buffer_test.cc
     manual_log_deletion_test.cc
     state_removal_test.cc
+    recovery_coordinator_test.cc
     configuration_manager_test.cc
 )
 

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -36,7 +36,13 @@ using namespace std::chrono_literals; // NOLINT
 struct mux_state_machine_fixture {
     mux_state_machine_fixture()
       : _self{0}
-      , _data_dir("test_dir_" + random_generators::gen_alphanum_string(6)) {}
+      , _data_dir("test_dir_" + random_generators::gen_alphanum_string(6)) {
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg()
+              .get("raft_recovery_grace_ms")
+              .set_value(200ms);
+        }).get();
+    }
 
     void start_raft(storage::ntp_config::default_overrides overrides = {}) {
         // configure and start kvstore

--- a/src/v/raft/tests/recovery_coordinator_test.cc
+++ b/src/v/raft/tests/recovery_coordinator_test.cc
@@ -1,0 +1,150 @@
+
+
+#include "config/mock_property.h"
+#include "raft/recovery_coordinator.h"
+#include "test_utils/fixture.h"
+#include "vlog.h"
+
+#include <seastar/core/manual_clock.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using recovery_coordinator_manual
+  = raft::recovery_coordinator_ticker<ss::manual_clock>;
+
+using namespace std::chrono_literals;
+
+static ss::logger logger("test");
+
+struct coordinator_fixture {
+    config::mock_property<std::chrono::milliseconds> period{100ms};
+    config::mock_property<std::chrono::milliseconds> grace_period{1000ms};
+    config::mock_property<size_t> concurrency{1};
+
+    coordinator_fixture()
+      : coordinator(concurrency.bind(), period.bind(), grace_period.bind()) {
+        coordinator.start().get();
+    }
+
+    ~coordinator_fixture() { coordinator.stop().get(); }
+
+    void advance_time(std::chrono::milliseconds d) {
+        ss::manual_clock::advance(d);
+
+        // Hack: prompt seastar runtime to actually schedule and run the
+        // tasks that were made ready by advancing the manual clock.
+        ss::sleep(10ms).get();
+    }
+
+    recovery_coordinator_manual coordinator;
+};
+
+FIXTURE_TEST(test_recovery_basic, coordinator_fixture) {
+    raft::recovery_coordinator_base* r = &coordinator;
+
+    // Set one recovery at a time, check that the limit is respected
+    // and the partitions go through in the expected order
+    concurrency.update(1);
+
+    // Exercise ordering rules:
+    // - internal topics come first
+    // - user topics are executed in order of how many offsets remain, smallest
+    //   first
+    auto p_internal = std::make_unique<raft::follower_recovery_state>(
+      r, model::tx_manager_ntp, model::offset{0}, model::offset{10}, false);
+    auto p_user_small = std::make_unique<raft::follower_recovery_state>(
+      r,
+      model::ntp("kafka", "smalltopic", 0),
+      model::offset{0},
+      model::offset{10},
+      false);
+    auto p_user_big = std::make_unique<raft::follower_recovery_state>(
+      r,
+      model::ntp("kafka", "bigtopic", 0),
+      model::offset{0},
+      model::offset{100},
+      false);
+
+    // The internal partition should have been fast-started
+    BOOST_REQUIRE(p_internal->recovering == true);
+    BOOST_REQUIRE(coordinator.get_status().partitions_active == 1);
+
+    // At the next tick, only the internal partition should
+    // still be in progress, status should have updated
+    advance_time(grace_period() + 1ms);
+    BOOST_REQUIRE(p_internal->recovering == true);
+    BOOST_REQUIRE(p_user_small->recovering == false);
+    BOOST_REQUIRE(p_user_big->recovering == false);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_pending, 2);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 1);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_pending, 120);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_hwm, 120);
+
+    p_internal->update(model::offset{5});
+
+    // Status doesn't update until next tick
+    advance_time(period() / 2);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_pending, 2);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 1);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_pending, 120);
+
+    advance_time(period() / 2 + 1ms);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 1);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_pending, 115);
+
+    // Internal topic's recovery finishes
+    p_internal.reset();
+
+    advance_time(period() + 1ms);
+    // p_user_small recovery starts
+    BOOST_REQUIRE_EQUAL(p_user_small->recovering, true);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 1);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_pending, 1);
+
+    // p_user_small recovery completes
+    p_user_small.reset();
+
+    advance_time(period() + 1ms);
+    // p_user_big recovery starts
+    BOOST_REQUIRE_EQUAL(p_user_big->recovering, true);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 1);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_pending, 0);
+
+    // p_user_big recovery completes
+    p_user_big.reset();
+
+    // All recoveries done
+    advance_time(period() + 1ms);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_active, 0);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().partitions_pending, 0);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_pending, 0);
+    BOOST_REQUIRE_EQUAL(coordinator.get_status().offsets_hwm, 120);
+}
+
+FIXTURE_TEST(test_recovery_grace, coordinator_fixture) {
+    raft::recovery_coordinator_base* r = &coordinator;
+
+    // Set one recovery at a time, check that the limit is respected
+    // and the partitions go through in the expected order
+    concurrency.update(1);
+
+    auto p_user = std::make_unique<raft::follower_recovery_state>(
+      r,
+      model::ntp("kafka", "topic", 0),
+      model::offset{10},
+      model::offset{20},
+      false);
+
+    BOOST_REQUIRE_EQUAL(p_user->recovering, false);
+
+    // Advancing the usual period should not result in a tick, we
+    // are still in grace.
+    advance_time(period() + 1ms);
+    BOOST_REQUIRE_EQUAL(p_user->recovering, false);
+
+    // Advancing past the grace period should result in a tick
+    advance_time(grace_period() - period() + 1ms);
+    BOOST_REQUIRE_EQUAL(p_user->recovering, true);
+}
+
+// TODO: test fast dispatch of internal topics when units are available
+// TODO: test handling of already_recovering=true follower states

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -68,9 +68,18 @@ void stop_node(raft_node& node) {
         node._nop_stm->stop().get0();
     }
     node.raft_manager.stop().get0();
-    node.consensus = nullptr;
+
     node.hbeats->stop().get0();
     node.hbeats.reset();
+
+    // Nothing else should reference the consensus object: if it lives
+    // on past this point, it could dereference destroyed references
+    // to storage and recovery coordinator objects.
+    std::cerr << node.consensus.use_count() << std::endl;
+    assert(node.consensus.owned());
+    node.consensus = nullptr;
+
+    node.recovery_coordinator.stop().get0();
     node.cache.stop().get0();
     node.log.reset();
     node.storage.stop().get0();

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -164,6 +164,53 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
           raft::vnode(model::node_id(one_k), model::revision_id(i)));
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip_serde) {
+    static constexpr int64_t one_k = 1'000;
+    raft::heartbeat_request req;
+    req.heartbeats = std::vector<raft::heartbeat_metadata>(one_k);
+    for (int64_t i = 0; i < one_k; ++i) {
+        req.heartbeats[i].node_id = raft::vnode(
+          model::node_id(one_k), model::revision_id(i));
+        req.heartbeats[i].meta.group = raft::group_id(i);
+        req.heartbeats[i].meta.commit_index = model::offset(i);
+        req.heartbeats[i].meta.term = model::term_id(i);
+        req.heartbeats[i].meta.prev_log_index = model::offset(i);
+        req.heartbeats[i].meta.prev_log_term = model::term_id(i);
+        req.heartbeats[i].meta.last_visible_index = model::offset(i);
+        req.heartbeats[i].target_node_id = raft::vnode(
+          model::node_id(0), model::revision_id(i));
+    }
+    iobuf buf;
+
+    serde::write_async(buf, std::move(req)).get();
+
+    BOOST_TEST_MESSAGE("Pre compression. Buffer size: " << buf);
+    compression::stream_zstd codec;
+    buf = codec.compress(std::move(buf));
+    BOOST_TEST_MESSAGE("Post compression. Buffer size: " << buf);
+    auto parser = iobuf_parser(codec.uncompress(std::move(buf)));
+    auto res = serde::read_async<raft::heartbeat_request>(parser).get();
+    for (int64_t i = 0; i < one_k; ++i) {
+        BOOST_REQUIRE_EQUAL(res.heartbeats[i].meta.group, raft::group_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.commit_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(res.heartbeats[i].meta.term, model::term_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.prev_log_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.prev_log_term, model::term_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.last_visible_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].target_node_id,
+          raft::vnode(model::node_id(0), model::revision_id(i)));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].node_id,
+          raft::vnode(model::node_id(one_k), model::revision_id(i)));
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip_with_negative) {
     static constexpr int64_t one_k = 10;
     raft::heartbeat_request req;
@@ -259,6 +306,66 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
           expected[gr].last_dirty_log_index,
           result.meta[i].last_dirty_log_index);
         BOOST_REQUIRE_EQUAL(expected[gr].result, result.meta[i].result);
+
+        // Legacy serialization treats may_recover as always true
+        BOOST_REQUIRE_EQUAL(result.meta[i].may_recover, true);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip_serde) {
+    static constexpr int64_t group_count = 10000;
+    raft::heartbeat_reply reply;
+    reply.meta.reserve(group_count);
+
+    for (size_t i = 0; i < group_count; ++i) {
+        // Negative offsets are special, so pick range starting at 0 here
+        // (heartbeat_response_negative below covers the negative case)
+        auto commited_idx = model::offset(
+          random_generators::get_int(0, 1000000000));
+        auto dirty_idx = commited_idx
+                         + model::offset(random_generators::get_int(10000));
+
+        reply.meta.push_back(raft::append_entries_reply{
+          .target_node_id = raft::vnode(
+            model::node_id(2), model::revision_id(i)),
+          .node_id = raft::vnode(model::node_id(1), model::revision_id(i)),
+          .group = raft::group_id(i),
+          .term = model::term_id(random_generators::get_int(0, 1000)),
+          .last_flushed_log_index = commited_idx,
+          .last_dirty_log_index = dirty_idx,
+          .result = raft::append_entries_reply::status::success,
+          .may_recover = bool(i % 2)});
+    }
+    absl::flat_hash_map<raft::group_id, raft::append_entries_reply> expected;
+    expected.reserve(reply.meta.size());
+    for (const auto& m : reply.meta) {
+        expected.emplace(m.group, m);
+    }
+    iobuf buf;
+    serde::write_async(buf, std::move(reply)).get0();
+    BOOST_TEST_MESSAGE("Pre compression. Buffer size: " << buf);
+    compression::stream_zstd codec;
+    buf = codec.compress(std::move(buf));
+    BOOST_TEST_MESSAGE("Post compression. Buffer size: " << buf);
+    auto parser = iobuf_parser(codec.uncompress(std::move(buf)));
+    auto result = serde::read_async<raft::heartbeat_reply>(parser).get0();
+
+    for (size_t i = 0; i < result.meta.size(); ++i) {
+        auto gr = result.meta[i].group;
+        BOOST_REQUIRE_EQUAL(expected[gr].node_id, result.meta[i].node_id);
+        BOOST_REQUIRE_EQUAL(
+          expected[gr].target_node_id, result.meta[i].target_node_id);
+        BOOST_REQUIRE_EQUAL(expected[gr].group, result.meta[i].group);
+        BOOST_REQUIRE_EQUAL(expected[gr].term, result.meta[i].term);
+        BOOST_REQUIRE_EQUAL(
+          expected[gr].last_flushed_log_index,
+          result.meta[i].last_flushed_log_index);
+        BOOST_REQUIRE_EQUAL(
+          expected[gr].last_dirty_log_index,
+          result.meta[i].last_dirty_log_index);
+        BOOST_REQUIRE_EQUAL(expected[gr].result, result.meta[i].result);
+        BOOST_REQUIRE_EQUAL(
+          expected[gr].may_recover, result.meta[i].may_recover);
     }
 }
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -268,7 +268,8 @@ struct append_entries_request
           req.target_node_id,
           std::move(req.meta),
           model::make_foreign_record_batch_reader(std::move(req.batches())),
-          req.flush);
+          req.flush,
+          req.is_recovery);
     }
 
     friend std::ostream&

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -101,7 +101,7 @@ ss::future<> vote_stm::vote(bool leadership_transfer) {
               return ss::make_ready_future<skip_vote>(skip_vote::yes);
           }
           // 5.2.1 mark node as candidate, and update leader id
-          _ptr->_vstate = consensus::vote_state::candidate;
+          _ptr->set_vstate(consensus::vote_state::candidate);
           //  only trigger notification when we had a leader previously
           if (_ptr->_leader_id) {
               _ptr->_leader_id = std::nullopt;
@@ -212,7 +212,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
                   _ctxlog.info, "Vote failed - received larger term: {}", term);
                 _ptr->_term = term;
                 _ptr->_voted_for = {};
-                _ptr->_vstate = consensus::vote_state::follower;
+                _ptr->set_vstate(consensus::vote_state::follower);
                 co_return;
             }
         }
@@ -232,7 +232,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
 
     if (!_success) {
         vlog(_ctxlog.info, "Vote failed");
-        _ptr->_vstate = consensus::vote_state::follower;
+        _ptr->set_vstate(consensus::vote_state::follower);
         co_return;
     }
 
@@ -241,7 +241,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
           _ctxlog.debug,
           "Ignoring successful vote. Node priority too low: {}",
           _ptr->_node_priority_override.value());
-        _ptr->_vstate = consensus::vote_state::follower;
+        _ptr->set_vstate(consensus::vote_state::follower);
         co_return;
     }
 
@@ -254,7 +254,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
 
     vlog(_ctxlog.trace, "vote acks in term {} from: {}", term, acks);
     // section vote:5.2.2
-    _ptr->_vstate = consensus::vote_state::leader;
+    _ptr->set_vstate(consensus::vote_state::leader);
     _ptr->_leader_id = _ptr->self();
     // reset target priority
     _ptr->_target_priority = voter_priority::max();

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -2,6 +2,7 @@ set(swags
   config
   cluster_config
   raft
+  recovery
   security
   status
   features

--- a/src/v/redpanda/admin/api-doc/recovery.json
+++ b/src/v/redpanda/admin/api-doc/recovery.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": "0.0.1",
+  "swaggerVersion": "1.2",
+  "basePath": "/v1",
+  "resourcePath": "/recovery",
+  "produces": [
+    "application/json"
+  ],
+  "apis": [
+    {
+      "path": "/v1/recovery",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get this node's recovery status",
+          "type": "recovery_status",
+          "nickname": "get_recovery_status",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "models": {
+    "recovery_status": {
+      "id": "recovery_status",
+      "description": "Node recovery status",
+      "properties": {
+        "partitions_pending": {
+          "type": "long",
+          "description": "Partitions waiting for recovery"
+        },
+        "partitions_active": {
+          "type": "long",
+          "description": "Partitions currently in recovery"
+        },
+        "offsets_pending": {
+          "type": "long",
+          "description": "Offsets currently awaiting recovery"
+        },
+        "offsets_hwm": {
+          "type": "long",
+          "description": "High watermark of offsets_pending"
+        }
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -63,6 +63,7 @@
 #include "redpanda/admin/api-doc/hbadger.json.h"
 #include "redpanda/admin/api-doc/partition.json.h"
 #include "redpanda/admin/api-doc/raft.json.h"
+#include "redpanda/admin/api-doc/recovery.json.h"
 #include "redpanda/admin/api-doc/security.json.h"
 #include "redpanda/admin/api-doc/shadow_indexing.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
@@ -104,6 +105,7 @@ static ss::logger logger{"admin_api_server"};
 admin_server::admin_server(
   admin_server_cfg cfg,
   ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<raft::group_manager>& rgm,
   ss::sharded<coproc::partition_manager>& cpm,
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
@@ -115,6 +117,7 @@ admin_server::admin_server(
   , _server("admin")
   , _cfg(std::move(cfg))
   , _partition_manager(pm)
+  , _raft_group_manager(rgm)
   , _cp_partition_manager(cpm)
   , _controller(controller)
   , _shard_table(st)
@@ -153,6 +156,8 @@ void admin_server::configure_admin_routes() {
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "raft");
     rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "recovery");
+    rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "kafka");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "partition");
@@ -175,6 +180,7 @@ void admin_server::configure_admin_routes() {
     register_config_routes();
     register_cluster_config_routes();
     register_raft_routes();
+    register_recovery_routes();
     register_kafka_routes();
     register_security_routes();
     register_status_routes();
@@ -1435,6 +1441,38 @@ void admin_server::register_raft_routes() {
       ss::httpd::raft_json::raft_transfer_leadership,
       [this](std::unique_ptr<ss::httpd::request> req) {
           return raft_transfer_leadership_handler(std::move(req));
+      });
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::_get_recovery_status(std::unique_ptr<ss::httpd::request>) {
+    ss::httpd::recovery_json::recovery_status result;
+
+    // Aggregate recovery status from all shards
+    auto s = co_await _raft_group_manager.map_reduce0(
+      [](auto& rgm) -> raft::recovery_status {
+          return rgm.get_recovery_status();
+      },
+      raft::recovery_status{},
+      [](raft::recovery_status acc, raft::recovery_status update) {
+          acc.merge(update);
+          return acc;
+      });
+
+    // Translate internal recovery_status struct to json-encodable
+    // swagger-defined equivalent.
+    result.partitions_active = s.partitions_active;
+    result.partitions_pending = s.partitions_pending;
+    result.offsets_pending = s.offsets_pending;
+    result.offsets_hwm = s.offsets_hwm;
+    co_return result;
+}
+
+void admin_server::register_recovery_routes() {
+    register_route<auth_level::user>(
+      ss::httpd::recovery_json::get_recovery_status,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return _get_recovery_status(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -48,6 +48,7 @@ public:
     explicit admin_server(
       admin_server_cfg,
       ss::sharded<cluster::partition_manager>&,
+      ss::sharded<raft::group_manager>&,
       ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
@@ -220,6 +221,7 @@ private:
     void register_config_routes();
     void register_cluster_config_routes();
     void register_raft_routes();
+    void register_recovery_routes();
     void register_kafka_routes();
     void register_security_routes();
     void register_status_routes();
@@ -238,6 +240,10 @@ private:
     /// Raft routes
     ss::future<ss::json::json_return_type>
       raft_transfer_leadership_handler(std::unique_ptr<ss::httpd::request>);
+
+    /// Recovery status routes
+    ss::future<ss::json::json_return_type>
+      _get_recovery_status(std::unique_ptr<ss::httpd::request>);
 
     /// Security routes
     ss::future<ss::json::json_return_type>
@@ -337,6 +343,7 @@ private:
     ss::http_server _server;
     admin_server_cfg _cfg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<raft::group_manager>& _raft_group_manager;
     ss::sharded<coproc::partition_manager>& _cp_partition_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -626,6 +626,7 @@ void application::configure_admin_server() {
       _admin,
       admin_server_cfg_from_global_cfg(_scheduling_groups),
       std::ref(partition_manager),
+      std::ref(raft_group_manager),
       std::ref(cp_partition_manager),
       controller.get(),
       std::ref(shard_table),

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -448,6 +448,11 @@ class RpkTool:
                     # Metadata directed us to a broker that is uncontactable, perhaps
                     # it was just stopped.  Retry should succeed once metadata updates.
                     return None
+                elif "did not reply with that broker in the broker list":
+                    # e.g. "all 1 DescribeGroups request failures, first error: broker replied that group repeat01 has broker coordinator 2, but did not reply with that broker in the broker list"
+                    # Broker coordinator identity can race with updates to node up-ness that influences
+                    # whether the node appears in the metadata response
+                    return None
                 else:
                     raise
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -776,3 +776,10 @@ class Admin:
             raise
         if len(r.text) > 0:
             return r.json()["cluster_uuid"]
+
+    def get_recovery_status(self, *, node: ClusterNode):
+        """
+        Node must be specified because this API reports on node-local state:
+        it would not make sense to send it to just any node.
+        """
+        return self._request("GET", "recovery", node=node).json()

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
+from ducktape.errors import TimeoutError
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.tests.test import TestContext
 
@@ -158,34 +159,35 @@ class KgoRepeaterService(Service):
         self.logger.debug("Activating producer loop")
         self.remote_to_all("activate")
 
-    def await_group_ready(self):
-
+    def _group_ready(self):
+        rpk = RpkTool(self.redpanda)
         expect_members = self.workers * len(self.nodes)
+        group = rpk.group_describe(self.group_name, summary=True)
+        if group is None:
+            self.logger.debug(
+                f"group_ready: {self.group_name} got None from describe")
+            return False
+        elif group.state != "Stable":
+            self.logger.debug(
+                f"group_ready: waiting for stable, current state {group.state}"
+            )
+            return False
+        elif group.members < expect_members:
+            self.logger.debug(
+                f"group_ready: waiting for node count ({group.members} != {expect_members})"
+            )
+            return False
+        else:
+            return True
 
-        def group_ready():
-            rpk = RpkTool(self.redpanda)
-            group = rpk.group_describe(self.group_name, summary=True)
-            if group is None:
-                self.logger.debug(
-                    f"group_ready: {self.group_name} got None from describe")
-                return False
-            elif group.state != "Stable":
-                self.logger.debug(
-                    f"group_ready: waiting for stable, current state {group.state}"
-                )
-                return False
-            elif group.members < expect_members:
-                self.logger.debug(
-                    f"group_ready: waiting for node count ({group.members} != {expect_members})"
-                )
-                return False
-            else:
-                return True
-
+    def await_group_ready(self):
         self.logger.debug(f"Waiting for group {self.group_name} to be ready")
         t1 = time.time()
+
         try:
-            wait_until(group_ready, timeout_sec=120, backoff_sec=10)
+            wait_until(lambda: self._group_ready(),
+                       timeout_sec=120,
+                       backoff_sec=10)
         except:
             # On failure, inspect the group to identify which workers
             # specifically were absent.  This information helps to
@@ -236,11 +238,21 @@ class KgoRepeaterService(Service):
         produced+consumed & how long you expect it to take.
         """
         initial_p, initial_c = self.total_messages()
+        last_c = initial_c
 
         # Give it at least some chance to progress before we start checking
         time.sleep(0.5)
 
-        def check():
+        # Minimum window for checking for progress: otherwise when the bandwidth
+        # expection is high, we end up failing if we happen to check at a moment
+        # the system isn't at peak throughput (e.g. when it's just warming up)
+        timeout_sec = max(timeout_sec, 60)
+        started_at = time.time()
+
+        group_sync_retries = 3
+
+        ready = False
+        while not ready:
             p, c = self.total_messages()
             pct = min(
                 float(p - initial_p) / (msg_count),
@@ -248,14 +260,30 @@ class KgoRepeaterService(Service):
             self.logger.debug(
                 f"await_progress: {pct:.1f}% p={p} c={c}, initial_p={initial_p}, initial_c={initial_c}, await count {msg_count})"
             )
-            return p >= initial_p + msg_count and c >= initial_c + msg_count
 
-        # Minimum window for checking for progress: otherwise when the bandwidth
-        # expection is high, we end up failing if we happen to check at a moment
-        # the system isn't at peak throughput (e.g. when it's just warming up)
-        timeout_sec = max(timeout_sec, 60)
+            if last_c == c:
+                # Consumer isn't progressing: maybe the group fell out of sync?
+                if group_sync_retries > 0 and not self._group_ready():
+                    self.await_group_ready()
 
-        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+                    # Reset the timeout clock: this function is about produce/consume data progress, we shouldn't
+                    # consider it a failure if the progress is delayed because a consumer group had to be renegotiated.
+                    started_at = time.time()
+
+                    group_sync_retries -= 1
+
+            last_c = c
+
+            ready = p >= initial_p + msg_count and c >= initial_c + msg_count
+
+            if not ready:
+                elapsed = time.time() - started_at
+                if elapsed > timeout_sec:
+                    raise TimeoutError(
+                        f"{self.who_am_i()} did not reach target progress after {elapsed} seconds",
+                    )
+                else:
+                    time.sleep(1)
 
 
 @contextmanager

--- a/tests/rptest/tests/raft_recovery_test.py
+++ b/tests/rptest/tests/raft_recovery_test.py
@@ -1,0 +1,209 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+import json
+from collections import defaultdict
+
+from rptest.util import wait_until
+from rptest.utils.mode_checks import skip_debug_mode
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from ducktape.cluster.cluster import ClusterNode
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.kgo_repeater_service import repeater_traffic, KgoRepeaterService
+
+
+class RaftRecoveryTest(RedpandaTest):
+
+    topics = [TopicSpec(
+        partition_count=128,
+        replication_factor=3,
+    )]
+
+    msg_size = 4096
+
+    def setUp(self):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
+    @skip_debug_mode
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_recovery_concurrency_limit(self):
+        """
+        Verify that `raft_concurrent_recoveries` is respected when
+        the number of partitions to recover exceeds it.
+        """
+
+        # Artificially low limits to slow down recovery enough that we
+        # can watch the partitions trickle through
+        shard_concurrency = 4
+        self.redpanda.set_extra_rp_conf({
+            'raft_recovery_concurrent_per_shard':
+            shard_concurrency,
+            'raft_max_recovery_memory':
+            32 * 1024 * 1024,
+        })
+
+        cpu_count = self.redpanda.get_node_cpu_count()
+        expect_concurrency = cpu_count * shard_concurrency
+
+        self.redpanda.start()
+
+        topic = "recoverytest"
+        partition_count = 128 * cpu_count
+        self.client().create_topic(
+            TopicSpec(name=topic,
+                      partition_count=partition_count,
+                      retention_bytes=16 * 1024 * 1024,
+                      segment_bytes=1024 * 1024))
+
+        # Arbitrary choice of node to be restarted
+        victim_node = self.redpanda.nodes[1]
+
+        with repeater_traffic(context=self.test_context,
+                              redpanda=self.redpanda,
+                              topic=topic,
+                              msg_size=self.msg_size,
+                              workers=1,
+                              max_buffered_records=1024) as repeater:
+            self._restart_and_verify(victim_node=victim_node,
+                                     repeater=repeater,
+                                     node_concurrency=expect_concurrency)
+
+        self._validate_recovery_log(victim_node, expect_concurrency)
+
+    def _validate_recovery_log(self, victim_node: ClusterNode,
+                               node_concurrency: int):
+        # The admin API does not give you a partition-by-partition readout
+        # because it would be prohibitively long.  We scrape the log to
+        # validate the order in which recoveries happened.
+        # Format from recovery_coordinator:
+        #  "Starting recovery of partition {} ({}) from {} to {}"
+
+        # Map of shard to list of lists, where each list is the recovery
+        # start events within a lifetime of redpanda (i.e. we split when
+        # we see redpanda restart)
+        partition_recovery_order = defaultdict(list)
+
+        for line in self.redpanda.filter_log(
+                patterns=[
+                    # Recovery start event
+                    "Starting recovery of partition",
+                    # Redpanda startup event
+                    "Welcome to the Redpanda community"
+                ],
+                node=victim_node):
+            if line.startswith("Welcome"):
+                cpu_count = self.redpanda.get_node_cpu_count()
+                for i in range(0, cpu_count):
+                    partition_recovery_order[i].append([])
+                continue
+
+            try:
+                shard, n, t, p = re.search(
+                    "\[shard (\d+)\].*Starting recovery of partition {(.+)/(.+)/(\d+)}",
+                    line).groups()
+            except AttributeError:
+                # If you get here, we probably changed logging and need to update
+                # the test
+                raise RuntimeError(f"Can't parse line '{line}'")
+
+            partition_recovery_order[int(shard)][-1].append((n, t, p))
+
+        for shard, orders in partition_recovery_order.items():
+            # Only care about last redpanda lifetime (not the recovery events
+            # that happened in its first startup when partitions were getting
+            # created)
+            order = orders[-1]
+
+            expect_order = sorted(
+                order,
+                key=lambda ntp: 0
+                if ntp[1] in ("__consumer_offsets", "id_allocator") else 1)
+            self.logger.info(
+                f"Recovery order[{shard}]: {json.dumps(order, indent=2)}")
+            self.logger.info(
+                f"Expect recovery order[{shard}]: {json.dumps(expect_order, indent=2)}"
+            )
+            assert order == expect_order
+
+    def _restart_and_verify(self, victim_node: ClusterNode,
+                            repeater: KgoRepeaterService,
+                            node_concurrency: int):
+
+        # Check traffic is flowing before stopping a node
+        repeater.await_group_ready()
+        repeater.await_progress(10, 30)
+
+        self.redpanda.stop_node(victim_node)
+
+        # FIXME: measure or flex with environment.
+        expect_bandwidth = 10E6
+        outage_time = 20
+        recovery_data_target = outage_time * expect_bandwidth
+
+        recovery_msgs_target = recovery_data_target // self.msg_size
+        expect_progress_time = outage_time * 2
+
+        # Wait for enough traffic to play that recovery will take long enough for us to
+        # observe its progress.
+        repeater.await_group_ready()
+
+        # FIXME  - this is timing out sometimes.  Is it because we're falsely
+        # seeing the group ready?
+        repeater.await_progress(recovery_msgs_target, expect_progress_time)
+
+        self.redpanda.start_node(victim_node)
+
+        admin = Admin(self.redpanda)
+
+        # TODO: enable leader balancer with a high enough frequency that it will
+        # try to run during recovery, and validate that it does not move leaderships
+        # to the recovering node until recovery is done.
+
+        # We will wait for various conditions, but continously want to validate
+        # general invariants such as that the concurrent recovery count
+        # is not violated.
+        def wait_with_invariants(check_fn, *, timeout_sec, backoff_sec):
+            def wrapped():
+                state = admin.get_recovery_status(node=victim_node)
+
+                assert state['partitions_active'] <= node_concurrency
+                assert state['offsets_hwm'] >= state['offsets_pending']
+                assert state['offsets_pending'] >= 0
+
+                return check_fn(state)
+
+            return wait_until(wrapped,
+                              timeout_sec=timeout_sec,
+                              backoff_sec=backoff_sec)
+
+        # The recovering node's offset highwatermark should rise to the amount
+        # of data it has to recover
+        wait_with_invariants(lambda s: s['offsets_hwm'] > 0,
+                             timeout_sec=15,
+                             backoff_sec=1)
+        wait_with_invariants(lambda s: s['partitions_pending'] > 0,
+                             timeout_sec=15,
+                             backoff_sec=1)
+        wait_with_invariants(lambda s: s['partitions_active'] > 0,
+                             timeout_sec=15,
+                             backoff_sec=1)
+
+        wait_with_invariants(lambda s: s['partitions_pending'] == 0,
+                             timeout_sec=120,
+                             backoff_sec=1)
+        wait_with_invariants(lambda s: s['partitions_active'] == 0,
+                             timeout_sec=120,
+                             backoff_sec=1)


### PR DESCRIPTION
## Cover letter

This PR implements a new behavior where recovery of many partitions is scheduled in an orderly sequence with a limit on how many recoveries may be done to a particular target node, rather than all attempting to recover concurrently up to a concurrency limit on the sending side.

The result should be improved system stability at high partition counts when nodes are restarted under load.

Fixes: https://github.com/redpanda-data/redpanda/issues/5958

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
