### PR TITLE
Fix test_restore_with_aborted_tx

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -6,12 +6,14 @@ import struct
 from collections import defaultdict, namedtuple
 from typing import Sequence
 
-import confluent_kafka
+import confluent_kafka as ck
 import xxhash
 
 from rptest.archival.s3_client import S3ObjectMetadata, S3Client
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+
+from ducktape.utils.util import wait_until
 
 EMPTY_SEGMENT_SIZE = 4096
 
@@ -288,15 +290,22 @@ class Producer:
         self.reconnect()
 
     def reconnect(self):
-        self.producer = confluent_kafka.Producer({
-            'bootstrap.servers':
-            self.brokers,
-            'transactional.id':
-            self.name,
-            'transaction.timeout.ms':
-            5000,
-        })
-        self.producer.init_transactions(self.timeout_sec)
+        def init():
+            try:
+                self.producer = ck.Producer({
+                    'bootstrap.servers': self.brokers,
+                    'transactional.id': self.name,
+                    'transaction.timeout.ms': 5000,
+                })
+                self.producer.init_transactions(self.timeout_sec)
+                return True
+            except ck.cimpl.KafkaException as e:
+                kafka_error = e.args[0]
+                if kafka_error.code() == ck.cimpl.KafkaError.NOT_COORDINATOR:
+                    return False
+                raise
+
+        wait_until(init, timeout_sec=10, backoff_sec=1)
 
     def produce(self, topic):
         """produce some messages inside a transaction with increasing keys


### PR DESCRIPTION
## Cover letter

PR adds retries to give a transactional coordinator to elect a leader after a cluster is started to prevent NOT_COORDINATOR.

Fixes #6328

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none