### PR TITLE
raft: suppress a spurious log warning

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -315,7 +315,10 @@ void heartbeat_manager::process_reply(
         auto consensus = *it;
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);
 
-        if (unlikely(m.target_node_id != consensus->self())) {
+        if (
+          unlikely(m.target_node_id != consensus->self())
+          && m.target_node_id.id() != model::node_id{}
+          && m.target_node_id.revision() != model::revision_id{}) {
             vlog(
               hbeatlog.warn,
               "Heartbeat response addressed to different node: {}, current "


### PR DESCRIPTION
## Cover letter

It's unclear how we end up with garbage values
in these append_entries_reply objects, perhaps
it's happening on errors?

Fixes https://github.com/redpanda-data/redpanda/issues/5807

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none