### PR TITLE
Fix BadLogLines appearing after we started logging exceptions in admin_server

### DIFF
--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -221,8 +221,12 @@ requires(State<T>, ...)
 
     auto u = get_units();
     auto promise = std::make_unique<promise_t>();
-    auto f = promise->get_future_with_timeout(
-      timeout, [] { return make_error_code(errc::timeout); }, as);
+    auto f = promise
+               ->get_future_with_timeout(
+                 timeout, [] { return make_error_code(errc::timeout); }, as)
+               .handle_exception_type([](const ss::abort_requested_exception&) {
+                   return make_error_code(errc::shutting_down);
+               });
 
     ssx::spawn_with_gate(
       _gate,

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -732,6 +732,7 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::leadership_changed:
         case cluster::errc::waiting_for_recovery:
         case cluster::errc::no_leader_controller:
+        case cluster::errc::shutting_down:
             throw ss::httpd::base_exception(
               fmt::format("Not ready ({})", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);
@@ -753,9 +754,14 @@ ss::future<> admin_server::throw_on_error(
         case raft::errc::disconnected_endpoint:
         case raft::errc::configuration_change_in_progress:
         case raft::errc::leadership_transfer_in_progress:
+        case raft::errc::shutting_down:
             throw ss::httpd::base_exception(
               fmt::format("Not ready: {}", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);
+        case raft::errc::timeout:
+            throw ss::httpd::base_exception(
+              fmt::format("Timeout: {}", ec.message()),
+              ss::httpd::reply::status_type::gateway_timeout);
         case raft::errc::transfer_to_current_leader:
             co_return;
         case raft::errc::not_leader:


### PR DESCRIPTION
## Cover letter

After #6198 got merged, 500 errors are now logged with the error severity, leading to `PartitionBalancerTest.test_fuzz_admin_ops` failing with the BadLogLines error when a node is shut down or replication times out. So we map shutting_down to 503 and timeout to 504.

Some examples (the test is ok-to-fail so does not result in failed CI runs):
* [`abort_requested`](https://ci-artifacts.dev.vectorized.cloud/redpanda/01831b83-4e16-497f-95e4-b8775de852a7/vbuild/ducktape/results/2022-09-08--001/PartitionBalancerTest/test_fuzz_admin_ops/85/)
* [`raft::timeout`](https://ci-artifacts.dev.vectorized.cloud/redpanda/018325c7-d2ff-4bd0-913f-bc525b8ce317/vbuild/ducktape/results/2022-09-10--001/PartitionBalancerTest/test_fuzz_admin_ops/87/)

## Backport Required

- [x] papercut/not impactful enough to backport

## UX changes

Return 503 from admin API handles when shutting down and 504 in case of a timeout.

## Release notes
* none