### PR TITLE
Fix end-to-end read replica test

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -57,11 +57,7 @@ class EndToEndTest(Test):
       - Perform some action (e.g. partition movement)
       - Run validation
     """
-    def __init__(self,
-                 test_context,
-                 extra_rp_conf=None,
-                 extra_node_conf=None,
-                 si_settings=None):
+    def __init__(self, test_context, extra_rp_conf=None, extra_node_conf=None):
         super(EndToEndTest, self).__init__(test_context=test_context)
         if extra_rp_conf is None:
             self._extra_rp_conf = {}

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -73,7 +73,6 @@ class EndToEndTest(Test):
         self.records_consumed = []
         self.last_consumed_offsets = {}
         self.redpanda: Optional[RedpandaService] = None
-        self.si_settings = si_settings
         self.topic = None
         self._client = None
 
@@ -83,9 +82,7 @@ class EndToEndTest(Test):
                        si_settings=None,
                        environment=None,
                        install_opts: Optional[InstallOptions] = None):
-        if si_settings is not None:
-            self.si_settings = si_settings
-
+        self.si_settings = si_settings
         if self.si_settings:
             self.si_settings.load_context(self.logger, self.test_context)
 


### PR DESCRIPTION
Fixes #6357 

- Revert "tests/end_to_end: fixed enabling si in end to end test"
- tests/e2e: remove unused si_settings from init

## Backport Required

TBD

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes

* none
