### PR TITLE
[v22.1.x] cloud_storage: re-set reader after exception

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -188,6 +188,15 @@ public:
               "gate_closed_exception while reading from remote_partition");
             _it = _end;
             _reader = {};
+        } catch (const std::exception& e) {
+            vlog(
+              _ctxlog.warn,
+              "exception thrown while reading from remote_partition: {}",
+              e.what());
+            _it = _end;
+            _reader = {};
+
+            throw;
         }
         vlog(
           _ctxlog.debug,


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6371.
Fixes https://github.com/redpanda-data/redpanda/issues/6397,