### PR TITLE
Fixed handling of `offsets_for_leader_epoch` request

### DIFF
--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -109,7 +109,7 @@ static ss::future<> fetch_offsets_from_shards(
                   results.size(),
                   responses.size());
                 for (auto& r : results) {
-                    it->get() = r;
+                    it->get() = std::move(r);
                     ++it;
                 }
             });

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -154,7 +154,7 @@ get_offsets_for_leader_epochs(
             if (!shard) {
                 partition_response = response_t::make_epoch_end_offset(
                   request_partition.partition,
-                  error_code::unknown_topic_or_partition);
+                  error_code::not_leader_for_partition);
                 continue;
             }
 

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -130,7 +130,7 @@ get_offsets_for_leader_epochs(
         result.back().partitions.reserve(request_topic.partitions.size());
 
         for (auto& request_partition : request_topic.partitions) {
-            // add reponse placeholder
+            // add response placeholder
             result.back().partitions.push_back(epoch_end_offset{});
             // we are reserving both topics and partitions, reference to
             // response is stable and we can capture it
@@ -149,7 +149,7 @@ get_offsets_for_leader_epochs(
             }
 
             auto shard = ctx.shards().shard_for(ntp);
-            // no shard found, we may be in the middle of partiton move, return
+            // no shard found, we may be in the middle of partition move, return
             // not leader for partition error
             if (!shard) {
                 partition_response = response_t::make_epoch_end_offset(

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -67,8 +67,9 @@ static ss::future<std::vector<epoch_end_offset>> fetch_offsets_from_shard(
               r.ntp,
               ctx.partition_manager().local(),
               ctx.coproc_partition_manager().local());
-
-            if (!p) {
+            // offsets_for_leader_epoch request should only be answered by
+            // leader
+            if (!p || !p->is_leader()) {
                 ret.push_back(response_t::make_epoch_end_offset(
                   r.ntp.tp.partition, error_code::not_leader_for_partition));
                 continue;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -631,9 +631,15 @@ class Admin:
     def list_users(self, node=None):
         return self._request("get", "security/users", node=node).json()
 
-    def partition_transfer_leadership(self, namespace, topic, partition,
-                                      target_id):
-        path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership?target={target_id}"
+    def partition_transfer_leadership(self,
+                                      namespace,
+                                      topic,
+                                      partition,
+                                      target_id=None):
+        path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership"
+        if target_id:
+            path += f"?target={target_id}"
+
         self._request("POST", path)
 
     def get_partition_leader(self, *, namespace, topic, partition, node=None):

--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -7,20 +7,22 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from collections import defaultdict
 import random
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kcl import KCL
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.services.rpk_producer import RpkProducer
 
 
-class OffsetForLeaderEpochTest(RedpandaTest):
+class OffsetForLeaderEpochTest(PreallocNodesTest):
     """
     Check offset for leader epoch handling
     """
@@ -54,7 +56,8 @@ class OffsetForLeaderEpochTest(RedpandaTest):
                              extra_rp_conf={
                                  'enable_leader_balancer': False,
                                  "log_compaction_interval_ms": 1000
-                             })
+                             },
+                             node_prealloc_count=1)
 
     def list_offsets(self, topics, total_partitions):
         kcl = KCL(self.redpanda)
@@ -142,3 +145,78 @@ class OffsetForLeaderEpochTest(RedpandaTest):
 
         for o in leader_epoch_offsets:
             assert o.error is not None and "UNKNOWN_LEADER_EPOCH" in o.error
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_offset_for_leader_epoch_transfer(self):
+
+        topic = TopicSpec(partition_count=64, replication_factor=3)
+
+        # create test topics
+        self.client().create_topic(topic)
+
+        kcl = KCL(self.redpanda)
+
+        def produce_some():
+            msg_size = 512
+            msg_cnt = 1000000 if self.redpanda.dedicated_nodes else 10000
+
+            producer = KgoVerifierProducer(self.test_context, self.redpanda,
+                                           topic.name, msg_size, msg_cnt,
+                                           self.preallocated_nodes)
+            producer.start()
+            producer.wait()
+
+        admin = Admin(self.redpanda)
+        offsets = {}
+
+        def get_offsets_for_leader_epoch(epoch):
+            offsets_for_leader_epoch = []
+
+            def have_all_offsets():
+                offsets_for_leader_epoch.clear()
+                offsets = kcl.offset_for_leader_epoch(topics=[topic.name],
+                                                      leader_epoch=epoch)
+                offsets_for_leader_epoch.extend(offsets)
+                return all([
+                    ofle.epoch_end_offset != -1
+                    for ofle in offsets_for_leader_epoch
+                ])
+
+            wait_until(have_all_offsets, 30, 1)
+
+            return offsets_for_leader_epoch
+
+        rpk = RpkTool(self.redpanda)
+
+        # store offsets after each epoch change
+        offsets_after_epochs = []
+
+        # generate some leader epoch changes
+        for _ in range(5):
+            produce_some()
+            # store partition epoch and offsets
+            offsets = rpk.describe_topic(topic.name)
+            offsets_after_epochs.append(list(offsets))
+
+            for p in offsets_after_epochs[-1]:
+                admin.partition_transfer_leadership("kafka",
+                                                    topic=topic.name,
+                                                    partition=p.id)
+        # generate some more leadership changes
+        for _ in range(5):
+            for p in offsets_after_epochs[-1]:
+                admin.partition_transfer_leadership("kafka",
+                                                    topic=topic.name,
+                                                    partition=p.id)
+        epoch_offsets = defaultdict(dict)
+
+        # group partitions per leader epoch
+        for offsets in offsets_after_epochs:
+            for p in offsets:
+                epoch_offsets[p.leader_epoch][p.id] = p.high_watermark
+
+        for epoch, partitions in epoch_offsets.items():
+            offsets_for_leader_epoch = get_offsets_for_leader_epoch(epoch)
+            for p in offsets_for_leader_epoch:
+                assert p.partition in partitions
+                assert partitions[p.partition] == p.epoch_end_offset


### PR DESCRIPTION
## Cover letter

Offsets for leader epoch request should only be replied from current
partition leader. Previously we did not check the partition leadership
which may lead to situation in which a node didn't have an up to date
offset information.

Fixes: #5435
Fixes: #6301

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
