### PR TITLE
transactions: support topic deletions with active transactions

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -95,7 +95,7 @@ ss::future<> controller::wire_up() {
           return _authorizer.start(
             []() { return config::shard_local_cfg().superusers.bind(); });
       })
-      .then([this] { return _tp_state.start(); })
+      .then([this] { return _tp_state.start(std::ref(_partition_manager)); })
       .then([this] { _probe.start(); });
 }
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -213,6 +213,10 @@ public:
 
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 
+    using ntp_filter = ss::noncopyable_function<bool(const model::ntp&)>;
+    absl::btree_set<kafka::transactional_id>
+    get_txs_matching_ntp_filter(ntp_filter&&);
+
     using get_txs_result
       = checked<std::vector<tm_transaction>, tm_stm::op_status>;
     ss::future<get_txs_result> get_all_transactions();

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -14,6 +14,7 @@
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
+#include "cluster/partition_manager.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -23,6 +24,14 @@
 #include <optional>
 
 namespace cluster {
+
+topic_table::topic_table(ss::sharded<partition_manager>& pm)
+  : _probe(*this)
+  , _pm(pm) {
+    register_delta_notification([this](const std::vector<delta>& deltas) {
+        _pm.local().notify_topic_table_deltas(deltas);
+    });
+};
 
 template<typename Func>
 std::vector<std::invoke_result_t<Func, const topic_table::topic_metadata_item&>>

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -167,8 +167,7 @@ public:
     using delta_cb_t
       = ss::noncopyable_function<void(const std::vector<delta>&)>;
 
-    explicit topic_table()
-      : _probe(*this){};
+    explicit topic_table(ss::sharded<partition_manager>&);
 
     cluster::notification_id_type register_delta_notification(delta_cb_t cb) {
         auto id = _notification_id++;
@@ -369,6 +368,7 @@ private:
     model::offset _last_consumed_by_notifier{
       model::model_limits<model::offset>::min()};
     topic_table_probe _probe;
+    ss::sharded<partition_manager>& _pm;
 };
 
 std::ostream& operator<<(std::ostream&, topic_table::in_progress_state);


### PR DESCRIPTION
## Cover letter

Builds on top of transaction expiration loop that periodically expires expired tx_ids. 
Now that expiration also attempts to expire transactions with deleted partitions.
For timely expiry we rely on deletion notifications from topics table that tickles
the expiration loop. 

Particularly sticky case here is when the transaction is in `preparing` mode and the
the partition disappears. In such cases, we attempt to commit first and if that fails,
abort with a reduced partition list (without the deleted partitions) and if that succeeds,
expire the transaction right away.

Primary focus of the patch is to unblock consumers on partitions within the same txn
scope but are not deleted (they may belong to a different topic). Also, relying on the
topic_table/metadata_cache may result in cause some sticky races in 
create-delete-create situations, especially after a node bootstraps and the replay of
the controller log is in progress. Such actions typically unsupported and may result
in weird outcomes (Kafka has the same behavior per docs). 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes [core-internal#28](https://github.com/redpanda-data/core-internal/issues/28)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Consumers have a better experience when deleting topics with active transactions without stuck consumers.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
