### PR TITLE
SI: Enable archival for compaction enabled partitions

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -101,7 +101,7 @@ archival_policy::lookup_result archival_policy::find_segment(
 
     const auto& ntp_conf = plog->config();
     auto it = set.lower_bound(start_offset);
-    if (it == set.end() || (*it)->is_compacted_segment()) {
+    if (it == set.end() || (*it)->finished_self_compaction()) {
         // Skip forward if we hit a gap or compacted segment
         for (auto i = set.begin(); i != set.end(); i++) {
             const auto& sg = *i;

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -48,6 +48,9 @@ public:
       std::optional<segment_time_limit> limit = std::nullopt,
       ss::io_priority_class io_priority = ss::default_priority_class());
 
+    using search_for_compacted_segments
+      = ss::bool_class<struct search_for_compacted_segments_tag>;
+
     /// \brief regurn next upload candidate
     ///
     /// \param begin_inclusive is an inclusive begining of the range
@@ -58,7 +61,8 @@ public:
       model::offset begin_inclusive,
       model::offset end_exclusive,
       storage::log,
-      const storage::offset_translator_state&);
+      const storage::offset_translator_state&,
+      search_for_compacted_segments = search_for_compacted_segments::no);
 
 private:
     /// Check if the upload have to be forced due to timeout
@@ -79,6 +83,9 @@ private:
       model::offset adjusted_lso,
       storage::log,
       const storage::offset_translator_state&);
+
+    lookup_result
+    find_compacted_segment(model::offset start_offset, storage::log log);
 
     model::ntp _ntp;
     std::optional<segment_time_limit> _upload_limit;

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -346,6 +346,160 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
     b.stop().get();
 }
 
+FIXTURE_TEST(
+  test_archival_policy_compacted_segment_search_when_no_segment_is_compacted,
+  archiver_fixture) {
+    model::offset lso{9999};
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset{0}, model::term_id(1)},
+    };
+
+    init_storage_api_local(segments);
+    auto& lm = get_local_storage_api().log_mgr();
+    log_segment_set(lm);
+
+    auto log = lm.get(manifest_ntp);
+    BOOST_REQUIRE(log);
+
+    auto partition = app.partition_manager.local().get(manifest_ntp);
+    BOOST_REQUIRE(partition);
+
+    auto candidate
+      = archival_policy{manifest_ntp}
+          .get_next_candidate(
+            model::offset(0),
+            lso,
+            *log,
+            *partition->get_offset_translator_state(),
+            archival::archival_policy::search_for_compacted_segments::yes)
+          .get();
+    BOOST_REQUIRE_EQUAL(candidate.source.get(), nullptr);
+}
+
+FIXTURE_TEST(
+  test_archival_policy_compacted_segment_search_when_a_segment_is_compacted,
+  archiver_fixture) {
+    model::offset lso{9999};
+
+    // We need two segments here because compaction only works if we have more
+    // than one segment in the log
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset{0}, model::term_id(1)},
+      {manifest_ntp, model::offset{1000}, model::term_id(1)},
+    };
+
+    storage::ntp_config::default_overrides o;
+    o.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    init_storage_api_local(segments, o);
+    auto& lm = get_local_storage_api().log_mgr();
+
+    log_segment_set(lm);
+
+    auto log = lm.get(manifest_ntp);
+    BOOST_REQUIRE(log);
+
+    ss::abort_source as{};
+    log
+      ->compact(storage::compaction_config(
+        model::timestamp::now(),
+        std::nullopt,
+        model::offset::max(),
+        ss::default_priority_class(),
+        as))
+      .get0();
+
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+
+    auto seg = plog->segments().begin();
+
+    BOOST_REQUIRE((*seg)->finished_self_compaction());
+
+    auto partition = app.partition_manager.local().get(manifest_ntp);
+    BOOST_REQUIRE(partition);
+
+    auto candidate
+      = archival::archival_policy{manifest_ntp}
+          .get_next_candidate(
+            model::offset(0),
+            lso,
+            *log,
+            *partition->get_offset_translator_state(),
+            archival::archival_policy::search_for_compacted_segments::yes)
+          .get();
+    BOOST_REQUIRE_NE(candidate.source.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(candidate.starting_offset(), 0);
+    BOOST_REQUIRE_EQUAL(
+      candidate.source->offsets().base_offset, model::offset{0});
+
+    // Search after the first compacted segment returns nothing
+    auto second
+      = archival::archival_policy{manifest_ntp}
+          .get_next_candidate(
+            model::next_offset(candidate.final_offset),
+            lso,
+            *log,
+            *partition->get_offset_translator_state(),
+            archival::archival_policy::search_for_compacted_segments::yes)
+          .get();
+    BOOST_REQUIRE_EQUAL(second.source.get(), nullptr);
+}
+
+FIXTURE_TEST(
+  test_archival_policy_compacted_segment_search_offset_inside_segment,
+  archiver_fixture) {
+    model::offset lso{9999};
+
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset{0}, model::term_id(1), 100},
+      {manifest_ntp, model::offset{1000}, model::term_id(1)},
+    };
+
+    storage::ntp_config::default_overrides o;
+    o.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    init_storage_api_local(segments, o);
+    auto& lm = get_local_storage_api().log_mgr();
+
+    log_segment_set(lm);
+
+    auto log = lm.get(manifest_ntp);
+    BOOST_REQUIRE(log);
+
+    ss::abort_source as{};
+    log
+      ->compact(storage::compaction_config(
+        model::timestamp::now(),
+        std::nullopt,
+        model::offset::max(),
+        ss::default_priority_class(),
+        as))
+      .get0();
+
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    auto seg = plog->segments().begin();
+    BOOST_REQUIRE((*seg)->finished_self_compaction());
+
+    auto partition = app.partition_manager.local().get(manifest_ntp);
+    BOOST_REQUIRE(partition);
+
+    auto candidate
+      = archival::archival_policy{manifest_ntp}
+          .get_next_candidate(
+            // TODO (abhijat) we should read into the segment and get an offset
+            //  ahead of first batch instead of guessing a value
+            model::offset(500),
+            lso,
+            *log,
+            *partition->get_offset_translator_state(),
+            archival::archival_policy::search_for_compacted_segments::yes)
+          .get();
+    BOOST_REQUIRE_NE(candidate.source.get(), nullptr);
+    BOOST_REQUIRE_GT(candidate.starting_offset(), 0);
+    BOOST_REQUIRE_EQUAL(
+      candidate.source->offsets().base_offset, model::offset{0});
+}
+
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     // This test simulates leadership transfer. In this situation the

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -173,7 +173,10 @@ public:
     storage::api& get_local_storage_api();
     /// \brief Init storage api for tests that require only storage
     /// The method doesn't add topics, only creates segments in data_dir
-    void init_storage_api_local(const std::vector<segment_desc>& segm);
+    void init_storage_api_local(
+      const std::vector<segment_desc>& segm,
+      std::optional<storage::ntp_config::default_overrides> overrides
+      = std::nullopt);
 
     std::vector<segment_layout> get_layouts(const model::ntp& ntp) const {
         return layouts.find(ntp)->second;
@@ -189,8 +192,10 @@ public:
       model::topic_namespace_view tp_ns, int partitions = 1);
 
 private:
-    void
-    initialize_shard(storage::api& api, const std::vector<segment_desc>& segm);
+    void initialize_shard(
+      storage::api& api,
+      const std::vector<segment_desc>& segm,
+      std::optional<storage::ntp_config::default_overrides> overrides);
 
     std::unordered_map<model::ntp, std::vector<segment_layout>> layouts;
 };

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -4,7 +4,7 @@ import pprint
 import random
 import struct
 from collections import defaultdict, namedtuple
-from typing import Sequence
+from typing import Sequence, Optional
 
 import confluent_kafka
 import xxhash
@@ -214,12 +214,14 @@ def gen_manifest_path(ntp, rev):
     return f"{hash}/meta/{path}/manifest.json"
 
 
-def _gen_segment_path(ntp, rev, name):
+def gen_segment_path(ntp: NTP, revision: int, name: str,
+                     archiver_term: Optional[int]) -> str:
     x = xxhash.xxh32()
-    path = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{rev}/{name}"
+    path = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{revision}/{name}"
     x.update(path.encode('ascii'))
-    hash = x.hexdigest()
-    return f"{hash}/{path}"
+    if archiver_term is not None:
+        return f'{x.intdigest():08x}/{path}.{archiver_term}'
+    return f'{x.intdigest():08x}/{path}'
 
 
 def get_on_disk_size_per_ntp(chk):


### PR DESCRIPTION
## Cover letter

Allows uploading non-compacted segments from compaction enabled topics to SI.

Additionally adds a search for the next compacted segment above a given offset to archival_policy in preparation for uploading compacted topics.

Fixes #6368 

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
