### PR TITLE
Fixed spurious log entry emitted on heartbeat timeout

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -315,6 +315,15 @@ void heartbeat_manager::process_reply(
         auto consensus = *it;
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);
 
+        if (unlikely(m.result == append_entries_reply::status::timeout)) {
+            vlog(
+              hbeatlog.debug,
+              "Heartbeat request for group {} timed out on the node {}",
+              m.group,
+              n);
+            continue;
+        }
+
         if (unlikely(m.target_node_id != consensus->self())) {
             vlog(
               hbeatlog.warn,


### PR DESCRIPTION
## Cover letter

When heartbeat request is timed out on the receiving node it is impossible to determine the response content. Handle timed out responses early to make sure that no additional validation and logging is made.

Fixes: #5807

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
