### PR TITLE
[v21.11.x] Fix flaky test_leader_transfers_recover

### DIFF
--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -223,12 +223,13 @@ class RaftAvailabilityTest(RedpandaTest):
     def _transfer_leadership(self, admin: Admin, namespace: str, topic: str,
                              target_node_id: int) -> None:
 
-        last_log_msg = ""      # avoid spamming log
+        last_log_msg = ""  # avoid spamming log
+
         def leader_predicate(l: Optional[int]) -> bool:
             nonlocal last_log_msg, target_node_id
             if not l:
                 return False
-            if l != target_node_id: # type: ignore
+            if l != target_node_id:  # type: ignore
                 log_msg = f'Still waiting for leader {target_node_id}, got {l}'
                 if log_msg != last_log_msg:  # type: ignore # "unbound"
                     self.logger.info(log_msg)
@@ -507,7 +508,8 @@ class RaftAvailabilityTest(RedpandaTest):
             target_idx = (initial_leader_id + n) % len(self.redpanda.nodes)
             target_node_id = target_idx + 1
 
-            self._transfer_leadership(admin, "kafka", self.topic, target_node_id)
+            self._transfer_leadership(admin, "kafka", self.topic,
+                                      target_node_id)
 
         self.logger.info(f"Completed {transfer_count} transfers successfully")
 

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -224,9 +224,20 @@ class RaftAvailabilityTest(RedpandaTest):
         self.logger.info(f"Starting transfer to {target_node_id}")
         admin.partition_transfer_leadership("kafka", topic, 0, target_node_id)
 
-        self._wait_for_leader(
-            lambda l : l and l == target_node_id,
-            timeout=ELECTION_TIMEOUT * 2)
+        last_log_msg = ""      # avoid spamming log
+        def leader_predicate(l: Optional[int]) -> bool:
+            nonlocal last_log_msg, target_node_id
+            if not l:
+                return False
+            if l != target_node_id:
+                log_msg = f'Still waiting for leader {target_node_id}, got {l}'
+                if log_msg != last_log_msg:  # type: ignore # "unbound"
+                    self.logger.info(log_msg)
+                    last_log_msg = log_msg
+                return False
+            return True
+
+        self._wait_for_leader(leader_predicate, timeout=ELECTION_TIMEOUT * 2)
         self.logger.info(f"Completed transfer to {target_node_id}")
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -11,6 +11,7 @@ import sys
 import time
 import re
 import random
+from typing import Optional
 
 from ducktape.mark.resource import cluster
 from ducktape.mark import parametrize
@@ -217,6 +218,16 @@ class RaftAvailabilityTest(RedpandaTest):
     def _expect_available(self):
         self._ping_pong()
         self.logger.info("Cluster is available as expected")
+
+    def _transfer_leadership(self, admin: Admin, namespace: str, topic: str,
+                             target_node_id: int) -> None:
+        self.logger.info(f"Starting transfer to {target_node_id}")
+        admin.partition_transfer_leadership("kafka", topic, 0, target_node_id)
+
+        self._wait_for_leader(
+            lambda l : l and l == target_node_id,
+            timeout=ELECTION_TIMEOUT * 2)
+        self.logger.info(f"Completed transfer to {target_node_id}")
 
     @cluster(num_nodes=3)
     def test_one_node_down(self):
@@ -469,14 +480,7 @@ class RaftAvailabilityTest(RedpandaTest):
             target_idx = (initial_leader_id + n) % len(self.redpanda.nodes)
             target_node_id = target_idx + 1
 
-            self.logger.info(f"Starting transfer to {target_node_id}")
-            admin.partition_transfer_leadership("kafka", self.topic, 0,
-                                                target_node_id)
-
-            self._wait_for_leader(
-                lambda l: l is not None and l == target_node_id,
-                timeout=ELECTION_TIMEOUT * 2)
-            self.logger.info(f"Completed transfer to {target_node_id}")
+            self._transfer_leadership(admin, "kafka", self.topic, target_node_id)
 
         self.logger.info(f"Completed {transfer_count} transfers successfully")
 

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -11,6 +11,7 @@ import sys
 import time
 import re
 import random
+import ducktape.errors
 from typing import Optional
 
 from ducktape.mark.resource import cluster
@@ -221,15 +222,13 @@ class RaftAvailabilityTest(RedpandaTest):
 
     def _transfer_leadership(self, admin: Admin, namespace: str, topic: str,
                              target_node_id: int) -> None:
-        self.logger.info(f"Starting transfer to {target_node_id}")
-        admin.partition_transfer_leadership("kafka", topic, 0, target_node_id)
 
         last_log_msg = ""      # avoid spamming log
         def leader_predicate(l: Optional[int]) -> bool:
             nonlocal last_log_msg, target_node_id
             if not l:
                 return False
-            if l != target_node_id:
+            if l != target_node_id: # type: ignore
                 log_msg = f'Still waiting for leader {target_node_id}, got {l}'
                 if log_msg != last_log_msg:  # type: ignore # "unbound"
                     self.logger.info(log_msg)
@@ -237,7 +236,24 @@ class RaftAvailabilityTest(RedpandaTest):
                 return False
             return True
 
-        self._wait_for_leader(leader_predicate, timeout=ELECTION_TIMEOUT * 2)
+        retry_once = True
+        while True:
+            self.logger.info(f"Starting transfer to {target_node_id}")
+            admin.partition_transfer_leadership("kafka", topic, 0,
+                                                target_node_id)
+            try:
+                self._wait_for_leader(leader_predicate,
+                                      timeout=ELECTION_TIMEOUT * 2)
+            except ducktape.errors.TimeoutError as e:
+                if retry_once:
+                    self.logger.info(
+                        f'Failed to get desired leader, retrying once.')
+                    retry_once = False
+                    continue
+                else:
+                    raise e
+            break
+
         self.logger.info(f"Completed transfer to {target_node_id}")
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -253,7 +253,7 @@ class RaftAvailabilityTest(RedpandaTest):
                     continue
                 else:
                     raise e
-            break
+            break  # no exception -> success, we can return now
 
         self.logger.info(f"Completed transfer to {target_node_id}")
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/3854.
Fixes https://github.com/redpanda-data/redpanda/issues/6414,