### PR TITLE
tests: log output on openssl errors

### DIFF
--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -99,10 +99,15 @@ class TLSCertManager:
 
     def _exec(self, cmd):
         self._logger.info(f"Running command: {cmd}")
-        output = subprocess.check_output(cmd.split(),
-                                         cwd=self._dir.name,
-                                         stderr=subprocess.STDOUT)
-        self._logger.debug(output)
+        try:
+            output = subprocess.check_output(cmd.split(),
+                                             cwd=self._dir.name,
+                                             stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            self._logger.error(f"openssl error: {e.output}")
+            raise
+        else:
+            self._logger.debug(output)
 
     def _create_ca(self):
         cfg = self._with_dir("ca.conf")


### PR DESCRIPTION
## Cover letter

An enigmatic failure occurred here: https://buildkite.com/redpanda/redpanda/builds/15295#01833c3d-a4f1-4f6a-a8a5-1b38c140202b

The test code was not logging stderr on failure -- fixing that, so that if this happens again we'll have a clue as to why.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none