### PR TITLE
raft: distinguish aborts & timeouts in offset_monitor exceptions

### DIFF
--- a/src/v/raft/offset_monitor.cc
+++ b/src/v/raft/offset_monitor.cc
@@ -17,7 +17,7 @@ namespace raft {
 
 void offset_monitor::stop() {
     for (auto& waiter : _waiters) {
-        waiter.second->done.set_exception(wait_aborted());
+        waiter.second->done.set_exception(ss::abort_requested_exception());
     }
     _waiters.clear();
 }
@@ -62,22 +62,40 @@ offset_monitor::waiter::waiter(
   : mon(mon) {
     if (as) {
         auto opt_sub = as->get().subscribe(
-          [this]() noexcept { handle_abort(); });
+          [this]() noexcept { handle_abort(false); });
         if (opt_sub) {
             sub = std::move(*opt_sub);
         } else {
-            done.set_exception(wait_aborted());
+            done.set_exception(ss::abort_requested_exception());
             return;
         }
     }
     if (timeout != model::no_timeout) {
-        timer.set_callback([this] { handle_abort(); });
+        timer.set_callback([this] { handle_abort(true); });
         timer.arm(timeout);
     }
 }
 
-void offset_monitor::waiter::handle_abort() {
-    done.set_exception(wait_aborted());
+/**
+ * Set an exception on our `done` promise and clean up waiters.
+ *
+ * This is behaviourally the same for aborts and timeouts, but
+ * we raise a different exception for those respective cases
+ * to help callers interpret it properly (distinguish between
+ * worrying timeouts, and non-worrying aborts during shutdown).
+ *
+ * @param is_timeout control the exception type that will be set
+ *                   on the future.
+ */
+void offset_monitor::waiter::handle_abort(bool is_timeout) {
+    if (is_timeout) {
+        done.set_exception(wait_timed_out());
+    } else {
+        // Use the generic seastar abort_requested_exception, because
+        // in many locations we handle this gracefully and do not log
+        // it as an error during shutdown.
+        done.set_exception(ss::abort_requested_exception());
+    }
     auto it = std::find_if(
       mon->_waiters.begin(),
       mon->_waiters.end(),

--- a/src/v/raft/offset_monitor.h
+++ b/src/v/raft/offset_monitor.h
@@ -35,10 +35,10 @@ public:
      * Exception used to indicate an aborted wait, either from a requested abort
      * via an abort source or because a timeout occurred.
      */
-    class wait_aborted final : public std::exception {
+    class wait_timed_out final : public std::exception {
     public:
         virtual const char* what() const noexcept final {
-            return "offset monitor wait aborted";
+            return "offset monitor wait timed out";
         }
     };
 
@@ -78,7 +78,7 @@ private:
           model::timeout_clock::time_point,
           std::optional<std::reference_wrapper<ss::abort_source>>);
 
-        void handle_abort();
+        void handle_abort(bool is_timeout);
     };
 
     friend waiter;

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -136,11 +136,15 @@ ss::future<> state_machine::apply() {
                 }
             });
       })
-      .handle_exception_type([](const raft::offset_monitor::wait_aborted&) {})
+      .handle_exception_type([](const raft::offset_monitor::wait_timed_out&) {})
+      .handle_exception_type([](const ss::abort_requested_exception&) {})
       .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
           vlog(
-            _log.info, "State machine for ntp={} handles {}", _raft->ntp(), e);
+            _log.info,
+            "State machine for ntp={} caught exception {}",
+            _raft->ntp(),
+            e);
       });
 }
 

--- a/src/v/raft/tests/offset_monitor_test.cc
+++ b/src/v/raft/tests/offset_monitor_test.cc
@@ -95,13 +95,7 @@ SEASTAR_THREAD_TEST_CASE(stop) {
     BOOST_REQUIRE(mon.empty());
 
     for (auto& f : fs) {
-        BOOST_CHECK_EXCEPTION(
-          f.get(),
-          raft::offset_monitor::wait_aborted,
-          [](raft::offset_monitor::wait_aborted e) {
-              return std::string(e.what()).find("offset monitor wait aborted")
-                     != std::string::npos;
-          });
+        BOOST_CHECK_THROW(f.get(), ss::abort_requested_exception);
     }
 }
 
@@ -154,13 +148,7 @@ SEASTAR_THREAD_TEST_CASE(wait_timeout) {
     BOOST_REQUIRE(!f0.available());
     BOOST_REQUIRE(!mon.empty());
 
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), raft::offset_monitor::wait_timed_out);
 
     BOOST_REQUIRE(mon.empty());
 }
@@ -176,13 +164,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source) {
     as.request_abort();
     BOOST_REQUIRE(f0.failed());
 
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), ss::abort_requested_exception);
 
     BOOST_REQUIRE(mon.empty());
 }
@@ -196,13 +178,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source_already_aborted) {
     BOOST_REQUIRE(mon.empty());
 
     BOOST_REQUIRE(f0.failed());
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), ss::abort_requested_exception);
 }
 
 SEASTAR_THREAD_TEST_CASE(wait_abort_source_with_timeout_first) {
@@ -215,13 +191,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source_with_timeout_first) {
 
     // there is an abort source, but only wait on timeout
 
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), raft::offset_monitor::wait_timed_out);
 
     BOOST_REQUIRE(mon.empty());
 }
@@ -238,13 +208,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source_with_timeout_abort_first) {
     BOOST_REQUIRE(f0.failed());
     BOOST_REQUIRE(mon.empty());
 
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), ss::abort_requested_exception);
 
     BOOST_REQUIRE(mon.empty());
 }
@@ -262,13 +226,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source_with_timeout_abort_before_timeout) {
 
     as.request_abort();
 
-    BOOST_CHECK_EXCEPTION(
-      f0.get(),
-      raft::offset_monitor::wait_aborted,
-      [](raft::offset_monitor::wait_aborted e) {
-          return std::string(e.what()).find("offset monitor wait aborted")
-                 != std::string::npos;
-      });
+    BOOST_CHECK_THROW(f0.get(), ss::abort_requested_exception);
 
     BOOST_REQUIRE(mon.empty());
 }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -85,6 +85,9 @@ CHAOS_LOG_ALLOW_LIST = [
         "(raft|rpc) - .*(client_request_timeout|disconnected_endpoint|Broken pipe|Connection reset by peer)"
     ),
 
+    # Failure to progress STMs promptly
+    re.compile("raft::offset_monitor::wait_timed_out"),
+
     # e.g. cluster - controller_backend.cc:466 - exception while executing partition operation: {type: update_finished, ntp: {kafka/test-topic-1944-1639161306808363/1}, offset: 413, new_assignment: { id: 1, group_id: 65, replicas: {{node_id: 3, shard: 2}, {node_id: 4, shard: 2}, {node_id: 1, shard: 0}} }, previous_assignment: {nullopt}} - std::__1::__fs::filesystem::filesystem_error (error system:39, filesystem error: remove failed: Directory not empty [/var/lib/redpanda/data/kafka/test-topic-1944-1639161306808363])
     re.compile("cluster - .*Directory not empty"),
     re.compile("r/heartbeat - .*cannot find consensus group"),

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -31,15 +31,6 @@ from ducktape.mark import ok_to_fail
 # consumer timeout than the default 30 seconds
 CONSUMER_TIMEOUT = 90
 
-# TODO: remove after https://github.com/redpanda-data/redpanda/issues/5154
-# is fixed
-LOG_ALLOW_LIST = CHAOS_LOG_ALLOW_LIST + [
-    # ERROR 2022-08-05 06:32:44,034 [shard 0]
-    # rpc - Service handler threw an exception:
-    # raft::offset_monitor::wait_aborted (offset monitor wait aborted)
-    "rpc - .* raft::offset_monitor::wait_aborted"
-]
-
 
 class PartitionBalancerTest(EndToEndTest):
     def __init__(self, ctx, *args, **kwargs):
@@ -246,7 +237,7 @@ class PartitionBalancerTest(EndToEndTest):
             self.f_injector._start_func(self.cur_failure.type)(
                 self.cur_failure.node)
 
-    @cluster(num_nodes=7, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_unavailable_nodes(self):
         self.start_redpanda(num_nodes=5)
 
@@ -295,7 +286,7 @@ class PartitionBalancerTest(EndToEndTest):
         self.redpanda.set_cluster_config(
             {"raft_learner_recovery_rate": str(new_value)})
 
-    @cluster(num_nodes=6, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_movement_cancellations(self):
         self.start_redpanda(num_nodes=4)
 
@@ -343,7 +334,7 @@ class PartitionBalancerTest(EndToEndTest):
 
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @cluster(num_nodes=8, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
         self.redpanda = RedpandaService(self.test_context,
@@ -386,7 +377,7 @@ class PartitionBalancerTest(EndToEndTest):
 
     @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5154
     # https://github.com/redpanda-data/redpanda/issues/6075
-    @cluster(num_nodes=7, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)
 
@@ -445,7 +436,7 @@ class PartitionBalancerTest(EndToEndTest):
 
     @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5884
     # https://github.com/redpanda-data/redpanda/issues/5980
-    @cluster(num_nodes=6, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_full_nodes(self):
         """
         Test partition balancer full disk node handling with the following scenario:
@@ -542,7 +533,7 @@ class PartitionBalancerTest(EndToEndTest):
                 f"disk used percentage: {int(100.0 * used_ratio)}")
             assert used_ratio < 0.8
 
-    @cluster(num_nodes=7, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @matrix(kill_same_node=[True, False])
     def test_maintenance_mode(self, kill_same_node):
         """
@@ -621,7 +612,7 @@ class PartitionBalancerTest(EndToEndTest):
         self.run_validation(enable_idempotence=False,
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @cluster(num_nodes=7, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @matrix(kill_same_node=[True, False], decommission_first=[True, False])
     def test_decommission(self, kill_same_node, decommission_first):
         """
@@ -721,7 +712,7 @@ class PartitionBalancerTest(EndToEndTest):
         self.run_validation(enable_idempotence=False,
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @cluster(num_nodes=4, log_allow_list=LOG_ALLOW_LIST)
+    @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_transfer_controller_leadership(self):
         """
         Test that unavailability timeout is correctly restarted after controller

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -40,7 +40,7 @@ MISSING_DATA_ERRORS = [
 ]
 
 TRANSIENT_ERRORS = RESTART_LOG_ALLOW_LIST + [
-    "raft::offset_monitor::wait_aborted",
+    "raft::offset_monitor::wait_timed_out",
     "Upload loop error: seastar::timed_out_error"
 ]
 


### PR DESCRIPTION
## Cover letter

Combining timeouts and aborts in the same exception type was problematic, because while timeouts are worth logging at WARN severity, aborts (during shutdown) are not.

It was also confusing in logs to refer to timeouts as "aborts", it makes the situation sound more worrying than it really is if the system is experiencing some transient timeouts.

Fixes #5154
## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* During shutdown, spurious "offset_monitor::wait_aborted" log error messages are no longer emitted.