### PR TITLE
cluster: offset_monitor change custom exceptions to ss

### DIFF
--- a/src/v/raft/offset_monitor.h
+++ b/src/v/raft/offset_monitor.h
@@ -31,16 +31,6 @@ namespace raft {
  */
 class offset_monitor {
 public:
-    /**
-     * Exception used to indicate an aborted wait, either from a requested abort
-     * via an abort source or because a timeout occurred.
-     */
-    class wait_aborted final : public std::exception {
-    public:
-        virtual const char* what() const noexcept final {
-            return "offset monitor wait aborted";
-        }
-    };
 
     /**
      * Exisiting waiters receive wait_aborted exception.
@@ -79,6 +69,8 @@ private:
           std::optional<std::reference_wrapper<ss::abort_source>>);
 
         void handle_abort();
+        void handle_timeout();
+        void remove_waiter();
     };
 
     friend waiter;

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -136,7 +136,7 @@ ss::future<> state_machine::apply() {
                 }
             });
       })
-      .handle_exception_type([](const raft::offset_monitor::wait_aborted&) {})
+      .handle_exception_type([](const ss::abort_requested_exception&) {})
       .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
           vlog(


### PR DESCRIPTION
## Cover letter

Change custom exceptions that we made for offset monitor to seastar default exceptions.
It will help to deal with these exceptions in common way.
simple_protocol will catch offset_monitor exceptions so they won't be logged as ERROR

Fixes #5154

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
