### PR TITLE
Disable debug, admin Console URLs

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -150,13 +150,20 @@ func (r *Reconciling) Do(
 		)
 	}
 
+	// Ingress with TLS and "/debug" "/admin" paths disabled
+	ingressResource := resources.NewIngress(r.Client, console, r.Scheme, subdomain, console.GetName(), consolepkg.ServicePortName, log)
+	ingressResource = ingressResource.WithTLS(resources.LEClusterIssuer, fmt.Sprintf("%s-redpanda", cluster.GetName()))
+	ingressResource = ingressResource.WithAnnotations(map[string]string{
+		"nginx.ingress.kubernetes.io/server-snippet": "if ($request_uri ~* ^/(debug|admin)) {\n\treturn 403;\n\t}",
+	})
+
 	applyResources := []resources.Resource{
 		consolepkg.NewKafkaSA(r.Client, r.Scheme, console, cluster, r.clusterDomain, r.AdminAPIClientFactory, log),
 		consolepkg.NewKafkaACL(r.Client, r.Scheme, console, cluster, r.KafkaAdminClientFactory, log),
 		configmapResource,
 		consolepkg.NewDeployment(r.Client, r.Scheme, console, cluster, r.Store, log),
 		consolepkg.NewService(r.Client, r.Scheme, console, r.clusterDomain, log),
-		resources.NewIngress(r.Client, console, r.Scheme, subdomain, console.GetName(), consolepkg.ServicePortName, log).WithTLS(resources.LEClusterIssuer, fmt.Sprintf("%s-redpanda", cluster.GetName())),
+		ingressResource,
 	}
 	for _, each := range applyResources {
 		if err := each.Ensure(ctx); err != nil { //nolint:gocritic // more readable

--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -86,11 +86,11 @@ func (r *IngressResource) WithAnnotations(
 }
 
 // WithTLS sets Ingress TLS with specified issuer
-func (r *IngressResource) WithTLS(issuer, secretName string) *IngressResource {
+func (r *IngressResource) WithTLS(clusterIssuer, secretName string) *IngressResource {
 	if r.annotations == nil {
 		r.annotations = map[string]string{}
 	}
-	r.annotations["cert-manager.io/issuer"] = issuer
+	r.annotations["cert-manager.io/cluster-issuer"] = clusterIssuer
 	r.annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
 
 	if r.TLS == nil {
@@ -103,6 +103,11 @@ func (r *IngressResource) WithTLS(issuer, secretName string) *IngressResource {
 	})
 
 	return r
+}
+
+// GetAnnotations returns the annotations for the Ingress resource
+func (r *IngressResource) GetAnnotations() map[string]string {
+	return r.annotations
 }
 
 // Ensure will manage kubernetes Ingress for redpanda.vectorized.io custom resource

--- a/src/go/k8s/pkg/resources/ingress_test.go
+++ b/src/go/k8s/pkg/resources/ingress_test.go
@@ -1,0 +1,50 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngressWithTLS(t *testing.T) {
+	table := []struct {
+		host      string
+		tlsSecret string
+		tlsIssuer string
+	}{
+		{
+			host:      "test.example.local",
+			tlsSecret: "rp-abc123-redpanda",
+			tlsIssuer: resources.LEClusterIssuer,
+		},
+	}
+	for _, tt := range table {
+		ingress := resources.NewIngress(nil, nil, nil, tt.host, "", "", logr.Discard()).WithTLS(tt.tlsIssuer, tt.tlsSecret)
+		annotations := ingress.GetAnnotations()
+
+		issuer, ok := annotations["cert-manager.io/cluster-issuer"]
+		require.True(t, ok)
+		require.Equal(t, tt.tlsIssuer, issuer)
+
+		sslRedirect, ok := annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"]
+		require.True(t, ok)
+		require.Equal(t, "true", sslRedirect)
+
+		var found bool
+		for _, tls := range ingress.TLS {
+			// Host and SecretName should be in same TLS element
+			var foundHost bool
+			for _, host := range tls.Hosts {
+				if host == tt.host {
+					foundHost = true
+				}
+			}
+			if foundHost && tls.SecretName == tt.tlsSecret {
+				found = true
+			}
+		}
+		require.True(t, found)
+	}
+}


### PR DESCRIPTION
## Cover letter
Return 403 for debug, admin Console URLs 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes [#2762](https://app.zenhub.com/workspaces/cloud-62684e2c6635e100149514fd/issues/redpanda-data/cloud/2762)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

URLs prefixed with "/debug" and "/admin" will not be available. This PR also fixes the cert-manager Lets Encrypt issuer used as it is defined as ClusterIssuer in v2.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
