### PR TITLE
raft: make heartbeat config properties live-editable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -163,14 +163,14 @@ configuration::configuration()
       *this,
       "raft_heartbeat_interval_ms",
       "Milliseconds for raft leader heartbeats",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(150),
       {.min = std::chrono::milliseconds(1)})
   , raft_heartbeat_timeout_ms(
       *this,
       "raft_heartbeat_timeout_ms",
       "raft heartbeat RPC timeout",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       3s,
       {.min = std::chrono::milliseconds(1)})
   , raft_heartbeat_disconnect_failures(

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -23,19 +23,21 @@ namespace raft {
 
 group_manager::group_manager(
   model::node_id self,
-  model::timeout_clock::duration disk_timeout,
   ss::scheduling_group raft_sg,
-  std::chrono::milliseconds heartbeat_interval,
-  std::chrono::milliseconds heartbeat_timeout,
+  group_manager::config_provider_fn cfg,
   recovery_memory_quota::config_provider_fn recovery_mem_cfg,
   ss::sharded<rpc::connection_cache>& clients,
   ss::sharded<storage::api>& storage,
   ss::sharded<recovery_throttle>& recovery_throttle)
   : _self(self)
-  , _disk_timeout(disk_timeout)
   , _raft_sg(raft_sg)
   , _client(make_rpc_client_protocol(self, clients))
-  , _heartbeats(heartbeat_interval, _client, _self, heartbeat_timeout)
+  , _configuration(cfg())
+  , _heartbeats(
+      _configuration.heartbeat_interval,
+      _client,
+      _self,
+      _configuration.heartbeat_timeout)
   , _storage(storage.local())
   , _recovery_throttle(recovery_throttle.local())
   , _recovery_mem_quota(std::move(recovery_mem_cfg)) {
@@ -80,7 +82,7 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
         config::shard_local_cfg().raft_election_timeout_ms()),
       log,
       scheduling_config(_raft_sg, raft_priority()),
-      _disk_timeout,
+      _configuration.raft_io_timeout_ms,
       _client,
       [this](raft::leadership_status st) {
           trigger_leadership_notification(std::move(st));

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -170,12 +170,12 @@ static heartbeat_requests requests_for_range(
 }
 
 heartbeat_manager::heartbeat_manager(
-  duration_type interval,
+  config::binding<std::chrono::milliseconds> interval,
   consensus_client_protocol proto,
   model::node_id self,
-  duration_type heartbeat_timeout)
-  : _heartbeat_interval(interval)
-  , _heartbeat_timeout(heartbeat_timeout)
+  config::binding<std::chrono::milliseconds> heartbeat_timeout)
+  : _heartbeat_interval(std::move(interval))
+  , _heartbeat_timeout(std::move(heartbeat_timeout))
   , _client_protocol(std::move(proto))
   , _self(self) {
     _heartbeat_timer.set_callback([this] { dispatch_heartbeats(); });
@@ -201,7 +201,7 @@ heartbeat_manager::send_heartbeats(std::vector<node_heartbeat> reqs) {
 }
 
 ss::future<> heartbeat_manager::do_dispatch_heartbeats() {
-    auto reqs = requests_for_range(_consensus_groups, _heartbeat_interval);
+    auto reqs = requests_for_range(_consensus_groups, _heartbeat_interval());
 
     for (const auto& node_id : reqs.reconnect_nodes) {
         if (co_await _client_protocol.ensure_disconnect(node_id)) {
@@ -244,7 +244,7 @@ ss::future<> heartbeat_manager::do_heartbeat(node_heartbeat&& r) {
                  r.target,
                  std::move(r.request),
                  rpc::client_opts(
-                   clock_type::now() + _heartbeat_timeout,
+                   clock_type::now() + _heartbeat_timeout(),
                    rpc::compression_type::zstd,
                    512))
                .then([node = r.target,
@@ -396,7 +396,7 @@ ss::future<> heartbeat_manager::stop() {
 }
 
 clock_type::time_point heartbeat_manager::next_heartbeat_timeout() {
-    return clock_type::now() + _heartbeat_interval;
+    return clock_type::now() + _heartbeat_interval();
 }
 
 } // namespace raft

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -121,10 +121,10 @@ public:
     };
 
     heartbeat_manager(
-      duration_type interval,
+      config::binding<std::chrono::milliseconds>,
       consensus_client_protocol,
       model::node_id,
-      duration_type);
+      config::binding<std::chrono::milliseconds>);
 
     ss::future<> register_group(ss::lw_shared_ptr<consensus>);
     ss::future<> deregister_group(raft::group_id);
@@ -162,8 +162,8 @@ private:
 
     mutex _lock;
     clock_type::time_point _hbeat = clock_type::now();
-    duration_type _heartbeat_interval;
-    duration_type _heartbeat_timeout;
+    config::binding<std::chrono::milliseconds> _heartbeat_interval;
+    config::binding<std::chrono::milliseconds> _heartbeat_timeout;
     timer_type _heartbeat_timer;
     /// \brief used to wait for background ops before shutting down
     ss::gate _bghbeats;

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -112,10 +112,12 @@ public:
                 storage::debug_sanitize_files::yes);
           })
       , _hbeats(
-          raft_heartbeat_interval,
+          config::mock_binding<std::chrono::milliseconds>(
+            std::chrono::milliseconds(raft_heartbeat_interval)),
           _consensus_client_protocol,
           self,
-          raft_heartbeat_interval * 20)
+          config::mock_binding<std::chrono::milliseconds>(
+            raft_heartbeat_interval * 20))
       , _recovery_memory_quota([] {
           return raft::recovery_memory_quota::configuration{
             .max_recovery_memory = config::mock_binding<std::optional<size_t>>(

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -61,10 +61,16 @@ struct mux_state_machine_fixture {
         _group_mgr
           .start(
             _self,
-            30s,
             ss::default_scheduling_group(),
-            std::chrono::milliseconds(100),
-            std::chrono::milliseconds(2000),
+            [] {
+                return raft::group_manager::configuration{
+                  .heartbeat_interval
+                  = config::mock_binding<std::chrono::milliseconds>(100ms),
+                  .heartbeat_timeout
+                  = config::mock_binding<std::chrono::milliseconds>(2000ms),
+                  .raft_io_timeout_ms = 30s,
+                };
+            },
             [] {
                 return raft::recovery_memory_quota::configuration{
                   .max_recovery_memory

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -57,7 +57,7 @@ inline ss::logger tstlog("raft_test");
 
 using namespace std::chrono_literals; // NOLINT
 
-inline static auto heartbeat_interval = 40ms;
+inline static std::chrono::milliseconds heartbeat_interval = 40ms;
 inline static const raft::replicate_options
   default_replicate_opts(raft::consistency_level::quorum_ack);
 
@@ -209,10 +209,12 @@ struct raft_node {
           .get0();
         server.invoke_on_all(&net::server::start).get0();
         hbeats = std::make_unique<raft::heartbeat_manager>(
-          heartbeat_interval,
+          config::mock_binding<std::chrono::milliseconds>(
+            std::chrono::milliseconds(heartbeat_interval)),
           raft::make_rpc_client_protocol(broker.id(), cache),
           broker.id(),
-          heartbeat_interval * 20);
+          config::mock_binding<std::chrono::milliseconds>(
+            heartbeat_interval * 20));
         hbeats->start().get0();
         hbeats->register_group(consensus).get();
         started = true;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -724,10 +724,16 @@ void application::wire_up_redpanda_services() {
     raft_group_manager
       .start(
         model::node_id(config::node().node_id()),
-        config::shard_local_cfg().raft_io_timeout_ms(),
         _scheduling_groups.raft_sg(),
-        config::shard_local_cfg().raft_heartbeat_interval_ms(),
-        config::shard_local_cfg().raft_heartbeat_timeout_ms(),
+        [] {
+            return raft::group_manager::configuration{
+              .heartbeat_interval
+              = config::shard_local_cfg().raft_heartbeat_interval_ms.bind(),
+              .heartbeat_timeout
+              = config::shard_local_cfg().raft_heartbeat_timeout_ms.bind(),
+              .raft_io_timeout_ms
+              = config::shard_local_cfg().raft_io_timeout_ms()};
+        },
         [] {
             return raft::recovery_memory_quota::configuration{
               .max_recovery_memory


### PR DESCRIPTION
## Cover letter

This is a mild improvement in itself, but it is done to
enable new-style binding of the heartbeat interval property
from the recovery coordinator in a subsequent change.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* The cluster configuration properties `raft_heartbeat_interval_ms` and `raft_heartbeat_timeout_ms` may now be modified without restarting redpanda.
