### PR TITLE
[v21.11.x] Update homebrew publish

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         formula-name: redpanda
         homebrew-tap: ${{ github.repository_owner }}/homebrew-tap
-        download-url: https://github.com/redpanda-data/redpanda/releases/download/${{ github.ref_name }}/rpk-darwin-amd64.zip
+        download-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/rpk-darwin-amd64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -31,14 +31,3 @@ jobs:
         download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
-
-    - name: Update the arm64 homebrew tap
-      if: contains(steps.get_version.outputs.VERSION, '-beta') == false
-      uses: mislav/bump-homebrew-formula-action@v1.8
-      with:
-        formula-name: redpanda
-        homebrew-tap: vectorizedio/homebrew-tap
-        base-branch: main
-        download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-arm64.zip
-      env:
-        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -22,11 +22,10 @@ jobs:
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
     - name: Update the amd64 homebrew tap
-      uses: mislav/bump-homebrew-formula-action@v1.8
+      uses: mislav/bump-homebrew-formula-action@v2
       with:
         formula-name: redpanda
         homebrew-tap: vectorizedio/homebrew-tap
-        base-branch: main
-        download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
+        download-url: https://github.com/redpanda-data/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -17,15 +17,11 @@ jobs:
     name: Update Homebrew
     runs-on: ubuntu-latest
     steps:
-    - name: Get the version
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
     - name: Update the amd64 homebrew tap
       uses: mislav/bump-homebrew-formula-action@v2
       with:
         formula-name: redpanda
         homebrew-tap: ${{ github.repository_owner }}/homebrew-tap
-        download-url: https://github.com/redpanda-data/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
+        download-url: https://github.com/redpanda-data/redpanda/releases/download/${{ github.ref_name }}/rpk-darwin-amd64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -25,7 +25,7 @@ jobs:
       uses: mislav/bump-homebrew-formula-action@v2
       with:
         formula-name: redpanda
-        homebrew-tap: vectorizedio/homebrew-tap
+        homebrew-tap: ${{ github.repository_owner }}/homebrew-tap
         download-url: https://github.com/redpanda-data/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -29,4 +29,4 @@ jobs:
         base-branch: main
         download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
       env:
-        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -22,7 +22,6 @@ jobs:
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
     - name: Update the amd64 homebrew tap
-      if: contains(steps.get_version.outputs.VERSION, '-beta') == false
       uses: mislav/bump-homebrew-formula-action@v1.8
       with:
         formula-name: redpanda


### PR DESCRIPTION
## Cover letter

Manual backport of PR #6390 to [v21.11.x](https://github.com/redpanda-data/redpanda/tree/v21.11.x) branch because the automatic cherry-picks had conflicts.

Resolved conflicts by only taking the changes from the commits in PR #6390

## UX changes

* none

## Release notes

* none