### PR TITLE
Fix consumer group test race condition

### DIFF
--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -26,7 +26,8 @@ class KafkaCliConsumer(BackgroundThreadService):
                  isolation_level=None,
                  from_beginning=False,
                  consumer_properties={},
-                 formatter_properties={}):
+                 formatter_properties={},
+                 instance_name=None):
         super(KafkaCliConsumer, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
@@ -38,6 +39,7 @@ class KafkaCliConsumer(BackgroundThreadService):
         self._consumer_properties = consumer_properties
         self._formatter_properties = formatter_properties
         self._stopping = threading.Event()
+        self._instance_name = "cli-consumer" if instance_name is None else instance_name
         assert self._partitions is not None or self._group is not None, "either partitions or group have to be set"
 
         self._cli = KafkaCliTools(self._redpanda)
@@ -71,7 +73,9 @@ class KafkaCliConsumer(BackgroundThreadService):
 
             for line in node.account.ssh_capture(' '.join(cmd)):
                 line.strip()
-                self.logger.debug(f"consumed: '{line}'")
+                line = line.replace("\n", "")
+                self.logger.debug(
+                    f"[{self._instance_name}] consumed: '{line}'")
                 self._messages.append(line)
         except:
             if self._stopping.is_set():

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -8,7 +8,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from collections import defaultdict
 from rptest.services.cluster import cluster
 
 from rptest.clients.rpk import RpkTool
@@ -82,6 +81,13 @@ class ConsumerGroupTest(RedpandaTest):
 
         for c in consumers:
             c.start()
+        rpk = RpkTool(self.redpanda)
+
+        def group_is_ready():
+            gr = rpk.group_describe(group=group, summary=True)
+            return gr.members == consumer_count
+
+        wait_until(group_is_ready, 60, 1)
         return consumers
 
     def consumed_at_least(consumers, count):
@@ -101,14 +107,18 @@ class ConsumerGroupTest(RedpandaTest):
             else:
                 assert p.instance_id is None
 
-    def setup_producer(self, p_cnt):
+    def create_topic(self, p_cnt):
         # create topic
         self.topic_spec = TopicSpec(partition_count=p_cnt,
                                     replication_factor=3)
+
         self.client().create_topic(specs=self.topic_spec)
+
+    def start_producer(self, msg_cnt=5000):
+
         # produce some messages to the topic
         self.producer = RpkProducer(self._ctx, self.redpanda,
-                                    self.topic_spec.name, 128, 5000, -1)
+                                    self.topic_spec.name, 128, msg_cnt, -1)
         self.producer.start()
 
     @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5885
@@ -119,8 +129,7 @@ class ConsumerGroupTest(RedpandaTest):
         """
         Test validating that consumers are able to join the group and consume topic
         """
-
-        self.setup_producer(20)
+        self.create_topic(20)
         group = 'test-gr-1'
         # use 2 consumers
         consumers = self.create_consumers(2,
@@ -128,6 +137,7 @@ class ConsumerGroupTest(RedpandaTest):
                                           group,
                                           static_members=static_members)
 
+        self.start_producer()
         # wait for some messages
         wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
                    30, 2)
@@ -148,7 +158,7 @@ class ConsumerGroupTest(RedpandaTest):
         """
         Test validating that dynamic and static consumers may exists in the same group
         """
-        self.setup_producer(20)
+        self.create_topic(20)
         group = 'test-gr-1'
         consumers = []
         consumers.append(
@@ -164,7 +174,7 @@ class ConsumerGroupTest(RedpandaTest):
 
         for c in consumers:
             c.start()
-
+        self.start_producer()
         # wait for some messages
         wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
                    30, 2)
@@ -212,7 +222,8 @@ class ConsumerGroupTest(RedpandaTest):
         """
         Test validating that re-joining static member will not casuse rebalance
         """
-        self.setup_producer(20)
+        self.create_topic(20)
+
         group = 'test-gr-1'
 
         consumers = self.create_consumers(
@@ -221,7 +232,7 @@ class ConsumerGroupTest(RedpandaTest):
             group,
             static_members=static_members,
             consumer_properties={"session.timeout.ms": 40000})
-
+        self.start_producer()
         # wait for some messages
         wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
                    30, 2)
@@ -274,7 +285,7 @@ class ConsumerGroupTest(RedpandaTest):
         """
         Test validating that consumer is evicted if it failed to deliver heartbeat to the broker
         """
-        self.setup_producer(20)
+        self.create_topic(20)
         group = 'test-gr-1'
         # using short session timeout to make the test finish faster
         consumers = self.create_consumers(
@@ -284,6 +295,7 @@ class ConsumerGroupTest(RedpandaTest):
             static_members=static_members,
             consumer_properties={"session.timeout.ms": 6000})
 
+        self.start_producer()
         # wait for some messages
         wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
                    30, 2)
@@ -324,8 +336,9 @@ class ConsumerGroupTest(RedpandaTest):
         """
         Test validating that all offsets persisted in the group are removed when corresponding partition is removed.
         """
-        self.setup_producer(20)
         group = 'test-gr-1'
+        self.create_topic(20)
+
         # using short session timeout to make the test finish faster
         consumers = self.create_consumers(
             2,
@@ -334,6 +347,7 @@ class ConsumerGroupTest(RedpandaTest):
             static_members=static_members,
             consumer_properties={"session.timeout.ms": 6000})
 
+        self.start_producer()
         # wait for some messages
         wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
                    30, 2)
@@ -345,6 +359,10 @@ class ConsumerGroupTest(RedpandaTest):
         # stop consumers
         for c in consumers:
             c.stop()
+            c.wait()
+            c.free()
+
+        consumers.clear()
 
         rpk = RpkTool(self.redpanda)
 
@@ -366,6 +384,8 @@ class ConsumerGroupTest(RedpandaTest):
             return rpk_group.members == 0 and rpk_group.state == "Dead"
 
         wait_until(group_is_dead, 30, 2)
+        self.producer.wait()
+        self.producer.free()
 
         # recreate topic
         self.redpanda.restart_nodes(self.redpanda.nodes)
@@ -373,8 +393,15 @@ class ConsumerGroupTest(RedpandaTest):
         wait_until(group_is_dead, 30, 2)
 
         self.client().create_topic(self.topic_spec)
-        for c in consumers:
-            c.start()
+        # recreate consumers
+        consumers = self.create_consumers(
+            2,
+            self.topic_spec.name,
+            group,
+            static_members=static_members,
+            consumer_properties={"session.timeout.ms": 6000})
+
+        self.start_producer()
         wait_until(
             lambda: ConsumerGroupTest.consumed_at_least(consumers, 2000), 30,
             2)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -44,6 +44,7 @@ class ConsumerGroupTest(RedpandaTest):
     def create_consumer(self,
                         topic,
                         group,
+                        instance_name,
                         instance_id=None,
                         consumer_properties={}):
         return KafkaCliConsumer(
@@ -52,6 +53,7 @@ class ConsumerGroupTest(RedpandaTest):
             topic=topic,
             group=group,
             from_beginning=True,
+            instance_name=instance_name,
             formatter_properties={
                 'print.value': 'false',
                 'print.key': 'false',
@@ -75,6 +77,7 @@ class ConsumerGroupTest(RedpandaTest):
                 self.create_consumer(topic,
                                      group=group,
                                      instance_id=instance_id,
+                                     instance_name=f"cli-consumer-{i}",
                                      consumer_properties=consumer_properties))
 
         for c in consumers:
@@ -149,10 +152,15 @@ class ConsumerGroupTest(RedpandaTest):
         group = 'test-gr-1'
         consumers = []
         consumers.append(
-            self.create_consumer(self.topic_spec.name, group,
-                                 "panda-instance"))
+            self.create_consumer(topic=self.topic_spec.name,
+                                 group=group,
+                                 instance_name="static-consumer",
+                                 instance_id="panda-instance"))
         consumers.append(
-            self.create_consumer(self.topic_spec.name, group, None))
+            self.create_consumer(topic=self.topic_spec.name,
+                                 group=group,
+                                 instance_name="dynamic-consumer",
+                                 instance_id=None))
 
         for c in consumers:
             c.start()

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -277,7 +277,6 @@ class ConsumerGroupTest(RedpandaTest):
             c.wait()
             c.free()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5952
     @cluster(num_nodes=6)
     @parametrize(static_members=True)
     @parametrize(static_members=False)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -121,7 +121,6 @@ class ConsumerGroupTest(RedpandaTest):
                                     self.topic_spec.name, 128, msg_cnt, -1)
         self.producer.start()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5885
     @cluster(num_nodes=6)
     @parametrize(static_members=True)
     @parametrize(static_members=False)


### PR DESCRIPTION
## Cover letter

The race condition in a tests caused them to fail as one of the consumer
consumed all of the messages before the others joined the group. As the
test is based on assumption that the consumers will consume from roughly
the same number of partitions it failed. Fixed the race condition by
starting producer after all of the consumers are started. This way we
are certain that consumers are members before any messages appear in the
partitions.

Fixes: #5885
Fixes: #5952

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
