### PR TITLE
Remove ok_to_fail from fixed tests

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -201,9 +201,7 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         rpk.alter_topic_config(self.topic, 'retention.bytes',
                                str(self.segment_size))
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6054
-    # https://github.com/redpanda-data/redpanda/issues/6061
-    # https://github.com/redpanda-data/redpanda/issues/6111
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6111
     @cluster(num_nodes=8)
     def test_create_or_delete_topics_while_busy(self):
         self.logger.info(f"Environment: {os.environ}")

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -375,8 +375,6 @@ class PartitionBalancerTest(EndToEndTest):
             ns.make_available()
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5154
-    # https://github.com/redpanda-data/redpanda/issues/6075
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)
@@ -435,7 +433,6 @@ class PartitionBalancerTest(EndToEndTest):
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5884
-    # https://github.com/redpanda-data/redpanda/issues/5980
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_full_nodes(self):
         """


### PR DESCRIPTION
## Cover letter

Remove ok_to_fail from fixed tests.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none