### PR TITLE
Collect node status information outside of the Raft sub-system

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -111,6 +111,7 @@ v_cc_library(
     partition_balancer_planner.cc
     partition_balancer_backend.cc
     partition_balancer_rpc_handler.cc
+    node_status_backend.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -35,6 +35,13 @@ rpcgen(
   INCLUDES ${CMAKE_BINARY_DIR}/src/v
 )
 
+rpcgen(
+  TARGET node_status_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/node_status_rpc.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/node_status_rpc_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+
 v_cc_library(
   NAME cluster
   SRCS
@@ -111,6 +118,7 @@ v_cc_library(
     id_allocator_rpc
     tx_gateway_rpc
     partition_balancer_rpc
+    node_status_rpc
     v::raft
     Roaring::roaring
     absl::flat_hash_map

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -112,6 +112,7 @@ v_cc_library(
     partition_balancer_backend.cc
     partition_balancer_rpc_handler.cc
     node_status_backend.cc
+    node_status_rpc_handler.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -94,6 +94,13 @@ inline std::vector<topic_result> create_topic_results(
       });
 }
 
+ss::future<> add_one_tcp_client(
+  ss::shard_id owner,
+  ss::sharded<rpc::connection_cache>& clients,
+  model::node_id node,
+  net::unresolved_address addr,
+  config::tls_config tls_config);
+
 ss::future<> update_broker_client(
   model::node_id,
   ss::sharded<rpc::connection_cache>&,

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -48,5 +48,7 @@ class feature_frontend;
 class feature_manager;
 class drain_manager;
 class partition_balancer_backend;
+class node_status_backend;
+class node_status_table;
 
 } // namespace cluster

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -219,25 +219,25 @@ bool members_table::contains(model::node_id id) const {
 notification_id_type
 members_table::register_maintenance_state_change_notification(
   maintenance_state_cb_t cb) {
-    auto id = _notification_id++;
-    _notifications.emplace_back(id, std::move(cb));
+    auto id = _maintenance_state_change_notification_id++;
+    _maintenance_state_change_notifications.emplace_back(id, std::move(cb));
     return id;
 }
 
 void members_table::unregister_maintenance_state_change_notification(
   notification_id_type id) {
     auto it = std::find_if(
-      _notifications.begin(), _notifications.end(), [id](const auto& n) {
-          return n.first == id;
-      });
-    if (it != _notifications.end()) {
-        _notifications.erase(it);
+      _maintenance_state_change_notifications.begin(),
+      _maintenance_state_change_notifications.end(),
+      [id](const auto& n) { return n.first == id; });
+    if (it != _maintenance_state_change_notifications.end()) {
+        _maintenance_state_change_notifications.erase(it);
     }
 }
 
 void members_table::notify_maintenance_state_change(
   model::node_id node_id, model::maintenance_state ms) {
-    for (const auto& [id, cb] : _notifications) {
+    for (const auto& [id, cb] : _maintenance_state_change_notifications) {
         cb(node_id, ms);
     }
 }

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -69,9 +69,9 @@ private:
 
     waiter_queue<model::node_id> _waiters;
 
-    notification_id_type _notification_id{0};
+    notification_id_type _maintenance_state_change_notification_id{0};
     std::vector<std::pair<notification_id_type, maintenance_state_cb_t>>
-      _notifications;
+      _maintenance_state_change_notifications;
 
     void
       notify_maintenance_state_change(model::node_id, model::maintenance_state);

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -57,10 +57,18 @@ public:
     using maintenance_state_cb_t = ss::noncopyable_function<void(
       model::node_id, model::maintenance_state)>;
 
+    using members_updated_cb_t
+      = ss::noncopyable_function<void(std::vector<model::node_id>)>;
+
     notification_id_type
       register_maintenance_state_change_notification(maintenance_state_cb_t);
 
     void unregister_maintenance_state_change_notification(notification_id_type);
+
+    notification_id_type
+      register_members_updated_notification(members_updated_cb_t);
+
+    void unregister_members_updated_notification(notification_id_type);
 
 private:
     using broker_cache_t = absl::flat_hash_map<model::node_id, broker_ptr>;
@@ -73,7 +81,13 @@ private:
     std::vector<std::pair<notification_id_type, maintenance_state_cb_t>>
       _maintenance_state_change_notifications;
 
+    notification_id_type _members_updated_notification_id{0};
+    std::vector<std::pair<notification_id_type, members_updated_cb_t>>
+      _members_updated_notifications;
+
     void
       notify_maintenance_state_change(model::node_id, model::maintenance_state);
+
+    void notify_members_updated();
 };
 } // namespace cluster

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/node_status_backend.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/errc.h"
+#include "cluster/logger.h"
+#include "config/node_config.h"
+#include "ssx/future-util.h"
+
+namespace cluster {
+
+node_status_backend::node_status_backend(
+  model::node_id self,
+  ss::sharded<members_table>& members_table,
+  ss::sharded<features::feature_table>& feature_table,
+  ss::sharded<node_status_table>& node_status_table,
+  config::binding<std::chrono::milliseconds> period)
+  : _self(self)
+  , _members_table(members_table)
+  , _feature_table(feature_table)
+  , _node_status_table(node_status_table)
+  , _period(std::move(period))
+  , _rpc_tls_config(config::node().rpc_server_tls()) {
+    if (!config::shard_local_cfg().disable_public_metrics()) {
+        setup_metrics(_public_metrics);
+    }
+
+    if (!config::shard_local_cfg().disable_metrics()) {
+        setup_metrics(_metrics);
+    }
+
+    _members_table_notification_handle
+      = _members_table.local().register_members_updated_notification(
+        [this](auto ids) {
+            handle_members_updated_notification(std::move(ids));
+        });
+
+    _timer.set_callback([this] { tick(); });
+}
+
+void node_status_backend::handle_members_updated_notification(
+  std::vector<model::node_id> node_ids) {
+    for (const auto& node_id : node_ids) {
+        if (node_id == _self || _discovered_peers.contains(node_id)) {
+            continue;
+        }
+
+        vlog(
+          clusterlog.info,
+          "Node {} has been discovered via members table",
+          node_id);
+        _discovered_peers.insert(node_id);
+    }
+}
+
+ss::future<> node_status_backend::start() {
+    vassert(ss::this_shard_id() == shard, "invoked on a wrong shard");
+
+    co_await _node_connection_cache.start(
+      rpc::connection_cache_label{"node_status_backend"});
+
+    _timer.rearm(ss::lowres_clock::now());
+}
+
+ss::future<> node_status_backend::stop() {
+    vassert(ss::this_shard_id() == shard, "invoked on a wrong shard");
+
+    _metrics.clear();
+    _public_metrics.clear();
+
+    _members_table.local().unregister_members_updated_notification(
+      _members_table_notification_handle);
+    _timer.cancel();
+    return _gate.close().then([this] { return _node_connection_cache.stop(); });
+}
+
+void node_status_backend::tick() {
+    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
+                          return collect_and_store_updates().finally([this] {
+                              if (!_gate.is_closed()) {
+                                  _timer.rearm(
+                                    ss::lowres_clock::now() + _period());
+                              }
+                          });
+                      }).handle_exception([](const std::exception_ptr& e) {
+        vlog(
+          clusterlog.debug,
+          "Exception during node status provider tick: {}",
+          e);
+    });
+}
+
+ss::future<> node_status_backend::collect_and_store_updates() {
+    if (!_feature_table.local().is_active(
+          features::feature::raftless_node_status)) {
+        co_return;
+    }
+
+    auto updates = co_await collect_updates_from_peers();
+    co_return co_await _node_status_table.invoke_on_all(
+      [updates = std::move(updates)](auto& table) {
+          table.update_peers(updates);
+      });
+}
+
+ss::future<std::vector<node_status>>
+node_status_backend::collect_updates_from_peers() {
+    node_status_request request = {.sender_metadata = {.node_id = _self}};
+
+    auto results = co_await ssx::parallel_transform(
+      _discovered_peers.begin(),
+      _discovered_peers.end(),
+      [this, request = std::move(request)](auto peer_id) {
+          return send_node_status_request(peer_id, request);
+      });
+
+    std::vector<node_status> updates;
+    updates.reserve(results.size());
+
+    for (auto& result : results) {
+        if (!result.has_error()) {
+            updates.push_back(std::move(result.value()));
+        }
+    }
+
+    co_return updates;
+}
+
+ss::future<result<node_status>> node_status_backend::send_node_status_request(
+  model::node_id target, node_status_request r) {
+    auto gate_holder = _gate.hold();
+
+    auto broker = _members_table.local().get_broker(target);
+    if (!broker) {
+        co_return make_error_code(errc::node_does_not_exists);
+    }
+
+    auto connection_source_shard = co_await maybe_create_client(
+      target, broker.value()->rpc_address());
+
+    auto send_by = rpc::clock_type::now() + _period();
+    auto reply = co_await _node_connection_cache.local()
+                   .with_node_client<node_status_rpc_client_protocol>(
+                     _self,
+                     connection_source_shard,
+                     target,
+                     send_by,
+                     [send_by, r = std::move(r)](auto client) mutable {
+                         return client.node_status(
+                           std::move(r), rpc::client_opts(send_by));
+                     })
+                   .then(&rpc::get_ctx_data<node_status_reply>);
+
+    co_return process_reply(reply);
+}
+
+ss::future<ss::shard_id> node_status_backend::maybe_create_client(
+  model::node_id target, net::unresolved_address address) {
+    auto source_shard = target % ss::smp::count;
+    auto target_shard = rpc::connection_cache::shard_for(
+      _self, source_shard, target);
+
+    co_await add_one_tcp_client(
+      target_shard, _node_connection_cache, target, address, _rpc_tls_config);
+
+    co_return source_shard;
+}
+
+result<node_status>
+node_status_backend::process_reply(result<node_status_reply> reply) {
+    vassert(ss::this_shard_id() == shard, "invoked on a wrong shard");
+
+    if (!reply.has_error()) {
+        _stats.rpcs_sent += 1;
+        auto& replier_metadata = reply.value().replier_metadata;
+
+        return node_status{
+          .node_id = replier_metadata.node_id,
+          .last_seen = rpc::clock_type::now()};
+    } else {
+        auto err = reply.error();
+        if (
+          err.category() == rpc::error_category()
+          && static_cast<rpc::errc>(err.value())
+               == rpc::errc::client_request_timeout) {
+            _stats.rpcs_timed_out += 1;
+        }
+
+        vlog(
+          clusterlog.debug,
+          "Error occurred while sending node status request: {}",
+          err.message());
+
+        return err;
+    }
+}
+
+ss::future<node_status_reply>
+node_status_backend::process_request(node_status_request) {
+    _stats.rpcs_received += 1;
+
+    node_status_reply reply = {.replier_metadata = {.node_id = _self}};
+    return ss::make_ready_future<node_status_reply>(std::move(reply));
+}
+
+void node_status_backend::setup_metrics(
+  ss::metrics::metric_groups& metric_groups) {
+    namespace sm = ss::metrics;
+
+    metric_groups.add_group(
+      prometheus_sanitize::metrics_name("node_status"),
+      {
+        sm::make_gauge(
+          "rpcs_sent",
+          [this] { return _stats.rpcs_sent; },
+          sm::description("Number of node status RPCs sent by this node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "rpcs_timed_out",
+          [this] { return _stats.rpcs_timed_out; },
+          sm::description(
+            "Number of timed out node status RPCs from this node"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "rpcs_received",
+          [this] { return _stats.rpcs_received; },
+          sm::description("Number of node status RPCs received by this node"))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/members_table.h"
+#include "cluster/node_status_rpc_service.h"
+#include "cluster/node_status_table.h"
+#include "config/property.h"
+#include "features/feature_table.h"
+#include "rpc/connection_cache.h"
+#include "rpc/types.h"
+#include "seastarx.h"
+#include "ssx/metrics.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timer.hh>
+
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster {
+
+/*
+ * node_status_backend is the backend behind node status sub-system. Its purpose
+ * is to collect metadata from which a peer's status can be inferred outside of
+ * Raft. It is intended for lower-level use cases such as the RPC and consensus
+ * layers. At higher levels of abstraction health_monitor should be used.
+ *
+ * node_status_backend runs on shard 0 of every node. Its operation is as
+ * follows:
+ * 1. Maintain a list of peers for this node. This is currently done via a
+ * callback from the members_table.
+ * 2. Send a periodic node_status RPC to all known peers
+ * 3. Update the shard-local node_status_table with the metadata from the
+ * responses
+ */
+class node_status_backend {
+public:
+    static constexpr ss::shard_id shard = 0;
+
+    node_status_backend(
+      model::node_id,
+      ss::sharded<members_table>&,
+      ss::sharded<features::feature_table>&,
+      ss::sharded<node_status_table>&,
+      config::binding<std::chrono::milliseconds>);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    void handle_members_updated_notification(std::vector<model::node_id>);
+
+    void tick();
+
+    ss::future<> collect_and_store_updates();
+    ss::future<std::vector<node_status>> collect_updates_from_peers();
+
+    result<node_status> process_reply(result<node_status_reply>);
+    ss::future<node_status_reply> process_request(node_status_request);
+
+    ss::future<result<node_status>>
+      send_node_status_request(model::node_id, node_status_request);
+
+    ss::future<ss::shard_id>
+      maybe_create_client(model::node_id, net::unresolved_address);
+
+    void setup_metrics(ss::metrics::metric_groups&);
+
+    struct statistics {
+        int64_t rpcs_sent;
+        int64_t rpcs_timed_out;
+        int64_t rpcs_received;
+    };
+
+private:
+    model::node_id _self;
+    ss::sharded<members_table>& _members_table;
+    ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<node_status_table>& _node_status_table;
+
+    config::binding<std::chrono::milliseconds> _period;
+    config::tls_config _rpc_tls_config;
+    ss::sharded<rpc::connection_cache> _node_connection_cache;
+
+    absl::flat_hash_set<model::node_id> _discovered_peers;
+    ss::gate _gate;
+    ss::timer<ss::lowres_clock> _timer;
+    notification_id_type _members_table_notification_handle;
+
+    statistics _stats{};
+    ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
+};
+
+} // namespace cluster

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -100,6 +100,8 @@ private:
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics{
       ssx::metrics::public_metrics_handle};
+
+    friend class node_status_rpc_handler;
 };
 
 } // namespace cluster

--- a/src/v/cluster/node_status_rpc.json
+++ b/src/v/cluster/node_status_rpc.json
@@ -1,0 +1,14 @@
+{
+    "namespace": "cluster",
+    "service_name": "node_status_rpc",
+    "includes": [
+        "cluster/node_status_rpc_types.h"
+    ],
+    "methods": [
+        {
+            "name": "node_status",
+            "input_type": "node_status_request",
+            "output_type": "node_status_reply"
+        }
+    ]
+}

--- a/src/v/cluster/node_status_rpc_handler.cc
+++ b/src/v/cluster/node_status_rpc_handler.cc
@@ -1,0 +1,20 @@
+#include "cluster/node_status_rpc_handler.h"
+
+namespace cluster {
+
+node_status_rpc_handler::node_status_rpc_handler(
+  ss::scheduling_group sg,
+  ss::smp_service_group ssg,
+  ss::sharded<node_status_backend>& node_status_backend)
+  : node_status_rpc_service(sg, ssg)
+  , _node_status_backend(node_status_backend) {}
+
+ss::future<node_status_reply> node_status_rpc_handler::node_status(
+  node_status_request&& r, rpc::streaming_context&) {
+    return _node_status_backend.invoke_on(
+      node_status_backend::shard, [r = std::move(r)](auto& service) {
+          return service.process_request(std::move(r));
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/node_status_rpc_handler.h
+++ b/src/v/cluster/node_status_rpc_handler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "cluster/node_status_backend.h"
+#include "cluster/node_status_rpc_service.h"
+#include "cluster/node_status_rpc_types.h"
+
+namespace cluster {
+
+class node_status_rpc_handler final : public node_status_rpc_service {
+public:
+    node_status_rpc_handler(
+      ss::scheduling_group,
+      ss::smp_service_group,
+      ss::sharded<node_status_backend>&);
+
+    virtual ss::future<node_status_reply>
+    node_status(node_status_request&&, rpc::streaming_context&) override;
+
+private:
+    ss::sharded<node_status_backend>& _node_status_backend;
+};
+
+} // namespace cluster

--- a/src/v/cluster/node_status_rpc_types.h
+++ b/src/v/cluster/node_status_rpc_types.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/metadata.h"
+#include "serde/serde.h"
+
+namespace cluster {
+
+struct node_status_metadata
+  : serde::envelope<node_status_metadata, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::node_id node_id;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const node_status_metadata& nsm) {
+        fmt::print(o, "{{node_id:{}}}", nsm.node_id);
+        return o;
+    }
+};
+
+struct node_status_request
+  : serde::envelope<node_status_request, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    node_status_metadata sender_metadata;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const node_status_request& r) {
+        fmt::print(o, "{{sender_metadata: {}}}", r.sender_metadata);
+        return o;
+    }
+};
+
+struct node_status_reply
+  : serde::envelope<node_status_reply, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    node_status_metadata replier_metadata;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const node_status_reply& r) {
+        fmt::print(o, "{{replier_metadata: {}}}", r.replier_metadata);
+        return o;
+    }
+};
+
+} // namespace cluster

--- a/src/v/cluster/node_status_table.h
+++ b/src/v/cluster/node_status_table.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/metadata.h"
+#include "rpc/types.h"
+
+namespace cluster {
+
+struct node_status {
+    model::node_id node_id;
+    rpc::clock_type::time_point last_seen;
+};
+
+class node_status_table {
+public:
+    explicit node_status_table(model::node_id self)
+      : _self(self) {}
+
+    std::optional<node_status> get_node_status(model::node_id node) const {
+        if (node == _self) {
+            return node_status{
+              .node_id = node, .last_seen = rpc::clock_type::now()};
+        }
+
+        if (auto it = _peers_status.find(node); it != _peers_status.end()) {
+            return it->second;
+        }
+
+        return std::nullopt;
+    }
+
+    void update_peers(std::vector<node_status> updates) {
+        for (auto& node_status : updates) {
+            _peers_status[node_status.node_id] = std::move(node_status);
+        }
+    }
+
+private:
+    model::node_id _self;
+    absl::flat_hash_map<model::node_id, node_status> _peers_status;
+};
+} // namespace cluster

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1387,7 +1387,14 @@ configuration::configuration()
       "enable_rack_awareness",
       "Enables rack-aware replica assignment",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false) {}
+      false)
+  , node_status_interval(
+      *this,
+      "node_status_interval",
+      "Time interval between two node status messages. Node status messages "
+      "establish liveness status outside of the Raft protocol.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100ms) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -296,6 +296,8 @@ struct configuration final : public config_store {
     // enables rack aware replica assignment
     property<bool> enable_rack_awareness;
 
+    property<std::chrono::milliseconds> node_status_interval;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -39,6 +39,8 @@ std::string_view to_string_view(feature f) {
         return "raft_improved_configuration";
     case feature::transaction_ga:
         return "transaction_ga";
+    case feature::raftless_node_status:
+        return "raftless_node_status";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -40,6 +40,7 @@ enum class feature : std::uint64_t {
     license = 0x40,
     raft_improved_configuration = 0x80,
     transaction_ga = 0x100,
+    raftless_node_status = 0x200,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -144,6 +145,12 @@ constexpr static std::array feature_schema{
     cluster_version{6},
     "transaction_ga",
     feature::transaction_ga,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{6},
+    "raftless_node_status",
+    feature::raftless_node_status,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "net/unresolved_address.h"
 #include "rpc/logger.h"
+#include "rpc/types.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -68,7 +69,7 @@ public:
 
     void setup_metrics(
       ss::metrics::metric_groups& mgs,
-      const std::optional<ss::sstring>& service_name,
+      const std::optional<rpc::connection_cache_label>& label,
       const net::unresolved_address& target_addr);
 
 private:

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -147,14 +147,14 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
 
 void client_probe::setup_metrics(
   ss::metrics::metric_groups& mgs,
-  const std::optional<ss::sstring>& service_name,
+  const std::optional<rpc::connection_cache_label>& label,
   const net::unresolved_address& target_addr) {
     namespace sm = ss::metrics;
     auto target = sm::label("target");
     std::vector<sm::label_instance> labels = {
       target(ssx::sformat("{}:{}", target_addr.host(), target_addr.port()))};
-    if (service_name) {
-        labels.push_back(sm::label("service_name")(*service_name));
+    if (label) {
+        labels.push_back(sm::label("connection_cache_label")((*label)()));
     }
     mgs.add_group(
       prometheus_sanitize::metrics_name("rpc_client"),

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -39,6 +39,28 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/peer_status/{id}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get peer status",
+                    "type": "peer_status",
+                    "nickname": "get_peer_status",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -77,6 +99,16 @@
                 "partition_revision": {
                     "type": "long",
                     "description": "partition revision"
+                }
+            }
+        },
+        "peer_status": {
+            "id": "peer_status",
+            "description": "Peer status",
+            "properties": {
+                "since_last_status": {
+                    "type": "long",
+                    "description": "Milliseconds since last update from peer"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -52,7 +52,8 @@ public:
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<archival::scheduler_service>&,
-      ss::sharded<rpc::connection_cache>&);
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<cluster::node_status_table>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -238,4 +239,5 @@ private:
     request_authenticator _auth;
     bool _ready{false};
     ss::sharded<archival::scheduler_service>& _archival_service;
+    ss::sharded<cluster::node_status_table>& _node_status_table;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -582,7 +582,8 @@ void application::configure_admin_server() {
       std::ref(shard_table),
       std::ref(metadata_cache),
       std::ref(archival_scheduler),
-      std::ref(_connection_cache))
+      std::ref(_connection_cache),
+      std::ref(node_status_table))
       .get();
 }
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,8 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "cluster/node_status_backend.h"
+#include "cluster/node_status_table.h"
 #include "config/node_config.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
@@ -103,6 +105,8 @@ public:
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
     ss::sharded<v8_engine::data_policy_table> data_policies;
     ss::sharded<cloud_storage::cache> shadow_index_cache;
+    ss::sharded<cluster::node_status_backend> node_status_backend;
+    ss::sharded<cluster::node_status_table> node_status_table;
 
 private:
     using deferred_actions

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -36,6 +36,7 @@ public:
           "raft_learner_recovery", 50);
         _archival_upload = co_await ss::create_scheduling_group(
           "archival_upload", 100);
+        _node_status = co_await ss::create_scheduling_group("node_status", 50);
     }
 
     ss::future<> destroy_groups() {
@@ -48,6 +49,7 @@ public:
         co_await destroy_scheduling_group(_compaction);
         co_await destroy_scheduling_group(_raft_learner_recovery);
         co_await destroy_scheduling_group(_archival_upload);
+        co_await destroy_scheduling_group(_node_status);
         co_return;
     }
 
@@ -64,6 +66,7 @@ public:
         return _raft_learner_recovery;
     }
     ss::scheduling_group archival_upload() { return _archival_upload; }
+    ss::scheduling_group node_status() { return _node_status; }
 
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
@@ -77,7 +80,9 @@ public:
           std::cref(_cache_background_reclaim),
           std::cref(_compaction),
           std::cref(_raft_learner_recovery),
-          std::cref(_archival_upload)};
+          std::cref(_archival_upload),
+          std::cref(_node_status),
+        };
     }
 
 private:
@@ -92,4 +97,5 @@ private:
     ss::scheduling_group _compaction;
     ss::scheduling_group _raft_learner_recovery;
     ss::scheduling_group _archival_upload;
+    ss::scheduling_group _node_status;
 };

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -17,6 +17,9 @@
 
 namespace rpc {
 
+connection_cache::connection_cache(std::optional<connection_cache_label> label)
+  : _label(std::move(label)) {}
+
 /// \brief needs to be a future, because mutations may come from different
 /// fibers and they need to be synchronized
 ss::future<> connection_cache::emplace(
@@ -33,7 +36,7 @@ ss::future<> connection_cache::emplace(
         _cache.emplace(
           n,
           ss::make_lw_shared<rpc::reconnect_transport>(
-            std::move(c), std::move(backoff_policy)));
+            std::move(c), std::move(backoff_policy), _label));
     });
 }
 ss::future<> connection_cache::remove(model::node_id n) {

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -40,7 +40,9 @@ public:
       model::node_id node,
       ss::shard_id max_shards = ss::smp::count);
 
-    connection_cache() = default;
+    explicit connection_cache(
+      std::optional<connection_cache_label> label = std::nullopt);
+
     bool contains(model::node_id n) const {
         return _cache.find(n) != _cache.end();
     }
@@ -127,6 +129,7 @@ public:
     }
 
 private:
+    std::optional<connection_cache_label> _label;
     mutex _mutex; // to add/remove nodes
     underlying _cache;
 };

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -27,8 +27,10 @@ namespace rpc {
 class reconnect_transport {
 public:
     explicit reconnect_transport(
-      rpc::transport_configuration c, backoff_policy backoff_policy)
-      : _transport(std::move(c))
+      rpc::transport_configuration c,
+      backoff_policy backoff_policy,
+      std::optional<connection_cache_label> label = std::nullopt)
+      : _transport(std::move(c), std::move(label))
       , _backoff_policy(std::move(backoff_policy)) {}
 
     bool is_valid() const { return _transport.is_valid(); }

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -52,15 +52,14 @@ struct client_context_impl final : streaming_context {
 };
 
 transport::transport(
-  transport_configuration c,
-  [[maybe_unused]] std::optional<ss::sstring> service_name)
+  transport_configuration c, std::optional<connection_cache_label> label)
   : base_transport(base_transport::configuration{
     .server_addr = std::move(c.server_addr),
     .credentials = std::move(c.credentials),
   })
   , _memory(c.max_queued_bytes, "rpc/transport-mem") {
     if (!c.disable_metrics) {
-        setup_metrics(service_name);
+        setup_metrics(label);
     }
 }
 
@@ -283,8 +282,9 @@ ss::future<> transport::dispatch(header h) {
     return fut;
 }
 
-void transport::setup_metrics(const std::optional<ss::sstring>& service_name) {
-    _probe.setup_metrics(_metrics, service_name, server_address());
+void transport::setup_metrics(
+  const std::optional<connection_cache_label>& label) {
+    _probe.setup_metrics(_metrics, label, server_address());
 }
 
 transport::~transport() {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -47,7 +47,7 @@ class transport final : public net::base_transport {
 public:
     explicit transport(
       transport_configuration c,
-      std::optional<ss::sstring> service_name = std::nullopt);
+      std::optional<connection_cache_label> label = std::nullopt);
     ~transport() override;
     transport(transport&&) noexcept = default;
     // semaphore is not move assignable
@@ -84,7 +84,7 @@ private:
     ss::future<> do_reads();
     ss::future<> dispatch(header);
     void fail_outstanding_futures() noexcept final;
-    void setup_metrics(const std::optional<ss::sstring>&);
+    void setup_metrics(const std::optional<connection_cache_label>&);
 
     ss::future<result<std::unique_ptr<streaming_context>>>
       do_send(sequence_t, netbuf, rpc::client_opts);

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -49,6 +49,9 @@ using timer_type = ss::timer<clock_type>;
 static constexpr clock_type::time_point no_timeout
   = clock_type::time_point::max();
 
+using connection_cache_label
+  = named_type<ss::sstring, struct connection_cache_label_tag>;
+
 enum class compression_type : uint8_t {
     none = 0,
     zstd,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -753,3 +753,7 @@ class Admin:
                              "cluster/partition_balancer/status",
                              node=node,
                              **kwargs).json()
+
+    def get_peer_status(self, node, peer_id):
+        return self._request("GET", f"debug/peer_status/{peer_id}",
+                             node=node).json()

--- a/tests/rptest/tests/node_status_test.py
+++ b/tests/rptest/tests/node_status_test.py
@@ -1,0 +1,175 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import requests
+from enum import IntEnum
+
+import numpy as np
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from ducktape.cluster.cluster import ClusterNode
+
+NODE_STATUS_INTERVAL = 100  # milliseconds
+JITTER = 25
+MAX_DELTA = NODE_STATUS_INTERVAL + JITTER
+
+
+def is_live(since_last_status: int) -> bool:
+    return since_last_status <= MAX_DELTA
+
+
+class ConnectionStatus(IntEnum):
+    ALIVE = 0
+    DOWN = 1
+    UNKNOWN = 2
+
+
+class StatusGraph:
+    """
+    This class models a status graph for the Redpanda nodes in a
+    cluster. It supports marking nodes available, unavailable (i.e. a
+    node that has joined the cluster, but is not available) and
+    unknown (i.e. a node that has not yet joined the cluster).
+
+    The cluster connection status can be verified via the
+    check_cluster_status member. It checks that the status is as
+    expected between each pair of nodes via the peer_status admin
+    request.
+    """
+    def __init__(self, redpanda):
+        self.redpanda = redpanda
+        nodes = self.redpanda.nodes
+
+        self.node_to_vertex = {node: i for i, node in enumerate(nodes)}
+        self.vertex_to_node = {
+            i: node
+            for node, i in self.node_to_vertex.items()
+        }
+        self.shape = (len(nodes), len(nodes))
+        self.edges = np.full(shape=self.shape,
+                             fill_value=ConnectionStatus.ALIVE)
+
+    def mark_node_unavailable(self, unavailable_node: ClusterNode):
+        generated_id = self.node_to_vertex[unavailable_node]
+        self.edges[:, generated_id] = ConnectionStatus.DOWN
+        self.edges[generated_id] = ConnectionStatus.DOWN
+
+    def mark_node_available(self, available_node: ClusterNode):
+        generated_id = self.node_to_vertex[available_node]
+        self.edges[generated_id] = ConnectionStatus.ALIVE
+        self.edges[:, generated_id] = ConnectionStatus.ALIVE
+
+    def mark_node_unknwon(self, available_node: ClusterNode):
+        generated_id = self.node_to_vertex[available_node]
+        self.edges[generated_id] = ConnectionStatus.UNKNOWN
+        self.edges[:, generated_id] = ConnectionStatus.UNKNOWN
+
+    def is_node_available(self, node: ClusterNode):
+        vertex = self.node_to_vertex[node]
+        return self.edges[vertex][vertex] == ConnectionStatus.ALIVE
+
+    def check_cluster_status(self):
+        admin = Admin(self.redpanda)
+
+        for node, peer, expected_status in self._all_edges():
+            if not self.is_node_available(node):
+                # The starting node is unavailable so the request
+                # for peer status would not get a response.
+                continue
+
+            self.redpanda.logger.debug(
+                f"Checking status of peer {self.redpanda.idx(peer)} "
+                f"from node {self.redpanda.idx(node)}")
+            peer_status = self._get_peer_status(admin, node, peer)
+
+            if expected_status == ConnectionStatus.UNKNOWN:
+                assert peer_status is None, f"Expected no reponse from node {peer.name}"
+            if expected_status == ConnectionStatus.ALIVE:
+                ms_since_last_status = peer_status["since_last_status"]
+                assert is_live(
+                    ms_since_last_status
+                ), f"Expected node {peer.name} to be alive, but since_last_status > max_delta: ms_since_last_status={ms_since_last_status}, tolerance={MAX_DELTA}"
+            elif expected_status == ConnectionStatus.DOWN:
+                ms_since_last_status = peer_status["since_last_status"]
+                assert not is_live(
+                    ms_since_last_status
+                ), f"Expected node {peer.name} to be down, but ms_since_last_status <= max_delta: ms_since_last_status={ms_since_last_status}, tolerance={MAX_DELTA}"
+
+    def _all_edges(self):
+        for start_vertex, end_vertex in np.ndindex(self.shape):
+            start_node = self.vertex_to_node[start_vertex]
+            end_node = self.vertex_to_node[end_vertex]
+
+            yield (start_node, end_node, self.edges[start_vertex, end_vertex])
+
+    def _get_peer_status(self, admin: Admin, node: ClusterNode,
+                         peer: ClusterNode):
+        try:
+            return admin.get_peer_status(node, self.redpanda.idx(peer))
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code
+            if status_code != 400:
+                raise e
+            else:
+                return None
+
+
+class NodeStatusTest(RedpandaTest):
+    def __init__(self, ctx):
+        super().__init__(
+            test_context=ctx,
+            extra_rp_conf={"node_status_interval": NODE_STATUS_INTERVAL})
+
+    @cluster(num_nodes=3)
+    def test_all_nodes_up(self):
+        status_graph = StatusGraph(self.redpanda)
+        status_graph.check_cluster_status()
+
+    @cluster(num_nodes=3)
+    def test_node_down(self):
+        status_graph = StatusGraph(self.redpanda)
+
+        node_to_stop = random.choice(self.redpanda.nodes)
+        status_graph.mark_node_unavailable(node_to_stop)
+
+        self.redpanda.stop_node(node_to_stop)
+
+        status_graph.check_cluster_status()
+
+
+class NodeStatusStartupTest(RedpandaTest):
+    def __init__(self, ctx):
+        super().__init__(
+            test_context=ctx,
+            num_brokers=3,
+            extra_rp_conf={"node_status_interval": NODE_STATUS_INTERVAL})
+
+    def setUp(self):
+        pass
+
+    @cluster(num_nodes=3)
+    def test_late_joiner(self):
+        # Start the first two nodes
+        self.redpanda.start(self.redpanda.nodes[0:-1])
+        late_joiner = self.redpanda.nodes[-1]
+
+        # Check the cluster status with the unavailable node
+        status_graph = StatusGraph(self.redpanda)
+        status_graph.mark_node_unknwon(late_joiner)
+        status_graph.check_cluster_status()
+
+        # Start the late joiner
+        self.redpanda.start([late_joiner])
+
+        # Check the cluster status again
+        status_graph.mark_node_available(late_joiner)
+        status_graph.check_cluster_status()


### PR DESCRIPTION
## Cover letter

This PR introduces a new node status mechanism that operates outside of Raft. The node_status_provider subsystem runs on shard 0 of every node. Briefly it operates like this:
1. Maintain a list of peers via a callback from the members table.
2. Periodically send a node_status RPC to all known peers and keep track of when the last reply was received from each node.
Note that this sub-system creates and uses it's own TCP connections and does not reuse the ones created by the RPC server. This is done in order to contention. 
3. Expose the metadata in the node_status request along with a timestamp of when the peer was last seen.

The users of this sub-system should be other low-level abstractions: the RPC and consensus layers. Higher level sub-systems should continue to use the health monitor.

This PR does not include integrations of the new subsystem. Those will come in follow up PRs. Currently the following integrations are planned:
1. Loosening of Raft timeouts if the leader has recently responded to a node_status RPC. This should result in less election activity when the system runs into heartbeat time-outs due to resource contention caused by competing Raft groups.
2. Expose disk queue metadata for the coordinate recovery subsystem.
2. Integrate with the health monitor in order to make the following liveness definition available to higher level subsystems:
"A node is alive if it can respond to node_status request" in a timely manner. This will co-exist with the existing Raft definition of liveness.

To keep this PR relatively small I've omitted a few things which I plan to add in separate PRs. They're listed below. Let me know if you think they have to be part of this PR.
1. Currently, no RPCs are sent until enough of the controller log has been replayed for the feature manager to become aware the feature is active. We can address this by persisting the feature manager state to the kv-store and initialising from it.
2. The list of peers is not initialised with the latest Raft configuration from the kv-store.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
