### PR TITLE
Change topic replication factor

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -91,6 +91,7 @@ static constexpr int8_t update_topic_properties_cmd_type = 4;
 static constexpr int8_t create_partition_cmd_type = 5;
 static constexpr int8_t create_non_replicable_topic_cmd_type = 6;
 static constexpr int8_t cancel_moving_partition_replicas_cmd_type = 7;
+static constexpr int8_t move_topic_replicas_cmd_type = 8;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -137,6 +138,12 @@ using move_partition_replicas_cmd = controller_command<
   move_partition_replicas_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::adl_and_serde>;
+
+using move_topic_replicas_cmd = controller_command<
+  model::topic_namespace,
+  std::vector<move_topic_replicas_data>,
+  move_topic_replicas_cmd_type,
+  model::record_batch_type::topic_management_cmd>;
 
 using finish_moving_partition_replicas_cmd = controller_command<
   model::ntp,

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -191,7 +191,11 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
             std::ref(_hm_frontend),
             std::ref(_as),
             std::ref(_cloud_storage_api),
-            std::ref(_feature_table));
+            std::ref(_feature_table),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .storage_space_alert_free_threshold_percent.bind();
+            }));
       })
       .then([this] {
           return _members_backend.start_single(

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -188,6 +188,7 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
             std::ref(_partition_leaders),
             std::ref(_tp_state),
             std::ref(_data_policy_frontend),
+            std::ref(_hm_frontend),
             std::ref(_as),
             std::ref(_cloud_storage_api),
             std::ref(_feature_table));

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -233,7 +233,7 @@ partition_constraints partition_balancer_planner::get_partition_constraints(
 
     return partition_constraints(
       assignments.id,
-      topic_metadata.get_configuration().replication_factor,
+      topic_metadata.get_replication_factor(),
       std::move(allocation_constraints));
 }
 

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -25,16 +25,20 @@
 #include <chrono>
 #include <vector>
 
-std::vector<cluster::topic_configuration> test_topics_configuration() {
+std::vector<cluster::topic_configuration> test_topics_configuration(
+  cluster::replication_factor rf = cluster::replication_factor{1}) {
     return std::vector<cluster::topic_configuration>{
-      cluster::topic_configuration(test_ns, model::topic("tp-1"), 10, 1),
-      cluster::topic_configuration(test_ns, model::topic("tp-2"), 10, 1),
-      cluster::topic_configuration(test_ns, model::topic("tp-3"), 10, 1),
+      cluster::topic_configuration(test_ns, model::topic("tp-1"), 10, rf),
+      cluster::topic_configuration(test_ns, model::topic("tp-2"), 10, rf),
+      cluster::topic_configuration(test_ns, model::topic("tp-3"), 10, rf),
     };
 }
 
 void validate_topic_metadata(cluster::metadata_cache& cache) {
-    auto expected_topics = test_topics_configuration();
+    cluster::replication_factor expected_replication_factor
+      = cluster::replication_factor{1};
+    auto expected_topics = test_topics_configuration(
+      expected_replication_factor);
 
     for (auto& t_cfg : expected_topics) {
         auto tp_md = cache.get_topic_metadata(t_cfg.tp_ns);
@@ -44,7 +48,8 @@ void validate_topic_metadata(cluster::metadata_cache& cache) {
         auto cfg = cache.get_topic_cfg(t_cfg.tp_ns);
         BOOST_REQUIRE_EQUAL(cfg->tp_ns, t_cfg.tp_ns);
         BOOST_REQUIRE_EQUAL(cfg->partition_count, t_cfg.partition_count);
-        BOOST_REQUIRE_EQUAL(cfg->replication_factor, t_cfg.replication_factor);
+        BOOST_REQUIRE_EQUAL(
+          tp_md->get_replication_factor(), expected_replication_factor);
         BOOST_REQUIRE_EQUAL(
           cfg->properties.compaction_strategy,
           t_cfg.properties.compaction_strategy);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -734,6 +734,14 @@ topic_table::get_topic_cfg(model::topic_namespace_view tp) const {
     return {};
 }
 
+std::optional<replication_factor> topic_table::get_topic_replication_factor(
+  model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return it->second.get_replication_factor();
+    }
+    return {};
+}
+
 std::optional<assignments_set>
 topic_table::get_topic_assignments(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -220,6 +220,7 @@ public:
       apply(create_non_replicable_topic_cmd, model::offset);
     ss::future<std::error_code>
       apply(cancel_moving_partition_replicas_cmd, model::offset);
+    ss::future<std::error_code> apply(move_topic_replicas_cmd, model::offset);
     ss::future<> stop();
 
     /// Delta API

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -365,6 +365,13 @@ private:
     std::vector<std::invoke_result_t<Func, const topic_metadata_item&>>
     transform_topics(Func&&) const;
 
+    void change_partition_replicas(
+      model::ntp ntp,
+      const std::vector<model::broker_shard>& new_assignment,
+      topic_metadata_item& metadata,
+      partition_assignment& current_assignment,
+      model::offset o);
+
     underlying_t _topics;
     hierarchy_t _topics_hierarchy;
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -149,6 +149,10 @@ public:
         topic_configuration& get_configuration() {
             return metadata.get_configuration();
         }
+
+        replication_factor get_replication_factor() const {
+            return metadata.get_replication_factor();
+        }
     };
 
     using delta = topic_table_delta;
@@ -259,6 +263,12 @@ public:
     /// If topic does not exists it returns an empty optional
     std::optional<topic_configuration>
       get_topic_cfg(model::topic_namespace_view) const;
+
+    ///\brief Returns configuration of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    std::optional<replication_factor>
+      get_topic_replication_factor(model::topic_namespace_view) const;
 
     ///\brief Returns partition assignments of single topic.
     ///

--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/cluster_utils.h"
 #include "cluster/topic_table.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "prometheus/prometheus_sanitize.h"
@@ -149,10 +150,10 @@ void topic_table_probe::handle_topic_creation(
          [this, topic_namespace] {
              auto md = _topic_table.get_topic_metadata_ref(topic_namespace);
              if (md) {
-                 return md.value().get().get_configuration().replication_factor;
+                 return md.value().get().get_replication_factor();
              }
 
-             return int16_t{0};
+             return cluster::replication_factor{0};
          },
          sm::description("Configured number of replicas for the topic"),
          labels)

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -65,7 +65,8 @@ public:
       update_topic_properties_cmd,
       create_partition_cmd,
       create_non_replicable_topic_cmd,
-      cancel_moving_partition_replicas_cmd>();
+      cancel_moving_partition_replicas_cmd,
+      move_topic_replicas_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -57,6 +57,7 @@ topics_frontend::topics_frontend(
   ss::sharded<partition_leaders_table>& l,
   ss::sharded<topic_table>& topics,
   ss::sharded<data_policy_frontend>& dp_frontend,
+  ss::sharded<health_monitor_frontend>& hm_frontend,
   ss::sharded<ss::abort_source>& as,
   ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::sharded<features::feature_table>& features)
@@ -67,6 +68,7 @@ topics_frontend::topics_frontend(
   , _leaders(l)
   , _topics(topics)
   , _dp_frontend(dp_frontend)
+  , _hm_frontend(hm_frontend)
   , _as(as)
   , _cloud_storage_api(cloud_storage_api)
   , _features(features) {}

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -257,6 +257,11 @@ ss::future<std::error_code> topics_frontend::do_update_replication_factor(
   topic_properties_update& update, model::timeout_clock::time_point timeout) {
     switch (update.custom_properties.replication_factor.op) {
     case incremental_update_operation::set: {
+        if (!_features.local().is_active(
+              features::feature::replication_factor_change)) {
+            co_return cluster::errc::feature_disabled;
+        }
+
         auto value = update.custom_properties.replication_factor.value;
         if (
           !value.has_value()

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -44,6 +44,7 @@ public:
       ss::sharded<partition_leaders_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<data_policy_frontend>&,
+      ss::sharded<health_monitor_frontend>&,
       ss::sharded<ss::abort_source>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<features::feature_table>&);
@@ -188,6 +189,7 @@ private:
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<topic_table>& _topics;
     ss::sharded<data_policy_frontend>& _dp_frontend;
+    ss::sharded<health_monitor_frontend>& _hm_frontend;
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<features::feature_table>& _features;

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -145,8 +145,25 @@ private:
 
     ss::future<std::error_code> do_update_data_policy(
       topic_properties_update&, model::timeout_clock::time_point);
+    ss::future<std::error_code> do_update_replication_factor(
+      topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(
       topic_properties_update, model::timeout_clock::time_point);
+
+    ss::future<std::error_code> change_replication_factor(
+      model::topic_namespace,
+      cluster::replication_factor,
+      model::timeout_clock::time_point);
+
+    using new_replicas_assigment = std::vector<move_topic_replicas_data>;
+    ss::future<std::error_code> increase_replication_factor(
+      model::topic_namespace,
+      cluster::replication_factor,
+      model::timeout_clock::time_point);
+    ss::future<std::error_code> decrease_replication_factor(
+      model::topic_namespace,
+      cluster::replication_factor,
+      model::timeout_clock::time_point);
 
     ss::future<result<model::offset>>
       stm_linearizable_barrier(model::timeout_clock::time_point);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -524,8 +524,10 @@ std::ostream&
 operator<<(std::ostream& o, const incremental_topic_custom_updates& i) {
     fmt::print(
       o,
-      "{{incremental_topic_custom_updates: data_policy: {}}}",
-      i.data_policy);
+      "{{incremental_topic_custom_updates: data_policy: {}, "
+      "replication_factor: {}}}",
+      i.data_policy,
+      i.replication_factor);
     return o;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -513,6 +513,13 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
     return o;
 }
 
+std::istream& operator>>(std::istream& i, replication_factor& cs) {
+    ss::sstring s;
+    i >> s;
+    cs = replication_factor(boost::lexical_cast<replication_factor::type>(s));
+    return i;
+};
+
 std::ostream&
 operator<<(std::ostream& o, const incremental_topic_custom_updates& i) {
     fmt::print(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -744,6 +744,11 @@ operator<<(std::ostream& o, const create_non_replicable_topics_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const move_topic_replicas_data& r) {
+    fmt::print(o, "{{partition: {}, replicas: {}}}", r.partition, r.replicas);
+    return o;
+}
+
 std::ostream& operator<<(
   std::ostream& o, const feature_update_license_update_cmd_data& fulu) {
     fmt::print(o, "{{redpanda_license {}}}", fulu.redpanda_license);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -599,6 +599,16 @@ topic_configuration& topic_metadata::get_configuration() {
 
 assignments_set& topic_metadata::get_assignments() { return _assignments; }
 
+replication_factor topic_metadata::get_replication_factor() const {
+    // The main idea is do not use anymore replication_factor from topic_config.
+    // replication factor is dynamic property. And it is size of assigments set.
+    // So we will return rf for 0 partition, becasue it should exist for each
+    // topic
+    auto it = _assignments.find(model::partition_id(0));
+    return replication_factor(
+      static_cast<replication_factor::type>(it->replicas.size()));
+}
+
 std::ostream& operator<<(std::ostream& o, const non_replicable_topic& d) {
     fmt::print(
       o, "{{Source topic: {}, non replicable topic: {}}}", d.source, d.name);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1974,6 +1974,23 @@ struct cancel_moving_partition_replicas_cmd_data
     auto serde_fields() { return std::tie(force); }
 };
 
+struct move_topic_replicas_data
+  : serde::envelope<move_topic_replicas_data, serde::version<0>> {
+    move_topic_replicas_data() noexcept = default;
+    explicit move_topic_replicas_data(
+      model::partition_id partition, std::vector<model::broker_shard> replicas)
+      : partition(partition)
+      , replicas(std::move(replicas)) {}
+
+    model::partition_id partition;
+    std::vector<model::broker_shard> replicas;
+
+    auto serde_fields() { return std::tie(partition, replicas); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const move_topic_replicas_data&);
+};
+
 struct feature_update_license_update_cmd_data
   : serde::envelope<feature_update_license_update_cmd_data, serde::version<0>> {
     using rpc_adl_exempt = std::true_type;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1217,6 +1217,11 @@ struct incremental_topic_updates
       = default;
 };
 
+using replication_factor
+  = named_type<uint16_t, struct replication_factor_type_tag>;
+
+std::istream& operator>>(std::istream& i, replication_factor& cs);
+
 // This class contains updates for topic properties which are replicates not by
 // topic_frontend
 struct incremental_topic_custom_updates

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2450,6 +2450,8 @@ public:
     const assignments_set& get_assignments() const;
     assignments_set& get_assignments();
 
+    replication_factor get_replication_factor() const;
+
 private:
     topic_configuration _configuration;
     assignments_set _assignments;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1225,10 +1225,12 @@ std::istream& operator>>(std::istream& i, replication_factor& cs);
 // This class contains updates for topic properties which are replicates not by
 // topic_frontend
 struct incremental_topic_custom_updates
-  : serde::envelope<incremental_topic_custom_updates, serde::version<0>> {
+  : serde::envelope<incremental_topic_custom_updates, serde::version<1>> {
     // Data-policy property is replicated by data_policy_frontend and handled by
     // data_policy_manager.
     property_update<std::optional<v8_engine::data_policy>> data_policy;
+    // Replication factor is custom handled.
+    property_update<std::optional<replication_factor>> replication_factor;
 
     friend std::ostream&
     operator<<(std::ostream&, const incremental_topic_custom_updates&);
@@ -1238,7 +1240,7 @@ struct incremental_topic_custom_updates
       const incremental_topic_custom_updates&)
       = default;
 
-    auto serde_fields() { return std::tie(data_policy); }
+    auto serde_fields() { return std::tie(data_policy, replication_factor); }
 };
 
 /**

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -47,6 +47,8 @@ std::string_view to_string_view(feature f) {
         return "cloud_retention";
     case feature::node_id_assignment:
         return "node_id_assignment";
+    case feature::replication_factor_change:
+        return "replication_factor_change";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -44,6 +44,7 @@ enum class feature : std::uint64_t {
     rpc_v2_by_default = 0x400,
     cloud_retention = 0x800,
     node_id_assignment = 0x1000,
+    replication_factor_change = 0x2000,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -172,6 +173,12 @@ constexpr static std::array feature_schema{
     cluster_version{7},
     "node_id_assignment",
     feature::node_id_assignment,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{7},
+    "replication_factor_change",
+    feature::replication_factor_change,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/server/handlers/alter_configs.h"
 
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/alter_configs_request.h"
@@ -116,6 +117,8 @@ create_topic_properties_update(alter_configs_resource& resource) {
       = cluster::incremental_update_operation::set;
     update.properties.shadow_indexing.op
       = cluster::incremental_update_operation::set;
+    update.custom_properties.replication_factor.op
+      = cluster::incremental_update_operation::set;
     update.custom_properties.data_policy.op
       = cluster::incremental_update_operation::none;
 
@@ -189,6 +192,11 @@ create_topic_properties_update(alter_configs_resource& resource) {
             if (cfg.name == topic_property_retention_local_target_bytes) {
                 parse_and_set_tristate(
                   update.properties.retention_local_target_bytes, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_replication_factor) {
+                parse_and_set_optional(
+                  update.custom_properties.replication_factor, cfg.value);
                 continue;
             }
             if (

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -110,6 +110,20 @@ static void parse_and_set_shadow_indexing_mode(
     }
 }
 
+static void parse_and_set_topic_replication_factor(
+  cluster::property_update<std::optional<cluster::replication_factor>>&
+    property,
+  const std::optional<ss::sstring>& value,
+  config_resource_operation op) {
+    // set property value
+    if (op == config_resource_operation::set) {
+        property.value = cluster::replication_factor(
+          boost::lexical_cast<cluster::replication_factor::type>(*value));
+        property.op = cluster::incremental_update_operation::set;
+    }
+    return;
+}
+
 /**
  * valides the optional config
  */
@@ -259,6 +273,11 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
             if (cfg.name == topic_property_max_message_bytes) {
                 parse_and_set_optional(
                   update.properties.batch_max_bytes, cfg.value, op);
+                continue;
+            }
+            if (cfg.name == topic_property_replication_factor) {
+                parse_and_set_topic_replication_factor(
+                  update.custom_properties.replication_factor, cfg.value, op);
                 continue;
             }
             if (

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -482,7 +482,8 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
         // The actual partition and replica count for this topic.
         int32_t pcount = topic_metadata.get_configuration().partition_count;
-        int32_t rcount = topic_metadata.get_configuration().replication_factor;
+        cluster::replication_factor rcount
+          = topic_metadata.get_replication_factor();
 
         size_estimate += pcount
                          * (bytes_per_partition + bytes_per_replica * rcount);

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -61,6 +61,8 @@ static constexpr std::string_view topic_property_retention_local_target_bytes
   = "retention.local.target.bytes";
 static constexpr std::string_view topic_property_retention_local_target_ms
   = "retention.local.target.ms";
+static constexpr std::string_view topic_property_replication_factor
+  = "replication.factor";
 
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -430,6 +430,7 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     properties.emplace("retention.ms", "1234");
     properties.emplace("cleanup.policy", "compact");
     properties.emplace("redpanda.remote.read", "true");
+    properties.emplace("replication.factor", "1");
 
     auto resp = alter_configs(
       {make_alter_topic_config_resource(test_tp, properties)});
@@ -457,9 +458,11 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     absl::flat_hash_map<ss::sstring, ss::sstring> properties_1;
     properties_1.emplace("retention.ms", "1234");
     properties_1.emplace("cleanup.policy", "compact");
+    properties_1.emplace("replication.factor", "1");
 
     absl::flat_hash_map<ss::sstring, ss::sstring> properties_2;
     properties_2.emplace("retention.bytes", "4096");
+    properties_2.emplace("replication.factor", "1");
 
     auto resp = alter_configs({
       make_alter_topic_config_resource(topic_1, properties_1),
@@ -492,6 +495,7 @@ FIXTURE_TEST(
 
     absl::flat_hash_map<ss::sstring, ss::sstring> properties;
     properties.emplace("unclean.leader.election.enable", "true");
+    properties.emplace("replication.factor", "1");
 
     auto resp = alter_configs(
       {make_alter_topic_config_resource(test_tp, properties)});
@@ -527,6 +531,7 @@ FIXTURE_TEST(
      */
     absl::flat_hash_map<ss::sstring, ss::sstring> properties;
     properties.emplace("retention.ms", "1234");
+    properties.emplace("replication.factor", "1");
 
     auto resp = alter_configs(
       {make_alter_topic_config_resource(test_tp, properties)});
@@ -545,6 +550,7 @@ FIXTURE_TEST(
      */
     absl::flat_hash_map<ss::sstring, ss::sstring> new_properties;
     new_properties.emplace("retention.bytes", "4096");
+    new_properties.emplace("replication.factor", "1");
 
     alter_configs({make_alter_topic_config_resource(test_tp, new_properties)});
 
@@ -757,6 +763,7 @@ FIXTURE_TEST(
 
     absl::flat_hash_map<ss::sstring, ss::sstring> alter_config_properties;
     alter_config_properties.emplace("retention.ms", "1234");
+    alter_config_properties.emplace("replication.factor", "1");
 
     auto resp_alter = alter_configs(
       {make_alter_topic_config_resource(test_tp, alter_config_properties)});

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -100,6 +100,12 @@ CHAOS_LOG_ALLOW_LIST = [
     ),
 ]
 
+# Log errors that are expected in tests that change replication factor
+CHANGE_REPLICATION_FACTOR_ALLOW_LIST = [
+    re.compile(
+        "cluster - .*Unable to allocate topic with given replication factor"),
+]
+
 
 class MetricSamples:
     def __init__(self, samples: list[MetricSample]):

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.services.admin import Admin
+from rptest.services.redpanda import CHANGE_REPLICATION_FACTOR_ALLOW_LIST
+
+
+class ReplicationFactorChangeTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=3, replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(ReplicationFactorChangeTest,
+              self).__init__(test_context=test_context, num_brokers=4)
+
+        self._rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+
+        self.rf_property = "replication.factor"
+        self.topic_name = self.topics[0].name
+
+    def check_rf(self, new_rf):
+        for partition in self._rpk.describe_topic(self.topic_name):
+            if len(partition.replicas) != new_rf:
+                return False
+        return True
+
+    @cluster(num_nodes=4)
+    def simple_test(self):
+        self.replication_factor = 4
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                     self.replication_factor)
+        self.check_rf(self.replication_factor)
+
+        def wait_rec():
+            return len(self.admin.list_reconfigurations()) == 0
+
+        wait_until(wait_rec,
+                   timeout_sec=60,
+                   backoff_sec=2,
+                   err_msg="Can not wait end of reconfiguration")
+
+        self.replication_factor = 2
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                     self.replication_factor)
+        self.check_rf(self.replication_factor)
+
+    @cluster(num_nodes=4, log_allow_list=CHANGE_REPLICATION_FACTOR_ALLOW_LIST)
+    def check_error_test(self):
+        self.replication_factor = -1
+        try:
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         self.replication_factor)
+            assert False, "We can not set replication factor <= 0"
+        except:
+            assert len(self.admin.list_reconfigurations()) == 0
+
+        self.replication_factor = 0
+        try:
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         self.replication_factor)
+            assert False, "We can not set replication factor <= 0"
+        except:
+            assert len(self.admin.list_reconfigurations()) == 0


### PR DESCRIPTION
## Cover letter
Replication factor is part of `topic_configuration`. It is fixed after topic creation, and users can not change it for the whole topic (but we can change replica sets for one partition per time).

The main idea of this pr - make the topic replication factor dynamic. After this replication factor will be the size of the replica set for partition (for example for first one).

It will be done via kafka `AlterConfig` request for `replication.factor`. User can increase and decrease replication factor

We have 2 parts:
* Decreasing replication factor: The easiest part. We just can delete replicas from replicas set. For example from the end. Free deleted replicas will be handled automatically by topic_table.

* Increasing replication factor: For this part we need to get a new place for new replica `_partition_allocator.reallocate_partition`. Also we need to get the best place for a new replica. Do not overflow disk space on new node. For this we can use `health_monitor` to get info for constraints.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Support `AlterConfig/IncrementalAlterConfig` request for `replication.factor` property.
