### PR TITLE
fix slash backport cmd: adding `--paginate` flag

### DIFF
--- a/.github/workflows/scripts/backport-command/get_backport_type.sh
+++ b/.github/workflows/scripts/backport-command/get_backport_type.sh
@@ -9,7 +9,7 @@ set -e
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
 gh_branch_exists() {
-  [[ -n $(gh api "/repos/$TARGET_FULL_REPO/branches" --jq \
+  [[ -n $(gh api "/repos/$TARGET_FULL_REPO/branches" --paginate --jq \
     '.[] | select(.name == '\""$1"\"')') ]] && return 0
   return 1
 }


### PR DESCRIPTION
## Cover letter

querying github using gh cli to get the branches
returns bu default 30 results so there are branches that simply are not in the result list. Adding `paginate` flag forces the cli to make additional HTTP requests to fetch all pages of results.

Fixes https://github.com/redpanda-data/devprod/issues/436

## Backport Required

No backport required. The slash cmds run all from default branch

- issue does not exist in previous branches

## UX changes

*none

## Release notes

* none