### PR TITLE
Fix Ingress overriding existing annotations

### DIFF
--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -69,7 +69,7 @@ func NewIngress(
 		host,
 		svcName,
 		svcPortName,
-		nil,
+		map[string]string{},
 		nil,
 		logger.WithValues(
 			"Kind", ingressKind(),
@@ -81,15 +81,14 @@ func NewIngress(
 func (r *IngressResource) WithAnnotations(
 	annot map[string]string,
 ) *IngressResource {
-	r.annotations = annot
+	for k, v := range annot {
+		r.annotations[k] = v
+	}
 	return r
 }
 
 // WithTLS sets Ingress TLS with specified issuer
 func (r *IngressResource) WithTLS(clusterIssuer, secretName string) *IngressResource {
-	if r.annotations == nil {
-		r.annotations = map[string]string{}
-	}
 	r.annotations["cert-manager.io/cluster-issuer"] = clusterIssuer
 	r.annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
 


### PR DESCRIPTION
## Cover letter

Fixes ingress resource `WithAnnotation()` func overriding existing annotations.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
