### PR TITLE
Serde: Split serde::write function

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -187,9 +187,6 @@ template<typename T>
 inline constexpr auto const are_bytes_and_string_different = !(
   std::is_same_v<T, ss::sstring> && std::is_same_v<T, bytes>);
 
-template<typename T>
-void write(iobuf&, T);
-
 template<class R, class P>
 int64_t checked_duration_cast_to_nanoseconds(
   const std::chrono::duration<R, P>& duration) {
@@ -533,15 +530,12 @@ inline void write(iobuf& out, iobuf t) {
     out.append(t.share(0, t.size_bytes()));
 }
 
-template<typename T>
-void write(iobuf& out, T t) {
-    using Type = std::decay_t<T>;
+template<typename Clock, typename Duration>
+void write(iobuf&, std::chrono::time_point<Clock, Duration> t) {
     static_assert(
-      !is_chrono_time_point<Type>,
+      !is_chrono_time_point<decltype(t)>,
       "Time point serialization is risky and can have unintended "
       "consequences. Check with Redpanda team before fixing this.");
-    static_assert(are_bytes_and_string_different<Type>);
-    static_assert(has_serde_write<Type> || is_serde_compatible_v<Type>);
 }
 
 template<typename T>

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -269,6 +269,8 @@ void write(iobuf& out, std::optional<T> t);
 template<typename Tag>
 void write(iobuf& out, ss::bool_class<Tag> t);
 
+inline void write(iobuf& out, bytes t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -370,6 +372,11 @@ void write(iobuf& out, ss::bool_class<Tag> t) {
     write(out, static_cast<int8_t>(bool(t)));
 }
 
+inline void write(iobuf& out, bytes t) {
+    write<serde_size_t>(out, t.size());
+    out.append(t.data(), t.size());
+}
+
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
@@ -437,9 +444,6 @@ void write(iobuf& out, T t) {
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         write<serde_size_t>(out, t.size_bytes());
         out.append(t.share(0, t.size_bytes()));
-    } else if constexpr (std::is_same_v<Type, bytes>) {
-        write<serde_size_t>(out, t.size());
-        out.append(t.data(), t.size());
     } else if constexpr (std::is_same_v<Type, uuid_t>) {
         out.append(t.uuid.data, uuid_t::length);
     } else if constexpr (

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -294,6 +294,8 @@ template<typename T>
 requires is_envelope<std::decay_t<T>>
 void write(iobuf& out, T t);
 
+inline void write(iobuf& out, iobuf t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -522,6 +524,11 @@ void write(iobuf& out, T t) {
     }
 }
 
+inline void write(iobuf& out, iobuf t) {
+    write<serde_size_t>(out, t.size_bytes());
+    out.append(t.share(0, t.size_bytes()));
+}
+
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
@@ -532,10 +539,7 @@ void write(iobuf& out, T t) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_write<Type> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, iobuf>) {
-        write<serde_size_t>(out, t.size_bytes());
-        out.append(t.share(0, t.size_bytes()));
-    } else if constexpr (std::is_same_v<Type, uuid_t>) {
+    if constexpr (std::is_same_v<Type, uuid_t>) {
         out.append(t.uuid.data, uuid_t::length);
     }
 }

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -254,6 +254,8 @@ requires(serde_is_enum_v<std::decay_t<T>>) void write(iobuf& out, T t);
 template<typename Rep, typename Period>
 void write(iobuf& out, std::chrono::duration<Rep, Period> t);
 
+inline void write(iobuf& out, ss::sstring t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -316,6 +318,11 @@ void write(iobuf& out, std::chrono::duration<Rep, Period> t) {
       "Floating point duration conversions are prone to precision and "
       "rounding issues.");
     write<int64_t>(out, checked_duration_cast_to_nanoseconds(t));
+}
+
+inline void write(iobuf& out, ss::sstring t) {
+    write<serde_size_t>(out, t.size());
+    out.append(t.data(), t.size());
 }
 
 template<typename T>
@@ -391,9 +398,6 @@ void write(iobuf& out, T t) {
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         write<serde_size_t>(out, t.size_bytes());
         out.append(t.share(0, t.size_bytes()));
-    } else if constexpr (std::is_same_v<Type, ss::sstring>) {
-        write<serde_size_t>(out, t.size());
-        out.append(t.data(), t.size());
     } else if constexpr (std::is_same_v<Type, bytes>) {
         write<serde_size_t>(out, t.size());
         out.append(t.data(), t.size());

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -42,8 +42,6 @@
 #include <string_view>
 #include <type_traits>
 
-struct uuid_t;
-
 namespace serde {
 
 template<typename T>
@@ -243,6 +241,8 @@ int64_t checked_duration_cast_to_nanoseconds(
       .count();
 }
 
+inline void write(iobuf& out, uuid_t t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -295,6 +295,10 @@ requires is_envelope<std::decay_t<T>>
 void write(iobuf& out, T t);
 
 inline void write(iobuf& out, iobuf t);
+
+inline void write(iobuf& out, uuid_t t) {
+    out.append(t.uuid.data, uuid_t::length);
+}
 
 template<typename T>
 requires(
@@ -538,10 +542,6 @@ void write(iobuf& out, T t) {
       "consequences. Check with Redpanda team before fixing this.");
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_write<Type> || is_serde_compatible_v<Type>);
-
-    if constexpr (std::is_same_v<Type, uuid_t>) {
-        out.append(t.uuid.data, uuid_t::length);
-    }
 }
 
 template<typename T>

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -258,6 +258,8 @@ inline void write(iobuf& out, ss::sstring t);
 
 inline void write(iobuf& out, bool t);
 
+inline void write(iobuf& out, ss::net::inet_address t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -328,6 +330,16 @@ inline void write(iobuf& out, ss::sstring t) {
 }
 
 inline void write(iobuf& out, bool t) { write(out, static_cast<int8_t>(t)); }
+
+inline void write(iobuf& out, ss::net::inet_address t) {
+    iobuf address_bytes;
+
+    // NOLINTNEXTLINE
+    address_bytes.append((const char*)t.data(), t.size());
+
+    write(out, t.is_ipv4());
+    write(out, std::move(address_bytes));
+}
 
 template<typename T>
 void write(iobuf& out, T t) {
@@ -469,14 +481,6 @@ void write(iobuf& out, T t) {
             write<int8_t>(out, 1);
             write(out, std::move(t.value()));
         }
-    } else if constexpr (std::is_same_v<T, ss::net::inet_address>) {
-        iobuf address_bytes;
-
-        // NOLINTNEXTLINE
-        address_bytes.append((const char*)t.data(), t.size());
-
-        write(out, t.is_ipv4());
-        write(out, std::move(address_bytes));
     }
 }
 

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -266,6 +266,9 @@ void write(iobuf& out, ::detail::base_named_type<T, Tag, IsConstexpr> t);
 template<typename T>
 void write(iobuf& out, std::optional<T> t);
 
+template<typename Tag>
+void write(iobuf& out, ss::bool_class<Tag> t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -362,6 +365,11 @@ void write(iobuf& out, std::optional<T> t) {
     }
 }
 
+template<typename Tag>
+void write(iobuf& out, ss::bool_class<Tag> t) {
+    write(out, static_cast<int8_t>(bool(t)));
+}
+
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
@@ -426,8 +434,6 @@ void write(iobuf& out, T t) {
         for (auto& el : t) {
             write(out, std::move(el));
         }
-    } else if constexpr (reflection::is_ss_bool_class<Type>) {
-        write(out, static_cast<int8_t>(bool(t)));
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         write<serde_size_t>(out, t.size_bytes());
         out.append(t.share(0, t.size_bytes()));

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -256,6 +256,8 @@ void write(iobuf& out, std::chrono::duration<Rep, Period> t);
 
 inline void write(iobuf& out, ss::sstring t);
 
+inline void write(iobuf& out, bool t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -325,6 +327,8 @@ inline void write(iobuf& out, ss::sstring t) {
     out.append(t.data(), t.size());
 }
 
+inline void write(iobuf& out, bool t) { write(out, static_cast<int8_t>(t)); }
+
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
@@ -378,8 +382,6 @@ void write(iobuf& out, T t) {
             checksum_placeholder.write(
               reinterpret_cast<char const*>(&checksum), sizeof(checksum_t));
         }
-    } else if constexpr (std::is_same_v<bool, Type>) {
-        write<int8_t>(out, t);
     } else if constexpr (reflection::is_std_vector<Type>) {
         if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
             throw serde_exception(fmt_with_ctx(

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -278,6 +278,11 @@ template<typename T>
 void write(iobuf& out, tristate<T> t);
 
 template<typename T>
+requires is_absl_node_hash_set<std::decay_t<T>> || is_absl_btree_set<
+  std::decay_t<T>>
+void write(iobuf& out, T t);
+
+template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
     T>> && !serde_is_enum_v<std::decay_t<T>>) void write(iobuf& out, T t) {
@@ -410,6 +415,23 @@ void write(iobuf& out, tristate<T> t) {
 }
 
 template<typename T>
+requires is_absl_node_hash_set<std::decay_t<T>> || is_absl_btree_set<
+  std::decay_t<T>>
+void write(iobuf& out, T t) {
+    if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "serde: {} size {} exceeds serde_size_t",
+          type_str<T>(),
+          t.size()));
+    }
+    write(out, static_cast<serde_size_t>(t.size()));
+    for (auto& e : t) {
+        write(out, e);
+    }
+}
+
+template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -478,18 +500,6 @@ void write(iobuf& out, T t) {
         out.append(t.share(0, t.size_bytes()));
     } else if constexpr (std::is_same_v<Type, uuid_t>) {
         out.append(t.uuid.data, uuid_t::length);
-    } else if constexpr (
-      is_absl_node_hash_set<Type> || is_absl_btree_set<Type>) {
-        if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
-            throw serde_exception(fmt_with_ctx(
-              ssx::sformat,
-              "serde: absl set size {} exceeds serde_size_t",
-              t.size()));
-        }
-        write(out, static_cast<serde_size_t>(t.size()));
-        for (auto& e : t) {
-            write(out, e);
-        }
     } else if constexpr (
       is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
         if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -260,6 +260,9 @@ inline void write(iobuf& out, bool t);
 
 inline void write(iobuf& out, ss::net::inet_address t);
 
+template<typename T, typename Tag, typename IsConstexpr>
+void write(iobuf& out, ::detail::base_named_type<T, Tag, IsConstexpr> t);
+
 template<typename T>
 requires(
   std::is_scalar_v<std::decay_t<
@@ -341,6 +344,11 @@ inline void write(iobuf& out, ss::net::inet_address t) {
     write(out, std::move(address_bytes));
 }
 
+template<typename T, typename Tag, typename IsConstexpr>
+void write(iobuf& out, ::detail::base_named_type<T, Tag, IsConstexpr> t) {
+    return write(out, static_cast<T>(t));
+}
+
 template<typename T>
 void write(iobuf& out, T t) {
     using Type = std::decay_t<T>;
@@ -405,8 +413,6 @@ void write(iobuf& out, T t) {
         for (auto& el : t) {
             write(out, std::move(el));
         }
-    } else if constexpr (reflection::is_rp_named_type<Type>) {
-        return write(out, static_cast<typename Type::type>(t));
     } else if constexpr (reflection::is_ss_bool_class<Type>) {
         write(out, static_cast<int8_t>(bool(t)));
     } else if constexpr (std::is_same_v<Type, iobuf>) {


### PR DESCRIPTION
## Cover letter

This PR splits the `serde::write` function into one function per case. This is a preparation for the next step which is to introduce one function for `const&` and one for r-values `&&` (to `std::move` out the guts of `iobuf` and `ss::sstring` directly into the serialization buffer) in order to allow for zero-copy writes.

This step should exactly replicate the behavior from previous versions. It just splits the `write` function into one per case of the long `if constexpr () { } else if constexpr ...` chain to prepare for further steps.

## Backport Required

- [x] not a bug fix

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none