### PR TITLE
operator: add workaround to console cert issuing

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
@@ -152,7 +153,8 @@ func (r *Reconciling) Do(
 
 	// Ingress with TLS and "/debug" "/admin" paths disabled
 	ingressResource := resources.NewIngress(r.Client, console, r.Scheme, subdomain, console.GetName(), consolepkg.ServicePortName, log)
-	ingressResource = ingressResource.WithTLS(resources.LEClusterIssuer, fmt.Sprintf("%s-redpanda", cluster.GetName()))
+	ingressResource = ingressResource.WithTLS(resources.LEClusterIssuer, fmt.Sprintf("%s-redpanda", cluster.GetName()),
+		strings.TrimPrefix(subdomain, "console.")) // @JB: workaround to put short SAN entry so LE can fill CN of cert.
 	ingressResource = ingressResource.WithAnnotations(map[string]string{
 		"nginx.ingress.kubernetes.io/server-snippet": "if ($request_uri ~* ^/(debug|admin)) {\n\treturn 403;\n\t}",
 	})

--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -88,7 +88,7 @@ func (r *IngressResource) WithAnnotations(
 }
 
 // WithTLS sets Ingress TLS with specified issuer
-func (r *IngressResource) WithTLS(clusterIssuer, secretName string) *IngressResource {
+func (r *IngressResource) WithTLS(clusterIssuer, secretName string, additionalHosts ...string) *IngressResource {
 	r.annotations["cert-manager.io/cluster-issuer"] = clusterIssuer
 	r.annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
 
@@ -96,7 +96,7 @@ func (r *IngressResource) WithTLS(clusterIssuer, secretName string) *IngressReso
 		r.TLS = []netv1.IngressTLS{}
 	}
 	r.TLS = append(r.TLS, netv1.IngressTLS{
-		Hosts: []string{r.host},
+		Hosts: append([]string{r.host}, additionalHosts...),
 		// Use the Cluster wildcard certificate
 		SecretName: secretName,
 	})


### PR DESCRIPTION


## Cover letter

Based on pvsune's https://github.com/redpanda-data/redpanda/pull/6462

The produced SAN is too long (>63 chars) in some cases. adding smaller
domain name makes it possible to issue the cert.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
