### PR TITLE
cleanup github workflow for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,16 +108,19 @@ jobs:
 
   sh:
     name: Lint shell scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: setup shfmt
+    - name: Install shfmt
+      env:
+        SHFMT_VER: 3.5.1
       run: |
-        wget "https://github.com/mvdan/sh/releases/download/v3.2.0/shfmt_v3.2.0_linux_amd64" -O shfmt
-        chmod +x shfmt
+        mkdir -v -p "$HOME/.local/bin"
+        wget -O "$HOME/.local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/v${SHFMT_VER}/shfmt_v${SHFMT_VER}_linux_amd64"
+        chmod 0700 "$HOME/.local/bin/shfmt"
 
     - name: Run shfmt
-      run: ./shfmt -i 2 -ci -s -d .
+      run: shfmt -i 2 -ci -s -d .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,22 +52,17 @@ jobs:
 
   js:
     name: Lint js files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '12.16.1'
+    - name: Install prettier
+      run: npm install prettier@2.7.1
 
-    - name: Set up prettier
-      run: npm install prettier@2.3.0
-
-    - name: Lint JS files
-      run: npx prettier --list-different src/**/*.{ts,js}
+    - name: Run prettier
+      run: npx prettier --check 'src/**/*.{ts,js}'
 
   py:
     name: Lint python files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,19 +71,17 @@ jobs:
 
   py:
     name: Lint python files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: Set up python
-      run: |
-        sudo apt-get install -y python3 python3-pip
-        sudo pip install yapf==0.30.0
+    - name: Install yapf
+      run: pip install yapf==0.32.0
 
-    - name: lint python files
-      run: find . -name *.py -type f | xargs -n1 yapf -d
+    - name: Run yapf
+      run: find . -type f -name '*.py' | xargs -n1 yapf -d
 
   cpp:
     name: Lint files with clang-format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,23 +87,15 @@ jobs:
 
   cpp:
     name: Lint files with clang-format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
-    - name: Fetch clang-format
-      run: |
-        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository --yes --update 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
-        sudo apt-get install -y git clang-format-14
-      env:
-        DEBIAN_FRONTEND: noninteractive
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Run clang fmt
+    - name: Run clang-format
       run: |
-        find . -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-14 -i -style=file -fallback-style=none
+        find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-14 -i -style=file -fallback-style=none
         git diff --exit-code
 
   sh:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,33 +21,35 @@ on:
 jobs:
   go:
     name: Lint go files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Go
+    - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.8
+        go-version: 1.17.13
 
-    - name: lint rpk
+    - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.49.0
         args: --timeout 5m
         working-directory: src/go/rpk/
 
-    - name: install gofumpt
-      working-directory: src/go/rpk
+    - name: Install gofumpt
+      env:
+        GOFUMPT_VER: 0.3.1
       run: |
-        go install mvdan.cc/gofumpt@v0.3.0
+        mkdir -v -p "$HOME/.local/bin"
+        wget -O "$HOME/.local/bin/gofumpt" "https://github.com/mvdan/gofumpt/releases/download/v${GOFUMPT_VER}/gofumpt_v${GOFUMPT_VER}_linux_amd64"
+        chmod 0700 "$HOME/.local/bin/gofumpt"
 
-    - name: format go files
-      working-directory: src/go
+    - name: Run gofumpt
       run: |
-        find . -name *.go -type f | xargs -n1 gofumpt -w -lang=1.17
+        find src/go -type f -name '*.go' | xargs -n1 gofumpt -w -lang=1.17
         git diff --exit-code
 
   js:

--- a/src/v/v8_engine/internal/tests/scripts/compile_timeout.js
+++ b/src/v/v8_engine/internal/tests/scripts/compile_timeout.js
@@ -1,3 +1,1 @@
-while(true) {
-
-}
+while (true) {}

--- a/src/v/v8_engine/internal/tests/scripts/run_timeout.js
+++ b/src/v/v8_engine/internal/tests/scripts/run_timeout.js
@@ -1,4 +1,3 @@
 function run_timeout(obj) {
-    while (true) {
-    }
+  while (true) {}
 }

--- a/src/v/v8_engine/internal/tests/scripts/sum.js
+++ b/src/v/v8_engine/internal/tests/scripts/sum.js
@@ -1,4 +1,4 @@
 function sum(obj) {
-    let array = new Int32Array(obj);
-    array[2] = array[0] + array[1];
+  let array = new Int32Array(obj);
+  array[2] = array[0] + array[1];
 }

--- a/src/v/v8_engine/internal/tests/scripts/to_upper.js
+++ b/src/v/v8_engine/internal/tests/scripts/to_upper.js
@@ -1,10 +1,10 @@
 function to_upper(obj) {
-    let array = new Int8Array(obj);
-    for (let i = 0; i < obj.byteLength; i++) {
-        if (array[i] >= 97 && array[i] <= 122) {
-                array[i] = array[i] - 32;
-        } else {
-            array[i] = array[i];
-        }
+  let array = new Int8Array(obj);
+  for (let i = 0; i < obj.byteLength; i++) {
+    if (array[i] >= 97 && array[i] <= 122) {
+      array[i] = array[i] - 32;
+    } else {
+      array[i] = array[i];
     }
+  }
 }

--- a/tools/redpanda-gdb.py
+++ b/tools/redpanda-gdb.py
@@ -1565,7 +1565,6 @@ class redpanda(gdb.Command):
 
 class sstring_printer(gdb.printing.PrettyPrinter):
     'print an sstring'
-
     def __init__(self, val):
         self.val = val
 
@@ -1584,7 +1583,6 @@ class sstring_printer(gdb.printing.PrettyPrinter):
 
 class model_ntp_printer(gdb.printing.PrettyPrinter):
     'print a model::ntp'
-
     def __init__(self, val):
         self.val = val
 


### PR DESCRIPTION
## Cover letter

This PR will make the github workflow for linting more robust. No functionality change.

Notable changes:
* fixed glob pattern to include source files that were suppose to be linted
* removed dependency on external services `mvdan.cc` and `apt.llvm.org`
* bumped to latest version of linting tools

## Backport Required

This would make maintenance of branches easier if backported to:
- [ ] [v22.2.x](https://github.com/redpanda-data/redpanda/tree/v22.2.x) (pretty similar to dev branch)
- [ ] [v22.1.x](https://github.com/redpanda-data/redpanda/tree/v22.1.x) (likely conflict with `clang-format-12` that should be easy to resolve)

no need to backport to [v21.11.x](https://github.com/redpanda-data/redpanda/tree/v21.11.x) branch because there are a lot of differences that would be more trouble than its worth given that branch is about to EOL

## UX changes

* none

## Release notes

* none