### PR TITLE
operator: add flag to restrict management of cluster based on rp version

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -49,12 +49,13 @@ var (
 // ClusterReconciler reconciles a Cluster object
 type ClusterReconciler struct {
 	client.Client
-	Log                      logr.Logger
-	configuratorSettings     resources.ConfiguratorSettings
-	clusterDomain            string
-	Scheme                   *runtime.Scheme
-	AdminAPIClientFactory    adminutils.AdminAPIClientFactory
-	DecommissionWaitInterval time.Duration
+	Log                       logr.Logger
+	configuratorSettings      resources.ConfiguratorSettings
+	clusterDomain             string
+	Scheme                    *runtime.Scheme
+	AdminAPIClientFactory     adminutils.AdminAPIClientFactory
+	DecommissionWaitInterval  time.Duration
+	RestrictToRedpandaVersion string
 }
 
 //+kubebuilder:rbac:groups=redpanda.vectorized.io,resources=clusters,verbs=get;list;watch;create;update;patch;delete
@@ -106,6 +107,9 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	if !isRedpandaClusterManaged(log, &redpandaCluster) {
+		return ctrl.Result{}, nil
+	}
+	if !isRedpandaClusterVersionManaged(log, &redpandaCluster, r.RestrictToRedpandaVersion) {
 		return ctrl.Result{}, nil
 	}
 
@@ -668,6 +672,19 @@ func isRedpandaClusterManaged(
 	if managed, exists := redpandaCluster.Annotations[managedAnnotationKey]; exists && managed == "false" {
 		log.Info(fmt.Sprintf("management of %s is disabled; to enable it, change the '%s' annotation to true or remove it",
 			redpandaCluster.Name, managedAnnotationKey))
+		return false
+	}
+	return true
+}
+
+func isRedpandaClusterVersionManaged(
+	log logr.Logger,
+	redpandaCluster *redpandav1alpha1.Cluster,
+	restrictToRedpandaVersion string,
+) bool {
+	if restrictToRedpandaVersion != "" && restrictToRedpandaVersion != redpandaCluster.Spec.Version {
+		log.Info(fmt.Sprintf("management of %s is restricted to cluster (spec) version %s; cluster has spec version %s and status version %s",
+			redpandaCluster.Name, restrictToRedpandaVersion, redpandaCluster.Spec.Version, redpandaCluster.Status.Version))
 		return false
 	}
 	return true

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -40,11 +40,12 @@ const (
 // ClusterConfigurationDriftReconciler detects drifts in the cluster configuration and triggers a reconciliation.
 type ClusterConfigurationDriftReconciler struct {
 	client.Client
-	Log                   logr.Logger
-	clusterDomain         string
-	Scheme                *runtime.Scheme
-	DriftCheckPeriod      *time.Duration
-	AdminAPIClientFactory adminutils.AdminAPIClientFactory
+	Log                       logr.Logger
+	clusterDomain             string
+	Scheme                    *runtime.Scheme
+	DriftCheckPeriod          *time.Duration
+	AdminAPIClientFactory     adminutils.AdminAPIClientFactory
+	RestrictToRedpandaVersion string
 }
 
 // Reconcile detects drift in configuration for clusters and schedules a patch.
@@ -72,6 +73,9 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 
 	if !isRedpandaClusterManaged(log, &redpandaCluster) {
 		return ctrl.Result{RequeueAfter: r.getDriftCheckPeriod()}, nil
+	}
+	if !isRedpandaClusterVersionManaged(log, &redpandaCluster, r.RestrictToRedpandaVersion) {
+		return ctrl.Result{}, nil
 	}
 
 	condition := redpandaCluster.Status.GetCondition(redpandav1alpha1.ClusterConfiguredConditionType)


### PR DESCRIPTION
## Cover letter

In environments where the operator and redpanda are upgraded "at once" we end up performing a double restart of redpanda, once due to the operator, e.g., because a default in the statefulset changed, and again to upgrade redpanda itself by updating its version in the CR.

To avoid the double restart it is useful disable management of redpanda while the operator is being upgraded and the CR is updated. Once those are complete the operator can be activated performing a single rolling upgrade/restart.

Currently the operator offers a "managed" annotation, such that management can be disabled (per CR). However, when using terraform or similar declarative languages, it is inconvenient to express this logic.

To solve this problem, we introduce a flag `restrict-redpanda-version` that takes as its value a redpanda version and compares it to the version in the CR spec. The operator skips management of that cluster if there's a mismatch. If the value is missing it continues as today.

This allows us to update the operator, providing it with the new version in the flag, and then update the CR version. When the latter occurs the single rolling upgrade will take place.