### PR TITLE
Fix console deletion if cluster is deleted

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/console_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/console_types.go
@@ -10,9 +10,23 @@
 package v1alpha1
 
 import (
+	"context"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// AllowConsoleAnyNamespace operator flag to control creating Console in any namespace aside from Redpanda namespace
+	// Console needs SchemaRegistry TLS certs Secret, if enabled this flag copies Secrets from Redpanda namespace to Console local namespace
+	// Secret syncing across namespaces might not be ideal especially for multi-tenant K8s clusters
+	AllowConsoleAnyNamespace = false
+
+	// ErrClusterNotConfigured is error returned if referenced Cluster is not yet configured
+	ErrClusterNotConfigured = fmt.Errorf("cluster not configured")
 )
 
 // ConsoleSpec defines the desired state of Console
@@ -209,11 +223,6 @@ func (c *Console) GenerationMatchesObserved() bool {
 	return c.GetGeneration() == c.Status.ObservedGeneration
 }
 
-// AllowConsoleAnyNamespace operator flag to control creating Console in any namespace aside from Redpanda namespace
-// Console needs SchemaRegistry TLS certs Secret, if enabled this flag copies Secrets from Redpanda namespace to Console local namespace
-// Secret syncing across namespaces might not be ideal especially for multi-tenant K8s clusters
-var AllowConsoleAnyNamespace bool
-
 // IsAllowedNamespace returns true if Console is valid to be created in current namespace
 func (c *Console) IsAllowedNamespace() bool {
 	return AllowConsoleAnyNamespace || c.GetNamespace() == c.Spec.ClusterRef.Namespace
@@ -222,6 +231,18 @@ func (c *Console) IsAllowedNamespace() bool {
 // GetClusterRef returns the NamespacedName of referenced Cluster object
 func (c *Console) GetClusterRef() types.NamespacedName {
 	return types.NamespacedName{Name: c.Spec.ClusterRef.Name, Namespace: c.Spec.ClusterRef.Namespace}
+}
+
+// GetCluster returns the referenced Cluster object
+func (c *Console) GetCluster(ctx context.Context, cl client.Client) (*Cluster, error) {
+	cluster := &Cluster{}
+	if err := cl.Get(ctx, c.GetClusterRef(), cluster); err != nil {
+		return nil, err
+	}
+	if cc := cluster.Status.GetCondition(ClusterConfiguredConditionType); cc == nil || cc.Status != corev1.ConditionTrue {
+		return nil, ErrClusterNotConfigured
+	}
+	return cluster, nil
 }
 
 //+kubebuilder:object:root=true

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
@@ -352,7 +352,7 @@ spec:
                     type: object
                   redpandaCloud:
                     description: EnterpriseLoginRedpandaCloud defines configurable
-                      fields for RedpandaCloud provider
+                      fields for RedpandaCloud SSO provider
                     properties:
                       allowedOrigins:
                         description: AllowedOrigins indicates if response is allowed

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -44,6 +44,9 @@ const (
 	// ClusterNotFoundEvent is a warning event if referenced Cluster not found
 	ClusterNotFoundEvent = "ClusterNotFound"
 
+	// ClusterNotConfiguredEvent is a warning event if referenced Cluster not yet configured
+	ClusterNotConfiguredEvent = "ClusterNotConfigured"
+
 	// NoSubdomainEvent is warning event if subdomain is not found in Cluster ExternalListener
 	NoSubdomainEvent = "NoSubdomain"
 )
@@ -79,24 +82,25 @@ func (r *ConsoleReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	cluster := &redpandav1alpha1.Cluster{}
-	if err := r.Get(ctx, console.GetClusterRef(), cluster); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Console will never reconcile if Cluster is not found
-			// Users shouldn't check logs of operator to know this
-			// Adding Conditions in Console status might not be apt, record Event instead
+	cluster, err := console.GetCluster(ctx, r.Client)
+	if err != nil {
+		// Create event instead of logging the error, so user can see in Console CR instead of checking logs in operator
+		switch {
+		case apierrors.IsNotFound(err):
 			r.EventRecorder.Eventf(
 				console,
 				corev1.EventTypeWarning, ClusterNotFoundEvent,
-				"Unable to reconcile Console as the referenced Cluster %s/%s is not found",
-				console.Spec.ClusterRef.Namespace, console.Spec.ClusterRef.Name,
+				"Unable to reconcile Console as the referenced Cluster %s is not found", console.GetClusterRef(),
 			)
+		case errors.Is(err, redpandav1alpha1.ErrClusterNotConfigured):
+			r.EventRecorder.Eventf(
+				console,
+				corev1.EventTypeWarning, ClusterNotConfiguredEvent,
+				"Unable to reconcile Console as the referenced Cluster %s is not yet configured", console.GetClusterRef(),
+			)
+			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, err
-	}
-	if cc := cluster.Status.GetCondition(redpandav1alpha1.ClusterConfiguredConditionType); cc == nil || cc.Status != corev1.ConditionTrue {
-		log.Info("Cluster not yet configured, requeueing", "redpandacluster", client.ObjectKeyFromObject(cluster).String())
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	var s state

--- a/src/go/k8s/tests/e2e/console/04-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console/04-cleanup.yaml
@@ -2,6 +2,10 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 - apiVersion: redpanda.vectorized.io/v1alpha1
+  kind: Cluster
+  name: cluster
+  namespace: console
+- apiVersion: redpanda.vectorized.io/v1alpha1
   kind: Console
   name: console
   namespace: console

--- a/src/go/k8s/webhooks/redpanda/console_webhook.go
+++ b/src/go/k8s/webhooks/redpanda/console_webhook.go
@@ -38,8 +38,10 @@ func (v *ConsoleValidator) Handle(
 		return admission.Denied(fmt.Sprintf("cluster %s/%s is in different namespace", console.Spec.ClusterRef.Namespace, console.Spec.ClusterRef.Name))
 	}
 
+	// Admit console even if cluster is not yet configured, controller will do backoff retries
+	// No checks on referenced cluster if console is deleting so controller can remove finalizers
 	cluster := &redpandav1alpha1.Cluster{}
-	if err := v.Client.Get(ctx, console.GetClusterRef(), cluster); err != nil {
+	if err := v.Client.Get(ctx, console.GetClusterRef(), cluster); err != nil && console.GetDeletionTimestamp() == nil {
 		if apierrors.IsNotFound(err) {
 			return admission.Denied(fmt.Sprintf("cluster %s/%s not found", console.Spec.ClusterRef.Namespace, console.Spec.ClusterRef.Name))
 		}


### PR DESCRIPTION
## Cover letter

If Redpanda cluster is deleted first, console will not reconcile any changes because of checks in the ClusterRef. This PR checks if console is deleted, then remove the finalizers if cluster is not found so changes can be reconciled.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Cleanup will not require to delete console first then cluster.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Improvements

* Console deletion is fully independent of Cluster

-->
