### PR TITLE
tests: extend consumer timeout in test with kills

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -160,7 +160,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                                            original_snapshot=original_snapshot)
 
             self.start_consumer()
-            self.run_validation()
+            self.run_validation(consumer_timeout_sec=90)
         ctx.assert_actions_triggered()
 
 


### PR DESCRIPTION
## Cover letter

test_write_with_node_failures randomly kills nodes while a verifiable consumer is running against the cluster. Hence, the consumer group members need to react to the broker failures. If we get unlucky, and the test continously kills the group coordinator broker, then there may be long periods of time when no data is consumed. This non-determinism coupled with a short consumer timeout (30s) makes the test flaky.

This commit increases the consumer timeout to 90s in order to increase the chances of all the required data being consumed before the timeout.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #4639 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [X] v22.1.x
- [X] v21.11.x