### PR TITLE
[v22.1.x] tests: extend consumer timeout in test with kills

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -124,5 +124,5 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                                       partition_idx=0,
                                       count=6)
             self.start_consumer()
-            self.run_validation()
+            self.run_validation(consumer_timeout_sec=90)
         ctx.assert_actions_triggered()


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6478.
Fixes https://github.com/redpanda-data/redpanda/issues/6481,