### PR TITLE
cloud_storage: Fix lifetime issue in `recursive_directory_walker`

### DIFF
--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -49,46 +49,42 @@ recursive_directory_walker::walk(
           start_dir);
 
         try {
+            auto on_dir_entry =
+              [&files, &current_cache_size, &dirlist, target, tracker](
+                ss::directory_entry entry) -> ss::future<> {
+                vlog(cst_log.debug, "Looking at directory {}", target);
+
+                auto entry_path = std::filesystem::path(target)
+                                  / std::filesystem::path(entry.name);
+                if (
+                  entry.type
+                  && entry.type == ss::directory_entry_type::regular) {
+                    vlog(cst_log.debug, "Regular file found {}", entry_path);
+
+                    auto file_stats = co_await ss::file_stat(
+                      entry_path.string());
+
+                    auto last_access_timepoint
+                      = tracker.estimate_timestamp(entry_path.native())
+                          .value_or(file_stats.time_accessed);
+
+                    current_cache_size += static_cast<uint64_t>(
+                      file_stats.size);
+                    files.push_back(
+                      {last_access_timepoint,
+                       (std::filesystem::path(target) / entry.name.data())
+                         .native(),
+                       static_cast<uint64_t>(file_stats.size)});
+                } else if (
+                  entry.type
+                  && entry.type == ss::directory_entry_type::directory) {
+                    vlog(cst_log.debug, "Dir found {}", entry_path);
+                    dirlist.push_front(entry_path.string());
+                }
+                co_return;
+            };
             ss::file target_dir = co_await open_directory(target);
-            auto sub = target_dir.list_directory(
-              [&files,
-               &current_cache_size,
-               &dirlist,
-               _target{target},
-               _tracker{tracker}](ss::directory_entry entry) -> ss::future<> {
-                  auto target{_target};
-                  auto tracker{_tracker};
-                  vlog(cst_log.debug, "Looking at directory {}", target);
-
-                  auto entry_path = std::filesystem::path(target)
-                                    / std::filesystem::path(entry.name);
-                  if (
-                    entry.type
-                    && entry.type == ss::directory_entry_type::regular) {
-                      vlog(cst_log.debug, "Regular file found {}", entry_path);
-
-                      auto file_stats = co_await ss::file_stat(
-                        entry_path.string());
-
-                      auto last_access_timepoint
-                        = tracker.estimate_timestamp(entry_path.native())
-                            .value_or(file_stats.time_accessed);
-
-                      current_cache_size += static_cast<uint64_t>(
-                        file_stats.size);
-                      files.push_back(
-                        {last_access_timepoint,
-                         (std::filesystem::path(target) / entry.name.data())
-                           .native(),
-                         static_cast<uint64_t>(file_stats.size)});
-                  } else if (
-                    entry.type
-                    && entry.type == ss::directory_entry_type::directory) {
-                      vlog(cst_log.debug, "Dir found {}", entry_path);
-                      dirlist.push_front(entry_path.string());
-                  }
-                  co_return;
-              });
+            auto sub = target_dir.list_directory(on_dir_entry);
             co_await sub.done().finally(
               [target_dir]() mutable { return target_dir.close(); });
         } catch (std::filesystem::filesystem_error& e) {


### PR DESCRIPTION
## Cover letter

Fix lifetime issue in directory walker. The directory walker is used to compute the size of the cache directory.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none

