### PR TITLE
compaction: Extend max_collectible_offset check to adjacent compaction

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -395,10 +395,12 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
         auto r = co_await compact_adjacent_segments(std::move(*range), cfg);
         vlog(
           stlog.debug,
-          "adjejcent segments of {}, compaction result: {}",
+          "Adjacent segments of {}, compaction result: {}",
           config().ntp(),
           r);
-        _compaction_ratio.update(r.compaction_ratio());
+        if (r.did_compact()) {
+            _compaction_ratio.update(r.compaction_ratio());
+        }
     }
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -124,7 +124,7 @@ private:
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
-    find_compaction_range();
+    find_compaction_range(const compaction_config&);
     ss::future<> gc(compaction_config);
 
     ss::future<> remove_empty_segments();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -528,7 +528,7 @@ ss::future<compaction_result> self_compact_segment(
           "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
     }
 
-    if (s->finished_self_compaction()) {
+    if (s->finished_self_compaction() || !s->has_compactible_offsets(cfg)) {
         co_return compaction_result{s->size_bytes()};
     }
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1349,7 +1349,18 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     log.compact(c_cfg).get0();
     log.compact(c_cfg).get0();
     log.compact(c_cfg).get0();
+    // Self compactions complete.
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
+
+    // Check if it honors max_compactible offset by resetting it to the base
+    // offset of first segment. Nothing should be compacted.
+    const auto first_segment_offsets = disk_log->segments().front()->offsets();
+    c_cfg.max_collectible_offset = first_segment_offsets.base_offset;
+    log.compact(c_cfg).get0();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
+
+    // reset
+    c_cfg.max_collectible_offset = model::offset::max();
 
     log.compact(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);


### PR DESCRIPTION
## Cover letter

Makes sure adjacent compaction honors max_collectible_offset check added in #5318. This is critical for transactions as we do not want to compact beyond LSO.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6335

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none