### PR TITLE
tests: fixed setting si settings in read replica tests

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -40,27 +40,28 @@ class BucketUsage(NamedTuple):
 class TestReadReplicaService(EndToEndTest):
     log_segment_size = 1048576  # 5MB
     topic_name = "panda-topic"
-    si_settings = SISettings(
-        cloud_storage_reconciliation_interval_ms=500,
-        cloud_storage_max_connections=5,
-        log_segment_size=log_segment_size,
-        cloud_storage_readreplica_manifest_sync_timeout_ms=500,
-        cloud_storage_segment_max_upload_interval_sec=5)
-
-    # Read reaplica shouldn't have it's own bucket.
-    # We're adding 'none' as a bucket name without creating
-    # an actual bucket with such name.
-    rr_settings = SISettings(
-        cloud_storage_bucket='none',
-        bypass_bucket_creation=True,
-        cloud_storage_reconciliation_interval_ms=500,
-        cloud_storage_max_connections=5,
-        log_segment_size=log_segment_size,
-        cloud_storage_readreplica_manifest_sync_timeout_ms=500,
-        cloud_storage_segment_max_upload_interval_sec=5)
 
     def __init__(self, test_context: TestContext):
-        super(TestReadReplicaService, self).__init__(test_context=test_context)
+        super(TestReadReplicaService, self).__init__(
+            test_context=test_context,
+            si_settings=SISettings(
+                cloud_storage_reconciliation_interval_ms=500,
+                cloud_storage_max_connections=5,
+                log_segment_size=TestReadReplicaService.log_segment_size,
+                cloud_storage_readreplica_manifest_sync_timeout_ms=500,
+                cloud_storage_segment_max_upload_interval_sec=5))
+
+        # Read reaplica shouldn't have it's own bucket.
+        # We're adding 'none' as a bucket name without creating
+        # an actual bucket with such name.
+        self.rr_settings = SISettings(
+            cloud_storage_bucket='none',
+            bypass_bucket_creation=True,
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            log_segment_size=TestReadReplicaService.log_segment_size,
+            cloud_storage_readreplica_manifest_sync_timeout_ms=500,
+            cloud_storage_segment_max_upload_interval_sec=5)
         self.second_cluster = None
 
     def start_second_cluster(self) -> None:


### PR DESCRIPTION
## Cover letter

Fixed incorrectly set shadow indexing properties in read replica tests.

Fixes: #6357

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
- none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
