### PR TITLE
gha: add slash command test-arm64

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -3,6 +3,7 @@ on:
     types: 
       - ci-repeat-command
       - test-codecov-command
+      - test-arm64-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -16,6 +16,7 @@ jobs:
             backport
             ci-repeat
             test-codecov
+            test-arm64
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
## Cover letter

Adds a new slash command `/test-arm64` that will trigger arm64 tests on a PR.

## Backport Required

* does not need backport because only the dev branch is used to run this type of workflow

## UX changes

* none

## Release notes

* none