### PR TITLE
storage: apply limits to segment.bytes

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -28,12 +28,31 @@ configuration::configuration()
   : log_segment_size(
     *this,
     "log_segment_size",
-    "How large in bytes should each log segment be (default 1G)",
+    "Default log segment size in bytes for topics which do not set "
+    "segment.bytes",
     {.needs_restart = needs_restart::no,
      .example = "2147483648",
      .visibility = visibility::tunable},
     1_GiB,
     {.min = 1_MiB})
+  , log_segment_size_min(
+      *this,
+      "log_segment_size_min",
+      "Lower bound on topic segment.bytes: lower values will be clamped to "
+      "this limit",
+      {.needs_restart = needs_restart::no,
+       .example = "16777216",
+       .visibility = visibility::tunable},
+      std::nullopt)
+  , log_segment_size_max(
+      *this,
+      "log_segment_size_max",
+      "Upper bound on topic segment.bytes: higher values will be clamped to "
+      "this limit",
+      {.needs_restart = needs_restart::no,
+       .example = "268435456",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , compacted_log_segment_size(
       *this,
       "compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -42,6 +42,8 @@ namespace config {
 struct configuration final : public config_store {
     // WAL
     bounded_property<uint64_t> log_segment_size;
+    property<std::optional<uint64_t>> log_segment_size_min;
+    property<std::optional<uint64_t>> log_segment_size_max;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
     // Network

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -56,8 +56,9 @@ namespace storage {
 disk_log_impl::disk_log_impl(
   ntp_config cfg, log_manager& manager, segment_set segs, kvstore& kvstore)
   : log::impl(std::move(cfg))
-  , _segment_size_jitter(storage::internal::random_jitter())
   , _manager(manager)
+  , _segment_size_jitter(
+      internal::random_jitter(_manager.config().segment_size_jitter))
   , _segs(std::move(segs))
   , _kvstore(kvstore)
   , _start_offset(read_start_offset())

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -829,12 +829,29 @@ ss::future<> disk_log_impl::flush() {
 
 size_t disk_log_impl::max_segment_size() const {
     // override for segment size
+    size_t result;
     if (config().has_overrides() && config().get_overrides().segment_size) {
-        return *config().get_overrides().segment_size;
+        result = *config().get_overrides().segment_size;
+    } else {
+        // no overrides use defaults
+        result = config().is_compacted()
+                   ? _manager.config().compacted_segment_size()
+                   : _manager.config().max_segment_size();
     }
-    // no overrides use defaults
-    return config().is_compacted() ? _manager.config().compacted_segment_size()
-                                   : _manager.config().max_segment_size();
+
+    // Clamp to safety limits on segment sizes, in case the
+    // property was set without proper validation (e.g. on
+    // an older version or before limits were set)
+    auto min_limit = config::shard_local_cfg().log_segment_size_min();
+    auto max_limit = config::shard_local_cfg().log_segment_size_max();
+    if (min_limit) {
+        result = std::max(*min_limit, result);
+    }
+    if (max_limit) {
+        result = std::min(*max_limit, result);
+    }
+
+    return result;
 }
 
 size_t disk_log_impl::bytes_left_before_roll() const {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -171,10 +171,10 @@ private:
         ss::promise<model::offset> promise;
         ss::abort_source::subscription subscription;
     };
-    float _segment_size_jitter;
     bool _closed{false};
     ss::gate _compaction_gate;
     log_manager& _manager;
+    float _segment_size_jitter;
     segment_set _segs;
     kvstore& _kvstore;
     model::offset _start_offset;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -20,6 +20,7 @@
 #include "storage/log_housekeeping_meta.h"
 #include "storage/ntp_config.h"
 #include "storage/segment.h"
+#include "storage/segment_utils.h"
 #include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "storage/version.h"
@@ -122,6 +123,9 @@ struct log_config {
     storage_type stype;
     ss::sstring base_dir;
     config::binding<size_t> max_segment_size;
+
+    // Default 5% jitter on segment size thresholds
+    internal::jitter_percents segment_size_jitter{5};
 
     // compacted segment size
     config::binding<size_t> compacted_segment_size;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -174,11 +174,10 @@ ss::future<> do_swap_data_file_handles(
 std::filesystem::path compacted_index_path(std::filesystem::path segment_path);
 
 using jitter_percents = named_type<int, struct jitter_percents_tag>;
-static constexpr jitter_percents default_segment_size_jitter(5);
 
 // Generates a random jitter percentage [as a fraction] with in the passed
 // percents range.
-float random_jitter(jitter_percents = default_segment_size_jitter);
+float random_jitter(jitter_percents);
 
 // key types used to store data in key-value store
 enum class kvstore_key_type : int8_t {

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -101,13 +101,18 @@ public:
 
         auto cache = i > 50 ? storage::with_cache::yes
                             : storage::with_cache::no;
-        return storage::log_config(
+        auto cfg = storage::log_config(
           stype,
           std::move(test_dir),
           200_MiB,
           storage::debug_sanitize_files::yes,
           ss::default_priority_class(),
           cache);
+
+        // Disable jitter for unit tests
+        cfg.segment_size_jitter = storage::internal::jitter_percents{0};
+
+        return cfg;
     }
 
     void


### PR DESCRIPTION
## Cover letter

To avoid introducing incompatibilities with applications that have existing segment.bytes settings during topic creation, we do not refuse topic creations/alterations that violate these limits.  Instead, we accept the user input, but clamp it when applying the segment size limit, so that the effective segment size remains within the bounds even if the apparent segment.bytes property violates it.

Fixes: https://github.com/redpanda-data/redpanda/issues/6036

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

See release notes.

## Release notes

### Improvements

* Tunable cluster configuration properties are added to set bounds on the `segment.bytes` topic property.  If `log_segment_size_min` and/or `log_segment_size_max` are set, then any `segment.bytes` outside these bounds will be silently clamped to the permitted range.  This prevents poorly-chosen configurations from inducing the cluster to create very large numbers of small segment files, or extremely large segment files.