### PR TITLE
Produce timeout

### DIFF
--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -9,27 +9,12 @@
 
 #include "raft/replicate_batcher.h"
 
-#include "model/fundamental.h"
-#include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "raft/consensus.h"
-#include "raft/consensus_utils.h"
-#include "raft/errc.h"
 #include "raft/replicate_entries_stm.h"
-#include "raft/types.h"
 #include "ssx/future-util.h"
 #include "utils/gate_guard.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/do_with.hh>
-#include <seastar/core/gate.hh>
-#include <seastar/core/sleep.hh>
-#include <seastar/core/smp.hh>
-
-#include <chrono>
-#include <cstddef>
-#include <exception>
 
 namespace raft {
 using namespace std::chrono_literals; // NOLINT

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -80,11 +80,11 @@ replicate_stages replicate_batcher::replicate(
                             return item->_promise.get_future();
                         });
                 });
-        return replicate_stages(std::move(enqueued_f), std::move(f));
+        return {std::move(enqueued_f), std::move(f)};
     } catch (...) {
-        return replicate_stages(
+        return {
           ss::current_exception_as_future<>(),
-          ss::make_ready_future<result<replicate_result>>(errc::shutting_down));
+          ss::make_ready_future<result<replicate_result>>(errc::shutting_down)};
     }
 }
 

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -123,7 +123,7 @@ public:
 
     replicate_stages replicate(
       std::optional<model::term_id>,
-      model::record_batch_reader&&,
+      model::record_batch_reader,
       consistency_level);
 
     ss::future<> flush(ssx::semaphore_units u, bool const transfer_flush);
@@ -139,7 +139,7 @@ private:
 
     ss::future<item_ptr> do_cache(
       std::optional<model::term_id>,
-      model::record_batch_reader&&,
+      model::record_batch_reader,
       consistency_level);
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -141,6 +141,13 @@ private:
       std::optional<model::term_id>,
       model::record_batch_reader,
       consistency_level);
+
+    ss::future<result<replicate_result>> cache_and_wait_for_result(
+      ss::promise<> enqueued,
+      std::optional<model::term_id> expected_term,
+      model::record_batch_reader r,
+      consistency_level consistency_lvl);
+
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,
       ss::circular_buffer<model::record_batch>,

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -26,19 +26,91 @@ class consensus;
 
 class replicate_batcher {
 public:
-    struct item {
-        ss::promise<result<replicate_result>> _promise;
-        size_t record_count;
-        std::vector<model::record_batch> data;
-        std::optional<model::term_id> expected_term;
+    class item {
+    public:
+        item(
+          size_t record_count,
+          std::vector<model::record_batch> batches,
+          ssx::semaphore_units u,
+          std::optional<model::term_id> expected_term,
+          consistency_level c_lvl,
+          std::optional<std::chrono::milliseconds> timeout)
+          : _record_count(record_count)
+          , _data(std::move(batches))
+          , _units(std::move(u))
+          , _expected_term(expected_term)
+          , _consistency_lvl(c_lvl) {
+            _timeout_timer.set_callback([this] { expire_with_timeout(); });
+            if (timeout) {
+                _timeout_timer.arm(timeout.value());
+            }
+        };
+
+        item(item&&) noexcept = default;
+        item& operator=(item&&) noexcept = delete;
+
+        item operator=(const item&) = delete;
+        item(const item&) = delete;
+
+        ~item() = default;
+
+        std::optional<model::term_id> get_expected_term() const {
+            return _expected_term;
+        }
+
+        size_t get_record_count() const { return _record_count; }
+        consistency_level get_consistency_level() const {
+            return _consistency_lvl;
+        }
+
+        auto release_data() {
+            return std::make_tuple(std::move(_data), std::move(_units));
+        }
+
+        void set_value(result<replicate_result> r) {
+            if (!_ready) {
+                _timeout_timer.cancel();
+                _ready = true;
+                _promise.set_value(r);
+            }
+        }
+
+        void set_exception(const std::exception_ptr& e) {
+            if (!_ready) {
+                _timeout_timer.cancel();
+                _ready = true;
+                _promise.set_exception(e);
+            }
+        }
+
+        ss::future<result<replicate_result>> get_future() {
+            return _promise.get_future();
+        }
+
+    private:
+        void expire_with_timeout() {
+            if (!_ready) {
+                _ready = true;
+                _data.clear();
+                _units.return_all();
+                _promise.set_value(errc::timeout);
+            }
+        }
+        size_t _record_count;
+        std::vector<model::record_batch> _data;
+        ssx::semaphore_units _units;
+        std::optional<model::term_id> _expected_term;
         // consistency level is stored to distinguish when an item promise
         // should be signaled with replication result
-        consistency_level consistency_lvl;
+        consistency_level _consistency_lvl;
         /**
          * Item keeps semaphore units until replicate batcher is done with
          * processing the request.
          */
-        ssx::semaphore_units units;
+
+        bool _ready{false};
+        ss::timer<> _timeout_timer;
+        ss::promise<result<replicate_result>> _promise;
     };
     using item_ptr = ss::lw_shared_ptr<item>;
     explicit replicate_batcher(consensus* ptr, size_t cache_size);

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -124,7 +124,8 @@ public:
     replicate_stages replicate(
       std::optional<model::term_id>,
       model::record_batch_reader,
-      consistency_level);
+      consistency_level,
+      std::optional<std::chrono::milliseconds> = std::nullopt);
 
     ss::future<> flush(ssx::semaphore_units u, bool const transfer_flush);
 
@@ -140,19 +141,22 @@ private:
     ss::future<item_ptr> do_cache(
       std::optional<model::term_id>,
       model::record_batch_reader,
-      consistency_level);
-
-    ss::future<result<replicate_result>> cache_and_wait_for_result(
-      ss::promise<> enqueued,
-      std::optional<model::term_id> expected_term,
-      model::record_batch_reader r,
-      consistency_level consistency_lvl);
+      consistency_level,
+      std::optional<std::chrono::milliseconds>);
 
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,
       ss::circular_buffer<model::record_batch>,
       size_t,
-      consistency_level);
+      consistency_level,
+      std::optional<std::chrono::milliseconds>);
+
+    ss::future<result<replicate_result>> cache_and_wait_for_result(
+      ss::promise<> enqueued,
+      std::optional<model::term_id> expected_term,
+      model::record_batch_reader r,
+      consistency_level consistency_lvl,
+      std::optional<std::chrono::milliseconds> timeout);
 
     consensus* _ptr;
     ssx::semaphore _max_batch_size_sem;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -472,9 +472,15 @@ enum class consistency_level { quorum_ack, leader_ack, no_ack };
 
 struct replicate_options {
     explicit replicate_options(consistency_level l)
-      : consistency(l) {}
+      : consistency(l)
+      , timeout(std::nullopt) {}
+
+    replicate_options(consistency_level l, std::chrono::milliseconds timeout)
+      : consistency(l)
+      , timeout(timeout) {}
 
     consistency_level consistency;
+    std::optional<std::chrono::milliseconds> timeout;
 };
 
 using offset_translator_delta = named_type<int64_t, struct ot_delta_tag>;


### PR DESCRIPTION
## Cover letter

Added handling for request timeout in replicate batcher. The timeout
handling in batcher is based on separate timer for each of the
replicate request. Arming and canceling a timer is a not resource
consuming operation in seastar.

Leveraging a separate timer for each replicate item allow us to release
memory and not hold the timed out task in the task queue.
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #203 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
