### PR TITLE
Fix 5079

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -10,7 +10,7 @@
 
 from rptest.services.cluster import cluster
 
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.kafka_cli_consumer import KafkaCliConsumer
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
@@ -377,9 +377,13 @@ class ConsumerGroupTest(RedpandaTest):
         rpk.delete_topic(self.topic_spec.name)
 
         def group_is_dead():
-            rpk_group = rpk.group_describe(group)
-
-            return rpk_group.members == 0 and rpk_group.state == "Dead"
+            try:
+                rpk_group = rpk.group_describe(group)
+                return rpk_group.members == 0 and rpk_group.state == "Dead"
+            except RpkException as e:
+                # allow RPK to throw an exception as redpanda nodes were
+                # restarted and the request may require a retry
+                return False
 
         wait_until(group_is_dead, 30, 2)
         self.producer.wait()

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -18,7 +18,6 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.utils.util import wait_until
 from ducktape.mark import parametrize
-from ducktape.mark import ok_to_fail
 
 
 class ConsumerGroupTest(RedpandaTest):
@@ -326,7 +325,6 @@ class ConsumerGroupTest(RedpandaTest):
             c.wait()
             c.free()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5079
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(static_members=True)
     @parametrize(static_members=False)


### PR DESCRIPTION
## Cover letter

When describing a group in a `test_dead_group` recovery test we must allow for `rpk` to return an error and then retry.

Fixes: #5079

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
