### PR TITLE
tests/services: two phase stop for kafka cli svc

### DIFF
--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -40,6 +40,7 @@ class KafkaCliConsumer(BackgroundThreadService):
         self._formatter_properties = formatter_properties
         self._stopping = threading.Event()
         self._instance_name = "cli-consumer" if instance_name is None else instance_name
+        self._done = None
         assert self._partitions is not None or self._group is not None, "either partitions or group have to be set"
 
         self._cli = KafkaCliTools(self._redpanda)
@@ -49,6 +50,7 @@ class KafkaCliConsumer(BackgroundThreadService):
         return self._cli._script("kafka-console-consumer.sh")
 
     def _worker(self, _, node):
+        self._done = False
         self._stopping.clear()
         try:
 
@@ -84,7 +86,7 @@ class KafkaCliConsumer(BackgroundThreadService):
             else:
                 raise
         finally:
-            self.done = True
+            self._done = True
 
     def wait_for_messages(self, messages, timeout=30):
         wait_until(lambda: len(self._messages) >= messages,
@@ -103,3 +105,18 @@ class KafkaCliConsumer(BackgroundThreadService):
     def stop_node(self, node):
         self._stopping.set()
         node.account.kill_process("java", clean_shutdown=True)
+
+        try:
+            wait_until(lambda: self._done is None or self._done == True,
+                       timeout_sec=10)
+        except:
+            self.logger.warn(
+                f"{self._instance_name} running on {node.name} failed to stop gracefully"
+            )
+            node.account.kill_process("java", clean_shutdown=False)
+            wait_until(
+                lambda: self._done is None or self._done == True,
+                timeout_sec=5,
+                err_msg=
+                f"{self._instance_name} running on {node.name} failed to stop after SIGKILL"
+            )


### PR DESCRIPTION
## Cover letter
This PR makes the KafkaCliConsumer stop procedure two phase. We first try to terminate it gracefully and allow it to leave the consumer group. If that doesn't work we SIGKILL the process to ensure we don't end up with a stray consumer like in #6490.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6490

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
