### PR TITLE
[v22.2.x] ducktape: partition balancer status add retries

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -59,7 +59,8 @@ class Admin:
                  redpanda,
                  default_node=None,
                  retry_codes=None,
-                 auth=None):
+                 auth=None,
+                 retries_amount=5):
         self.redpanda = redpanda
 
         self._session = AuthPreservingSession()
@@ -78,7 +79,7 @@ class Admin:
         if retry_codes is None:
             retry_codes = [503]
 
-        retries = Retry(status=5,
+        retries = Retry(status=retries_amount,
                         connect=0,
                         read=0,
                         backoff_factor=1,

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -77,7 +77,7 @@ class PartitionBalancerTest(EndToEndTest):
     def wait_until_status(self, predicate, timeout_sec=120):
         # We may get a 504 if we proxy a status request to a suspended node.
         # It is okay to retry (the controller leader will get re-elected in the meantime).
-        admin = Admin(self.redpanda, retry_codes=[503, 504])
+        admin = Admin(self.redpanda, retry_codes=[503, 504], retries_amount=10)
         start = time.time()
 
         def check():


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6392.
Fixes https://github.com/redpanda-data/redpanda/issues/6504,