### PR TITLE
Demote an archival snapshot log line to debug

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -404,7 +404,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
       snapshot{.segments = std::move(segments)});
 
     vlog(
-      _logger.info,
+      _logger.debug,
       "creating snapshot at offset: {}, remote start_offset: {}, last_offset: "
       "{}",
       _insync_offset,


### PR DESCRIPTION
This info line was very noisy since it logs proportional to the amount of data being ingested. Move it to debug.