### PR TITLE
cloud_storage: check that we have serialized the whole manifest

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -752,6 +752,12 @@ serialized_json_stream partition_manifest::serialize() const {
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
+    if (!os.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "could not serialize partition manifest {}",
+          get_manifest_path()));
+    }
     size_t size_bytes = serialized.size_bytes();
     return {
       .stream = make_iobuf_input_stream(std::move(serialized)),

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -313,6 +313,12 @@ serialized_json_stream topic_manifest::serialize() const {
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
+    if (!os.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "could not serialize topic manifest {}",
+          get_manifest_path()));
+    }
     size_t size_bytes = serialized.size_bytes();
     return {
       .stream = make_iobuf_input_stream(std::move(serialized)),

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -82,6 +82,12 @@ serialized_json_stream tx_range_manifest::serialize() const {
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
+    if (!os.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "could not serialize tx range manifest {}",
+          get_manifest_path()));
+    }
     size_t size_bytes = serialized.size_bytes();
     return {
       .stream = make_iobuf_input_stream(std::move(serialized)),


### PR DESCRIPTION
## Cover letter

It turns out that if the underlying buffer object throws (e.g. a bad_alloc exception), `std::ostream` swallows the exception and sets the "badbit". If we don't check it, this can lead to the serialized manifest being truncated and to corrupt manifests being uploaded to the cloud storage. To prevent that we check that `std::ostream` is in a good state after serializing manifests.

More info: https://en.cppreference.com/w/cpp/io/ios_base/iostate

## Backport Required

- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes
none

## Release notes
### Bug fixes
* Fix possible shadow indexing manifest corruption under memory pressure.
