### PR TITLE
[v22.1.x] cloud_storage: check that we have serialized the whole manifest

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -412,6 +412,12 @@ serialized_json_stream partition_manifest::serialize() const {
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
+    if (!os.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "could not serialize partition manifest {}",
+          get_manifest_path()));
+    }
     size_t size_bytes = serialized.size_bytes();
     return {
       .stream = make_iobuf_input_stream(std::move(serialized)),

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -312,6 +312,12 @@ serialized_json_stream topic_manifest::serialize() const {
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
+    if (!os.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "could not serialize topic manifest {}",
+          get_manifest_path()));
+    }
     size_t size_bytes = serialized.size_bytes();
     return {
       .stream = make_iobuf_input_stream(std::move(serialized)),


### PR DESCRIPTION
Backport from pull request: #6507 