### PR TITLE
serde: pass header by value to serde_async_read

### DIFF
--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -578,7 +578,7 @@ ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
 }
 
 ss::future<> append_entries_request::serde_async_read(
-  iobuf_parser& src, const serde::header& hdr) {
+  iobuf_parser& src, const serde::header hdr) {
     using serde::read_nested;
     auto tmp = read_nested<iobuf>(src, hdr._bytes_left_limit);
     iobuf_parser in(std::move(tmp));

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -273,7 +273,7 @@ struct append_entries_request
     }
 
     ss::future<> serde_async_write(iobuf& out);
-    ss::future<> serde_async_read(iobuf_parser&, const serde::header&);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 
 private:
     /*

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -85,8 +85,7 @@ concept has_serde_write = requires(T t, iobuf& out) {
 };
 
 template<typename T>
-concept has_serde_async_read
-  = requires(T t, iobuf_parser& in, const header& h) {
+concept has_serde_async_read = requires(T t, iobuf_parser& in, header h) {
     { t.serde_async_read(in, h) } -> seastar::Future;
 };
 

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -377,7 +377,7 @@ struct test_snapshot_header
       test_snapshot_header,
       serde::version<1>,
       serde::compat_version<0>> {
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const&);
+    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
     ss::future<> serde_async_write(iobuf&) const;
 
     model::ns ns_;
@@ -392,7 +392,7 @@ static_assert(serde::has_serde_async_read<test_snapshot_header>);
 static_assert(serde::has_serde_async_write<test_snapshot_header>);
 
 ss::future<> test_snapshot_header::serde_async_read(
-  iobuf_parser& in, serde::header const& h) {
+  iobuf_parser& in, serde::header const h) {
     ns_ = serde::read_nested<decltype(ns_)>(in, h._bytes_left_limit);
     header_crc = serde::read_nested<decltype(header_crc)>(
       in, h._bytes_left_limit);


### PR DESCRIPTION

## Cover letter

Previously, it was very easy to write subtly broken serde_async_read coroutines that tried to refer
to `hdr` after a scheduling point.  They would
occasionally get zeroed memory, which isn't an obvious failure because zero is a valid version for most structs, but causes logical misbehavior when the rest of the application is expecting the fields on latest-version structs to be present + decoded.

This safety could also be achieved by putting the header in the `do_with` function that invokes serde_async_read (I tried it), but that makes it less obvious to writers of `serde_async_read` what the safety rules are: they would have to know how they're being called to know how long the reference was valid.  It's more robust and easier to understand to simply pass this small struct by value.


## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none