### PR TITLE
tests: disable segment size jitter in integration tests

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -53,6 +53,15 @@ configuration::configuration()
        .example = "268435456",
        .visibility = visibility::tunable},
       std::nullopt)
+  , log_segment_size_jitter_percent(
+      *this,
+      "log_segment_size_jitter_percent",
+      "Random variation to the segment size limit used for each partition",
+      {.needs_restart = needs_restart::yes,
+       .example = "2",
+       .visibility = visibility::tunable},
+      5,
+      {.min = 0, .max = 99})
   , compacted_log_segment_size(
       *this,
       "compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -44,6 +44,7 @@ struct configuration final : public config_store {
     bounded_property<uint64_t> log_segment_size;
     property<std::optional<uint64_t>> log_segment_size_min;
     property<std::optional<uint64_t>> log_segment_size_max;
+    bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
     // Network

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -611,6 +611,7 @@ manager_config_from_global_config(scheduling_groups& sgs) {
       config::shard_local_cfg().log_segment_size.bind(),
       config::shard_local_cfg().compacted_log_segment_size.bind(),
       config::shard_local_cfg().max_compacted_log_segment_size.bind(),
+      int(config::shard_local_cfg().log_segment_size_jitter_percent()),
       storage::debug_sanitize_files::no,
       priority_manager::local().compaction_priority(),
       config::shard_local_cfg().retention_bytes.bind(),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -611,7 +611,8 @@ manager_config_from_global_config(scheduling_groups& sgs) {
       config::shard_local_cfg().log_segment_size.bind(),
       config::shard_local_cfg().compacted_log_segment_size.bind(),
       config::shard_local_cfg().max_compacted_log_segment_size.bind(),
-      int(config::shard_local_cfg().log_segment_size_jitter_percent()),
+      storage::jitter_percents(
+        config::shard_local_cfg().log_segment_size_jitter_percent()),
       storage::debug_sanitize_files::no,
       priority_manager::local().compaction_priority(),
       config::shard_local_cfg().retention_bytes.bind(),

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -88,6 +88,7 @@ struct log_config {
       config::binding<size_t> segment_size,
       config::binding<size_t> compacted_segment_size,
       config::binding<size_t> max_compacted_segment_size,
+      int segment_size_jitter,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority,
       config::binding<std::optional<size_t>> ret_bytes,
@@ -100,6 +101,7 @@ struct log_config {
       : stype(type)
       , base_dir(std::move(directory))
       , max_segment_size(segment_size)
+      , segment_size_jitter(internal::jitter_percents{segment_size_jitter})
       , compacted_segment_size(compacted_segment_size)
       , max_compacted_segment_size(max_compacted_segment_size)
       , sanitize_fileops(should)
@@ -125,7 +127,7 @@ struct log_config {
     config::binding<size_t> max_segment_size;
 
     // Default 5% jitter on segment size thresholds
-    internal::jitter_percents segment_size_jitter{5};
+    internal::jitter_percents segment_size_jitter;
 
     // compacted segment size
     config::binding<size_t> compacted_segment_size;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -88,7 +88,7 @@ struct log_config {
       config::binding<size_t> segment_size,
       config::binding<size_t> compacted_segment_size,
       config::binding<size_t> max_compacted_segment_size,
-      int segment_size_jitter,
+      jitter_percents segment_size_jitter,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority,
       config::binding<std::optional<size_t>> ret_bytes,
@@ -101,7 +101,7 @@ struct log_config {
       : stype(type)
       , base_dir(std::move(directory))
       , max_segment_size(segment_size)
-      , segment_size_jitter(internal::jitter_percents{segment_size_jitter})
+      , segment_size_jitter(segment_size_jitter)
       , compacted_segment_size(compacted_segment_size)
       , max_compacted_segment_size(max_compacted_segment_size)
       , sanitize_fileops(should)
@@ -127,7 +127,7 @@ struct log_config {
     config::binding<size_t> max_segment_size;
 
     // Default 5% jitter on segment size thresholds
-    internal::jitter_percents segment_size_jitter;
+    jitter_percents segment_size_jitter;
 
     // compacted segment size
     config::binding<size_t> compacted_segment_size;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -173,8 +173,6 @@ ss::future<> do_swap_data_file_handles(
 
 std::filesystem::path compacted_index_path(std::filesystem::path segment_path);
 
-using jitter_percents = named_type<int, struct jitter_percents_tag>;
-
 // Generates a random jitter percentage [as a fraction] with in the passed
 // percents range.
 float random_jitter(jitter_percents);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1343,7 +1343,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
 
     // Switch on jitter: it is off by default in default_log_config because
     // for most tests randomness is undesirable.
-    cfg.segment_size_jitter = storage::internal::jitter_percents{5};
+    cfg.segment_size_jitter = storage::jitter_percents{5};
 
     // defaults
     cfg.max_segment_size = config::mock_binding<size_t>(100_KiB);

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -109,9 +109,6 @@ public:
           ss::default_priority_class(),
           cache);
 
-        // Disable jitter for unit tests
-        cfg.segment_size_jitter = storage::internal::jitter_percents{0};
-
         return cfg;
     }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -30,6 +30,7 @@
 namespace storage {
 using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
+using jitter_percents = named_type<int, struct jitter_percents_tag>;
 
 enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
 

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -73,6 +73,16 @@ class KgoVerifierTest(KgoVerifierBase):
 
     topics = (TopicSpec(partition_count=100, replication_factor=3), )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            **kwargs,
+            extra_rp_conf={
+                # Enable segment size jitter as this is a stress test and does not
+                # rely on exact segment counts.
+                'log_segment_size_jitter_percent': 5,
+            })
+
     @cluster(num_nodes=4)
     def test_with_all_type_of_loads(self):
         self.logger.info(f"Environment: {os.environ}")
@@ -144,6 +154,10 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
                 # intervals
                 'election_timeout_ms': 5000,
                 'raft_heartbeat_interval_ms': 500,
+
+                # Enable segment size jitter as this is a stress test and does not
+                # rely on exact segment counts.
+                'log_segment_size_jitter_percent': 5,
             },
             si_settings=si_settings)
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -227,6 +227,10 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # not expect to hit them.
                 'kafka_connection_rate_limit': 10000,
                 'kafka_connections_max': 50000,
+
+                # Enable segment size jitter as this is a stress test and does not
+                # rely on exact segment counts.
+                'log_segment_size_jitter_percent': 5,
             },
             # Configure logging the same way a user would when they have
             # very many partitions: set logs with per-partition messages

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -59,6 +59,8 @@ class KgoVerifierService(Service):
             if not hasattr(node, "kgo_verifier_ports"):
                 node.kgo_verifier_ports = {}
 
+        self._status_thread = None
+
     def __del__(self):
         self._release_port()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1594,6 +1594,11 @@ class RedpandaService(Service):
 
     def write_bootstrap_cluster_config(self):
         conf = copy.deepcopy(self.CLUSTER_CONFIG_DEFAULTS)
+
+        if self._installer.installed_version != RedpandaInstaller.HEAD:
+            # If we're running an older version, exclude some newer configs
+            del conf['log_segment_size_jitter_percent']
+
         if self._extra_rp_conf:
             self.logger.debug(
                 "Setting custom cluster configuration options: {}".format(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -448,6 +448,10 @@ class RedpandaService(Service):
         'default_topic_partitions': 4,
         'enable_metrics_reporter': False,
         'superusers': [SUPERUSER_CREDENTIALS[0]],
+        # Disable segment size jitter to make tests more deterministic if they rely on
+        # inspecting storage internals (e.g. number of segments after writing a certain
+        # amount of data).
+        'log_segment_size_jitter_percent': 0,
     }
 
     logs = {

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -142,6 +142,12 @@ class RedpandaInstaller:
         # (i.e. root_for_version(), etc).
         self._install_lock_fd = None
 
+        self._installed_version = self.HEAD
+
+    @property
+    def installed_version(self):
+        return self._installed_version
+
     def _acquire_install_lock(self, timeout_sec=600):
         """
         Attempt to take the install lock, preventing other test processes from
@@ -313,6 +319,7 @@ class RedpandaInstaller:
         try:
             self._acquire_install_lock()
             self._install_unlocked(nodes, version)
+            self._installed_version = version
         finally:
             self._release_install_lock()
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -25,14 +25,7 @@ def bytes_for_segments(want_segments, segment_size):
     just this number of segments (assuming all segments are written
     to their size limit).
     """
-
-    # When predicting segment sizes, we must account for segment_size_jitter
-    # which adjusts segment sizes up or down by 5%.  We must handle the case
-    # where segments are the smallest they can be.
-    # (see `jitter_segment_size` in segment_utils.cc)
-    segment_size_jitter_factor = 0.95
-
-    return int((want_segments * segment_size) * segment_size_jitter_factor)
+    return int(want_segments * segment_size)
 
 
 class RetentionPolicyTest(RedpandaTest):

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -246,7 +246,6 @@ def is_close_size(actual_size, expected_size):
     """Checks if the log size is close to expected size.
     The actual size shouldn't be less than expected. Also, the difference
     between two values shouldn't be greater than the size of one segment.
-    It also takes into account segment size jitter.
     """
     lower_bound = expected_size
     upper_bound = expected_size + default_log_segment_size + \


### PR DESCRIPTION
## Cover letter

Segment size jitter is a good defensive measure in real systems to space out any overhead from segment rolls over time.  In testing, this jitter creates two problems:
- A test which appears to work reliably can occasionally fail later when it gets unlucky on the segment size lottery, if it depends on particular numbers of segments (especially storage and cloud storage test)
- Tests end up with fudge factors in their assertions, which allow for segment size variation but might hide other issues.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* A new tunable cluster property `log_segment_size_jitter_percent` is added, to enable greater determinism in test/benchmark environments by disabling jitter.  The default 5% jitter is the same as in previous versions.