### PR TITLE
SI: enable concatenated segment upload

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -398,12 +398,12 @@ ss::future<upload_result> remote::upload_segment(
               bucket,
               path,
               content_length,
-              reader_handle.take_stream(),
+              reader_handle->take_stream(),
               tags,
               fib.get_timeout());
             _probe.successful_upload();
             _probe.register_upload_size(content_length);
-            co_await reader_handle.close();
+            co_await reader_handle->close();
             co_return upload_result::success;
         } catch (...) {
             eptr = std::current_exception();
@@ -411,7 +411,7 @@ ss::future<upload_result> remote::upload_segment(
 
         // `put_object` closed the encapsulated input_stream, but we must
         // call close() on the segment_reader_handle to release the FD.
-        co_await reader_handle.close();
+        co_await reader_handle->close();
 
         co_await client->shutdown();
         auto outcome = categorize_error(eptr, fib, bucket, path);

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -104,8 +104,8 @@ class remote : public ss::peering_sharded_service<remote> {
 public:
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
-    using reset_input_stream
-      = ss::noncopyable_function<ss::future<storage::segment_reader_handle>()>;
+    using reset_input_stream = ss::noncopyable_function<
+      ss::future<std::unique_ptr<storage::stream_provider>>()>;
 
     /// Functor that attempts to consume the input stream. If the connection
     /// is broken during the download the functor is responsible for he cleanup.

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -62,11 +62,11 @@ static cloud_storage::lazy_abort_source always_continue("no-op", [](auto&) {
  * Helper: generate a function suitable for passing to upload_segment(),
  * exposing some synthetic data as a segment_reader_handle.
  */
-ss::noncopyable_function<ss::future<storage::segment_reader_handle>()>
-make_reset_fn(iobuf& segment_bytes) {
-    return [&segment_bytes]() -> ss::future<storage::segment_reader_handle> {
+remote::reset_input_stream make_reset_fn(iobuf& segment_bytes) {
+    return [&segment_bytes]()
+             -> ss::future<std::unique_ptr<storage::stream_provider>> {
         auto out = iobuf_deep_copy(segment_bytes);
-        co_return storage::segment_reader_handle(
+        co_return std::make_unique<storage::segment_reader_handle>(
           make_iobuf_input_stream(std::move(out)));
     };
 }

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ rp_test(
     kvstore_test.cc
     backlog_controller_test.cc
     readers_cache_test.cc
+    concat_segment_reader_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "model/tests/random_batch.h"
+#include "storage/directories.h"
+#include "storage/log_manager.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+constexpr size_t segment_size{32_MiB};
+
+using namespace storage;
+
+size_t copy_stream(concat_segment_reader_view& cv) {
+    auto concat_str = cv.take_stream();
+    iobuf buffer{};
+    auto ostream = make_iobuf_ref_output_stream(buffer);
+    ss::copy(concat_str, ostream).get();
+
+    // We do not actually need to close this, because the stream has been moved
+    // out of this view.
+    cv.close().get();
+
+    // Closes the stream, the data source and the
+    // concat_segment_data_source_impl
+    concat_str.close().get();
+    auto sz = buffer.size_bytes();
+    ostream.close().get();
+    return sz;
+}
+
+SEASTAR_THREAD_TEST_CASE(
+  test_multiple_segments_read_with_content_verification) {
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    disk_log_builder b{log_config{
+      log_config::storage_type::disk,
+      data_path.string(),
+      segment_size,
+      debug_sanitize_files::yes,
+    }};
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    size_t start_offset = 0;
+
+    // Set up the first segment and start_pos
+    // Add a sentinel batch after which view will start reading
+    b | add_segment(start_offset)
+      | add_random_batch(
+        start_offset,
+        1,
+        maybe_compress_batches::yes,
+        model::record_batch_type::acl_management_cmd);
+
+    size_t start_pos = b.bytes_written();
+    start_offset = b.get_segment(0).offsets().dirty_offset + model::offset{1};
+    b
+      | add_random_batch(
+        start_offset,
+        10,
+        maybe_compress_batches::yes,
+        model::record_batch_type::user_management_cmd);
+
+    // Add intermediate segments
+    start_offset = b.get_segment(0).offsets().dirty_offset + model::offset{1};
+    for (auto i = 1; i < 4; ++i) {
+        b | add_segment(start_offset)
+          | add_random_batch(
+            start_offset,
+            10,
+            maybe_compress_batches::yes,
+            model::record_batch_type::user_management_cmd);
+        start_offset = b.get_segment(i).offsets().dirty_offset
+                       + model::offset{1};
+    }
+
+    // Set up the last segment and end_pos
+    b | add_segment(start_offset)
+      | add_random_batch(
+        start_offset,
+        10,
+        maybe_compress_batches::yes,
+        model::record_batch_type::user_management_cmd);
+    start_offset = b.get_segment(4).offsets().dirty_offset + model::offset{1};
+
+    // Add a sentinel batch, view will read upto here
+    auto final_segment = b.get_log_segments().back();
+    size_t end_pos = final_segment->file_size();
+    b
+      | add_random_batch(
+        start_offset,
+        1,
+        maybe_compress_batches::yes,
+        model::record_batch_type::acl_management_cmd);
+
+    const auto& log_segments = b.get_log_segments();
+    auto segments = std::vector<ss::lw_shared_ptr<segment>>{
+      log_segments.begin(), log_segments.end()};
+
+    // All the batches in the view should have user_management_cmd as type. The
+    // boundaries should exclude acl_management_cmd.
+    concat_segment_reader_view cv{
+      segments, start_pos, end_pos, ss::default_priority_class()};
+
+    iobuf buf;
+    auto result = transform_stream(
+                    cv.take_stream(),
+                    make_iobuf_ref_output_stream(buf),
+                    [](model::record_batch_header h) {
+                        BOOST_REQUIRE_EQUAL(
+                          h.type,
+                          model::record_batch_type::user_management_cmd);
+                        return batch_consumer::consume_result::accept_batch;
+                    })
+                    .get();
+    BOOST_REQUIRE(!result.has_error());
+    BOOST_REQUIRE_EQUAL(
+      result.value(),
+      b.get_disk_log_impl().size_bytes()
+        - (start_pos + final_segment->file_size() - end_pos));
+    b.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_single_segment_read_with_bounds) {
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+
+    using namespace storage;
+
+    disk_log_builder b{log_config{
+      log_config::storage_type::disk,
+      data_path.string(),
+      segment_size,
+      debug_sanitize_files::yes,
+    }};
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}})
+      | add_segment(0) | add_random_batch(0, 10);
+
+    const auto& log_segments = b.get_log_segments();
+    auto segments = std::vector<ss::lw_shared_ptr<segment>>{
+      log_segments.begin(), log_segments.end()};
+
+    size_t start_pos = 20;
+    size_t end_pos = log_segments.back()->file_size() - 20;
+
+    concat_segment_reader_view cv{
+      segments, start_pos, end_pos, ss::default_priority_class()};
+    BOOST_REQUIRE_EQUAL(
+      b.get_disk_log_impl().size_bytes() - 40, copy_stream(cv));
+    b.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_single_segment_read_full) {
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    disk_log_builder b{log_config{
+      log_config::storage_type::disk,
+      data_path.string(),
+      segment_size,
+      debug_sanitize_files::yes,
+    }};
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}})
+      | add_segment(0) | add_random_batch(0, 10);
+
+    const auto& log_segments = b.get_log_segments();
+    auto segments = std::vector<ss::lw_shared_ptr<segment>>{
+      log_segments.begin(), log_segments.end()};
+
+    size_t start_pos = 0;
+    size_t end_pos = log_segments.back()->file_size();
+    concat_segment_reader_view cv{
+      segments, start_pos, end_pos, ss::default_priority_class()};
+    BOOST_REQUIRE_EQUAL(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
+    b.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    disk_log_builder b{log_config{
+      log_config::storage_type::disk,
+      data_path.string(),
+      segment_size,
+      debug_sanitize_files::yes,
+    }};
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    size_t start_offset = 0;
+    for (auto i = 0; i < 5; ++i) {
+        b | add_segment(start_offset) | add_random_batch(start_offset, 10);
+        start_offset = b.get_segment(i).offsets().dirty_offset
+                       + model::offset{1};
+    }
+
+    const auto& log_segments = b.get_log_segments();
+    auto segments = std::vector<ss::lw_shared_ptr<segment>>{
+      log_segments.begin(), log_segments.end()};
+
+    size_t start_pos = 0;
+    size_t end_pos = log_segments.back()->file_size();
+    concat_segment_reader_view cv{
+      segments, start_pos, end_pos, ss::default_priority_class()};
+    BOOST_REQUIRE_EQUAL(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
+    b.stop().get();
+}


### PR DESCRIPTION
## Cover letter

Introduces a concatenated segment reader view and data source implementation. This view provides an input stream which reads from multiple segments starting from a given file position and ending at a file position, sequentially. 

The data source implementation switches to the next segment when one segment is depleted. The first segment is read beginning from the given start file position and the last segment is read upto the given end file position.

The reader view API is modelled after  segment reader handle, so that archival remote can either upload a single segment (using segment reader handle) or upload multiple segments with a preset start and end offset (using the concatenated segment reader view).

This view will be used to upload multiple adjacent compacted segments during compacted segment upload, to ensure alignment with segments already in SI manifest.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* None

### Features

Enables the archival remote utility to upload multiple adjacent segments.
