### PR TITLE
Fix issue with changing metrics settings in centralized config

### DIFF
--- a/src/go/k8s/pkg/resources/configuration/configuration.go
+++ b/src/go/k8s/pkg/resources/configuration/configuration.go
@@ -158,8 +158,8 @@ func isKnownNodeProperty(prop string) bool {
 func init() {
 	knownNodeProperties = make(map[string]bool)
 
-	// The assumption here is that all explicit fields of RedpandaConfig are node properties
-	cfg := reflect.TypeOf(config.RedpandaConfig{})
+	// The assumption here is that all explicit fields of RedpandaNodeConfig are node properties
+	cfg := reflect.TypeOf(config.RedpandaNodeConfig{})
 	for i := 0; i < cfg.NumField(); i++ {
 		tag := cfg.Field(i).Tag
 		yamlTag := tag.Get("yaml")

--- a/src/go/k8s/tests/e2e-unstable/centralized-configuration/03-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e-unstable/centralized-configuration/03-redpanda-cluster-change.yaml
@@ -25,4 +25,4 @@ spec:
     developerMode: true
   additionalConfiguration:
     redpanda.segment_appender_flush_timeout_ms: "1003"
-    redpanda.append_chunk_size: "40960" # cluster property that currently needs restart
+    redpanda.aggregate_metrics: "true" # cluster property that currently needs restart (also see: https://github.com/redpanda-data/redpanda/issues/6514)

--- a/src/go/k8s/tests/e2e-unstable/centralized-configuration/05-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/centralized-configuration/05-assert.yaml
@@ -9,7 +9,7 @@ status:
       state:
         terminated:
           message: |
-            40960
+            true
   phase: Succeeded
 ---
 

--- a/src/go/k8s/tests/e2e-unstable/centralized-configuration/05-probe.yaml
+++ b/src/go/k8s/tests/e2e-unstable/centralized-configuration/05-probe.yaml
@@ -22,9 +22,9 @@ spec:
           args:
             - >
               url=http://centralized-configuration-0.centralized-configuration.$NAMESPACE.svc.cluster.local:9644/v1/config
-              res=$(curl --silent -L $url | grep -o '\"append_chunk_size\":[^,}]*' | grep -o '[^:]*$') &&
+              res=$(curl --silent -L $url | grep -o '\"aggregate_metrics\":[^,}]*' | grep -o '[^:]*$') &&
               echo $res > /dev/termination-log &&
-              if [[ "$res" != "40960" ]]; then
+              if [[ "$res" != "true" ]]; then
                 exit 1;
               fi
       restartPolicy: Never

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -30,7 +30,7 @@ const (
 func Default() *Config {
 	return &Config{
 		fileLocation: DefaultPath,
-		Redpanda: RedpandaConfig{
+		Redpanda: RedpandaNodeConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{
 				Address: "0.0.0.0",

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -447,7 +447,7 @@ func TestDefault(t *testing.T) {
 		fileLocation:   DefaultPath,
 		Pandaproxy:     &Pandaproxy{},
 		SchemaRegistry: &SchemaRegistry{},
-		Redpanda: RedpandaConfig{
+		Redpanda: RedpandaNodeConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{"0.0.0.0", 33145},
 			KafkaAPI: []NamedAuthNSocketAddress{{

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -142,7 +142,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 	}
 	expCfg := &Config{
 		fileLocation: "/etc/redpanda/redpanda.yaml",
-		Redpanda: RedpandaConfig{
+		Redpanda: RedpandaNodeConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{
 				Address: "0.0.0.0",

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -66,8 +66,6 @@ type RedpandaConfig struct {
 	AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api,omitempty" json:"advertised_rpc_api,omitempty"`
 	AdvertisedKafkaAPI         []NamedSocketAddress      `yaml:"advertised_kafka_api,omitempty" json:"advertised_kafka_api,omitempty"`
 	DeveloperMode              bool                      `yaml:"developer_mode,omitempty" json:"developer_mode"`
-	AggregateMetrics           bool                      `yaml:"aggregate_metrics,omitempty" json:"aggregate_metrics,omitempty"`
-	DisablePublicMetrics       bool                      `yaml:"disable_public_metrics,omitempty" json:"disable_public_metrics,omitempty"`
 	Other                      map[string]interface{}    `yaml:",inline"`
 }
 

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -48,6 +48,11 @@ func (c *Config) FileLocation() string {
 	return c.fileLocation
 }
 
+// RedpandaConfig is the source of truth for Redpanda node configuration.
+//
+// Cluster properties must NOT be enlisted in this struct. Adding a cluster
+// property here would cause the dependent libraries (e.g. operator) to wrongly
+// consider it a node property.
 type RedpandaConfig struct {
 	Directory                  string                    `yaml:"data_directory,omitempty" json:"data_directory"`
 	ID                         int                       `yaml:"node_id" json:"node_id"`

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -21,16 +21,16 @@ type Config struct {
 	file         *Config
 	fileLocation string
 
-	NodeUUID             string          `yaml:"node_uuid,omitempty" json:"node_uuid"`
-	Organization         string          `yaml:"organization,omitempty" json:"organization"`
-	LicenseKey           string          `yaml:"license_key,omitempty" json:"license_key"`
-	ClusterID            string          `yaml:"cluster_id,omitempty" json:"cluster_id"`
-	Redpanda             RedpandaConfig  `yaml:"redpanda,omitempty" json:"redpanda"`
-	Rpk                  RpkConfig       `yaml:"rpk,omitempty" json:"rpk"`
-	Pandaproxy           *Pandaproxy     `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
-	PandaproxyClient     *KafkaClient    `yaml:"pandaproxy_client,omitempty" json:"pandaproxy_client,omitempty"`
-	SchemaRegistry       *SchemaRegistry `yaml:"schema_registry,omitempty" json:"schema_registry,omitempty"`
-	SchemaRegistryClient *KafkaClient    `yaml:"schema_registry_client,omitempty" json:"schema_registry_client,omitempty"`
+	NodeUUID             string             `yaml:"node_uuid,omitempty" json:"node_uuid"`
+	Organization         string             `yaml:"organization,omitempty" json:"organization"`
+	LicenseKey           string             `yaml:"license_key,omitempty" json:"license_key"`
+	ClusterID            string             `yaml:"cluster_id,omitempty" json:"cluster_id"`
+	Redpanda             RedpandaNodeConfig `yaml:"redpanda,omitempty" json:"redpanda"`
+	Rpk                  RpkConfig          `yaml:"rpk,omitempty" json:"rpk"`
+	Pandaproxy           *Pandaproxy        `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
+	PandaproxyClient     *KafkaClient       `yaml:"pandaproxy_client,omitempty" json:"pandaproxy_client,omitempty"`
+	SchemaRegistry       *SchemaRegistry    `yaml:"schema_registry,omitempty" json:"schema_registry,omitempty"`
+	SchemaRegistryClient *KafkaClient       `yaml:"schema_registry_client,omitempty" json:"schema_registry_client,omitempty"`
 
 	Other map[string]interface{} `yaml:",inline"`
 }
@@ -48,12 +48,12 @@ func (c *Config) FileLocation() string {
 	return c.fileLocation
 }
 
-// RedpandaConfig is the source of truth for Redpanda node configuration.
+// RedpandaNodeConfig is the source of truth for Redpanda node configuration.
 //
 // Cluster properties must NOT be enlisted in this struct. Adding a cluster
 // property here would cause the dependent libraries (e.g. operator) to wrongly
 // consider it a node property.
-type RedpandaConfig struct {
+type RedpandaNodeConfig struct {
 	Directory                  string                    `yaml:"data_directory,omitempty" json:"data_directory"`
 	ID                         int                       `yaml:"node_id" json:"node_id"`
 	Rack                       string                    `yaml:"rack,omitempty" json:"rack"`

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -344,8 +344,6 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api"`
 		AdvertisedKafkaAPI         namedSocketAddresses      `yaml:"advertised_kafka_api"`
 		DeveloperMode              weakBool                  `yaml:"developer_mode"`
-		AggregateMetrics           weakBool                  `yaml:"aggregate_metrics"`
-		DisablePublicMetrics       weakBool                  `yaml:"disable_public_metrics"`
 		Other                      map[string]interface{}    `yaml:",inline"`
 	}
 

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -369,8 +369,6 @@ func (rpc *RedpandaConfig) UnmarshalYAML(n *yaml.Node) error {
 	rpc.AdvertisedRPCAPI = internal.AdvertisedRPCAPI
 	rpc.AdvertisedKafkaAPI = internal.AdvertisedKafkaAPI
 	rpc.DeveloperMode = bool(internal.DeveloperMode)
-	rpc.AggregateMetrics = bool(internal.AggregateMetrics)
-	rpc.DisablePublicMetrics = bool(internal.DisablePublicMetrics)
 	rpc.Other = internal.Other
 	return nil
 }

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -294,16 +294,16 @@ func (ss *seedServers) UnmarshalYAML(n *yaml.Node) error {
 
 func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
-		NodeUUID             weakString      `yaml:"node_uuid"`
-		Organization         weakString      `yaml:"organization"`
-		LicenseKey           weakString      `yaml:"license_key"`
-		ClusterID            weakString      `yaml:"cluster_id"`
-		Redpanda             RedpandaConfig  `yaml:"redpanda"`
-		Rpk                  RpkConfig       `yaml:"rpk"`
-		Pandaproxy           *Pandaproxy     `yaml:"pandaproxy"`
-		PandaproxyClient     *KafkaClient    `yaml:"pandaproxy_client"`
-		SchemaRegistry       *SchemaRegistry `yaml:"schema_registry"`
-		SchemaRegistryClient *KafkaClient    `yaml:"schema_registry_client"`
+		NodeUUID             weakString         `yaml:"node_uuid"`
+		Organization         weakString         `yaml:"organization"`
+		LicenseKey           weakString         `yaml:"license_key"`
+		ClusterID            weakString         `yaml:"cluster_id"`
+		Redpanda             RedpandaNodeConfig `yaml:"redpanda"`
+		Rpk                  RpkConfig          `yaml:"rpk"`
+		Pandaproxy           *Pandaproxy        `yaml:"pandaproxy"`
+		PandaproxyClient     *KafkaClient       `yaml:"pandaproxy_client"`
+		SchemaRegistry       *SchemaRegistry    `yaml:"schema_registry"`
+		SchemaRegistryClient *KafkaClient       `yaml:"schema_registry_client"`
 
 		Other map[string]interface{} `yaml:",inline"`
 	}
@@ -325,7 +325,7 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-func (rpc *RedpandaConfig) UnmarshalYAML(n *yaml.Node) error {
+func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
 		Directory                  weakString                `yaml:"data_directory"`
 		ID                         weakInt                   `yaml:"node_id" `

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -1002,8 +1002,6 @@ rpk:
 					SeedServers: []SeedServer{
 						{SocketAddress{"192.168.0.1", 33145}},
 					},
-					AggregateMetrics:     true,
-					DisablePublicMetrics: true,
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
 					},
@@ -1240,8 +1238,6 @@ rpk:
 						{SocketAddress{"192.168.0.1", 33145}},
 						{SocketAddress{"192.168.0.1", 33145}},
 					},
-					AggregateMetrics:     true,
-					DisablePublicMetrics: true,
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
 					},

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -971,7 +971,7 @@ rpk:
 				Organization: "my_organization",
 				ClusterID:    "cluster_id",
 				NodeUUID:     "node_uuid",
-				Redpanda: RedpandaConfig{
+				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             1,
 					AdminAPIDocDir: "/usr/share/redpanda/admin-api-doc",
@@ -1205,7 +1205,7 @@ rpk:
 				Organization: "1",
 				ClusterID:    "cluster_id",
 				NodeUUID:     "124.42",
-				Redpanda: RedpandaConfig{
+				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             1,
 					AdminAPIDocDir: "/usr/share/redpanda/admin-api-doc",

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -889,8 +889,6 @@ redpanda:
   - address: 192.168.0.1
     port: 33145
   rack: "rack-id"
-  aggregate_metrics: true
-  disable_public_metrics: true
 pandaproxy:
   pandaproxy_api:
   - address: "0.0.0.0"
@@ -1124,8 +1122,6 @@ redpanda:
   - address: 192.168.0.1
     port: 33145
   rack: "rack-id"
-  aggregate_metrics: "true"
-  disable_public_metrics: "true"
 pandaproxy:
   pandaproxy_api:
   - address: "0.0.0.0"


### PR DESCRIPTION
## Cover letter

This remove properties incorrectly listed among node properties, making the operator recognize them as cluster properties.


Fixes #6514

## Backport Required

- [x] v22.2.x

