### PR TITLE
rpk: reorder options passed to hwloc-calc

### DIFF
--- a/src/go/rpk/pkg/tuners/hwloc/hwloc_cmd.go
+++ b/src/go/rpk/pkg/tuners/hwloc/hwloc_cmd.go
@@ -90,8 +90,7 @@ func (hwLocCmd *hwLocCmd) GetPhysIntersection(
 func (hwLocCmd *hwLocCmd) getNumberOf(
 	mask string, resource string,
 ) (uint, error) {
-	output, err := hwLocCmd.runCalc("--number-of", resource, "machine:0",
-		"--restrict", mask)
+	output, err := hwLocCmd.runCalc("--restrict", mask, "--number-of", resource, "machine:0")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Cover letter

With the upgrade of `hwloc-calc` to 2.8.0 in PR https://github.com/redpanda-data/vtools/pull/896, the command requires `--restrict` option at the beginning:

```console
root@ip-172-31-59-76:~# /opt/redpanda/bin/hwloc-calc-redpanda --number-of core machine:0 --restrict 0x0000000f
Unrecognized option: --restrict
Usage: hwloc-calc [topology options] [options] <location> ...
 <location> may be a space-separated list of cpusets or objects
            as supported by the hwloc-bind utility, e.g:
    core:2-3        for the third and fourth cores
    node:1.pu:2       the third PU of the second NUMA node
    0x12345678        a CPU set given a bitmask string
    os=eth0           the operating system device named eth0
    pci=0000:01:02.0  the PCI device with the given bus ID
  with prefix ~ to remove, ^ for xor and x for intersection
  (see Location Specification in hwloc(7) for details).
Input topology options (must be at the beginning):
  --no-smt                  Only keep a single PU per core
  --cpukind <n>             Only keep PUs in the CPU kind <n>
  --cpukind <name>=<value>  Only keep PUs whose CPU kind match info <name>=<value>
  --restrict [nodeset=]<bitmap>
                            Restrict the topology to some processors or NUMA nodes.
  --restrict-flags <n>      Set the flags to be used during restrict
...
root@ip-172-31-59-76:~# echo $?
1
```

This fix addresses issue https://github.com/redpanda-data/devprod/issues/440

## Backport Required

* none

If PR https://github.com/redpanda-data/vtools/pull/896 is backported to any of the supported branches (currently it is not), then this PR will also need to be backported along with it.

## UX changes

* none

## Release notes

* none