### PR TITLE
[transaction] Do not write prepare marker on rm_stm

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -637,6 +637,9 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
         }
         transaction_tx_seq = prepare_it->second.tx_seq;
     } else {
+        _mem_state.expected.erase(pid);
+        _mem_state.preparing.erase(pid);
+
         // checking fencing from prepared phase
         auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
         if (fence_it == _log_state.fence_pid_epoch.end()) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1992,7 +1992,7 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
     }
 
     if (bid.is_transactional) {
-        if (_log_state.prepared.contains(bid.pid)) {
+        if (!is_transaction_ga() && _log_state.prepared.contains(bid.pid)) {
             vlog(
               _ctx_log.error,
               "Adding a record with pid:{} to a tx after it was prepared",

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -13,6 +13,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/protocol/response_writer.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -1699,19 +1700,32 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
 
     _mem_state.expected.erase(pid);
 
+    model::tx_seq transaction_seq;
     std::optional<prepare_marker> marker;
-    auto prepare_it = _mem_state.preparing.find(pid);
-    if (prepare_it != _mem_state.preparing.end()) {
-        marker = prepare_it->second;
-    }
-    prepare_it = _log_state.prepared.find(pid);
-    if (prepare_it != _log_state.prepared.end()) {
-        marker = prepare_it->second;
+
+    if (is_transaction_ga()) {
+        auto tx_seqs_it = _log_state.tx_seqs.find(pid);
+        if (tx_seqs_it == _log_state.tx_seqs.end()) {
+            vlog(clusterlog.error, "Can not find tx_seq for pid {}", pid);
+            co_return;
+        }
+        transaction_seq = tx_seqs_it->second;
+    } else {
+        auto prepare_it = _mem_state.preparing.find(pid);
+        if (prepare_it != _mem_state.preparing.end()) {
+            marker = prepare_it->second;
+            transaction_seq = marker->tx_seq;
+        }
+        prepare_it = _log_state.prepared.find(pid);
+        if (prepare_it != _log_state.prepared.end()) {
+            marker = prepare_it->second;
+            transaction_seq = marker->tx_seq;
+        }
     }
 
-    if (marker) {
+    if (is_transaction_ga() || marker) {
         auto r = co_await _tx_gateway_frontend.local().try_abort(
-          marker->tm_partition, marker->pid, marker->tx_seq, _sync_timeout);
+          model::partition_id(0), pid, transaction_seq, _sync_timeout);
         if (r.ec == tx_errc::none) {
             if (r.commited) {
                 auto batch = make_tx_control_batch(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -451,6 +451,14 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    if (is_transaction_ga()) {
+        vlog(
+          _ctx_log.error,
+          "Redpanda should skip prepared rpc to rm_stm. Smth wrong. pid:({})",
+          pid);
+        co_return tx_errc::unknown_server_error;
+    }
+
     if (!check_tx_permitted()) {
         co_return tx_errc::request_rejected;
     }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1932,6 +1932,7 @@ ss::future<> rm_stm::apply_control(
 
     if (crt == model::control_record_type::tx_abort) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             // make a list
@@ -1950,6 +1951,7 @@ ss::future<> rm_stm::apply_control(
         }
     } else if (crt == model::control_record_type::tx_commit) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             _log_state.ongoing_set.erase(offset_it->second.first);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -582,49 +582,61 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
         }
     }
 
-    auto preparing_it = _mem_state.preparing.find(pid);
+    model::tx_seq transaction_tx_seq;
+    if (!is_transaction_ga()) {
+        auto preparing_it = _mem_state.preparing.find(pid);
 
-    if (preparing_it != _mem_state.preparing.end()) {
-        if (preparing_it->second.tx_seq > tx_seq) {
-            // - tm_stm & rm_stm failed during prepare
-            // - during recovery tm_stm recommits its previous tx
-            // - that commit (we're here) collides with "next" failed prepare
-            // it may happen only if the commit passed => acking
+        if (preparing_it != _mem_state.preparing.end()) {
+            if (preparing_it->second.tx_seq > tx_seq) {
+                // - tm_stm & rm_stm failed during prepare
+                // - during recovery tm_stm recommits its previous tx
+                // - that commit (we're here) collides with "next" failed
+                // prepare it may happen only if the commit passed => acking
+                co_return tx_errc::none;
+            }
+
+            ss::sstring msg;
+            if (preparing_it->second.tx_seq == tx_seq) {
+                msg = ssx::sformat(
+                  "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
+                  pid,
+                  tx_seq);
+            } else {
+                msg = ssx::sformat(
+                  "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
+                  pid,
+                  tx_seq,
+                  preparing_it->second.tx_seq);
+            }
+
+            if (_recovery_policy == best_effort) {
+                vlog(_ctx_log.error, "{}", msg);
+                co_return tx_errc::request_rejected;
+            }
+            vassert(false, "{}", msg);
+        }
+
+        auto prepare_it = _log_state.prepared.find(pid);
+
+        if (prepare_it == _log_state.prepared.end()) {
+            vlog(
+              clusterlog.trace,
+              "Can't find prepare for pid:{} => replaying already comitted "
+              "commit",
+              pid);
             co_return tx_errc::none;
         }
-
-        ss::sstring msg;
-        if (preparing_it->second.tx_seq == tx_seq) {
-            msg = ssx::sformat(
-              "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
-              pid,
-              tx_seq);
-        } else {
-            msg = ssx::sformat(
-              "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
-              pid,
-              tx_seq,
-              preparing_it->second.tx_seq);
+        transaction_tx_seq = prepare_it->second.tx_seq;
+    } else {
+        auto tx_seqs_it = _log_state.tx_seqs.find(pid);
+        if (tx_seqs_it == _log_state.tx_seqs.end()) {
+            vlog(clusterlog.trace, "Can't find tx_seqs for pid:{}", pid);
+            co_return tx_errc::none;
         }
-
-        if (_recovery_policy == best_effort) {
-            vlog(_ctx_log.error, "{}", msg);
-            co_return tx_errc::request_rejected;
-        }
-        vassert(false, "{}", msg);
+        transaction_tx_seq = tx_seqs_it->second;
     }
 
-    auto prepare_it = _log_state.prepared.find(pid);
-
-    if (prepare_it == _log_state.prepared.end()) {
-        vlog(
-          _ctx_log.trace,
-          "Can't find prepare for pid:{} => replaying already comitted commit",
-          pid);
-        co_return tx_errc::none;
-    }
-
-    if (prepare_it->second.tx_seq > tx_seq) {
+    if (transaction_tx_seq > tx_seq) {
         // rare situation:
         //   * tm_stm prepares (tx_seq+1)
         //   * prepare on this rm passes but tm_stm failed to write to disk
@@ -635,15 +647,15 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
           "prepare for pid:{} has higher tx_seq:{} than given: {} => replaying "
           "already comitted commit",
           pid,
-          prepare_it->second.tx_seq,
+          transaction_tx_seq,
           tx_seq);
         co_return tx_errc::none;
-    } else if (prepare_it->second.tx_seq < tx_seq) {
+    } else if (transaction_tx_seq < tx_seq) {
         std::string msg = fmt::format(
           "Rejecting commit with tx_seq:{} since prepare with lesser tx_seq:{} "
           "exists",
           tx_seq,
-          prepare_it->second.tx_seq);
+          transaction_tx_seq);
         if (_recovery_policy == best_effort) {
             vlog(_ctx_log.error, "{}", msg);
             co_return tx_errc::request_rejected;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -145,6 +145,7 @@ public:
 
     static constexpr int8_t prepare_control_record_version{0};
     static constexpr int8_t fence_control_record_version{0};
+    static constexpr int8_t tx_seq_constrol_record_version{0};
 
     explicit rm_stm(
       ss::logger&,
@@ -339,6 +340,7 @@ private:
     void apply_prepare(rm_stm::prepare_marker);
     ss::future<>
       apply_control(model::producer_identity, model::control_record_type);
+    void apply_tx_seq(model::record_batch&&);
     void apply_data(model::batch_identity, model::offset);
 
     ss::future<> reduce_aborted_list();
@@ -370,6 +372,9 @@ private:
         // a heap of the first offsets of the ongoing transactions
         absl::btree_set<model::offset> ongoing_set;
         absl::flat_hash_map<model::producer_identity, prepare_marker> prepared;
+        // After transaction GA we do not write prepare marker, so we need to
+        // store tx_seq number for expiring
+        absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
         std::vector<tx_range> aborted;
         std::vector<abort_index> abort_indexes;
         abort_snapshot last_abort_snapshot{.last = model::offset(-1)};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -508,6 +508,11 @@ private:
 
     uint8_t active_snapshot_version();
 
+    bool is_transaction_ga() const {
+        return _feature_table.local().is_active(
+          features::feature::transaction_ga);
+    }
+
     template<class T>
     void fill_snapshot_wo_seqs(T&);
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -259,7 +259,11 @@ ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::mark_tx_prepared(
         co_return tm_stm::op_status::not_found;
     }
     auto tx = tx_opt.value();
-    if (tx.status != tm_transaction::tx_status::preparing) {
+
+    auto check_status = is_transaction_ga()
+                          ? tm_transaction::tx_status::ongoing
+                          : tm_transaction::tx_status::preparing;
+    if (tx.status != check_status) {
         co_return tm_stm::op_status::conflict;
     }
     tx.status = cluster::tm_transaction::tx_status::prepared;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -276,11 +276,14 @@ private:
           raft::replicate_options{raft::consistency_level::quorum_ack});
     }
 
-    use_tx_version_with_last_pid_bool use_new_tx_version() {
+    bool is_transaction_ga() {
         return _feature_table.local().is_active(
-                 features::feature::transaction_ga)
-                 ? use_tx_version_with_last_pid_bool::yes
-                 : use_tx_version_with_last_pid_bool::no;
+          features::feature::transaction_ga);
+    }
+
+    use_tx_version_with_last_pid_bool use_new_tx_version() {
+        return is_transaction_ga() ? use_tx_version_with_last_pid_bool::yes
+                                   : use_tx_version_with_last_pid_bool::no;
     }
 
     model::record_batch serialize_tx(tm_transaction tx);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -94,7 +94,10 @@ private:
     std::chrono::milliseconds _transactional_id_expiration;
     bool _transactions_enabled;
 
-    bool allow_init_tm_request_with_expected_pid() {
+    // Transaction GA includes: KIP_447, KIP-360, fix for compaction tx_group*
+    // records, perf fix#1(Do not writing preparing state on disk in tm_stn),
+    // perf fix#2(Do not writeing prepared marker in rm_stm)
+    bool is_transaction_ga() {
         return _feature_table.local().is_active(
           features::feature::transaction_ga);
     }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -352,6 +352,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::cluster_config_cmd";
     case record_batch_type::feature_update:
         return o << "batch_type::feature_update";
+    case record_batch_type::tx_seq_cmd:
+        return o << "batch_type::tx_seq_cmd";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -39,6 +39,7 @@ enum class record_batch_type : int8_t {
     archival_metadata = 19,          // archival metadata updates
     cluster_config_cmd = 20,         // cluster config deltas and status
     feature_update = 21,             // Node logical versions updates
+    tx_seq_cmd = 22,                 // tx_seq used for expire old txs
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -341,8 +341,7 @@ class TxAdminTest(RedpandaTest):
             raise Exception("init_transaction should fail")
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
-            assert kafka_error.code(
-            ) == ck.cimpl.KafkaError.BROKER_NOT_AVAILABLE
+            assert kafka_error.code() == ck.cimpl.KafkaError.INVALID_TXN_STATE
 
         txs_info = self.admin.get_all_transactions()
         assert len(


### PR DESCRIPTION
## Cover letter

Idea is: do not write prepare marker for rm_stm. We did it to sync all prev records for tx. Because we write data_batches with leader ack. And it does not provide that all followers flush thus records. Prepare marker was written with quorum_ack. And after we apply it we can be sure that records for transaction is replicated and flushed.

What we wanna do:
- Do not write prepare_marker
- Change leader_ack to quorum_ack for data batches
- Store tx_seq at the begin_tx because we need it on expire old_txs

Fixes #6484 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
