### PR TITLE
raft: use ss::timed_out_error in offset_monitor

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -230,7 +230,7 @@ ss::future<bool> persisted_stm::do_sync(
             co_return false;
         } catch (const ss::condition_variable_timed_out&) {
             co_return false;
-        } catch (const raft::offset_monitor::wait_timed_out&) {
+        } catch (const ss::timed_out_error&) {
             vlog(
               clusterlog.warn,
               "sync timeout: waiting for offset={}; committed "
@@ -316,7 +316,7 @@ ss::future<bool> persisted_stm::wait_no_throw(
           return false;
       })
       .handle_exception_type(
-        [offset, ntp = _c->ntp()](const raft::offset_monitor::wait_timed_out&) {
+        [offset, ntp = _c->ntp()](const ss::timed_out_error&) {
             vlog(
               clusterlog.warn,
               "timed out while waiting for offset: {}, ntp: {}",

--- a/src/v/raft/offset_monitor.cc
+++ b/src/v/raft/offset_monitor.cc
@@ -9,6 +9,7 @@
 
 #include "raft/offset_monitor.h"
 
+#include "raft/logger.h"
 #include "vassert.h"
 
 #include <seastar/core/future-util.hh>
@@ -89,7 +90,7 @@ offset_monitor::waiter::waiter(
  */
 void offset_monitor::waiter::handle_abort(bool is_timeout) {
     if (is_timeout) {
-        done.set_exception(wait_timed_out());
+        done.set_exception(ss::timed_out_error());
     } else {
         // Use the generic seastar abort_requested_exception, because
         // in many locations we handle this gracefully and do not log

--- a/src/v/raft/offset_monitor.h
+++ b/src/v/raft/offset_monitor.h
@@ -32,17 +32,6 @@ namespace raft {
 class offset_monitor {
 public:
     /**
-     * Exception used to indicate an aborted wait, either from a requested abort
-     * via an abort source or because a timeout occurred.
-     */
-    class wait_timed_out final : public std::exception {
-    public:
-        virtual const char* what() const noexcept final {
-            return "offset monitor wait timed out";
-        }
-    };
-
-    /**
      * Exisiting waiters receive wait_aborted exception.
      */
     void stop();

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -136,7 +136,14 @@ ss::future<> state_machine::apply() {
                 }
             });
       })
-      .handle_exception_type([](const raft::offset_monitor::wait_timed_out&) {})
+      .handle_exception_type([this](const ss::timed_out_error&) {
+          // This is a safe retry, but if it happens in tests we're interested
+          // in seeing what happened in the debug log
+          vlog(
+            _log.debug,
+            "Timeout in state_machine::apply on ntp {}",
+            _raft->ntp());
+      })
       .handle_exception_type([](const ss::abort_requested_exception&) {})
       .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {

--- a/src/v/raft/tests/offset_monitor_test.cc
+++ b/src/v/raft/tests/offset_monitor_test.cc
@@ -148,7 +148,7 @@ SEASTAR_THREAD_TEST_CASE(wait_timeout) {
     BOOST_REQUIRE(!f0.available());
     BOOST_REQUIRE(!mon.empty());
 
-    BOOST_CHECK_THROW(f0.get(), raft::offset_monitor::wait_timed_out);
+    BOOST_CHECK_THROW(f0.get(), ss::timed_out_error);
 
     BOOST_REQUIRE(mon.empty());
 }
@@ -191,7 +191,7 @@ SEASTAR_THREAD_TEST_CASE(wait_abort_source_with_timeout_first) {
 
     // there is an abort source, but only wait on timeout
 
-    BOOST_CHECK_THROW(f0.get(), raft::offset_monitor::wait_timed_out);
+    BOOST_CHECK_THROW(f0.get(), ss::timed_out_error);
 
     BOOST_REQUIRE(mon.empty());
 }


### PR DESCRIPTION
## Cover letter

Using this generic exception type loses us a little information on what kind of error occurred, but gains us the generic exception handling in the RPC layer that knows how to translate a seastar timeout into a kafka protocol timeout.

Fixes: https://github.com/redpanda-data/redpanda/issues/6078

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none