### PR TITLE
raft, cloud_storage: log hygiene improvements

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -71,7 +71,9 @@ static error_outcome categorize_error(
         std::rethrow_exception(err);
     } catch (const s3::rest_error_response& err) {
         if (err.code() == s3::s3_error_code::no_such_key) {
-            vlog(ctxlog.info, "NoSuchKey response received {}", path);
+            // Unexpected 404s are logged elsewhere by the s3 client at warn
+            // level, so only log at debug level here.
+            vlog(ctxlog.debug, "NoSuchKey response received {}", path);
             result = error_outcome::notfound;
         } else if (
           err.code() == s3::s3_error_code::slow_down

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -161,6 +161,25 @@ public:
       base_manifest& manifest,
       retry_chain_node& parent);
 
+    /// \brief Download manifest from pre-defined S3 location
+    ///
+    /// Method downloads the manifest and handles backpressure and
+    /// errors. It retries multiple times until timeout excedes.
+    /// The method expects that the manifest might be missing from
+    /// S3 bucket. It behaves exactly the same as 'download_manifest'.
+    /// The only difference is that 'NoSuchKey' error is not logged
+    /// using 'warn' log level.
+    ///
+    /// \param bucket is a bucket name
+    /// \param key is an object key of the manifest
+    /// \param manifest is a manifest to download
+    /// \return future that returns success code
+    ss::future<download_result> maybe_download_manifest(
+      const s3::bucket_name& bucket,
+      const remote_manifest_path& key,
+      base_manifest& manifest,
+      retry_chain_node& parent);
+
     /// \brief Upload manifest to the pre-defined S3 location
     ///
     /// \param bucket is a bucket name
@@ -217,6 +236,13 @@ public:
       const s3::bucket_name& bucket,
       const remote_segment_path& segment_path,
       retry_chain_node& parent);
+
+    ss::future<download_result> do_download_manifest(
+      const s3::bucket_name& bucket,
+      const remote_manifest_path& key,
+      base_manifest& manifest,
+      retry_chain_node& parent,
+      bool expect_missing = false);
 
 private:
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -375,7 +375,7 @@ ss::future<bool> remote_segment::do_materialize_segment() {
 ss::future<bool> remote_segment::do_materialize_txrange() {
     if (_tx_range) {
         vlog(
-          _ctxlog.info,
+          _ctxlog.debug,
           "materialize tx_range, {} transactions available",
           _tx_range->size());
         co_return true;
@@ -399,7 +399,7 @@ ss::future<bool> remote_segment::do_materialize_txrange() {
             co_await manifest.update(std::move(inp_stream));
             _tx_range = std::move(manifest).get_tx_range();
             vlog(
-              _ctxlog.info,
+              _ctxlog.debug,
               "materialize tx_range, {} transactions materialized",
               _tx_range->size());
         } catch (...) {
@@ -412,7 +412,7 @@ ss::future<bool> remote_segment::do_materialize_txrange() {
         co_await cache_item->body.close();
     } else {
         vlog(
-          _ctxlog.info,
+          _ctxlog.debug,
           "tx_range '{}' is not available in cache, retrying",
           path);
         co_return false;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -318,7 +318,7 @@ ss::future<> remote_segment::do_hydrate_txrange() {
 
     tx_range_manifest manifest(_path);
 
-    auto res = co_await _api.download_manifest(
+    auto res = co_await _api.maybe_download_manifest(
       _bucket, manifest.get_manifest_path(), manifest, local_rtc);
 
     vlog(

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -271,7 +271,7 @@ ss::future<> offset_translator::prefix_truncate(model::offset offset) {
     ++_map_version;
 
     vlog(
-      _logger.info,
+      _logger.debug,
       "prefix_truncate at offset: {}, new state: {}",
       offset,
       _state);

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -522,7 +522,7 @@ ss::future<http::client::response_stream_ref> client::get_object(
               if (result != boost::beast::http::status::ok) {
                   // Got error response, consume the response body and produce
                   // rest api error
-                  if (expect_no_such_key) {
+                  if (expect_no_such_key && result == boost::beast::http::status::not_found) {
                       vlog(
                         s3_log.debug,
                         "S3 replied with expected error: {}",

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -502,7 +502,8 @@ ss::future<> client::shutdown() {
 ss::future<http::client::response_stream_ref> client::get_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout) {
+  const ss::lowres_clock::duration& timeout,
+  bool expect_no_such_key) {
     auto header = _requestor.make_get_object_request(name, key);
     if (!header) {
         return ss::make_exception_future<http::client::response_stream_ref>(
@@ -510,20 +511,28 @@ ss::future<http::client::response_stream_ref> client::get_object(
     }
     vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
-      .then([](http::client::response_stream_ref&& ref) {
+      .then([expect_no_such_key](http::client::response_stream_ref&& ref) {
           // here we didn't receive any bytes from the socket and
           // ref->is_header_done() is 'false', we need to prefetch
           // the header first
-          return ref->prefetch_headers().then([ref = std::move(ref)]() mutable {
+          return ref->prefetch_headers().then([ref = std::move(ref),
+                                               expect_no_such_key]() mutable {
               vassert(ref->is_header_done(), "Header is not received");
               const auto result = ref->get_headers().result();
               if (result != boost::beast::http::status::ok) {
                   // Got error response, consume the response body and produce
                   // rest api error
-                  vlog(
-                    s3_log.warn,
-                    "S3 replied with error: {}",
-                    ref->get_headers());
+                  if (expect_no_such_key) {
+                      vlog(
+                        s3_log.debug,
+                        "S3 replied with expected error: {}",
+                        ref->get_headers());
+                  } else {
+                      vlog(
+                        s3_log.warn,
+                        "S3 replied with error: {}",
+                        ref->get_headers());
+                  }
                   return drain_response_stream(std::move(ref))
                     .then([result](iobuf&& res) {
                         return parse_rest_error_response<
@@ -554,7 +563,14 @@ ss::future<client::head_object_result> client::head_object(
             return ref->prefetch_headers().then(
               [ref, key]() -> ss::future<head_object_result> {
                   auto status = ref->get_headers().result();
-                  if (status != boost::beast::http::status::ok) {
+                  if (status == boost::beast::http::status::not_found) {
+                      vlog(
+                        s3_log.debug,
+                        "Object not available, error: {}",
+                        ref->get_headers());
+                      return parse_head_error_response<head_object_result>(
+                        ref->get_headers(), key);
+                  } else if (status != boost::beast::http::status::ok) {
                       vlog(
                         s3_log.warn,
                         "S3 replied with error: {}",

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -185,11 +185,14 @@ public:
     ///
     /// \param name is a bucket name
     /// \param key is an object key
+    /// \param timeout is a timeout of the operation
+    /// \param expect_no_such_key log 404 as warning if set to false
     /// \return future that gets ready after request was sent
     ss::future<http::client::response_stream_ref> get_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout);
+      const ss::lowres_clock::duration& timeout,
+      bool expect_no_such_key = false);
 
     struct head_object_result {
         uint64_t object_size;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1024,7 +1024,7 @@ disk_log_impl::timequery(timequery_config cfg) {
 
 ss::future<> disk_log_impl::remove_segment_permanently(
   ss::lw_shared_ptr<segment> s, std::string_view ctx) {
-    vlog(stlog.info, "{} - tombstone & delete segment: {}", ctx, s);
+    vlog(stlog.info, "Removing \"{}\" ({}, {})", s->filename(), ctx, s);
     // stats accounting must happen synchronously
     _probe.delete_segment(*s);
     // background close


### PR DESCRIPTION
## Cover letter

This PR extends https://github.com/redpanda-data/redpanda/pull/5504

There are various messages at WARN and INFO level that are noticeably frequent when looking at the output of a test like KgoVerifierWithSiTestLargeSegments that uses cloud storage and retention policies.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Suppress logging for harmless 404 responses from S3 while probing for transaction range objects