### PR TITLE
[transaction] Do not write preparing state on disk

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -259,7 +259,11 @@ ss::future<checked<tm_transaction, tm_stm::op_status>> tm_stm::mark_tx_prepared(
         co_return tm_stm::op_status::not_found;
     }
     auto tx = tx_opt.value();
-    if (tx.status != tm_transaction::tx_status::preparing) {
+
+    auto check_status = is_transaction_ga()
+                          ? tm_transaction::tx_status::ongoing
+                          : tm_transaction::tx_status::preparing;
+    if (tx.status != check_status) {
         co_return tm_stm::op_status::conflict;
     }
     tx.status = cluster::tm_transaction::tx_status::prepared;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -276,11 +276,14 @@ private:
           raft::replicate_options{raft::consistency_level::quorum_ack});
     }
 
-    use_tx_version_with_last_pid_bool use_new_tx_version() {
+    bool is_transaction_ga() {
         return _feature_table.local().is_active(
-                 features::feature::transaction_ga)
-                 ? use_tx_version_with_last_pid_bool::yes
-                 : use_tx_version_with_last_pid_bool::no;
+          features::feature::transaction_ga);
+    }
+
+    use_tx_version_with_last_pid_bool use_new_tx_version() {
+        return is_transaction_ga() ? use_tx_version_with_last_pid_bool::yes
+                                   : use_tx_version_with_last_pid_bool::no;
     }
 
     model::record_batch serialize_tx(tm_transaction tx);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1480,7 +1480,9 @@ tx_gateway_frontend::do_commit_tm_tx(
               group.group_id, group.etag, tx.pid, tx.tx_seq, timeout));
         }
 
-        if (tx.status == tm_transaction::tx_status::ongoing) {
+        if (
+          !is_transaction_ga()
+          && tx.status == tm_transaction::tx_status::ongoing) {
             auto preparing_tx = co_await stm->mark_tx_preparing(
               expected_term, tx.id);
             if (!preparing_tx.has_value()) {
@@ -1528,15 +1530,26 @@ tx_gateway_frontend::do_commit_tm_tx(
         outcome->set_value(tx_errc::unknown_server_error);
         throw;
     }
-    outcome->set_value(tx_errc::none);
 
     auto changed_tx = co_await stm->mark_tx_prepared(expected_term, tx.id);
     if (!changed_tx.has_value()) {
         if (changed_tx.error() == tm_stm::op_status::not_leader) {
+            outcome->set_value(tx_errc::not_coordinator);
             co_return tx_errc::not_coordinator;
         }
+        outcome->set_value(tx_errc::unknown_server_error);
         co_return tx_errc::unknown_server_error;
     }
+
+    // We can reduce the number of disk operation if we will not write
+    // preparing state on disk. But after it we should ans to client when we
+    // sure that tx will be recommited after fail. We can guarantee it only
+    // if we ans after marking tx prepared. Becase after fail tx will be
+    // recommited again and client will see expected bechavior.
+    // Also we do not need to support old bechavior with feature flag, because
+    // now we will ans client later than in old versions. So we do not break
+    // anything
+    outcome->set_value(tx_errc::none);
     tx = changed_tx.value();
 
     std::vector<ss::future<commit_group_tx_reply>> gfs;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -500,9 +500,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
   std::chrono::milliseconds transaction_timeout_ms,
   model::timeout_clock::duration timeout,
   model::producer_identity expected_pid) {
-    if (
-      expected_pid != model::unknown_pid
-      && !allow_init_tm_request_with_expected_pid()) {
+    if (expected_pid != model::unknown_pid && !is_transaction_ga()) {
         co_return cluster::init_tm_tx_reply{tx_errc::not_coordinator};
     }
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -94,7 +94,10 @@ private:
     std::chrono::milliseconds _transactional_id_expiration;
     bool _transactions_enabled;
 
-    bool allow_init_tm_request_with_expected_pid() {
+    // Transaction GA includes: KIP_447, KIP-360, fix for compaction tx_group*
+    // records, perf fix#1(Do not writing preparing state on disk in tm_stn),
+    // perf fix#2(Do not writeing prepared marker in rm_stm)
+    bool is_transaction_ga() {
         return _feature_table.local().is_active(
           features::feature::transaction_ga);
     }

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -341,8 +341,7 @@ class TxAdminTest(RedpandaTest):
             raise Exception("init_transaction should fail")
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
-            assert kafka_error.code(
-            ) == ck.cimpl.KafkaError.BROKER_NOT_AVAILABLE
+            assert kafka_error.code() == ck.cimpl.KafkaError.INVALID_TXN_STATE
 
         txs_info = self.admin.get_all_transactions()
         assert len(


### PR DESCRIPTION
## Cover letter
We can reduce the number of disk operation if we will not write preparing
state on disk during commit phase.

After this change we can ans client only after phase when tx will be recommited after fail.

We can do it only if we ans after marking tx prepared.

Fixes #4829 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none