### PR TITLE
rpc: add a feature for using transport v2 from start of connection

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -129,7 +129,8 @@ ss::future<> maybe_create_tcp_client(
                     .server_addr = std::move(rpc_address),
                     .credentials = cert,
                     .disable_metrics = net::metrics_disabled(
-                      config::shard_local_cfg().disable_metrics)},
+                      config::shard_local_cfg().disable_metrics),
+                    .version = cache.get_default_transport_version()},
                   rpc::make_exponential_backoff_policy<rpc::clock_type>(
                     std::chrono::seconds(1), std::chrono::seconds(15)));
             });

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -69,7 +69,7 @@ std::string_view to_string_view(feature_state::state s) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
-static constexpr cluster_version latest_version = cluster_version{6};
+static constexpr cluster_version latest_version = cluster_version{7};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -41,6 +41,8 @@ std::string_view to_string_view(feature f) {
         return "transaction_ga";
     case feature::raftless_node_status:
         return "raftless_node_status";
+    case feature::rpc_v2_by_default:
+        return "rpc_v2_by_default";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -324,7 +324,20 @@ public:
 
     ss::future<> await_feature(feature f, ss::abort_source& as);
 
+    /**
+     * Variant of await_feature that uses a built-in abort source rather
+     * than requiring one to be passed in.
+     *
+     * You should almost always use an explicit abort_source version above:
+     * using the built-in feature table abort source is only for locations
+     * early in startup that otherwise don't have an abort source
+     * handy.
+     */
+    ss::future<> await_feature(feature f) { return await_feature(f, _as); };
+
     ss::future<> await_feature_preparing(feature f, ss::abort_source& as);
+
+    ss::future<> stop();
 
     static cluster_version get_latest_logical_version();
 
@@ -384,6 +397,9 @@ private:
 
     // Unit testing hook.
     friend class feature_table_fixture;
+
+    ss::gate _gate;
+    ss::abort_source _as;
 };
 
 } // namespace features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -148,7 +148,7 @@ constexpr static std::array feature_schema{
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{6},
+    cluster_version{7},
     "raftless_node_status",
     feature::raftless_node_status,
     feature_spec::available_policy::always,

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -41,6 +41,7 @@ enum class feature : std::uint64_t {
     raft_improved_configuration = 0x80,
     transaction_ga = 0x100,
     raftless_node_status = 0x200,
+    rpc_v2_by_default = 0x400,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -153,6 +154,13 @@ constexpr static std::array feature_schema{
     feature::raftless_node_status,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{7},
+    "rpc_v2_by_default",
+    feature::rpc_v2_by_default,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+
   feature_spec{
     cluster_version{2001},
     "__test_alpha",

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -67,7 +67,7 @@ public:
       std::optional<YAML::Node> schema_reg_client_cfg = std::nullopt,
       std::optional<scheduling_groups> = std::nullopt);
     void check_environment();
-    void wire_up_and_start(::stop_signal&);
+    void wire_up_and_start(::stop_signal&, bool test_mode = false);
 
     explicit application(ss::sstring = "redpanda::main");
     ~application();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -82,7 +82,7 @@ public:
           proxy_client_config(kafka_port),
           sch_groups);
         app.check_environment();
-        app.wire_up_and_start(*app_signal);
+        app.wire_up_and_start(*app_signal, true);
 
         // used by request context builder
         proto = std::make_unique<kafka::protocol>(

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -59,6 +59,17 @@ public:
     /// \brief closes all connections
     ss::future<> stop();
 
+    /**
+     * RPC version to use for newly constructed `transport` objects
+     */
+    transport_version get_default_transport_version() {
+        return _default_transport_version;
+    }
+
+    void set_default_transport_version(transport_version v) {
+        _default_transport_version = v;
+    }
+
     template<typename Protocol, typename Func>
     requires requires(Func&& f, Protocol proto) { f(proto); }
     auto with_node_client(
@@ -132,6 +143,7 @@ private:
     std::optional<connection_cache_label> _label;
     mutex _mutex; // to add/remove nodes
     underlying _cache;
+    transport_version _default_transport_version{transport_version::v1};
 };
 inline ss::shard_id connection_cache::shard_for(
   model::node_id self,

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -57,7 +57,9 @@ transport::transport(
     .server_addr = std::move(c.server_addr),
     .credentials = std::move(c.credentials),
   })
-  , _memory(c.max_queued_bytes, "rpc/transport-mem") {
+  , _memory(c.max_queued_bytes, "rpc/transport-mem")
+  , _version(c.version)
+  , _default_version(c.version) {
     if (!c.disable_metrics) {
         setup_metrics(label);
     }
@@ -87,7 +89,7 @@ void transport::reset_state() {
      */
     _last_seq = sequence_t{0};
     _seq = sequence_t{0};
-    _version = transport_version::v1;
+    _version = _default_version;
 }
 
 ss::future<>

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -111,10 +111,15 @@ private:
      * version level used when dispatching requests. this value may change
      * during the lifetime of the transport. for example the version may be
      * upgraded if it is discovered that a server supports a newer version.
-     *
-     * reset to v1 in reset_state() to support reconnect_transport.
      */
-    transport_version _version{transport_version::v1};
+    transport_version _version;
+
+    /*
+     * The initial version for new connections.  If we upgrade to a newer
+     * version from negotiation with a peer, _version will be incremented
+     * but will reset to _default_version when reset_state() is called.
+     */
+    transport_version _default_version;
 
     friend class ::rpc_integration_fixture_oc_ns_adl_serde_no_upgrade;
     friend class ::rpc_integration_fixture_oc_ns_adl_only_no_upgrade;

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -303,6 +303,7 @@ struct transport_configuration {
     uint32_t max_queued_bytes = std::numeric_limits<uint32_t>::max();
     ss::shared_ptr<ss::tls::certificate_credentials> credentials;
     net::metrics_disabled disable_metrics = net::metrics_disabled::no;
+    transport_version version{transport_version::v1};
 };
 
 std::ostream& operator<<(std::ostream&, const status&);

--- a/src/v/utils/waiter_queue.h
+++ b/src/v/utils/waiter_queue.h
@@ -44,7 +44,15 @@ class waiter_queue {
     std::vector<std::unique_ptr<wait_item>> _items;
 
 public:
-    ~waiter_queue() {
+    ~waiter_queue() { abort_all(); }
+
+    /**
+     * Callers of await() *should* use abort sources that fire
+     * before this object is destroyed.  However, to make it
+     * easier to reason about safety during shutdown, we also
+     * explicitly evict them all.
+     */
+    void abort_all() {
         for (auto& i : _items) {
             i->p.set_exception(ss::abort_requested_exception());
         }

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -22,7 +22,7 @@ from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.utils.util import wait_until
 from rptest.util import wait_until_result
 
-CURRENT_LOGICAL_VERSION = 6
+CURRENT_LOGICAL_VERSION = 7
 
 # The upgrade tests defined below rely on having a logical version lower than
 # CURRENT_LOGICAL_VERSION. For the sake of these tests, the exact version


### PR DESCRIPTION
## Cover letter

Depends on https://github.com/redpanda-data/redpanda/pull/6528

When we introduced transport version 2 in Redpanda 22.2, the way that nodes switch to the new encoding is to wait for the first RPC to receive a response, and then upgrade to v2 if we can tell our peer is new enough.  That is fine while we have ADL encoding available for all the RPCs that might be the first on the connection, but is problematic if we would like to rely on getting serde encoding for a structure we are changing/improving, without having to handle the case of occasionally getting the legacy version of the structure when it happens to be the first on the connection.

This PR will land in Redpanda 22.3.  Once all nodes are upgraded, the rpc_v2_by_default feature will activate, and new connections will no longer rely on negotiating up to v2.  This means that nodes running Redpanda 22.1 or earlier will not be able to communicate with the cluster.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
