### PR TITLE
cloud_storage: cleanup empty directories on startup

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -116,8 +116,8 @@ ss::future<> cache::consume_cache_space(size_t sz) {
 
 ss::future<> cache::clean_up_at_start() {
     gate_guard guard{_gate};
-    auto [cache_size, candidates_for_deletion] = co_await _walker.walk(
-      _cache_dir.native(), _access_time_tracker);
+    auto [cache_size, candidates_for_deletion, empty_dirs]
+      = co_await _walker.walk(_cache_dir.native(), _access_time_tracker);
     probe.set_size(cache_size);
     probe.set_num_files(candidates_for_deletion.size());
 
@@ -132,7 +132,7 @@ ss::future<> cache::clean_up_at_start() {
     _access_time_tracker.remove_others(tmp);
     _current_cache_size = cache_size;
 
-    for (auto& file_item : candidates_for_deletion) {
+    for (const auto& file_item : candidates_for_deletion) {
         auto filepath_to_remove = file_item.path;
 
         // delete only tmp files that are left from previous RedPanda run
@@ -143,12 +143,27 @@ ss::future<> cache::clean_up_at_start() {
             } catch (std::exception& e) {
                 vlog(
                   cst_log.error,
-                  "Cache eviction couldn't delete {}: {}.",
+                  "Startup cache cleanup couldn't delete {}: {}.",
                   filepath_to_remove,
                   e.what());
             }
         }
     }
+
+    for (const auto& path : empty_dirs) {
+        try {
+            co_await ss::remove_file(path);
+        } catch (std::exception& e) {
+            // Leaving an empty dir will not prevent progress, so tolerate
+            // errors on deletion (could be e.g. a permissions error)
+            vlog(
+              cst_log.error,
+              "Startup cache cleanup couldn't delete {}: {}.",
+              path,
+              e);
+        }
+    }
+
     vlog(
       cst_log.debug,
       "Clean up at start deleted files of total size {}.",
@@ -158,8 +173,8 @@ ss::future<> cache::clean_up_at_start() {
 ss::future<> cache::clean_up_cache() {
     vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     gate_guard guard{_gate};
-    auto [current_cache_size, candidates_for_deletion] = co_await _walker.walk(
-      _cache_dir.native(), _access_time_tracker);
+    auto [current_cache_size, candidates_for_deletion, _]
+      = co_await _walker.walk(_cache_dir.native(), _access_time_tracker);
     _current_cache_size = current_cache_size;
     probe.set_size(_current_cache_size);
     probe.set_num_files(candidates_for_deletion.size());

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -194,6 +194,12 @@ ss::future<> cache::clean_up_cache() {
           = _current_cache_size
             - (_max_cache_size * (long double)_cache_size_low_watermark);
 
+        // Sort by atime for the subsequent LRU trimming loop
+        std::sort(
+          candidates_for_deletion.begin(),
+          candidates_for_deletion.end(),
+          [](auto& a, auto& b) { return a.access_time < b.access_time; });
+
         size_t i_to_delete = 0;
         while (i_to_delete < candidates_for_deletion.size()
                && deleted_size < size_to_delete) {

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -33,6 +33,8 @@ static constexpr size_t default_write_buffer_size = 128_KiB;
 static constexpr unsigned default_writebehind = 10;
 static constexpr const char* access_time_tracker_file_name = "accesstime";
 
+class cache_test_fixture;
+
 struct cache_item {
     ss::file body;
     size_t size;
@@ -130,6 +132,8 @@ private:
     cache_probe probe;
     access_time_tracker _access_time_tracker;
     ss::timer<ss::lowres_clock> _tracker_timer;
+
+    friend class cache_test_fixture;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -111,7 +111,7 @@ ss::future<walk_result> recursive_directory_walker::walk(
 
     co_return walk_result{
       .cache_size = current_cache_size,
-      .deletion_candidates = files,
+      .regular_files = files,
       .empty_dirs = empty_dirs};
 }
 

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -105,9 +105,6 @@ ss::future<walk_result> recursive_directory_walker::walk(
             }
         }
     }
-    std::sort(files.begin(), files.end(), [](auto& a, auto& b) {
-        return a.access_time < b.access_time;
-    });
 
     co_return walk_result{
       .cache_size = current_cache_size,

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -29,8 +29,7 @@
 
 namespace cloud_storage {
 
-ss::future<std::pair<uint64_t, std::vector<file_list_item>>>
-recursive_directory_walker::walk(
+ss::future<walk_result> recursive_directory_walker::walk(
   ss::sstring start_dir, const access_time_tracker& tracker) {
     gate_guard guard{_gate};
 
@@ -103,7 +102,8 @@ recursive_directory_walker::walk(
         return a.access_time < b.access_time;
     });
 
-    co_return std::make_pair(current_cache_size, files);
+    co_return walk_result{
+      .cache_size = current_cache_size, .deletion_candidates = files};
 }
 
 ss::future<> recursive_directory_walker::stop() {

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -28,7 +28,7 @@ struct file_list_item {
 
 struct walk_result {
     uint64_t cache_size{0};
-    std::vector<file_list_item> deletion_candidates;
+    std::vector<file_list_item> regular_files;
     std::vector<ss::sstring> empty_dirs;
 };
 

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -19,18 +19,25 @@
 #include <chrono>
 
 namespace cloud_storage {
+
 struct file_list_item {
     std::chrono::system_clock::time_point access_time;
     ss::sstring path;
     uint64_t size;
 };
+
+struct walk_result {
+    uint64_t cache_size{0};
+    std::vector<file_list_item> deletion_candidates;
+};
+
 class recursive_directory_walker {
 public:
     ss::future<> stop();
 
     // recursively walks start_dir, returns the total size of files in this
     // directory and a list of files sorted by access time from oldest to newest
-    ss::future<std::pair<uint64_t, std::vector<file_list_item>>>
+    ss::future<walk_result>
     walk(ss::sstring start_dir, const access_time_tracker& tracker);
 
 private:

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -29,6 +29,7 @@ struct file_list_item {
 struct walk_result {
     uint64_t cache_size{0};
     std::vector<file_list_item> deletion_candidates;
+    std::vector<ss::sstring> empty_dirs;
 };
 
 class recursive_directory_walker {

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -14,6 +14,7 @@
 #include "cloud_storage/cache_service.h"
 #include "test_utils/fixture.h"
 #include "units.h"
+#include "utils/file_io.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
@@ -368,4 +369,49 @@ SEASTAR_THREAD_TEST_CASE(test_access_time_tracker_serializer) {
         auto ts = out.estimate_timestamp(names[i]);
         BOOST_REQUIRE(ts.value() >= timestamps[i]);
     }
+}
+
+/**
+ * Validate that .part files and empty directories are deleted if found during
+ * the startup walk of the cache.
+ */
+FIXTURE_TEST(test_clean_up_on_start, cache_test_fixture) {
+    // A temporary file, this should be deleted on startup
+    put_into_cache(create_data_string('a', 1_KiB), KEY);
+    std::filesystem::path tmp_key = KEY;
+    tmp_key.replace_extension(".part");
+    ss::rename_file((CACHE_DIR / KEY).native(), (CACHE_DIR / tmp_key).native())
+      .get();
+
+    // A normal looking segment, we'll check this isn't deleted
+    put_into_cache(create_data_string('b', 1_KiB), KEY);
+
+    // An empty directory, this should be deleted
+    auto empty_dir_path = std::filesystem::path{CACHE_DIR / "empty_dir"};
+    ss::make_directory(empty_dir_path.native()).get();
+
+    // A non-empty-directory, this should be preserved
+    auto populated_dir_path = CACHE_DIR / "populated_dir";
+    ss::make_directory(populated_dir_path.native()).get();
+    write_fully(populated_dir_path / "populated_file", {}).get();
+
+    clean_up_at_start().get();
+
+    BOOST_CHECK(ss::file_exists((CACHE_DIR / KEY).native()).get());
+    BOOST_CHECK(!ss::file_exists((CACHE_DIR / tmp_key).native()).get());
+    BOOST_CHECK(!ss::file_exists(empty_dir_path.native()).get());
+    BOOST_CHECK(ss::file_exists(populated_dir_path.native()).get());
+}
+
+/**
+ * Validate that the empty directory deletion code in clean_up_at_start
+ * does not consider the cache directory itself an empty directory
+ * to be deleted.
+ */
+FIXTURE_TEST(test_clean_up_on_start_empty, cache_test_fixture) {
+    ss::make_directory(CACHE_DIR.native()).get();
+
+    clean_up_at_start().get();
+
+    BOOST_CHECK(ss::file_exists(CACHE_DIR.native()).get());
 }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -25,12 +25,15 @@
 #include <chrono>
 #include <filesystem>
 
-using namespace cloud_storage;
 using namespace std::chrono_literals;
 
 static inline std::filesystem::path get_cache_dir(std::filesystem::path p) {
     return p / "test_cache_dir";
 }
+
+// In cloud_storage namespace so we can befriend this fixture from
+// the class under test.
+namespace cloud_storage {
 
 class cache_test_fixture {
 public:
@@ -72,4 +75,10 @@ public:
         auto input = make_iobuf_input_stream(std::move(buf));
         sharded_cache.local().put(key, input).get();
     }
+
+    ss::future<> clean_up_at_start() {
+        return sharded_cache.local().clean_up_at_start();
+    }
 };
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/tests/directory_walker_test.cc
+++ b/src/v/cloud_storage/tests/directory_walker_test.cc
@@ -55,11 +55,9 @@ SEASTAR_THREAD_TEST_CASE(one_level) {
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
     BOOST_REQUIRE_EQUAL(result.cache_size, 0);
-    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 2);
-    BOOST_REQUIRE_EQUAL(
-      result.deletion_candidates[0].path, file_path1.native());
-    BOOST_REQUIRE_EQUAL(
-      result.deletion_candidates[1].path, file_path2.native());
+    BOOST_REQUIRE_EQUAL(result.regular_files.size(), 2);
+    BOOST_REQUIRE_EQUAL(result.regular_files[0].path, file_path1.native());
+    BOOST_REQUIRE_EQUAL(result.regular_files[1].path, file_path2.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(three_levels) {
@@ -95,13 +93,10 @@ SEASTAR_THREAD_TEST_CASE(three_levels) {
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
     BOOST_REQUIRE_EQUAL(result.cache_size, 0);
-    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 3);
-    BOOST_REQUIRE_EQUAL(
-      result.deletion_candidates[0].path, file_path1.native());
-    BOOST_REQUIRE_EQUAL(
-      result.deletion_candidates[1].path, file_path2.native());
-    BOOST_REQUIRE_EQUAL(
-      result.deletion_candidates[2].path, file_path3.native());
+    BOOST_REQUIRE_EQUAL(result.regular_files.size(), 3);
+    BOOST_REQUIRE_EQUAL(result.regular_files[0].path, file_path1.native());
+    BOOST_REQUIRE_EQUAL(result.regular_files[1].path, file_path2.native());
+    BOOST_REQUIRE_EQUAL(result.regular_files[2].path, file_path3.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(no_files) {
@@ -118,7 +113,7 @@ SEASTAR_THREAD_TEST_CASE(no_files) {
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
     BOOST_REQUIRE_EQUAL(result.cache_size, 0);
-    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 0);
+    BOOST_REQUIRE_EQUAL(result.regular_files.size(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(empty_dir) {
@@ -130,7 +125,7 @@ SEASTAR_THREAD_TEST_CASE(empty_dir) {
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
     BOOST_REQUIRE_EQUAL(result.cache_size, 0);
-    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 0);
+    BOOST_REQUIRE_EQUAL(result.regular_files.size(), 0);
 }
 
 void write_to_file(auto& target_file, uint64_t size) {
@@ -174,5 +169,5 @@ SEASTAR_THREAD_TEST_CASE(total_size_correct) {
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
     BOOST_REQUIRE_EQUAL(result.cache_size, 3412 + 8 + 342);
-    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 3);
+    BOOST_REQUIRE_EQUAL(result.regular_files.size(), 3);
 }

--- a/src/v/cloud_storage/tests/directory_walker_test.cc
+++ b/src/v/cloud_storage/tests/directory_walker_test.cc
@@ -54,10 +54,12 @@ SEASTAR_THREAD_TEST_CASE(one_level) {
     access_time_tracker tracker;
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
-    BOOST_REQUIRE_EQUAL(result.first, 0);
-    BOOST_REQUIRE_EQUAL(result.second.size(), 2);
-    BOOST_REQUIRE_EQUAL(result.second[0].path, file_path1.native());
-    BOOST_REQUIRE_EQUAL(result.second[1].path, file_path2.native());
+    BOOST_REQUIRE_EQUAL(result.cache_size, 0);
+    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 2);
+    BOOST_REQUIRE_EQUAL(
+      result.deletion_candidates[0].path, file_path1.native());
+    BOOST_REQUIRE_EQUAL(
+      result.deletion_candidates[1].path, file_path2.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(three_levels) {
@@ -92,11 +94,14 @@ SEASTAR_THREAD_TEST_CASE(three_levels) {
     access_time_tracker tracker;
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
-    BOOST_REQUIRE_EQUAL(result.first, 0);
-    BOOST_REQUIRE_EQUAL(result.second.size(), 3);
-    BOOST_REQUIRE_EQUAL(result.second[0].path, file_path1.native());
-    BOOST_REQUIRE_EQUAL(result.second[1].path, file_path2.native());
-    BOOST_REQUIRE_EQUAL(result.second[2].path, file_path3.native());
+    BOOST_REQUIRE_EQUAL(result.cache_size, 0);
+    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 3);
+    BOOST_REQUIRE_EQUAL(
+      result.deletion_candidates[0].path, file_path1.native());
+    BOOST_REQUIRE_EQUAL(
+      result.deletion_candidates[1].path, file_path2.native());
+    BOOST_REQUIRE_EQUAL(
+      result.deletion_candidates[2].path, file_path3.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(no_files) {
@@ -112,8 +117,8 @@ SEASTAR_THREAD_TEST_CASE(no_files) {
     access_time_tracker tracker;
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
-    BOOST_REQUIRE_EQUAL(result.first, 0);
-    BOOST_REQUIRE_EQUAL(result.second.size(), 0);
+    BOOST_REQUIRE_EQUAL(result.cache_size, 0);
+    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(empty_dir) {
@@ -124,8 +129,8 @@ SEASTAR_THREAD_TEST_CASE(empty_dir) {
     access_time_tracker tracker;
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
-    BOOST_REQUIRE_EQUAL(result.first, 0);
-    BOOST_REQUIRE_EQUAL(result.second.size(), 0);
+    BOOST_REQUIRE_EQUAL(result.cache_size, 0);
+    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 0);
 }
 
 void write_to_file(auto& target_file, uint64_t size) {
@@ -168,6 +173,6 @@ SEASTAR_THREAD_TEST_CASE(total_size_correct) {
     access_time_tracker tracker;
     auto result = _walker.walk(target_dir.native(), tracker).get();
 
-    BOOST_REQUIRE_EQUAL(result.first, 3412 + 8 + 342);
-    BOOST_REQUIRE_EQUAL(result.second.size(), 3);
+    BOOST_REQUIRE_EQUAL(result.cache_size, 3412 + 8 + 342);
+    BOOST_REQUIRE_EQUAL(result.deletion_candidates.size(), 3);
 }


### PR DESCRIPTION
## Cover letter

This is to cover us against upgraded systems from earlier versions that didn't properly remove empty directories, and also to cover the case where redpanda stops in between removing a file and checking for an empty directory to delete.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Redpanda now cleans up empty directories in the tiered storage cache directory on startup, as well as after removing segments.
