### PR TITLE
cluster: hygiene improvements in members management

### DIFF
--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -35,7 +35,7 @@ class drain_manager : public ss::peering_sharded_service<drain_manager> {
 
 public:
     /*
-     * finsihed:     draining has completed
+     * finished:     draining has completed
      * errors:       draining finished with errors
      * partitions:   total partitions
      * eligible:     total drain-eligible partitions

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -96,18 +96,6 @@ ss::future<> members_manager::start() {
     co_return;
 }
 
-/**
- * Sends a join RPC if we aren't already a member, else sends a node
- * configuration update if our local state differs from that stored
- * in the members table.
- *
- * This is separate to start() so that calling it can be delayed until
- * after our internal RPC listener is up: as soon as we send a join message,
- * the controller leader will expect us to be listening for its raft messages,
- * and if we're not ready it'll back off and make joining take several seconds
- * longer than it should.
- * (ref https://github.com/redpanda-data/redpanda/issues/3030)
- */
 ss::future<> members_manager::join_cluster() {
     if (is_already_member()) {
         ssx::spawn_with_gate(

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -173,11 +173,11 @@ private:
     ss::future<std::error_code>
       apply_raft_configuration_batch(model::record_batch);
 
-    std::vector<config::seed_server> _seed_servers;
-    model::broker _self;
+    const std::vector<config::seed_server> _seed_servers;
+    const model::broker _self;
     simple_time_jitter<model::timeout_clock> _join_retry_jitter;
-    std::chrono::milliseconds _join_timeout;
-    consensus_ptr _raft0;
+    const std::chrono::milliseconds _join_timeout;
+    const consensus_ptr _raft0;
     ss::sharded<members_table>& _members_table;
     ss::sharded<rpc::connection_cache>& _connection_cache;
 
@@ -198,7 +198,7 @@ private:
 
     ss::sharded<ss::abort_source>& _as;
 
-    config::tls_config _rpc_tls_config;
+    const config::tls_config _rpc_tls_config;
 
     // Gate with which to guard new work (e.g. if stop() has been called).
     ss::gate _gate;

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -26,13 +26,19 @@
 
 namespace cluster {
 
-// Members manager class is responsible for updating information about
-// cluster members, joining the cluster and creating inter cluster
-// connections. This class receives updates from controller STM. It reacts
-// only on raft configuration batch types. All the updates are propagated to
-// core local cluster::members instances. There is only one instance of
-// members manager running on core-0. The member manager is also responsible
-// for validation of node configuration invariants.
+// Implementation of a raft::mux_state_machine that is responsible for
+// updating information about cluster members, joining the cluster, updating
+// member states, and creating intra-cluster connections.
+//
+// This class receives updates from members_frontend by way of a Raft record
+// batch being committed. In addition to various controller command batch
+// types, it reacts to Raft configuration batch types, e.g. when a new node is
+// added to the controller Raft group.
+//
+// All the updates are propagated to core-local cluster::members_table
+// instances. There is only one instance of members_manager running on
+// core-0. The members_manager is also responsible for validation of node
+// configuration invariants.
 class members_manager {
 public:
     static constexpr auto accepted_commands = make_commands_list<
@@ -42,13 +48,28 @@ public:
       maintenance_mode_cmd>{};
     static constexpr ss::shard_id shard = 0;
     static constexpr size_t max_updates_queue_size = 100;
+
+    // Update types, used for communication between the manager and backend.
+    //
+    // NOTE: maintenance mode doesn't interact with the members_backend,
+    // instead interacting with each core via their respective drain_manager.
     enum class node_update_type : int8_t {
+        // A node has been added to the cluster.
         added,
+
+        // A node has been decommissioned from the cluster.
         decommissioned,
+
+        // A node has been recommissioned after an incomplete decommission.
         recommissioned,
+
+        // All reallocations associated with a given node update have completed
+        // (e.g. it's been fully decommissioned, indicating it can no longer be
+        // recommissioned).
         reallocation_finished,
     };
 
+    // Node update information to be processed by the members_backend.
     struct node_update {
         model::node_id id;
         node_update_type type;
@@ -71,28 +92,53 @@ public:
       ss::sharded<drain_manager>&,
       ss::sharded<ss::abort_source>&);
 
-    ss::future<> start();
-    ss::future<> stop();
+    // Checks invariants. Must be called before calling start().
     ss::future<> validate_configuration_invariants();
+
+    // Initializes connections to all known members.
+    ss::future<> start();
+
+    // Sends a join RPC if we aren't already a member, else sends a node
+    // configuration update if our local state differs from that stored in the
+    // members table.
+    //
+    // This is separate to start() so that calling it can be delayed until
+    // after our internal RPC listener is up: as soon as we send a join
+    // message, the controller leader will expect us to be listening for its
+    // raft messages, and if we're not ready it'll back off and make joining
+    // take several seconds longer than it should.
+    // (ref https://github.com/redpanda-data/redpanda/issues/3030)
+    ss::future<> join_cluster();
+
+    // Stop this manager. Only prevents new update requests; pending updates in
+    // the queue are aborted separately.
+    ss::future<> stop();
+
+    // Adds a node to the controller Raft group, dispatching to the leader if
+    // necessary. If the node already exists, just updates the node config
+    // instead.
     ss::future<result<join_node_reply>>
     handle_join_request(join_node_request const r);
+
+    // Applies a committed record batch, specializing handling based on the
+    // batch type.
     ss::future<std::error_code> apply_update(model::record_batch);
 
+    // Updates the configuration of a node in the existing controller Raft
+    // config, dispatching to the leader if necessary.
     ss::future<result<configuration_update_reply>>
       handle_configuration_update_request(configuration_update_request);
 
+    // Whether the given batch applies to this raft::mux_state_machine.
     bool is_batch_applicable(const model::record_batch& b) {
         return b.header().type == model::record_batch_type::node_management_cmd
                || b.header().type
                     == model::record_batch_type::raft_configuration;
     }
-    /**
-     * This API is backed by the seastar::queue. It can not be called
-     * concurrently from multiple fibers.
-     */
-    ss::future<std::vector<node_update>> get_node_updates();
 
-    ss::future<> join_cluster();
+    // This API is backed by the seastar::queue. It can not be called
+    // concurrently from multiple fibers.
+    ss::future<std::vector<node_update>> get_node_updates();
 
 private:
     using seed_iterator = std::vector<config::seed_server>::const_iterator;
@@ -134,14 +180,38 @@ private:
     consensus_ptr _raft0;
     ss::sharded<members_table>& _members_table;
     ss::sharded<rpc::connection_cache>& _connection_cache;
+
+    // Partition allocator to update when receiving node lifecycle commands.
     ss::sharded<partition_allocator>& _allocator;
+
+    // Storage with which to look at the kv-store to store and verify
+    // configuration invariants.
+    //
+    // TODO: since the members manager is only ever on shard-0, seems like we
+    // should just be passing a single reference to the kv-store.
     ss::sharded<storage::api>& _storage;
+
+    // Per-core management of operations that remove leadership away from a
+    // node. Needs to be per-core since each shard is managed by a different
+    // shard of the sharded partition_manager.
     ss::sharded<drain_manager>& _drain_manager;
+
     ss::sharded<ss::abort_source>& _as;
+
     config::tls_config _rpc_tls_config;
+
+    // Gate with which to guard new work (e.g. if stop() has been called).
     ss::gate _gate;
+
+    // Cluster membership updates that have yet to be released via the call to
+    // get_node_updates().
     ss::queue<node_update> _update_queue;
+
+    // Subscription to _as with which to signal an abort to _update_queue.
     ss::abort_source::subscription _queue_abort_subscription;
+
+    // The last config update controller log offset for which we successfully
+    // updated our broker connections.
     model::offset _last_connection_update_offset;
 };
 

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -138,17 +138,6 @@ members_table::apply(model::offset version, recommission_node_cmd cmd) {
     return errc::node_does_not_exists;
 }
 
-std::vector<model::node_id> members_table::get_decommissioned() const {
-    std::vector<model::node_id> ret;
-    for (const auto& [id, broker] : _brokers) {
-        if (
-          broker->get_membership_state() == model::membership_state::draining) {
-            ret.push_back(id);
-        }
-    }
-    return ret;
-}
-
 std::error_code
 members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     _version = model::revision_id(version());

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -36,8 +36,6 @@ public:
     /// Returns single broker if exists in cache
     std::optional<broker_ptr> get_broker(model::node_id) const;
 
-    std::vector<model::node_id> get_decommissioned() const;
-
     bool contains(model::node_id) const;
 
     void update_brokers(model::offset, const std::vector<model::broker>&);

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -21,7 +21,7 @@
 namespace cluster {
 
 /// Class containing information about cluster members. The members class is
-/// instantiated on each core. Cluster members updates are comming directly from
+/// instantiated on each core. Cluster members updates are coming directly from
 /// cluster::members_manager
 class members_table {
 public:

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -21,6 +21,12 @@
 
 namespace cluster {
 
+// This class keeps track of the partition assignments of each group, also
+// tracking the lifecycle events (decommissioning, etc) of each node to
+// determine where to place new partitions.
+//
+// Under the hood, this doesn't do any bookkeeping of what partitions exist on
+// each shard, only how many partition replicas are assigned per shard.
 class partition_allocator {
 public:
     static constexpr ss::shard_id shard = 0;
@@ -49,7 +55,7 @@ public:
 
     result<allocation_units> allocate(allocation_request);
 
-    /// Realocates partition replicas, moving them away from decommissioned
+    /// Reallocates partition replicas, moving them away from decommissioned
     /// nodes. Replicas on nodes that were left untouched are not changed.
     /// Allocation domain must match the one used to allocate the partition.
     ///
@@ -62,7 +68,7 @@ public:
       const partition_assignment&,
       partition_allocation_domain);
 
-    /// best effort. Does not throw if we cannot find the old partition.
+    /// Best effort. Does not throw if we cannot find the replicas.
     /// Allocation domain must match the one used to allocate the partition.
     void deallocate(
       const std::vector<model::broker_shard>&, partition_allocation_domain);

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -28,9 +28,7 @@ public:
         }).get0();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
-        app.configure_admin_server();
-        app.wire_up_services();
-        app.start(*app_signal);
+        app.wire_up_and_start(*app_signal);
     }
 
     kc::client make_client() { return kc::client{proxy_client_config()}; }

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -130,9 +130,7 @@ public:
         }).get0();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
-        app.configure_admin_server();
-        app.wire_up_services();
-        app.start(*app_signal);
+        app.wire_up_and_start(*app_signal);
     }
 };
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -246,9 +246,7 @@ int application::run(int ac, char** av) {
                 initialize();
                 check_environment();
                 setup_metrics();
-                wire_up_services();
-                configure_admin_server();
-                start(app_signal);
+                wire_up_and_start(app_signal);
                 app_signal.wait().get();
                 vlog(_log.info, "Stopping...");
             } catch (...) {
@@ -686,6 +684,7 @@ void application::wire_up_services() {
           *_schema_reg_config,
           std::reference_wrapper(controller));
     }
+    configure_admin_server();
 }
 
 void application::wire_up_redpanda_services() {
@@ -909,7 +908,7 @@ void application::wire_up_redpanda_services() {
     }
 
     // group membership
-    syschecks::systemd_message("Creating partition manager").get();
+    syschecks::systemd_message("Creating kafka group managers").get();
     construct_service(
       _group_manager,
       model::kafka_group_nt,
@@ -1235,7 +1234,8 @@ application::set_proxy_client_config(ss::sstring name, std::any val) {
       });
 }
 
-void application::start(::stop_signal& app_signal) {
+void application::wire_up_and_start(::stop_signal& app_signal) {
+    wire_up_services();
     start_redpanda(app_signal);
 
     if (_proxy_config) {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -61,12 +61,7 @@ public:
       std::optional<YAML::Node> schema_reg_client_cfg = std::nullopt,
       std::optional<scheduling_groups> = std::nullopt);
     void check_environment();
-    void configure_admin_server();
-    void wire_up_services();
-    void wire_up_redpanda_services();
-    void start(::stop_signal&);
-    void start_redpanda(::stop_signal&);
-    void start_kafka(::stop_signal&);
+    void wire_up_and_start(::stop_signal&);
 
     explicit application(ss::sstring = "redpanda::main");
     ~application();
@@ -112,6 +107,12 @@ public:
 private:
     using deferred_actions
       = std::vector<ss::deferred_action<std::function<void()>>>;
+
+    void configure_admin_server();
+    void wire_up_services();
+    void wire_up_redpanda_services();
+    void start_redpanda(::stop_signal&);
+    void start_kafka(::stop_signal&);
 
     // All methods are calleds from Seastar thread
     ss::app_template::config setup_app_config();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -82,9 +82,7 @@ public:
           proxy_client_config(kafka_port),
           sch_groups);
         app.check_environment();
-        app.configure_admin_server();
-        app.wire_up_services();
-        app.start(*app_signal);
+        app.wire_up_and_start(*app_signal);
 
         // used by request context builder
         proto = std::make_unique<kafka::protocol>(


### PR DESCRIPTION
## Cover letter

This PR adds some hygiene improvements to the members management subsystems including:
- fleshing out and updating comments
- moving high-level comments into headers
- making some methods private
- making some variables const

There are no major functional changes in this PR.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
