### PR TITLE
utils: add UUID type

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -23,6 +23,7 @@
 #include "tristate.h"
 #include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
+#include "utils/uuid.h"
 #include "vlog.h"
 
 #include <seastar/core/future.hh>
@@ -40,6 +41,8 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+
+struct uuid_t;
 
 namespace serde {
 
@@ -173,6 +176,7 @@ inline constexpr auto const is_serde_compatible_v
     || std::is_same_v<T, iobuf>
     || std::is_same_v<T, ss::sstring>
     || std::is_same_v<T, bytes>
+    || std::is_same_v<T, uuid_t>
     || is_absl_btree_set<T>
     || is_absl_flat_hash_map<T>
     || is_absl_node_hash_set<T>
@@ -347,6 +351,8 @@ void write(iobuf& out, T t) {
     } else if constexpr (std::is_same_v<Type, bytes>) {
         write<serde_size_t>(out, t.size());
         out.append(t.data(), t.size());
+    } else if constexpr (std::is_same_v<Type, uuid_t>) {
+        out.append(t.uuid.data, uuid_t::length);
     } else if constexpr (reflection::is_std_optional<Type>) {
         if (t) {
             write(out, true);
@@ -634,6 +640,8 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());
         t = str;
+    } else if constexpr (std::is_same_v<Type, uuid_t>) {
+        in.consume_to(uuid_t::length, t.uuid.begin());
     } else if constexpr (reflection::is_std_optional<Type>) {
         t = read_nested<bool>(in, bytes_left_limit)
               ? Type{read_nested<typename Type::value_type>(

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -15,6 +15,7 @@
 #include "serde/serde.h"
 #include "tristate.h"
 #include "utils/fragmented_vector.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sstring.hh>
@@ -22,6 +23,7 @@
 #include <seastar/testing/thread_test_case.hh>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/uuid/uuid_generators.hpp>
 
 #include <chrono>
 #include <limits>
@@ -220,6 +222,79 @@ SEASTAR_THREAD_TEST_CASE(vector_test) {
     auto parser = iobuf_parser{std::move(b)};
     auto const m = serde::read<std::vector<int>>(parser);
     BOOST_CHECK((m == std::vector{1, 2, 3}));
+}
+
+SEASTAR_THREAD_TEST_CASE(uuid_test) {
+    auto b = iobuf();
+    boost::uuids::random_generator uuid_gen;
+    uuid_t u(uuid_gen());
+    serde::write(b, u);
+
+    auto parser = iobuf_parser{std::move(b)};
+    const auto r = serde::read<uuid_t>(parser);
+    BOOST_REQUIRE_EQUAL(u, r);
+}
+
+struct uuid_struct : serde::envelope<uuid_struct, serde::version<0>> {
+    uuid_t single;
+    std::optional<uuid_t> opt1;
+    std::optional<uuid_t> opt2;
+    std::vector<uuid_t> vec;
+    std::vector<std::optional<uuid_t>> opt_vec;
+};
+
+template<typename map_t>
+void verify_uuid_map(boost::uuids::random_generator& uuid_gen) {
+    map_t m = {
+      {uuid_t(uuid_gen()), 0},
+      {uuid_t(uuid_gen()), 1},
+      {uuid_t(uuid_gen()), 2},
+    };
+    auto b = iobuf();
+    serde::write(b, m);
+    auto parser = iobuf_parser{std::move(b)};
+    const auto r = serde::read<map_t>(parser);
+    BOOST_CHECK_EQUAL(m.size(), r.size());
+    for (const auto& [k, v] : m) {
+        const auto r_it = r.find(k);
+        BOOST_CHECK(m.end() != r_it);
+        BOOST_CHECK_EQUAL(v, r_it->second);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(complex_uuid_types_test) {
+    boost::uuids::random_generator uuid_gen;
+    uuid_struct us;
+    us.single = uuid_t(uuid_gen());
+    us.opt1 = std::make_optional<uuid_t>(uuid_gen());
+    us.opt2 = std::nullopt;
+    us.vec = {
+      uuid_t(uuid_gen()),
+      uuid_t(uuid_gen()),
+      uuid_t(uuid_gen()),
+    };
+    us.opt_vec = {
+      std::make_optional<uuid_t>(uuid_gen()),
+      std::nullopt,
+      std::make_optional<uuid_t>(uuid_gen()),
+      std::nullopt,
+    };
+    auto b = iobuf();
+    serde::write(b, us);
+    auto parser = iobuf_parser{std::move(b)};
+    const auto r = serde::read<uuid_struct>(parser);
+    BOOST_CHECK_EQUAL(us.single, r.single);
+    BOOST_CHECK(us.opt1 == r.opt1);
+    BOOST_CHECK(us.opt2 == r.opt2);
+    BOOST_CHECK_EQUAL(us.vec, r.vec);
+    BOOST_CHECK_EQUAL(us.opt_vec.size(), r.opt_vec.size());
+    for (int i = 0; i < us.opt_vec.size(); ++i) {
+        BOOST_CHECK(us.opt_vec[i] == r.opt_vec[i]);
+    }
+
+    // Map types.
+    verify_uuid_map<std::unordered_map<uuid_t, int>>(uuid_gen);
+    verify_uuid_map<absl::flat_hash_map<uuid_t, int>>(uuid_gen);
 }
 
 // struct with differing sizes:

--- a/src/v/utils/uuid.h
+++ b/src/v/utils/uuid.h
@@ -1,0 +1,74 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "bytes/details/out_of_range.h"
+#include "reflection/adl.h"
+
+#include <absl/hash/hash.h>
+#include <boost/functional/hash.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <vector>
+
+// Wrapper around Boost's UUID type suitable for serialization with serde.
+// Provides utilities to construct and convert to other types.
+//
+// Expected usage is to supply a UUID v4 (i.e. based on random numbers). As
+// such, serialization of this type simply serializes 16 bytes.
+struct uuid_t {
+public:
+    static constexpr auto length = 16;
+    using underlying_t = boost::uuids::uuid;
+
+    underlying_t uuid;
+
+    explicit uuid_t(const underlying_t& uuid)
+      : uuid(uuid) {}
+
+    explicit uuid_t(const std::vector<uint8_t>& v)
+      : uuid({}) {
+        if (v.size() != length) {
+            details::throw_out_of_range(
+              "Expected size of {} for UUID, got {}", length, v.size());
+        }
+        std::copy(v.begin(), v.end(), uuid.begin());
+    }
+
+    uuid_t() noexcept = default;
+
+    std::vector<uint8_t> to_vector() const {
+        return {uuid.begin(), uuid.end()};
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const uuid_t& u) {
+        return os << fmt::format("{}", u.uuid);
+    }
+
+    bool operator==(const uuid_t& u) const { return this->uuid == u.uuid; }
+
+    template<typename H>
+    friend H AbslHashValue(H h, const uuid_t& u) {
+        for (const uint8_t byte : u.uuid) {
+            H tmp = H::combine(std::move(h), byte);
+            h = std::move(tmp);
+        }
+        return h;
+    }
+};
+
+namespace std {
+template<>
+struct hash<uuid_t> {
+    size_t operator()(const uuid_t& u) const {
+        return boost::hash<uuid_t::underlying_t>()(u.uuid);
+    }
+};
+} // namespace std


### PR DESCRIPTION
## Cover letter

This commit adds a new type uuid_t that will soon be used for node UUID and cluster UUID. It wraps boost::uuids::uuid and includes some hooks required for serialization, hashing, and interacting with vectors (NOTE: the current `join_node_request` has a node UUID of type vector<uint8_t>).

Note that there already exists a kafka::uuid type that wraps `std::array<uint18_t, 16>`. I opted to avoid reusing it since it is exposed via the Kafka API, making it difficult to modify in the future if need be.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
