### PR TITLE
operator fix regression in console TLS for #6471

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -152,12 +152,12 @@ func (r *Reconciling) Do(
 
 	// Ingress with TLS and "/debug" "/admin" paths disabled
 	ingressResource := resources.NewIngress(r.Client, console, r.Scheme, subdomain, console.GetName(), consolepkg.ServicePortName, log)
+	ingressResource = ingressResource.WithDefaultEndpoint("console")
+	ingressResource = ingressResource.WithUserConfig(console.Spec.Ingress)
 	ingressResource = ingressResource.WithTLS(resources.LEClusterIssuer, fmt.Sprintf("%s-redpanda", cluster.GetName()))
 	ingressResource = ingressResource.WithAnnotations(map[string]string{
 		"nginx.ingress.kubernetes.io/server-snippet": "if ($request_uri ~* ^/(debug|admin)) {\n\treturn 403;\n\t}",
 	})
-	ingressResource = ingressResource.WithUserConfig(console.Spec.Ingress)
-	ingressResource = ingressResource.WithDefaultEndpoint("console")
 
 	applyResources := []resources.Resource{
 		consolepkg.NewKafkaSA(r.Client, r.Scheme, console, cluster, r.clusterDomain, r.AdminAPIClientFactory, log),

--- a/src/go/k8s/pkg/resources/ingress_test.go
+++ b/src/go/k8s/pkg/resources/ingress_test.go
@@ -1,58 +1,65 @@
 package resources_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIngressWithTLS(t *testing.T) {
 	table := []struct {
-		host        string
-		tlsSecret   string
-		tlsIssuer   string
-		annotations map[string]string
+		defaultEndpoint string
+		host            string
+		tlsSecret       string
+		tlsIssuer       string
+		annotations     map[string]string
+		tlsHosts        []string
 	}{
 		{
 			host:        "test.example.local",
 			tlsSecret:   "rp-abc123-redpanda",
 			tlsIssuer:   resources.LEClusterIssuer,
 			annotations: map[string]string{"foo.vectorized.io": "bar"},
+			tlsHosts:    []string{"test.example.local"},
+		},
+		{
+			defaultEndpoint: "console",
+			host:            "test.example.local",
+			tlsSecret:       "rp-abc123-redpanda",
+			tlsIssuer:       resources.LEClusterIssuer,
+			tlsHosts:        []string{"console.test.example.local", "test.example.local"},
 		},
 	}
-	for _, tt := range table {
-		ingress := resources.NewIngress(nil, nil, nil, tt.host, "", "", logr.Discard()).WithTLS(tt.tlsIssuer, tt.tlsSecret).WithAnnotations(tt.annotations)
-		annotations := ingress.GetAnnotations()
+	for i, tt := range table {
+		t.Run(fmt.Sprintf("%s-%d", tt.host, i), func(t *testing.T) {
+			ingress := resources.NewIngress(nil, nil, nil, tt.host, "", "", logr.Discard()).
+				WithDefaultEndpoint(tt.defaultEndpoint).
+				WithTLS(tt.tlsIssuer, tt.tlsSecret).
+				WithAnnotations(tt.annotations)
 
-		issuer, ok := annotations["cert-manager.io/cluster-issuer"]
-		require.True(t, ok)
-		require.Equal(t, tt.tlsIssuer, issuer)
+			annotations := ingress.GetAnnotations()
 
-		sslRedirect, ok := annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"]
-		require.True(t, ok)
-		require.Equal(t, "true", sslRedirect)
-
-		for k, v := range tt.annotations {
-			val, ok := annotations[k]
+			issuer, ok := annotations["cert-manager.io/cluster-issuer"]
 			require.True(t, ok)
-			require.Equal(t, v, val)
-		}
+			require.Equal(t, tt.tlsIssuer, issuer)
 
-		var found bool
-		for _, tls := range ingress.TLS {
-			// Host and SecretName should be in same TLS element
-			var foundHost bool
-			for _, host := range tls.Hosts {
-				if host == tt.host {
-					foundHost = true
-				}
+			sslRedirect, ok := annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"]
+			require.True(t, ok)
+			require.Equal(t, "true", sslRedirect)
+
+			for k, v := range tt.annotations {
+				val, ok := annotations[k]
+				require.True(t, ok)
+				require.Equal(t, v, val)
 			}
-			if foundHost && tls.SecretName == tt.tlsSecret {
-				found = true
-			}
-		}
-		require.True(t, found)
+
+			require.Len(t, ingress.TLS, 1)
+			assert.Equal(t, ingress.TLS[0].Hosts, tt.tlsHosts)
+			assert.Equal(t, ingress.TLS[0].SecretName, tt.tlsSecret)
+		})
 	}
 }


### PR DESCRIPTION
## Cover letter

There was an error in the order of operations when refactoring the code.

The additional host in TLS is probably causing errors, so we may need to remove it later, but let's fix generation for now.

