### PR TITLE
compaction: Factor in max_collectible_offset for all cleanup types.

### DIFF
--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -144,12 +144,10 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<>
-    garbage_collect_max_partition_size(size_t max_bytes, ss::abort_source*);
-    ss::future<>
-    garbage_collect_oldest_segments(model::timestamp, ss::abort_source*);
+    ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
+    ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
     ss::future<> garbage_collect_segments(
-      model::offset, ss::abort_source*, std::string_view);
+      compaction_config cfg, model::offset, std::string_view);
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);
 


### PR DESCRIPTION
## Cover letter

We can have max_collectible_offset set by different subsystems in multiple places. We need to consider the min of all the values and be conservative when cleaning up segments. This patch adds a regression test and fixes the problem.

For example, without this fix, a transaction in flight spanning two segments can potentially be cleaned up while in flight because the older segment exceeded size based threshold.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none.
