### PR TITLE
cluster: allow for serde-only controller commands

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -222,16 +222,21 @@ ss::future<std::error_code> replicate_and_wait(
        &as = as,
        timeout,
        use_serde_serialization](controller_stm& stm) mutable {
-          if (likely(use_serde_serialization)) {
-              auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
-              return stm.replicate_and_wait(
-                std::move(b), timeout, as.local(), term);
+          if constexpr (Cmd::serde_opts == serde_opts::adl_and_serde) {
+              if (unlikely(!use_serde_serialization)) {
+                  return serialize_cmd(std::forward<Cmd>(cmd))
+                    .then([&stm, timeout, term, &as](model::record_batch b) {
+                        return stm.replicate_and_wait(
+                          std::move(b), timeout, as.local(), term);
+                    });
+              }
           }
-          return serialize_cmd(std::forward<Cmd>(cmd))
-            .then([&stm, timeout, term, &as](model::record_batch b) {
-                return stm.replicate_and_wait(
-                  std::move(b), timeout, as.local(), term);
-            });
+          vassert(
+            use_serde_serialization,
+            "Requested to ADL serialize a serde-only type");
+          auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
+          return stm.replicate_and_wait(
+            std::move(b), timeout, as.local(), term);
       });
 }
 

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -274,7 +274,7 @@ using feature_update_license_update_cmd = controller_command<
   int8_t, // unused
   feature_update_license_update_cmd_type,
   model::record_batch_type::feature_update,
-  serde_opts::adl_and_serde>;
+  serde_opts::serde_only>;
 
 // typelist utils
 template<typename T>

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -31,6 +31,16 @@
 namespace cluster {
 
 using command_type = named_type<int8_t, struct command_type_tag>;
+
+enum class serde_opts {
+    // The command type requires both ADL and serde serialization.
+    adl_and_serde = 0,
+
+    // The command type only supports serde, e.g. because it will only be used
+    // when all nodes are on a Redpanda version that supports serde.
+    serde_only = 1,
+};
+
 // Controller state updates are represented in terms of commands. Each
 // command represent different type of action that is going to be executed
 // over state when applying replicated entry. The controller_command is a
@@ -40,7 +50,17 @@ using command_type = named_type<int8_t, struct command_type_tag>;
 // handling.
 //
 // Generic controller command, this type is base for all commands
-template<typename K, typename V, int8_t tp, model::record_batch_type bt>
+//
+// NOTE: some types are required to compile ADL for compatibility with data
+// from older versions of Redpanda that only supported ADL. New types should be
+// serde-only, and should not be sent to older versions of Redpanda (e.g. by
+// gating with the feature manager).
+template<
+  typename K,
+  typename V,
+  int8_t tp,
+  model::record_batch_type bt,
+  serde_opts so = serde_opts::serde_only>
 struct controller_command {
     static_assert(
       tp >= 0,
@@ -52,6 +72,7 @@ struct controller_command {
 
     static constexpr command_type type{tp};
     static constexpr model::record_batch_type batch_type{bt};
+    static constexpr serde_opts serde_opts{so};
 
     controller_command(K k, V v)
       : key(std::move(k))
@@ -99,138 +120,161 @@ using create_topic_cmd = controller_command<
   model::topic_namespace,
   topic_configuration_assignment,
   create_topic_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using delete_topic_cmd = controller_command<
   model::topic_namespace,
   model::topic_namespace,
   delete_topic_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using move_partition_replicas_cmd = controller_command<
   model::ntp,
   std::vector<model::broker_shard>,
   move_partition_replicas_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using finish_moving_partition_replicas_cmd = controller_command<
   model::ntp,
   std::vector<model::broker_shard>,
   finish_moving_partition_replicas_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using update_topic_properties_cmd = controller_command<
   model::topic_namespace,
   incremental_topic_updates,
   update_topic_properties_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using create_partition_cmd = controller_command<
   model::topic_namespace,
   create_partitions_configuration_assignment,
   create_partition_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using create_non_replicable_topic_cmd = controller_command<
   non_replicable_topic,
   int8_t, // unused
   create_non_replicable_topic_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using cancel_moving_partition_replicas_cmd = controller_command<
   model::ntp,
   cancel_moving_partition_replicas_cmd_data,
   cancel_moving_partition_replicas_cmd_type,
-  model::record_batch_type::topic_management_cmd>;
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using create_user_cmd = controller_command<
   security::credential_user,
   security::scram_credential,
   create_user_cmd_type,
-  model::record_batch_type::user_management_cmd>;
+  model::record_batch_type::user_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using delete_user_cmd = controller_command<
   security::credential_user,
   int8_t, // unused
   delete_user_cmd_type,
-  model::record_batch_type::user_management_cmd>;
+  model::record_batch_type::user_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using update_user_cmd = controller_command<
   security::credential_user,
   security::scram_credential,
   update_user_cmd_type,
-  model::record_batch_type::user_management_cmd>;
+  model::record_batch_type::user_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using create_acls_cmd = controller_command<
   create_acls_cmd_data,
   int8_t, // unused
   create_acls_cmd_type,
-  model::record_batch_type::acl_management_cmd>;
+  model::record_batch_type::acl_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using delete_acls_cmd = controller_command<
   delete_acls_cmd_data,
   int8_t, // unused
   delete_acls_cmd_type,
-  model::record_batch_type::acl_management_cmd>;
+  model::record_batch_type::acl_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using create_data_policy_cmd = controller_command<
   model::topic_namespace,
   create_data_policy_cmd_data,
   create_data_policy_cmd_type,
-  model::record_batch_type::data_policy_management_cmd>;
+  model::record_batch_type::data_policy_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using delete_data_policy_cmd = controller_command<
   model::topic_namespace,
   std::optional<ss::sstring>,
   delete_data_policy_cmd_type,
-  model::record_batch_type::data_policy_management_cmd>;
+  model::record_batch_type::data_policy_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using decommission_node_cmd = controller_command<
   model::node_id,
   int8_t, // unused
   decommission_node_cmd_type,
-  model::record_batch_type::node_management_cmd>;
+  model::record_batch_type::node_management_cmd,
+  serde_opts::adl_and_serde>;
 using recommission_node_cmd = controller_command<
   model::node_id,
   int8_t, // unused
   recommission_node_cmd_type,
-  model::record_batch_type::node_management_cmd>;
+  model::record_batch_type::node_management_cmd,
+  serde_opts::adl_and_serde>;
 using finish_reallocations_cmd = controller_command<
   model::node_id,
   int8_t, // unused
   finish_reallocations_cmd_type,
-  model::record_batch_type::node_management_cmd>;
+  model::record_batch_type::node_management_cmd,
+  serde_opts::adl_and_serde>;
 
 using maintenance_mode_cmd = controller_command<
   model::node_id,
   bool, // enabled or disabled
   maintenance_mode_cmd_type,
-  model::record_batch_type::node_management_cmd>;
+  model::record_batch_type::node_management_cmd,
+  serde_opts::adl_and_serde>;
 
 // Cluster configuration deltas
 using cluster_config_delta_cmd = controller_command<
   config_version,
   cluster_config_delta_cmd_data,
   cluster_config_delta_cmd_type,
-  model::record_batch_type::cluster_config_cmd>;
+  model::record_batch_type::cluster_config_cmd,
+  serde_opts::adl_and_serde>;
 
 using cluster_config_status_cmd = controller_command<
   model::node_id,
   cluster_config_status_cmd_data,
   cluster_config_status_cmd_type,
-  model::record_batch_type::cluster_config_cmd>;
+  model::record_batch_type::cluster_config_cmd,
+  serde_opts::adl_and_serde>;
 
 using feature_update_cmd = controller_command<
   feature_update_cmd_data,
   int8_t, // unused
   feature_update_cmd_type,
-  model::record_batch_type::feature_update>;
+  model::record_batch_type::feature_update,
+  serde_opts::adl_and_serde>;
 
 using feature_update_license_update_cmd = controller_command<
   feature_update_license_update_cmd_data,
   int8_t, // unused
   feature_update_license_update_cmd_type,
-  model::record_batch_type::feature_update>;
+  model::record_batch_type::feature_update,
+  serde_opts::adl_and_serde>;
 
 // typelist utils
 template<typename T>
@@ -318,21 +362,16 @@ struct deserializer {
     using value_t = typename Cmd::value_t;
     ss::future<Cmd>
     deserialize(iobuf_parser k_parser, iobuf_parser v_parser, bool use_serde) {
-        if (likely(use_serde)) {
-            co_return serde_deserialize(
-              std::move(k_parser), std::move(v_parser));
+        if constexpr (Cmd::serde_opts == serde_opts::adl_and_serde) {
+            if (unlikely(!use_serde)) {
+                auto results = co_await ss::when_all_succeed(
+                  reflection::async_adl<key_t>{}.from(k_parser),
+                  reflection::async_adl<value_t>{}.from(v_parser));
+                co_return Cmd(std::get<0>(results), std::get<1>(results));
+            }
         }
-        co_return co_await adl_deserialize(
-          std::move(k_parser), std::move(v_parser));
-    }
-
-    ss::future<Cmd>
-    adl_deserialize(iobuf_parser k_parser, iobuf_parser v_parser) {
-        auto results = co_await ss::when_all_succeed(
-          reflection::async_adl<key_t>{}.from(k_parser),
-          reflection::async_adl<value_t>{}.from(v_parser));
-
-        co_return Cmd(std::get<0>(results), std::get<1>(results));
+        vassert(use_serde, "Requested to ADL serialize a serde-only type");
+        co_return serde_deserialize(std::move(k_parser), std::move(v_parser));
     }
 
     Cmd serde_deserialize(iobuf_parser k_parser, iobuf_parser v_parser) {

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -33,6 +33,30 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+
+// Fake command type used to test serde-only types.
+static constexpr int8_t fake_serde_only_cmd_type = 0;
+struct fake_serde_only_key
+  : serde::envelope<fake_serde_only_key, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    ss::sstring str;
+};
+struct fake_serde_only_val
+  : serde::envelope<fake_serde_only_val, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    ss::sstring str;
+};
+using fake_serde_only_cmd = cluster::controller_command<
+  fake_serde_only_key,
+  fake_serde_only_val,
+  fake_serde_only_cmd_type,
+  model::record_batch_type::ghost_batch>;
+
+} // anonymous namespace
+
 struct cmd_test_fixture {
     cluster::topic_configuration_assignment make_tp_configuration(
       const ss::sstring& topic, int partitions, int replication_factor) {
@@ -83,6 +107,23 @@ struct cmd_test_fixture {
         return {};
     }
 };
+
+FIXTURE_TEST(test_serde_only_cmd, cmd_test_fixture) {
+    fake_serde_only_key k;
+    fake_serde_only_val v;
+    k.str = "foo";
+    v.str = "bar";
+    fake_serde_only_cmd cmd(std::move(k), std::move(v));
+    auto batch = cluster::serde_serialize_cmd(cmd);
+    auto deser = cluster::deserialize(
+                   std::move(batch),
+                   cluster::make_commands_list<fake_serde_only_cmd>())
+                   .get0();
+    ss::visit(deser, [&cmd](fake_serde_only_cmd c) {
+        BOOST_REQUIRE_EQUAL(c.key.str, cmd.key.str);
+        BOOST_REQUIRE_EQUAL(c.value.str, cmd.value.str);
+    });
+}
 
 FIXTURE_TEST(test_create_topic_cmd_serialization, cmd_test_fixture) {
     auto cmd = make_create_topic_cmd("test_tp", 2, 3);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1683,22 +1683,6 @@ adl<cluster::feature_update_cmd_data>::from(iobuf_parser& in) {
     return {.logical_version = logical_version, .actions = std::move(actions)};
 }
 
-void adl<cluster::feature_update_license_update_cmd_data>::to(
-  iobuf&, cluster::feature_update_license_update_cmd_data&&) {
-    vassert(
-      false,
-      "cluster::feature_update_license_update_cmd_data should always use "
-      "serde, never adl");
-}
-
-cluster::feature_update_license_update_cmd_data
-adl<cluster::feature_update_license_update_cmd_data>::from(iobuf_parser&) {
-    vassert(
-      false,
-      "cluster::feature_update_license_update_cmd_data should always use "
-      "serde, never adl");
-}
-
 void adl<cluster::feature_barrier_request>::to(
   iobuf& out, cluster::feature_barrier_request&& r) {
     reflection::serialize(out, r.current_version, r.tag, r.peer, r.entered);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1917,6 +1917,8 @@ struct cancel_moving_partition_replicas_cmd_data
 
 struct feature_update_license_update_cmd_data
   : serde::envelope<feature_update_license_update_cmd_data, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
     // Struct encoding version
     static constexpr int8_t current_version = 1;
 
@@ -2686,12 +2688,6 @@ template<>
 struct adl<cluster::feature_update_cmd_data> {
     void to(iobuf&, cluster::feature_update_cmd_data&&);
     cluster::feature_update_cmd_data from(iobuf_parser&);
-};
-
-template<>
-struct adl<cluster::feature_update_license_update_cmd_data> {
-    void to(iobuf& out, cluster::feature_update_license_update_cmd_data&&);
-    cluster::feature_update_license_update_cmd_data from(iobuf_parser&);
 };
 
 template<>


### PR DESCRIPTION
## Cover letter

Currently controller commands must support both ADL and serde serialization by virtue of the serialization being determined at runtime based on a feature flag. Moving forward, some types will never be ADL serialized, by virtue of having certain commands only being sent once all nodes are upgraded.

This commit addresses this by adding a new type argument `serde_opts` that, when specified as `serde_only`, will statically avoid hitting ADL code serialization paths.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
