### PR TITLE
Use cached term value when updating voter state

### DIFF
--- a/docs/rfcs/20200421_raft_recovery.md
+++ b/docs/rfcs/20200421_raft_recovery.md
@@ -210,7 +210,7 @@ In order to make it possible new fields have to be added to
             // next index to send to this follower
             model::offset next_index;
             // timestamp of last append_entries_rpc call
-            clock_type::time_point last_sent_append_entries_req_timesptamp;
+            clock_type::time_point last_sent_append_entries_req_timestamp;
             uint64_t failed_appends{0};
             bool is_learner = false;
             bool is_recovering = false;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2360,8 +2360,8 @@ model::term_id consensus::get_term(model::offset o) const {
 }
 
 clock_type::time_point
-consensus::last_sent_append_entries_req_timesptamp(vnode id) {
-    return _fstats.get(id).last_sent_append_entries_req_timesptamp;
+consensus::last_sent_append_entries_req_timestamp(vnode id) {
+    return _fstats.get(id).last_sent_append_entries_req_timestamp;
 }
 
 protocol_metadata consensus::meta() const {
@@ -2380,7 +2380,7 @@ protocol_metadata consensus::meta() const {
 
 void consensus::update_node_append_timestamp(vnode id) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
-        it->second.last_sent_append_entries_req_timesptamp = clock_type::now();
+        it->second.last_sent_append_entries_req_timestamp = clock_type::now();
     }
 }
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -164,7 +164,7 @@ public:
         return _became_leader_at;
     };
 
-    clock_type::time_point last_sent_append_entries_req_timesptamp(vnode);
+    clock_type::time_point last_sent_append_entries_req_timestamp(vnode);
     /**
      * \brief Persist snapshot with given data and start offset
      *

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -118,10 +118,10 @@ static heartbeat_requests requests_for_range(
                   ptr->group());
                 return;
             }
-            auto last_sent_append_entries_req_timesptamp
-              = ptr->last_sent_append_entries_req_timesptamp(rni);
+            auto last_sent_append_entries_req_timestamp
+              = ptr->last_sent_append_entries_req_timestamp(rni);
 
-            if (last_sent_append_entries_req_timesptamp > last_heartbeat) {
+            if (last_sent_append_entries_req_timestamp > last_heartbeat) {
                 vlog(
                   hbeatlog.trace,
                   "Heartbeat skipped - target: {}, ntp: {}, group_id: {}",

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -98,7 +98,7 @@ struct follower_index_metadata {
     model::offset next_index;
     model::offset last_sent_offset;
     // timestamp of last append_entries_rpc call
-    clock_type::time_point last_sent_append_entries_req_timesptamp;
+    clock_type::time_point last_sent_append_entries_req_timestamp;
     clock_type::time_point last_received_append_entries_reply_timestamp;
     uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and


### PR DESCRIPTION
## Cover letter

`raft::vote_stm` is optimized not to hold the consensus `_op_lock` while
waiting for the vote request replies. The locking is done in two phases.
In a first phase a lock is acquired to make a snapshot of a current
state and create a `vote_request` then in the second phase candidate
state is updated according to the election result.

The two phase approach make it possible for other request to be
responded by the node after `vote_stm` released the first phase lock.
In this situation a node may no longer be a candidate and the term might
have already changed. In this case a candidate even if an election was
successful must not become a leader.

The second phase lock is kept after the successful election up the point
where a newly elected leader dispatches request to replicate
configuration. After this (when waiting for replication result) a lock
is released.

Newly introduced assertion checking `_confirmed_term` was preceded with
a condition validating if current term is equal to the term that was
cached during the second phase lock. This approach is incorrect as there
might have been term update between the phases or during configuration
replication. In other words an assertion was validating the result of an
election which was won in `current_term-1` with the assumption it was
won in `current_term`.

Additionally not using a cached term value may introduce a confusion as
log entries coming from the `vote_stm` were using current consensus term
but not the one which the election was actually won in. This way the
logs might have been suggesting that there were two active leaders in
the same term (which is not true).

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

- fixes incorrect assertion in `vote_stm` that in some situation may lead to redpanda crash
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
