### PR TITLE
[v22.2.x] s/disk_log_impl: advance segment generation after adjacent compaction

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -49,9 +49,11 @@ segment::segment(
   segment_appender_ptr a,
   std::optional<compacted_index_writer> ci,
   std::optional<batch_cache_index> c,
-  storage_resources& resources) noexcept
+  storage_resources& resources,
+  segment::generation_id gen) noexcept
   : _resources(resources)
   , _appender_callbacks(this)
+  , _generation_id(gen)
   , _tracker(tkr)
   , _reader(std::move(r))
   , _idx(std::move(i))

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -72,7 +72,8 @@ public:
       segment_appender_ptr,
       std::optional<compacted_index_writer>,
       std::optional<batch_cache_index>,
-      storage_resources&) noexcept;
+      storage_resources&,
+      generation_id = generation_id{}) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -195,7 +196,7 @@ private:
      * - segment appender is flushed
      * - segment is compacted
      */
-    generation_id _generation_id{};
+    generation_id _generation_id;
 
     offset_tracker _tracker;
     segment_reader _reader;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -662,7 +662,8 @@ make_concatenated_segment(
         nullptr,
         std::nullopt,
         std::nullopt,
-        resources),
+        resources,
+        segments.front()->get_generation_id() + segment::generation_id(1)),
       std::move(generations));
 }
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6254.
Fixes https://github.com/redpanda-data/redpanda/issues/6547,