### PR TITLE
cloud_storage: cache improvements (strict space management)

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -257,7 +257,7 @@ std::string iobuf::hexdump(size_t limit) const {
             }
 
             auto c = data[i];
-            result << fmt::format("{:02x} ", int(c));
+            result << fmt::format("{:02x} ", uint8_t(c));
 
             if (std::isprint(c) && c != '\n') {
                 trail.push_back(c);

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_storage/access_time_tracker.h"
 
+#include "bytes/iostream.h"
 #include "serde/serde.h"
 #include "units.h"
 
@@ -22,16 +23,6 @@
 #include <variant>
 
 namespace absl {
-
-template<class Key, class Value>
-void write(iobuf& out, const btree_map<Key, Value>& btree) {
-    using serde::write;
-    write(out, static_cast<uint64_t>(btree.size()));
-    for (auto it : btree) {
-        write(out, it.first);
-        write(out, it.second);
-    }
-}
 
 template<class Key, class Value>
 void read_nested(
@@ -54,21 +45,145 @@ void read_nested(
 
 namespace cloud_storage {
 
+// For async serialization/deserialization, the fixed-size content
+// is defined in a header struct, and then the main body of the encoding
+// is defined by hand in the read/write methods so that it can be done
+// with streaming.
+struct table_header
+  : serde::envelope<table_header, serde::version<0>, serde::compat_version<0>> {
+    size_t table_size{0};
+
+    auto serde_fields() { return std::tie(table_size); }
+};
+
+ss::future<> access_time_tracker::write(ss::output_stream<char>& out) {
+    // This lock protects us from the _table being mutated while we
+    // are iterating over it and yielding during the loop.
+    auto lock_guard = co_await ss::get_units(_table_lock, 1);
+
+    _dirty = false;
+
+    const table_header h{.table_size = _table.size()};
+    iobuf header_buf;
+    serde::write(header_buf, h);
+    co_await write_iobuf_to_output_stream(std::move(header_buf), out);
+
+    // How many items to serialize per stream write()
+    constexpr size_t chunk_count = 2048;
+
+    size_t i = 0;
+    iobuf serialize_buf;
+    for (auto it : _table) {
+        serde::write(serialize_buf, it.first);
+        serde::write(serialize_buf, it.second);
+        ++i;
+        if (i % chunk_count == 0 || i == _table.size()) {
+            for (const auto& f : serialize_buf) {
+                co_await out.write(f.get(), f.size());
+            }
+            serialize_buf.clear();
+        }
+    }
+
+    lock_guard.return_all();
+    on_released_table_lock();
+}
+
+void access_time_tracker::on_released_table_lock() {
+    // When dropping lock, drain any pending upserts that came in via
+    // add/remove calls while we were locking the main table.
+    if (!_pending_upserts.empty()) {
+        // We will drain some deferred updates, this will dirty the table.
+        _dirty = true;
+    }
+
+    for (const auto& [hash, ts] : _pending_upserts) {
+        if (ts.has_value()) {
+            _table[hash] = ts.value();
+        } else {
+            _table.erase(hash);
+        }
+    }
+    _pending_upserts.clear();
+}
+
+ss::future<> access_time_tracker::read(ss::input_stream<char>& in) {
+    auto lock_guard = co_await ss::get_units(_table_lock, 1);
+
+    _table.clear();
+    _dirty = false;
+
+    // Accumulate a serialized table_header in this buffer
+    iobuf header_buf;
+
+    // Read serde envelope header
+    auto envelope_header_tmp = co_await in.read_exactly(
+      serde::envelope_header_size);
+    header_buf.append(envelope_header_tmp.get(), envelope_header_tmp.size());
+
+    // Peek at the size of the header's serde body
+    iobuf envelope_header_buf = header_buf.copy();
+    auto peek_parser = iobuf_parser(std::move(envelope_header_buf));
+    auto header_size = serde::peek_body_size(peek_parser);
+
+    // Read the rest of the header + decode it
+    auto tmp = co_await in.read_exactly(header_size);
+    header_buf.append(tmp.get(), tmp.size());
+    auto h_parser = iobuf_parser(std::move(header_buf));
+    table_header h = serde::read_nested<table_header>(h_parser, 0);
+
+    // How many items to consume per stream read()
+    constexpr size_t chunk_count = 2048;
+
+    for (size_t i = 0; i < h.table_size; i += chunk_count) {
+        auto item_count = std::min(chunk_count, h.table_size - i);
+        auto tmp_buf = co_await in.read_exactly(item_count * table_item_size);
+        iobuf items_buf;
+        items_buf.append(std::move(tmp_buf));
+        auto parser = iobuf_parser(std::move(items_buf));
+        for (size_t j = 0; j < item_count; ++j) {
+            uint32_t hash = serde::read_nested<uint32_t>(parser, 0);
+            timestamp_t t = serde::read_nested<timestamp_t>(parser, 0);
+            _table.emplace(hash, t);
+        }
+    }
+
+    lock_guard.return_all();
+    // Any writes while we were reading are dropped
+    _pending_upserts.clear();
+}
+
 void access_time_tracker::add_timestamp(
   std::string_view key, std::chrono::system_clock::time_point ts) {
     uint32_t seconds = std::chrono::time_point_cast<std::chrono::seconds>(ts)
                          .time_since_epoch()
                          .count();
     uint32_t hash = xxhash_32(key.data(), key.size());
-    _table.data[hash] = seconds;
-    _dirty = true;
+
+    auto units = seastar::try_get_units(_table_lock, 1);
+    if (units.has_value()) {
+        // Got lock, update main table
+        _table[hash] = seconds;
+        _dirty = true;
+    } else {
+        // Locked during serialization, defer write
+        _pending_upserts[hash] = seconds;
+    }
 }
 
 void access_time_tracker::remove_timestamp(std::string_view key) noexcept {
     try {
         uint32_t hash = xxhash_32(key.data(), key.size());
-        _table.data.erase(hash);
-        _dirty = true;
+
+        auto units = seastar::try_get_units(_table_lock, 1);
+        if (units.has_value()) {
+            // Unlocked, update main table
+            _table.erase(hash);
+            _dirty = true;
+        } else {
+            // Locked during serialization, defer write
+            _pending_upserts[hash] = std::nullopt;
+        }
     } catch (...) {
         vassert(
           false,
@@ -78,37 +193,42 @@ void access_time_tracker::remove_timestamp(std::string_view key) noexcept {
     }
 }
 
-void access_time_tracker::remove_others(const access_time_tracker& t) {
+ss::future<>
+access_time_tracker::trim(const std::vector<file_list_item>& existent) {
+    absl::btree_set<uint32_t> existent_hashes;
+    for (const auto& i : existent) {
+        existent_hashes.insert(xxhash_32(i.path.data(), i.path.size()));
+    }
+
+    auto lock_guard = co_await ss::get_units(_table_lock, 1);
+
     table_t tmp;
-    for (auto it : _table.data) {
-        if (t._table.data.contains(it.first)) {
-            tmp.data.insert(it);
+    for (auto it : _table) {
+        if (existent_hashes.contains(it.first)) {
+            tmp.insert(it);
         }
+        co_await ss::maybe_yield();
+    }
+    if (_table.size() != tmp.size()) {
+        // We dropped one or more entries, therefore mutated the table.
+        _dirty = true;
     }
     _table = std::move(tmp);
+
+    lock_guard.return_all();
+    on_released_table_lock();
 }
 
 std::optional<std::chrono::system_clock::time_point>
 access_time_tracker::estimate_timestamp(std::string_view key) const {
     uint32_t hash = xxhash_32(key.data(), key.size());
-    auto it = _table.data.find(hash);
-    if (it == _table.data.end()) {
+    auto it = _table.find(hash);
+    if (it == _table.end()) {
         return std::nullopt;
     }
     auto seconds = std::chrono::seconds(it->second);
     std::chrono::system_clock::time_point ts(seconds);
     return ts;
-}
-
-iobuf access_time_tracker::to_iobuf() {
-    _dirty = false;
-    return serde::to_iobuf(_table);
-}
-
-void access_time_tracker::from_iobuf(iobuf b) {
-    iobuf_parser parser(std::move(b));
-    _table = serde::read<table_t>(parser);
-    _dirty = false;
 }
 
 bool access_time_tracker::is_dirty() const { return _dirty; }

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -194,7 +194,7 @@ void access_time_tracker::remove_timestamp(std::string_view key) noexcept {
 }
 
 ss::future<>
-access_time_tracker::trim(const std::vector<file_list_item>& existent) {
+access_time_tracker::trim(const fragmented_vector<file_list_item>& existent) {
     absl::btree_set<uint32_t> existent_hashes;
     for (const auto& i : existent) {
         existent_hashes.insert(xxhash_32(i.path.data(), i.path.size()));

--- a/src/v/cloud_storage/access_time_tracker.h
+++ b/src/v/cloud_storage/access_time_tracker.h
@@ -65,7 +65,7 @@ public:
     bool is_dirty() const;
 
     /// Remove every key which isn't present in list of existing files
-    ss::future<> trim(const std::vector<file_list_item>&);
+    ss::future<> trim(const fragmented_vector<file_list_item>&);
 
     size_t size() const { return _table.size(); }
 

--- a/src/v/cloud_storage/access_time_tracker.h
+++ b/src/v/cloud_storage/access_time_tracker.h
@@ -12,8 +12,11 @@
 
 #include "bytes/iobuf.h"
 #include "hashing/xx.h"
+#include "recursive_directory_walker.h"
+#include "seastar/core/iostream.hh"
 #include "seastarx.h"
 #include "serde/envelope.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/future.hh>
 
@@ -36,10 +39,10 @@ namespace cloud_storage {
 /// 'cloud_storage/cache_service' is ready for that.
 class access_time_tracker {
     using timestamp_t = uint32_t;
-    struct table_t
-      : serde::envelope<table_t, serde::version<0>, serde::compat_version<0>> {
-        absl::btree_map<uint32_t, timestamp_t> data;
-    };
+    using table_t = absl::btree_map<uint32_t, timestamp_t>;
+
+    // Serialized size of each pair in table_t
+    static constexpr size_t table_item_size = 8;
 
 public:
     /// Add access time to the container.
@@ -54,20 +57,34 @@ public:
     std::optional<std::chrono::system_clock::time_point>
     estimate_timestamp(std::string_view key) const;
 
-    iobuf to_iobuf();
-    void from_iobuf(iobuf b);
+    ss::future<> write(ss::output_stream<char>&);
+    ss::future<> read(ss::input_stream<char>&);
 
     /// Returns true if tracker has new data which wasn't serialized
     /// to disk.
     bool is_dirty() const;
 
-    /// Remove every key which isn't present in 't'
-    void remove_others(const access_time_tracker& t);
+    /// Remove every key which isn't present in list of existing files
+    ss::future<> trim(const std::vector<file_list_item>&);
 
-    size_t size() const { return _table.data.size(); }
+    size_t size() const { return _table.size(); }
 
 private:
-    table_t _table;
+    /// Drain _pending_upserts for any writes made while table lock was held
+    void on_released_table_lock();
+
+    absl::btree_map<uint32_t, timestamp_t> _table;
+
+    // Lock taken during async loops over the table (ser/de and trim())
+    // modifications may proceed without the lock if it is not taken.
+    // When releasing lock, drain _pending_upserts.
+    ss::semaphore _table_lock{1};
+
+    // Calls into add_timestamp/remove_timestamp populate this
+    // if the _serialization_lock is unavailable.  The serialization code is
+    // responsible for draining it upon releasing the lock.
+    absl::btree_map<uint32_t, std::optional<timestamp_t>> _pending_upserts;
+
     bool _dirty{false};
 };
 

--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -68,6 +68,12 @@ cache_probe::cache_probe() {
                   sm::description("Sum of size of cached objects."))
                   .aggregate(aggregate_labels),
                 sm::make_gauge(
+                  "hwm_size_bytes",
+                  [this] { return _hwm_size_bytes; },
+                  sm::description(
+                    "High watermark of sum of size of cached objects."))
+                  .aggregate(aggregate_labels),
+                sm::make_gauge(
                   "files",
                   [this] { return _cur_num_files; },
                   sm::description("Number of objects in cache."))

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -26,7 +26,10 @@ public:
     void cached_get() { ++_num_cached_gets; }
     void miss_get() { ++_num_miss_gets; }
 
-    void set_size(uint64_t size) { _cur_size_bytes = size; }
+    void set_size(uint64_t size) {
+        _cur_size_bytes = size;
+        _hwm_size_bytes = std::max(_cur_size_bytes, _hwm_size_bytes);
+    }
     void set_num_files(uint64_t num_files) { _cur_num_files = num_files; }
     void put_started() { ++_cur_in_progress_files; }
     void put_ended() { --_cur_in_progress_files; }
@@ -38,6 +41,7 @@ private:
     uint64_t _num_miss_gets = 0;
 
     int64_t _cur_size_bytes = 0;
+    int64_t _hwm_size_bytes = 0;
     int64_t _cur_num_files = 0;
     int64_t _cur_in_progress_files = 0;
 

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -89,11 +89,6 @@ cache::recursive_delete_empty_directory(const std::string_view& key) {
         } catch (std::filesystem::filesystem_error& e) {
             if (e.code() == std::errc::directory_not_empty) {
                 // we stop when we find a non-empty directory
-                vlog(
-                  cst_log.debug,
-                  "Could not delete directory {}: {}.",
-                  normal_path,
-                  e.what());
                 co_return;
             } else {
                 throw;

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -500,6 +500,7 @@ ss::future<> cache::stop() {
     _tracker_timer.cancel();
     _as.request_abort();
     _block_puts_cond.broken();
+    _cleanup_sm.broken();
     if (ss::this_shard_id() == 0) {
         co_await save_access_time_tracker();
     }

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -497,6 +497,7 @@ ss::future<> cache::stop() {
     vlog(cst_log.debug, "Stopping archival cache service");
     _tracker_timer.cancel();
     _as.request_abort();
+    _block_puts_cond.broken();
     if (ss::this_shard_id() == 0) {
         co_await save_access_time_tracker();
     }
@@ -697,6 +698,13 @@ ss::future<> cache::invalidate(const std::filesystem::path& key) {
 };
 
 ss::future<space_reservation_guard> cache::reserve_space(size_t bytes) {
+    while (_block_puts) {
+        vlog(
+          cst_log.warn,
+          "Blocking tiered storage cache write, disk space critically low.");
+        co_await _block_puts_cond.wait();
+    }
+
     co_await container().invoke_on(
       0, [bytes](cache& c) { return c.do_reserve_space(bytes); });
 
@@ -794,6 +802,40 @@ ss::future<> cache::do_reserve_space(size_t bytes) {
 
     _reservations_pending -= bytes;
     _reserved_cache_size += bytes;
+}
+
+void cache::set_block_puts(bool block_puts) {
+    if (_block_puts && !block_puts) {
+        _block_puts_cond.signal();
+    }
+    _block_puts = block_puts;
+}
+
+void cache::notify_disk_status(
+  [[maybe_unused]] uint64_t total_space,
+  [[maybe_unused]] uint64_t free_space,
+  storage::disk_space_alert alert) {
+    vassert(ss::this_shard_id() == 0, "Called on wrong shard");
+
+    bool block_puts = (alert == storage::disk_space_alert::degraded);
+
+    if (block_puts && !_block_puts) {
+        // Start blocking: log, and propagate to other shards
+        vlog(
+          cst_log.warn,
+          "Tiered storage cache blocking segment promotions, disk space is "
+          "critically low.");
+        ssx::spawn_with_gate(_gate, [this, block_puts]() {
+            return container().invoke_on_all(
+              [block_puts](cache& c) { c.set_block_puts(block_puts); });
+        });
+    } else if (!block_puts && _block_puts) {
+        // Log on un-blocking
+        vlog(
+          cst_log.info,
+          "Tiered storage cache un-blocking promotions, disk space is no "
+          "longer critical.");
+    }
 }
 
 space_reservation_guard::~space_reservation_guard() {

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -13,6 +13,7 @@
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_probe.h"
 #include "cloud_storage/recursive_directory_walker.h"
+#include "config/property.h"
 #include "resource_mgmt/io_priority.h"
 #include "seastarx.h"
 #include "ssx/semaphore.h"
@@ -71,7 +72,7 @@ public:
     /// C-tor.
     ///
     /// \param cache_dir is a directory where cached data is stored
-    cache(std::filesystem::path cache_dir, size_t _max_cache_size) noexcept;
+    cache(std::filesystem::path cache_dir, config::binding<uint64_t>) noexcept;
 
     ss::future<> start();
     ss::future<> stop();
@@ -131,7 +132,7 @@ private:
     ss::future<> maybe_save_access_time_tracker();
 
     /// Triggers directory walker, creates a list of files to delete and deletes
-    /// them until cache size <= _cache_size_low_watermark * max_cache_size
+    /// them until cache size <= _cache_size_low_watermark * max_bytes
     ss::future<> trim();
 
     /// Invoke trim, waiting if not enough time passed since the last trim
@@ -166,7 +167,7 @@ private:
     void do_reserve_space_release(size_t bytes);
 
     std::filesystem::path _cache_dir;
-    size_t _max_cache_size;
+    config::binding<uint64_t> _max_bytes;
 
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -132,7 +132,10 @@ private:
 
     /// Triggers directory walker, creates a list of files to delete and deletes
     /// them until cache size <= _cache_size_low_watermark * max_cache_size
-    ss::future<> clean_up_cache();
+    ss::future<> trim();
+
+    /// Invoke trim, waiting if not enough time passed since the last trim
+    ss::future<> trim_throttled();
 
     /// Triggers directory walker, creates a list of files to delete and deletes
     /// only tmp files that are left from previous Red Panda run
@@ -142,7 +145,7 @@ private:
     /// until it meet a non-empty directory.
     ///
     /// \param key if a path to a file what should be deleted
-    ss::future<> recursive_delete_empty_directory(const std::string_view& key);
+    ss::future<> delete_file_and_empty_parents(const std::string_view& key);
 
     /// This method is called on shard 0 by other shards to report disk
     /// space changes.

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -32,7 +32,6 @@ namespace cloud_storage {
 
 static constexpr size_t default_write_buffer_size = 128_KiB;
 static constexpr unsigned default_writebehind = 10;
-static constexpr const char* access_time_tracker_file_name = "accesstime";
 
 class cache_test_fixture;
 
@@ -73,6 +72,9 @@ public:
     ///
     /// \param cache_dir is a directory where cached data is stored
     cache(std::filesystem::path cache_dir, config::binding<uint64_t>) noexcept;
+
+    cache(const cache&) = delete;
+    cache(cache&& rhs) = delete;
 
     ss::future<> start();
     ss::future<> stop();
@@ -121,12 +123,15 @@ public:
     // a background fiber in order to be callable from the guard destructor.
     void reserve_space_release(size_t);
 
+    static ss::future<> initialize(std::filesystem::path);
+
 private:
     /// Load access time tracker from file
     ss::future<> load_access_time_tracker();
 
     /// Save access time tracker to file
     ss::future<> save_access_time_tracker();
+    ss::future<> _save_access_time_tracker(ss::file);
 
     /// Save access time tracker state to the file if needed
     ss::future<> maybe_save_access_time_tracker();

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -208,6 +208,13 @@ private:
     /// hint to clean_up_cache on how much extra space to try and free
     uint64_t _reservations_pending{0};
 
+    /// A _lazily updated_ record of physical space on the drive.  This is only
+    /// for use in corner cases when we e.g. cannot trim the cache far enough
+    /// and have to decide whether to block writes, or exceed our configured
+    /// limit.
+    /// (shard 0 only)
+    uint64_t _free_space{0};
+
     ssx::semaphore _cleanup_sm{1, "cloud/cache"};
     std::set<std::filesystem::path> _files_in_progress;
     cache_probe probe;

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -72,7 +72,7 @@ struct walk_accumulator {
     const access_time_tracker& tracker;
     bool seen_dentries{false};
     std::deque<ss::sstring> dirlist;
-    std::vector<file_list_item> files;
+    fragmented_vector<file_list_item> files;
     uint64_t current_cache_size{0};
 };
 

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -29,7 +30,7 @@ struct file_list_item {
 
 struct walk_result {
     uint64_t cache_size{0};
-    std::vector<file_list_item> regular_files;
+    fragmented_vector<file_list_item> regular_files;
     std::vector<ss::sstring> empty_dirs;
 };
 

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "cloud_storage/access_time_tracker.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -19,6 +18,8 @@
 #include <chrono>
 
 namespace cloud_storage {
+
+class access_time_tracker;
 
 struct file_list_item {
     std::chrono::system_clock::time_point access_time;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -173,6 +173,9 @@ private:
     model::offset_delta _base_offset_delta;
     model::offset _max_rp_offset;
 
+    // The expected size according to the manifest entry for the segment
+    size_t _size{0};
+
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     /// Notifies the background hydration fiber

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -83,8 +83,7 @@ public:
     void trim_cache() {
         sharded_cache
           .invoke_on(
-            ss::shard_id{0},
-            [](cloud_storage::cache& c) { return c.clean_up_cache(); })
+            ss::shard_id{0}, [](cloud_storage::cache& c) { return c.trim(); })
           .get();
     }
 };

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -79,6 +79,14 @@ public:
     ss::future<> clean_up_at_start() {
         return sharded_cache.local().clean_up_at_start();
     }
+
+    void trim_cache() {
+        sharded_cache
+          .invoke_on(
+            ss::shard_id{0},
+            [](cloud_storage::cache& c) { return c.clean_up_cache(); })
+          .get();
+    }
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "bytes/iobuf.h"
 #include "cloud_storage/cache_service.h"
+#include "config/property.h"
 #include "seastarx.h"
 #include "test_utils/tmp_dir.h"
 #include "units.h"
@@ -50,7 +51,9 @@ public:
     cache_test_fixture()
       : test_dir("test_cache_dir")
       , CACHE_DIR(get_cache_dir(test_dir.get_path())) {
-        sharded_cache.start(CACHE_DIR, 1_MiB + 500_KiB).get();
+        sharded_cache
+          .start(CACHE_DIR, config::mock_binding<uint64_t>(1_MiB + 500_KiB))
+          .get();
         sharded_cache
           .invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
           .get();

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -51,6 +51,7 @@ public:
     cache_test_fixture()
       : test_dir("test_cache_dir")
       , CACHE_DIR(get_cache_dir(test_dir.get_path())) {
+        cache::initialize(CACHE_DIR).get();
         sharded_cache
           .start(CACHE_DIR, config::mock_binding<uint64_t>(1_MiB + 500_KiB))
           .get();

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -28,9 +28,11 @@ using namespace cloud_storage;
 struct cloud_storage_fixture : s3_imposter_fixture {
     cloud_storage_fixture() {
         tmp_directory.create().get();
-        constexpr size_t cache_size = 1024 * 1024 * 1024;
-
-        cache.start(tmp_directory.get_path(), cache_size).get();
+        cache
+          .start(
+            tmp_directory.get_path(),
+            config::mock_binding<uint64_t>(1024 * 1024 * 1024))
+          .get();
 
         cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
           .get();

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -362,14 +362,13 @@ health_monitor_backend::dispatch_refresh_cluster_health_request(
     for (auto& n_report : reply.value().report->node_reports) {
         const auto id = n_report.id;
 
-        // TODO serialize storage_space_alert, instead of recomputing here.
-        auto node_disk_health = node::local_monitor::eval_disks(
-          n_report.local_state.disks);
-        n_report.local_state.storage_space_alert = node_disk_health;
+        // Recompute alert state, in case it was deserialized from an old
+        // node that didn't include alert state in the serialized storage::disk.
+        node::local_monitor::update_alert(n_report.local_state.data_disk);
 
         // Update cached cluster-level disk health: non-raft0-leader nodes
         cluster_disk_health = storage::max_severity(
-          cluster_disk_health, node_disk_health);
+          cluster_disk_health, n_report.local_state.data_disk.alert);
 
         _reports.emplace(id, std::move(n_report));
     }
@@ -538,7 +537,7 @@ result<node_health_report> health_monitor_backend::process_node_reply(
 
     // TODO serialize storage_space_alert, instead of recomputing here.
     auto& s = res.value().local_state;
-    s.storage_space_alert = node::local_monitor::eval_disks(s.disks);
+    node::local_monitor::update_alert(s.data_disk);
 
     it->second.last_reply_timestamp = ss::lowres_clock::now();
     if (!it->second.is_alive && clusterlog.is_enabled(ss::log_level::info)) {
@@ -598,7 +597,7 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
                 cb.second(r.value(), old_report);
             }
             cluster_disk_health = storage::max_severity(
-              r.value().local_state.storage_space_alert, cluster_disk_health);
+              r.value().local_state.get_disk_alert(), cluster_disk_health);
 
             _reports.emplace(id, std::move(r.value()));
         }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -61,10 +61,12 @@ std::ostream& operator<<(std::ostream& o, const node_state& s) {
 std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
     fmt::print(
       o,
-      "{{id: {}, disks: {}, topics: {}, redpanda_version: {}, uptime: "
+      "{{id: {}, data_disk: {}, cache_disk: {}, topics: {}, redpanda_version: "
+      "{}, uptime: "
       "{}, logical_version: {}, drain_status: {}}}",
       r.id,
-      r.local_state.disks,
+      r.local_state.data_disk,
+      r.local_state.cache_disk,
       r.topics,
       r.local_state.redpanda_version,
       r.local_state.uptime,

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "cluster/node/types.h"
 #include "config/property.h"
+#include "resource_mgmt/storage.h"
 #include "storage/types.h"
 #include "units.h"
 

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -23,12 +23,81 @@ namespace cluster::node {
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,
-      "{{redpanda_version: {}, uptime: {}, disks: {}, space_alert: {}}}",
+      "{{redpanda_version: {}, uptime: {}, data_disk: {}, cache_disk: {}}}",
       s.redpanda_version,
       s.uptime,
-      s.disks,
-      s.storage_space_alert);
+      s.data_disk,
+      s.cache_disk);
     return o;
+}
+
+void local_state::serde_read(iobuf_parser& in, const serde::header& h) {
+    redpanda_version = serde::read_nested<application_version>(in, 0);
+    logical_version = serde::read_nested<cluster_version>(in, 0);
+    uptime = serde::read_nested<std::chrono::milliseconds>(in, 0);
+    auto disks = serde::read_nested<std::vector<storage::disk>>(in, 0);
+
+    if (disks.empty()) {
+        throw serde::serde_exception("Empty disk vector in local_state");
+    }
+
+    // Redpanda <= 23.1 did not explicitly track data+cache drives, just sent
+    // a vector.  For compatibility, we retain the vector, and adopt the
+    // convention that data disk always comes first, cache disk second.
+    set_disks(disks);
+
+    // Version 0 has a node-global space alert, instead of per drive.
+    // Later versions encode this field but it may be ignored.
+    auto storage_space_alert = serde::read_nested<storage::disk_space_alert>(
+      in, 0);
+    if (h._version == 0) {
+        for (auto& d : disks) {
+            d.alert = storage_space_alert;
+        }
+    }
+}
+
+void local_state::serde_write(iobuf& out) const {
+    serde::write(out, redpanda_version);
+    serde::write(out, logical_version);
+    serde::write(out, uptime);
+    serde::write(out, disks());
+    serde::write(out, get_disk_alert());
+}
+
+storage::disk_space_alert local_state::get_disk_alert() const {
+    if (cache_disk.has_value()) {
+        return storage::max_severity(data_disk.alert, cache_disk.value().alert);
+    } else {
+        return data_disk.alert;
+    }
+}
+
+std::vector<storage::disk> local_state::disks() const {
+    std::vector<storage::disk> disks;
+    disks.push_back(data_disk);
+    if (!shared_disk()) {
+        disks.push_back(cache_disk.value());
+    }
+    return disks;
+}
+
+void local_state::set_disk(storage::disk d) {
+    data_disk = d;
+    cache_disk = std::nullopt;
+}
+
+void local_state::set_disks(std::vector<storage::disk> v) {
+    if (v.size() == 0) {
+        // This is invalid input, but we can cope gracefully by ignoring it
+    } else {
+        data_disk = v[0];
+        if (v.size() > 1) {
+            cache_disk = v[1];
+        } else {
+            cache_disk = std::nullopt;
+        }
+    }
 }
 
 } // namespace cluster::node

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -36,26 +36,43 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
 struct local_state
-  : serde::envelope<local_state, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<local_state, serde::version<1>, serde::compat_version<0>> {
     application_version redpanda_version;
     cluster_version logical_version{invalid_version};
     std::chrono::milliseconds uptime;
-    // Eventually support multiple volumes.
-    std::vector<storage::disk> disks;
 
-    storage::disk_space_alert storage_space_alert;
+    // Depending on how the operating system is configured, these may point
+    // to the same state if the cache & data dirs share a drive.
+    storage::disk data_disk;
+    std::optional<storage::disk> cache_disk;
 
-    auto serde_fields() {
-        return std::tie(
-          redpanda_version,
-          logical_version,
-          uptime,
-          disks,
-          storage_space_alert);
+    // Get a reference to the cache disk, which will be the same
+    // object as the data disk if shared_disk() is true
+    storage::disk& get_cache_disk() {
+        if (cache_disk.has_value()) {
+            return cache_disk.value();
+        } else {
+            return data_disk;
+        }
     }
 
+    bool shared_disk() const { return !cache_disk.has_value(); }
+
+    /// Report a generalized node-wide disk alert state: this is the worst of
+    /// all drive's alert state.
+    storage::disk_space_alert get_disk_alert() const;
+
+    void serde_read(iobuf_parser&, const serde::header&);
+    void serde_write(iobuf& out) const;
+
+    /// For tests + serialization, where we would like an array of disks,
+    /// which is of length 1 or 2, depending on shared_disk() (data disk comes
+    /// first).
+    std::vector<storage::disk> disks() const;
+    void set_disk(storage::disk);
+    void set_disks(std::vector<storage::disk>);
+
     friend std::ostream& operator<<(std::ostream&, const local_state&);
-    friend bool operator==(const local_state&, const local_state&) = default;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -124,12 +124,9 @@ void partition_balancer_planner::init_per_node_state(
     }
 
     for (const auto& node_report : health_report.node_reports) {
-        uint64_t total = 0;
-        uint64_t free = 0;
-        for (const auto& disk : node_report.local_state.disks) {
-            total += disk.total;
-            free += disk.free;
-        }
+        const uint64_t total = node_report.local_state.data_disk.total;
+        const uint64_t free = node_report.local_state.data_disk.free;
+
         rrs.node_disk_reports.emplace(
           node_report.id, node_disk_space(node_report.id, total, total - free));
     }

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -56,10 +56,9 @@ void check_reports_the_same(
         BOOST_TEST_REQUIRE(
           lr.local_state.redpanda_version == rr.local_state.redpanda_version);
         BOOST_TEST_REQUIRE(lr.topics == rr.topics);
-        BOOST_TEST_REQUIRE(lr.local_state.disks == rr.local_state.disks);
+        BOOST_TEST_REQUIRE(lr.local_state.disks() == rr.local_state.disks());
         BOOST_TEST_REQUIRE(
-          lr.local_state.storage_space_alert
-          == rr.local_state.storage_space_alert);
+          lr.local_state.get_disk_alert() == rr.local_state.get_disk_alert());
     }
 }
 
@@ -99,9 +98,6 @@ FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
                   return false;
               }
               if (res.value().node_reports.empty()) {
-                  return false;
-              }
-              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;
@@ -197,9 +193,6 @@ FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
                   return false;
               }
               if (res.value().node_reports.empty()) {
-                  return false;
-              }
-              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;
@@ -318,9 +311,6 @@ FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
                   return false;
               }
               if (res.value().node_reports.empty()) {
-                  return false;
-              }
-              if (res.value().node_reports[0].local_state.disks.empty()) {
                   return false;
               }
               return true;

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -38,6 +38,7 @@ local_monitor_fixture::local_monitor_fixture()
     config::shard_local_cfg().storage_space_alert_free_threshold_percent.bind(),
     config::shard_local_cfg().storage_min_free_bytes.bind(),
     config::node_config().data_directory().as_sstring(),
+    config::node_config().cloud_storage_cache_path().string(),
     _storage_node_api,
     _storage_api) {
     _storage_node_api.start_single().get0();
@@ -129,7 +130,7 @@ void local_monitor_fixture::set_config_free_thresholds(
 
 FIXTURE_TEST(local_state_has_single_disk, local_monitor_fixture) {
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.disks.size() == 1);
+    BOOST_TEST_REQUIRE(ls.disks().size() == 1);
 }
 
 FIXTURE_TEST(local_monitor_inject_statvfs, local_monitor_fixture) {
@@ -139,9 +140,8 @@ FIXTURE_TEST(local_monitor_inject_statvfs, local_monitor_fixture) {
     _local_monitor.testing_only_set_statvfs(lamb);
 
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.disks.size() == 1);
-    BOOST_TEST_REQUIRE(ls.disks[0].total == total * block_size);
-    BOOST_TEST_REQUIRE(ls.disks[0].free == free * block_size);
+    BOOST_TEST_REQUIRE(ls.data_disk.total == total * block_size);
+    BOOST_TEST_REQUIRE(ls.data_disk.free == free * block_size);
 }
 
 void local_monitor_fixture::assert_space_alert(
@@ -161,7 +161,7 @@ void local_monitor_fixture::assert_space_alert(
     _local_monitor.testing_only_set_statvfs(lamb);
 
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == expected);
+    BOOST_TEST_REQUIRE(ls.data_disk.alert == expected);
 }
 
 FIXTURE_TEST(local_monitor_alert_none, local_monitor_fixture) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -314,7 +314,7 @@ struct partition_balancer_planner_fixture {
                 node_disk.free = nearly_full_node_free_size;
             }
             node_report.id = model::node_id(i);
-            node_report.local_state.disks.push_back(node_disk);
+            node_report.local_state.set_disk(node_disk);
             health_report.node_reports.push_back(node_report);
         }
         health_report.node_reports[0].topics = topics;

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -476,8 +476,8 @@ FIXTURE_TEST(test_move_part_of_replicas, partition_balancer_planner_fixture) {
     auto fm = create_follower_metrics();
 
     // Set order of full nodes
-    hr.node_reports[1].local_state.disks[0].free -= 1_MiB;
-    hr.node_reports[2].local_state.disks[0].free -= 2_MiB;
+    hr.node_reports[1].local_state.data_disk.free -= 1_MiB;
+    hr.node_reports[2].local_state.data_disk.free -= 2_MiB;
 
     auto plan_data = planner.plan_reassignments(hr, fm);
 
@@ -521,7 +521,7 @@ FIXTURE_TEST(
     auto fm = create_follower_metrics();
 
     // Set order of full nodes
-    hr.node_reports[0].local_state.disks[0].free -= 1_MiB;
+    hr.node_reports[0].local_state.data_disk.free -= 1_MiB;
 
     // Set partition sizes
     for (auto& topic : hr.node_reports[0].topics) {
@@ -709,8 +709,8 @@ FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
     // Make node_4 disk free size less to make partition allocator disk usage
     // constraint prefer node_3 rather than node_4
-    hr.node_reports[4].local_state.disks[0].free
-      = hr.node_reports[3].local_state.disks[0].free - 10_MiB;
+    hr.node_reports[4].local_state.data_disk.free
+      = hr.node_reports[3].local_state.data_disk.free - 10_MiB;
 
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -20,15 +20,13 @@
 namespace cluster::node {
 
 inline local_state random_local_state() {
-    return local_state{
+    auto r = local_state{
       {},
       tests::random_named_string<application_version>(),
       tests::random_named_int<cluster::cluster_version>(),
-      tests::random_duration<std::chrono::milliseconds>(),
-      tests::random_vector(storage::random_disk),
-      storage::disk_space_alert{
-        0} // TODO: replace with storage::random_disk_space_alert()
-    };
+      tests::random_duration<std::chrono::milliseconds>()};
+    r.set_disks({storage::random_disk()});
+    return r;
 }
 
 } // namespace cluster::node

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -460,7 +460,26 @@ template<typename T>
 void roundtrip_test(const T original) {
     auto serde_in = original;
     auto serde_out = serde::to_iobuf(std::move(serde_in));
-    auto from_serde = serde::from_iobuf<T>(std::move(serde_out));
+
+    T from_serde;
+    std::exception_ptr err;
+    try {
+        from_serde = serde::from_iobuf<T>(serde_out.copy());
+    } catch (...) {
+        err = std::current_exception();
+    }
+
+    // On failures, log the type and the content of the buffer.
+    if (err || original != from_serde) {
+        std::cerr << "Failed serde roundtrip on " << typeid(T).name()
+                  << std::endl;
+        std::cerr << "Dump " << serde_out.size_bytes()
+                  << " bytes: " << serde_out.hexdump(1024) << std::endl;
+    }
+
+    if (err) {
+        std::rethrow_exception(err);
+    }
 
     BOOST_REQUIRE(original == from_serde);
 }
@@ -705,22 +724,30 @@ cluster::topic_status random_topic_status() {
 }
 
 cluster::node::local_state random_local_state() {
-    std::vector<storage::disk> disks;
-    for (int i = 0, mi = random_generators::get_int(10); i < mi; i++) {
-        disks.push_back(storage::disk{
+    auto data_disk = storage::disk{
+      .path = random_generators::gen_alphanum_string(
+        random_generators::get_int(20)),
+      .free = random_generators::get_int<uint64_t>(),
+      .total = random_generators::get_int<uint64_t>(),
+    };
+
+    // Maybe report a separate cache drive
+    std::optional<storage::disk> cache_disk;
+    if (random_generators::get_int(0, 1) == 0) {
+        cache_disk = storage::disk{
           .path = random_generators::gen_alphanum_string(
             random_generators::get_int(20)),
           .free = random_generators::get_int<uint64_t>(),
           .total = random_generators::get_int<uint64_t>(),
-        });
+        };
     }
     cluster::node::local_state data{
       .redpanda_version
       = tests::random_named_string<cluster::node::application_version>(),
       .logical_version = tests::random_named_int<cluster::cluster_version>(),
       .uptime = tests::random_duration_ms(),
-      .disks = disks,
-    };
+      .data_disk = data_disk,
+      .cache_disk = cache_disk};
     return data;
 }
 
@@ -739,13 +766,18 @@ cluster::cluster_health_report random_cluster_health_report() {
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             topics.push_back(random_topic_status());
         }
-        node_reports.push_back(cluster::node_health_report{
+        auto report = cluster::node_health_report{
           .id = tests::random_named_int<model::node_id>(),
           .local_state = random_local_state(),
           .topics = topics,
           .include_drain_status = true, // so adl considers drain status
           .drain_status = random_drain_status(),
-        });
+        };
+
+        // Reduce to an ADL-encodable state
+        report.local_state.cache_disk = std::nullopt;
+
+        node_reports.push_back(report);
     }
     cluster::cluster_health_report data{
       .raft0_leader = std::nullopt,
@@ -1592,8 +1624,6 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // but don't need to add adl encoding in this case.
         //
         // use a non-default value here for serde test. tests that use adl need
-        // to keep the default value because thsi field isn't seiralized in adl.
-        data.storage_space_alert = storage::disk_space_alert::degraded;
         roundtrip_test(data);
     }
     {
@@ -1629,6 +1659,11 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .drain_status = random_drain_status(),
         };
         data.include_drain_status = true; // so adl considers drain status
+
+        // Squash local_state to a form that ADL represents, since we will
+        // test ADL roundtrip.
+        data.local_state.cache_disk = std::nullopt;
+
         roundtrip_test(data);
     }
     {
@@ -1642,6 +1677,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .topics = topics,
           .drain_status = random_drain_status(),
         };
+
+        // Squash to ADL-understood disk state
+        report.local_state.cache_disk = report.local_state.data_disk;
+
         report.include_drain_status = true; // so adl considers drain status
         cluster::get_node_health_reply data{
           .report = report,

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1106,10 +1106,12 @@ ss::future<topics_frontend::capacity_info> topics_frontend::get_health_info(
     for (const auto& node_report : health_report.value().node_reports) {
         uint64_t total = 0;
         uint64_t free = 0;
-        for (const auto& disk : node_report.local_state.disks) {
-            total += disk.total;
-            free += disk.free;
-        }
+
+        // This health report is just on the data disk.  If the cache has
+        // a separate disk, it is not reflected in the node health.
+        total += node_report.local_state.data_disk.total;
+        free += node_report.local_state.data_disk.free;
+
         info.node_disk_reports.emplace(
           node_report.id, node_disk_space(node_report.id, total, total - free));
     }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -284,9 +284,7 @@ inline void rjson_serialize(
     w.Key("uptime");
     rjson_serialize(w, f.uptime);
     w.Key("disks");
-    rjson_serialize(w, f.disks);
-    w.Key("storage_space_alert");
-    rjson_serialize(w, f.storage_space_alert);
+    rjson_serialize(w, f.disks());
     w.EndObject();
 }
 
@@ -431,21 +429,15 @@ inline void read_value(json::Value const& rd, cluster::node::local_state& obj) {
     cluster::cluster_version logical_version;
     std::chrono::milliseconds uptime;
     std::vector<storage::disk> disks;
-    int storage_space_alert;
 
     read_member(rd, "redpanda_version", redpanda_version);
     read_member(rd, "logical_version", logical_version);
     read_member(rd, "uptime", uptime);
     read_member(rd, "disks", disks);
-    read_member(rd, "storage_space_alert", storage_space_alert);
 
     obj = cluster::node::local_state{
-      {},
-      redpanda_version,
-      logical_version,
-      uptime,
-      disks,
-      storage::disk_space_alert(storage_space_alert)};
+      {}, redpanda_version, logical_version, uptime};
+    obj.set_disks(disks);
 }
 
 inline void

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1415,7 +1415,7 @@ configuration::configuration()
       *this,
       "cloud_storage_cache_size",
       "Max size of archival cache",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       20_GiB)
   , cloud_storage_cache_check_interval_ms(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1420,9 +1420,12 @@ configuration::configuration()
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",
-      "Timeout to check if cache eviction should be triggered",
+      "Minimum time between trims of tiered storage cache.  If a fetch "
+      "operation requires trimming the cache, and the most recent trim was "
+      "within this period, then trimming will be delayed until this period has "
+      "elapsed",
       {.visibility = visibility::tunable},
-      30s)
+      5s)
   , cloud_storage_max_readers_per_shard(
       *this,
       "cloud_storage_max_readers_per_shard",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -289,7 +289,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_target_ms_default;
 
     // Archival cache
-    property<size_t> cloud_storage_cache_size;
+    property<uint64_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
     property<std::optional<uint32_t>>

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -79,6 +79,18 @@ public:
         return data_directory().path / "syschecks";
     }
 
+    /**
+     * Return the configured cache path if set, otherwise a default
+     * path within the data directory.
+     */
+    std::filesystem::path cloud_storage_cache_path() const {
+        if (cloud_storage_cache_directory().has_value()) {
+            return std::string(cloud_storage_cache_directory().value());
+        } else {
+            return data_directory().path / "cloud_storage_cache";
+        }
+    }
+
     std::vector<model::broker_endpoint> advertised_kafka_api() const {
         if (_advertised_kafka_api().empty()) {
             std::vector<model::broker_endpoint> eps;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -720,12 +720,17 @@ get_brokers(cluster::controller* const controller) {
                   it->second.maintenance_status = fill_maintenance_status(
                     r_it->drain_status);
 
-                  for (auto& ds : r_it->local_state.disks) {
+                  auto add_disk = [&ds_list = it->second.disk_space](
+                                    const storage::disk& ds) {
                       ss::httpd::broker_json::disk_space_info dsi;
                       dsi.path = ds.path;
                       dsi.free = ds.free;
                       dsi.total = ds.total;
-                      it->second.disk_space.push(dsi);
+                      ds_list.push(dsi);
+                  };
+                  add_disk(r_it->local_state.data_disk);
+                  if (!r_it->local_state.shared_disk()) {
+                      add_disk(r_it->local_state.get_cache_disk());
                   }
               }
           }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1208,6 +1208,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         // changes
         auto cloud_storage_cache_disk_notification
           = storage_node.local().register_disk_notification(
+            storage::node_api::disk_type::cache,
             [this](
               uint64_t total_space,
               uint64_t free_space,
@@ -1217,6 +1218,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
             });
         _deferred.emplace_back([this, cloud_storage_cache_disk_notification] {
             storage_node.local().unregister_disk_notification(
+              storage::node_api::disk_type::cache,
               cloud_storage_cache_disk_notification);
         });
 
@@ -1561,6 +1563,7 @@ void application::wire_up_bootstrap_services() {
     // Hook up local_monitor to update storage_resources when disk state changes
     auto storage_disk_notification
       = storage_node.local().register_disk_notification(
+        storage::node_api::disk_type::data,
         [this](
           uint64_t total_space,
           uint64_t free_space,
@@ -1572,7 +1575,7 @@ void application::wire_up_bootstrap_services() {
         });
     _deferred.emplace_back([this, storage_disk_notification] {
         storage_node.local().unregister_disk_notification(
-          storage_disk_notification);
+          storage::node_api::disk_type::data, storage_disk_notification);
     });
 
     // Start empty, populated from snapshot in start_bootstrap_services

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1545,7 +1545,10 @@ void application::wire_up_bootstrap_services() {
     // Hook up local_monitor to update storage_resources when disk state changes
     auto storage_disk_notification
       = storage_node.local().register_disk_notification(
-        [this](uint64_t total_space, uint64_t free_space) {
+        [this](
+          uint64_t total_space,
+          uint64_t free_space,
+          storage::disk_space_alert) {
             return storage.invoke_on_all(
               [total_space, free_space](storage::api& api) {
                   api.resources().update_allowance(total_space, free_space);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -678,6 +678,8 @@ void application::check_environment() {
     storage::directories::initialize(
       config::node().data_directory().as_sstring())
       .get();
+    cloud_storage::cache::initialize(config::node().cloud_storage_cache_path())
+      .get();
 
     if (config::shard_local_cfg().storage_strict_data_init()) {
         // Look for the special file that indicates a user intends

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1201,9 +1201,11 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         if (cache_path_cfg) {
             cache_dir = std::filesystem::path(cache_path_cfg.value());
         }
-        auto cache_size
-          = config::shard_local_cfg().cloud_storage_cache_size.value();
-        construct_service(shadow_index_cache, cache_dir, cache_size).get();
+        construct_service(
+          shadow_index_cache, cache_dir, ss::sharded_parameter([] {
+              return config::shard_local_cfg().cloud_storage_cache_size.bind();
+          }))
+          .get();
 
         shadow_index_cache
           .invoke_on_all(

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
   NAME resource_mgmt
   SRCS
     available_memory.cc
+    storage.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "storage.h"
+
+namespace storage {
+
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
+
+} // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <iostream>
+
+namespace storage {
+
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+
+inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
+    return std::max(a, b);
+}
+
+std::ostream& operator<<(std::ostream& o, const storage::disk_space_alert d);
+
+} // namespace storage

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -45,6 +45,10 @@ struct envelope {
     static constexpr auto redpanda_inherits_from_envelope = true;
 };
 
+// Overhead of the envelope in bytes: 4 bytes of size, one byte of version,
+// one byte of compat version.
+static constexpr size_t envelope_header_size = 6;
+
 /**
  * Checksum envelope uses CRC32c to check data integrity.
  * The idea is that CRC32 has hardware support and is faster than
@@ -61,6 +65,11 @@ struct checksum_envelope {
     static constexpr auto redpanda_inherits_from_envelope = true;
     static constexpr auto redpanda_serde_build_checksum = true;
 };
+
+// Overhead of the envelope in bytes: a checksummed envelope is
+// a regular envelope plus 4 bytes of checksum.
+static constexpr size_t checksum_envelope_header_size = envelope_header_size
+                                                        + 4;
 
 template<typename T, typename Version = const serde::version_t&>
 concept is_envelope = requires {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -973,6 +973,18 @@ inline version_t peek_version(iobuf_parser& in) {
     return serde::read_nested<serde::version_t>(version_reader, 0);
 }
 
+inline serde::serde_size_t peek_body_size(iobuf_parser& in) {
+    if (unlikely(in.bytes_left() < envelope_header_size)) {
+        throw serde_exception{"cannot peek size"};
+    }
+
+    // Take bytes 2-6
+    auto header_buf = in.peek(envelope_header_size);
+    header_buf.trim_front(2);
+    auto size_reader = iobuf_parser{std::move(header_buf)};
+    return serde::read_nested<serde::serde_size_t>(size_reader, 0);
+}
+
 template<typename T>
 iobuf to_iobuf(T&& t) {
     iobuf b;

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -38,11 +38,12 @@ public:
     ss::future<> stop() { return ss::now(); }
 
     using notification_id = named_type<int32_t, struct notification_id_t>;
-    using disk_cb_t = ss::noncopyable_function<void(uint64_t, uint64_t)>;
+    using disk_cb_t
+      = ss::noncopyable_function<void(uint64_t, uint64_t, disk_space_alert)>;
 
     void set_disk_metrics(
       uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert) {
-        _watchers.notify(uint64_t(total_bytes), uint64_t(free_bytes));
+        _watchers.notify(uint64_t(total_bytes), uint64_t(free_bytes), alert);
         _probe.set_disk_metrics(total_bytes, free_bytes, alert);
     }
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -65,6 +65,16 @@ public:
     segment_index(const segment_index&) = delete;
     segment_index& operator=(const segment_index&) = delete;
 
+    /**
+     * Estimate the size of an index file for a log segment
+     * of a certain size.
+     */
+    static uint64_t estimate_size(uint64_t log_size) {
+        // Index entry every `step` bytes, each entry is 16 bytes
+        // plus one entry that is with the first batch.
+        return 1 + 16 * log_size / default_data_buffer_step;
+    }
+
     void maybe_track(const model::record_batch_header&, size_t filepos);
     std::optional<entry> find_nearest(model::offset);
     std::optional<entry> find_nearest(model::timestamp);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -31,21 +31,6 @@ model::offset stm_manager::max_collectible_offset() {
     return result;
 }
 
-std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
-    switch (d) {
-    case disk_space_alert::ok:
-        o << "ok";
-        break;
-    case disk_space_alert::low_space:
-        o << "low_space";
-        break;
-    case disk_space_alert::degraded:
-        o << "degraded";
-        break;
-    }
-    return o;
-}
-
 std::ostream& operator<<(std::ostream& o, const disk& d) {
     fmt::print(
       o,

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -34,14 +34,15 @@ using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 using jitter_percents = named_type<int, struct jitter_percents_tag>;
 
 struct disk
-  : serde::envelope<disk, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<disk, serde::version<1>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     ss::sstring path;
-    uint64_t free;
-    uint64_t total;
+    uint64_t free{0};
+    uint64_t total{0};
+    disk_space_alert alert{disk_space_alert::ok};
 
-    auto serde_fields() { return std::tie(path, free, total); }
+    auto serde_fields() { return std::tie(path, free, total, alert); }
 
     friend std::ostream& operator<<(std::ostream&, const disk&);
     friend bool operator==(const disk&, const disk&) = default;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -16,6 +16,7 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
+#include "resource_mgmt/storage.h"
 #include "storage/fwd.h"
 #include "tristate.h"
 
@@ -32,12 +33,6 @@ using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 using jitter_percents = named_type<int, struct jitter_percents_tag>;
 
-enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
-
-inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
-    return std::max(a, b);
-}
-
 struct disk
   : serde::envelope<disk, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
@@ -51,8 +46,6 @@ struct disk
     friend std::ostream& operator<<(std::ostream&, const disk&);
     friend bool operator==(const disk&, const disk&) = default;
 };
-
-std::ostream& operator<<(std::ostream& o, const storage::disk_space_alert d);
 
 // Helps to identify transactional stms in the registered list of stms.
 // Avoids an ugly dynamic cast to the base class.


### PR DESCRIPTION
## Cover letter

Previously, the consume_cache_space path would notice only _after_ the limit was breached, and run a trim.  Same for background trims: they would only take action after the limit had been breached.

Space management:
- To provide strict management, force the remote segment download path to wait for a space reservation before they start requesting data from S3.
- This also changes the clean_up_cache logic to reduce the target size by however many reservation bytes
are awaiting, to enable reservation waiters to proceed.
- The tracking of `_current_cache_size` changes: it is no longer reset to the result of the directory walk in clean_up_cache, because this races with updates via consume_cache_space, and causes it to falsely seem as if we have violated the cache size.  To avoid too much drift between the internal tracking of used space and the results of our scan in clean_up_cache, the `_current_cache_size` is reset if it clearly underestimates usage.
- This change does not make the space management perfect: notably, any lingering readers with open file handles to cached segments will cause those segments to continue to use disk space until the readers drop.
- `cloud_storage_cache_size` may now be adjusted without restart, and a trim is kicked off if necessary on cache size shrink

Other improvements:
- Refactor cluster/storage disk space monitoring code to handle data + cache drives separately
- Respect write-blocking on low disk, based on the same `storage_min_bytes` threshold as kafka writes
- Use `cloud_storage_cache_check_interval_ms` as the minimum period between trims (previously this property was unused).
- Use fragmented_vector in directory listings to reduce risk of bad_alloc on very large caches
- Use async streaming load+store for access_time_tracker
- Forbid cache trim from deleting access time tracker's file
- Do not write access time tracker via general put/get paths, to avoid polluting statistics.

Fixes https://github.com/redpanda-data/redpanda/issues/4746

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* The tiered storage read cache has improved space management, and will delay downloading segments if the download would cause `cloud_storage_cache_size` to be breached.  Previously this was a soft limit, and the cache would be trimmed after it had exceeded it.