### PR TITLE
tests: disable unreliable backtrace decodes

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -36,7 +36,11 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             except:
                 self.redpanda.logger.exception(
                     "Test failed, doing failure checks...")
-                self.redpanda.decode_backtraces()
+
+                # Disabled to avoid addr2line hangs
+                # (https://github.com/redpanda-data/redpanda/issues/5004)
+                # self.redpanda.decode_backtraces()
+
                 self.redpanda.raise_on_crash()
                 raise
             else:


### PR DESCRIPTION
## Cover letter

This tends to hang when running ducktape locally,
and doesn't often provide useful content when
crashes occur in CI.

It needs re-visiting per
https://github.com/redpanda-data/redpanda/issues/5004

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none