### PR TITLE
tests: updated kgo-verifier version

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 6197450 && \
+    cd /opt/kgo-verifier && git reset --hard 857e4a4 && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients


### PR DESCRIPTION
## Cover letter

Updated `kgo-verifier` version to include latest logging imporovements from https://github.com/redpanda-data/kgo-verifier/pull/11

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
