### PR TITLE
archival: Use archival_metadata_stm manifest

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -59,13 +59,12 @@ ntp_archiver::ntp_archiver(
   , _partition(std::move(part))
   , _policy(_ntp, conf.time_limit, conf.upload_io_priority)
   , _bucket(conf.bucket_name)
-  , _manifest(_ntp, _rev)
   , _gate()
   , _rtcnode(_as)
   , _rtclog(archival_log, _rtcnode, _ntp.path())
   , _cloud_storage_initial_backoff(conf.cloud_storage_initial_backoff)
   , _segment_upload_timeout(conf.segment_upload_timeout)
-  , _manifest_upload_timeout(conf.manifest_upload_timeout)
+  , _metadata_sync_timeout(conf.manifest_upload_timeout)
   , _upload_loop_initial_backoff(conf.upload_loop_initial_backoff)
   , _upload_loop_max_backoff(conf.upload_loop_max_backoff)
   , _sync_manifest_timeout(
@@ -87,6 +86,15 @@ ntp_archiver::ntp_archiver(
       "created ntp_archiver {} in term {}",
       _ntp,
       _start_term);
+}
+
+const cloud_storage::partition_manifest& ntp_archiver::manifest() const {
+    vassert(_partition, "Partition {} is not available", _ntp.path());
+    vassert(
+      _partition->archival_meta_stm(),
+      "Archival STM is not available for {}",
+      _ntp.path());
+    return _partition->archival_meta_stm()->manifest();
 }
 
 void ntp_archiver::run_sync_manifest_loop() {
@@ -169,12 +177,18 @@ ss::future<> ntp_archiver::upload_loop() {
         // Bump up archival STM's state to make sure that it's not lagging
         // behind too far. If the STM is lagging behind we will have to read a
         // lot of data next time we upload something.
-        if (_partition->archival_meta_stm()) {
-            auto sync_timeout
-              = config::shard_local_cfg()
-                  .cloud_storage_metadata_sync_timeout_ms.value();
-            co_await _partition->archival_meta_stm()->sync(sync_timeout);
-        }
+        vassert(
+          _partition,
+          "Upload loop: partition is not set for {} archiver",
+          _ntp.path());
+        vassert(
+          _partition->archival_meta_stm(),
+          "Upload loop: archival metadata STM is not created for {} archiver",
+          _ntp.path());
+
+        auto sync_timeout = config::shard_local_cfg()
+                              .cloud_storage_metadata_sync_timeout_ms.value();
+        co_await _partition->archival_meta_stm()->sync(sync_timeout);
 
         auto result = co_await upload_next_candidates();
         if (result.num_failed != 0) {
@@ -236,49 +250,44 @@ ss::future<> ntp_archiver::sync_manifest_loop() {
             vlog(
               _rtclog.error,
               "Failed to download manifest {}",
-              _manifest.get_manifest_path());
+              manifest().get_manifest_path());
         } else {
             vlog(
               _rtclog.debug,
               "Successfuly downloaded manifest {}",
-              _manifest.get_manifest_path());
+              manifest().get_manifest_path());
         }
         co_await ss::sleep_abortable(_sync_manifest_timeout(), _as);
     }
 }
 
 ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
-    cloud_storage::download_result r = co_await download_manifest();
-    if (r == cloud_storage::download_result::success) {
-        vlog(_rtclog.debug, "Downloading manifest in read-replica mode");
-        if (_partition->archival_meta_stm()) {
-            vlog(
-              _rtclog.debug,
-              "Updating the archival_meta_stm in read-replica mode");
-            auto sync_timeout
-              = config::shard_local_cfg()
-                  .cloud_storage_metadata_sync_timeout_ms.value();
-            auto deadline = ss::lowres_clock::now() + sync_timeout;
-            auto error = co_await _partition->archival_meta_stm()->add_segments(
-              _manifest, deadline, _as);
-            if (
-              error != cluster::errc::success
-              && error != cluster::errc::not_leader) {
-                vlog(
-                  _rtclog.warn,
-                  "archival metadata STM update failed: {}",
-                  error);
-            }
-            auto last_offset
-              = _partition->archival_meta_stm()->manifest().get_last_offset();
-            vlog(_rtclog.debug, "manifest last_offset: {}", last_offset);
-        }
-    } else {
+    vlog(_rtclog.debug, "Downloading manifest in read-replica mode");
+    auto [m, res] = co_await download_manifest();
+    if (res != cloud_storage::download_result::success) {
         vlog(
           _rtclog.error,
           "Failed to download partition manifest in read-replica mode");
+        co_return res;
+    } else {
+        vlog(
+          _rtclog.debug, "Updating the archival_meta_stm in read-replica mode");
+        auto sync_timeout = config::shard_local_cfg()
+                              .cloud_storage_metadata_sync_timeout_ms.value();
+        auto deadline = ss::lowres_clock::now() + sync_timeout;
+        auto error = co_await _partition->archival_meta_stm()->add_segments(
+          m, deadline, _as);
+        if (
+          error != cluster::errc::success
+          && error != cluster::errc::not_leader) {
+            vlog(
+              _rtclog.warn, "archival metadata STM update failed: {}", error);
+        }
+        auto last_offset = manifest().get_last_offset();
+        vlog(_rtclog.debug, "manifest last_offset: {}", last_offset);
+        co_return cloud_storage::download_result::success;
     }
-    co_return r;
+    __builtin_unreachable();
 }
 
 bool ntp_archiver::upload_loop_can_continue() const {
@@ -309,21 +318,18 @@ const ss::lowres_clock::time_point ntp_archiver::get_last_upload_time() const {
     return _last_upload_time;
 }
 
-const cloud_storage::partition_manifest&
-ntp_archiver::get_remote_manifest() const {
-    return _manifest;
-}
-
-ss::future<cloud_storage::download_result> ntp_archiver::download_manifest() {
+ss::future<
+  std::pair<cloud_storage::partition_manifest, cloud_storage::download_result>>
+ntp_archiver::download_manifest() {
     gate_guard guard{_gate};
     retry_chain_node fib(
-      _manifest_upload_timeout, _cloud_storage_initial_backoff, &_rtcnode);
-    auto path = _manifest.get_manifest_path();
+      _metadata_sync_timeout, _cloud_storage_initial_backoff, &_rtcnode);
+    cloud_storage::partition_manifest tmp(_ntp, _rev);
+    auto path = tmp.get_manifest_path();
     auto key = cloud_storage::remote_manifest_path(
       std::filesystem::path(std::move(path)));
     vlog(_rtclog.debug, "Downloading manifest");
-    auto result = co_await _remote.download_manifest(
-      _bucket, key, _manifest, fib);
+    auto result = co_await _remote.download_manifest(_bucket, key, tmp, fib);
 
     // It's OK if the manifest is not found for a newly created topic. The
     // condition in if statement is not guaranteed to cover all cases for new
@@ -341,19 +347,19 @@ ss::future<cloud_storage::download_result> ntp_archiver::download_manifest() {
           _partition->term());
     }
 
-    co_return result;
+    co_return std::make_pair(tmp, result);
 }
 
 ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest() {
     gate_guard guard{_gate};
     retry_chain_node fib(
-      _manifest_upload_timeout, _cloud_storage_initial_backoff, &_rtcnode);
+      _metadata_sync_timeout, _cloud_storage_initial_backoff, &_rtcnode);
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
     vlog(
       ctxlog.debug,
       "Uploading manifest, path: {}",
-      _manifest.get_manifest_path());
-    co_return co_await _remote.upload_manifest(_bucket, _manifest, fib);
+      manifest().get_manifest_path());
+    co_return co_await _remote.upload_manifest(_bucket, manifest(), fib);
 }
 
 // from offset to offset (by record batch boundary)
@@ -467,7 +473,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
           .segment_read_lock = std::nullopt,
         };
     }
-    if (_manifest.contains(upload.exposed_name)) {
+    if (manifest().contains(upload.exposed_name)) {
         // If the manifest already contains the name we have the following
         // cases
         //
@@ -490,7 +496,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
         // - B == D:
         //   - Same as previoius. We need to log error and continue with the
         //   largest offset.
-        const auto& meta = _manifest.get(upload.exposed_name);
+        const auto& meta = manifest().get(upload.exposed_name);
         auto dirty_offset = upload.source->offsets().dirty_offset;
         if (meta->committed_offset < dirty_offset) {
             vlog(
@@ -573,9 +579,9 @@ ntp_archiver::schedule_uploads(model::offset last_stable_offset) {
     // latest uploaded segment but '_policy' requires offset that
     // belongs to the next offset or the gap. No need to do this
     // if there is no segments.
-    auto start_upload_offset = _manifest.size() ? _manifest.get_last_offset()
-                                                    + model::offset(1)
-                                                : model::offset(0);
+    auto start_upload_offset = manifest().size() ? manifest().get_last_offset()
+                                                     + model::offset(1)
+                                                 : model::offset(0);
 
     vlog(
       _rtclog.debug,
@@ -662,6 +668,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
     total.num_failed = results.size()
                        - (total.num_succeded + total.num_cancelled);
 
+    cloud_storage::partition_manifest mdiff(_ntp, _rev);
     for (size_t i = 0; i < results.size(); i++) {
         if (results[i] != cloud_storage::upload_result::success) {
             break;
@@ -671,10 +678,10 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
         _probe.uploaded(*upload.delta);
         _probe.uploaded_bytes(upload.meta->size_bytes);
         model::offset expected_base_offset;
-        if (_manifest.get_last_offset() < model::offset{0}) {
+        if (manifest().get_last_offset() < model::offset{0}) {
             expected_base_offset = model::offset{0};
         } else {
-            expected_base_offset = _manifest.get_last_offset()
+            expected_base_offset = manifest().get_last_offset()
                                    + model::offset{1};
         }
         if (upload.meta->base_offset > expected_base_offset) {
@@ -682,9 +689,26 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
               upload.meta->base_offset - expected_base_offset);
         }
 
-        _manifest.add(segment_name(*upload.name), *upload.meta);
+        mdiff.add(segment_name(*upload.name), *upload.meta);
     }
+
     if (total.num_succeded != 0) {
+        vassert(
+          _partition, "Partition is not set for {} archiver", _ntp.path());
+        vassert(
+          _partition->archival_meta_stm(),
+          "Archival metadata STM is not created for {} archiver",
+          _ntp.path());
+        auto deadline = ss::lowres_clock::now() + _metadata_sync_timeout;
+        auto error = co_await _partition->archival_meta_stm()->add_segments(
+          mdiff, deadline, _as);
+        if (
+          error != cluster::errc::success
+          && error != cluster::errc::not_leader) {
+            vlog(
+              _rtclog.warn, "archival metadata STM update failed: {}", error);
+        }
+
         vlog(
           _rtclog.debug,
           "successfully uploaded {} segments (failed {} uploads), "
@@ -697,21 +721,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
             vlog(
               _rtclog.warn,
               "manifest upload to {} failed",
-              _manifest.get_manifest_path());
-        }
-
-        if (_partition->archival_meta_stm()) {
-            auto deadline = ss::lowres_clock::now() + _manifest_upload_timeout;
-            auto error = co_await _partition->archival_meta_stm()->add_segments(
-              _manifest, deadline, _as);
-            if (
-              error != cluster::errc::success
-              && error != cluster::errc::not_leader) {
-                vlog(
-                  _rtclog.warn,
-                  "archival metadata STM update failed: {}",
-                  error);
-            }
+              manifest().get_manifest_path());
         }
 
         _last_upload_time = ss::lowres_clock::now();
@@ -745,9 +755,9 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
 }
 
 uint64_t ntp_archiver::estimate_backlog_size() {
-    auto last_offset = _manifest.size() ? _manifest.get_last_offset()
-                                        : model::offset(0);
-    auto opt_log = _partition_manager.log(_manifest.get_ntp());
+    auto last_offset = manifest().size() ? manifest().get_last_offset()
+                                         : model::offset(0);
+    auto opt_log = _partition_manager.log(_ntp);
     if (!opt_log) {
         return 0U;
     }
@@ -775,9 +785,9 @@ ntp_archiver::maybe_truncate_manifest(retry_chain_node& rtc) {
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     vlog(ctxlog.info, "archival metadata cleanup started");
     model::offset adjusted_start_offset = model::offset::min();
-    for (const auto& [key, meta] : _manifest) {
+    for (const auto& [key, meta] : manifest()) {
         retry_chain_node fib(
-          _manifest_upload_timeout, _upload_loop_initial_backoff, &rtc);
+          _metadata_sync_timeout, _upload_loop_initial_backoff, &rtc);
         auto sname = cloud_storage::generate_segment_name(
           key.base_offset, key.term);
         auto spath = cloud_storage::generate_remote_segment_path(
@@ -802,18 +812,17 @@ ntp_archiver::maybe_truncate_manifest(retry_chain_node& rtc) {
           ctxlog.info,
           "archival metadata cleanup, some segments will be removed from the "
           "manifest, start offset before cleanup: {}",
-          _manifest.get_start_offset());
+          manifest().get_start_offset());
         retry_chain_node rc_node(
-          _manifest_upload_timeout, _upload_loop_initial_backoff, &rtc);
+          _metadata_sync_timeout, _upload_loop_initial_backoff, &rtc);
         auto error = co_await _partition->archival_meta_stm()->truncate(
           adjusted_start_offset,
-          ss::lowres_clock::now() + _manifest_upload_timeout,
+          ss::lowres_clock::now() + _metadata_sync_timeout,
           _as);
         if (error != cluster::errc::success) {
             vlog(ctxlog.warn, "archival metadata STM update failed: {}", error);
             throw std::system_error(error);
         } else {
-            result = _manifest.truncate(adjusted_start_offset);
             vlog(
               ctxlog.debug,
               "archival metadata STM update passed, re-uploading manifest");
@@ -822,7 +831,7 @@ ntp_archiver::maybe_truncate_manifest(retry_chain_node& rtc) {
         vlog(
           ctxlog.info,
           "archival metadata cleanup completed, start offset after cleanup: {}",
-          _manifest.get_start_offset());
+          manifest().get_start_offset());
     } else {
         // Nothing to cleanup, return empty manifest
         result = cloud_storage::partition_manifest(_ntp, _rev);

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -115,10 +115,10 @@ public:
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
-    ss::future<cloud_storage::download_result> download_manifest();
-
-    const cloud_storage::partition_manifest& get_remote_manifest() const;
-
+    ss::future<std::pair<
+      cloud_storage::partition_manifest,
+      cloud_storage::download_result>>
+    download_manifest();
     struct batch_result {
         size_t num_succeded;
         size_t num_failed;
@@ -205,6 +205,7 @@ private:
 
     bool upload_loop_can_continue() const;
     bool sync_manifest_loop_can_continue() const;
+    const cloud_storage::partition_manifest& manifest() const;
 
     ntp_level_probe _probe;
     model::ntp _ntp;
@@ -215,16 +216,13 @@ private:
     model::term_id _start_term;
     archival_policy _policy;
     s3::bucket_name _bucket;
-    /// Remote manifest contains representation of the data stored in S3 (it
-    /// gets uploaded to the remote location)
-    cloud_storage::partition_manifest _manifest;
     ss::gate _gate;
     ss::abort_source _as;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
     ss::lowres_clock::duration _cloud_storage_initial_backoff;
     ss::lowres_clock::duration _segment_upload_timeout;
-    ss::lowres_clock::duration _manifest_upload_timeout;
+    ss::lowres_clock::duration _metadata_sync_timeout;
     ssx::semaphore _mutex{1, "archive/ntp"};
     ss::lowres_clock::duration _upload_loop_initial_backoff;
     ss::lowres_clock::duration _upload_loop_max_backoff;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -251,64 +251,28 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
     ss::gate::holder gh(_gate);
 
     _archivers.emplace(archiver->get_ntp(), archiver);
-    auto result = co_await archiver->download_manifest();
-
     auto ntp = archiver->get_ntp();
     auto part = _partition_manager.local().get(ntp);
     if (!part) {
         co_return;
     }
-    switch (result) {
-    case cloud_storage::download_result::success:
-        vlog(_rtclog.info, "Found manifest for partition {}", ntp);
+    vlog(_rtclog.info, "Starting archiver for partition {}", ntp);
 
-        if (part->get_ntp_config().is_read_replica_mode_enabled()) {
-            archiver->run_sync_manifest_loop();
-        } else {
-            if (ntp.tp.partition == 0) {
-                // Upload manifest once per topic. GCS has strict
-                // limits for single object updates.
-                ssx::background = upload_topic_manifest(
-                  model::topic_namespace(ntp.ns, ntp.tp.topic),
-                  archiver->get_revision_id());
-            }
-            _probe.start_archiving_ntp();
-            archiver->run_upload_loop();
+    if (part->get_ntp_config().is_read_replica_mode_enabled()) {
+        archiver->run_sync_manifest_loop();
+    } else {
+        if (ntp.tp.partition == 0) {
+            // Upload manifest once per topic. GCS has strict
+            // limits for single object updates.
+            ssx::background = upload_topic_manifest(
+              model::topic_namespace(ntp.ns, ntp.tp.topic),
+              archiver->get_revision_id());
         }
-
-        co_return;
-    case cloud_storage::download_result::notfound:
-        if (part->get_ntp_config().is_read_replica_mode_enabled()) {
-            vlog(
-              _rtclog.info,
-              "Couldn't download manifest for partition {} in read replica",
-              ntp);
-            archiver->run_sync_manifest_loop();
-        } else {
-            vlog(_rtclog.info, "Start archiving new partition {}", ntp);
-            // Start topic manifest upload
-            // asynchronously
-            if (ntp.tp.partition == 0) {
-                // Upload manifest once per topic. GCS has strict
-                // limits for single object updates.
-                ssx::background = upload_topic_manifest(
-                  model::topic_namespace(ntp.ns, ntp.tp.topic),
-                  archiver->get_revision_id());
-            }
-            _probe.start_archiving_ntp();
-
-            archiver->run_upload_loop();
-        }
-
-        co_return;
-    case cloud_storage::download_result::failed:
-    case cloud_storage::download_result::timedout:
-        vlog(_rtclog.warn, "Manifest download failed");
-        _archivers.erase(archiver->get_ntp());
-        co_return co_await archiver->stop().finally([archiver]() {
-            return ss::make_exception_future<>(ss::timed_out_error());
-        });
+        _probe.start_archiving_ntp();
+        archiver->run_upload_loop();
     }
+
+    co_return;
 }
 
 ss::future<>
@@ -373,8 +337,13 @@ ss::future<> scheduler_service_impl::reconcile_archivers() {
     std::vector<model::ntp> to_create;
     // find new ntps that present in the snapshot only
     for (const auto& [ntp, p] : pm.partitions()) {
+        // archival_metadata_stm is only created for topics in kafka namespace
+        // if we ever uploaded some topics from kafka_internal by accident these
+        // topics won't have an STM and the snapshot so it's safe to limit
+        // creation of archivers by 'kafka' namespace for now.
+        // we will change this in the future when we will add DR
         if (
-          ntp.ns != model::redpanda_ns && !_archivers.contains(ntp)
+          ntp.ns == model::kafka_namespace && !_archivers.contains(ntp)
           && p->is_elected_leader()) {
             to_create.push_back(ntp);
         }

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -133,6 +133,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
         BOOST_REQUIRE_EQUAL(req._method, "PUT"); // NOLINT
         verify_manifest_content(req.content);
         manifest = load_manifest(req.content);
+        BOOST_REQUIRE(manifest == part->archival_meta_stm()->manifest());
     }
 
     {
@@ -165,7 +166,6 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
 
         BOOST_CHECK_EQUAL(segment.base_offset, it->second.base_offset);
     }
-    BOOST_REQUIRE(stm_manifest == archiver.get_remote_manifest());
 }
 
 // NOLINTNEXTLINE
@@ -542,16 +542,16 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       .committed_offset = segment1->offsets().dirty_offset - model::offset(1)};
     auto oldname = archival::segment_name("2-2-v1.log");
     old_manifest.add(oldname, old_meta);
-    std::stringstream old_str;
-    old_manifest.serialize(old_str);
     ss::sstring segment3_url = "/dfee62b1/kafka/test-topic/42_0/2-2-v1.log";
 
-    std::vector<s3_imposter_fixture::expectation> expectations({
-      s3_imposter_fixture::expectation{
-        .url = manifest_url, .body = ss::sstring(old_str.str())},
-    });
+    // Simulate pre-existing state in the snapshot
+    part->archival_meta_stm()
+      ->add_segments(old_manifest, ss::lowres_clock::now() + 1s)
+      .get();
 
+    std::vector<s3_imposter_fixture::expectation> expectations;
     set_expectations_and_listen(expectations);
+
     auto [arch_conf, remote_conf] = get_configurations();
     cloud_storage::remote remote(
       remote_conf.connection_limit,
@@ -564,8 +564,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
 
     retry_chain_node fib;
 
-    archiver.download_manifest().get();
-
     auto res = archiver.upload_next_candidates().get();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
@@ -573,24 +571,16 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     for (auto req : get_requests()) {
         vlog(test_log.info, "{} {}", req._method, req._url);
     }
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 4);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     cloud_storage::partition_manifest manifest;
     {
         auto [begin, end] = get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);
-        BOOST_REQUIRE_EQUAL(len, 2);
-        std::set<ss::sstring> expected = {"PUT", "GET"};
-        for (auto it = begin; it != end; it++) {
-            auto key = it->second._method;
-            BOOST_REQUIRE(expected.contains(key));
-            expected.erase(key);
-
-            if (key == "PUT") {
-                manifest = load_manifest(it->second.content);
-            }
-        }
-        BOOST_REQUIRE(expected.empty());
+        BOOST_REQUIRE_EQUAL(len, 1);
+        BOOST_REQUIRE(begin->second._method == "PUT");
+        manifest = load_manifest(begin->second.content);
+        BOOST_REQUIRE(manifest == part->archival_meta_stm()->manifest());
     }
     for (const segment_name& name : {s1name, s2name}) {
         auto url = get_segment_path(manifest, name);
@@ -613,8 +603,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
         BOOST_CHECK(stm_manifest.get(s1name));
         BOOST_CHECK_EQUAL(stm_manifest.get(name)->base_offset, base_offset);
     }
-
-    BOOST_CHECK(stm_manifest == archiver.get_remote_manifest());
 }
 
 class counting_batch_consumer : public storage::batch_consumer {
@@ -745,9 +733,9 @@ static void test_partial_upload_impl(
       .ntp_revision = manifest.get_revision_id()};
 
     manifest.add(s1name, segment_meta);
-
-    std::stringstream old_str;
-    manifest.serialize(old_str);
+    part->archival_meta_stm()
+      ->add_segments(manifest, ss::lowres_clock::now() + 1s)
+      .get();
 
     segment_name s2name{
       ssx::sformat("{}-1-v1.log", last_uploaded_offset() + 1)};
@@ -763,12 +751,7 @@ static void test_partial_upload_impl(
       last_uploaded_offset,
       lso);
 
-    std::vector<s3_imposter_fixture::expectation> expectations({
-      s3_imposter_fixture::expectation{
-        .url = manifest_url, .body = ss::sstring(old_str.str())},
-    });
-
-    test.set_expectations_and_listen(expectations);
+    test.set_expectations_and_listen({});
 
     auto [aconf, cconf] = get_configurations();
     cloud_storage::remote remote(
@@ -783,8 +766,6 @@ static void test_partial_upload_impl(
 
     retry_chain_node fib;
 
-    archiver.download_manifest().get();
-
     auto res = archiver.upload_next_candidates(lso).get();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
@@ -792,23 +773,15 @@ static void test_partial_upload_impl(
     for (auto req : test.get_requests()) {
         vlog(test_log.info, "{} {}", req._method, req._url);
     }
-    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 3);
+    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 2);
 
     {
         auto [begin, end] = test.get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);
-        BOOST_REQUIRE_EQUAL(len, 2);
-        std::set<ss::sstring> expected = {"PUT", "GET"};
-        for (auto it = begin; it != end; it++) {
-            auto key = it->second._method;
-            BOOST_REQUIRE(expected.contains(key));
-            expected.erase(key);
-
-            if (key == "PUT") {
-                manifest = load_manifest(it->second.content);
-            }
-        }
-        BOOST_REQUIRE(expected.empty());
+        BOOST_REQUIRE_EQUAL(len, 1);
+        BOOST_REQUIRE(begin->second._method == "PUT");
+        manifest = load_manifest(begin->second.content);
+        BOOST_REQUIRE(manifest == part->archival_meta_stm()->manifest());
     }
 
     ss::sstring url2 = "/" + get_segment_path(manifest, s2name)().string();
@@ -833,12 +806,12 @@ static void test_partial_upload_impl(
     BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
-    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 5);
+    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 4);
     {
         auto [begin, end] = test.get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);
-        BOOST_REQUIRE_EQUAL(len, 3);
-        std::multiset<ss::sstring> expected = {"PUT", "PUT", "GET"};
+        BOOST_REQUIRE_EQUAL(len, 2);
+        std::multiset<ss::sstring> expected = {"PUT", "PUT"};
         for (auto it = begin; it != end; it++) {
             auto key = it->second._method;
             BOOST_REQUIRE(expected.contains(key));
@@ -853,6 +826,9 @@ static void test_partial_upload_impl(
             }
         }
         BOOST_REQUIRE(expected.empty());
+        BOOST_REQUIRE(part->archival_meta_stm());
+        const auto& stm_manifest = part->archival_meta_stm()->manifest();
+        BOOST_REQUIRE(stm_manifest == manifest);
     }
 
     {
@@ -874,10 +850,6 @@ static void test_partial_upload_impl(
         BOOST_REQUIRE_EQUAL(stats.min_offset, base_upl2);
         BOOST_REQUIRE_EQUAL(stats.max_offset, last_upl2);
     }
-
-    BOOST_REQUIRE(part->archival_meta_stm());
-    const auto& stm_manifest = part->archival_meta_stm()->manifest();
-    BOOST_REQUIRE(stm_manifest == archiver.get_remote_manifest());
 }
 
 // NOLINTNEXTLINE

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -13,6 +13,7 @@
 #include "archival/types.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "cluster/archival_metadata_stm.h"
 #include "cluster/members_table.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
@@ -288,6 +289,12 @@ ss::future<> archiver_fixture::add_topic_with_archival_enabled(
           return wait_for_topics(std::move(results));
       });
 }
+ss::future<> archiver_fixture::create_archival_snapshot(
+  const storage::ntp_config& cfg, cloud_storage::partition_manifest manifest) {
+    return cluster::archival_metadata_stm::make_snapshot(
+      cfg, manifest, model::offset(0));
+}
+
 storage::api& archiver_fixture::get_local_storage_api() {
     return app.storage.local();
 }
@@ -483,6 +490,7 @@ cloud_storage::partition_manifest load_manifest(std::string_view v) {
 archival::remote_segment_path get_segment_path(
   const cloud_storage::partition_manifest& manifest,
   const archival::segment_name& name) {
+    vlog(fixt_log.debug, "get_segment_path {}", name);
     auto meta = manifest.get(name);
     BOOST_REQUIRE(meta);
     auto key = cloud_storage::parse_segment_name(name);

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "archival/ntp_archiver_service.h"
+#include "archival/service.h"
 #include "cloud_storage/types.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/types.h"
@@ -161,6 +162,10 @@ class archiver_fixture
   , public redpanda_thread_fixture
   , public segment_matcher<archiver_fixture> {
 public:
+    archiver_fixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{}) {}
+
     std::unique_ptr<storage::disk_log_builder> get_started_log_builder(
       model::ntp ntp, model::revision_id rev = model::revision_id(0));
     /// Wait unill all information will be replicated and the local node
@@ -171,6 +176,12 @@ public:
     void add_topic_with_random_data(const model::ntp& ntp, int num_batches);
     /// Provides access point for segment_matcher CRTP template
     storage::api& get_local_storage_api();
+    /// Get archival scheduler service
+    archival::internal::scheduler_service_impl& get_scheduler_service() {
+        auto p = reinterpret_cast<archival::internal::scheduler_service_impl*>(
+          &app.archival_scheduler.local());
+        return *p;
+    }
     /// \brief Init storage api for tests that require only storage
     /// The method doesn't add topics, only creates segments in data_dir
     void init_storage_api_local(
@@ -190,6 +201,10 @@ public:
 
     ss::future<> add_topic_with_archival_enabled(
       model::topic_namespace_view tp_ns, int partitions = 1);
+
+    ss::future<> create_archival_snapshot(
+      const storage::ntp_config& cfg,
+      cloud_storage::partition_manifest manifest);
 
 private:
     void initialize_shard(

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -35,10 +35,6 @@ inline seastar::logger arch_svc_log("SVC-TEST");
 static const model::ns test_ns = model::ns("kafka");
 using namespace std::chrono_literals;
 
-static ss::future<> launch_remote(ss::sharded<cloud_storage::remote>& r) {
-    return r.invoke_on(0, [](auto& s) { return s.start(); });
-}
-
 FIXTURE_TEST(test_reconciliation_manifest_download, archiver_fixture) {
     wait_for_controller_leadership().get();
     auto topic1 = model::topic("topic_1");

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+#include "archival/types.h"
+#include "cloud_roles/types.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/controller.h"
 #include "cluster/members_table.h"
@@ -36,6 +38,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "redpanda/application.h"
 #include "resource_mgmt/cpu_scheduling.h"
+#include "s3/client.h"
 #include "storage/directories.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"
@@ -46,6 +49,7 @@
 
 #include <fmt/format.h>
 
+#include <chrono>
 #include <filesystem>
 
 class redpanda_thread_fixture {
@@ -62,7 +66,10 @@ public:
       std::vector<config::seed_server> seed_servers,
       ss::sstring base_dir,
       std::optional<scheduling_groups> sch_groups,
-      bool remove_on_shutdown)
+      bool remove_on_shutdown,
+      std::optional<s3::configuration> s3_config = std::nullopt,
+      std::optional<archival::configuration> archival_cfg = std::nullopt,
+      std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt)
       : app(ssx::sformat("redpanda-{}", node_id()))
       , proxy_port(proxy_port)
       , schema_reg_port(schema_reg_port)
@@ -74,7 +81,10 @@ public:
           kafka_port,
           rpc_port,
           coproc_supervisor_port,
-          std::move(seed_servers));
+          std::move(seed_servers),
+          std::move(s3_config),
+          std::move(archival_cfg),
+          std::move(cloud_cfg));
         app.initialize(
           proxy_config(proxy_port),
           proxy_client_config(kafka_port),
@@ -135,6 +145,25 @@ public:
         std::nullopt,
         true) {}
 
+    struct init_cloud_storage_tag {};
+
+    // Start redpanda with shadow indexing enabled
+    explicit redpanda_thread_fixture(init_cloud_storage_tag)
+      : redpanda_thread_fixture(
+        model::node_id(1),
+        9092,
+        33145,
+        8082,
+        8081,
+        43189,
+        {},
+        ssx::sformat("test.dir_{}", time(0)),
+        std::nullopt,
+        true,
+        get_s3_config(),
+        get_archival_config(),
+        get_cloud_config()) {}
+
     ~redpanda_thread_fixture() {
         shutdown();
         if (remove_on_shutdown) {
@@ -151,19 +180,59 @@ public:
 
     config::configuration& lconf() { return config::shard_local_cfg(); }
 
+    static s3::configuration get_s3_config() {
+        net::unresolved_address server_addr("127.0.0.1", 4430);
+        s3::configuration s3conf{
+          .uri = s3::access_point_uri("127.0.0.1"),
+          .access_key = cloud_roles::public_key_str("acess-key"),
+          .secret_key = cloud_roles::private_key_str("secret-key"),
+          .region = cloud_roles::aws_region_name("us-east-1"),
+        };
+        s3conf.server_addr = server_addr;
+        return s3conf;
+    }
+
+    static archival::configuration get_archival_config() {
+        archival::configuration aconf;
+        aconf.bucket_name = s3::bucket_name("test-bucket");
+        aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
+        aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
+        aconf.cloud_storage_initial_backoff = 100ms;
+        aconf.segment_upload_timeout = 1s;
+        aconf.manifest_upload_timeout = 1s;
+        aconf.time_limit = std::nullopt;
+        return aconf;
+    }
+
+    static cloud_storage::configuration get_cloud_config() {
+        auto s3conf = get_s3_config();
+        cloud_storage::configuration cconf;
+        cconf.client_config = s3conf;
+        cconf.bucket_name = s3::bucket_name("test-bucket");
+        cconf.connection_limit = archival::s3_connection_limit(4);
+        cconf.metrics_disabled = cloud_storage::remote_metrics_disabled::yes;
+        return cconf;
+    }
+
     void configure(
       model::node_id node_id,
       int32_t kafka_port,
       int32_t rpc_port,
       int32_t coproc_supervisor_port,
-      std::vector<config::seed_server> seed_servers) {
+      std::vector<config::seed_server> seed_servers,
+      std::optional<s3::configuration> s3_config = std::nullopt,
+      std::optional<archival::configuration> archival_cfg = std::nullopt,
+      std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt) {
         auto base_path = std::filesystem::path(data_dir);
         ss::smp::invoke_on_all([node_id,
                                 kafka_port,
                                 rpc_port,
                                 coproc_supervisor_port,
                                 seed_servers = std::move(seed_servers),
-                                base_path]() mutable {
+                                base_path,
+                                s3_config,
+                                archival_cfg,
+                                cloud_cfg]() mutable {
             auto& config = config::shard_local_cfg();
 
             config.get("enable_pid_file").set_value(false);
@@ -192,6 +261,48 @@ public:
             node_config.get("coproc_supervisor_server")
               .set_value(
                 net::unresolved_address("127.0.0.1", coproc_supervisor_port));
+            if (s3_config) {
+                config.get("cloud_storage_enabled").set_value(true);
+                config.get("cloud_storage_region")
+                  .set_value(std::make_optional(s3_config->region()));
+                config.get("cloud_storage_access_key")
+                  .set_value(std::make_optional((*s3_config->access_key)()));
+                config.get("cloud_storage_secret_key")
+                  .set_value(std::make_optional((*s3_config->secret_key)()));
+                config.get("cloud_storage_api_endpoint")
+                  .set_value(std::make_optional(s3_config->server_addr.host()));
+                config.get("cloud_storage_api_endpoint_port")
+                  .set_value(
+                    static_cast<int16_t>(s3_config->server_addr.port()));
+            }
+            if (archival_cfg) {
+                config.get("cloud_storage_disable_tls").set_value(true);
+                config.get("cloud_storage_bucket")
+                  .set_value(std::make_optional(archival_cfg->bucket_name()));
+                config.get("cloud_storage_initial_backoff_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->cloud_storage_initial_backoff));
+                config.get("cloud_storage_reconciliation_interval_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->reconciliation_interval));
+                config.get("cloud_storage_manifest_upload_timeout_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->manifest_upload_timeout));
+                config.get("cloud_storage_segment_upload_timeout_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->segment_upload_timeout));
+            }
+            if (cloud_cfg) {
+                config.get("cloud_storage_enable_remote_read").set_value(true);
+                config.get("cloud_storage_enable_remote_write").set_value(true);
+                config.get("cloud_storage_max_connections")
+                  .set_value(
+                    static_cast<int16_t>(cloud_cfg->connection_limit()));
+            }
         }).get0();
     }
 


### PR DESCRIPTION
## Cover letter

Currently, the `ntp_archiver_service` downloads a manifest on startup. If the manifest is corrupted the whole process may crash. Going further, the `ntp_archiver_service` keeps the manifest in memory and applies updates to it. At the same time all updates are added to the `archival_metadata_stm` which has its own copy of the manifest. This manifest is not uploaded to S3 but it's supposed to be the same. It's possible to have a divergence if the manifest in S3 was altered. The archiver will continue using altered manifest but archival snapshot will still hold an original one.

This PR changes this approach.  The archiver is no longer downloading the manifest from S3. Instead, it uses the manifest stored inside the `archival_metadata_stm`. This prevents redpanda crash in case if the state in S3 is corrupted (e.g. the manifest doesn't have valid json).  The archiver only uploads the manifest and never downloads it. This change also lowers the memory usage per partition (the manifests are the main source of memory issues in SI).

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/5ca01ad9992d054a471074f5261a49a0f51fc345..b34b3d10135789eede06aaaf6919eca7af88f003)
* git rebase dev

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/b34b3d10135789eede06aaaf6919eca7af88f003..7f933a5bbbb34f258db19c6d3300060a80fe9752)
* fix code review issues

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/7f933a5bbbb34f258db19c6d3300060a80fe9752..93f5f8054d701ad5884a40805bb41a2cd9f0b8aa)
* fix broken unit-tests

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/93f5f8054d701ad5884a40805bb41a2cd9f0b8aa..24e0d010bebbd694d848e158171bbdf5df8a09ed)
* git rebase dev

Changes in [force push](https://github.com/redpanda-data/redpanda/compare/24e0d010bebbd694d848e158171bbdf5df8a09ed..b101e12073b182f2f0b7e725f008686af9addb66)
* fix code review issue (remove unused function)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Shadow-indexing memory usage is decreased

### Features

* none

### Improvements

*  Improved shadow indexing memory efficiency 
