### PR TITLE
net: Improve IPv6 support

### DIFF
--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -18,3 +18,14 @@ rp_test(
         ARGS "-- -c 8"
         LABELS net
 )
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME dns
+        SOURCES
+        dns.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+        ARGS "-- -c 1"
+        LABELS net
+)

--- a/src/v/net/tests/dns.cc
+++ b/src/v/net/tests/dns.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "net/dns.h"
+
+#include "net/unresolved_address.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+SEASTAR_THREAD_TEST_CASE(dns_resolve) {
+    net::unresolved_address ipv4_addr("127.0.0.1", 19092);
+    auto ipv4 = net::resolve_dns(ipv4_addr).get();
+
+    BOOST_REQUIRE_EQUAL(ipv4.port(), ipv4_addr.port());
+    BOOST_REQUIRE_EQUAL(
+      ipv4.family(), static_cast<short>(ss::net::inet_address::family::INET));
+    BOOST_REQUIRE(ipv4.addr().is_ipv4());
+    BOOST_REQUIRE_EQUAL(ipv4.addr().hostname().get(), "localhost");
+
+    net::unresolved_address ipv6_addr("::1", 19093);
+    auto ipv6 = net::resolve_dns(ipv6_addr).get();
+    BOOST_REQUIRE_EQUAL(ipv6.port(), ipv6_addr.port());
+    BOOST_REQUIRE_EQUAL(
+      ipv6.family(), static_cast<short>(ss::net::inet_address::family::INET6));
+    BOOST_REQUIRE(ipv6.addr().is_ipv6());
+}

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -34,9 +34,7 @@ public:
 
     unresolved_address() = default;
     unresolved_address(
-      ss::sstring host,
-      uint16_t port,
-      inet_family family = ss::net::inet_address::family::INET)
+      ss::sstring host, uint16_t port, inet_family family = std::nullopt)
       : _host(std::move(host))
       , _port(port)
       , _family(family) {}


### PR DESCRIPTION
## Cover letter

Instead of insisting that IP addresses are IPv4 by default, let the implementation figure it out.

This allows to bind addresses to `::` or `::1`, for example:

```yaml
pandaproxy:
  pandaproxy_api:
    - # curl https://[::1]:18082/topics
      address: "::1"
      port: 18082
      name: ipv6_listener
```

### Notes for Reviewer

I'd like to have included tests, but not all systems have IPv6 enabled. I ran this locally:
```c++

#include "net/dns.h"

#include "net/unresolved_address.h"

#include <seastar/testing/thread_test_case.hh>

#include <boost/test/tools/old/interface.hpp>

SEASTAR_THREAD_TEST_CASE(dns_resolve) {
    net::unresolved_address ipv4_addr("127.0.0.1", 19092);
    auto ipv4 = net::resolve_dns(ipv4_addr).get();

    BOOST_REQUIRE_EQUAL(ipv4.port(), ipv4_addr.port());
    BOOST_REQUIRE_EQUAL(
      ipv4.family(), static_cast<short>(ss::net::inet_address::family::INET));
    BOOST_REQUIRE(ipv4.addr().is_ipv4());
    BOOST_REQUIRE_EQUAL(ipv4.addr().hostname().get(), "localhost");

    net::unresolved_address ipv6_addr("::1", 19093);
    auto ipv6 = net::resolve_dns(ipv6_addr).get();
    BOOST_REQUIRE_EQUAL(ipv6.port(), ipv6_addr.port());
    BOOST_REQUIRE_EQUAL(
      ipv6.family(), static_cast<short>(ss::net::inet_address::family::INET6));
    BOOST_REQUIRE(ipv6.addr().is_ipv6());
    BOOST_REQUIRE_EQUAL(ipv6.addr().hostname().get(), "ip6-localhost");

    net::unresolved_address ipv6_addr2("ip6-localhost", 19094);
    ipv6 = net::resolve_dns(ipv6_addr2).get();
    BOOST_REQUIRE_EQUAL(ipv6.port(), ipv6_addr2.port());
    BOOST_REQUIRE_EQUAL(
      ipv6.family(), static_cast<short>(ss::net::inet_address::family::INET6));
    BOOST_REQUIRE(ipv6.addr().is_ipv6());
    BOOST_REQUIRE_EQUAL(ipv6.addr().hostname().get(), "ip6-localhost");
}
```

Signed-off-by: Ben Pope <ben@redpanda.com>
<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## UX changes

This allows to bind addresses to `::` or `::1`, for example:

```yaml
pandaproxy:
  pandaproxy_api:
    - # curl https://[::1]:18082/topics
      address: "::1"
      port: 18082
      name: ipv6_listener
```

## Release notes

### Improvements

* Improve support for IPv6 listeners.
