### PR TITLE
archival: adds segment reupload collection utility

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     probe.cc
     types.cc
     upload_controller.cc
+    segment_reupload.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "segment_reupload.h"
+
+#include "cloud_storage/partition_manifest.h"
+#include "logger.h"
+#include "storage/disk_log_impl.h"
+#include "storage/fs_utils.h"
+
+namespace archival {
+segment_collector::segment_collector(
+  model::offset begin_inclusive,
+  const cloud_storage::partition_manifest* manifest,
+  const storage::disk_log_impl* log,
+  size_t max_uploaded_segment_size)
+  : _begin_inclusive(begin_inclusive)
+  , _manifest(manifest)
+  , _log(log)
+  , _max_uploaded_segment_size(max_uploaded_segment_size) {}
+
+void segment_collector::collect_segments() {
+    if (_manifest->size() == 0) {
+        vlog(
+          archival_log.warn,
+          "No segments to collect for ntp {}",
+          _manifest->get_ntp());
+        return;
+    }
+
+    align_begin_offset_to_manifest();
+
+    if (_begin_inclusive >= _manifest->get_last_offset()) {
+        vlog(
+          archival_log.warn,
+          "Start offset {} is ahead of manifest last offset {} for ntp {}",
+          _begin_inclusive,
+          _manifest->get_last_offset(),
+          _manifest->get_ntp());
+        return;
+    }
+
+    do_collect();
+}
+
+segment_collector::segment_seq segment_collector::segments() {
+    return _segments;
+}
+
+void segment_collector::do_collect() {
+    auto replace_boundary = find_replacement_boundary();
+    auto start = _begin_inclusive;
+    model::offset current_segment_end{0};
+    size_t collected_size = 0;
+    while (current_segment_end < _manifest->get_last_offset()) {
+        auto result = find_next_compacted_segment(start);
+        if (result.segment.get() == nullptr) {
+            break;
+        }
+
+        if (unlikely(!_ntp_cfg)) {
+            _ntp_cfg = result.ntp_conf;
+        }
+
+        auto segment_size = result.segment->size_bytes();
+        if (collected_size + segment_size > _max_uploaded_segment_size) {
+            vlog(
+              archival_log.debug,
+              "Compacted segment collect for ntp {} stopping collection, total "
+              "size: {} will overflow max allowed upload size: {}, current "
+              "collected size: {}",
+              _manifest->get_ntp(),
+              collected_size + segment_size,
+              _max_uploaded_segment_size,
+              collected_size);
+            break;
+        }
+
+        // For the first compacted segment found, begin offset needs to be
+        // re-aligned if it falls inside manifest segment.
+        if (_segments.empty()) {
+            _begin_inclusive = result.segment->offsets().base_offset;
+            align_begin_offset_to_manifest();
+        }
+        _segments.push_back(result.segment);
+        current_segment_end = result.segment->offsets().committed_offset;
+        start = current_segment_end + model::offset{1};
+        collected_size += segment_size;
+    }
+
+    if (current_segment_end >= replace_boundary) {
+        _can_replace_manifest_segment = true;
+    }
+
+    align_end_offset_to_manifest(current_segment_end);
+}
+
+model::offset segment_collector::find_replacement_boundary() const {
+    auto it = _manifest->segment_containing(_begin_inclusive);
+
+    // Crossing this boundary means that the collection can replace at least one
+    // segment in manifest.
+    model::offset replace_boundary;
+
+    // manifest: 10-19, 25-29
+    // _begin_inclusive (in gap): 22.
+    if (it == _manifest->end()) {
+        // first segment after gap: 25-29
+        it = std::find_if(
+          _manifest->begin(), _manifest->end(), [this](const auto& entry) {
+              return entry.first.base_offset > _begin_inclusive;
+          });
+
+        // The collection is valid if it can reach the end of the gap: 24
+        replace_boundary = it->first.base_offset - model::offset{1};
+    } else {
+        replace_boundary = it->second.committed_offset;
+    }
+
+    return replace_boundary;
+}
+
+void segment_collector::align_end_offset_to_manifest(
+  model::offset compacted_segment_end) {
+    if (compacted_segment_end >= _manifest->get_last_offset()) {
+        vlog(
+          archival_log.debug,
+          "Compacted segment collect for ntp {} offset {} advanced "
+          "ahead of manifest, clamping to {}",
+          _manifest->get_ntp(),
+          compacted_segment_end,
+          _manifest->get_last_offset());
+        _end_inclusive = _manifest->get_last_offset();
+    } else {
+        // Align the end offset to the nearest segment ending in manifest.
+        auto it = _manifest->segment_containing(compacted_segment_end);
+        if (it == _manifest->end()) {
+            // compacted_segment_end is in a gap in the manifest.
+            if (
+              compacted_segment_end >= _manifest->get_start_offset().value()) {
+                vlog(
+                  archival_log.info,
+                  "Compacted segment collect for ntp {}: collection ended at "
+                  "gap in manifest: {}",
+                  _manifest->get_ntp(),
+                  compacted_segment_end);
+
+                // try to fill the manifest gap with the data locally available.
+                _end_inclusive = compacted_segment_end;
+            }
+            return;
+        }
+
+        // If the compacted segment end is not aligned to manifest segment, then
+        // pull back to the end of the previous segment.
+        if (it->second.committed_offset == compacted_segment_end) {
+            _end_inclusive = compacted_segment_end;
+        } else {
+            _end_inclusive = it->first.base_offset - model::offset{1};
+        }
+    }
+}
+
+segment_collector::lookup_result
+segment_collector::find_next_compacted_segment(model::offset start_offset) {
+    const auto& segment_set = _log->segments();
+    auto it = segment_set.lower_bound(start_offset);
+    // start_offset < log start due to eviction of compacted segments before
+    // they could be uploaded, skip forward to log start.
+    if (start_offset < _log->offsets().start_offset) {
+        vlog(
+          archival_log.debug,
+          "Finding next compacted segment for {}: start_offset: {} behind log "
+          "start: {}, skipping forward",
+          _manifest->get_ntp(),
+          start_offset,
+          _log->offsets().start_offset);
+        it = segment_set.begin();
+    }
+
+    if (it == segment_set.end()) {
+        vlog(
+          archival_log.debug,
+          "Finding next compacted segment for {}: can't find segment after "
+          "offset: {}",
+          _manifest->get_ntp(),
+          start_offset);
+        return {};
+    }
+
+    const auto& segment = *it;
+    if (segment->finished_self_compaction()) {
+        vlog(
+          archival_log.trace,
+          "Found compacted segment for ntp {}: {}",
+          _manifest->get_ntp(),
+          segment);
+        return {.segment = segment, .ntp_conf = &_log->config()};
+    }
+    vlog(
+      archival_log.debug,
+      "Finding next compacted segment for {}: no compacted "
+      "segments after offset: {}",
+      _manifest->get_ntp(),
+      start_offset);
+    return {};
+}
+
+model::offset segment_collector::begin_inclusive() const {
+    return _begin_inclusive;
+}
+
+model::offset segment_collector::end_inclusive() const {
+    return _end_inclusive;
+}
+
+const storage::ntp_config* segment_collector::ntp_cfg() const {
+    return _ntp_cfg;
+}
+
+bool segment_collector::can_replace_manifest_segment() const {
+    return _can_replace_manifest_segment && _begin_inclusive < _end_inclusive;
+}
+
+cloud_storage::segment_name segment_collector::adjust_segment_name() const {
+    vassert(
+      !_segments.empty(), "Cannot calculate segment name with no segments");
+
+    auto first = _segments.front();
+    auto file_name = first->filename();
+    auto meta = storage::segment_path::parse_segment_filename(file_name);
+    auto version = meta ? meta->version : storage::record_version_type::v1;
+
+    cloud_storage::segment_name name{};
+    if (_begin_inclusive == first->offsets().base_offset) {
+        auto orig_path = std::filesystem::path(file_name);
+        name = cloud_storage::segment_name(orig_path.filename().string());
+        vlog(archival_log.debug, "Using original segment name: {}", name);
+    } else {
+        auto path = storage::segment_path::make_segment_path(
+          *_ntp_cfg, _begin_inclusive, first->offsets().term, version);
+        name = cloud_storage::segment_name(path.filename().string());
+        vlog(archival_log.debug, "Using adjusted segment name: {}", name);
+    }
+
+    return name;
+}
+
+void segment_collector::align_begin_offset_to_manifest() {
+    if (_begin_inclusive >= _manifest->get_last_offset()) {
+        return;
+    }
+
+    if (_begin_inclusive < _manifest->get_start_offset().value()) {
+        vlog(
+          archival_log.debug,
+          "_begin_inclusive is behind manifest for ntp: {}, skipping forward "
+          "to "
+          "start of manifest from: {} to: {}",
+          _manifest->get_ntp(),
+          _begin_inclusive,
+          _manifest->get_start_offset().value());
+
+        // manifest: 10-40
+        // _begin_inclusive: before: 5, after: 10
+        _begin_inclusive = _manifest->get_start_offset().value();
+        return;
+    }
+
+    auto it = _manifest->find(_begin_inclusive);
+
+    // If iterator points to a segment, it means that _begin_inclusive is
+    // aligned on manifest segment boundary, so do nothing. Otherwise, skip
+    // _begin_inclusive to the start of the next manifest segment.
+    if (it == _manifest->end()) {
+        it = _manifest->segment_containing(_begin_inclusive);
+
+        // manifest: 10-19, 25-29
+        // _begin_inclusive (in gap): before: 22, after: 22
+        if (it == _manifest->end()) {
+            vlog(
+              archival_log.debug,
+              "_begin_inclusive lies in manifest gap for ntp: {} "
+              "value: {}",
+              _manifest->get_ntp(),
+              _begin_inclusive);
+            return;
+        }
+
+        // manifest: 10-19, 20-29
+        // _begin_inclusive: before: 15, after: 20 OR
+        // _begin_inclusive: before: 25, after: 30
+        _begin_inclusive = it->second.committed_offset + model::offset{1};
+        vlog(
+          archival_log.debug,
+          "_begin_inclusive skipped to start of next segment for ntp: {} "
+          "to: {}",
+          _manifest->get_ntp(),
+          _begin_inclusive);
+    }
+}
+
+} // namespace archival

--- a/src/v/archival/segment_reupload.h
+++ b/src/v/archival/segment_reupload.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+
+namespace cloud_storage {
+class partition_manifest;
+} // namespace cloud_storage
+
+namespace storage {
+class disk_log_impl;
+class ntp_config;
+class segment;
+} // namespace storage
+
+namespace archival {
+
+class segment_collector {
+public:
+    using segment_seq = std::vector<ss::lw_shared_ptr<storage::segment>>;
+
+    segment_collector(
+      model::offset begin_inclusive,
+      const cloud_storage::partition_manifest* manifest,
+      const storage::disk_log_impl* log,
+      size_t max_uploaded_segment_size);
+
+    void collect_segments();
+
+    segment_seq segments();
+
+    /// Once segments are collected, this query determines if the collected
+    /// segments will be able to replace at least one segment in manifest.
+    bool can_replace_manifest_segment() const;
+
+    /// The starting point for the collection, this may not coincide with the
+    /// start of the first collected compacted segment. It should be aligned
+    /// with the manifest segment boundary.
+    model::offset begin_inclusive() const;
+
+    /// The ending point for the collection, aligned with manifest segment
+    /// boundary.
+    model::offset end_inclusive() const;
+
+    const storage::ntp_config* ntp_cfg() const;
+
+    cloud_storage::segment_name adjust_segment_name() const;
+
+private:
+    struct lookup_result {
+        segment_seq::value_type segment;
+        const storage::ntp_config* ntp_conf;
+    };
+
+    /// Collects compacted segments until the end of the manifest, or until the
+    /// end of compacted segments in log.
+    void do_collect();
+
+    lookup_result find_next_compacted_segment(model::offset start_offset);
+
+    /// Makes sure that the begin offset of the collection is aligned to the
+    /// manifest segment boundary. If the begin offset is inside a manifest
+    /// segment, we advance the offset enough to the beginning of the next
+    /// manifest segment, so that when we re-upload segments there is no
+    /// overlap.
+    void align_begin_offset_to_manifest();
+
+    /// Makes sure that the end offset of the collection is aligned to the
+    /// manifest segment boundary. If the end offset is inside a manifest
+    /// segment, we decrement the offset enough to the end of the previous
+    /// manifest segment, so that when we re-upload segments there is no
+    /// overlap.
+    void align_end_offset_to_manifest(model::offset compacted_segment_end);
+
+    /// Finds the offset which the collection needs to progress upto in order to
+    /// replace at least one manifest segment. The collection is valid if it
+    /// reaches the replacement boundary.
+    model::offset find_replacement_boundary() const;
+
+    model::offset _begin_inclusive;
+    model::offset _end_inclusive;
+
+    const cloud_storage::partition_manifest* _manifest;
+    const storage::disk_log_impl* _log;
+    const storage::ntp_config* _ntp_cfg{};
+    segment_seq _segments;
+    bool _can_replace_manifest_segment{false};
+    size_t _max_uploaded_segment_size;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 rp_test(
   UNIT_TEST
   BINARY_NAME test_archival_service
-  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc
+  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -1,0 +1,713 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/segment_reupload.h"
+#include "cloud_storage/partition_manifest.h"
+#include "storage/log_manager.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+static constexpr std::string_view manifest = R"json({
+    "version": 1,
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 1,
+    "last_offset": 39,
+    "segments": {
+        "10-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 1024,
+            "base_offset": 10,
+            "committed_offset": 19
+        },
+        "20-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 2048,
+            "base_offset": 20,
+            "committed_offset": 29,
+            "max_timestamp": 1234567890
+        },
+        "30-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 4096,
+            "base_offset": 30,
+            "committed_offset": 39,
+            "max_timestamp": 1234567890
+        }
+    }
+})json";
+
+static constexpr std::string_view manifest_with_gaps = R"json({
+    "version": 1,
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 1,
+    "last_offset": 59,
+    "segments": {
+        "10-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 1024,
+            "base_offset": 10,
+            "committed_offset": 19
+        },
+        "30-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 2048,
+            "base_offset": 30,
+            "committed_offset": 39,
+            "max_timestamp": 1234567890
+        },
+        "50-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 4096,
+            "base_offset": 50,
+            "committed_offset": 59,
+            "max_timestamp": 1234567890
+        }
+    }
+})json";
+
+static constexpr size_t max_upload_size{4096_KiB};
+
+ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+/// Specification for the segments and data to go into the log for a test
+struct log_spec {
+    // The base offsets for all segments. The difference in adjacent base
+    // offsets is converted to how many records we will write into each segment
+    // (as a single batch)
+    std::vector<size_t> segment_starts;
+    // The indices of the segments which will be marked as compacted for the
+    // test. The segments are not actually compacted, only marked as such.
+    std::vector<size_t> compacted_segment_indices;
+    // The number of records in the final segment, required separately because
+    // there is no delta to use for the last segment.
+    size_t last_segment_num_records;
+};
+
+storage::disk_log_builder make_log_builder(std::string_view data_path) {
+    return storage::disk_log_builder{storage::log_config{
+      storage::log_config::storage_type::disk,
+      {data_path.data(), data_path.size()},
+      4_KiB,
+      storage::debug_sanitize_files::yes,
+    }};
+}
+
+static void populate_log(storage::disk_log_builder& b, const log_spec& spec) {
+    auto first = spec.segment_starts.begin();
+    auto second = std::next(first);
+    for (; second != spec.segment_starts.end(); ++first, ++second) {
+        auto num_records = *second - *first;
+        b | storage::add_segment(*first)
+          | storage::add_random_batch(*first, num_records);
+    }
+    b | storage::add_segment(*first)
+      | storage::add_random_batch(*first, spec.last_segment_num_records);
+
+    for (auto i : spec.compacted_segment_indices) {
+        b.get_segment(i).mark_as_finished_self_compaction();
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Local disk log starts before manifest and ends after manifest. First
+    // three segments are compacted.
+    populate_log(
+      b,
+      {.segment_starts = {5, 22, 35, 50},
+       .compacted_segment_indices = {0, 1, 2},
+       .last_segment_num_records = 10});
+
+    auto& disk_log = b.get_disk_log_impl();
+
+    archival::segment_collector collector{
+      model::offset{4}, &m, &disk_log, max_upload_size};
+
+    collector.collect_segments();
+
+    // The three compacted segments are collected, with the begin and end
+    // markers set to align with manifest segment.
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
+    BOOST_REQUIRE_EQUAL(3, collector.segments().size());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    {
+        // start ahead of manifest end, no collection happens.
+        archival::segment_collector collector{
+          model::offset{400}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+        collector.collect_segments();
+
+        BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+        auto segments = collector.segments();
+        BOOST_REQUIRE(segments.empty());
+    }
+
+    {
+        // start at manifest end. the collector will advance it first to prevent
+        // overlap. no collection happens.
+        archival::segment_collector collector{
+          model::offset{39}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+        collector.collect_segments();
+
+        BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+        auto segments = collector.segments();
+        BOOST_REQUIRE(segments.empty());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_empty_manifest) {
+    cloud_storage::partition_manifest m;
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    archival::segment_collector collector{
+      model::offset{2}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.segments().empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_short_compacted_segment_inside_manifest_segment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // segment [12-14] lies inside manifest segment [10-19]. start offset 12 is
+    // adjusted to 19+1 = 20 to avoid overlap with manifest segment. no
+    // collection will be done after adjustment.
+    populate_log(
+      b,
+      {.segment_starts = {12},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 2});
+
+    archival::segment_collector collector{
+      model::offset{12}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.segments().empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    populate_log(
+      b,
+      {.segment_starts = {10, 20, 45, 55},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 10});
+
+    archival::segment_collector collector{
+      model::offset{10}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    auto segments = collector.segments();
+    BOOST_REQUIRE_EQUAL(1, segments.size());
+
+    const auto& seg = segments.front();
+    BOOST_REQUIRE_EQUAL(seg->offsets().base_offset, model::offset{10});
+    BOOST_REQUIRE_EQUAL(seg->offsets().committed_offset, model::offset{19});
+}
+
+SEASTAR_THREAD_TEST_CASE(
+  test_short_compacted_segment_aligned_with_manifest_segment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // compacted segment start aligned with manifest segment start, but segment
+    // is too short.
+    populate_log(
+      b,
+      {.segment_starts = {10},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 5});
+
+    archival::segment_collector collector{
+      model::offset{10}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    auto segments = collector.segments();
+    BOOST_REQUIRE_EQUAL(1, segments.size());
+
+    const auto& seg = segments.front();
+    BOOST_REQUIRE_EQUAL(seg->offsets().base_offset, model::offset{10});
+    BOOST_REQUIRE_EQUAL(seg->offsets().committed_offset, model::offset{14});
+}
+
+SEASTAR_THREAD_TEST_CASE(
+  test_many_compacted_segments_make_up_to_manifest_segment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // The compacted segments are small, but combine to cover one
+    // manifest segment.
+    populate_log(
+      b,
+      {.segment_starts = {10, 12, 14, 16, 18},
+       .compacted_segment_indices = {0, 1, 2, 3, 4},
+       .last_segment_num_records = 3});
+
+    archival::segment_collector collector{
+      model::offset{10}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    auto segments = collector.segments();
+    BOOST_REQUIRE_EQUAL(5, segments.size());
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{19});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_compacted_segment_larger_than_manifest_segment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Compacted segment larger than manifest segment, extending out from both
+    // begin and end.
+    populate_log(
+      b,
+      {.segment_starts = {8},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{8}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    auto segments = collector.segments();
+
+    BOOST_REQUIRE_EQUAL(1, segments.size());
+
+    // Begin and end markers are aligned to manifest segment.
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{19});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_collect_capped_by_size) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Normally the greedy collector would pick up all four compacted segments,
+    // but because we restrict size, it will only pick the first three segments.
+    populate_log(
+      b,
+      {.segment_starts = {5, 15, 25, 35, 50, 60},
+       .compacted_segment_indices = {0, 1, 2, 3},
+       .last_segment_num_records = 20});
+
+    size_t max_size = b.get_segment(0).file_size()
+                      + b.get_segment(1).file_size()
+                      + b.get_segment(2).file_size();
+    archival::segment_collector collector{
+      model::offset{5}, &m, &b.get_disk_log_impl(), max_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    auto segments = collector.segments();
+
+    BOOST_REQUIRE_EQUAL(3, segments.size());
+
+    // Begin marker starts on first manifest segment boundary.
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+
+    // End marker ends on second manifest segment boundary.
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{29});
+
+    size_t collected_size = std::transform_reduce(
+      segments.begin(), segments.end(), 0, std::plus<>{}, [](const auto& seg) {
+          return seg->size_bytes();
+      });
+    BOOST_REQUIRE_LE(collected_size, max_size);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_no_compacted_segments) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    populate_log(
+      b,
+      {.segment_starts = {5, 15, 25, 35, 50, 60},
+       .compacted_segment_indices = {},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{5}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+
+    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.segments().empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_name_adjustment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    populate_log(
+      b,
+      {.segment_starts = {8},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{8}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+    auto name = collector.adjust_segment_name();
+    BOOST_REQUIRE_EQUAL(name, cloud_storage::segment_name{"10-0-v1.log"});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_name_no_adjustment) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    populate_log(
+      b,
+      {.segment_starts = {10},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{8}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+    auto name = collector.adjust_segment_name();
+    BOOST_REQUIRE_EQUAL(name, cloud_storage::segment_name{"10-0-v1.log"});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest_with_gaps)).get();
+
+    using namespace storage;
+
+    {
+        temporary_dir tmp_dir("concat_segment_read");
+        auto data_path = tmp_dir.get_path();
+
+        auto b = make_log_builder(data_path.string());
+
+        b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+        auto defer = ss::defer([&b] { b.stop().get(); });
+
+        // The manifest has gap from 20-29. It will be replaced by re-uploaded
+        // data. The re-upload will end at the gap boundary due to adjustment of
+        // end offset.
+        populate_log(
+          b,
+          {.segment_starts = {5, 15, 25, 35, 50, 60},
+           .compacted_segment_indices = {0, 1, 2, 3},
+           .last_segment_num_records = 20});
+
+        size_t max_size = b.get_segment(0).file_size()
+                          + b.get_segment(1).file_size()
+                          + b.get_segment(2).file_size();
+        archival::segment_collector collector{
+          model::offset{5}, &m, &b.get_disk_log_impl(), max_size};
+
+        collector.collect_segments();
+
+        BOOST_REQUIRE(collector.can_replace_manifest_segment());
+        auto segments = collector.segments();
+
+        BOOST_REQUIRE_EQUAL(3, segments.size());
+
+        // Collection start aligned to manifest start at 10
+        BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+
+        // End marker adjusted to the end of the gap.
+        BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{29});
+
+        size_t collected_size = std::transform_reduce(
+          segments.begin(),
+          segments.end(),
+          0,
+          std::plus<>{},
+          [](const auto& seg) { return seg->size_bytes(); });
+        BOOST_REQUIRE_LE(collected_size, max_size);
+    }
+
+    {
+        temporary_dir tmp_dir("concat_segment_read");
+        auto data_path = tmp_dir.get_path();
+
+        auto b = make_log_builder(data_path.string());
+
+        b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+        auto defer = ss::defer([&b] { b.stop().get(); });
+
+        // Re-uploaded segments completely cover gap.
+        populate_log(
+          b,
+          {.segment_starts = {5, 15, 25, 40, 50, 60},
+           .compacted_segment_indices = {0, 1, 2, 3},
+           .last_segment_num_records = 20});
+
+        size_t max_size = b.get_segment(0).file_size()
+                          + b.get_segment(1).file_size()
+                          + b.get_segment(2).file_size();
+        archival::segment_collector collector{
+          model::offset{5}, &m, &b.get_disk_log_impl(), max_size};
+
+        collector.collect_segments();
+
+        BOOST_REQUIRE(collector.can_replace_manifest_segment());
+        auto segments = collector.segments();
+
+        BOOST_REQUIRE_EQUAL(3, segments.size());
+
+        // Collection start aligned to manifest start at 10
+        BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+
+        // End marker adjusted to the end of the gap.
+        BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
+
+        size_t collected_size = std::transform_reduce(
+          segments.begin(),
+          segments.end(),
+          0,
+          std::plus<>{},
+          [](const auto& seg) { return seg->size_bytes(); });
+        BOOST_REQUIRE_LE(collected_size, max_size);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_collection_starts_in_gap) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest_with_gaps)).get();
+
+    using namespace storage;
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Start offset 25 is in gap 20-29. It will be kept as is to reduce the gap
+    // in manifest.
+    populate_log(
+      b,
+      {.segment_starts = {25, 40, 50},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{5}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(1, collector.segments().size());
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{25});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_collection_ends_in_gap) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest_with_gaps)).get();
+
+    using namespace storage;
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // End offset 44 is in gap 40-49. It will be kept as is to reduce the gap
+    // in manifest.
+    populate_log(
+      b,
+      {.segment_starts = {15, 45, 50},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{5}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(1, collector.segments().size());
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{20});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{44});
+}
+
+SEASTAR_THREAD_TEST_CASE(test_compacted_segment_after_manifest_start) {
+    cloud_storage::partition_manifest m;
+    m.update(make_manifest_stream(manifest)).get();
+
+    using namespace storage;
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+
+    auto b = make_log_builder(data_path.string());
+
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // manifest start: 10, compacted segment start: 15, search start: 5
+    // begin offset will be realigned to end of segment 10-19 to avoid overlap.
+    populate_log(
+      b,
+      {.segment_starts = {15, 45, 50},
+       .compacted_segment_indices = {0},
+       .last_segment_num_records = 20});
+
+    archival::segment_collector collector{
+      model::offset{5}, &m, &b.get_disk_log_impl(), max_upload_size};
+
+    collector.collect_segments();
+    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(1, collector.segments().size());
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{20});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
+}

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -177,6 +177,10 @@ public:
         return manifest_type::partition;
     };
 
+    /// Returns an iterator to the segment containing offset o, such that o >=
+    /// segment.base_offset and o <= segment.committed_offset.
+    const_iterator segment_containing(model::offset o) const;
+
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file


### PR DESCRIPTION
## Cover letter

Segment collector allows collecting log segments for re-uploads. It is intended for use with compacted segment reuploads, while also collecting some extra information related to segment alignment with the partition manifest.

A start and end offset is also collected, this is intended to be used to "trim" the collected segments so that the start and end align with the segments in partition manifest.

The invariants required by the collector are that the start offset lies within the manifest, and the manifest is not empty. The collector may skip the start offset forward if it is behind the manifest. If the start offset is ahead of manifest or manifest is empty, no segments are collected.

The segments collected by this object along with the start and end offsets will be used to create the concat segment reader view introduced in an earlier PR.

[force push](https://github.com/redpanda-data/redpanda/compare/aa2922415d1f3a916815da67f63f9db2df964fa2..16eb781b4df9fbd1074c67c4625a1df14c4c731d) gap handling in `segment_containing`, gap handling in collector, tests for gap handling

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
