### PR TITLE
cloud_storage: fix stale materialized segment gc logic when force gc is requested

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -413,7 +413,7 @@ void remote_partition::gc_stale_materialized_segments(bool force_collection) {
       _segments.size());
 
     auto now = ss::lowres_clock::now();
-    auto max_idle = force_collection ? stm_max_idle_time : 0ms;
+    auto max_idle = force_collection ? 0ms : stm_max_idle_time;
 
     std::vector<model::offset> offsets;
     for (auto& st : _materialized) {


### PR DESCRIPTION
## Cover letter

when force_collection is passed to gc stale materialized segments, use a max idle time of 0ms. Otherwise use the preconfigured stm max idle time.

This way when the force param is true, all stale segments are immediately offloaded.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

### Features

* none
