### PR TITLE
Available memory API

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(cloud_roles)
 add_subdirectory(v8_engine)
 add_subdirectory(compat)
 add_subdirectory(rp_util)
+add_subdirectory(resource_mgmt)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -756,6 +756,7 @@ void application::wire_up_runtime_services(model::node_id node_id) {
 
 void application::wire_up_redpanda_services(model::node_id node_id) {
     ss::smp::invoke_on_all([] {
+        resources::available_memory::local().register_metrics();
         return storage::internal::chunks().start();
     }).get();
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -80,37 +80,48 @@ public:
     ss::future<> set_proxy_config(ss::sstring name, std::any val);
     ss::future<> set_proxy_client_config(ss::sstring name, std::any val);
 
-    ss::sharded<features::feature_table> feature_table;
-    ss::sharded<cluster::metadata_cache> metadata_cache;
-    ss::sharded<kafka::group_router> group_router;
-    ss::sharded<cluster::shard_table> shard_table;
-    ss::sharded<storage::api> storage;
-    ss::sharded<storage::node_api> storage_node;
-    std::unique_ptr<coproc::api> coprocessing;
-    ss::sharded<coproc::partition_manager> cp_partition_manager;
-    ss::sharded<cluster::partition_manager> partition_manager;
-    ss::sharded<raft::recovery_throttle> recovery_throttle;
-    ss::sharded<raft::group_manager> raft_group_manager;
-    ss::sharded<cluster::metadata_dissemination_service>
-      md_dissemination_service;
-    ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
-    ss::sharded<kafka::coordinator_ntp_mapper> co_coordinator_ntp_mapper;
-    std::unique_ptr<cluster::controller> controller;
-    ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
     smp_groups smp_service_groups;
-    ss::sharded<kafka::quota_manager> quota_mgr;
-    ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
-    ss::sharded<cloud_storage::remote> cloud_storage_api;
+
+    // Sorted list of services (public members)
+    ss::sharded<archival::scheduler_service> archival_scheduler;
+
+    ss::sharded<cloud_storage::cache> shadow_index_cache;
     ss::sharded<cloud_storage::partition_recovery_manager>
       partition_recovery_manager;
-    ss::sharded<archival::scheduler_service> archival_scheduler;
-    ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
-    ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
-    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
-    ss::sharded<v8_engine::data_policy_table> data_policies;
-    ss::sharded<cloud_storage::cache> shadow_index_cache;
+    ss::sharded<cloud_storage::remote> cloud_storage_api;
+
+    ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
+    ss::sharded<cluster::metadata_cache> metadata_cache;
+    ss::sharded<cluster::metadata_dissemination_service>
+      md_dissemination_service;
     ss::sharded<cluster::node_status_backend> node_status_backend;
     ss::sharded<cluster::node_status_table> node_status_table;
+    ss::sharded<cluster::partition_manager> partition_manager;
+    ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
+    ss::sharded<cluster::shard_table> shard_table;
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+
+    ss::sharded<coproc::partition_manager> cp_partition_manager;
+
+    ss::sharded<features::feature_table> feature_table;
+
+    ss::sharded<kafka::coordinator_ntp_mapper> co_coordinator_ntp_mapper;
+    ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
+    ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
+    ss::sharded<kafka::group_router> group_router;
+    ss::sharded<kafka::quota_manager> quota_mgr;
+    ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
+
+    ss::sharded<raft::group_manager> raft_group_manager;
+    ss::sharded<raft::recovery_throttle> recovery_throttle;
+
+    ss::sharded<storage::api> storage;
+    ss::sharded<storage::node_api> storage_node;
+
+    ss::sharded<v8_engine::data_policy_table> data_policies;
+
+    std::unique_ptr<cluster::controller> controller;
+    std::unique_ptr<coproc::api> coprocessing;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -157,6 +157,17 @@ private:
 
     bool archival_storage_enabled();
 
+    /**
+     * @brief Construct service boilerplate.
+     *
+     * Construct the given service s, calling start with the given arguments
+     * and set up a shutdown callback to stop it.
+     *
+     * Returns the future from start(), typically you'll call get() on it
+     * immediately to wait for creation to complete.
+     *
+     * @return the future returned by start()
+     */
     template<typename Service, typename... Args>
     ss::future<> construct_service(ss::sharded<Service>& s, Args&&... args) {
         auto f = s.start(std::forward<Args>(args)...);

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -5,3 +5,5 @@ v_cc_library(
   DEPS
     Seastar::seastar
   )
+
+add_subdirectory(tests)

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -1,0 +1,7 @@
+v_cc_library(
+  NAME resource_mgmt
+  SRCS
+    available_memory.cc
+  DEPS
+    Seastar::seastar
+  )

--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/available_memory.h"
+
+#include "prometheus/prometheus_sanitize.h"
+#include "seastarx.h"
+
+#include <seastar/core/memory.hh>
+#include <seastar/core/metrics.hh>
+
+#include <fmt/core.h>
+
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+
+namespace resources {
+
+available_memory::deregister_holder
+available_memory::inner_register(const ss::sstring& name, afn&& fn) {
+    auto ret = std::unique_ptr<reporter>(new reporter{name, std::move(fn)});
+    _reporters.push_back(*ret);
+    return ret;
+}
+
+size_t available_memory::available() const {
+    return ss::memory::free_memory() + reclaimable();
+}
+
+size_t available_memory::reclaimable() const {
+    size_t reclaimable = 0;
+    for (const auto& r : _reporters) {
+        reclaimable += r.avail_fn();
+    }
+    return reclaimable;
+}
+
+void available_memory::register_metrics() {
+    if (_metrics) {
+        // already initialized
+        return;
+    }
+    _metrics.emplace().add_group(
+      prometheus_sanitize::metrics_name("memory"),
+      {ss::metrics::make_gauge(
+        "available_memory",
+        [this] { return get_available(); },
+        ss::metrics::description(
+          "Total shard memory potentially available in bytes "
+          "(free_memory plus reclaimable)"))});
+}
+
+thread_local available_memory available_memory::_local_instance;
+
+} // namespace resources

--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -69,11 +69,16 @@ void available_memory::register_metrics() {
     m.groups.add_group(
       prometheus_sanitize::metrics_name("memory"),
       {ss::metrics::make_gauge(
-        "available_memory",
-        [this] { return available(); },
-        ss::metrics::description(
-          "Total shard memory potentially available in bytes "
-          "(free_memory plus reclaimable)"))});
+         "available_memory",
+         [this] { return available(); },
+         ss::metrics::description(
+           "Total shard memory potentially available in bytes "
+           "(free_memory plus reclaimable)")),
+       ss::metrics::make_gauge(
+         "available_memory_low_water_mark",
+         [this] { return available_low_water_mark(); },
+         ss::metrics::description(
+           "The low-water mark for available_memory from process start"))});
 }
 
 thread_local available_memory available_memory::_local_instance;

--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -16,6 +16,7 @@
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
 
 #include <fmt/core.h>
 
@@ -50,11 +51,13 @@ void available_memory::register_metrics() {
         // already initialized
         return;
     }
-    _metrics.emplace().add_group(
+
+    auto& m = _metrics.emplace();
+    m.groups.add_group(
       prometheus_sanitize::metrics_name("memory"),
       {ss::metrics::make_gauge(
         "available_memory",
-        [this] { return get_available(); },
+        [this] { return available(); },
         ss::metrics::description(
           "Total shard memory potentially available in bytes "
           "(free_memory plus reclaimable)"))});

--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -21,11 +21,15 @@
 #include <fmt/core.h>
 
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
 
 namespace resources {
+
+available_memory::available_memory()
+  : _lwm(std::numeric_limits<decltype(_lwm)>::max()) {}
 
 available_memory::deregister_holder
 available_memory::inner_register(const ss::sstring& name, afn&& fn) {
@@ -44,6 +48,15 @@ size_t available_memory::reclaimable() const {
         reclaimable += r.avail_fn();
     }
     return reclaimable;
+}
+
+size_t available_memory::available_low_water_mark() {
+    update_low_water_mark();
+    return _lwm;
+}
+
+void available_memory::update_low_water_mark() {
+    _lwm = std::min(_lwm, available());
 }
 
 void available_memory::register_metrics() {

--- a/src/v/resource_mgmt/available_memory.h
+++ b/src/v/resource_mgmt/available_memory.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/intrusive_list_helpers.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <memory>
+#include <vector>
+
+namespace resources {
+
+class available_memory;
+
+/**
+ * @brief Allows determining the available memory on a shard.
+ *
+ * Available memory is free memory (e.g., as reported by the
+ * seastar allocator) *plus* memory which can be reclaimed.
+ * That is, it is the amount of memory that new allocations can
+ * reasonably expect to be able to use.
+ */
+class available_memory final {
+    // type erased function to report available memory for a
+    // registered reclaimer
+    using afn = ss::noncopyable_function<size_t()>;
+
+    struct reporter {
+        friend available_memory;
+        ss::sstring name;
+        afn avail_fn;
+        intrusive_list_hook hook;
+    };
+
+public:
+    using deregister_holder = std::unique_ptr<reporter>;
+
+    // does not make sense to move or cpoy this object
+    available_memory() = default;
+    available_memory(available_memory&) = delete;
+    available_memory& operator=(const available_memory&) = delete;
+
+    /**
+     * @brief Return the current available memory value.
+     *
+     * Available memory is free memory, plus all the memory that can be in
+     * princple reclaimed from subsystems which have registered a reclaim hook.
+     *
+     * Effectively, this is reclaimable() + ss::memory::stats().free_memory()
+     *
+     * @return size_t the estimated amount of available memory in the system
+     */
+    size_t available() const;
+
+    /**
+     * This method calculates the current reclaimable by polling all the
+     * registered reclaimers for how much reclaimable memory they hold, and
+     * returning the sum of all of these amounts.
+     *
+     * The returned value is the assumed amount of memory that could be released
+     * back to the allocator if all reclaimers did an exhaustive reclaim.
+     */
+    size_t reclaimable() const;
+
+    /**
+     * @brief Register associated metric(s) for available memory.
+     *
+     * This call registers an "available_memory" metric in the default
+     * metric groups, which reports the get_available() call when it is
+     * polled. Without this call, the class still works fine, exposing
+     * its API to callers, but no metrics are created.
+     */
+    void register_metrics();
+
+    /**
+     * @brief Register an available memory reporter.
+     *
+     * A reporter is a component that can reclaim memory, and so needs to
+     * report the amount of reclaimable memory it holds.
+     *
+     * This method returns a deregister_holder, which when destroyed
+     * deregisters this reporter. Typically, this object will be stored as
+     * a memory of the object to which the reporter function points so that
+     * the function does not access a dangling reference after it is destroyed.
+     *
+     * @param name name of the reporter
+     * @param reporter_fn a function which returns the amount of reclaimable
+     * memory held at any moment in time by this reporter
+     * @return an opaque object that deregisters the reporter
+     */
+    template<typename F>
+    [[nodiscard("You need to hold the returned object to maintain "
+                "registration")]] deregister_holder
+    register_reporter(const ss::sstring& name, F reporter_fn) {
+        return inner_register(name, std::move(reporter_fn));
+    }
+
+    /**
+     * @brief Get a reference to the shard-global available_memory instance.
+     *
+     * @return The global available_memory object for this shard.
+     */
+    static available_memory& local() { return _local_instance; }
+
+private:
+    deregister_holder inner_register(const ss::sstring& name, afn&& fn);
+
+    static thread_local available_memory _local_instance;
+
+    intrusive_list<reporter, &reporter::hook> _reporters;
+    std::optional<ss::metrics::metric_groups> _metrics;
+};
+
+} // namespace resources

--- a/src/v/resource_mgmt/available_memory.h
+++ b/src/v/resource_mgmt/available_memory.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/metrics.h"
 #include "utils/intrusive_list_helpers.h"
 
 #include <seastar/core/future.hh>
@@ -119,10 +120,11 @@ public:
 private:
     deregister_holder inner_register(const ss::sstring& name, afn&& fn);
 
-    static thread_local available_memory _local_instance;
+    static thread_local available_memory
+      _local_instance; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     intrusive_list<reporter, &reporter::hook> _reporters;
-    std::optional<ss::metrics::metric_groups> _metrics;
+    std::optional<ssx::metrics::public_metrics_group> _metrics;
 };
 
 } // namespace resources

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME resource_mgmt
+  SOURCES
+    available_memory_test.cc
+  LIBRARIES v::seastar_testing_main v::resource_mgmt
+  LABELS resource_mgmt
+)

--- a/src/v/resource_mgmt/tests/available_memory_test.cc
+++ b/src/v/resource_mgmt/tests/available_memory_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "resource_mgmt/available_memory.h"
+
+#include <seastar/core/memory.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace {
+auto& local() { return resources::available_memory::local(); }
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(check_empty_reporters) {
+    // when no reclaimers are registered, reclaimable should be 0
+    BOOST_CHECK_EQUAL(local().reclaimable(), 0);
+
+    // and available should be equal to seastar free
+    auto free = seastar::memory::stats().free_memory();
+    BOOST_CHECK_EQUAL(local().available(), free);
+}
+
+SEASTAR_THREAD_TEST_CASE(check_with_reporters) {
+    size_t reclaimable = 0;
+    {
+        auto holder = local().register_reporter(
+          "test_reporter", [&] { return reclaimable; });
+
+        BOOST_CHECK_EQUAL(local().reclaimable(), 0);
+
+        reclaimable = 5;
+        BOOST_CHECK_EQUAL(local().reclaimable(), 5);
+
+        reclaimable = 7;
+        BOOST_CHECK_EQUAL(local().reclaimable(), 7);
+
+        {
+            auto holder2 = local().register_reporter(
+              "test_reporter2", [&] { return 2; });
+
+            BOOST_CHECK_EQUAL(local().reclaimable(), 7 + 2);
+        }
+
+        BOOST_CHECK_EQUAL(local().reclaimable(), 7);
+    }
+
+    BOOST_CHECK_EQUAL(local().reclaimable(), 0);
+}

--- a/src/v/resource_mgmt/tests/available_memory_test.cc
+++ b/src/v/resource_mgmt/tests/available_memory_test.cc
@@ -15,9 +15,18 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <memory>
+#include <stdexcept>
+
 namespace {
 auto& local() { return resources::available_memory::local(); }
 } // namespace
+
+// clang is pretty adept at optimizing away heap allocations, when the
+// pointer doens't escape out into the wild, which applies to allocations
+// we want to do here, so we "sink" the value by writing it to a global
+// volatile which prevents optimization.
+void* volatile sink;
 
 SEASTAR_THREAD_TEST_CASE(check_empty_reporters) {
     // when no reclaimers are registered, reclaimable should be 0
@@ -25,6 +34,10 @@ SEASTAR_THREAD_TEST_CASE(check_empty_reporters) {
 
     // and available should be equal to seastar free
     auto free = seastar::memory::stats().free_memory();
+    BOOST_CHECK_EQUAL(local().available(), free);
+    // this second identical check effectively asserts that BOOST_CHECK_EQUAL
+    // does not allocate (or at least does not reduce free memory), which is
+    // required for the remaining tests
     BOOST_CHECK_EQUAL(local().available(), free);
 }
 
@@ -54,3 +67,52 @@ SEASTAR_THREAD_TEST_CASE(check_with_reporters) {
 
     BOOST_CHECK_EQUAL(local().reclaimable(), 0);
 }
+
+// this next test only makes sense if we are using the seastar
+// allocator since otherwise the stats return bogus, fixed values
+#ifndef SEASTAR_DEFAULT_ALLOCATOR
+
+SEASTAR_THREAD_TEST_CASE(check_low_water_mark) {
+    resources::available_memory am;
+
+    auto free = seastar::memory::stats().free_memory();
+    BOOST_CHECK_EQUAL(am.available(), free);
+    BOOST_CHECK_EQUAL(am.reclaimable(), 0);
+
+    // initially the LWM is equal to available since the only update is
+    // within this available_low_water_mark call
+    BOOST_CHECK_EQUAL(am.available_low_water_mark(), free);
+
+    // 500 KB: larger than the small pool threshold, otherwise available may not
+    // decrease
+    constexpr size_t large_size = 500 * 1000;
+    auto bytes = std::make_unique<char[]>(large_size);
+    sink = bytes.get();
+
+    auto free_after = am.available();
+    auto lwm_after = am.available_low_water_mark();
+    BOOST_CHECK(free - free_after >= large_size);
+    BOOST_CHECK_EQUAL(free_after, lwm_after);
+
+    // free the bytes, we expect free to rebound but lwm unchanged
+    bytes.reset();
+    BOOST_CHECK_EQUAL(free, am.available());
+    BOOST_CHECK_EQUAL(lwm_after, am.available_low_water_mark());
+
+    // check that a large allocation without any corresponding
+    // update_low_water_mark() call is "invisble" to the LVM
+    bytes = std::make_unique<char[]>(large_size * 2);
+    BOOST_CHECK(am.available() < free_after);
+    bytes.reset();
+    BOOST_CHECK_EQUAL(lwm_after, am.available_low_water_mark());
+
+    // same as the last case, but this time we call update, so expect
+    // the LWM to drop
+    bytes = std::make_unique<char[]>(large_size * 2);
+    BOOST_CHECK(am.available() < free_after);
+    am.update_low_water_mark();
+    bytes.reset();
+    BOOST_CHECK(am.available_low_water_mark() < lwm_after);
+}
+
+#endif

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "ssx/sformat.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/future.hh>

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -44,6 +44,7 @@ v_cc_library(
     v::syschecks
     v::compression
     v::rprandom
+    v::resource_mgmt
     absl::flat_hash_map
     absl::btree
     Roaring::roaring

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -202,6 +202,12 @@ void batch_cache::evict(range_ptr&& e) {
 }
 
 size_t batch_cache::reclaim(size_t size) {
+    // update the available_memory low-water mark: this is a good place to do
+    // this because under memory pressure the reclaimer will be called
+    // frequently so we expect the LWM to track closely the true LWM if we
+    // update it here
+    resources::available_memory().update_low_water_mark();
+
     if (is_memory_reclaiming()) {
         return 0;
     }

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -11,7 +11,9 @@
 
 #include "bytes/iobuf_parser.h"
 #include "model/adl_serde.h"
+#include "resource_mgmt/available_memory.h"
 #include "ssx/future-util.h"
+#include "storage/logger.h"
 #include "utils/gate_guard.h"
 #include "utils/to_string.h"
 #include "vassert.h"
@@ -115,6 +117,24 @@ uint32_t batch_cache::range::add(const model::record_batch& b) {
     _offsets.push_back(b.base_offset());
 
     return offset;
+}
+
+static resources::available_memory::deregister_holder
+register_memory_reporter(const batch_cache& bc) {
+    auto& ab = resources::available_memory::local();
+    return ab.register_reporter(
+      "batch_cache", [&bc] { return bc.size_bytes(); });
+}
+
+batch_cache::batch_cache(const reclaim_options& opts)
+  : _reclaimer(
+    [this](reclaimer::request r) { return reclaim(r); }, reclaim_scope::sync)
+  , _reclaim_opts(opts)
+  , _reclaim_size(_reclaim_opts.min_size)
+  , _background_reclaimer(
+      *this, opts.min_free_memory, opts.background_reclaimer_sg)
+  , _available_mem_deregister(register_memory_reporter(*this)) {
+    _background_reclaimer.start();
 }
 
 batch_cache::entry


### PR DESCRIPTION
Introduce available_memory API and metric.

Available memory is free memory (e.g., as reported by the
seastar allocator) *plus* memory which can be reclaimed.

That is, it is the amount of memory that new allocations can
reasonably expect to be able to use without suffering an allocation
failure.

This change adds an available_memory class, which exposes an API to
return the estimated amount of available memory, as
described above. It keeps a list of reclaimers which must
register with it to provide their estimate of relcaimable memory.

Currently there is only one such reclaimer: the batch cache,
which already knows how much memory it is holding.

Fixes https://github.com/redpanda-data/core-internal/issues/103


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
