### PR TITLE
[v22.2.x] cloud_storage: fix stale materialized segment gc logic when force gc is requested

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -413,7 +413,7 @@ void remote_partition::gc_stale_materialized_segments(bool force_collection) {
       _segments.size());
 
     auto now = ss::lowres_clock::now();
-    auto max_idle = force_collection ? stm_max_idle_time : 0ms;
+    auto max_idle = force_collection ? 0ms : stm_max_idle_time;
 
     std::vector<model::offset> offsets;
     for (auto& st : _materialized) {


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6568.
