### PR TITLE
[v22.2.x] Validate under replicated metric after consumer is done

### DIFF
--- a/tests/rptest/tests/cluster_metadata_test.py
+++ b/tests/rptest/tests/cluster_metadata_test.py
@@ -79,4 +79,4 @@ class MetadataTest(RedpandaTest):
                 returned_ids = [n.id for n in nodes]
                 return len(nodes) == 2 and node_id not in returned_ids
 
-            wait_until(contains_only_alive_nodes, 30, 1)
+            wait_until(contains_only_alive_nodes, 60)

--- a/tests/rptest/tests/full_node_recovery_test.py
+++ b/tests/rptest/tests/full_node_recovery_test.py
@@ -107,13 +107,13 @@ class FullNodeRecoveryTest(EndToEndTest):
                 f"under replicated partitions: {list(under_replicated)}")
             return len(under_replicated) == 0
 
-        # wait for prepopulated topic to recover
-        wait_until(all_topics_recovered, 60, 1)
-
         self.run_validation(min_records=20000,
                             enable_idempotence=False,
                             producer_timeout_sec=60,
                             consumer_timeout_sec=180)
+
+        # wait for prepopulated topic to recover
+        wait_until(all_topics_recovered, 60, 1)
 
         # validate prepopulated topic offsets
         assert offsets == list_offsets()


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6184.
Fixes https://github.com/redpanda-data/redpanda/issues/6582,