### PR TITLE
Fix bug for incorrect parsing of flex requests when client id is missing or null

### DIFF
--- a/src/v/coproc/tests/kafka_api_materialized_tests.cc
+++ b/src/v/coproc/tests/kafka_api_materialized_tests.cc
@@ -24,9 +24,11 @@
 #include <boost/test/unit_test_log.hpp>
 
 static kafka::client::transport make_kafka_client() {
-    return kafka::client::transport(net::base_transport::configuration{
-      .server_addr = config::node().kafka_api()[0].address,
-    });
+    return kafka::client::transport(
+      net::base_transport::configuration{
+        .server_addr = config::node().kafka_api()[0].address,
+      },
+      "test_client");
 }
 
 class push_some_data_fixture : public coproc_test_fixture {

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -25,10 +25,12 @@ ss::future<shared_broker_t> make_broker(
   const configuration& config) {
     return cluster::maybe_build_reloadable_certificate_credentials(
              config.broker_tls())
-      .then([addr](ss::shared_ptr<ss::tls::certificate_credentials> creds) {
+      .then([addr, client_id = config.client_identifier()](
+              ss::shared_ptr<ss::tls::certificate_credentials> creds) mutable {
           return ss::make_lw_shared<transport>(
             net::base_transport::configuration{
-              .server_addr = addr, .credentials = std::move(creds)});
+              .server_addr = addr, .credentials = std::move(creds)},
+            std::move(client_id));
       })
       .then([node_id, addr](ss::lw_shared_ptr<transport> client) {
           return client->connect().then(

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -107,6 +107,12 @@ configuration::configuration()
       "scram_password",
       "Password to use for SCRAM authentication mechanisms",
       {.secret = config::is_secret::yes},
-      "") {}
+      "")
+  , client_identifier(
+      *this,
+      "client_identifier",
+      "Identifier to use within the kafka request header",
+      {},
+      "test_client") {}
 
 } // namespace kafka::client

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -43,6 +43,8 @@ struct configuration final : public config::config_store {
     config::property<ss::sstring> scram_username;
     config::property<ss::sstring> scram_password;
 
+    config::property<std::optional<ss::sstring>> client_identifier;
+
     configuration();
     explicit configuration(const YAML::Node& cfg);
 };

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -110,7 +110,13 @@ private:
     }
 
 public:
-    using net::base_transport::base_transport;
+    // using net::base_transport::base_transport;
+
+    transport(
+      net::base_transport::configuration c,
+      std::optional<ss::sstring> client_id)
+      : net::base_transport(c)
+      , _client_id(std::move(client_id)) {}
 
     /*
      * TODO: the concept here can be improved once we convert all of the request
@@ -206,7 +212,7 @@ private:
         wr.write(int16_t(key()));
         wr.write(int16_t(version()));
         wr.write(int32_t(_correlation()));
-        wr.write(std::string_view("test_client"));
+        wr.write(_client_id);
         vassert(
           flex_versions::is_api_in_schema(key),
           "Attempted to send request to non-existent API: {}",
@@ -220,6 +226,7 @@ private:
     }
 
     correlation_id _correlation{0};
+    std::optional<ss::sstring> _client_id;
 };
 
 } // namespace kafka::client

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -261,11 +261,13 @@ public:
           });
     }
 
-    ss::future<kafka::client::transport> make_kafka_client() {
+    ss::future<kafka::client::transport>
+    make_kafka_client(std::optional<ss::sstring> client_id = "test_client") {
         return ss::make_ready_future<kafka::client::transport>(
           net::base_transport::configuration{
             .server_addr = config::node().kafka_api()[0].address,
-          });
+          },
+          std::move(client_id));
     }
 
     model::ntp


### PR DESCRIPTION
## Cover Letter

A community member noticed that when making flex requests with a missing or null client id, the request would fail. @dotnwat identified the failure coming from parsing of the api_versions_request.

## Investigation

Using the supplied reproducer from the github issue (https://github.com/redpanda-data/redpanda/issues/6570), I easily reproduced the issue and observed that the cause of the bug was indeed with redpanda's flex implementation, specifically when parsing the request header. There is a conditional which returns the header when it is null or empty (https://github.com/redpanda-data/redpanda/blob/dev/src/v/kafka/server/protocol_utils.cc#L49). This return skips further processing of the header, for which is necessary for flex, in particular the flex request tag fields section, which is guaranteed to at least have 1 byte (0) when there are no tags present in the header.

## Observation

The request continues to be processed however the internal iterator is now pointing to the wrong byte in the buffer since it wasn't incremented due to skipping the tags section. Therefore exceptions may be observed when deserializing the rest of the request, due to aforementioned inconsistencies. In the issue reported, the next field to be parsed was a flex string for which 0 is an invalid size for. The internal pointer, not having moving passed the tags field, reads 0, and interprets it as a null size for a non null flex string, and an exception is thrown.