### PR TITLE
cloud_storage: Use strong offset types in SI

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -523,8 +523,10 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
     auto offset = upload.final_offset;
     auto base = upload.starting_offset;
     start_upload_offset = offset + model::offset(1);
-    auto delta
-      = base - _partition->get_offset_translator_state()->from_log_offset(base);
+    auto delta = base
+                 - model::offset_cast(
+                   _partition->get_offset_translator_state()->from_log_offset(
+                     base));
 
     auto segment_lock_deadline = std::chrono::steady_clock::now()
                                  + _segment_upload_timeout;

--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -29,7 +29,7 @@ ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
     retry_chain_logger ctxlog(cst_log, fib);
     auto removed = _initial_delta;
     vassert(
-      removed != model::offset::min(),
+      removed != model::offset_delta::min(),
       "Can't copy segment with initial delta {}",
       removed);
     model::offset min_offset = model::offset::max();
@@ -44,7 +44,7 @@ ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
             return storage::batch_consumer::consume_result::skip_batch;
         }
         auto old_offset = hdr.base_offset;
-        hdr.base_offset = hdr.base_offset - removed;
+        hdr.base_offset = kafka::offset_cast(hdr.base_offset - removed);
 
         min_offset = std::min(min_offset, hdr.base_offset);
         max_offset = std::max(max_offset, hdr.last_offset());

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -28,7 +28,7 @@ namespace cloud_storage {
 class offset_translator final {
 public:
     offset_translator(
-      model::offset initial_delta,
+      model::offset_delta initial_delta,
       storage::opt_abort_source_t as = std::nullopt)
       : _initial_delta(initial_delta)
       , _as(as) {}
@@ -55,7 +55,7 @@ public:
       const partition_manifest::key& s, retry_chain_node& fib) const;
 
 private:
-    model::offset _initial_delta;
+    model::offset_delta _initial_delta;
     storage::opt_abort_source_t _as;
 };
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -488,7 +488,7 @@ struct partition_manifest_handler
             } else if ("max_timestamp" == _segment_meta_key) {
                 _max_timestamp = model::timestamp(u);
             } else if ("delta_offset" == _segment_meta_key) {
-                _delta_offset = model::offset(u);
+                _delta_offset = model::offset_delta(u);
             } else if ("ntp_revision" == _segment_meta_key) {
                 _ntp_revision = model::initial_revision_id(u);
             } else if ("archiver_term" == _segment_meta_key) {
@@ -527,7 +527,8 @@ struct partition_manifest_handler
                 model::timestamp::missing()),
               .max_timestamp = _max_timestamp.value_or(
                 model::timestamp::missing()),
-              .delta_offset = _delta_offset.value_or(model::offset::min()),
+              .delta_offset = _delta_offset.value_or(
+                model::offset_delta::min()),
               .ntp_revision = _ntp_revision.value_or(
                 _revision_id.value_or(model::initial_revision_id())),
               .archiver_term = _archiver_term.value_or(model::term_id{})};
@@ -629,7 +630,7 @@ struct partition_manifest_handler
     // optional segment meta fields
     std::optional<model::timestamp> _base_timestamp;
     std::optional<model::timestamp> _max_timestamp;
-    std::optional<model::offset> _delta_offset;
+    std::optional<model::offset_delta> _delta_offset;
     std::optional<model::initial_revision_id> _ntp_revision;
     std::optional<model::term_id> _archiver_term;
 
@@ -803,7 +804,7 @@ void partition_manifest::serialize(std::ostream& out) const {
                 w.Key("max_timestamp");
                 w.Int64(meta.max_timestamp.value());
             }
-            if (meta.delta_offset != model::offset::min()) {
+            if (meta.delta_offset != model::offset_delta::min()) {
                 w.Key("delta_offset");
                 w.Int64(meta.delta_offset());
             }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -76,7 +76,7 @@ public:
         model::offset committed_offset;
         model::timestamp base_timestamp;
         model::timestamp max_timestamp;
-        model::offset delta_offset;
+        model::offset_delta delta_offset;
 
         model::initial_revision_id ntp_revision;
         model::term_id archiver_term;

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -355,7 +355,7 @@ partition_downloader::download_log_with_capped_size(
     size_t total_size = 0;
     std::deque<segment> staged_downloads;
     model::offset start_offset{0};
-    model::offset start_delta{0};
+    model::offset_delta start_delta{0};
     for (auto it = offset_map.rbegin(); it != offset_map.rend(); it++) {
         const auto& meta = it->second.meta;
         if (total_size > max_size) {
@@ -375,8 +375,9 @@ partition_downloader::download_log_with_capped_size(
         staged_downloads.push_front(it->second);
         total_size += meta.size_bytes;
         start_offset = meta.base_offset;
-        start_delta = meta.delta_offset == model::offset() ? start_delta
-                                                           : meta.delta_offset;
+        start_delta = meta.delta_offset == model::offset_delta()
+                        ? start_delta
+                        : meta.delta_offset;
     }
     vlog(
       _ctxlog.info,
@@ -447,7 +448,7 @@ partition_downloader::download_log_with_capped_time(
 
     std::deque<segment> staged_downloads;
     model::offset start_offset{0};
-    model::offset start_delta{0};
+    model::offset_delta start_delta{0};
     for (auto it = offset_map.rbegin(); it != offset_map.rend(); it++) {
         const auto& meta = it->second.meta;
         if (
@@ -470,8 +471,9 @@ partition_downloader::download_log_with_capped_time(
         }
         staged_downloads.push_front(it->second);
         start_offset = meta.base_offset;
-        start_delta = meta.delta_offset == model::offset() ? start_delta
-                                                           : meta.delta_offset;
+        start_delta = meta.delta_offset == model::offset_delta()
+                        ? start_delta
+                        : meta.delta_offset;
     }
     vlog(
       _ctxlog.info,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -180,7 +180,7 @@ public:
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
     /// Return first uploaded kafka offset
-    model::offset first_uploaded_offset();
+    kafka::offset first_uploaded_offset();
 
     /// Return last uploaded kafka offset
     model::offset last_uploaded_offset();
@@ -192,7 +192,7 @@ public:
     bool is_data_available() const;
 
     // returns term last kafka offset
-    std::optional<model::offset> get_term_last_offset(model::term_id) const;
+    std::optional<kafka::offset> get_term_last_offset(model::term_id) const;
 
     // Get list of aborted transactions that overlap with the offset range
     ss::future<std::vector<model::tx_range>>
@@ -216,7 +216,7 @@ private:
         explicit offloaded_segment_state(model::offset bo);
 
         std::unique_ptr<materialized_segment_state>
-        materialize(remote_partition& p, model::offset offset_key);
+        materialize(remote_partition& p, kafka::offset offset_key);
 
         ss::future<> stop();
 
@@ -236,7 +236,7 @@ private:
     /// remote segment.
     struct materialized_segment_state {
         materialized_segment_state(
-          model::offset bo, model::offset offk, remote_partition& p);
+          model::offset bo, kafka::offset offk, remote_partition& p);
 
         void return_reader(std::unique_ptr<remote_segment_batch_reader> reader);
 
@@ -254,7 +254,7 @@ private:
         /// Base offsetof the segment
         model::offset base_rp_offset;
         /// Key of the segment in _segments collection of the remote_partition
-        model::offset offset_key;
+        kafka::offset offset_key;
         ss::lw_shared_ptr<remote_segment> segment;
         /// Batch readers that can be used to scan the segment
         std::list<std::unique_ptr<remote_segment_batch_reader>> readers;
@@ -274,7 +274,7 @@ private:
       "segment_state has unexpected size");
 
     using iterator
-      = details::btree_map_stable_iterator<model::offset, segment_state>;
+      = details::btree_map_stable_iterator<kafka::offset, segment_state>;
 
     /// Materialize segment if needed and create a reader
     ///
@@ -283,7 +283,7 @@ private:
     /// \param st is a segment state referenced by offset_key
     std::unique_ptr<remote_segment_batch_reader> borrow_reader(
       storage::log_reader_config config,
-      model::offset offset_key,
+      kafka::offset offset_key,
       segment_state& st);
 
     /// Return reader back to segment_state
@@ -304,9 +304,9 @@ private:
     /// Iterators used by the partition_record_batch_reader_impl class
     iterator begin();
     iterator end();
-    iterator upper_bound(model::offset);
+    iterator upper_bound(kafka::offset);
 
-    using segment_map_t = absl::btree_map<model::offset, segment_state>;
+    using segment_map_t = absl::btree_map<kafka::offset, segment_state>;
 
     using evicted_resource_t = std::variant<
       std::unique_ptr<remote_segment_batch_reader>,

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -86,13 +86,13 @@ public:
 
     /// Number of non-data batches in all previous
     /// segments
-    const model::offset get_base_offset_delta() const;
+    const model::offset_delta get_base_offset_delta() const;
 
     /// Get base offset of the segment (redpanda offset)
     const model::offset get_base_rp_offset() const;
 
     /// Get base offset of the segment (kafka offset)
-    const model::offset get_base_kafka_offset() const;
+    const kafka::offset get_base_kafka_offset() const;
 
     ss::future<> stop();
 
@@ -104,12 +104,12 @@ public:
     struct input_stream_with_offsets {
         ss::input_stream<char> stream;
         model::offset rp_offset;
-        model::offset kafka_offset;
+        kafka::offset kafka_offset;
     };
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
     ss::future<input_stream_with_offsets>
-    offset_data_stream(model::offset kafka_offset, ss::io_priority_class);
+    offset_data_stream(kafka::offset kafka_offset, ss::io_priority_class);
 
     /// Hydrate the segment
     ss::future<> hydrate();
@@ -129,7 +129,7 @@ private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available
     std::optional<offset_index::find_result>
-    maybe_get_offsets(model::offset kafka_offset);
+    maybe_get_offsets(kafka::offset kafka_offset);
 
     /// Run hydration loop. The method is supposed to be constantly running
     /// in the background. The background loop is triggered by the condition
@@ -162,7 +162,7 @@ private:
 
     model::term_id _term;
     model::offset _base_rp_offset;
-    model::offset _base_offset_delta;
+    model::offset_delta _base_offset_delta;
     model::offset _max_rp_offset;
 
     retry_chain_node _rtc;
@@ -257,7 +257,7 @@ private:
     std::unique_ptr<storage::continuous_batch_parser> _parser;
     model::term_id _term;
     model::offset _cur_rp_offset;
-    model::offset _cur_delta;
+    model::offset_delta _cur_delta;
     size_t _bytes_consumed{0};
     ss::gate _gate;
     bool _stopped{false};

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -355,7 +355,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_segment_meta_update) {
          model::offset(19),
          model::timestamp(123456),
          model::timestamp(123456789),
-         model::offset(12313),
+         model::offset_delta(12313),
          model::initial_revision_id(3),
          model::term_id(3)}}};
 
@@ -397,7 +397,7 @@ SEASTAR_THREAD_TEST_CASE(test_metas_get_smaller) {
          .committed_offset = model::offset(19),
          .base_timestamp = model::timestamp(123456),
          .max_timestamp = model::timestamp(123456789),
-         .delta_offset = model::offset(12313),
+         .delta_offset = model::offset_delta(12313),
          .ntp_revision = model::initial_revision_id(3),
          .archiver_term = model::term_id(3)}},
       {"20-1-v1.log",
@@ -578,7 +578,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_meta_serde_compat) {
       .committed_offset = model::offset{34},
       .base_timestamp = timestamp,
       .max_timestamp = timestamp,
-      .delta_offset = model::offset{7},
+      .delta_offset = model::offset_delta{7},
       .ntp_revision = model::initial_revision_id{42},
       .archiver_term = model::term_id{123},
     };
@@ -595,7 +595,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_meta_serde_compat) {
       .committed_offset = meta_new.committed_offset,
       .base_timestamp = meta_new.base_timestamp,
       .max_timestamp = meta_new.max_timestamp,
-      .delta_offset = meta_new.delta_offset,
+      .delta_offset = model::offset_cast(meta_new.delta_offset),
     };
 
     BOOST_CHECK(

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -210,7 +210,7 @@ make_imposter_expectations(
           .committed_offset = s.max_offset,
           .base_timestamp = {},
           .max_timestamp = {},
-          .delta_offset = model::offset(delta),
+          .delta_offset = model::offset_delta(delta),
           .ntp_revision = m.get_revision_id(),
         };
         m.add(s.sname, meta);

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -33,10 +33,10 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     // rows + almost full buffer.
     size_t segment_num_batches = 1023;
     model::offset segment_base_rp_offset{1234};
-    model::offset segment_base_kaf_offset{1210};
+    kafka::offset segment_base_kaf_offset{1210};
 
     std::vector<model::offset> rp_offsets;
-    std::vector<model::offset> kaf_offsets;
+    std::vector<kafka::offset> kaf_offsets;
     std::vector<size_t> file_offsets;
     int64_t rp = segment_base_rp_offset();
     int64_t kaf = segment_base_kaf_offset();
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     for (size_t i = 0; i < segment_num_batches; i++) {
         if (!is_config) {
             rp_offsets.push_back(model::offset(rp));
-            kaf_offsets.push_back(model::offset(kaf));
+            kaf_offsets.push_back(kafka::offset(kaf));
             file_offsets.push_back(fpos);
         }
         // The test queries every element using the key that matches the element
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     offset_index tmp_index(
       segment_base_rp_offset, segment_base_kaf_offset, 0U, 1000);
     model::offset last;
-    model::offset klast;
+    kafka::offset klast;
     size_t flast;
     for (size_t i = 0; i < rp_offsets.size(); i++) {
         tmp_index.add(rp_offsets.at(i), kaf_offsets.at(i), file_offsets.at(i));
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     BOOST_REQUIRE(!opt_first.has_value());
 
     auto kopt_first = index.find_kaf_offset(
-      segment_base_kaf_offset - model::offset(1));
+      segment_base_kaf_offset - kafka::offset(1));
     BOOST_REQUIRE(!kopt_first.has_value());
 
     for (unsigned ix = 0; ix < rp_offsets.size(); ix++) {
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     BOOST_REQUIRE_EQUAL(kaf_last, klast);
     BOOST_REQUIRE_EQUAL(file_last, flast);
 
-    auto kopt_last = index.find_kaf_offset(klast + model::offset(1));
+    auto kopt_last = index.find_kaf_offset(klast + kafka::offset(1));
     BOOST_REQUIRE_EQUAL(kopt_last->rp_offset, last);
     BOOST_REQUIRE_EQUAL(kopt_last->kaf_offset, klast);
     BOOST_REQUIRE_EQUAL(kopt_last->file_pos, flast);
@@ -114,6 +114,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
 
 SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     static const model::offset base_offset{100};
+    static const kafka::offset kbase_offset{100};
     std::vector<batch_t> batches;
     for (int i = 0; i < 1000; i++) {
         auto num_records = random_generators::get_int(1, 20);
@@ -130,21 +131,23 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     }
     auto segment = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
-    offset_index ix(base_offset, base_offset, 0, 0);
+    offset_index ix(base_offset, kbase_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(
-      std::move(is), ix, model::offset(0), 0);
+      std::move(is), ix, model::offset_delta(0), 0);
     auto result = parser->consume().get();
     BOOST_REQUIRE(result.has_value());
     BOOST_REQUIRE(result.value() != 0);
     parser->close().get();
 
     auto offset = base_offset;
+    auto koffset = kbase_offset;
     for (const auto& batch : batches) {
         auto res = ix.find_rp_offset(offset + model::offset(1));
         BOOST_REQUIRE(res.has_value());
         BOOST_REQUIRE_EQUAL(res->rp_offset, offset);
-        BOOST_REQUIRE_EQUAL(res->kaf_offset, offset);
+        BOOST_REQUIRE_EQUAL(res->kaf_offset, koffset);
 
         offset += batch.num_records;
+        koffset += batch.num_records;
     }
 }

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -96,7 +96,7 @@ FIXTURE_TEST(
       .committed_offset = model::offset(20),
       .base_timestamp = {},
       .max_timestamp = {},
-      .delta_offset = model::offset(0),
+      .delta_offset = model::offset_delta(0),
       .ntp_revision = segment_ntp_revision};
     auto path = m.generate_segment_path(key, meta);
     auto upl_res = remote
@@ -137,7 +137,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
         .committed_offset = model::offset(123),
         .base_timestamp = {},
         .max_timestamp = {},
-        .delta_offset = model::offset(0),
+        .delta_offset = model::offset_delta(0),
         .ntp_revision = manifest_revision});
 
     retry_chain_node fib(100ms, 20ms);
@@ -166,7 +166,7 @@ FIXTURE_TEST(
       .committed_offset = model::offset(100),
       .base_timestamp = {},
       .max_timestamp = {},
-      .delta_offset = model::offset(0),
+      .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
     auto path = m.generate_segment_path(key, meta);
     uint64_t clen = segment_bytes.size_bytes();
@@ -254,7 +254,7 @@ void test_remote_segment_batch_reader(
       .committed_offset = headers.back().last_offset(),
       .base_timestamp = {},
       .max_timestamp = {},
-      .delta_offset = model::offset(0),
+      .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
     auto path = m.generate_segment_path(key, meta);
     auto reset_stream = make_reset_fn(segment_bytes);
@@ -366,7 +366,7 @@ FIXTURE_TEST(
       .committed_offset = headers.back().last_offset(),
       .base_timestamp = {},
       .max_timestamp = {},
-      .delta_offset = model::offset(0),
+      .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
     auto path = m.generate_segment_path(key, meta);
     auto reset_stream = make_reset_fn(segment_bytes);

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -95,8 +95,8 @@ struct configuration {
 };
 
 struct offset_range {
-    model::offset begin;
-    model::offset end;
+    kafka::offset begin;
+    kafka::offset end;
     model::offset begin_rp;
     model::offset end_rp;
 };

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -140,7 +140,8 @@ model::offset partition::start_cloud_offset() const {
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return _cloud_storage_partition->first_uploaded_offset();
+    return kafka::offset_cast(
+      _cloud_storage_partition->first_uploaded_offset());
 }
 
 model::offset partition::last_cloud_offset() const {
@@ -348,7 +349,7 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
     }
     // Kafka defines leader epoch last offset as a first offset of next leader
     // epoch
-    return model::next_offset(*o);
+    return model::next_offset(kafka::offset_cast(*o));
 }
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -204,8 +204,8 @@ replicated_partition::aborted_transactions(
     auto base_rp = ot_state->to_log_offset(base);
     auto last_rp = ot_state->to_log_offset(last);
     cloud_storage::offset_range offsets = {
-      .begin = base,
-      .end = last,
+      .begin = model::offset_cast(base),
+      .end = model::offset_cast(last),
       .begin_rp = base_rp,
       .end_rp = last_rp,
     };


### PR DESCRIPTION
## Cover letter

Use `kafka::offset` and newly introduced `model::offset_delta` types to represent kafka offsets and offset deltas in SI.
SI is doing offset translation independently from kafka layer, so it is notoriously difficult to deal with because of that.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
* 
## Release notes


* none

### Features

* none

### Improvements

* none
