### PR TITLE
Made upgrade test sequential consumer logs more verbose

### DIFF
--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -159,11 +159,12 @@ public:
     ss::future<response_ptr> respond(ResponseType r) {
         vlog(
           klog.trace,
-          "[{}:{}] sending {}:{} response {}",
+          "[{}:{}] sending {}:{} for {}, response {}",
           _conn->client_host(),
           _conn->client_port(),
           ResponseType::api_type::key,
           ResponseType::api_type::name,
+          _header.client_id,
           r);
         /// KIP-511 bumps api_versions_request/response to 3, past the first
         /// supported flex version for this API, and makes an exception

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -31,7 +31,8 @@ class KgoVerifierService(Service):
     To validate produced record user should run consumer and producer in one node.
     Use ctx.cluster.alloc(ClusterSpec.simple_linux(1)) to allocate node and pass it to constructor
     """
-    def __init__(self, context, redpanda, topic, msg_size, custom_node):
+    def __init__(self, context, redpanda, topic, msg_size, custom_node,
+                 debug_logs):
         self.use_custom_node = custom_node is not None
 
         # We should pass num_nodes to allocate for our service in BackgroundThreadService,
@@ -54,6 +55,7 @@ class KgoVerifierService(Service):
         self._msg_size = msg_size
         self._pid = None
         self._remote_port = None
+        self._debug_logs = debug_logs
 
         for node in self.nodes:
             if not hasattr(node, "kgo_verifier_ports"):
@@ -95,7 +97,7 @@ class KgoVerifierService(Service):
 
         self._remote_port = self._select_port(node)
 
-        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} > {self.log_path} 2>&1 & echo $!"
+        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {'--debug' if self._debug_logs else ''}> {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
         pid_str = node.account.ssh_output(wrapped_cmd)
         self.logger.debug(
@@ -410,9 +412,16 @@ class ConsumerStatus:
 
 
 class KgoVerifierSeqConsumer(KgoVerifierService):
-    def __init__(self, context, redpanda, topic, msg_size, nodes=None):
-        super(KgoVerifierSeqConsumer, self).__init__(context, redpanda, topic,
-                                                     msg_size, nodes)
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 msg_size,
+                 nodes=None,
+                 debug_logs=False):
+        super(KgoVerifierSeqConsumer,
+              self).__init__(context, redpanda, topic, msg_size, nodes,
+                             debug_logs)
         self._status = ConsumerStatus()
 
     @property
@@ -438,8 +447,9 @@ class KgoVerifierRandomConsumer(KgoVerifierService):
                  msg_size,
                  rand_read_msgs,
                  parallel,
-                 nodes=None):
-        super().__init__(context, redpanda, topic, msg_size, nodes)
+                 nodes=None,
+                 debug_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
         self._rand_read_msgs = rand_read_msgs
         self._parallel = parallel
         self._status = ConsumerStatus()
@@ -466,8 +476,9 @@ class KgoVerifierConsumerGroupConsumer(KgoVerifierService):
                  topic,
                  msg_size,
                  readers,
-                 nodes=None):
-        super().__init__(context, redpanda, topic, msg_size, nodes)
+                 nodes=None,
+                 debug_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
 
         self._readers = readers
         self._status = ConsumerStatus()
@@ -517,9 +528,11 @@ class KgoVerifierProducer(KgoVerifierService):
                  msg_size,
                  msg_count,
                  custom_node=None,
-                 batch_max_bytes=None):
-        super(KgoVerifierProducer, self).__init__(context, redpanda, topic,
-                                                  msg_size, custom_node)
+                 batch_max_bytes=None,
+                 debug_logs=False):
+        super(KgoVerifierProducer,
+              self).__init__(context, redpanda, topic, msg_size, custom_node,
+                             debug_logs)
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -151,9 +151,11 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                                              self.PRODUCE_COUNT,
                                              self.preallocated_nodes)
         self._seq_consumer = KgoVerifierSeqConsumer(test_context,
-                                                    self.redpanda, self.topic,
+                                                    self.redpanda,
+                                                    self.topic,
                                                     self.MSG_SIZE,
-                                                    self.preallocated_nodes)
+                                                    self.preallocated_nodes,
+                                                    debug_logs=True)
         self._rand_consumer = KgoVerifierRandomConsumer(
             test_context, self.redpanda, self.topic, self.MSG_SIZE,
             self.RANDOM_READ_COUNT, self.RANDOM_READ_PARALLEL,


### PR DESCRIPTION
## Cover letter

This PR is introduced to help debugging SequentialConsumer shutdown issues causing the `UpgradeBackToBackTest.test_upgrade_with_all_workloads` test failures as described in #6399.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
