### PR TITLE
[v22.2.x] Fix bug for incorrect parsing of flex requests when client id is missing or null

### DIFF
--- a/src/v/coproc/tests/kafka_api_materialized_tests.cc
+++ b/src/v/coproc/tests/kafka_api_materialized_tests.cc
@@ -24,9 +24,11 @@
 #include <boost/test/unit_test_log.hpp>
 
 static kafka::client::transport make_kafka_client() {
-    return kafka::client::transport(net::base_transport::configuration{
-      .server_addr = config::node().kafka_api()[0].address,
-    });
+    return kafka::client::transport(
+      net::base_transport::configuration{
+        .server_addr = config::node().kafka_api()[0].address,
+      },
+      "test_client");
 }
 
 class push_some_data_fixture : public coproc_test_fixture {

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -25,10 +25,12 @@ ss::future<shared_broker_t> make_broker(
   const configuration& config) {
     return cluster::maybe_build_reloadable_certificate_credentials(
              config.broker_tls())
-      .then([addr](ss::shared_ptr<ss::tls::certificate_credentials> creds) {
+      .then([addr, client_id = config.client_identifier()](
+              ss::shared_ptr<ss::tls::certificate_credentials> creds) mutable {
           return ss::make_lw_shared<transport>(
             net::base_transport::configuration{
-              .server_addr = addr, .credentials = std::move(creds)});
+              .server_addr = addr, .credentials = std::move(creds)},
+            std::move(client_id));
       })
       .then([node_id, addr](ss::lw_shared_ptr<transport> client) {
           return client->connect().then(

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -107,6 +107,12 @@ configuration::configuration()
       "scram_password",
       "Password to use for SCRAM authentication mechanisms",
       {.secret = config::is_secret::yes},
-      "") {}
+      "")
+  , client_identifier(
+      *this,
+      "client_identifier",
+      "Identifier to use within the kafka request header",
+      {},
+      "test_client") {}
 
 } // namespace kafka::client

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -43,6 +43,8 @@ struct configuration final : public config::config_store {
     config::property<ss::sstring> scram_username;
     config::property<ss::sstring> scram_password;
 
+    config::property<std::optional<ss::sstring>> client_identifier;
+
     configuration();
     explicit configuration(const YAML::Node& cfg);
 };

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -110,7 +110,13 @@ private:
     }
 
 public:
-    using net::base_transport::base_transport;
+    // using net::base_transport::base_transport;
+
+    transport(
+      net::base_transport::configuration c,
+      std::optional<ss::sstring> client_id)
+      : net::base_transport(c)
+      , _client_id(std::move(client_id)) {}
 
     /*
      * TODO: the concept here can be improved once we convert all of the request
@@ -206,7 +212,7 @@ private:
         wr.write(int16_t(key()));
         wr.write(int16_t(version()));
         wr.write(int32_t(_correlation()));
-        wr.write(std::string_view("test_client"));
+        wr.write(_client_id);
         vassert(
           flex_versions::is_api_in_schema(key),
           "Attempted to send request to non-existent API: {}",
@@ -220,6 +226,7 @@ private:
     }
 
     correlation_id _correlation{0};
+    std::optional<ss::sstring> _client_id;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -20,8 +20,8 @@
 
 namespace kafka {
 
-ss::future<std::optional<request_header>>
-parse_header(ss::input_stream<char>& src) {
+static ss::future<std::optional<request_header>>
+parse_v1_header(ss::input_stream<char>& src) {
     constexpr int16_t no_client_id = -1;
 
     auto buf = co_await src.read_exactly(request_header_size);
@@ -69,16 +69,24 @@ parse_header(ss::input_stream<char>& src) {
     header.client_id = std::string_view(
       header.client_id_buffer.get(), header.client_id_buffer.size());
     validate_utf8(*header.client_id);
+    co_return header;
+}
 
-    /// Conditionally handle v1 (flex) header
-    if (!flex_versions::is_api_in_schema(header.key)) {
-        /// User provided unsupported an invalid key that does not map
-        /// to any known kafka requests, code will throw when it eventually
-        /// reaches the request router
-    } else if (flex_versions::is_flexible_request(header.key, header.version)) {
-        auto [tags, bytes_read] = co_await parse_tags(src);
-        header.tags = std::move(tags);
-        header.tags_size_bytes = bytes_read;
+ss::future<std::optional<request_header>>
+parse_header(ss::input_stream<char>& src) {
+    auto header = co_await parse_v1_header(src);
+    if (header) {
+        /// Conditionally handle v1 (flex) header
+        if (!flex_versions::is_api_in_schema(header->key)) {
+            /// User provided unsupported an invalid key that does not map
+            /// to any known kafka requests, code will throw when it eventually
+            /// reaches the request router
+        } else if (flex_versions::is_flexible_request(
+                     header->key, header->version)) {
+            auto [tags, bytes_read] = co_await parse_tags(src);
+            header->tags = std::move(tags);
+            header->tags_size_bytes = bytes_read;
+        }
     }
     co_return header;
 }

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -262,11 +262,13 @@ public:
           });
     }
 
-    ss::future<kafka::client::transport> make_kafka_client() {
+    ss::future<kafka::client::transport>
+    make_kafka_client(std::optional<ss::sstring> client_id = "test_client") {
         return ss::make_ready_future<kafka::client::transport>(
           net::base_transport::configuration{
             .server_addr = config::node().kafka_api()[0].address,
-          });
+          },
+          std::move(client_id));
     }
 
     model::ntp


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6585.
