### PR TITLE
storage/kafka: fix time queries

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -238,6 +238,8 @@ replicated_partition::aborted_transactions(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
+    cfg.max_offset = _translator->to_log_offset(cfg.max_offset);
+
     return _partition->timequery(cfg).then(
       [this](std::optional<storage::timequery_result> r) {
           if (r) {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -660,7 +660,18 @@ public:
         verify_iterable();
         iobuf_const_parser parser(_records);
         for (auto i = 0; i < _header.record_count; i++) {
-            f(model::parse_one_record_copy_from_buffer(parser));
+            if constexpr (std::is_same_v<
+                            std::invoke_result_t<Func, model::record>,
+                            void>) {
+                f(model::parse_one_record_copy_from_buffer(parser));
+
+            } else {
+                ss::stop_iteration s = f(
+                  model::parse_one_record_copy_from_buffer(parser));
+                if (s == ss::stop_iteration::yes) {
+                    return;
+                }
+            }
         }
         if (unlikely(parser.bytes_left())) {
             throw std::out_of_range(fmt::format(

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -308,7 +308,7 @@ batch_cache_index::read_result batch_cache_index::read(
         auto batch = it->second.batch();
 
         auto take = !type_filter || type_filter == batch.header().type;
-        take &= !first_ts || batch.header().first_timestamp >= *first_ts;
+        take &= !first_ts || batch.header().max_timestamp >= *first_ts;
         offset = batch.last_offset() + model::offset(1);
         if (take) {
             batch_cache::range::lock_guard g(*it->second.range());

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -245,7 +245,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
           batch.base_offset(),
           batch.last_offset(),
           batch.header().first_timestamp,
-          batch.header().max_timestamp)) {
+          batch.header().max_timestamp,
+          batch.header().type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     co_await storage::write(*_appender, batch);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1030,10 +1030,8 @@ disk_log_impl::timequery(timequery_config cfg) {
                   st);
                 if (
                   !batches.empty()
-                  && batches.front().header().first_timestamp >= cfg.time) {
-                    return ret_t(timequery_result(
-                      batches.front().base_offset(),
-                      batches.front().header().first_timestamp));
+                  && batches.front().header().max_timestamp >= cfg.time) {
+                    return ret_t(batch_timequery(batches.front(), cfg.time));
                 }
                 return ret_t();
             });

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -86,7 +86,8 @@ struct index_state
       model::offset base_offset,
       model::offset batch_max_offset,
       model::timestamp first_timestamp,
-      model::timestamp last_timestamp);
+      model::timestamp last_timestamp,
+      bool user_data);
 
     friend bool operator==(const index_state&, const index_state&) = default;
 
@@ -96,6 +97,8 @@ struct index_state
     friend void read_nested(iobuf_parser&, index_state&, const size_t);
 
 private:
+    bool non_data_timestamps{false};
+
     index_state(const index_state& o) noexcept
       : bitflags(o.bitflags)
       , base_offset(o.base_offset)

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -62,9 +62,9 @@ batch_consumer::consume_result skipping_consumer::accept_batch_start(
         _reader._config.start_offset = header.last_offset() + model::offset(1);
         return batch_consumer::consume_result::skip_batch;
     }
-    if (_reader._config.first_timestamp > header.first_timestamp) {
-        // kakfa needs to guarantee that the returned record is >=
-        // first_timestamp
+    if (_reader._config.first_timestamp > header.max_timestamp) {
+        // kakfa requires that we return messages >= the timestamp, it is
+        // permitted to include a few earlier
         _reader._config.start_offset = header.last_offset() + model::offset(1);
         return batch_consumer::consume_result::skip_batch;
     }

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -236,4 +236,16 @@ private:
     ss::abort_source::subscription _as_sub;
 };
 
+/**
+ * Assuming caller has already determined that this batch contains
+ * the record that should be the result to the timequery, traverse
+ * the batch to find which record matches.
+ *
+ * This is used by both storage's disk_log_impl and by cloud_storage's
+ * remote_partition, to seek to their final result after finding
+ * the batch.
+ */
+timequery_result
+batch_timequery(const model::record_batch& b, model::timestamp t);
+
 } // namespace storage

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -208,9 +208,6 @@ private:
     bool is_done();
     ss::future<> find_next_valid_iterator();
 
-    using reader_available = ss::bool_class<struct create_reader_tag>;
-    reader_available maybe_create_segment_reader();
-
 private:
     struct iterator_pair {
         iterator_pair(segment_set::iterator i)

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -93,7 +93,8 @@ void segment_index::maybe_track(
           hdr.base_offset,
           hdr.last_offset(),
           hdr.first_timestamp,
-          hdr.max_timestamp)) {
+          hdr.max_timestamp,
+          hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -35,6 +35,7 @@ public:
 
     const model::record_batch_header
     modify_get(model::offset o, int32_t batch_size) {
+        _base_hdr.type = model::record_batch_type::raft_data;
         _base_hdr.base_offset = o;
         _base_hdr.size_bytes = batch_size;
         return _base_hdr;

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -186,4 +186,5 @@ operator<<(std::ostream& o, compacted_index::recovery_state state) {
     }
     __builtin_unreachable();
 }
+
 } // namespace storage

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -359,4 +359,5 @@ struct compaction_result {
     size_t size_after;
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
+
 } // namespace storage

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -81,6 +81,12 @@ public:
         return frag.at(index % elems_per_frag);
     }
 
+    T& operator[](size_t index) {
+        vassert(index < _size, "Index out of range {}/{}", index, _size);
+        auto& frag = _frags.at(index / elems_per_frag);
+        return frag.at(index % elems_per_frag);
+    }
+
     const T& back() const { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 857e4a4 && \
+    cd /opt/kgo-verifier && git reset --hard cf552ccba1c6a68f53b51bbdbbcdb50c4e2c8cfe && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -10,6 +10,7 @@
 import subprocess
 import time
 import json
+from typing import Optional
 
 from rptest.util import wait_until_result
 
@@ -26,10 +27,23 @@ class KafkaCat:
     def metadata(self):
         return self._cmd(["-L"])
 
-    def consume_one(self, topic, partition, offset):
+    def consume_one(self,
+                    topic,
+                    partition,
+                    offset=None,
+                    *,
+                    first_timestamp: Optional[int] = None):
+        if offset is not None:
+            # <value>  (absolute offset)
+            query = offset
+        else:
+            assert first_timestamp is not None
+            # s@<value> (timestamp in ms to start at)
+            query = f"s@{first_timestamp}"
+
         return self._cmd([
             "-C", "-e", "-t", f"{topic}", "-p", f"{partition}", "-o",
-            f"{offset}", "-c1"
+            f"{query}", "-c1"
         ])
 
     def produce_one(self, topic, msg, tx_id=None):

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -76,3 +76,28 @@ class RpkRemoteTool:
 
     def _rpk_binary(self):
         return self._redpanda.find_binary('rpk')
+
+    def read_timestamps(self, topic: str, partition: int, count: int,
+                        timeout_sec: int):
+        """
+        Read all the timestamps of messages in a partition, as milliseconds
+        since epoch.
+
+        :return: generator of 2-tuples like (offset:int, timestamp:int)
+        """
+        cmd = [
+            self._rpk_binary(), "--brokers",
+            self._redpanda.brokers(), "topic", "consume", topic, "-f",
+            "\"%o %d\\n\"", "--num",
+            str(count), "-p",
+            str(partition)
+        ]
+        for line in self._node.account.ssh_capture(' '.join(cmd),
+                                                   timeout_sec=timeout_sec):
+            try:
+                offset, ts = line.split()
+            except:
+                self._redpanda.logger.error(f"Bad line: '{line}'")
+                raise
+
+            yield (int(offset), int(ts))

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -529,13 +529,15 @@ class KgoVerifierProducer(KgoVerifierService):
                  msg_count,
                  custom_node=None,
                  batch_max_bytes=None,
-                 debug_logs=False):
+                 debug_logs=False,
+                 fake_timestamp_ms=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
                              debug_logs)
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes
+        self._fake_timestamp_ms = fake_timestamp_ms
 
     @property
     def produce_status(self):
@@ -581,6 +583,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
         if self._batch_max_bytes is not None:
             cmd = cmd + f' --batch_max_bytes {self._batch_max_bytes}'
+
+        if self._fake_timestamp_ms is not None:
+            cmd = cmd + f' --fake-timestamp-ms {self._fake_timestamp_ms}'
 
         self.spawn(cmd, node)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -552,9 +552,10 @@ class RedpandaService(Service):
             f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
 
         if si_settings is not None:
-            self._extra_rp_conf = si_settings.update_rp_conf(
-                self._extra_rp_conf)
-        self._si_settings = si_settings
+            self.set_si_settings(si_settings)
+        else:
+            self._si_settings = None
+
         self.s3_client: Optional[S3Client] = None
 
         if environment is None:
@@ -582,6 +583,14 @@ class RedpandaService(Service):
 
     def set_extra_rp_conf(self, conf):
         self._extra_rp_conf = conf
+        if self._si_settings is not None:
+            self._extra_rp_conf = self._si_settings.update_rp_conf(
+                self._extra_rp_conf)
+
+    def set_si_settings(self, si_settings: SISettings):
+        self._si_settings = si_settings
+        self._extra_rp_conf = self._si_settings.update_rp_conf(
+            self._extra_rp_conf)
 
     def add_extra_rp_conf(self, conf):
         self._extra_rp_conf = {**self._extra_rp_conf, **conf}

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -1,0 +1,188 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk_remote import RpkRemoteTool
+
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+
+from ducktape.mark import parametrize
+
+from rptest.services.kafka import KafkaServiceAdapter
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.zookeeper import ZookeeperService
+from ducktape.mark.resource import cluster as ducktape_cluster
+from kafkatest.version import V_3_0_0
+from ducktape.tests.test import Test
+from rptest.clients.default import DefaultClient
+
+
+class BaseTimeQuery:
+    def _test_timequery(self):
+        total_segments = 12
+        record_size = 1024
+
+        topic = TopicSpec(name="tqtopic",
+                          partition_count=1,
+                          replication_factor=3)
+
+        self.client().create_topic(topic)
+
+        # Configure topic to trust client-side timestamps, so that
+        # we can generate fake ones for the test
+        self.client().alter_topic_config(topic.name, 'message.timestamp.type',
+                                         "CreateTime")
+
+        # Use small segments
+        self.client().alter_topic_config(topic.name, 'segment.bytes',
+                                         self.log_segment_size)
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_count = (self.log_segment_size * total_segments) // record_size
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topic=topic.name,
+            msg_size=record_size,
+            msg_count=msg_count,
+
+            # A respectable number of messages per batch so that we are covering
+            # the case of looking up timestamps that fall in the middle of a batch,
+            # but small enough that we are getting plenty of distinct batches.
+            batch_max_bytes=record_size * 10,
+
+            # A totally arbitrary artificial timestamp base in milliseconds
+            fake_timestamp_ms=1664453149000)
+        producer.start()
+        producer.wait()
+
+        # Confirm messages written
+        rpk = RpkTool(self.redpanda)
+        p = next(rpk.describe_topic(topic.name))
+        assert p.high_watermark == msg_count
+
+        # Read back timestamps
+        self.logger.info(f"Retrieving timestamps for {msg_count} messages")
+        rpk_remote = RpkRemoteTool(self.redpanda, self.redpanda.nodes[0])
+        timestamps = dict(
+            rpk_remote.read_timestamps(topic.name,
+                                       0,
+                                       msg_count,
+                                       timeout_sec=30))
+
+        for k, v in timestamps.items():
+            self.logger.debug(f"  Offset {k} -> Timestamp {v}")
+
+        # Interesting cases
+        offsets = [0, msg_count // 4, msg_count // 2, msg_count - 1]
+
+        kcat = KafkaCat(self.redpanda)
+        for o in offsets:
+            # read_timestamps gives values in millis
+            ts = int(timestamps[o])
+
+            self.logger.info(
+                f"Attempting time lookup ts={ts} (should be o={o})")
+            offset = kcat.query_offset(topic.name, 0, ts)
+            self.logger.info(f"Time query returned offset {offset}")
+            assert offset == o
+
+            self.logger.info(
+                f"Attempting time-based reader lookup ts={ts} (should be o={o})"
+            )
+            record = kcat.consume_one(topic.name, 0, first_timestamp=ts)
+            self.logger.info(f"Time-based consumer returned record {record}")
+            assert record['offset'] == o
+
+
+class TimeQueryTest(RedpandaTest, BaseTimeQuery):
+    # We use small segments to enable quickly exercising the
+    # lookup of the proper segment for a time index, as well
+    # as the lookup of the offset within that segment.
+    log_segment_size = 1024 * 1024
+
+    def setUp(self):
+        # Don't start up redpanda yet, because we will need the
+        # test parameter to set cluster configs before starting.
+        pass
+
+    @cluster(num_nodes=4)
+    @parametrize(batch_cache=True)
+    @parametrize(batch_cache=False)
+    def test_timequery(self, batch_cache: bool):
+        self.redpanda.set_extra_rp_conf({
+            # Testing with batch cache disabled is important, because otherwise
+            # we won't touch the path in skipping_consumer that applies
+            # timestamp bounds
+            'disable_batch_cache': not batch_cache,
+        })
+
+        self.redpanda.start()
+
+        return self._test_timequery()
+
+
+class TimeQueryKafkaTest(Test, BaseTimeQuery):
+    """
+    Time queries are one of the less clearly defined aspects of the
+    Kafka protocol, so we run our test procedure against Apache Kafka
+    to establish a baseline behavior to ensure our compatibility.
+    """
+    log_segment_size = 1024 * 1024
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.zk = ZookeeperService(self.test_context,
+                                   num_nodes=1,
+                                   version=V_3_0_0)
+
+        self.kafka = KafkaServiceAdapter(
+            self.test_context,
+            KafkaService(self.test_context,
+                         num_nodes=3,
+                         zk=self.zk,
+                         version=V_3_0_0))
+
+        self._client = DefaultClient(self.kafka)
+
+    def client(self):
+        return self._client
+
+    @property
+    def redpanda(self):
+        return self.kafka
+
+    def setUp(self):
+        self.zk.start()
+        self.kafka.start()
+        time.sleep(5)
+
+    def tearDown(self):
+        # ducktape handle service teardown automatically, but it is hard
+        # to tell what went wrong if one of the services hangs.  Do it
+        # explicitly here with some logging, to enable debugging issues
+        # like https://github.com/redpanda-data/redpanda/issues/4270
+
+        self.logger.info("Stopping Kafka...")
+        self.kafka.stop()
+
+        self.logger.info("Stopping zookeeper...")
+        self.zk.stop()
+
+    @ducktape_cluster(num_nodes=5)
+    def test_timequery(self):
+        self._test_timequery()


### PR DESCRIPTION
## Cover letter

Time queries had several issues:
- queries skip records: incorrectly compares the query timestamp to the max_timestamp of a batch to decide whether to skip to the next batch, skipping any records within batches whose first timestamp is less than the query but whose max timestamp is greater.
- queries return earlier offset than they should: does not seek into a batch to find the specific record, just returns the start of a batch
- queries on recent timestamps may incorrectly return zero offset: does not translate the input max_offset attribute into a raft offset

Most of the issues with time queries don't become apparent until you use CreateTime mode (i.e. kafka clients get to pick their timestamps).  Once timestamps are set client side, we can no longer assume that all the timestamps in a batch are equal, or that the timestamps of raft batches are even roughly monotonic (because config batches get walltime but user data batches can be anything).

This PR adds an integration test for time queries (both via list_offsets and via fetch rpcs), and validates that Redpanda's behavior is the same as Apache Kafka by running the same test routine against both backends.

There will be a following PR that extends the test to cover cloud_storage and implements time queries on remote_partition.

Fixes: https://github.com/redpanda-data/redpanda/issues/6604
Related: https://github.com/redpanda-data/redpanda/issues/4035

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Time queries are more reliable on topics using client-set timestamps via the `CreateTime` mode 
