### PR TITLE
operator: change console to use wildcard certificate

### DIFF
--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -100,15 +100,8 @@ func (r *IngressResource) WithTLS(clusterIssuer, secretName string) *IngressReso
 		r.TLS = []netv1.IngressTLS{}
 	}
 
-	host := r.host()
-	allHosts := []string{host}
-	if r.subdomain != host {
-		// Workaround to put short SAN entry so LE can fill CN of cert.
-		// See: https://github.com/redpanda-data/redpanda/pull/6471
-		allHosts = append(allHosts, r.subdomain)
-	}
 	r.TLS = append(r.TLS, netv1.IngressTLS{
-		Hosts: allHosts,
+		Hosts: []string{r.subdomain, fmt.Sprintf("*.%s", r.subdomain)},
 		// Use the Cluster wildcard certificate
 		SecretName: secretName,
 	})

--- a/src/go/k8s/pkg/resources/ingress_test.go
+++ b/src/go/k8s/pkg/resources/ingress_test.go
@@ -24,14 +24,14 @@ func TestIngressWithTLS(t *testing.T) {
 			tlsSecret:   "rp-abc123-redpanda",
 			tlsIssuer:   resources.LEClusterIssuer,
 			annotations: map[string]string{"foo.vectorized.io": "bar"},
-			tlsHosts:    []string{"test.example.local"},
+			tlsHosts:    []string{"test.example.local", "*.test.example.local"},
 		},
 		{
 			defaultEndpoint: "console",
 			host:            "test.example.local",
 			tlsSecret:       "rp-abc123-redpanda",
 			tlsIssuer:       resources.LEClusterIssuer,
-			tlsHosts:        []string{"console.test.example.local", "test.example.local"},
+			tlsHosts:        []string{"test.example.local", "*.test.example.local"},
 		},
 	}
 	for i, tt := range table {


### PR DESCRIPTION
## Cover letter

This changes the console to use the same strategy as the cluster for certificates (i.e. use wildcard certificates).

Provider such as LetsEncrypt allow creating [multiple identical certificates](https://community.letsencrypt.org/t/2-ssl-certs-for-the-same-domain/166293) up to a certain quota.
