### PR TITLE
operator: allow to customize schema registry advertised address

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -552,6 +552,9 @@ type SchemaRegistryExternalConnectivityConfig struct {
 	ExternalConnectivityConfig `json:",inline"`
 	// Indicates that the node port for the service needs not to be generated.
 	StaticNodePort bool `json:"staticNodePort,omitempty"`
+	// Indicates the global endpoint that (together with subdomain), should be
+	// advertised for schema registry.
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // SchemaRegistryStatus reports addresses where schema registry

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -587,6 +587,12 @@ func (r *Cluster) validateSchemaRegistryListener() field.ErrorList {
 				r.Spec.Configuration.SchemaRegistry,
 				"port must be in the range [30000-32768] when using a static node port"))
 	}
+	if schemaRegistry.External.Endpoint != "" && !validHostnameSegment.MatchString(schemaRegistry.External.Endpoint) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("configuration").Child("schemaRegistry").Child("external").Child("endpoint"),
+				r.Spec.Configuration.SchemaRegistry.External.Endpoint,
+				fmt.Sprintf("endpoint for schema registry does not match regexp %s", validHostnameSegment.String())))
+	}
 
 	return allErrs
 }

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -1028,6 +1028,7 @@ func TestCreation(t *testing.T) {
 		err := rp.ValidateCreate()
 		assert.Error(t, err)
 	})
+	//nolint:dupl // not really a duplicate
 	t.Run("endpoint template not allowed for schemaregistry", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		const commonDomain = "company.org"
@@ -1042,6 +1043,44 @@ func TestCreation(t *testing.T) {
 				Subdomain:        commonDomain,
 				EndpointTemplate: "xxx",
 			},
+		}}
+		err := rp.ValidateCreate()
+		assert.Error(t, err)
+	})
+	//nolint:dupl // not really a duplicate
+	t.Run("endpoint allowed for schemaregistry", func(t *testing.T) {
+		rp := redpandaCluster.DeepCopy()
+		const commonDomain = "company.org"
+
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+			Enabled:   true,
+			Subdomain: commonDomain,
+		}})
+		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+				Enabled:   true,
+				Subdomain: commonDomain,
+			},
+			Endpoint: "xxx",
+		}}
+		err := rp.ValidateCreate()
+		assert.NoError(t, err)
+	})
+	//nolint:dupl // not really a duplicate
+	t.Run("invalid endpoint not allowed for schemaregistry", func(t *testing.T) {
+		rp := redpandaCluster.DeepCopy()
+		const commonDomain = "company.org"
+
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+			Enabled:   true,
+			Subdomain: commonDomain,
+		}})
+		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+				Enabled:   true,
+				Subdomain: commonDomain,
+			},
+			Endpoint: "xx.xx",
 		}}
 		err := rp.ValidateCreate()
 		assert.Error(t, err)

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -513,6 +513,10 @@ spec:
                             description: Enabled enables the external connectivity
                               feature
                             type: boolean
+                          endpoint:
+                            description: Indicates the global endpoint that (together
+                              with subdomain), should be advertised for schema registry.
+                            type: string
                           endpointTemplate:
                             description: "EndpointTemplate is a Golang template string
                               that allows customizing each broker advertised address.

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -495,7 +495,12 @@ func (r *ClusterReconciler) createExternalNodesList(
 	}
 
 	if schemaRegistryConf != nil && schemaRegistryConf.External != nil && len(schemaRegistryConf.External.Subdomain) > 0 {
-		result.SchemaRegistry.External = fmt.Sprintf("%s:%d",
+		prefix := ""
+		if schemaRegistryConf.External.Endpoint != "" {
+			prefix = fmt.Sprintf("%s.", schemaRegistryConf.External.Endpoint)
+		}
+		result.SchemaRegistry.External = fmt.Sprintf("%s%s:%d",
+			prefix,
 			schemaRegistryConf.External.Subdomain,
 			getNodePort(&nodePortSvc, resources.SchemaRegistryPortName),
 		)


### PR DESCRIPTION
## Cover letter

When exposing schema registry to a different hostname, Console is not able to detect it, since the cluster advertises the wrong host.

This allows to inject the external endpoint used for schema registry.