### PR TITLE
Add local-target topic configuration options for SI topics

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -61,7 +61,8 @@ enum class errc : int16_t {
     feature_disabled,
     invalid_request,
     no_update_in_progress,
-    unknown_update_interruption_error
+    unknown_update_interruption_error,
+    invalid_retention_configuration
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -176,6 +177,10 @@ struct errc_category final : public std::error_category {
             return "Partition configuration is not being updated";
         case errc::unknown_update_interruption_error:
             return "Error while cancelling partition reconfiguration";
+        case errc::invalid_retention_configuration:
+            return "retention.bytes and retention.ms must be greater or equal "
+                   "than retention.local.target.bytes and "
+                   "retention.local.target.ms respectively";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -241,6 +241,14 @@ std::optional<std::chrono::milliseconds>
 metadata_cache::get_default_retention_duration() const {
     return config::shard_local_cfg().delete_retention_ms();
 }
+std::optional<size_t>
+metadata_cache::get_default_retention_local_target_bytes() const {
+    return config::shard_local_cfg().retention_local_target_bytes_default();
+}
+std::chrono::milliseconds
+metadata_cache::get_default_retention_local_target_ms() const {
+    return config::shard_local_cfg().retention_local_target_ms_default();
+}
 
 uint32_t metadata_cache::get_default_batch_max_bytes() const {
     return config::shard_local_cfg().kafka_batch_max_bytes();
@@ -272,6 +280,11 @@ topic_properties metadata_cache::get_default_properties() const {
     tp.recovery = {false};
     tp.shadow_indexing = {get_default_shadow_indexing_mode()};
     tp.batch_max_bytes = get_default_batch_max_bytes();
+    tp.retention_local_target_bytes = tristate{
+      get_default_retention_local_target_bytes()};
+    tp.retention_local_target_ms = tristate<std::chrono::milliseconds>{
+      get_default_retention_local_target_ms()};
+
     return tp;
 }
 

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -165,6 +165,8 @@ public:
     std::optional<size_t> get_default_retention_bytes() const;
     std::optional<std::chrono::milliseconds>
     get_default_retention_duration() const;
+    std::optional<size_t> get_default_retention_local_target_bytes() const;
+    std::chrono::milliseconds get_default_retention_local_target_ms() const;
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;
     topic_properties get_default_properties() const;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -566,6 +566,13 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(properties.shadow_indexing, overrides.shadow_indexing);
     incremental_update(properties.batch_max_bytes, overrides.batch_max_bytes);
 
+    incremental_update(
+      properties.retention_local_target_bytes,
+      overrides.retention_local_target_bytes);
+    incremental_update(
+      properties.retention_local_target_ms,
+      overrides.retention_local_target_ms);
+
     // generate deltas for controller backend
     std::vector<topic_table_delta> deltas;
     deltas.reserve(tp->second.get_assignments().size());

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -432,6 +432,24 @@ errc topics_frontend::validate_topic_configuration(
         }
     }
 
+    const auto& properties = assignable_config.cfg.properties;
+
+    if (
+      properties.retention_bytes.has_value()
+      && properties.retention_local_target_bytes.has_value()
+      && properties.retention_bytes.value()
+           < properties.retention_local_target_bytes.value()) {
+        return errc::invalid_retention_configuration;
+    }
+
+    if (
+      properties.retention_duration.has_value()
+      && properties.retention_local_target_ms.has_value()
+      && properties.retention_duration.value()
+           < properties.retention_local_target_ms.value()) {
+        return errc::invalid_retention_configuration;
+    }
+
     return errc::success;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -10,6 +10,7 @@
 #include "cluster/types.h"
 
 #include "cluster/fwd.h"
+#include "config/configuration.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -113,6 +114,33 @@ storage::ntp_config topic_configuration::make_ntp_config(
       std::move(overrides),
       rev,
       init_rev};
+}
+
+void topic_configuration::maybe_adjust_retention_policies(
+  std::optional<model::shadow_indexing_mode> topic_shadow_indexing_mode,
+  tristate<std::size_t>& retention_bytes,
+  tristate<std::chrono::milliseconds>& retention_ms,
+  tristate<std::size_t>& local_target_bytes,
+  tristate<std::chrono::milliseconds>& local_target_ms) {
+    auto cloud_storage_enabled
+      = config::shard_local_cfg().cloud_storage_enabled();
+
+    // Note that `remote_write_enabled` true when either of the topic
+    // config or cluster config are set to true. This includes the case
+    // when the topic property is explicitly set to false. This is confusing
+    // and may require revisiting.
+    auto remote_write_enabled
+      = model::is_archival_enabled(topic_shadow_indexing_mode.value_or(
+          model::shadow_indexing_mode::disabled))
+        || config::shard_local_cfg().cloud_storage_enable_remote_write();
+
+    if (cloud_storage_enabled && remote_write_enabled) {
+        local_target_bytes = retention_bytes;
+        local_target_ms = retention_ms;
+
+        retention_bytes = tristate<size_t>{};
+        retention_ms = tristate<std::chrono::milliseconds>{};
+    }
 }
 
 model::topic_metadata topic_configuration_assignment::get_metadata() const {
@@ -911,6 +939,14 @@ adl<cluster::topic_configuration>::from(iobuf_parser& in) {
         cfg.properties.shadow_indexing
           = adl<std::optional<model::shadow_indexing_mode>>{}.from(in);
     }
+
+    cluster::topic_configuration::maybe_adjust_retention_policies(
+      cfg.properties.shadow_indexing,
+      cfg.properties.retention_bytes,
+      cfg.properties.retention_duration,
+      cfg.properties.retention_local_target_bytes,
+      cfg.properties.retention_local_target_ms);
+
     return cfg;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -70,9 +70,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.retention_bytes = retention_bytes;
     ret.retention_time = retention_duration;
     ret.segment_size = segment_size;
-    ret.shadow_indexing_mode = shadow_indexing
-                                 ? *shadow_indexing
-                                 : model::shadow_indexing_mode::disabled;
+    ret.shadow_indexing_mode = shadow_indexing;
     ret.read_replica = read_replica;
     ret.retention_local_target_bytes = retention_local_target_bytes;
     ret.retention_local_target_ms = retention_local_target_ms;
@@ -100,9 +98,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .cache_enabled = storage::with_cache(!is_internal()),
             .recovery_enabled = storage::topic_recovery_enabled(
               properties.recovery ? *properties.recovery : false),
-            .shadow_indexing_mode = properties.shadow_indexing
-                                      ? *properties.shadow_indexing
-                                      : model::shadow_indexing_mode::disabled,
+            .shadow_indexing_mode = properties.shadow_indexing,
             .read_replica = properties.read_replica,
             .retention_local_target_bytes
             = properties.retention_local_target_bytes,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1166,15 +1166,19 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
+    static constexpr int8_t version_with_batch_max_bytes_and_local_retention
+      = -4;
     // negative version indicating different format:
     // -1 - topic_updates with data_policy
     // -2 - topic_updates without data_policy
     // -3 - topic_updates with shadow_indexing
-    static constexpr int8_t version = -3;
+    // -4 - topic update with batch_max_bytes and retention.local.target
+    static constexpr int8_t version
+      = version_with_batch_max_bytes_and_local_retention;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -1186,6 +1190,9 @@ struct incremental_topic_updates
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
     property_update<std::optional<model::shadow_indexing_mode>> shadow_indexing;
     property_update<std::optional<uint32_t>> batch_max_bytes;
+    property_update<tristate<size_t>> retention_local_target_bytes;
+    property_update<tristate<std::chrono::milliseconds>>
+      retention_local_target_ms;
 
     auto serde_fields() {
         return std::tie(
@@ -1197,7 +1204,9 @@ struct incremental_topic_updates
           retention_bytes,
           retention_duration,
           shadow_indexing,
-          batch_max_bytes);
+          batch_max_bytes,
+          retention_local_target_bytes,
+          retention_local_target_ms);
     }
 
     friend std::ostream&

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1012,7 +1012,7 @@ struct remote_topic_properties
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<2>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<3>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -1027,7 +1027,9 @@ struct topic_properties
       std::optional<bool> read_replica,
       std::optional<ss::sstring> read_replica_bucket,
       std::optional<remote_topic_properties> remote_topic_properties,
-      std::optional<uint32_t> batch_max_bytes)
+      std::optional<uint32_t> batch_max_bytes,
+      tristate<size_t> retention_local_target_bytes,
+      tristate<std::chrono::milliseconds> retention_local_target_ms)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1040,7 +1042,9 @@ struct topic_properties
       , read_replica(read_replica)
       , read_replica_bucket(std::move(read_replica_bucket))
       , remote_topic_properties(remote_topic_properties)
-      , batch_max_bytes(batch_max_bytes) {}
+      , batch_max_bytes(batch_max_bytes)
+      , retention_local_target_bytes(retention_local_target_bytes)
+      , retention_local_target_ms(retention_local_target_ms) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1055,6 +1059,8 @@ struct topic_properties
     std::optional<ss::sstring> read_replica_bucket;
     std::optional<remote_topic_properties> remote_topic_properties;
     std::optional<uint32_t> batch_max_bytes;
+    tristate<size_t> retention_local_target_bytes{std::nullopt};
+    tristate<std::chrono::milliseconds> retention_local_target_ms{std::nullopt};
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1076,7 +1082,9 @@ struct topic_properties
           read_replica,
           read_replica_bucket,
           remote_topic_properties,
-          batch_max_bytes);
+          batch_max_bytes,
+          retention_local_target_bytes,
+          retention_local_target_ms);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -327,6 +327,8 @@ struct compat_check<cluster::topic_properties> {
         json_write(read_replica_bucket);
         json_write(remote_topic_properties);
         json_write(batch_max_bytes);
+        json_write(retention_local_target_bytes);
+        json_write(retention_local_target_ms);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -344,6 +346,8 @@ struct compat_check<cluster::topic_properties> {
         json_read(read_replica_bucket);
         json_read(remote_topic_properties);
         json_read(batch_max_bytes);
+        json_read(retention_local_target_bytes);
+        json_read(retention_local_target_ms);
         return obj;
     }
 
@@ -361,6 +365,9 @@ struct compat_check<cluster::topic_properties> {
         auto reply = reflection::adl<cluster::topic_properties>{}.from(iobp);
 
         obj.batch_max_bytes = std::nullopt;
+        obj.retention_local_target_bytes = tristate<size_t>{std::nullopt};
+        obj.retention_local_target_ms = tristate<std::chrono::milliseconds>{
+          std::nullopt};
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -420,6 +427,10 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.read_replica_bucket = std::nullopt;
         obj.properties.remote_topic_properties = std::nullopt;
         obj.properties.batch_max_bytes = std::nullopt;
+        obj.properties.retention_local_target_bytes = tristate<size_t>{
+          std::nullopt};
+        obj.properties.retention_local_target_ms
+          = tristate<std::chrono::milliseconds>{std::nullopt};
         if (cfg != obj) {
             throw compat_error(fmt::format(
               "Verify of {{cluster::topic_property}} decoding "
@@ -470,6 +481,10 @@ struct compat_check<cluster::create_topics_request> {
             topic.properties.read_replica_bucket = std::nullopt;
             topic.properties.remote_topic_properties = std::nullopt;
             topic.properties.batch_max_bytes = std::nullopt;
+            topic.properties.retention_local_target_bytes = tristate<size_t>{
+              std::nullopt};
+            topic.properties.retention_local_target_ms
+              = tristate<std::chrono::milliseconds>{std::nullopt};
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -522,6 +537,10 @@ struct compat_check<cluster::create_topics_reply> {
             topic.properties.read_replica_bucket = std::nullopt;
             topic.properties.remote_topic_properties = std::nullopt;
             topic.properties.batch_max_bytes = std::nullopt;
+            topic.properties.retention_local_target_bytes = tristate<size_t>{
+              std::nullopt};
+            topic.properties.retention_local_target_ms
+              = tristate<std::chrono::milliseconds>{std::nullopt};
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -685,6 +685,9 @@ struct instance_generator<cluster::topic_properties> {
           instance_generator<cluster::remote_topic_properties>::random(),
           tests::random_optional(
             [] { return random_generators::get_int<uint32_t>(1024 * 1024); }),
+          tests::random_tristate(
+            [] { return random_generators::get_int<size_t>(); }),
+          tests::random_tristate([] { return tests::random_duration_ms(); }),
         };
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -578,6 +578,9 @@ inline void rjson_serialize(
     write_member(w, "read_replica_bucket", tps.read_replica_bucket);
     write_member(w, "remote_topic_properties", tps.remote_topic_properties);
     write_member(w, "batch_max_bytes", tps.batch_max_bytes);
+    write_member(
+      w, "retention_local_target_bytes", tps.retention_local_target_bytes);
+    write_member(w, "retention_local_target_ms", tps.retention_local_target_ms);
     w.EndObject();
 }
 
@@ -595,6 +598,9 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "read_replica_bucket", obj.read_replica_bucket);
     read_member(rd, "remote_topic_properties", obj.remote_topic_properties);
     read_member(rd, "batch_max_bytes", obj.batch_max_bytes);
+    read_member(
+      rd, "retention_local_target_bytes", obj.retention_local_target_bytes);
+    read_member(rd, "retention_local_target_ms", obj.retention_local_target_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1142,6 +1142,20 @@ configuration::configuration()
       "maximum number of IO and CPU shares that archival upload can use",
       {.visibility = visibility::tunable},
       1000)
+  , retention_local_target_bytes_default(
+      *this,
+      "retention_local_target_bytes_default",
+      "Local retention size target for partitions of topics with cloud storage "
+      "write enabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt)
+  , retention_local_target_ms_default(
+      *this,
+      "retention_local_target_ms_default",
+      "Local retention time target for partitions of topics with cloud storage "
+      "write enabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      24h)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -240,6 +240,11 @@ struct configuration final : public config_store {
     property<int16_t> cloud_storage_upload_ctrl_min_shares;
     property<int16_t> cloud_storage_upload_ctrl_max_shares;
 
+    // Defaults for local retention for partitions of topics with
+    // cloud storage read and write enabled
+    property<std::optional<size_t>> retention_local_target_bytes_default;
+    property<std::chrono::milliseconds> retention_local_target_ms_default;
+
     // Archival cache
     property<size_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -43,6 +43,8 @@ std::string_view to_string_view(feature f) {
         return "raftless_node_status";
     case feature::rpc_v2_by_default:
         return "rpc_v2_by_default";
+    case feature::cloud_retention:
+        return "cloud_retention";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -42,6 +42,7 @@ enum class feature : std::uint64_t {
     transaction_ga = 0x100,
     raftless_node_status = 0x200,
     rpc_v2_by_default = 0x400,
+    cloud_retention = 0x800,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -160,7 +161,12 @@ constexpr static std::array feature_schema{
     feature::rpc_v2_by_default,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
-
+  feature_spec{
+    cluster_version{7},
+    "cloud_retention",
+    feature::cloud_retention,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
   feature_spec{
     cluster_version{2001},
     "__test_alpha",

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -19,6 +19,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::success:
         return error_code::none;
     case cluster::errc::topic_invalid_config:
+    case cluster::errc::invalid_retention_configuration:
         return error_code::invalid_config;
     case cluster::errc::topic_invalid_partitions:
         return error_code::invalid_partitions;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -181,6 +181,16 @@ create_topic_properties_update(alter_configs_resource& resource) {
                   update.properties.batch_max_bytes, cfg.value);
                 continue;
             }
+            if (cfg.name == topic_property_retention_local_target_ms) {
+                parse_and_set_tristate(
+                  update.properties.retention_local_target_ms, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_retention_local_target_bytes) {
+                parse_and_set_tristate(
+                  update.properties.retention_local_target_bytes, cfg.value);
+                continue;
+            }
             if (
               std::find(
                 std::begin(allowlist_topic_noop_confs),

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -34,7 +34,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 12> supported_configs{
+static constexpr std::array<std::string_view, 14> supported_configs{
   topic_property_compression,
   topic_property_cleanup_policy,
   topic_property_timestamp_type,
@@ -46,7 +46,9 @@ static constexpr std::array<std::string_view, 12> supported_configs{
   topic_property_remote_write,
   topic_property_remote_read,
   topic_property_read_replica,
-  topic_property_max_message_bytes};
+  topic_property_max_message_bytes,
+  topic_property_retention_local_target_bytes,
+  topic_property_retention_local_target_ms};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -564,6 +564,25 @@ ss::future<response_ptr> describe_configs_handler::handle(
               request.data.include_synonyms,
               &describe_as_string<bool>);
 
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_retention_local_target_bytes,
+              ctx.metadata_cache().get_default_retention_local_target_bytes(),
+              topic_property_retention_local_target_bytes,
+              topic_config->properties.retention_local_target_bytes,
+              request.data.include_synonyms);
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_retention_local_target_ms,
+              std::make_optional(
+                ctx.metadata_cache().get_default_retention_local_target_ms()),
+              topic_property_retention_local_target_ms,
+              topic_config->properties.retention_local_target_ms,
+              request.data.include_synonyms);
+
             // Data-policy property
             ss::sstring property_name = "redpanda.datapolicy";
             add_topic_config_if_requested(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -236,6 +236,18 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
                   model::shadow_indexing_mode::archival);
                 continue;
             }
+            if (cfg.name == topic_property_retention_local_target_bytes) {
+                parse_and_set_tristate(
+                  update.properties.retention_local_target_bytes,
+                  cfg.value,
+                  op);
+                continue;
+            }
+            if (cfg.name == topic_property_retention_local_target_ms) {
+                parse_and_set_tristate(
+                  update.properties.retention_local_target_ms, cfg.value, op);
+                continue;
+            }
             if (cfg.name == topic_property_remote_read) {
                 parse_and_set_shadow_indexing_mode(
                   update.properties.shadow_indexing,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -178,6 +178,13 @@ to_cluster_type(const creatable_topic& t) {
     if (cfg.properties.read_replica_bucket.has_value()) {
         cfg.properties.read_replica = true;
     }
+
+    cfg.properties.retention_local_target_bytes = get_tristate_value<size_t>(
+      config_entries, topic_property_retention_local_target_bytes);
+    cfg.properties.retention_local_target_ms
+      = get_tristate_value<std::chrono::milliseconds>(
+        config_entries, topic_property_retention_local_target_ms);
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 
@@ -275,6 +282,16 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
     if (properties.read_replica_bucket) {
         config_entries[topic_property_read_replica] = from_config_type(
           *properties.read_replica_bucket);
+    }
+
+    if (properties.retention_local_target_bytes.has_value()) {
+        config_entries[topic_property_retention_local_target_bytes]
+          = from_config_type(*properties.retention_local_target_bytes);
+    }
+
+    if (properties.retention_local_target_ms.has_value()) {
+        config_entries[topic_property_retention_local_target_ms]
+          = from_config_type(*properties.retention_local_target_ms);
     }
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -57,6 +57,10 @@ static constexpr std::string_view topic_property_remote_read
   = "redpanda.remote.read";
 static constexpr std::string_view topic_property_read_replica
   = "redpanda.remote.readreplica";
+static constexpr std::string_view topic_property_retention_local_target_bytes
+  = "retention.local.target.bytes";
+static constexpr std::string_view topic_property_retention_local_target_ms
+  = "retention.local.target.ms";
 
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -344,7 +344,9 @@ FIXTURE_TEST(
       "redpanda.datapolicy",
       "redpanda.remote.read",
       "redpanda.remote.write",
-      "max.message.bytes"};
+      "max.message.bytes",
+      "retention.local.target.bytes",
+      "retention.local.target.ms"};
 
     // All properies_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -130,7 +130,7 @@ public:
         }).get0();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
-        app.wire_up_and_start(*app_signal);
+        app.wire_up_and_start(*app_signal, true);
     }
 };
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -160,6 +160,8 @@ private:
 
     void wrote_stm_bytes(size_t);
 
+    compaction_config override_retention_config(compaction_config cfg) const;
+
 private:
     size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -49,6 +49,10 @@ public:
 
         std::optional<bool> read_replica;
 
+        tristate<size_t> retention_local_target_bytes{std::nullopt};
+        tristate<std::chrono::milliseconds> retention_local_target_ms{
+          std::nullopt};
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -44,8 +44,7 @@ public:
         topic_recovery_enabled recovery_enabled = topic_recovery_enabled::yes;
         // if set the value will control how data is uploaded and retrieved
         // to/from S3
-        model::shadow_indexing_mode shadow_indexing_mode
-          = model::shadow_indexing_mode::disabled;
+        std::optional<model::shadow_indexing_mode> shadow_indexing_mode;
 
         std::optional<bool> read_replica;
 
@@ -147,13 +146,15 @@ public:
     }
 
     bool is_archival_enabled() const {
-        return _overrides != nullptr
-               && model::is_archival_enabled(_overrides->shadow_indexing_mode);
+        return _overrides != nullptr && _overrides->shadow_indexing_mode
+               && model::is_archival_enabled(
+                 _overrides->shadow_indexing_mode.value());
     }
 
     bool is_remote_fetch_enabled() const {
-        return _overrides != nullptr
-               && model::is_fetch_enabled(_overrides->shadow_indexing_mode);
+        return _overrides != nullptr && _overrides->shadow_indexing_mode
+               && model::is_fetch_enabled(
+                 _overrides->shadow_indexing_mode.value());
     }
 
     bool is_read_replica_mode_enabled() const {

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -97,3 +97,133 @@ FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
     BOOST_CHECK_EQUAL(
       builder.get_disk_log_impl().get_probe().partition_size(), 0);
 }
+
+FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
+    /*
+     * This test sets the size retention limit on a cloud storage topic
+     * via the rention.local.target.bytes topic configuration option.
+     *
+     * Fixed size segments are added until the limit is breached.
+     * After each segment is added compaction is triggered and we check
+     * if it acted correctly.
+     */
+
+    config::shard_local_cfg().get("cloud_storage_enabled").set_value(true);
+
+    size_t size_limit = 1000;
+
+    storage::ntp_config config{
+      storage::log_builder_ntp(), builder.get_log_config().base_dir};
+
+    storage::ntp_config::default_overrides overrides;
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    overrides.retention_local_target_bytes = tristate<size_t>{size_limit};
+    config.set_overrides(overrides);
+
+    auto batch_builder = [](size_t offset, size_t size) {
+        return model::test::make_random_batch(
+          model::offset{offset},
+          1,
+          true,
+          model::record_batch_type::raft_data,
+          std::vector<size_t>{size});
+    };
+
+    auto partition_size = 0;
+    size_t dirty_offset = 0;
+
+    builder.start(std::move(config)).get();
+    while (partition_size <= size_limit) {
+        builder.add_segment(model::offset{dirty_offset}).get();
+        builder.add_batch(batch_builder(dirty_offset, 100)).get();
+
+        ++dirty_offset;
+        partition_size
+          = builder.get_disk_log_impl().get_probe().partition_size();
+
+        builder.get_log().set_collectible_offset(
+          builder.get_log().offsets().dirty_offset);
+
+        auto segment_count_before_gc = builder.get_log().segment_count();
+        builder
+          .gc(
+            model::timestamp(1),
+            std::make_optional<size_t>(std::numeric_limits<size_t>::max()))
+          .get();
+        auto segment_count_after_gc = builder.get_log().segment_count();
+
+        if (partition_size > size_limit) {
+            BOOST_CHECK_GT(segment_count_before_gc, segment_count_after_gc);
+        } else {
+            BOOST_CHECK_EQUAL(segment_count_before_gc, segment_count_after_gc);
+        }
+    }
+
+    auto final_partition_size
+      = builder.get_disk_log_impl().get_probe().partition_size();
+
+    BOOST_CHECK_GE(size_limit, final_partition_size);
+
+    builder.stop().get();
+}
+
+FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
+    /*
+     * This test sets the time retention limit on a cloud storage topic
+     * via the rention.local.target.ms topic configuration option.
+     */
+    using namespace std::chrono_literals;
+    auto batch_age = std::chrono::duration_cast<std::chrono::milliseconds>(1h);
+
+    config::shard_local_cfg().get("cloud_storage_enabled").set_value(true);
+
+    storage::ntp_config config{
+      storage::log_builder_ntp(), builder.get_log_config().base_dir};
+
+    storage::ntp_config::default_overrides overrides;
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    config.set_overrides(overrides);
+
+    auto log_creation_time = model::timestamp{
+      model::timestamp::now().value() - batch_age.count()};
+
+    // Create two log segments that are 1h old.
+    builder | storage::start(std::move(config)) | storage::add_segment(0)
+      | storage::add_random_batch(
+        0,
+        100,
+        storage::maybe_compress_batches::yes,
+        model::record_batch_type::raft_data,
+        storage::append_config(),
+        storage::disk_log_builder::should_flush_after::yes,
+        log_creation_time)
+      | storage::add_segment(100)
+      | storage::add_random_batch(
+        100,
+        100,
+        storage::maybe_compress_batches::yes,
+        model::record_batch_type::raft_data,
+        storage::append_config(),
+        storage::disk_log_builder::should_flush_after::yes,
+        log_creation_time);
+
+    builder.get_log().set_collectible_offset(
+      builder.get_log().offsets().dirty_offset);
+
+    // Try to garbage collet the segments. None should get collected
+    // because we are currently using the default local target retention.
+    builder | storage::garbage_collect(model::timestamp{1}, std::nullopt);
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 2);
+
+    // Override the local target retention.
+    storage::ntp_config::default_overrides time_override;
+    time_override.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    time_override.retention_local_target_ms
+      = tristate<std::chrono::milliseconds>{0ms};
+    builder.update_configuration(time_override).get();
+
+    // Collect again. One segment should be removed this time.
+    builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
+      | storage::stop();
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+}

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -97,7 +97,7 @@ inline constexpr auto add_segment = [](auto&&... args) {
 };
 
 inline constexpr auto add_random_batch = [](auto&&... args) {
-    arg_3_way_assert<sizeof...(args), 1, 6>();
+    arg_3_way_assert<sizeof...(args), 1, 7>();
     return std::make_tuple(
       add_random_batch_tag(), std::forward<decltype(args)>(args)...);
 };
@@ -207,6 +207,16 @@ public:
                   std::get<4>(args),
                   std::get<5>(args),
                   std::get<6>(args))
+                  .get();
+            } else if constexpr (size == 8) {
+                add_random_batch(
+                  model::offset(std::get<1>(args)),
+                  std::get<2>(args),
+                  std::get<3>(args),
+                  std::get<4>(args),
+                  std::get<5>(args),
+                  std::get<6>(args),
+                  std::get<7>(args))
                   .get();
             }
 
@@ -334,6 +344,14 @@ public:
     requires model::BatchReaderConsumer<Consumer>
     auto consume(Consumer c, log_reader_config config = reader_config()) {
         return consume_impl(std::move(c), std::move(config));
+    }
+
+    ss::future<> update_configuration(ntp_config::default_overrides o) {
+        if (_log) {
+            return _log->update_configuration(o);
+        }
+
+        return ss::make_ready_future<>();
     }
 
     // Configuration getters

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -91,13 +91,16 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
     fmt::print(
       o,
       "{{compaction_strategy: {}, cleanup_policy_bitflags: {}, segment_size: "
-      "{}, retention_bytes: {}, retention_time_ms: {}, recovery_enabled: {}}}",
+      "{}, retention_bytes: {}, retention_time_ms: {}, recovery_enabled: {}, "
+      "retention_local_target_bytes: {}, retention_local_target_ms: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
       v.retention_bytes,
       v.retention_time,
-      v.recovery_enabled);
+      v.recovery_enabled,
+      v.retention_local_target_bytes,
+      v.retention_local_target_ms);
 
     return o;
 }

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -29,6 +29,8 @@ class TopicSpec:
     PROPERTY_RETENTION_TIME = "retention.ms"
     PROPERTY_DATA_POLICY_FUNCTION_NAME = "redpanda.datapolicy.function.name"
     PROPERTY_DATA_POLICY_SCRIPT_NAME = "redpanda.datapolicy.script.name"
+    PROPERTY_RETENTION_LOCAL_TARGET_BYTES = "retention.local.target.bytes"
+    PROPERTY_RETENTION_LOCAL_TARGET_MS = "retention.local.target.ms"
 
     # compression types
     COMPRESSION_NONE = "none"

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -378,7 +378,8 @@ class ArchivalTest(RedpandaTest):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.log_segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.log_segment_size,
             },
         )
 

--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -46,11 +46,11 @@ class ControllerUpgradeTest(EndToEndTest):
         Validates that cluster is operational when upgrading controller log
         '''
 
-        # set redpanda version to v22.1 - last version without serde encoding
+        # set redpanda version to v22.2.5 - the latest previous major version
         self.redpanda = RedpandaService(self.test_context, 5)
 
         installer = self.redpanda._installer
-        installer.install(self.redpanda.nodes, (22, 1, 4))
+        installer.install(self.redpanda.nodes, (22, 2, 5))
 
         self.redpanda.start()
         admin_fuzz = AdminOperationsFuzzer(self.redpanda)

--- a/tests/rptest/tests/e2e_iam_role_test.py
+++ b/tests/rptest/tests/e2e_iam_role_test.py
@@ -46,7 +46,8 @@ class AWSRoleFetchTests(EndToEndShadowIndexingBase):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,
@@ -118,7 +119,8 @@ class STSRoleFetchTests(EndToEndShadowIndexingBase):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,
@@ -187,7 +189,8 @@ class ShortLivedCredentialsTests(EndToEndShadowIndexingBase):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -107,7 +107,8 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
             },
         )
 
@@ -153,7 +154,8 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
             },
         )
 
@@ -249,7 +251,10 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
 
         self.kafka_tools.alter_topic_config(
             self.topic,
-            {TopicSpec.PROPERTY_RETENTION_BYTES: 5 * self.segment_size},
+            {
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size
+            },
         )
 
         assert self.redpanda

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -52,11 +52,12 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
         def alter_and_verify():
             try:
                 rpk.alter_topic_config(
-                    topic, TopicSpec.PROPERTY_RETENTION_BYTES,
+                    topic, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
                     OffsetForLeaderEpochArchivalTest.segment_size)
 
                 cfgs = rpk.describe_topic_configs(topic)
-                retention = int(cfgs[TopicSpec.PROPERTY_RETENTION_BYTES][0])
+                retention = int(
+                    cfgs[TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES][0])
                 return retention == OffsetForLeaderEpochArchivalTest.segment_size
             except:
                 return False

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -6,17 +6,22 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import itertools
 
 from rptest.services.cluster import cluster
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
+from ducktape.errors import TimeoutError
 from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk import RpkTool
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.util import (produce_until_segments, wait_for_segments_removal,
-                         segments_count)
+from rptest.util import (produce_until_segments, produce_total_bytes,
+                         wait_for_segments_removal, segments_count,
+                         expect_exception)
 
 
 def bytes_for_segments(want_segments, segment_size):
@@ -184,3 +189,113 @@ class RetentionPolicyTest(RedpandaTest):
                        err_msg="Segments were not removed")
 
         validate_time_query_until_deleted()
+
+
+class ShadowIndexingRetentionTest(RedpandaTest):
+    segment_size = 1000000  # 1MB
+    default_retention_segments = 2
+    retention_segments = 4
+    total_segments = 10
+    topic_name = "si_test_topic"
+
+    def __init__(self, test_context):
+        extra_rp_conf = dict(log_compaction_interval_ms=1000,
+                             retention_local_target_bytes_default=self.
+                             default_retention_segments * self.segment_size)
+
+        super(ShadowIndexingRetentionTest, self).__init__(
+            test_context=test_context,
+            num_brokers=1,
+            si_settings=SISettings(log_segment_size=self.segment_size),
+            extra_rp_conf=extra_rp_conf,
+            log_level="trace")
+
+        self.rpk = RpkTool(self.redpanda)
+
+    def segments_removed(self, limit: int):
+        segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+            "kafka", self.topic_name, 0)
+        self.logger.debug(f"Current segments: {segs}")
+
+        return len(segs) <= limit
+
+    @cluster(num_nodes=1)
+    @matrix(cluster_remote_write=[True, False],
+            topic_remote_write=["true", "false", "-1"])
+    def test_shadow_indexing_default_local_retention(self,
+                                                     cluster_remote_write,
+                                                     topic_remote_write):
+        """
+        Test the default local retention on topics with remote write enabled.
+        The retention.local.target topic configuration properties control
+        the local retention of topics with remote write enabled. The defaults
+        for these topic configs are controlled via cluster level configs:
+        * retention_local_target_bytes_ms_default
+        * retention_local_target_bytes_bytes_default
+
+        This test goes through all possible combinations of cluster and topic
+        level remote write configurations and checks if segments were removed
+        at the end.
+        """
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_remote_write": cluster_remote_write},
+            expect_restart=True)
+
+        self.rpk.create_topic(topic=self.topic_name,
+                              partitions=1,
+                              replicas=1,
+                              config={
+                                  "cleanup.policy": TopicSpec.CLEANUP_DELETE,
+                                  "redpanda.remote.write": topic_remote_write
+                              })
+
+        expect_deletion = cluster_remote_write or topic_remote_write == "true"
+
+        produce_total_bytes(self.redpanda,
+                            topic=self.topic_name,
+                            partition_index=0,
+                            bytes_to_produce=self.total_segments *
+                            self.segment_size)
+
+        if expect_deletion:
+            wait_until(
+                lambda: self.segments_removed(self.default_retention_segments),
+                timeout_sec=5,
+                backoff_sec=1,
+                err_msg=f"Segments were not removed")
+        else:
+            with expect_exception(TimeoutError, lambda e: True):
+                wait_until(lambda: self.segments_removed(
+                    self.default_retention_segments),
+                           timeout_sec=5,
+                           backoff_sec=1)
+
+    @cluster(num_nodes=1)
+    def test_shadow_indexing_non_default_local_retention(self):
+        """
+        Test that the topic level retention.local.target.bytes config
+        overrides the cluster level default.
+        """
+        self.rpk.create_topic(topic=self.topic_name,
+                              partitions=1,
+                              replicas=1,
+                              config={
+                                  "cleanup.policy":
+                                  TopicSpec.CLEANUP_DELETE,
+                                  "redpanda.remote.write":
+                                  "true",
+                                  "retention.local.target.bytes":
+                                  str(self.segment_size *
+                                      self.retention_segments)
+                              })
+
+        produce_total_bytes(self.redpanda,
+                            topic=self.topic_name,
+                            partition_index=0,
+                            bytes_to_produce=self.total_segments *
+                            self.segment_size)
+
+        wait_until(lambda: self.segments_removed(self.retention_segments),
+                   timeout_sec=5,
+                   backoff_sec=1,
+                   err_msg=f"Segments were not removed")

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -86,7 +86,7 @@ class SIAdminApiTest(RedpandaTest):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 1024,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES: 1024,
             },
         )
 

--- a/tests/rptest/tests/shadow_indexing_firewall_test.py
+++ b/tests/rptest/tests/shadow_indexing_firewall_test.py
@@ -57,9 +57,10 @@ class ShadowIndexingFirewallTest(RedpandaTest):
                                count=5,
                                acks=-1)
 
-        self.rpk.alter_topic_config(self.s3_topic_name,
-                                    TopicSpec.PROPERTY_RETENTION_BYTES,
-                                    self.retention_bytes)
+        self.rpk.alter_topic_config(
+            self.s3_topic_name,
+            TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
+            self.retention_bytes)
 
         wait_for_segments_removal(redpanda=self.redpanda,
                                   topic=self.s3_topic_name,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -96,7 +96,8 @@ class ShadowIndexingTxTest(RedpandaTest):
         kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 3 * self.segment_size,
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                3 * self.segment_size,
             },
         )
         wait_for_segments_removal(redpanda=self.redpanda,

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -20,11 +20,12 @@ from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.producer_swarm import ProducerSwarm
 from rptest.services.redpanda import ResourceSettings, SISettings
+from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import matrix, parametrize
+from ducktape.mark import matrix, parametrize, ok_to_fail
 
 from rptest.tests.redpanda_test import RedpandaTest
 
@@ -416,3 +417,136 @@ class RecreateTopicMetadataTest(RedpandaTest):
             return True
 
         wait_until(metadata_consistent, 45, backoff_sec=2)
+
+
+class CreateTopicUpgradeTest(RedpandaTest):
+    def __init__(self, test_context):
+        si_settings = SISettings(cloud_storage_enable_remote_write=False,
+                                 cloud_storage_enable_remote_read=False)
+
+        super(CreateTopicUpgradeTest, self).__init__(test_context=test_context,
+                                                     num_brokers=3,
+                                                     si_settings=si_settings)
+        self.installer = self.redpanda._installer
+        self.rpk = RpkTool(self.redpanda)
+
+    def setUp(self):
+        self.installer.install(
+            self.redpanda.nodes,
+            (22, 2, 4),
+        )
+        self.redpanda.start()
+
+    @cluster(num_nodes=3)
+    def test_retention_config_on_upgrade_from_v22_2_to_v22_3(self):
+        self.rpk.create_topic("test-topic-with-retention",
+                              config={"retention.bytes": 10000})
+
+        self.rpk.create_topic("test-si-topic-with-retention",
+                              config={
+                                  "retention.bytes": 10000,
+                                  "redpanda.remote.write": "true"
+                              })
+
+        self.installer.install(
+            self.redpanda.nodes,
+            RedpandaInstaller.HEAD,
+        )
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        non_si_configs = self.rpk.describe_topic_configs(
+            "test-topic-with-retention")
+        si_configs = self.rpk.describe_topic_configs(
+            "test-si-topic-with-retention")
+
+        self.logger.debug(f"test-si-topic-with-retention conig: {si_configs}")
+        self.logger.debug(f"test-topic-with-retention: {non_si_configs}")
+
+        # "test-topic-with-retention" did not have remote write enabled
+        # at the time of the upgrade, so retention.* configs are preserved
+        # and retention.local.target.* configs are set to their default values,
+        # but ignored
+        assert non_si_configs["retention.bytes"] == ("10000",
+                                                     "DYNAMIC_TOPIC_CONFIG")
+        assert non_si_configs["retention.ms"][1] == "DEFAULT_CONFIG"
+
+        assert non_si_configs["retention.local.target.bytes"] == (
+            "-1", "DEFAULT_CONFIG")
+        assert non_si_configs["retention.local.target.ms"][
+            1] == "DEFAULT_CONFIG"
+
+        # 'test-si-topic-with-retention' was enabled from remote write
+        # at the time of the upgrade, so retention.local.target.* configs
+        # should be initialised from retention.* and retention.* configs should
+        # be disabled.
+        assert si_configs["retention.bytes"] == ("-1", "DYNAMIC_TOPIC_CONFIG")
+        assert si_configs["retention.ms"] == ("-1", "DYNAMIC_TOPIC_CONFIG")
+
+        assert si_configs["retention.local.target.bytes"] == (
+            "10000", "DYNAMIC_TOPIC_CONFIG")
+        assert si_configs["retention.local.target.ms"][1] == "DEFAULT_CONFIG"
+
+    # Previous version of Redpanda have a bug due to which the topic
+    # level overrides are not applied for remote read/write. This causes
+    # the test to fail. Remove ok_to_fail once #6663 is merged and
+    # backported. TODO(vlad)
+    @ok_to_fail
+    @cluster(num_nodes=3)
+    def test_retention_upgrade_with_cluster_remote_write(self):
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_remote_write": "true"}, expect_restart=True)
+
+        self.rpk.create_topic("test-topic-with-remote-write",
+                              config={"retention.bytes": 10000})
+
+        self.rpk.create_topic("test-topic-without-remote-write",
+                              config={
+                                  "retention.bytes": 10000,
+                                  "redpanda.remote.write": "false"
+                              })
+
+        self.installer.install(
+            self.redpanda.nodes,
+            RedpandaInstaller.HEAD,
+        )
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        without_remote_write_config = self.rpk.describe_topic_configs(
+            "test-topic-without-remote-write")
+        with_remote_write_config = self.rpk.describe_topic_configs(
+            "test-topic-with-remote-write")
+
+        self.logger.debug(
+            f"test-topic-with-remote-write config: {with_remote_write_config}")
+        self.logger.debug(
+            f"test-topic-without-remote-write config: {without_remote_write_config}"
+        )
+
+        # 'test-topic-without-remote-write' overwrites the global cluster config,
+        # so retention.* configs are preserved and retention.local.target.* configs
+        # are set to their default values, but ignored
+        assert without_remote_write_config["retention.bytes"] == (
+            "10000", "DYNAMIC_TOPIC_CONFIG")
+        assert without_remote_write_config["retention.ms"][
+            1] == "DEFAULT_CONFIG"
+
+        assert without_remote_write_config["retention.local.target.bytes"] == (
+            "-1", "DEFAULT_CONFIG")
+        assert with_remote_write_config["retention.local.target.ms"][
+            1] == "DEFAULT_CONFIG"
+
+        # "test-topic-with-remote-write-config" does not overwrite the
+        # cluster level remote write enablement, so retention.local.target.* configs
+        # should be initialised from retention.* and retention.* configs should
+        # be disabled.
+        assert with_remote_write_config["retention.bytes"] == (
+            "-1", "DYNAMIC_TOPIC_CONFIG")
+        assert with_remote_write_config["retention.ms"] == (
+            "-1", "DYNAMIC_TOPIC_CONFIG")
+
+        assert with_remote_write_config["retention.local.target.bytes"] == (
+            "10000", "DYNAMIC_TOPIC_CONFIG")
+        assert with_remote_write_config["retention.local.target.ms"][
+            1] == "DEFAULT_CONFIG"

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -123,6 +123,26 @@ def segments_count(redpanda, topic, partition_idx):
     )
 
 
+def produce_total_bytes(redpanda,
+                        topic,
+                        partition_index,
+                        bytes_to_produce,
+                        acks=-1):
+    kafka_tools = KafkaCliTools(redpanda)
+
+    def done():
+        nonlocal bytes_to_produce
+
+        kafka_tools.produce(topic, 10000, 1024, acks=acks)
+        bytes_to_produce -= 10000 * 1024
+        return bytes_to_produce < 0
+
+    wait_until(done,
+               timeout_sec=60,
+               backoff_sec=1,
+               err_msg="f{bytes_to_produce} bytes still left to produce")
+
+
 def produce_until_segments(redpanda,
                            topic,
                            partition_idx,


### PR DESCRIPTION
## Cover letter

This PR introduces two new topic configuration options (remote.local-target.bytes and remote.local-target.ms) which control the retention policy for partitions in topics with remote write enabled.

In v22.2 retention.bytes and retention.ms controlled the size of the local log for all topics (SI and non-SI).

For v22.3 we are going to have two sets of topic configuration properties dealing with retention:
* retention.bytes and retention.ms: For non-SI topics the behaviour does not change from v22.2. For SI topics they will control the total retention for the partition (retention for local and remote log).
* retention.local-target.bytes and retention.local-target.ms: For non-SI topics, these are ignored. For SI topics they will control the local retention for the partition (i.e. retention of the local log). Note that these configuration options have the same behaviour as retention.* for SI topics in v22.2.

Related https://github.com/redpanda-data/core-internal/issues/17

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Two new topic configuration options are added: retention.local-target.ms and retention.local-target.bytes. They control the way in which the local retention operates for topics with remote write enabled.

## Release notes
* Introduced retention.local-target.ms and retention.local-target.bytes topic configuration options. They control the retention policy of each partition within the topic and are only relevant for topics with remote write enabled.