### PR TITLE
Fixed segfault that may happen when data stream is opened during compaction

### DIFF
--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -42,7 +42,7 @@ segment_reader::~segment_reader() noexcept {
     }
 
     for (auto& i : _streams) {
-        i.detach();
+        i._parent = nullptr;
     }
 
     _streams.clear();
@@ -52,14 +52,13 @@ segment_reader::segment_reader(segment_reader&& rhs) noexcept
   : _filename(std::move(rhs._filename))
   , _data_file(std::move(rhs._data_file))
   , _data_file_refcount(rhs._data_file_refcount)
+  , _streams(std::move(rhs._streams))
   , _file_size(rhs._file_size)
   , _buffer_size(rhs._buffer_size)
   , _read_ahead(rhs._read_ahead)
   , _sanitize(rhs._sanitize) {
-    for (auto& i : rhs._streams) {
+    for (auto& i : _streams) {
         i._parent = this;
-        i._hook.unlink();
-        _streams.push_back(i);
     }
 }
 

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -62,6 +62,21 @@ segment_reader::segment_reader(segment_reader&& rhs) noexcept
     }
 }
 
+segment_reader& segment_reader::operator=(segment_reader&& rhs) noexcept {
+    _filename = std::move(rhs._filename);
+    _data_file = std::move(rhs._data_file);
+    _data_file_refcount = rhs._data_file_refcount;
+    _file_size = rhs._file_size;
+    _buffer_size = rhs._buffer_size;
+    _read_ahead = rhs._read_ahead;
+    _sanitize = rhs._sanitize;
+    _streams = std::move(rhs._streams);
+    for (auto& i : _streams) {
+        i._parent = this;
+    }
+    return *this;
+}
+
 ss::future<> segment_reader::load_size() {
     auto s = co_await stat();
     set_file_size(s.st_size);

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -101,11 +101,6 @@ public:
 
     ss::future<> close() override;
 
-    void detach() {
-        _parent = nullptr;
-        _hook.unlink();
-    }
-
     ~segment_reader_handle() override;
 };
 

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -113,7 +113,7 @@ public:
       debug_sanitize_files) noexcept;
     ~segment_reader() noexcept;
     segment_reader(segment_reader&&) noexcept;
-    segment_reader& operator=(segment_reader&&) noexcept = default;
+    segment_reader& operator=(segment_reader&&) noexcept;
     segment_reader(const segment_reader&) = delete;
     segment_reader& operator=(const segment_reader&) = delete;
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2769,6 +2769,58 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
     BOOST_REQUIRE_LE(post_compact_gaps.last_gap_end, max_compact_offset);
 };
 
+FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
+    // Test setup.
+    auto cfg = default_log_config(test_dir);
+    cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
+    cfg.stype = storage::log_config::storage_type::disk;
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto ntp = model::ntp("default", "test", 0);
+    storage::ntp_config::default_overrides overrides;
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    storage::ntp_config ntp_cfg(
+      ntp,
+      mgr.config().base_dir,
+      std::make_unique<storage::ntp_config::default_overrides>(overrides));
+    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto disk_log = get_disk_log(log);
+
+    // (1) append some random data, with limited number of distinct keys, so
+    // compaction can make progress.
+    auto headers = append_random_batches<key_limited_random_batch_generator>(
+      log, 20);
+
+    // (2) remember log offset, roll log, and produce more messages
+    log.flush().get0();
+
+    disk_log->force_roll(ss::default_priority_class()).get();
+    headers = append_random_batches<key_limited_random_batch_generator>(
+      log, 20);
+
+    // (3) roll log and trigger compaction, analyzing offset gaps before and
+    // after, to observe compaction behavior.
+    log.flush().get0();
+
+    disk_log->force_roll(ss::default_priority_class()).get();
+    storage::compaction_config ccfg(
+      model::timestamp::max(), // no time-based deletion
+      std::nullopt,
+      model::offset::max(),
+      ss::default_priority_class(),
+      as);
+    auto& segment = *(disk_log->segments().begin());
+    auto stream = segment
+                    ->offset_data_stream(
+                      model::offset(0), ss::default_priority_class())
+                    .get();
+    log.compact(std::move(ccfg)).get();
+    stream.close().get();
+};
+
 struct compact_test_args {
     model::offset max_compact_offs;
     long num_compactable_msg;

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -21,6 +21,7 @@
 #include "seastarx.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
+#include "storage/types.h"
 #include "test_utils/fixture.h"
 #include "units.h"
 
@@ -109,6 +110,7 @@ public:
           ss::default_priority_class(),
           cache);
 
+        cfg.segment_size_jitter = storage::jitter_percents(0);
         return cfg;
     }
 


### PR DESCRIPTION
## Cover letter

Fixed two issues that happened when self compacting segment with open output file streams. 

### Modifying list when iterating over

When `_stream` list was iterated and modified in the same loop this
invalidated the reference and caused segmentation fault. Using intrusive
list move constructor instead and then updating the parent pointer in
handler.

### Missing custom assignment operator

Added custom move assignment operator to `segment_reader` as when
assigned all the handlers must be updated with the parent pointer.

### Backtrace

```
void seastar::backtrace<seastar::backtrace_buffer::append_backtrace()::{lambda(seastar::frame)#1}>(seastar::backtrace_buffer::append_backtrace()::{lambda(seastar::frame)#1}&&) at /v/build/v_deps_build/seastar-prefix/src/seastar/include/seastar/util/backtrace.hh:59
 (inlined by) seastar::backtrace_buffer::append_backtrace() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:758
 (inlined by) seastar::print_with_backtrace(seastar::backtrace_buffer&, bool) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:788
seastar::print_with_backtrace(char const*, bool) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:800
 (inlined by) seastar::sigsegv_action() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3685
 (inlined by) operator() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3671
 (inlined by) __invoke at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3667
?? ??:0
boost::intrusive::list_node_traits<void*>::set_previous(boost::intrusive::list_node<void*>*, boost::intrusive::list_node<void*>*) at /vectorized/include/boost/intrusive/detail/list_node.hpp:57
 (inlined by) boost::intrusive::circular_list_algorithms<boost::intrusive::list_node_traits<void*> >::link_before(boost::intrusive::list_node<void*>*, boost::intrusive::list_node<void*>*) at /vectorized/include/boost/intrusive/circular_list_algorithms.hpp:181
 (inlined by) boost::intrusive::list_impl<boost::intrusive::mhtraits<storage::segment_reader_handle, boost::intrusive::list_member_hook<boost::intrusive::link_mode<(boost::intrusive::link_mode_type)2> >, &storage::segment_reader_handle::_hook>, unsigned long, false, void>::push_back(storage::segment_reader_handle&) at /vectorized/include/boost/intrusive/list.hpp:272
 (inlined by) segment_reader at /var/lib/buildkite-agent/builds/buildkite-amd64-xfs-builders-i-024fc11f21c7b9fe3-1/redpanda/redpanda/vbuild/release/clang/../../../src/v/storage/segment_reader.cc:62
_ZNSt3__14swapIN7storage14segment_readerEEENS_9enable_ifIXaasr21is_move_constructibleIT_EE5valuesr18is_move_assignableIS4_EE5valueEvE4typeERS4_S7_ at /vectorized/llvm/bin/../include/c++/v1/__utility/swap.h:35
storage::internal::do_swap_data_file_handles(std::__1::__fs::filesystem::path, seastar::lw_shared_ptr<storage::segment>, storage::compaction_config, storage::probe&) at /var/lib/buildkite-agent/builds/buildkite-amd64-xfs-builders-i-024fc11f21c7b9fe3-1/redpanda/redpanda/vbuild/release/clang/../../../src/v/storage/segment_utils.cc:437
std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume() const at /vectorized/llvm/bin/../include/c++/v1/__coroutine/coroutine_handle.h:168
 (inlined by) seastar::internal::coroutine_traits_base<void>::promise_type::run_and_dispose() at /vectorized/include/seastar/core/coroutine.hh:120
seastar::reactor::run_tasks(seastar::reactor::task_queue&) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2356
 (inlined by) seastar::reactor::run_some_tasks() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2769
seastar::reactor::do_run() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2938
operator() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:4163
 (inlined by) decltype ((static_cast<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94&>({parm#1}))()) std::__1::__invoke<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94&) at /vectorized/llvm/bin/../include/c++/v1/type_traits:3640
 (inlined by) void std::__1::__invoke_void_return_wrapper<void, true>::__call<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94&) at /vectorized/llvm/bin/../include/c++/v1/__functional/invoke.h:61
 (inlined by) std::__1::__function::__alloc_func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94>, void ()>::operator()() at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:180
 (inlined by) std::__1::__function::__func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_94>, void ()>::operator()() at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:354
std::__1::__function::__value_func<void ()>::operator()() const at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:507
 (inlined by) std::__1::function<void ()>::operator()() const at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:1184
 (inlined by) seastar::posix_thread::start_routine(void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/posix.cc:60
/opt/redpanda/lib/libpthread.so.0: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=7b0cdaf878ab4f99078439d864af70a5fd7b5a2c, for GNU/Linux 3.2.0, stripped
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
