### PR TITLE
Parameterize output directory of typescript codegenerator script

### DIFF
--- a/src/js/generate-entries.sh
+++ b/src/js/generate-entries.sh
@@ -30,17 +30,24 @@ fi
 echo "Using ${py}"
 
 root=$(git rev-parse --show-toplevel)
+output_dir=$1
+
+if [ ! -d "${output_dir}" ]; then
+  echo "Script expects one parameter, root directory of nodejs project"
+  exit 1
+fi
+
 cd "$root"/tools/ts-generator/types &&
   $py types_gen_js.py \
     --entities-define-file "$root"/src/js/modules/domain/generatedRpc/entitiesDefinition.json \
-    --output-file "$root"/src/js/modules/domain/generatedRpc/generatedClasses.ts
+    --output-file "$output_dir"/modules/domain/generatedRpc/generatedClasses.ts
 
 cd "$root"/tools/ts-generator/types &&
   $py types_gen_js.py \
     --entities-define-file "$root"/src/js/modules/domain/generatedRpc/enableDisableCoproc.json \
-    --output-file "$root"/src/js/modules/domain/generatedRpc/enableDisableCoprocClasses.ts
+    --output-file "$output_dir"/modules/domain/generatedRpc/enableDisableCoprocClasses.ts
 
 cd "$root"/tools/ts-generator/rpc &&
   $py rpc_gen_js.py \
     --server-define-file "$root"/src/v/coproc/gen.json \
-    --output-file "$root"/src/js/modules/rpc/serverAndClients/rpcServer.ts
+    --output-file "$output_dir"/modules/rpc/serverAndClients/rpcServer.ts

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -12,7 +12,7 @@
     "prettier:check": "npx prettier --list-different \".\"",
     "eslint:check": "eslint . --ext .ts",
     "code:ckeck": "npm run prettier:check && npm run eslint:check",
-    "generate:serialization": "./generate-entries.sh && npm run prettier:format",
+    "generate:serialization": "./generate-entries.sh $(pwd) && npm run prettier:format",
     "postinstall": "npm run generate:serialization",
     "publish:wasm-api": "./publish-wasm-dependecy.js",
     "start:dev": "sudo npx ts-node ./modules/rpc/service.ts",


### PR DESCRIPTION
This change removes a hardcoded path within a wasm engine build script and replaces it with a parameterized value passed to the script via cmd line args. 

This will be used in subsequent vtools pull requests to modify the nodejs installation

## Release notes
- none