### PR TITLE
bootstrap: plug in initial abstractions

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -1,6 +1,12 @@
 find_package(Roaring REQUIRED)
 include(rpcgen)
 rpcgen(
+  TARGET bootstrap_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/cluster_bootstrap_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+rpcgen(
   TARGET controller_rpc
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/controller.json
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/controller_service.h
@@ -114,8 +120,10 @@ v_cc_library(
     partition_balancer_rpc_handler.cc
     node_status_backend.cc
     node_status_rpc_handler.cc
+    bootstrap_service.cc
   DEPS
     Seastar::seastar
+    bootstrap_rpc
     controller_rpc
     metadata_rpc
     id_allocator_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -85,6 +85,7 @@ v_cc_library(
     security_frontend.cc
     data_policy_manager.cc
     data_policy_frontend.cc
+    cluster_discovery.cc
     controller_api.cc
     members_frontend.cc
     members_backend.cc

--- a/src/v/cluster/bootstrap.json
+++ b/src/v/cluster/bootstrap.json
@@ -1,0 +1,15 @@
+{
+    "namespace": "cluster",
+    "service_name": "cluster_bootstrap",
+    "includes": [
+        "cluster/bootstrap_types.h"
+    ],
+    "methods": [
+        {
+            "name": "cluster_bootstrap_info",
+            "input_type": "cluster_bootstrap_info_request",
+            "output_type": "cluster_bootstrap_info_reply"
+        }
+    ]
+}
+

--- a/src/v/cluster/bootstrap_service.cc
+++ b/src/v/cluster/bootstrap_service.cc
@@ -1,0 +1,24 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/bootstrap_service.h"
+
+#include "cluster/bootstrap_types.h"
+
+namespace cluster {
+
+ss::future<cluster_bootstrap_info_reply>
+bootstrap_service::cluster_bootstrap_info(
+  cluster_bootstrap_info_request&&, rpc::streaming_context&) {
+    cluster_bootstrap_info_reply r{};
+    // TODO: add fields!
+    co_return r;
+}
+
+} // namespace cluster

--- a/src/v/cluster/bootstrap_service.h
+++ b/src/v/cluster/bootstrap_service.h
@@ -1,0 +1,29 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "cluster/bootstrap_types.h"
+#include "cluster/cluster_bootstrap_service.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+// RPC service to be used when initialially bootstrapping a cluster.
+// TODO: talk about how it's a slim service with few dependencies.
+class bootstrap_service : public cluster_bootstrap_service {
+public:
+    bootstrap_service(ss::scheduling_group sg, ss::smp_service_group ssg)
+      : cluster_bootstrap_service(sg, ssg) {}
+
+    ss::future<cluster_bootstrap_info_reply> cluster_bootstrap_info(
+      cluster_bootstrap_info_request&&, rpc::streaming_context&) override;
+};
+
+} // namespace cluster

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -1,0 +1,48 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "model/fundamental.h"
+#include "serde/serde.h"
+
+#include <fmt/core.h>
+
+#include <vector>
+
+namespace cluster {
+
+struct cluster_bootstrap_info_request
+  : serde::envelope<cluster_bootstrap_info_request, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const cluster_bootstrap_info_request&) {
+        fmt::print(o, "{{}}");
+        return o;
+    }
+
+    auto serde_fields() { return std::tie(); }
+};
+
+struct cluster_bootstrap_info_reply
+  : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    // TODO: add fields!
+
+    auto serde_fields() { return std::tie(); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const cluster_bootstrap_info_reply&) {
+        fmt::print(o, "{{}}");
+        return o;
+    }
+};
+
+} // namespace cluster

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -1,0 +1,48 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/cluster_discovery.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/logger.h"
+#include "config/node_config.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <chrono>
+
+using model::broker;
+using model::node_id;
+using std::vector;
+
+namespace cluster {
+
+cluster_discovery::cluster_discovery(const model::node_uuid& node_uuid)
+  : _node_uuid(node_uuid) {}
+
+ss::future<node_id> cluster_discovery::determine_node_id() {
+    co_return config::node().node_id();
+}
+
+vector<broker> cluster_discovery::initial_raft0_brokers() const {
+    // If configured as the root node, we'll want to start the cluster with
+    // just this node as the initial seed.
+    if (is_cluster_founder()) {
+        // TODO: we should only return non-empty seed list if our log is empty.
+        return {make_self_broker(config::node())};
+    }
+    return {};
+}
+
+bool cluster_discovery::is_cluster_founder() const {
+    return config::node().seed_servers().empty();
+}
+
+} // namespace cluster

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -31,9 +31,9 @@ public:
     // Determines what the node ID for this node should be. Once called, we can
     // proceed with initializing anything that depends on node ID.
     //
-    // On an seed server with no data on it (i.e. a fresh node), this sends
+    // On a seed server with no data on it (i.e. a fresh node), this sends
     // requests to all other seed servers to determine if there is a valid
-    // assigned of node IDs for the seeds.
+    // assignment of node IDs for the seeds.
     //
     // On a non-seed server with no node ID specified via config, this sends a
     // request to the controllers to register this node's UUID and assign it a

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -1,0 +1,70 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+#include <optional>
+#include <vector>
+
+namespace cluster {
+
+// Provides metadata pertaining to initial cluster discovery.
+class cluster_discovery {
+public:
+    explicit cluster_discovery(const model::node_uuid& node_uuid);
+
+    // Returns this node's node ID.
+    //
+    // TODO: implement the below behavior.
+    //
+    // Determines what the node ID for this node should be. Once called, we can
+    // proceed with initializing anything that depends on node ID.
+    //
+    // On an seed server with no data on it (i.e. a fresh node), this sends
+    // requests to all other seed servers to determine if there is a valid
+    // assigned of node IDs for the seeds.
+    //
+    // On a non-seed server with no node ID specified via config, this sends a
+    // request to the controllers to register this node's UUID and assign it a
+    // node ID.
+    ss::future<model::node_id> determine_node_id();
+
+    // If configured as the root, return this broker as the sole initial Raft0
+    // broker.
+    //
+    // TODO: implement the below behavior.
+    //
+    // Returns brokers to be used to form a Raft group for a new cluster.
+    //
+    // If this node is a seed server, returns all seed servers, assuming seeds
+    // are configured with identical seed servers.
+    //
+    // If this node is not a seed server returns an empty list.
+    std::vector<model::broker> initial_raft0_brokers() const;
+
+private:
+    // Returns whether this node is the root node.
+    //
+    // TODO: implement the below behavior.
+    //
+    // Returns true if the local node is a founding member of the cluster, as
+    // indicated by either us having an empty seed server (we are the root node
+    // in a legacy config) or our node UUID matching one of those returned by
+    // the seed servers.
+    bool is_cluster_founder() const;
+
+    const model::node_uuid _node_uuid;
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -98,12 +98,8 @@ ss::future<> controller::wire_up() {
       .then([this] { _probe.start(); });
 }
 
-ss::future<> controller::start() {
-    std::vector<model::broker> initial_raft0_brokers;
-    if (config::node().seed_servers().empty()) {
-        initial_raft0_brokers.push_back(
-          cluster::make_self_broker(config::node()));
-    }
+ss::future<>
+controller::start(std::vector<model::broker> initial_raft0_brokers) {
     return create_raft0(
              _partition_manager,
              _shard_table,

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -118,7 +118,7 @@ public:
 
     ss::future<> wire_up();
 
-    ss::future<> start();
+    ss::future<> start(std::vector<model::broker>);
     // prevents controller from accepting new requests
     ss::future<> shutdown_input();
     ss::future<> stop();

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -16,6 +16,7 @@
 #include "serde/serde.h"
 #include "ssx/sformat.h"
 #include "utils/named_type.h"
+#include "utils/uuid.h"
 #include "vassert.h"
 
 #include <seastar/core/sstring.hh>
@@ -42,6 +43,8 @@ using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
 } // namespace s3
 
 namespace model {
+
+using node_uuid = named_type<uuid_t, struct node_uuid_type>;
 
 // Named after Kafka cleanup.policy topic property
 enum class cleanup_policy_bitflags : uint8_t {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -50,6 +50,10 @@
 
 namespace po = boost::program_options; // NOLINT
 
+namespace cluster {
+class cluster_discovery;
+} // namespace cluster
+
 namespace kafka {
 struct group_metadata_migration;
 } // namespace kafka
@@ -114,11 +118,22 @@ private:
     using deferred_actions
       = std::vector<ss::deferred_action<std::function<void()>>>;
 
+    // Constructs services across shards required to get bootstrap metadata.
+    void wire_up_bootstrap_services();
+
+    // Starts services across shards required to get bootstrap metadata.
+    void start_bootstrap_services();
+
+    // Constructs services across shards meant for Redpanda runtime.
+    void wire_up_runtime_services(model::node_id node_id);
     void configure_admin_server();
-    void wire_up_services();
-    void wire_up_redpanda_services();
-    void start_redpanda(::stop_signal&);
-    void start_kafka(::stop_signal&);
+    void wire_up_redpanda_services(model::node_id);
+
+    // Starts the services meant for Redpanda runtime. Must be called after
+    // having constructed the subsystems via the corresponding `wire_up` calls.
+    void
+    start_runtime_services(const cluster::cluster_discovery&, ::stop_signal&);
+    void start_kafka(const model::node_id&, ::stop_signal&);
 
     // All methods are calleds from Seastar thread
     ss::app_template::config setup_app_config();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -36,6 +36,7 @@
 #include "resource_mgmt/scheduling_groups_probe.h"
 #include "resource_mgmt/smp_groups.h"
 #include "rpc/fwd.h"
+#include "rpc/rpc_server.h"
 #include "seastarx.h"
 #include "ssx/metrics.h"
 #include "storage/fwd.h"
@@ -173,7 +174,7 @@ private:
     ss::sharded<features::feature_table> _feature_table;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<kafka::group_manager> _co_group_manager;
-    ss::sharded<net::server> _rpc;
+    ss::sharded<rpc::rpc_server> _rpc;
     ss::sharded<admin_server> _admin;
     ss::sharded<net::conn_quota> _kafka_conn_quotas;
     ss::sharded<net::server> _kafka_server;

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/fundamental.h"
 #include "seastarx.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
@@ -75,6 +76,12 @@ public:
         return f;
     }
 
+    void set_node_uuid(const model::node_uuid& node_uuid) {
+        _node_uuid = node_uuid;
+    }
+
+    model::node_uuid node_uuid() const { return _node_uuid; }
+
     kvstore& kvs() { return *_kvstore; }
     log_manager& log_mgr() { return *_log_mgr; }
     storage_resources& resources() { return _resources; }
@@ -87,6 +94,11 @@ private:
 
     std::unique_ptr<kvstore> _kvstore;
     std::unique_ptr<log_manager> _log_mgr;
+
+    // UUID that uniquely identifies the contents of this node's data
+    // directory. Should be generated once upon first starting up and
+    // immediately persisted into `_kvstore`.
+    model::node_uuid _node_uuid;
 };
 
 } // namespace storage


### PR DESCRIPTION
## Cover letter

This PR introduces and plumbs some new abstractions into the `redpanda::application` that will be useful for node ID assignment and a revamp of cluster bootstrap. The new abstractions are more or less empty (or fall back on today's behavior), with the intention of being developed in parallel.

Pushing this separately to get some CI runs in.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


## Release notes

* none
