### PR TITLE
test: remove tiny falloc config in test_cpu_limited

### DIFF
--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -75,7 +75,6 @@ class ResourceLimitsTest(RedpandaTest):
         self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
 
         self.redpanda.set_extra_rp_conf({
-            'segment_fallocation_step': 16384,
             # Disable memory limit: on a test node the physical memory can easily
             # be the limiting factor
             'topic_memory_per_partition': None,


### PR DESCRIPTION
## Cover letter

This used to be needed because partition_allocator applied a condition that at least one falloc-step of space was needed per partition, so the test de-facto disabled this check by setting a tiny falloc step.

However, since storage_resources was added with its dynamic falloc size, that space check is no longer applied at partition creation time, so it is unnecessary for the test to set a custom falloc size.

This tiny falloc step was a suspected contributor to occasional failures of this test with unstable raft leadership (perhaps the tiny falloc step was making the storage layer too slow).

Related: https://github.com/redpanda-data/redpanda/issues/6545

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none