### PR TITLE
Allow using public TLS certificates for Pandaproxy API

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -491,18 +491,16 @@ func (r *Cluster) validatePandaproxyListeners() field.ErrorList {
 			}
 			foundListenerWithTLS = true
 		}
-		tlsErrors := validatePandaproxyTLS(p.TLS,
+		tlsErrs := validateListener(
+			p.TLS.Enabled,
+			p.TLS.RequireClientAuth,
+			p.TLS.IssuerRef,
+			p.TLS.NodeSecretRef,
 			field.NewPath("spec").Child("configuration").Child("pandaproxyApi").Index(i).Child("tls"),
-			&p.External,
-			field.NewPath("spec").Child("configuration").Child("pandaproxyApi").Index(i).Child("external"))
-		allErrs = append(allErrs, tlsErrors...)
-		// TODO(#2256): Add support for external listener + TLS certs for IPs
-		if p.TLS.Enabled && p.External.Enabled && p.External.Subdomain == "" {
-			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec").Child("configuration").Child("pandaproxyApi").Index(i).Child("external").Child("subdomain"),
-					r.Spec.Configuration.PandaproxyAPI[i].External.Subdomain,
-					"TLS requires specifying a subdomain"))
-		}
+			&p.External.ExternalConnectivityConfig,
+			field.NewPath("spec").Child("configuration").Child("pandaproxyApi").Index(i).Child("external"),
+		)
+		allErrs = append(allErrs, tlsErrs...)
 	}
 
 	// If we have an external proxy listener and no other listeners, we're missing an internal one
@@ -792,30 +790,6 @@ func validateListener(
 				"Cannot provide both IssuerRef and NodeSecretRef"))
 	}
 	if tlsEnabled && external != nil && external.Enabled && external.Subdomain == "" {
-		allErrs = append(allErrs,
-			field.Invalid(
-				externalPath.Child("subdomain"),
-				external.Subdomain,
-				"TLS requires specifying a subdomain"))
-	}
-	return allErrs
-}
-
-func validatePandaproxyTLS(
-	tlsConfig PandaproxyAPITLS,
-	path *field.Path,
-	external *PandaproxyExternalConnectivityConfig,
-	externalPath *field.Path,
-) field.ErrorList {
-	var allErrs field.ErrorList
-	if tlsConfig.RequireClientAuth && !tlsConfig.Enabled {
-		allErrs = append(allErrs,
-			field.Invalid(
-				path.Child("requireclientauth"),
-				tlsConfig.RequireClientAuth,
-				"Enabled has to be set to true for RequireClientAuth to be allowed to be true"))
-	}
-	if tlsConfig.Enabled && external != nil && external.Enabled && external.Subdomain == "" {
 		allErrs = append(allErrs,
 			field.Invalid(
 				externalPath.Child("subdomain"),

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -527,20 +527,18 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("external proxy listener cannot have port specified", func(t *testing.T) {
-		multiPort := redpandaCluster.DeepCopy()
-		multiPort.Spec.Configuration.PandaproxyAPI = append(multiPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123},
-			v1alpha1.PandaproxyAPI{Port: 321})
-		err := multiPort.ValidateUpdate(redpandaCluster)
-
-		assert.Error(t, err)
-	})
-
 	t.Run("pandaproxy tls disabled with client auth enabled", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{TLS: v1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true}})
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+			External: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+			Port:     30092,
+		})
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
+			External: v1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+			},
+			TLS: v1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true},
+		})
 
 		err := tls.ValidateUpdate(redpandaCluster)
 		assert.Error(t, err)

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -544,6 +544,40 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("pandaproxy tls issuerref with secretref is not allowed", func(t *testing.T) {
+		tls := redpandaCluster.DeepCopy()
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+			External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+			Port:     30092,
+		})
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
+			External: v1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+			},
+			TLS: v1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmeta.ObjectReference{}, NodeSecretRef: &corev1.ObjectReference{}},
+		})
+
+		err := tls.ValidateUpdate(redpandaCluster)
+		assert.Error(t, err)
+	})
+
+	t.Run("pandaproxy tls can specify issuerref", func(t *testing.T) {
+		tls := redpandaCluster.DeepCopy()
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+			External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+			Port:     30092,
+		})
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
+			External: v1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+			},
+			TLS: v1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmeta.ObjectReference{}},
+		})
+
+		err := tls.ValidateUpdate(redpandaCluster)
+		assert.NoError(t, err)
+	})
+
 	t.Run("resource limits/requests on redpanda resources", func(t *testing.T) {
 		c := redpandaCluster.DeepCopy()
 		c.Spec.Resources.Limits = corev1.ResourceList{

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -473,7 +473,79 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                            issuerRef:
+                              description: References cert-manager Issuer or ClusterIssuer.
+                                When provided, this issuer will be used to issue node
+                                certificates. Typically you want to provide the issuer
+                                when a generated self-signed one is not enough and
+                                you need to have a verifiable chain with a proper
+                                CA certificate.
+                              properties:
+                                group:
+                                  description: Group of the resource being referred
+                                    to.
+                                  type: string
+                                kind:
+                                  description: Kind of the resource being referred
+                                    to.
+                                  type: string
+                                name:
+                                  description: Name of the resource being referred
+                                    to.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            nodeSecretRef:
+                              description: 'If provided, operator uses certificate
+                                in this secret instead of issuing its own node certificate.
+                                The secret is expected to provide the following keys:
+                                ''ca.crt'', ''tls.key'' and ''tls.crt'' If NodeSecretRef
+                                points to secret in different namespace, operator
+                                will duplicate the secret to the same namespace as
+                                redpanda CRD to be able to mount it to the nodes'
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                    instead of an entire object, this string should
+                                    contain a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2]. For
+                                    example, if the object reference is to a container
+                                    within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to
+                                    the name of the container that triggered the event)
+                                    or if no container name is specified "spec.containers[2]"
+                                    (container with index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined way of
+                                    referencing a part of an object. TODO: this design
+                                    is not final and this field is subject to change
+                                    in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
                             requireClientAuth:
+                              description: Enables two-way verification on the server
+                                side. If enabled, all Pandaproxy API clients are required
+                                to have a valid client certificate.
                               type: boolean
                           type: object
                       type: object

--- a/src/go/k8s/tests/e2e/explicit-ports-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/explicit-ports-tls/00-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: explicit-ports-tls
+status:
+  nodes:
+    external:
+    - kafka-0.cluster.com:30092
+    externalPandaproxy:
+    - panda-proxy-0.cluster.com:30082
+    schemaRegistry:
+      external: schema-registry.cluster.com:30081
+  readyReplicas: 1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: explicit-ports-tls-external
+spec:
+  ports:
+  - name: kafka-external
+    nodePort: 30092
+    port: 30092
+    protocol: TCP
+    targetPort: 30092
+  - name: proxy-external
+    nodePort: 30082
+    port: 30082
+    protocol: TCP
+    targetPort: 30082
+  - name: schema-registry
+    nodePort: 30081
+    port: 30081
+    protocol: TCP
+    targetPort: 30081
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: explicit-ports-tls-proxy-api-node
+spec:
+  issuerRef:
+    kind: Issuer
+    name: explicit-port-tls-issuer
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: app.kubernetes.io/name=redpanda
+    tail: -1
+  - type: pod
+    namespace: redpanda-system
+    selector: control-plane=controller-manager
+    tail: -1
+  - type: command
+    command: kubectl get clusters -o jsonpath={@} -n $NAMESPACE
+  - type: command
+    command: kubectl get pods -o jsonpath={@} -n $NAMESPACE

--- a/src/go/k8s/tests/e2e/explicit-ports-tls/00-initial-resources.yaml
+++ b/src/go/k8s/tests/e2e/explicit-ports-tls/00-initial-resources.yaml
@@ -1,0 +1,65 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: explicit-port-tls-issuer
+spec:
+  selfSigned: {}
+
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: explicit-ports-tls
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    adminApi:
+    - port: 9644
+    kafkaApi:
+    - port: 9092
+    - port: 30092
+      external:
+        enabled: true
+        subdomain: cluster.com
+        endpointTemplate: "kafka-{{ .Index }}"
+      tls:
+        enabled: true
+        issuerRef:
+          kind: Issuer
+          name: explicit-port-tls-issuer
+    pandaproxyApi:
+     - port: 8082
+     - port: 30082
+       external:
+         enabled: true
+         subdomain: cluster.com
+         endpointTemplate: "panda-proxy-{{ .Index }}"
+       tls:
+         enabled: true
+         issuerRef:
+           kind: Issuer
+           name: explicit-port-tls-issuer
+    schemaRegistry:
+      port: 30081
+      external:
+        staticNodePort: true
+        enabled: true
+        subdomain: cluster.com
+        endpoint: schema-registry
+      tls:
+        enabled: true
+        issuerRef:
+          kind: Issuer
+          name: explicit-port-tls-issuer
+    developerMode: true

--- a/src/go/k8s/tests/e2e/explicit-ports-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/explicit-ports-tls/01-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    job-name: explicit-ports-tls-check
+status:
+  phase: Succeeded
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: app.kubernetes.io/name=redpanda
+    tail: -1
+  - type: pod
+    namespace: redpanda-system
+    selector: control-plane=controller-manager
+    tail: -1
+  - type: command
+    command: kubectl get clusters -o jsonpath={@} -n $NAMESPACE
+  - type: command
+    command: kubectl get pods -o jsonpath={@} -n $NAMESPACE

--- a/src/go/k8s/tests/e2e/explicit-ports-tls/01-probes.yaml
+++ b/src/go/k8s/tests/e2e/explicit-ports-tls/01-probes.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: explicit-ports-tls-check
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      activeDeadlineSeconds: 90
+      containers:
+        - name: curl
+          image: curlimages/curl:latest
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - >
+              echo "Checking that the listener is bound to both Pandaproxy and schema registry ports and TLS is used" && 
+              sr_res=$(curl --silent -o /dev/null -w "%{http_code}" -k https://explicit-ports-tls-0.explicit-ports-tls.$NAMESPACE.svc.cluster.local:30081) &&
+              pp_res=$(curl --silent -o /dev/null -w "%{http_code}" -k https://explicit-ports-tls-0.explicit-ports-tls.$NAMESPACE.svc.cluster.local:30082) &&
+              if [[ "$sr_res" != "404" ]] || [[ "$pp_res" != "404" ]]; then
+                exit 1;
+              fi
+      restartPolicy: Never


### PR DESCRIPTION
## Cover letter

This adds the possibility to specify a TLS issuer for Pandaproxy, like it happens for Kafka and Schema registry. It does so by adding two new fields (issuerRef, nodeSecretRef) to PandaproxyAPI spec.

## Release notes

### Improvements

* Operator: it's now possible to specify a TLS issuer for Pandaproxy API
