### PR TITLE
sr: add basic auth support to the schema registry

### DIFF
--- a/src/v/config/rest_authn_endpoint.cc
+++ b/src/v/config/rest_authn_endpoint.cc
@@ -44,6 +44,15 @@ std::ostream& operator<<(std::ostream& os, const rest_authn_endpoint& ep) {
     return os;
 }
 
+rest_authn_method get_authn_method(
+  const std::vector<rest_authn_endpoint>& endpoints, size_t listener_idx) {
+    if (listener_idx >= endpoints.size()) {
+        return rest_authn_method::none;
+    }
+
+    return endpoints[listener_idx].authn_method.value_or(
+      rest_authn_method::none);
+}
 } // namespace config
 
 namespace YAML {

--- a/src/v/config/rest_authn_endpoint.h
+++ b/src/v/config/rest_authn_endpoint.h
@@ -58,6 +58,11 @@ struct rest_authn_endpoint {
 rest_authn_method get_authn_method(
   const std::vector<rest_authn_endpoint>& endpoints, size_t listener_idx);
 
+struct always_true : public binding<bool> {
+    always_true()
+      : binding<bool>(true) {}
+};
+
 namespace detail {
 
 template<>

--- a/src/v/config/rest_authn_endpoint.h
+++ b/src/v/config/rest_authn_endpoint.h
@@ -24,6 +24,7 @@
 #include <iosfwd>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace config {
 
@@ -50,6 +51,12 @@ struct rest_authn_endpoint {
     friend std::ostream&
     operator<<(std::ostream& os, const rest_authn_endpoint& ep);
 };
+
+// A helper method that searches for the listener within a vector of
+// rest_authn_endpoints. Returns the authn method if the address is found.
+// Returns none type otherwise
+rest_authn_method get_authn_method(
+  const std::vector<rest_authn_endpoint>& endpoints, size_t listener_idx);
 
 namespace detail {
 

--- a/src/v/pandaproxy/auth_utils.h
+++ b/src/v/pandaproxy/auth_utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "config/rest_authn_endpoint.h"
+#include "pandaproxy/types.h"
+#include "redpanda/request_auth.h"
+
+#include <seastar/http/request.hh>
+
+#include <vector>
+
+namespace pandaproxy {
+// Authenticate the request when HTTP Basic Auth is enabled and return the
+// authenticated user. Otherwise return the default user.
+inline credential_t maybe_authenticate_request(
+  config::rest_authn_method authn_method,
+  request_authenticator& authenticator,
+  const ss::httpd::request& req) {
+    credential_t user;
+
+    if (authn_method == config::rest_authn_method::http_basic) {
+        // Will throw 400 & 401 if auth fails
+        auto auth_result = authenticator.authenticate(req);
+        // Will throw 403 if user enabled HTTP Basic Auth but
+        // did not give the authorization header.
+        auth_result.require_authenticated();
+        user = credential_t{
+          auth_result.get_username(), auth_result.get_password()};
+    }
+
+    return user;
+}
+} // namespace pandaproxy

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -83,15 +83,4 @@ configuration::configuration()
           }
           return msg;
       }) {}
-
-config::rest_authn_method configuration::authn_method(size_t listener_idx) {
-    const auto& pp_api = pandaproxy_api.value();
-
-    if (listener_idx < 0 || listener_idx >= pp_api.size()) {
-        return config::rest_authn_method::none;
-    }
-
-    return pp_api[listener_idx].authn_method.value_or(
-      config::rest_authn_method::none);
-}
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -41,12 +41,6 @@ struct configuration final : public config::config_store {
 
     configuration();
     explicit configuration(const YAML::Node& cfg);
-
-    // A helper method that searches for the listener within
-    // the list of pandaproxy_api endpoints.
-    // Returns the authn method if the address is found.
-    // Returns none type otherwise
-    config::rest_authn_method authn_method(size_t listener_idx);
 };
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -9,16 +9,15 @@
 
 #include "pandaproxy/rest/proxy.h"
 
-#include "config/rest_authn_endpoint.h"
 #include "net/unresolved_address.h"
 #include "pandaproxy/api/api-doc/rest.json.h"
+#include "pandaproxy/auth_utils.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/exceptions.h"
 #include "pandaproxy/parsing/from_chars.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/handlers.h"
 #include "pandaproxy/sharded_client_cache.h"
-#include "pandaproxy/types.h"
 #include "utils/gate_guard.h"
 
 #include <seastar/core/future-util.hh>
@@ -38,16 +37,8 @@ auto wrap(Handler h) {
           rq.service().config().pandaproxy_api.value(),
           rq.req->get_listener_idx());
 
-        if (rq.authn_method == config::rest_authn_method::http_basic) {
-            // Will throw 400 & 401 if auth fails
-            auto auth_result = rq.service().authenticator().authenticate(
-              *rq.req);
-            // Will throw 403 if user enabled HTTP Basic Auth but
-            // did not give the authorization header.
-            auth_result.require_authenticated();
-            rq.user = credential_t{
-              auth_result.get_username(), auth_result.get_password()};
-        }
+        rq.user = maybe_authenticate_request(
+          rq.authn_method, rq.service().authenticator(), *rq.req);
 
         return h(std::move(rq), std::move(rp));
     };
@@ -91,11 +82,6 @@ server::routes_t get_proxy_routes() {
     return routes;
 }
 
-struct always_true : public config::binding<bool> {
-    always_true()
-      : config::binding<bool>(true) {}
-};
-
 proxy::proxy(
   const YAML::Node& config,
   ss::smp_service_group smp_sg,
@@ -116,7 +102,7 @@ proxy::proxy(
       "/definitions",
       _ctx,
       json::serialization_format::application_json)
-  , _auth{always_true(), controller} {}
+  , _auth{config::always_true(), controller} {}
 
 ss::future<> proxy::start() {
     _server.routes(get_proxy_routes());

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -34,7 +34,8 @@ auto wrap(Handler h) {
     return [h{std::move(h)}](
              server::request_t rq,
              server::reply_t rp) -> ss::future<server::reply_t> {
-        rq.authn_method = rq.service().config().authn_method(
+        rq.authn_method = config::get_authn_method(
+          rq.service().config().pandaproxy_api.value(),
           rq.req->get_listener_idx());
 
         if (rq.authn_method == config::rest_authn_method::http_basic) {

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -17,6 +17,7 @@
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/util.h"
 #include "pandaproxy/server.h"
+#include "redpanda/request_auth.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -51,6 +52,7 @@ public:
     ss::sharded<kafka::client::client>& client() { return _client; }
     seq_writer& writer() { return _writer.local(); }
     sharded_store& schema_store() { return _store; }
+    request_authenticator& authenticator() { return _auth; }
 
 private:
     ss::future<> do_start();
@@ -67,6 +69,7 @@ private:
     std::unique_ptr<cluster::controller>& _controller;
 
     one_shot _ensure_started;
+    request_authenticator _auth;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -374,6 +374,7 @@ class SecurityConfig:
         self.tls_provider: Optional[TLSProvider] = None
         self.require_client_auth: bool = True
         self.pp_authn_method: Optional[str] = None
+        self.sr_authn_method: Optional[str] = None
 
         # The rules to extract principal from mtls
         self.principal_mapping_rules = self.__DEFAULT_PRINCIPAL_MAPPING_RULES
@@ -1592,7 +1593,8 @@ class RedpandaService(Service):
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           pp_authn_method=self.pp_authn_method())
+                           pp_authn_method=self._security.pp_authn_method,
+                           sr_authn_method=self._security.sr_authn_method)
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -85,8 +85,27 @@ schema_registry:
   schema_registry_api:
     address: "{{node.account.hostname}}"
     port: 8081
+    {% if sr_authn_method %}
+    authentication_method: {{ sr_authn_method }}
+    {% endif %}
 
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc
+
+schema_registry_client:
+  # kafka-api compatible brokers
+  brokers:
+  {% for node in nodes.values() %}
+    - address: "{{node.account.hostname}}"
+      port: 9092
+  {% endfor %}
+
+  retries: 10
+  retry_base_backoff_ms: 10
+  {% if sasl_enabled %}
+  sasl_mechanism: {{superuser[2]}}
+  scram_username: {{superuser[0]}}
+  scram_password: {{superuser[1]}}
+  {% endif %}
 {% endif %}
 
 rpk:

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1367,3 +1367,47 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         self.logger.debug("Get initial global mode")
         result_raw = self._get_mode(auth=(super_username, super_password))
         assert result_raw.json()["mode"] == "READWRITE"
+
+    @cluster(num_nodes=3)
+    def test_post_compatibility_subject_version(self):
+        """
+        Verify compatibility
+        """
+
+        topic = create_topic_names(1)[0]
+
+        self.logger.debug(f"Register a schema against a subject")
+        schema_1_data = json.dumps({"schema": schema1_def})
+
+        super_username, super_password, _ = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.logger.debug("Posting schema 1 as a subject key")
+        result_raw = self._post_subjects_subject_versions(
+            subject=f"{topic}-key",
+            data=schema_1_data,
+            auth=(super_username, super_password))
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Set subject config - NONE")
+        result_raw = self._set_config_subject(
+            subject=f"{topic}-key",
+            data=json.dumps({"compatibility": "NONE"}),
+            auth=(super_username, super_password))
+        assert result_raw.status_code == requests.codes.ok
+
+        result_raw = self._post_compatibility_subject_version(
+            subject=f"{topic}-key",
+            version=1,
+            data=schema_1_data,
+            auth=(self.username, self.password))
+        assert result_raw.json()['error_code'] == 40101
+
+        self.logger.debug("Check compatibility none, no default")
+        result_raw = self._post_compatibility_subject_version(
+            subject=f"{topic}-key",
+            version=1,
+            data=schema_1_data,
+            auth=(super_username, super_password))
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["is_compatible"] == True

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1353,3 +1353,17 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
                                               auth=(super_username,
                                                     super_password))
         assert result_raw.json()["compatibilityLevel"] == "BACKWARD_TRANSITIVE"
+
+    @cluster(num_nodes=3)
+    def test_mode(self):
+        """
+        Smoketest get_mode endpoint
+        """
+        result_raw = self._get_mode(auth=(self.username, self.password))
+        assert result_raw.json()['error_code'] == 40101
+
+        super_username, super_password, _ = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.logger.debug("Get initial global mode")
+        result_raw = self._get_mode(auth=(super_username, super_password))
+        assert result_raw.json()["mode"] == "READWRITE"


### PR DESCRIPTION
## Cover letter

At Redpanda there is an effort to improve security by supporting HTTP Basic Authentication on some of out services such as the Schema Registry. PR #6452 introduced HTTP Basic Authentication to the Pandaproxy but not the Schema Registry.

This PR adds Basic Auth support to all Schema Registry endpoints but it does not include support for multiple authenticated connections. That will come at a later time.

This PR includes configuration changes to enable basic auth:

The new configuration options to enable basic auth are attached to the listener in schema_registry_api:
```yaml
authentication_method: string
    Optional values: none, http_basic
    Default value: none
```

Examples for the new authn config:
```yaml
schema_registry:
  schema_registry_api:
  - address: localhost
    port: 8081
    authentication_method: none
```

```yaml
schema_registry:
  schema_registry_api:
  - address: localhost
    port: 8081
    authentication_method: http_basic
```

After this PR, the leftover tasks are:
- Add kafka client cache to the Pandaproxy endpoints `/consumers`
- Address follow-up points from #6452
- Add ducktape tests for: 1) mTLS only 2) mTLS + Basic Auth
- Create upgrade, scale, and feature tests in ducktape
- Manual tests on cloud infra


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Adds HTTP Basic Auth to all Schema Registry endpoints