### PR TITLE
Controller log rate limiting

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -79,6 +79,7 @@ v_cc_library(
     topics_frontend.cc
     controller_backend.cc
     controller_probe.cc
+    controller_log_limiter.cc
     controller.cc
     partition.cc
     partition_probe.cc

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -229,6 +229,10 @@ ss::future<std::error_code> replicate_and_wait(
        &as = as,
        timeout,
        use_serde_serialization](controller_stm& stm) mutable {
+          if (!stm.throttle<Cmd>()) {
+              return ss::make_ready_future<std::error_code>(
+                errc::throttling_quota_exceeded);
+          }
           if constexpr (Cmd::serde_opts == serde_opts::adl_and_serde) {
               if (unlikely(!use_serde_serialization)) {
                   return serialize_cmd(std::forward<Cmd>(cmd))

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -13,6 +13,7 @@
 #include "cluster/config_frontend.h"
 #include "cluster/controller_api.h"
 #include "cluster/controller_backend.h"
+#include "cluster/controller_log_limiter.h"
 #include "cluster/controller_service.h"
 #include "cluster/data_policy_frontend.h"
 #include "cluster/feature_backend.h"
@@ -144,7 +145,33 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
             std::ref(_as));
       })
       .then([this] {
+          limiter_configuration limiter_conf{
+            config::shard_local_cfg()
+              .enable_controller_log_rate_limiting.bind(),
+            config::shard_local_cfg().rps_limit_topic_operations.bind(),
+            config::shard_local_cfg()
+              .controller_log_accummulation_rps_capacity_topic_operations
+              .bind(),
+            config::shard_local_cfg()
+              .rps_limit_acls_and_users_operations.bind(),
+            config::shard_local_cfg()
+              .controller_log_accummulation_rps_capacity_acls_and_users_operations
+              .bind(),
+            config::shard_local_cfg()
+              .rps_limit_node_management_operations.bind(),
+            config::shard_local_cfg()
+              .controller_log_accummulation_rps_capacity_node_management_operations
+              .bind(),
+            config::shard_local_cfg().rps_limit_move_operations.bind(),
+            config::shard_local_cfg()
+              .controller_log_accummulation_rps_capacity_move_operations.bind(),
+            config::shard_local_cfg().rps_limit_configuration_operations.bind(),
+            config::shard_local_cfg()
+              .controller_log_accummulation_rps_capacity_configuration_operations
+              .bind(),
+          };
           return _stm.start_single(
+            std::move(limiter_conf),
             std::ref(clusterlog),
             _raft0.get(),
             raft::persistent_last_applied::yes,

--- a/src/v/cluster/controller_log_limiter.cc
+++ b/src/v/cluster/controller_log_limiter.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/controller_log_limiter.h"
+
+#include "cluster/commands.h"
+#include "ssx/sformat.h"
+
+#include <optional>
+
+namespace cluster {
+
+group_limiter::group_limiter(
+  ss::sstring group_name,
+  config::binding<size_t> rate_binding,
+  config::binding<std::optional<size_t>> capacity_binding)
+  : _group_name(std::move(group_name))
+  , _rate_binding(std::move(rate_binding))
+  , _capacity_binding(std::move(capacity_binding))
+  , _throttler(_rate_binding(), _group_name, _rate_binding()) {
+    // By default capacity should be equal to rate
+    update_capacity();
+    _rate_binding.watch([this]() { update_rate(); });
+    _capacity_binding.watch([this]() { update_capacity(); });
+}
+
+bool group_limiter::try_throttle() {
+    vlog(
+      controller_rate_limiter_log.debug,
+      "Controller log request try throttle {}, token available: {}",
+      _group_name,
+      _throttler.available());
+    return _throttler.try_throttle(1);
+}
+
+void group_limiter::update_rate() { _throttler.update_rate(_rate_binding()); }
+
+void group_limiter::update_capacity() {
+    if (_capacity_binding() == std::nullopt) {
+        _throttler.update_capacity(_rate_binding());
+    } else {
+        _throttler.update_capacity(_capacity_binding().value());
+    }
+}
+
+controller_log_limiter::controller_log_limiter(
+  limiter_configuration configuration)
+  : _enabled(std::move(configuration.enable))
+  , _topic_operations_limiter(
+      "topic_operations", configuration.topic_rps, configuration.topic_capacity)
+  , _acls_and_users_operations_limiter(
+      "acls_and_users_operations",
+      configuration.acls_and_users_rps,
+      configuration.acls_and_users_capacity)
+  , _node_management_operations_limiter(
+      "node_management_operations",
+      configuration.node_management_rps,
+      configuration.node_management_capacity)
+  , _move_operations_limiter(
+      "move_operations", configuration.move_rps, configuration.move_capacity)
+  , _configuration_operations_limiter(
+      "configuration_operations",
+      configuration.configuration_rps,
+      configuration.configuration_capacity) {}
+
+} // namespace cluster

--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/commands.h"
+#include "config/configuration.h"
+#include "ssx/metrics.h"
+#include "utils/token_bucket.h"
+#include "vlog.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <optional>
+
+namespace cluster {
+
+inline ss::logger controller_rate_limiter_log("controller_rate_limiter_log");
+
+struct limiter_configuration {
+    config::binding<bool> enable;
+    config::binding<size_t> topic_rps;
+    config::binding<std::optional<size_t>> topic_capacity;
+    config::binding<size_t> acls_and_users_rps;
+    config::binding<std::optional<size_t>> acls_and_users_capacity;
+    config::binding<size_t> node_management_rps;
+    config::binding<std::optional<size_t>> node_management_capacity;
+    config::binding<size_t> move_rps;
+    config::binding<std::optional<size_t>> move_capacity;
+    config::binding<size_t> configuration_rps;
+    config::binding<std::optional<size_t>> configuration_capacity;
+};
+
+class group_limiter {
+public:
+    explicit group_limiter(
+      ss::sstring group_name,
+      config::binding<size_t> rate_binding,
+      config::binding<std::optional<size_t>> capacity_binding);
+
+    bool try_throttle();
+
+private:
+    void update_rate();
+    void update_capacity();
+
+    ss::sstring _group_name;
+    config::binding<size_t> _rate_binding;
+    config::binding<std::optional<size_t>> _capacity_binding;
+    token_bucket<> _throttler;
+};
+
+class controller_log_limiter {
+public:
+    explicit controller_log_limiter(limiter_configuration configuration);
+
+    template<typename Cmd>
+    bool throttle() {
+        if (!_enabled()) {
+            return true;
+        }
+        if constexpr (
+          std::is_same_v<Cmd, create_topic_cmd> ||            //
+          std::is_same_v<Cmd, delete_topic_cmd> ||            //
+          std::is_same_v<Cmd, update_topic_properties_cmd> || //
+          std::is_same_v<Cmd, create_partition_cmd> ||        //
+          std::is_same_v<Cmd, create_non_replicable_topic_cmd>) {
+            return _topic_operations_limiter.try_throttle();
+        } else if constexpr (
+          std::is_same_v<Cmd, move_partition_replicas_cmd> || //
+          std::is_same_v<Cmd, cancel_moving_partition_replicas_cmd>) {
+            return _move_operations_limiter.try_throttle();
+        } else if constexpr (
+          std::is_same_v<Cmd, create_user_cmd> || //
+          std::is_same_v<Cmd, delete_user_cmd> || //
+          std::is_same_v<Cmd, update_user_cmd> || //
+          std::is_same_v<Cmd, create_acls_cmd> || //
+          std::is_same_v<Cmd, delete_acls_cmd>) {
+            return _acls_and_users_operations_limiter.try_throttle();
+        } else if constexpr (
+          std::is_same_v<Cmd, create_data_policy_cmd> ||    //
+          std::is_same_v<Cmd, delete_data_policy_cmd> ||    //
+          std::is_same_v<Cmd, cluster_config_delta_cmd> ||  //
+          std::is_same_v<Cmd, cluster_config_status_cmd> || //
+          std::is_same_v<Cmd, feature_update_cmd> ||        //
+          std::is_same_v<Cmd, feature_update_license_update_cmd>) {
+            return _configuration_operations_limiter.try_throttle();
+        } else if constexpr (
+          std::is_same_v<Cmd, maintenance_mode_cmd> ||  //
+          std::is_same_v<Cmd, recommission_node_cmd> || //
+          std::is_same_v<Cmd, decommission_node_cmd>) {
+            return _node_management_operations_limiter.try_throttle();
+        } else {
+            return true;
+        }
+    }
+
+private:
+    config::binding<bool> _enabled;
+    group_limiter _topic_operations_limiter;
+    group_limiter _acls_and_users_operations_limiter;
+    group_limiter _node_management_operations_limiter;
+    group_limiter _move_operations_limiter;
+    group_limiter _configuration_operations_limiter;
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -51,11 +51,17 @@ public:
 private:
     void update_rate();
     void update_capacity();
+    void setup_public_metrics();
+
+    void account_dropped() { _dropped_requests_amount += 1; }
 
     ss::sstring _group_name;
     config::binding<size_t> _rate_binding;
     config::binding<std::optional<size_t>> _capacity_binding;
     token_bucket<> _throttler;
+    int64_t _dropped_requests_amount{};
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
 };
 
 class controller_log_limiter {

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -62,7 +62,8 @@ enum class errc : int16_t {
     invalid_request,
     no_update_in_progress,
     unknown_update_interruption_error,
-    invalid_retention_configuration
+    invalid_retention_configuration,
+    throttling_quota_exceeded
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -181,6 +182,8 @@ struct errc_category final : public std::error_category {
             return "retention.bytes and retention.ms must be greater or equal "
                    "than retention.local.target.bytes and "
                    "retention.local.target.ms respectively";
+        case errc::throttling_quota_exceeded:
+            return "Request declined due to exceeded requests quotas";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1417,7 +1417,78 @@ configuration::configuration()
       "Time interval between two node status messages. Node status messages "
       "establish liveness status outside of the Raft protocol.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      100ms) {}
+      100ms)
+  , enable_controller_log_rate_limiting(
+      *this,
+      "enable_controller_log_rate_limiting",
+      "Enables limiting of controller log write rate",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
+  , rps_limit_topic_operations(
+      *this,
+      "rps_limit_topic_operations",
+      "Rate limit for controller topic operations",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000)
+  , controller_log_accummulation_rps_capacity_topic_operations(
+      *this,
+      "controller_log_accummulation_rps_capacity_topic_operations",
+      "Maximum capacity of rate limit accumulation"
+      "in controller topic operations limit",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
+  , rps_limit_acls_and_users_operations(
+      *this,
+      "rps_limit_acls_and_users_operations",
+      "Rate limit for controller acls and users operations",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000)
+  , controller_log_accummulation_rps_capacity_acls_and_users_operations(
+      *this,
+      "controller_log_accummulation_rps_capacity_acls_and_users_operations",
+      "Maximum capacity of rate limit accumulation"
+      "in controller acls and users operations limit",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
+  , rps_limit_node_management_operations(
+      *this,
+      "rps_limit_node_management_operations",
+      "Rate limit for controller node management operations",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000)
+  , controller_log_accummulation_rps_capacity_node_management_operations(
+      *this,
+      "controller_log_accummulation_rps_capacity_node_management_operations",
+      "Maximum capacity of rate limit accumulation"
+      "in controller node management operations limit",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
+  , rps_limit_move_operations(
+      *this,
+      "rps_limit_move_operations",
+      "Rate limit for controller move operations",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000)
+  , controller_log_accummulation_rps_capacity_move_operations(
+      *this,
+      "controller_log_accummulation_rps_capacity_move_operations",
+      "Maximum capacity of rate limit accumulation"
+      "in controller move operations limit",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
+  , rps_limit_configuration_operations(
+      *this,
+      "rps_limit_configuration_operations",
+      "Rate limit for controller configuration operations",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000)
+  , controller_log_accummulation_rps_capacity_configuration_operations(
+      *this,
+      "controller_log_accummulation_rps_capacity_configuration_operations",
+      "Maximum capacity of rate limit accumulation"
+      "in controller configuration operations limit",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -303,6 +303,23 @@ struct configuration final : public config_store {
     property<bool> enable_rack_awareness;
 
     property<std::chrono::milliseconds> node_status_interval;
+    // controller log limitng
+    property<bool> enable_controller_log_rate_limiting;
+    property<size_t> rps_limit_topic_operations;
+    property<std::optional<size_t>>
+      controller_log_accummulation_rps_capacity_topic_operations;
+    property<size_t> rps_limit_acls_and_users_operations;
+    property<std::optional<size_t>>
+      controller_log_accummulation_rps_capacity_acls_and_users_operations;
+    property<size_t> rps_limit_node_management_operations;
+    property<std::optional<size_t>>
+      controller_log_accummulation_rps_capacity_node_management_operations;
+    property<size_t> rps_limit_move_operations;
+    property<std::optional<size_t>>
+      controller_log_accummulation_rps_capacity_move_operations;
+    property<size_t> rps_limit_configuration_operations;
+    property<std::optional<size_t>>
+      controller_log_accummulation_rps_capacity_configuration_operations;
 
     configuration();
 

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -46,6 +46,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::not_coordinator;
     case cluster::errc::invalid_request:
         return error_code::invalid_request;
+    case cluster::errc::throttling_quota_exceeded:
+        return error_code::throttling_quota_exceeded;
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -92,7 +92,7 @@ using persistent_last_applied
 //      |<------------------------|               |          |
 //      |                         |               |          |
 template<typename... T>
-requires(State<T>, ...) class mux_state_machine final : public state_machine {
+requires(State<T>, ...) class mux_state_machine : public state_machine {
 public:
     explicit mux_state_machine(
       ss::logger&, consensus*, persistent_last_applied, T&...);
@@ -101,7 +101,7 @@ public:
     mux_state_machine(const mux_state_machine&) = delete;
     mux_state_machine& operator=(mux_state_machine&&) = delete;
     mux_state_machine& operator=(const mux_state_machine&) = delete;
-    ~mux_state_machine() final = default;
+    ~mux_state_machine() = default;
 
     // Lifecycle management
     ss::future<> start() final { return raft::state_machine::start(); }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -749,6 +749,10 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::bad_request_exception(
               "Cannot cancel partition move operation as there is no move "
               "in progress");
+        case cluster::errc::throttling_quota_exceeded:
+            throw ss::httpd::base_exception(
+              fmt::format("Too many requests: {}", ec.message()),
+              ss::httpd::reply::status_type::too_many_requests);
         default:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected cluster error: {}", ec.message()));

--- a/src/v/utils/tests/token_bucket_test.cc
+++ b/src/v/utils/tests/token_bucket_test.cc
@@ -20,34 +20,37 @@ using namespace std::chrono_literals;
 
 constexpr size_t RATE = 25;
 
-SEASTAR_THREAD_TEST_CASE(test_simple_throttle) {
-    token_bucket<ss::manual_clock> throttler(RATE, "test_simple_throttle");
-    for (size_t i = 0; i < RATE; ++i) {
+template<typename T>
+void try_consume(token_bucket<T>& throttler, size_t amount) {
+    for (size_t i = 0; i < amount; ++i) {
+        BOOST_REQUIRE(throttler.try_throttle(1));
+    }
+}
+
+template<typename T>
+void consume(token_bucket<T>& throttler, size_t amount) {
+    for (size_t i = 0; i < amount; ++i) {
         ss::abort_source as;
         throttler.throttle(1, as).get();
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(test_simple_throttle) {
+    token_bucket<> throttler(RATE, "test_simple_throttle");
+    consume(throttler, RATE);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_throttle_wait) {
     token_bucket<> throttler(RATE, "test_throttle_wait");
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     auto start_time = ss::lowres_clock::now();
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     BOOST_REQUIRE(ss::lowres_clock::now() - start_time >= 1s);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_throttle_shutdown) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_throttle_shutdown");
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     ss::abort_source as;
     auto result = throttler.throttle(1, as);
     throttler.shutdown();
@@ -65,10 +68,7 @@ SEASTAR_THREAD_TEST_CASE(test_throttle_shutdown) {
 
 SEASTAR_THREAD_TEST_CASE(test_throttle_abort) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_throttle_abort");
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     ss::abort_source as;
     auto result = throttler.throttle(1, as);
     as.request_abort();
@@ -80,43 +80,30 @@ SEASTAR_THREAD_TEST_CASE(test_throttle_abort) {
 
 SEASTAR_THREAD_TEST_CASE(test_try_throttle) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_try_throttle");
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_throttle_then_try) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_throttle_then_try");
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_wait_until_available) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_wait_until_available");
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     BOOST_REQUIRE(!throttler.try_throttle(1));
     ss::manual_clock::advance(ss::lowres_clock::duration(2s));
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_burst) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_burst", RATE * 3);
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     BOOST_REQUIRE(!throttler.try_throttle(1));
     ss::manual_clock::advance(ss::lowres_clock::duration(4s));
-    for (size_t i = 0; i < RATE * 3; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE * 3);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 }
 
@@ -124,31 +111,23 @@ SEASTAR_THREAD_TEST_CASE(test_update_rate) {
     const size_t RATE_PART = RATE - 10;
     token_bucket<ss::manual_clock> throttler(RATE, "test_update_rate");
 
-    for (size_t i = 0; i < RATE_PART; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE_PART);
     throttler.update_rate(RATE_PART);
     // Right after update there should be 0 points because we consumed RATE_PART
     // and downscaled rate to RATE_PART
     BOOST_REQUIRE(!throttler.try_throttle(1));
 
     ss::manual_clock::advance(ss::lowres_clock::duration(2s));
-    for (size_t i = 0; i < RATE_PART; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE_PART);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 
     ss::manual_clock::advance(ss::lowres_clock::duration(2s));
-    for (size_t i = 0; i < RATE_PART; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE_PART);
     BOOST_REQUIRE(!throttler.try_throttle(1));
     throttler.update_rate(RATE);
     // Right after update there should be RATE - RATE_PART points because we
     // consumed RATE_PART and upgraded rate to RATE_PART
-    for (size_t i = 0; i < RATE - RATE_PART; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE - RATE_PART);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 }
 
@@ -158,46 +137,32 @@ SEASTAR_THREAD_TEST_CASE(test_update_rate_burst) {
       RATE, "test_update_rate_burst", RATE * 3);
 
     ss::manual_clock::advance(ss::lowres_clock::duration(4s));
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     throttler.update_rate(RATE_PART);
 
     // Right after update there should be RATE_PART points
     // because we accumulated 2 x Rate point before update
     // and downscaled rate to RATE_PART. So accumulated points
     // should drop to RATE_PART points
-    for (size_t i = 0; i < RATE_PART; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE_PART);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 
     ss::manual_clock::advance(ss::lowres_clock::duration(4s));
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     throttler.update_rate(RATE);
-    for (size_t i = 0; i < RATE; ++i) {
-        BOOST_REQUIRE(throttler.try_throttle(1));
-    }
+    try_consume(throttler, RATE);
     BOOST_REQUIRE(!throttler.try_throttle(1));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_available_tokens) {
     token_bucket<ss::manual_clock> throttler(RATE, "test_available_tokens");
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE);
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     BOOST_REQUIRE_EQUAL(throttler.available(), 0);
 
     ss::manual_clock::advance(ss::lowres_clock::duration(2s));
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE);
-    for (size_t i = 0; i < 10; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, 10);
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE - 10);
 }
 
@@ -205,17 +170,11 @@ SEASTAR_THREAD_TEST_CASE(test_available_tokens_capacity) {
     token_bucket<ss::manual_clock> throttler(
       RATE, "test_available_tokens_capacity", RATE * 3);
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE);
-    for (size_t i = 0; i < RATE; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, RATE);
     BOOST_REQUIRE_EQUAL(throttler.available(), 0);
 
     ss::manual_clock::advance(ss::lowres_clock::duration(4s));
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 3);
-    for (size_t i = 0; i < 10; ++i) {
-        ss::abort_source as;
-        throttler.throttle(1, as).get();
-    }
+    consume(throttler, 10);
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 3 - 10);
 }

--- a/src/v/utils/tests/token_bucket_test.cc
+++ b/src/v/utils/tests/token_bucket_test.cc
@@ -178,3 +178,16 @@ SEASTAR_THREAD_TEST_CASE(test_available_tokens_capacity) {
     consume(throttler, 10);
     BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 3 - 10);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_available_tokens_change_capacity) {
+    token_bucket<ss::manual_clock> throttler(
+      RATE, "test_available_tokens_change_capacity", RATE * 3);
+    ss::manual_clock::advance(ss::lowres_clock::duration(4s));
+    BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 3);
+    throttler.update_capacity(RATE * 2);
+    BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 2);
+    throttler.update_capacity(RATE * 3);
+    BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 2);
+    ss::manual_clock::advance(ss::lowres_clock::duration(2s));
+    BOOST_REQUIRE_EQUAL(throttler.available(), RATE * 3);
+}

--- a/src/v/utils/token_bucket.h
+++ b/src/v/utils/token_bucket.h
@@ -80,6 +80,18 @@ public:
         _sem.broken();
     }
 
+    void update_capacity(size_t new_capacity) {
+        if (_capacity == new_capacity) {
+            return;
+        }
+
+        if (new_capacity < _capacity && _sem.current() > new_capacity) {
+            _sem.consume(_sem.current() - new_capacity);
+        }
+
+        _capacity = new_capacity;
+    }
+
     void update_rate(size_t new_rate) {
         if (_rate == new_rate) {
             return;

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -188,8 +188,11 @@ class ClusterMetricsTest(RedpandaTest):
         cluster_metrics = MetricCheck(
             self.logger,
             self.redpanda,
-            controller,
-            re.compile("redpanda_cluster_.*"),
+            controller, [
+                "redpanda_cluster_brokers", "redpanda_cluster_topics",
+                "redpanda_cluster_partitions",
+                "redpanda_cluster_unavailable_partitions"
+            ],
             metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
 
         RpkTool(self.redpanda).create_topic("test-topic", partitions=3)

--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -1,0 +1,413 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import json
+from subprocess import CalledProcessError
+from ducktape.mark import ok_to_fail
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.tests.partition_movement import PartitionMovementMixin
+from rptest.tests.mirror_maker_test import MirrorMakerService
+from rptest.tests.partition_balancer_test import PartitionBalancerService, CONSUMER_TIMEOUT
+
+from rptest.clients.types import TopicSpec
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.kcl import RawKCL, KclCreateTopicsRequestTopic
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.services.admin import Admin
+from rptest.services.redpanda import MetricsEndpoint, CHAOS_LOG_ALLOW_LIST
+from rptest.services.mirror_maker2 import MirrorMaker2
+from rptest.services.cluster import cluster
+from requests.exceptions import HTTPError
+from ducktape.utils.util import wait_until
+
+OPERATIONS_LIMIT = 3
+TOO_MANY_REQUESTS_ERROR_CODE = 89
+TOO_MANY_REQUESTS_HTTP_ERROR_CODE = 429
+
+
+def get_metric(redpanda, metric_type, label):
+    admin = redpanda._admin
+    controller_node = redpanda.get_node(
+        admin.await_stable_leader(
+            topic="controller",
+            partition=0,
+            namespace="redpanda",
+        ))
+    metrics = redpanda.metrics_sample(
+        metric_type,
+        nodes=[controller_node],
+        metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS).label_filter(
+            {"redpanda_cmd_group": label})
+    assert len(metrics.samples) == 1
+    return metrics.samples[0].value
+
+
+def check_metric(redpanda, metric_type, label, value):
+    metric_value = get_metric(redpanda, metric_type, label)
+    assert metric_value == value
+
+
+class TopicOperationsLimitingTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        additional_options = {
+            "enable_controller_log_rate_limiting": True,
+            "rps_limit_topic_operations": OPERATIONS_LIMIT,
+        }
+        super().__init__(*args,
+                         num_brokers=3,
+                         extra_rp_conf=additional_options,
+                         **kwargs)
+        self.kcl = RawKCL(self.redpanda)
+
+    def check_available_metric(self, value):
+        check_metric(self.redpanda, "requests_available_rps",
+                     "topic_operations", value)
+
+    def check_dropped_metric(self, value):
+        check_metric(self.redpanda, "requests_dropped", "topic_operations",
+                     value)
+
+    def chek_capacity_is_full(self, value):
+        return get_metric(self.redpanda, "requests_available_rps",
+                          "topic_operations") == value
+
+    @cluster(num_nodes=3)
+    def test_create_partition_limit(self):
+        requsts_amount_1 = OPERATIONS_LIMIT * 2
+        self.check_available_metric(OPERATIONS_LIMIT)
+        exceed_quota_req = []
+        for i in range(requsts_amount_1):
+            exceed_quota_req.append(KclCreateTopicsRequestTopic(str(i), 1, 1))
+        wait_until(lambda: self.chek_capacity_is_full(OPERATIONS_LIMIT),
+                   timeout_sec=10,
+                   backoff_sec=1)
+        response = self.kcl.raw_create_topics(6, exceed_quota_req)
+        response = json.loads(response)
+        assert response['Version'] == 6
+        success_amount = 0
+        errors_amount = 0
+        for topic_response in response['Topics']:
+            if topic_response['ErrorCode'] == 0:
+                success_amount += 1
+            if topic_response['ErrorCode'] == TOO_MANY_REQUESTS_ERROR_CODE:
+                errors_amount += 1
+        assert success_amount + errors_amount == requsts_amount_1
+        assert success_amount == OPERATIONS_LIMIT
+        assert errors_amount == requsts_amount_1 - OPERATIONS_LIMIT
+
+        self.check_dropped_metric(OPERATIONS_LIMIT)
+
+        wait_until(lambda: self.chek_capacity_is_full(OPERATIONS_LIMIT),
+                   timeout_sec=10,
+                   backoff_sec=1)
+
+        self.check_available_metric(OPERATIONS_LIMIT)
+
+        exceed_quota_req = []
+        requests_amount_2 = OPERATIONS_LIMIT * 3
+        for i in range(OPERATIONS_LIMIT * 2, OPERATIONS_LIMIT * 5):
+            exceed_quota_req.append(KclCreateTopicsRequestTopic(str(i), 1, 1))
+
+        response = self.kcl.raw_create_topics(6, exceed_quota_req)
+        response = json.loads(response)
+        assert response['Version'] == 6
+        success_amount = 0
+        errors_amount = 0
+        for topic_response in response['Topics']:
+            if topic_response['ErrorCode'] == 0:
+                success_amount += 1
+            if topic_response['ErrorCode'] == TOO_MANY_REQUESTS_ERROR_CODE:
+                errors_amount += 1
+        assert success_amount + errors_amount == requests_amount_2
+        assert success_amount == OPERATIONS_LIMIT
+        assert errors_amount == requests_amount_2 - OPERATIONS_LIMIT
+
+        self.check_dropped_metric(OPERATIONS_LIMIT * 3)
+
+    @cluster(num_nodes=3)
+    def test_create_partition_limit_accumulation(self):
+        self.client().alter_broker_config(
+            {
+                "controller_log_accummulation_rps_capacity_topic_operations":
+                OPERATIONS_LIMIT * 2
+            },
+            incremental=True)
+        wait_until(lambda: self.chek_capacity_is_full(OPERATIONS_LIMIT * 2),
+                   timeout_sec=10,
+                   backoff_sec=1)
+
+        exceed_quota_req = []
+        for i in range(OPERATIONS_LIMIT * 2):
+            exceed_quota_req.append(KclCreateTopicsRequestTopic(str(i), 1, 1))
+
+        response = self.kcl.raw_create_topics(6, exceed_quota_req)
+        response = json.loads(response)
+        assert response['Version'] == 6
+        for topic_response in response['Topics']:
+            assert topic_response['ErrorCode'] == 0
+
+
+class ControllerConfigLimitTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={
+                             "rps_limit_configuration_operations":
+                             OPERATIONS_LIMIT,
+                             "enable_controller_log_rate_limiting": True
+                         },
+                         **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_alter_configs_limit(self):
+        requests_amount = OPERATIONS_LIMIT * 2
+        success_amount = 0
+        quota_error_amount = 0
+        wait_until(lambda: self.check_capcity_is_full(OPERATIONS_LIMIT),
+                   timeout_sec=10,
+                   backoff_sec=1)
+        for i in range(requests_amount):
+            out = self.client().alter_broker_config(
+                {
+                    "controller_log_accummulation_rps_capacity_topic_operations":
+                    i
+                },
+                incremental=True)
+            if "THROTTLING_QUOTA_EXCEEDED" in out:
+                quota_error_amount += 1
+            if "OK" in out:
+                success_amount += 1
+            time.sleep(0.1)
+        assert quota_error_amount > 0
+        assert success_amount > 0
+
+    def check_capcity_is_full(self, capacity):
+        return get_metric(self.redpanda, "requests_available_rps",
+                          "configuration_operations") == capacity
+
+    @ok_to_fail
+    @cluster(num_nodes=3)
+    def test_alter_configs_limit_accumulate(self):
+        requests_amount = OPERATIONS_LIMIT * 2
+        capacity = requests_amount * 2
+        self.client().alter_broker_config(
+            {
+                "controller_log_accummulation_rps_capacity_configuration_operations":
+                capacity
+            },
+            incremental=True)
+        success_amount = 0
+        quota_error_amount = 0
+
+        wait_until(lambda: self.check_capcity_is_full(capacity),
+                   timeout_sec=10,
+                   backoff_sec=1)
+        for i in range(requests_amount):
+            out = self.client().alter_broker_config(
+                {
+                    "controller_log_accummulation_rps_capacity_topic_operations":
+                    i + 25
+                },
+                incremental=True)
+            if "THROTTLING_QUOTA_EXCEEDED" in out:
+                quota_error_amount += 1
+            if "OK" in out:
+                success_amount += 1
+        assert quota_error_amount == 0
+        assert success_amount > 0
+
+
+class ControllerPartitionMovementLimitTest(PartitionMovementMixin,
+                                           EndToEndTest):
+    def __init__(self, ctx, *args, **kwargs):
+        super(ControllerPartitionMovementLimitTest,
+              self).__init__(ctx,
+                             *args,
+                             extra_rp_conf={
+                                 "rps_limit_move_operations": 0,
+                                 "enable_controller_log_rate_limiting": True,
+                             },
+                             **kwargs)
+        self._ctx = ctx
+
+    def perform_move(self, topic, partition):
+        old_assignments, new_assignment = self._dispatch_random_partition_move(
+            topic=topic.name, partition=partition)
+        return old_assignments == new_assignment
+
+    @cluster(num_nodes=3)
+    def test_move_partition_limit(self):
+        self.start_redpanda(num_nodes=3)
+
+        topic = TopicSpec(partition_count=3)
+        self.client().create_topic(topic)
+        try:
+            while (self.perform_move(topic, 0)):
+                pass
+        except HTTPError as err:
+            assert err.response.status_code == TOO_MANY_REQUESTS_HTTP_ERROR_CODE
+        else:
+            assert 0, "Too Many Requests error must be raised"
+
+
+class ControllerAclsAndUsersLimitTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={
+                             "rps_limit_acls_and_users_operations":
+                             OPERATIONS_LIMIT,
+                             "enable_controller_log_rate_limiting": True
+                         },
+                         **kwargs)
+
+    def check_capacity_is_full(self, capacity):
+        return get_metric(self.redpanda, "requests_available_rps",
+                          "acls_and_users_operations") == capacity
+
+    @cluster(num_nodes=3)
+    def test_create_user_limit(self):
+        rpk = RpkTool(self.redpanda)
+        wait_until(lambda: self.check_capacity_is_full(OPERATIONS_LIMIT),
+                   timeout_sec=10,
+                   backoff_sec=1)
+        for i in range(OPERATIONS_LIMIT * 2):
+            try:
+                rpk.sasl_create_user(
+                    f"testuser_{i}", "password",
+                    self.redpanda.SUPERUSER_CREDENTIALS.algorithm)
+            except RpkException as err:
+                if i >= OPERATIONS_LIMIT:
+                    assert 'Too many requests' in err.stderr
+                else:
+                    raise err
+            else:
+                if i >= OPERATIONS_LIMIT:
+                    assert 0, "Too Many Requests error must be raised"
+
+    @cluster(num_nodes=3)
+    def test_create_acl_limit(self):
+        client = KafkaCliTools(self.redpanda)
+        self.client().alter_broker_config(
+            {"rps_limit_acls_and_users_operations": 0}, incremental=True)
+        try:
+            client.create_cluster_acls("User", "describe")
+        except CalledProcessError as err:
+            assert "ThrottlingQuotaExceededException" in err.output
+        else:
+            assert 0, "Too Many Requests error must be raised"
+
+
+class ControllerNodeManagementLimitTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={
+                             "rps_limit_node_management_operations": 1,
+                             "enable_controller_log_rate_limiting": True
+                         },
+                         **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_maintance_mode_limit(self):
+        self.admin = Admin(self.redpanda)
+        admin = self.redpanda._admin
+        controller_node = self.redpanda.get_node(
+            admin.await_stable_leader(
+                topic="controller",
+                partition=0,
+                namespace="redpanda",
+            ))
+        node = next(
+            filter(lambda node: node != controller_node, self.redpanda.nodes))
+        self.admin.maintenance_start(node)
+        try:
+            self.admin.maintenance_stop(node)
+        except HTTPError as err:
+            assert err.response.status_code == TOO_MANY_REQUESTS_HTTP_ERROR_CODE
+        else:
+            assert 0, "Too Many Requests error must be raised"
+
+
+class ControllerLogLimitMirrorMakerTests(MirrorMakerService):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @cluster(num_nodes=10)
+    def test_mirror_maker_with_limits(self):
+        # start brokers
+        self.start_brokers(source_type=MirrorMakerService.redpanda_source)
+        target_client = DefaultClient(self.redpanda)
+        target_client.alter_broker_config(
+            {
+                "enable_controller_log_rate_limiting": True,
+                "rps_limit_topic_operations": 25,
+                "rps_limit_acls_and_users_operations": 25,
+                "rps_limit_node_management_operations": 25,
+                "rps_limit_move_operations": 25,
+                "rps_limit_configuration_operations": 25
+            },
+            incremental=True)
+
+        # start mirror maker
+        self.mirror_maker = MirrorMaker2(self.test_context,
+                                         num_nodes=1,
+                                         source_cluster=self.source_broker,
+                                         target_cluster=self.redpanda)
+        topics = []
+        for i in range(0, 50):
+            topics.append(TopicSpec(partition_count=3))
+        self.source_client.create_topic(topics)
+        self.mirror_maker.start()
+        # start source producer & target consumer
+        self.start_workload()
+
+        self.run_validation(consumer_timeout_sec=120)
+        self.mirror_maker.stop()
+        for t in topics:
+            desc = target_client.describe_topic(t.name)
+            self.logger.debug(f'source topic: {t}, target topic: {desc}')
+            assert len(desc.partitions) == t.partition_count
+
+
+class ControllerLogLimitPartitionBalancerTests(PartitionBalancerService):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    def test_partition_balancer_with_limits(self):
+        self.start_redpanda(num_nodes=5)
+        client = DefaultClient(self.redpanda)
+        client.alter_broker_config(
+            {
+                "enable_controller_log_rate_limiting": True,
+                "rps_limit_topic_operations": 25,
+                "rps_limit_acls_and_users_operations": 25,
+                "rps_limit_node_management_operations": 25,
+                "rps_limit_move_operations": 25,
+                "rps_limit_configuration_operations": 25
+            },
+            incremental=True)
+
+        self.topic = TopicSpec(partition_count=200)
+        self.client().create_topic(self.topic)
+
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+
+        with self.NodeStopper(self) as ns:
+            node = self.redpanda.nodes[1]
+            ns.make_unavailable(node)
+            self.wait_until_ready(expected_unavailable_node=node,
+                                  timeout_sec=240)
+            self.check_no_replicas_on_node(node)
+            ns.make_available()
+            self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)

--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -30,12 +30,12 @@ from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.version import V_3_0_0
 
 
-class TestMirrorMakerService(EndToEndTest):
+class MirrorMakerService(EndToEndTest):
     kafka_source = "kafka"
     redpanda_source = "redpanda"
 
     def __init__(self, test_context):
-        super(TestMirrorMakerService, self).__init__(test_context)
+        super(MirrorMakerService, self).__init__(test_context)
 
         self.topic = TopicSpec(replication_factor=3)
         # create single zookeeper node for Kafka
@@ -116,9 +116,14 @@ class TestMirrorMakerService(EndToEndTest):
             "Producer failed to produce %d messages in a reasonable amount of time."
             % n_messages)
 
+
+class TestMirrorMakerService(MirrorMakerService):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     @cluster(num_nodes=10)
-    @parametrize(source_type=kafka_source)
-    @parametrize(source_type=redpanda_source)
+    @parametrize(source_type=MirrorMakerService.kafka_source)
+    @parametrize(source_type=MirrorMakerService.redpanda_source)
     def test_simple_end_to_end(self, source_type):
         # start brokers
         self.start_brokers(source_type=source_type)
@@ -148,8 +153,8 @@ class TestMirrorMakerService(EndToEndTest):
             assert len(desc.partitions) == t.partition_count
 
     @cluster(num_nodes=10)
-    @parametrize(source_type=kafka_source)
-    @parametrize(source_type=redpanda_source)
+    @parametrize(source_type=MirrorMakerService.kafka_source)
+    @parametrize(source_type=MirrorMakerService.redpanda_source)
     def test_consumer_group_mirroring(self, source_type):
         # start redpanda
         self.start_brokers(source_type=source_type)

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -32,9 +32,9 @@ from ducktape.mark import ok_to_fail
 CONSUMER_TIMEOUT = 90
 
 
-class PartitionBalancerTest(EndToEndTest):
+class PartitionBalancerService(EndToEndTest):
     def __init__(self, ctx, *args, **kwargs):
-        super(PartitionBalancerTest, self).__init__(
+        super(PartitionBalancerService, self).__init__(
             ctx,
             *args,
             extra_rp_conf={
@@ -236,6 +236,11 @@ class PartitionBalancerTest(EndToEndTest):
             self.cur_failure = FailureSpec(random.choice(failure_types), node)
             self.f_injector._start_func(self.cur_failure.type)(
                 self.cur_failure.node)
+
+
+class PartitionBalancerTest(PartitionBalancerService):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_unavailable_nodes(self):


### PR DESCRIPTION
## Cover letter

Controller log rate limiting iplementation

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/core-internal/issues/37

## UX changes

This pr introduce controller log rate limiting mechanism.
Users now able to limit rps for 5 groups of requests.
Groups:
```
    Topic operations:
        create_topic
        delete_topic
        create_partition
        create_non_replicable_topic
        update_topic_properties
    Cluster acls and users:
        create_user
        delete_user
        update_user
        create_acls
        delete_acls
    Node management:
        decommission_node
        recommission_node
        maintenance_mode
    Move operations:
        move_partition_replicas
        cancel_moving_partition
    Configuration operations:
        cluster_config_delta
        cluster_config_status
        feature_update
        feature_update_license_update
        create_data_policy
        delete_data_policy
```


<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
### Features
Contoller log limiting mechanism
Rps of requests that creates entry in controller log can now be limited.
### Config options
`enable_controller_log_rate_limiting` - enable controller log limiting
`rps_limit_topic_operations` - rps limit for topic operations
`controller_log_accummulation_rps_capacity_topic_operations` - max capacity accumulation for topic operaions request
`rps_limit_acls_and_users_operations` - rps limit for acls and users operations
`controller_log_accummulation_rps_capacity_acls_and_users_operations` - max capacity accumulation for acls and users operaions
`rps_limit_node_management_operations` - rps limit for node management operations
`controller_log_accummulation_rps_capacity_node_management_operations` - max capacity accumulation for node management operaions
`rps_limit_move_operations` - rps limit for move operations
`controller_log_accummulation_rps_capacity_move_operations` - max capacity accumulation for move operaions
`rps_limit_configuration_operations` - rps limit for configuration operations
`controller_log_accummulation_rps_capacity_configuration_operations` - max capacity accumulation for configuration operaions
