### PR TITLE
admin: return 503 on `replication_error`

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -731,13 +731,14 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::base_exception(
               fmt::format("Timeout: {}", ec.message()),
               ss::httpd::reply::status_type::gateway_timeout);
+        case cluster::errc::replication_error:
         case cluster::errc::update_in_progress:
         case cluster::errc::leadership_changed:
         case cluster::errc::waiting_for_recovery:
         case cluster::errc::no_leader_controller:
         case cluster::errc::shutting_down:
             throw ss::httpd::base_exception(
-              fmt::format("Not ready ({})", ec.message()),
+              fmt::format("Service unavailable ({})", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);
         case cluster::errc::not_leader:
             throw co_await redirect_to_leader(req, ntp);
@@ -745,7 +746,7 @@ ss::future<> admin_server::throw_on_error(
             throw co_await redirect_to_leader(req, model::controller_ntp);
         case cluster::errc::no_update_in_progress:
             throw ss::httpd::bad_request_exception(
-              "can not cancel partition move operation as there is no move "
+              "Cannot cancel partition move operation as there is no move "
               "in progress");
         default:
             throw ss::httpd::server_error_exception(


### PR DESCRIPTION
## Cover letter

It's possible we get a `replication_error` in the admin server if we dispatch request to a node that loses leadership as it attempts to `replicate_and_wait()` the request to followers. This commit treats such errors as transient and retriable, and returns a 503.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6642

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
