### PR TITLE
tests: disable retention.ms in TimeQueryTest

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -45,6 +45,10 @@ class BaseTimeQuery:
         self.client().alter_topic_config(topic.name, 'message.timestamp.type',
                                          "CreateTime")
 
+        # Disable time based retention because we will use synthetic timestamps
+        # that may well fall outside of the default 1 week relative to walltime
+        self.client().alter_topic_config(topic.name, 'retention.ms', "-1")
+
         # Use small segments
         self.client().alter_topic_config(topic.name, 'segment.bytes',
                                          self.log_segment_size)


### PR DESCRIPTION
## Cover letter

This test uses hardcoded timestamps for reproducibility, but that means it stopped working a week after creating the test because we hit the default 1 week retention.ms.

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none