### PR TITLE
cloud_storage: implement time query

### DIFF
--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -112,6 +112,10 @@ public:
     /// Get revision
     model::initial_revision_id get_revision_id() const;
 
+    /// Find the earliest segment that has max timestamp >= t
+    std::optional<std::reference_wrapper<const segment_meta>>
+    timequery(model::timestamp t) const;
+
     remote_segment_path
     generate_segment_path(const key&, const segment_meta&) const;
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -14,6 +14,7 @@
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
+#include "storage/log_reader.h"
 #include "storage/parser_errc.h"
 #include "storage/types.h"
 #include "utils/gate_guard.h"
@@ -250,16 +251,30 @@ private:
         remote_partition::iterator iter;
     };
 
+    /// Find the starting segment for a reader
+    remote_partition::iterator
+    seek_segment(const storage::log_reader_config& config) {
+        if (config.first_timestamp) {
+            // Seek by timestamp
+            return _partition->seek_by_timestamp(*config.first_timestamp);
+        } else {
+            // Seek by offset
+            auto it = _partition->upper_bound(
+              model::offset_cast(config.start_offset));
+            if (it != _partition->begin()) {
+                it = std::prev(it);
+            }
+            return it;
+        }
+    }
+
     std::optional<cache_reader_lookup_result>
     find_cached_reader(const storage::log_reader_config& config) {
         if (!_partition || _partition->_segments.empty()) {
             return std::nullopt;
         }
-        auto it = _partition->upper_bound(
-          model::offset_cast(config.start_offset));
-        if (it != _partition->begin()) {
-            it = std::prev(it);
-        }
+
+        auto it = seek_segment(config);
         auto reader = _partition->borrow_reader(config, it->first, it->second);
         // Here we know the exact type of the reader_state because of
         // the invariant of the borrow_reader
@@ -698,6 +713,50 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};
 }
 
+ss::future<std::optional<storage::timequery_result>>
+remote_partition::timequery(storage::timequery_config cfg) {
+    if (_segments.size() < _manifest.size()) {
+        update_segments_incrementally();
+    }
+
+    if (_segments.empty()) {
+        vlog(_ctxlog.debug, "timequery: no segments");
+        co_return std::nullopt;
+    }
+
+    auto start_offset = _segments.begin()->first;
+
+    // Synthesize a log_reader_config from our timequery_config
+    storage::log_reader_config config(
+      kafka::offset_cast(start_offset),
+      cfg.max_offset,
+      0,
+      2048, // We just need one record batch
+      cfg.prio,
+      cfg.type_filter,
+      cfg.time,
+      cfg.abort_source);
+
+    // Construct a reader that will skip to the requested timestamp
+    // by virtue of log_reader_config::start_timestamp
+    auto translating_reader = co_await make_reader(config);
+    auto ot_state = std::move(translating_reader.ot_state);
+
+    // Read one batch from the reader to learn the offset
+    model::record_batch_reader::storage_t data
+      = co_await model::consume_reader_to_memory(
+        std::move(translating_reader.reader), model::no_timeout);
+
+    auto& batches = std::get<model::record_batch_reader::data_t>(data);
+    vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
+
+    if (batches.size()) {
+        co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+    } else {
+        co_return std::nullopt;
+    }
+}
+
 remote_partition::offloaded_segment_state::offloaded_segment_state(
   model::offset base_offset)
   : base_rp_offset(base_offset) {}
@@ -798,6 +857,27 @@ remote_partition::iterator remote_partition::upper_bound(kafka::offset o) {
         return iterator(_segments, it->first);
     }
     return end();
+}
+
+remote_partition::iterator
+remote_partition::seek_by_timestamp(model::timestamp t) {
+    auto segment_meta = _manifest.timequery(t);
+
+    if (segment_meta) {
+        kafka::offset o = get_kafka_base_offset(*segment_meta);
+        auto found = _segments.find(o);
+
+        // Cannot happen because timequery() calls
+        // update_segments_incrementally first.
+        vassert(
+          found != _segments.end(),
+          "Timequery t={} found offset {} in manifest, but no segment "
+          "state found for that offset");
+        return iterator(_segments, found->first);
+    } else {
+        // They queried a time that is later than all our data
+        return end();
+    }
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -179,6 +179,10 @@ public:
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
+    /// Look up offset from timestamp
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg);
+
     /// Return first uploaded kafka offset
     kafka::offset first_uploaded_offset();
 
@@ -305,6 +309,7 @@ private:
     iterator begin();
     iterator end();
     iterator upper_bound(kafka::offset);
+    iterator seek_by_timestamp(model::timestamp);
 
     using segment_map_t = absl::btree_map<kafka::offset, segment_state>;
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -200,19 +200,36 @@ remote_segment::data_stream(size_t pos, ss::io_priority_class io_priority) {
 
 ss::future<remote_segment::input_stream_with_offsets>
 remote_segment::offset_data_stream(
-  kafka::offset kafka_offset, ss::io_priority_class io_priority) {
+  kafka::offset kafka_offset,
+  std::optional<model::timestamp> first_timestamp,
+  ss::io_priority_class io_priority) {
     vlog(
       _ctxlog.debug,
       "remote segment file input stream at offset {}",
       kafka_offset);
     ss::gate::holder g(_gate);
     co_await hydrate();
-    auto pos = maybe_get_offsets(kafka_offset)
-                 .value_or(offset_index::find_result{
-                   .rp_offset = _base_rp_offset,
-                   .kaf_offset = _base_rp_offset - _base_offset_delta,
-                   .file_pos = 0,
-                 });
+    offset_index::find_result pos;
+    if (first_timestamp) {
+        // Time queries are linear search from front of the segment.  The
+        // dominant cost of a time query on a remote partition is promoting
+        // the segment into our local cache: once it's here, the cost of
+        // a scan is comparatively small.  For workloads that do many time
+        // queries in close proximity on the same partition, an additional
+        // index could be added here, for hydrated segments.
+        pos = {
+          .rp_offset = _base_rp_offset,
+          .kaf_offset = _base_rp_offset - _base_offset_delta,
+          .file_pos = 0,
+        };
+    } else {
+        pos = maybe_get_offsets(kafka_offset)
+                .value_or(offset_index::find_result{
+                  .rp_offset = _base_rp_offset,
+                  .kaf_offset = _base_rp_offset - _base_offset_delta,
+                  .file_pos = 0,
+                });
+    }
     ss::file_input_stream_options options{};
     options.buffer_size = config::shard_local_cfg().storage_read_buffer_size();
     options.read_ahead
@@ -791,9 +808,7 @@ public:
             return batch_consumer::consume_result::stop_parser;
         }
 
-        if (_config.first_timestamp > header.first_timestamp) {
-            // kakfa needs to guarantee that the returned record is >=
-            // first_timestamp
+        if (_config.first_timestamp > header.max_timestamp) {
             vlog(
               _ctxlog.debug,
               "accept_batch_start skip because header timestamp is {}",
@@ -958,9 +973,12 @@ remote_segment_batch_reader::init_parser() {
       _ctxlog.debug,
       "remote_segment_batch_reader::init_parser, start_offset: {}",
       _config.start_offset);
+
     auto stream_off = co_await _seg->offset_data_stream(
       model::offset_cast(_config.start_offset),
+      _config.first_timestamp,
       priority_manager::local().shadow_indexing_priority());
+
     auto parser = std::make_unique<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_batch_consumer>(
         _config, *this, _seg->get_term(), _seg->get_ntp(), _rtc),

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -108,8 +108,10 @@ public:
     };
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
-    ss::future<input_stream_with_offsets>
-    offset_data_stream(kafka::offset kafka_offset, ss::io_priority_class);
+    ss::future<input_stream_with_offsets> offset_data_stream(
+      kafka::offset kafka_offset,
+      std::optional<model::timestamp>,
+      ss::io_priority_class);
 
     /// Hydrate the segment
     ss::future<> hydrate();

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -44,21 +44,25 @@ static constexpr std::string_view complete_manifest_json = R"json({
             "is_compacted": false,
             "size_bytes": 1024,
             "base_offset": 10,
-            "committed_offset": 19
+            "committed_offset": 19,
+            "base_timestamp": 123000,
+            "max_timestamp": 123009
         },
         "20-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 2048,
             "base_offset": 20,
             "committed_offset": 29,
-            "max_timestamp": 1234567890
+            "base_timestamp": 123010,
+            "max_timestamp": 123019
         },
         "30-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 4096,
             "base_offset": 30,
             "committed_offset": 39,
-            "max_timestamp": 1234567890
+            "base_timestamp": 123020,
+            "max_timestamp": 123029
         }
     }
 })json";
@@ -95,6 +99,23 @@ static constexpr std::string_view no_size_bytes_segment_meta = R"json({
     "segments": {
         "10-1-v1.log": {
             "is_compacted": false,
+            "base_offset": 10,
+            "committed_offset": 19
+        }
+    }
+})json";
+
+static constexpr std::string_view no_timestamps_segment_meta = R"json({
+    "version": 1,
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 1,
+    "last_offset": 39,
+    "segments": {
+        "10-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 1024,
             "base_offset": 10,
             "committed_offset": 19
         }
@@ -179,17 +200,10 @@ static constexpr std::string_view missing_last_offset_manifest_json = R"json({
     }
 })json";
 
-static const model::ntp manifest_ntp(
-  model::ns("test-ns"), model::topic("test-topic"), model::partition_id(42));
-
-inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
-    iobuf i;
-    i.append(json.data(), json.size());
-    return make_iobuf_input_stream(std::move(i));
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
-    constexpr std::string_view manifest_with_gaps = R"json({
+/**
+ * This manifest has gaps in both its offsets and timestamps.
+ */
+constexpr std::string_view manifest_with_gaps = R"json({
     "version": 1,
     "namespace": "test-ns",
     "topic": "test-topic",
@@ -201,31 +215,47 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
             "is_compacted": false,
             "size_bytes": 1024,
             "base_offset": 10,
-            "committed_offset": 19
+            "committed_offset": 19,
+            "base_timestamp": 123001,
+            "max_timestamp": 123020
         },
         "20-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 2048,
             "base_offset": 20,
             "committed_offset": 29,
-            "max_timestamp": 1234567890
+            "base_timestamp": 123021,
+            "max_timestamp": 123030
         },
         "30-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 4096,
             "base_offset": 30,
             "committed_offset": 39,
-            "max_timestamp": 1234567890
+            "base_timestamp": 123031,
+            "max_timestamp": 123040
         },
         "50-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 4096,
             "base_offset": 50,
             "committed_offset": 59,
-            "max_timestamp": 1234567890
+            "base_timestamp": 123051,
+            "max_timestamp": 123060
         }
     }
     })json";
+
+static const model::ntp manifest_ntp(
+  model::ns("test-ns"), model::topic("test-topic"), model::partition_id(42));
+
+inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
     partition_manifest m;
     m.update(make_manifest_stream(manifest_with_gaps)).get0();
     BOOST_REQUIRE(m.segment_containing(model::offset{9}) == m.end());
@@ -365,6 +395,8 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          .size_bytes = 1024,
          .base_offset = model::offset(10),
          .committed_offset = model::offset(19),
+         .base_timestamp = model::timestamp(123000),
+         .max_timestamp = model::timestamp(123009),
          .ntp_revision = model::initial_revision_id(
            1) // revision is propagated from manifest
        }},
@@ -374,7 +406,8 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          .size_bytes = 2048,
          .base_offset = model::offset(20),
          .committed_offset = model::offset(29),
-         .max_timestamp = model::timestamp(1234567890),
+         .base_timestamp = model::timestamp(123010),
+         .max_timestamp = model::timestamp(123019),
          .ntp_revision = model::initial_revision_id(
            1) // revision is propagated from manifest
        }},
@@ -384,7 +417,8 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          .size_bytes = 4096,
          .base_offset = model::offset(30),
          .committed_offset = model::offset(39),
-         .max_timestamp = model::timestamp(1234567890),
+         .base_timestamp = model::timestamp(123020),
+         .max_timestamp = model::timestamp(123029),
          .ntp_revision = model::initial_revision_id(
            1) // revision is propagated from manifest
        }},
@@ -437,6 +471,24 @@ SEASTAR_THREAD_TEST_CASE(test_no_size_bytes_segment_meta) {
                    "Missing size_bytes value in {10-1-v1.log} segment meta")
                  != std::string::npos;
       });
+}
+
+/**
+ * Segment metadata with missing timestamps are default initialized
+ */
+SEASTAR_THREAD_TEST_CASE(test_timestamps_segment_meta) {
+    partition_manifest m;
+    m.update(make_manifest_stream(no_timestamps_segment_meta)).get0();
+    std::map<ss::sstring, partition_manifest::segment_meta> expected = {
+      {"10-1-v1.log",
+       partition_manifest::segment_meta{
+         .is_compacted = false,
+         .size_bytes = 1024,
+         .base_offset = model::offset(10),
+         .committed_offset = model::offset(19),
+         .ntp_revision = model::initial_revision_id(
+           1) // revision is propagated from manifest
+       }}};
 }
 
 SEASTAR_THREAD_TEST_CASE(test_metas_get_smaller) {
@@ -688,4 +740,320 @@ SEASTAR_THREAD_TEST_CASE(test_segment_meta_serde_compat) {
     BOOST_CHECK(
       serde::from_iobuf<old::metadata_stm_segment>(serde::to_iobuf(segment_new))
       == segment_old);
+}
+
+/**
+ * Reference implementation of partition_manifest::timequery
+ */
+std::optional<partition_manifest::segment_meta>
+reference_timequery(const partition_manifest& m, model::timestamp t) {
+    auto segment_iter = m.begin();
+    while (segment_iter != m.end()) {
+        auto base_timestamp = segment_iter->second.base_timestamp;
+        auto max_timestamp = segment_iter->second.max_timestamp;
+        if (base_timestamp > t || max_timestamp >= t) {
+            break;
+        } else {
+            ++segment_iter;
+        }
+    }
+
+    if (segment_iter == m.end()) {
+        return std::nullopt;
+    } else {
+        return segment_iter->second;
+    }
+}
+
+/**
+ * Assert equality of results from actual implementation
+ * and reference implementation at a particualr timestamp.
+ */
+void reference_check_timequery(
+  const partition_manifest& m, model::timestamp t) {
+    auto result = m.timequery(t);
+    auto reference_result = reference_timequery(m, t);
+    BOOST_REQUIRE(result == reference_result);
+}
+
+/**
+ * Generalized variation of scan_ts_segments that doesn't
+ * make assumptions about the overlapping-ness of segments: this
+ * does its own linear scan of segments, as a reference implementation
+ * of timequery.
+ */
+void scan_ts_segments_general(partition_manifest const& m) {
+    // Before range: should get first segment
+    reference_check_timequery(
+      m, model::timestamp{m.begin()->second.base_timestamp() - 100});
+
+    for (partition_manifest::const_iterator i = m.begin(); i != m.end(); ++i) {
+        auto& s = i->second;
+
+        // Time queries on times within the segment's range should return
+        // this segment.
+        reference_check_timequery(m, s.base_timestamp);
+        reference_check_timequery(m, s.max_timestamp);
+    }
+
+    // After range: should get null
+    reference_check_timequery(
+      m, model::timestamp{m.rbegin()->second.max_timestamp() + 1});
+}
+/**
+ * For a timequery() result, assert it is non-null and equal to the expected
+ * offset
+ */
+void expect_ts_segment(
+  std::optional<partition_manifest::segment_meta> const& s, int base_offset) {
+    BOOST_REQUIRE(s);
+    BOOST_REQUIRE_EQUAL(s->base_offset, model::offset{base_offset});
+}
+
+/**
+ * For non-overlapping time ranges on segments, verify that each timestamp
+ * maps to the expected segment.
+ */
+void scan_ts_segments(partition_manifest const& m) {
+    // Before range: should get first segment
+    expect_ts_segment(
+      m.timequery(model::timestamp{m.begin()->second.base_timestamp() - 100}),
+      m.begin()->second.base_offset);
+
+    partition_manifest::const_iterator previous;
+    for (partition_manifest::const_iterator i = m.begin(); i != m.end(); ++i) {
+        auto& s = i->second;
+
+        // Time queries on times within the segment's range should return
+        // this segment.
+        expect_ts_segment(m.timequery(s.base_timestamp), s.base_offset);
+        expect_ts_segment(m.timequery(s.max_timestamp), s.base_offset);
+
+        previous = i;
+    }
+
+    // After range: should get null
+    BOOST_REQUIRE(
+      m.timequery(model::timestamp{m.rbegin()->second.max_timestamp() + 1})
+      == std::nullopt);
+
+    // Also compare all results with reference implementation.
+    scan_ts_segments_general(m);
+}
+
+/**
+ * Test time queries on a manifest with contiguous non-overlapping time ranges.
+ */
+SEASTAR_THREAD_TEST_CASE(test_timequery_complete) {
+    partition_manifest m;
+    m.update(make_manifest_stream(complete_manifest_json)).get0();
+
+    scan_ts_segments(m);
+}
+
+/**
+ * Test time query when there is only one segment in the manifest
+ */
+SEASTAR_THREAD_TEST_CASE(test_timequery_single_segment) {
+    partition_manifest m;
+    m.update(make_manifest_stream(max_segment_meta_manifest_json)).get0();
+
+    scan_ts_segments(m);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timequery_gaps) {
+    partition_manifest m;
+    m.update(make_manifest_stream(manifest_with_gaps)).get0();
+
+    // Timestamps within the segments and off the ends
+    scan_ts_segments(m);
+
+    // Timestamp in the gap
+    expect_ts_segment(m.timequery(model::timestamp{123045}), 50);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timequery_wide_range) {
+    // Intentionaly ruin the initial interpolation guess by setting
+    // a minimum timestamp bound very far away from other timestamps: this
+    // makes sure we aren't just getting lucky in other tests when their guesses
+    // happen to hit the right segment in one shot.
+
+    static constexpr std::string_view wide_timestamps = R"json({
+    "version": 1,
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 1,
+    "last_offset": 39,
+    "segments": {
+        "10-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 1024,
+            "base_offset": 10,
+            "committed_offset": 19,
+            "base_timestamp": 123000,
+            "max_timestamp": 123009
+        },
+        "20-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 2048,
+            "base_offset": 20,
+            "committed_offset": 29,
+            "base_timestamp": 923010,
+            "max_timestamp": 923019
+        },
+        "30-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 4096,
+            "base_offset": 30,
+            "committed_offset": 39,
+            "base_timestamp": 923020,
+            "max_timestamp": 923029
+        },
+        "40-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 4096,
+            "base_offset": 40,
+            "committed_offset": 49,
+            "base_timestamp": 923030,
+            "max_timestamp": 923039
+        }
+    }
+})json";
+
+    partition_manifest m;
+    m.update(make_manifest_stream(wide_timestamps)).get0();
+
+    scan_ts_segments(m);
+}
+
+/**
+ * Nothing internally to redpanda guarantees anything about the relationship
+ * between timestamps on different segments.  In CreateTime, the timestamps
+ * are totally arbitrary and don't even have to be in any kind of order:
+ * one segment's base_timestamp might be before a previous segment's
+ * base_timestamp.
+ *
+ * There are no particular rules about how redpanda has to handle totally
+ * janky out of order timestamps, but simple overlaps should work fine.
+ */
+SEASTAR_THREAD_TEST_CASE(test_timequery_overlaps) {
+    static constexpr std::string_view overlapping_timestamps = R"json({
+        "version": 1,
+        "namespace": "test-ns",
+        "topic": "test-topic",
+        "partition": 42,
+        "revision": 1,
+        "last_offset": 39,
+        "segments": {
+            "10-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 1024,
+                "base_offset": 10,
+                "committed_offset": 19,
+                "base_timestamp": 123000,
+                "max_timestamp": 123010
+            },
+            "20-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 2048,
+                "base_offset": 20,
+                "committed_offset": 29,
+                "base_timestamp": 123010,
+                "max_timestamp": 123020
+            },
+            "30-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 4096,
+                "base_offset": 30,
+                "committed_offset": 39,
+                "base_timestamp": 923020,
+                "max_timestamp": 923030
+            },
+            "40-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 4096,
+                "base_offset": 40,
+                "committed_offset": 49,
+                "base_timestamp": 923030,
+                "max_timestamp": 923040
+            }
+        }
+    })json";
+
+    partition_manifest m;
+    m.update(make_manifest_stream(overlapping_timestamps)).get0();
+
+    scan_ts_segments_general(m);
+}
+
+/**
+ * With entirely out of order timestamps, all bets are off, other than that
+ * we should not e.g. crash under these circumstances, and that queries
+ * outside the outer begin/end timestamps should return the first segment
+ * and null respectively.
+ */
+SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
+    static constexpr std::string_view raw = R"json({
+        "version": 1,
+        "namespace": "test-ns",
+        "topic": "test-topic",
+        "partition": 42,
+        "revision": 1,
+        "last_offset": 39,
+        "segments": {
+            "10-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 1024,
+                "base_offset": 10,
+                "committed_offset": 19,
+                "base_timestamp": 123000,
+                "max_timestamp": 123010
+            },
+            "20-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 2048,
+                "base_offset": 20,
+                "committed_offset": 29,
+                "base_timestamp": 113000,
+                "max_timestamp": 113020
+            },
+            "30-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 4096,
+                "base_offset": 30,
+                "committed_offset": 39,
+                "base_timestamp": 112000,
+                "max_timestamp": 114000
+            },
+            "40-1-v1.log": {
+                "is_compacted": false,
+                "size_bytes": 4096,
+                "base_offset": 40,
+                "committed_offset": 49,
+                "base_timestamp": 150000,
+                "max_timestamp": 150333
+            }
+        }
+    })json";
+
+    partition_manifest m;
+    m.update(make_manifest_stream(raw)).get0();
+
+    // Before range: should get first segment
+    expect_ts_segment(
+      m.timequery(model::timestamp{m.begin()->second.base_timestamp() - 100}),
+      m.begin()->second.base_offset);
+
+    for (partition_manifest::const_iterator i = m.begin(); i != m.end(); ++i) {
+        auto& s = i->second;
+        // Not checking results: undefined for out of order data.
+        m.timequery(s.base_timestamp);
+        m.timequery(s.max_timestamp);
+    }
+
+    // After range: should get null
+    BOOST_REQUIRE(
+      m.timequery(model::timestamp{m.rbegin()->second.max_timestamp() + 1})
+      == std::nullopt);
 }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -322,7 +322,56 @@ ss::future<> partition::stop() {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::timequery(storage::timequery_config cfg) {
-    return _raft->timequery(cfg);
+    std::optional<storage::timequery_result> result;
+    if (
+      _cloud_storage_partition && _raft->log().start_timestamp() >= cfg.time
+      && _cloud_storage_partition->is_data_available()) {
+        // We have data in the remote partition, and all the data in the raft
+        // log is ahead of the query timestamp, so proceed to query the
+        // remote partition to try and find the earliest data that has timestamp
+        // >= the query time.
+        vlog(
+          clusterlog.debug,
+          "timequery (cloud) {} t={} max_offset(k)={}",
+          _raft->ntp(),
+          cfg.time,
+          cfg.max_offset);
+
+        // remote_partition pre-translates offsets for us, so no call into
+        // the offset translator here
+        auto cloud_result = co_await _cloud_storage_partition->timequery(cfg);
+        if (cloud_result) {
+            co_return cloud_result;
+        }
+
+        // Fall-through: if cfg.time is ahead of the end of the remote_partition
+        // data, search for it in the local data.
+    }
+
+    vlog(
+      clusterlog.debug,
+      "timequery (raft) {} t={} max_offset(k)={}",
+      _raft->ntp(),
+      cfg.time,
+      cfg.max_offset);
+
+    // Translate input (kafka) offset into raft offset
+    cfg.max_offset = _raft->get_offset_translator_state()->to_log_offset(
+      cfg.max_offset);
+    result = co_await _raft->timequery(cfg);
+    if (result) {
+        vlog(
+          clusterlog.debug,
+          "timequery (raft) {} t={} max_offset(r)={} result(r)={}",
+          _raft->ntp(),
+          cfg.time,
+          cfg.max_offset,
+          result->offset);
+        result->offset = _raft->get_offset_translator_state()->from_log_offset(
+          result->offset);
+    }
+
+    co_return result;
 }
 
 ss::future<> partition::update_configuration(topic_properties properties) {

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -238,15 +238,9 @@ replicated_partition::aborted_transactions(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
-    cfg.max_offset = _translator->to_log_offset(cfg.max_offset);
-
-    return _partition->timequery(cfg).then(
-      [this](std::optional<storage::timequery_result> r) {
-          if (r) {
-              r->offset = _translator->from_log_offset(r->offset);
-          }
-          return r;
-      });
+    // cluster::partition::timequery returns a result in Kafka offsets,
+    // no further offset translation is required here.
+    return _partition->timequery(cfg);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -95,13 +95,15 @@ model::record_batch make_random_batch(
   int num_records,
   bool allow_compression,
   model::record_batch_type bt,
-  std::optional<std::vector<size_t>> record_sizes) {
+  std::optional<std::vector<size_t>> record_sizes,
+  std::optional<model::timestamp> ts) {
     return make_random_batch(record_batch_spec{
       .offset = o,
       .allow_compression = allow_compression,
       .count = num_records,
       .bt = bt,
-      .record_sizes = std::move(record_sizes)});
+      .record_sizes = std::move(record_sizes),
+      .timestamp = ts});
 }
 
 model::record_batch
@@ -115,10 +117,8 @@ make_random_batch(model::offset o, int num_records, bool allow_compression) {
 }
 
 model::record_batch make_random_batch(record_batch_spec spec) {
-    auto ts = spec.timestamp.value_or(
-      model::timestamp(model::timestamp::now()() - (spec.count - 1)));
-    auto max_ts = spec.timestamp.value_or(
-      model::timestamp(ts.value() + spec.count - 1));
+    auto ts = spec.timestamp.value_or(model::timestamp::now());
+    auto max_ts = model::timestamp(ts() + spec.count - 1);
     auto header = model::record_batch_header{
       .size_bytes = 0, // computed later
       .base_offset = spec.offset,
@@ -185,22 +185,32 @@ model::record_batch make_random_batch(record_batch_spec spec) {
     return batch;
 }
 
-model::record_batch make_random_batch(model::offset o, bool allow_compression) {
+model::record_batch make_random_batch(
+  model::offset o, bool allow_compression, std::optional<model::timestamp> ts) {
     auto num_records = get_int(2, 30);
     return make_random_batch(
-      o, num_records, allow_compression, model::record_batch_type::raft_data);
+      o,
+      num_records,
+      allow_compression,
+      model::record_batch_type::raft_data,
+      std::nullopt,
+      ts);
 }
 
-ss::circular_buffer<model::record_batch>
-make_random_batches(model::offset o, int count, bool allow_compression) {
+ss::circular_buffer<model::record_batch> make_random_batches(
+  model::offset o,
+  int count,
+  bool allow_compression,
+  std::optional<model::timestamp> base_ts) {
     // start offset + count
     ss::circular_buffer<model::record_batch> ret;
     ret.reserve(count);
+    model::timestamp ts = base_ts.value_or(model::timestamp::now());
     for (int i = 0; i < count; i++) {
         // TODO: it looks like a bug: make_random_batch adds
         // random number of records like we increment offset
         // always by one
-        auto b = make_random_batch(o, allow_compression);
+        auto b = make_random_batch(o, allow_compression, ts);
         o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
         ret.push_back(std::move(b));
@@ -219,9 +229,12 @@ make_random_batches(record_batch_spec spec) {
     ret.reserve(spec.count);
     model::offset o = spec.offset;
     int32_t base_sequence = spec.base_sequence;
+    model::timestamp ts = spec.timestamp.value_or(model::timestamp::now());
     for (int i = 0; i < spec.count; i++) {
         auto num_records = spec.records ? *spec.records : get_int(2, 30);
         auto batch_spec = spec;
+        batch_spec.timestamp = ts;
+        ts = model::timestamp(ts() + num_records);
         batch_spec.offset = o;
         batch_spec.count = num_records;
         if (spec.enable_idempotence) {

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -46,18 +46,24 @@ model::record_batch make_random_batch(
   int num_records,
   bool allow_compression,
   model::record_batch_type bt,
-  std::optional<std::vector<size_t>> record_sizes = std::nullopt);
+  std::optional<std::vector<size_t>> record_sizes = std::nullopt,
+  std::optional<model::timestamp> ts = std::nullopt);
 
 model::record_batch
 make_random_batch(model::offset o, int num_records, bool allow_compression);
 
 model::record_batch make_random_batch(record_batch_spec);
 
-model::record_batch
-make_random_batch(model::offset o, bool allow_compression = true);
+model::record_batch make_random_batch(
+  model::offset o,
+  bool allow_compression = true,
+  std::optional<model::timestamp> ts = std::nullopt);
 
-ss::circular_buffer<model::record_batch>
-make_random_batches(model::offset o, int count, bool allow_compression = true);
+ss::circular_buffer<model::record_batch> make_random_batches(
+  model::offset o,
+  int count,
+  bool allow_compression = true,
+  std::optional<model::timestamp> ts = std::nullopt);
 
 ss::circular_buffer<model::record_batch>
 make_random_batches(model::offset o = model::offset(0));

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -771,6 +771,15 @@ offset_stats disk_log_impl::offsets() const {
     };
 }
 
+model::timestamp disk_log_impl::start_timestamp() const {
+    if (_segs.empty()) {
+        return model::timestamp{};
+    }
+
+    auto& s = _segs.front();
+    return s->index().base_timestamp();
+}
+
 ss::future<> disk_log_impl::new_segment(
   model::offset o, model::term_id t, ss::io_priority_class pc) {
     vassert(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -79,6 +79,7 @@ public:
     timequery(timequery_config cfg) final;
     size_t segment_count() const final { return _segs.size(); }
     offset_stats offsets() const final;
+    model::timestamp start_timestamp() const final;
     std::optional<model::term_id> get_term(model::offset) const final;
     std::optional<model::offset>
     get_term_last_offset(model::term_id term) const final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -70,6 +70,7 @@ public:
 
         virtual size_t segment_count() const = 0;
         virtual storage::offset_stats offsets() const = 0;
+        virtual model::timestamp start_timestamp() const = 0;
         virtual std::ostream& print(std::ostream& o) const = 0;
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
         virtual std::optional<model::offset>
@@ -146,6 +147,10 @@ public:
     const ntp_config& config() const { return _impl->config(); }
 
     size_t segment_count() const { return _impl->segment_count(); }
+
+    model::timestamp start_timestamp() const {
+        return _impl->start_timestamp();
+    }
 
     storage::offset_stats offsets() const { return _impl->offsets(); }
 

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -412,6 +412,14 @@ struct mem_log_impl final : log::impl {
           .last_term_start_offset = last_term_base_offset};
     }
 
+    model::timestamp start_timestamp() const final {
+        if (_data.size()) {
+            return _data.begin()->header().first_timestamp;
+        } else {
+            return model::timestamp{};
+        }
+    }
+
     size_t size_bytes() const override {
         return std::accumulate(
           _data.cbegin(),

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -25,6 +25,8 @@ FIXTURE_TEST(empty_log_garbage_collect, gc_fixture) {
 }
 
 FIXTURE_TEST(retention_test_time, gc_fixture) {
+    auto base_ts = model::timestamp{123000};
+    builder.set_time(base_ts);
     builder | storage::start() | storage::add_segment(0)
       | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
       | storage::add_random_batch(100, 2, storage::maybe_compress_batches::yes)
@@ -47,7 +49,9 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
 
     BOOST_TEST_MESSAGE("Should leave one active segment");
-    builder | storage::garbage_collect(model::timestamp::now(), std::nullopt)
+    builder
+      | storage::garbage_collect(
+        model::timestamp{base_ts() + 1000}, std::nullopt)
       | storage::stop();
 
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -103,7 +103,7 @@ inline constexpr auto add_random_batch = [](auto&&... args) {
 };
 
 inline constexpr auto add_random_batches = [](auto&&... args) {
-    arg_3_way_assert<sizeof...(args), 1, 5>();
+    arg_3_way_assert<sizeof...(args), 1, 6>();
     return std::make_tuple(
       add_random_batches_tag(), std::forward<decltype(args)>(args)...);
 };
@@ -243,6 +243,23 @@ public:
                   std::get<3>(args),
                   std::get<4>(args))
                   .get();
+            } else if constexpr (size == 6) {
+                add_random_batches(
+                  model::offset(std::get<1>(args)),
+                  std::get<2>(args),
+                  std::get<3>(args),
+                  std::get<4>(args),
+                  std::get<5>(args))
+                  .get();
+            } else if constexpr (size == 7) {
+                add_random_batches(
+                  model::offset(std::get<1>(args)),
+                  std::get<2>(args),
+                  std::get<3>(args),
+                  std::get<4>(args),
+                  std::get<5>(args),
+                  std::get<6>(args))
+                  .get();
             }
         }
         return *this;
@@ -254,13 +271,15 @@ public:
       maybe_compress_batches comp = maybe_compress_batches::yes,
       model::record_batch_type bt = model::record_batch_type::raft_data, // data
       log_append_config config = append_config(),
-      should_flush_after flush = should_flush_after::yes);
+      should_flush_after flush = should_flush_after::yes,
+      std::optional<model::timestamp> base_ts = std::nullopt);
     ss::future<> add_random_batches(
       model::offset offset,
       int count,
       maybe_compress_batches comp = maybe_compress_batches::yes,
       log_append_config config = append_config(),
-      should_flush_after flush = should_flush_after::yes);
+      should_flush_after flush = should_flush_after::yes,
+      std::optional<model::timestamp> base_ts = std::nullopt);
     ss::future<> add_random_batches(
       model::offset offset,
       log_append_config config = append_config(),
@@ -324,6 +343,8 @@ public:
 
     storage::api& storage() { return _storage; }
 
+    void set_time(model::timestamp t) { _ts_cursor = t; }
+
 private:
     template<typename Consumer>
     auto consume_impl(Consumer c, log_reader_config config) {
@@ -331,6 +352,20 @@ private:
           [c = std::move(c)](model::record_batch_reader reader) mutable {
               return std::move(reader).consume(std::move(c), model::no_timeout);
           });
+    }
+
+    std::optional<model::timestamp> now(std::optional<model::timestamp> input) {
+        if (input) {
+            return input;
+        } else if (_ts_cursor) {
+            return _ts_cursor;
+        } else {
+            return model::timestamp::now();
+        }
+    }
+
+    void advance_time(const model::record_batch& b) {
+        _ts_cursor = model::timestamp{b.header().max_timestamp() + 1};
     }
 
     ss::future<> write(
@@ -344,6 +379,7 @@ private:
     size_t _bytes_written{0};
     std::vector<std::vector<model::record_batch>> _batches;
     ss::abort_source _abort_source;
+    std::optional<model::timestamp> _ts_cursor;
 };
 
 } // namespace storage

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1814,6 +1814,10 @@ class RedpandaService(Service):
         for ns in listdir(store.data_dir, True):
             if ns == '.coprocessor_offset_checkpoints':
                 continue
+            if ns == 'cloud_storage_cache':
+                # Default cache dir is sub-path of data dir
+                continue
+
             ns = store.add_namespace(ns, os.path.join(store.data_dir, ns))
             for topic in listdir(ns.path):
                 topic = ns.add_topic(topic, os.path.join(ns.path, topic))

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -6,13 +6,11 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
-from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import RedpandaService, SISettings
 
 from rptest.services.admin import Admin
-from rptest.archival.s3_client import S3Client
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -21,16 +19,6 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 from ducktape.utils.util import wait_until
-
-import xxhash
-from collections import namedtuple, defaultdict
-import time
-import os
-import json
-import traceback
-import uuid
-import sys
-import re
 
 # Log errors expected when connectivity between redpanda and the S3
 # backend is disrupted

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -7,14 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
+import re
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService, SISettings
+from rptest.services.metrics_check import MetricCheck
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk_remote import RpkRemoteTool
+from rptest.util import (segments_count, wait_for_segments_removal)
 
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
@@ -30,7 +33,8 @@ from rptest.clients.default import DefaultClient
 
 
 class BaseTimeQuery:
-    def _test_timequery(self):
+    def _test_timequery(self, cluster, cloud_storage: bool, batch_cache: bool):
+        local_retain_segments = 4
         total_segments = 12
         record_size = 1024
 
@@ -39,6 +43,15 @@ class BaseTimeQuery:
                           replication_factor=3)
 
         self.client().create_topic(topic)
+
+        if cloud_storage:
+            for k, v in {
+                    'redpanda.remote.read': True,
+                    'redpanda.remote.write': True,
+                    'retention.bytes':
+                    self.log_segment_size * local_retain_segments
+            }.items():
+                self.client().alter_topic_config(topic.name, k, v)
 
         # Configure topic to trust client-side timestamps, so that
         # we can generate fake ones for the test
@@ -56,9 +69,10 @@ class BaseTimeQuery:
         # Produce a run of messages with CreateTime-style timestamps, each
         # record having a timestamp 1ms greater than the last.
         msg_count = (self.log_segment_size * total_segments) // record_size
+        base_ts = 1664453149000
         producer = KgoVerifierProducer(
             context=self.test_context,
-            redpanda=self.redpanda,
+            redpanda=cluster,
             topic=topic.name,
             msg_size=record_size,
             msg_count=msg_count,
@@ -69,34 +83,87 @@ class BaseTimeQuery:
             batch_max_bytes=record_size * 10,
 
             # A totally arbitrary artificial timestamp base in milliseconds
-            fake_timestamp_ms=1664453149000)
+            fake_timestamp_ms=base_ts)
         producer.start()
         producer.wait()
 
         # Confirm messages written
-        rpk = RpkTool(self.redpanda)
+        rpk = RpkTool(cluster)
         p = next(rpk.describe_topic(topic.name))
         assert p.high_watermark == msg_count
 
-        # Read back timestamps
-        self.logger.info(f"Retrieving timestamps for {msg_count} messages")
-        rpk_remote = RpkRemoteTool(self.redpanda, self.redpanda.nodes[0])
-        timestamps = dict(
-            rpk_remote.read_timestamps(topic.name,
-                                       0,
-                                       msg_count,
-                                       timeout_sec=30))
+        if cloud_storage:
+            # If using cloud storage, we must wait for some segments
+            # to fall out of local storage, to ensure we are really
+            # hitting the cloud storage read path when querying.
+            wait_for_segments_removal(redpanda=cluster,
+                                      topic=topic.name,
+                                      partition_idx=0,
+                                      count=local_retain_segments)
 
+        # Identify partition leader for use in our metrics checks
+        leader_node = cluster.get_node(
+            next(rpk.describe_topic(topic.name)).leader)
+
+        # We know timestamps, they are generated linearly from the
+        # base we provided to kgo-verifier
+        timestamps = dict((i, base_ts + i) for i in range(0, msg_count))
         for k, v in timestamps.items():
             self.logger.debug(f"  Offset {k} -> Timestamp {v}")
 
-        # Interesting cases
-        offsets = [0, msg_count // 4, msg_count // 2, msg_count - 1]
+        # Class defining expectations of timequery results to be checked
+        class ex:
+            def __init__(self, offset, ts=None, expect_read=True):
+                if ts is None:
+                    ts = timestamps[offset]
+                self.ts = ts
+                self.offset = offset
+                self.expect_read = expect_read
 
-        kcat = KafkaCat(self.redpanda)
-        for o in offsets:
-            # read_timestamps gives values in millis
-            ts = int(timestamps[o])
+        # Selection of interesting cases
+        expectations = [
+            ex(0),  # First message
+            ex(msg_count // 4),  # 25%th message
+            ex(msg_count // 2),  # 50%th message
+            ex(msg_count - 1),  # last message
+            ex(0, timestamps[0] - 1000),
+            ex(-1, timestamps[msg_count - 1] + 1000,
+               False)  # After last message
+        ]
+
+        # For when using cloud storage, we expectr offsets ahead
+        # of this to still hit raft for their timequeries.  This is approximate,
+        # but fine as long as the test cases don't tread too near the gap.
+        local_start_offset = msg_count - (
+            (local_retain_segments * self.log_segment_size) / record_size)
+
+        is_redpanda = isinstance(cluster, RedpandaService)
+
+        # Remember which offsets we already hit, so that we can
+        # make a good guess at whether subsequent hits on the same
+        # offset should cause cloud downloads.
+        hit_offsets = set()
+
+        kcat = KafkaCat(cluster)
+        for e in expectations:
+            ts = e.ts
+            o = e.offset
+
+            if is_redpanda and cloud_storage:
+                cloud_metrics = MetricCheck(
+                    self.logger,
+                    cluster,
+                    leader_node,
+                    re.compile("vectorized_cloud_storage_.*"),
+                    reduce=sum)
+
+            if is_redpanda and not cloud_storage:
+                local_metrics = MetricCheck(
+                    self.logger,
+                    cluster,
+                    leader_node,
+                    re.compile("vectorized_storage_.*"),
+                    reduce=sum)
 
             self.logger.info(
                 f"Attempting time lookup ts={ts} (should be o={o})")
@@ -104,12 +171,28 @@ class BaseTimeQuery:
             self.logger.info(f"Time query returned offset {offset}")
             assert offset == o
 
-            self.logger.info(
-                f"Attempting time-based reader lookup ts={ts} (should be o={o})"
-            )
-            record = kcat.consume_one(topic.name, 0, first_timestamp=ts)
-            self.logger.info(f"Time-based consumer returned record {record}")
-            assert record['offset'] == o
+            if is_redpanda and cloud_storage and o < local_start_offset and o not in hit_offsets and e.expect_read:
+                # We should have hydrated exactly one segment: this shows we are properly
+                # looking up the segment and not e.g. seeking from the start.  We may
+                cloud_metrics.expect([
+                    ("vectorized_cloud_storage_successful_downloads_total",
+                     lambda a, b: b == a + 1)
+                ])
+
+            if is_redpanda and not cloud_storage and not batch_cache and e.expect_read:
+                # Expect to read at most one segment from disk: this validates that
+                # we are correctly looking up the right segment before seeking to
+                # the exact offset, and not e.g. reading from the start of the log.
+                local_metrics.expect([
+                    ("vectorized_storage_log_read_bytes_total",
+                     lambda a, b: b > a and b - a < self.log_segment_size)
+                ])
+
+            hit_offsets.add(o)
+
+        # TODO: do some double-restarts to generate segments with
+        # no user data, to check that their timestamps don't
+        # break out indexing.
 
 
 class TimeQueryTest(RedpandaTest, BaseTimeQuery):
@@ -124,19 +207,38 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         pass
 
     @cluster(num_nodes=4)
-    @parametrize(batch_cache=True)
-    @parametrize(batch_cache=False)
-    def test_timequery(self, batch_cache: bool):
+    @parametrize(cloud_storage=True, batch_cache=False)
+    @parametrize(cloud_storage=False, batch_cache=True)
+    @parametrize(cloud_storage=False, batch_cache=False)
+    def test_timequery(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise
             # we won't touch the path in skipping_consumer that applies
             # timestamp bounds
             'disable_batch_cache': not batch_cache,
+
+            # Our time bounds on segment removal depend on the leadership
+            # staying in one place.
+            'enable_leader_balancer': False,
         })
+
+        if cloud_storage:
+            si_settings = SISettings(
+                cloud_storage_max_connections=5,
+                log_segment_size=self.log_segment_size,
+
+                # Off by default: test is parametrized to turn
+                # on if SI is wanted.
+                cloud_storage_enable_remote_read=True,
+                cloud_storage_enable_remote_write=True,
+            )
+            self.redpanda.set_si_settings(si_settings)
 
         self.redpanda.start()
 
-        return self._test_timequery()
+        return self._test_timequery(cluster=self.redpanda,
+                                    cloud_storage=cloud_storage,
+                                    batch_cache=batch_cache)
 
 
 class TimeQueryKafkaTest(Test, BaseTimeQuery):
@@ -166,14 +268,9 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
     def client(self):
         return self._client
 
-    @property
-    def redpanda(self):
-        return self.kafka
-
     def setUp(self):
         self.zk.start()
         self.kafka.start()
-        time.sleep(5)
 
     def tearDown(self):
         # ducktape handle service teardown automatically, but it is hard
@@ -189,4 +286,6 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
 
     @ducktape_cluster(num_nodes=5)
     def test_timequery(self):
-        self._test_timequery()
+        self._test_timequery(cluster=self.kafka,
+                             cloud_storage=False,
+                             batch_cache=True)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -123,14 +123,19 @@ def segments_count(redpanda, topic, partition_idx):
     )
 
 
-def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
+def produce_until_segments(redpanda,
+                           topic,
+                           partition_idx,
+                           count,
+                           acks=-1,
+                           record_size=1024):
     """
     Produce into the topic until given number of segments will appear
     """
     kafka_tools = KafkaCliTools(redpanda)
 
     def done():
-        kafka_tools.produce(topic, 10000, 1024, acks=acks)
+        kafka_tools.produce(topic, 10000, record_size=record_size, acks=acks)
         topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:


### PR DESCRIPTION
## Cover letter

Previously, a time query to a remote.read topic would only scan the part of the log in local storage.

This PR adds:
- a branch in cluster::partition::timequery to call into remote_partition::timequery if the query timestamp is earlier than the start of the local log.
- partition_manifest::timequery, which finds the lowest segment (if any) that contains a timestamp >= the query timestamp, using the existing timestamp info available on segment_meta.  Calls into the same `batch_timequery` function as local storage uses to find the right record within the batch returned by the time-limited reader.
- remote_partition::seek_by_timestamp, which calls into partition_manifest::timequery and then maps the manifest segment offset to a segment_state.
- partition_record_batch_reader_impl::find_cached_reader uses helper `seek_segment` for either looking up by offset (existing code) or by calling into remote_partition::seek_by_timestamp.
- `remote_segment::offset_data_stream` skips offset lookup and opens at start of segment if a `first_timestamp` is set.

`remote_segment_batch_consumer::accept_batch_start` already has logic for skipping records, so that didn't need adding.

There is no index on timestamp, either at the partition level or at the segment level.  We can add these later if necessary.:
- The typical use case of timequeries is expected to be clients issuing a relative small number of time queries, then reading sequentially from the returned offsets.
- A timestamp->segment index would have substantial memory cost.  Local storage gets bisection search for free because segment_set is a circular buffer, whereas partition_manifest is a btree_map, so we would either need to change that structure, or hold a separate structure for timestamp index.
- A timestamp->byte offset index per segment would be more practical, but has relatively little performance impact in the general case where the dominant cost is promoting the segment from S3 to cache.

The lookup of timestamp to segment in `partition_manifest` is done by doing linear interpolation to find the estimated offset based on the partitions min/max timestamps and offsets, followed by a linear search from the guess position to the correct segment.

We could extend this to do a ln(n)^2 search by bisecting the offset space and doing btree_map lookups for each offset guess to find a segment and inspect its timestamps, but this probably isn't worth it: if there is a roughly linear relationship between offset and timestamp, then the existing initial guess will get us very close, and if there isn't such a relation then a subsequent bisection will not be very efficient (worst case will still be a linear search).  A typical worst case cost is iterating over ~1000 segments (a 10 minute upload frequency with 1wk retention is a typical use case).

## Backport Required

Backport together with https://github.com/redpanda-data/redpanda/pull/6606 and https://github.com/redpanda-data/redpanda/pull/6654

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none