### PR TITLE
storage: do not try to timequery into compressed batches

### DIFF
--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -353,7 +353,7 @@ batch_timequery(const model::record_batch& b, model::timestamp t) {
     // records in the batch have different timestamps.
     model::offset result_o = b.base_offset();
     model::timestamp result_t = b.header().first_timestamp;
-    if (b.header().first_timestamp < t) {
+    if (b.header().first_timestamp < t && !b.compressed()) {
         b.for_each_record(
           [&result_o, &result_t, t, &b](
             const model::record& r) -> ss::stop_iteration {


### PR DESCRIPTION

## Cover letter

`list_offsets` unit test fails nondeterministically on this, probably because we only try to seek if the query timestamp doesn't match the batches base timestamp, which only happens if the batch spans a step between milliseconds, and the test is using the wall clock for its query timestamp and the data timestamps.

Fixes: https://github.com/redpanda-data/redpanda/issues/6657

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none