### PR TITLE
cluster: support automatically assigning a node ID

### DIFF
--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -28,7 +28,7 @@ cluster_discovery::cluster_discovery(const model::node_uuid& node_uuid)
   : _node_uuid(node_uuid) {}
 
 ss::future<node_id> cluster_discovery::determine_node_id() {
-    co_return config::node().node_id();
+    co_return *config::node().node_id();
 }
 
 vector<broker> cluster_discovery::initial_raft0_brokers() const {

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -24,8 +24,10 @@ using std::vector;
 
 namespace cluster {
 
-cluster_discovery::cluster_discovery(const model::node_uuid& node_uuid)
-  : _node_uuid(node_uuid) {}
+cluster_discovery::cluster_discovery(
+  const model::node_uuid& node_uuid, ss::abort_source& as)
+  : _node_uuid(node_uuid)
+  , _as(as) {}
 
 ss::future<node_id> cluster_discovery::determine_node_id() {
     co_return *config::node().node_id();

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -10,6 +10,7 @@
 #include "cluster/cluster_discovery.h"
 
 #include "cluster/cluster_utils.h"
+#include "cluster/controller_service.h"
 #include "cluster/logger.h"
 #include "config/node_config.h"
 #include "model/fundamental.h"
@@ -27,10 +28,34 @@ namespace cluster {
 cluster_discovery::cluster_discovery(
   const model::node_uuid& node_uuid, ss::abort_source& as)
   : _node_uuid(node_uuid)
+  , _join_retry_jitter(config::shard_local_cfg().join_retry_timeout_ms())
+  , _join_timeout(std::chrono::seconds(2))
   , _as(as) {}
 
 ss::future<node_id> cluster_discovery::determine_node_id() {
-    co_return *config::node().node_id();
+    // TODO: read from disk if empty.
+    const auto& configured_node_id = config::node().node_id();
+    if (configured_node_id != std::nullopt) {
+        clusterlog.info("Using configured node ID {}", configured_node_id);
+        co_return *configured_node_id;
+    }
+    // TODO: once is_cluster_founder() refers to all seeds, verify that all the
+    // seeds' seed_servers lists match and assign node IDs based on the
+    // ordering.
+    if (is_cluster_founder()) {
+        // If this is the root node, assign node 0.
+        co_return model::node_id(0);
+    }
+    model::node_id assigned_node_id;
+    while (!_as.abort_requested()) {
+        auto assigned = co_await dispatch_node_uuid_registration_to_seeds(
+          assigned_node_id);
+        if (assigned) {
+            break;
+        }
+        co_await ss::sleep_abortable(_join_retry_jitter.next_duration(), _as);
+    }
+    co_return assigned_node_id;
 }
 
 vector<broker> cluster_discovery::initial_raft0_brokers() const {
@@ -41,6 +66,67 @@ vector<broker> cluster_discovery::initial_raft0_brokers() const {
         return {make_self_broker(config::node())};
     }
     return {};
+}
+
+ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
+  model::node_id& assigned_node_id) {
+    const auto& seed_servers = config::node().seed_servers();
+    auto self = make_self_broker(config::node());
+    for (const auto& s : seed_servers) {
+        vlog(
+          clusterlog.info,
+          "Requesting node ID for UUID {} from {}",
+          _node_uuid,
+          s.addr);
+        result<join_node_reply> r(join_node_reply{});
+        try {
+            r = co_await do_with_client_one_shot<controller_client_protocol>(
+              s.addr,
+              config::node().rpc_server_tls(),
+              _join_timeout,
+              [&self, this](controller_client_protocol c) {
+                  return c
+                    .join_node(
+                      join_node_request(
+                        features::feature_table::get_latest_logical_version(),
+                        _node_uuid().to_vector(),
+                        self),
+                      rpc::client_opts(rpc::clock_type::now() + _join_timeout))
+                    .then(&rpc::get_ctx_data<join_node_reply>);
+              });
+        } catch (...) {
+            vlog(
+              clusterlog.debug,
+              "Error registering UUID {}, retrying: {}",
+              _node_uuid,
+              std::current_exception());
+            continue;
+        }
+        if (r.has_error()) {
+            vlog(
+              clusterlog.debug,
+              "Error registering UUID {}: {}, retrying",
+              _node_uuid,
+              r.error());
+            continue;
+        }
+        if (!r.has_value() || !r.value().success) {
+            vlog(
+              clusterlog.debug,
+              "Error registering UUID {}, retrying",
+              _node_uuid);
+            continue;
+        }
+        const auto& reply = r.value();
+        if (reply.id < 0) {
+            // Something else went wrong. Maybe duplicate UUID?
+            vlog(clusterlog.debug, "Negative node ID {}", reply.id);
+            continue;
+        }
+        assigned_node_id = reply.id;
+        co_return true;
+    }
+    co_return false;
 }
 
 bool cluster_discovery::is_cluster_founder() const {

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -19,6 +19,10 @@
 #include <optional>
 #include <vector>
 
+namespace storage {
+class kvstore;
+} // namespace storage
+
 namespace cluster {
 
 // Provides metadata pertaining to initial cluster discovery. It is the
@@ -56,7 +60,10 @@ namespace cluster {
 // TODO: reconcile the RPC dispatch logic here with that in members_manager.
 class cluster_discovery {
 public:
-    cluster_discovery(const model::node_uuid& node_uuid, ss::abort_source&);
+    cluster_discovery(
+      const model::node_uuid& node_uuid,
+      storage::kvstore& kvstore,
+      ss::abort_source&);
 
     // Determines what the node ID for this node should be. Once called, we can
     // proceed with initializing anything that depends on node ID (Raft
@@ -106,6 +113,7 @@ private:
     simple_time_jitter<model::timeout_clock> _join_retry_jitter;
     const std::chrono::milliseconds _join_timeout;
 
+    storage::kvstore& _kvstore;
     ss::abort_source& _as;
 };
 

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -10,6 +10,8 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "random/simple_time_jitter.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -19,25 +21,56 @@
 
 namespace cluster {
 
-// Provides metadata pertaining to initial cluster discovery.
+// Provides metadata pertaining to initial cluster discovery. It is the
+// entrypoint into the steps to join a cluster.
+//
+// Node ID assignment and joining a cluster
+// ========================================
+// When a node starts up, before it can initialize most of its subsystems, it
+// must be made aware of its node ID. It can either get this from its config,
+// the kv-store, or be assigned one by the controller leader. In all cases, the
+// node ID and node UUID must be registered with the controller, after which
+// the node can proceed join the cluster.
+//
+// The high level steps are as follows:
+//
+// When the node ID is unknown:
+// 1. Generate or load node UUID
+// 2. Get assigned a node ID by sending a request to the controller leader
+// 3. Start subsystems with our known node ID
+// 4. Join the cluster and get added to the controller Raft group by sending a
+//    request to the controller leader
+// 5. Once added to the cluster, open endpoints for user traffic
+//
+// When the node ID is known:
+// 1. Generate or load node UUID
+// 2. Load node ID from config or kv-store
+// 3. Start subsystems with our known node ID
+// 4. Register our UUID with our node ID and join the cluster by sending a
+//    request to the controller leader
+// 5. Once added to the cluster, open endpoints for user traffic
+//
+// These steps are implemented here, in redpanda/application.cc, and in
+// cluster/members_manager.cc
+//
+// TODO: reconcile the RPC dispatch logic here with that in members_manager.
 class cluster_discovery {
 public:
     cluster_discovery(const model::node_uuid& node_uuid, ss::abort_source&);
 
-    // Returns this node's node ID.
+    // Determines what the node ID for this node should be. Once called, we can
+    // proceed with initializing anything that depends on node ID (Raft
+    // subsystem, etc).
+    //
+    // On a non-seed server with no node ID specified via config or on disk,
+    // this sends a request to the controllers to register this node's UUID and
+    // assign it a node ID.
     //
     // TODO: implement the below behavior.
-    //
-    // Determines what the node ID for this node should be. Once called, we can
-    // proceed with initializing anything that depends on node ID.
     //
     // On a seed server with no data on it (i.e. a fresh node), this sends
     // requests to all other seed servers to determine if there is a valid
     // assignment of node IDs for the seeds.
-    //
-    // On a non-seed server with no node ID specified via config, this sends a
-    // request to the controllers to register this node's UUID and assign it a
-    // node ID.
     ss::future<model::node_id> determine_node_id();
 
     // If configured as the root, return this broker as the sole initial Raft0
@@ -64,7 +97,14 @@ private:
     // the seed servers.
     bool is_cluster_founder() const;
 
+    // Sends requests to each seed server to register the local node UUID until
+    // one succeeds. Upon success, sets `node_id` to the assigned node ID and
+    // returns true.
+    ss::future<bool> dispatch_node_uuid_registration_to_seeds(model::node_id&);
+
     const model::node_uuid _node_uuid;
+    simple_time_jitter<model::timeout_clock> _join_retry_jitter;
+    const std::chrono::milliseconds _join_timeout;
 
     ss::abort_source& _as;
 };

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -22,7 +22,7 @@ namespace cluster {
 // Provides metadata pertaining to initial cluster discovery.
 class cluster_discovery {
 public:
-    explicit cluster_discovery(const model::node_uuid& node_uuid);
+    cluster_discovery(const model::node_uuid& node_uuid, ss::abort_source&);
 
     // Returns this node's node ID.
     //
@@ -65,6 +65,8 @@ private:
     bool is_cluster_founder() const;
 
     const model::node_uuid _node_uuid;
+
+    ss::abort_source& _as;
 };
 
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -193,8 +193,15 @@ model::broker make_self_broker(const config::node_config& node_cfg) {
     // As for memory, if disk_gb is zero this is handled like a legacy broker.
     uint32_t disk_gb = space_info.capacity >> 30;
 
+    // If this node hasn't been configured with a node ID, use -1 to indicate
+    // that we don't yet know it yet. This shouldn't be used during the normal
+    // operation of a broker, and instead should be used to indicate a broker
+    // that needs to be assigned a node ID when it first starts up.
+    model::node_id node_id = node_cfg.node_id() == std::nullopt
+                               ? model::node_id(-1)
+                               : *node_cfg.node_id();
     return model::broker(
-      model::node_id(node_cfg.node_id),
+      node_id,
       kafka_addr,
       rpc_addr,
       node_cfg.rack,

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -107,6 +107,7 @@ static constexpr int8_t decommission_node_cmd_type = 0;
 static constexpr int8_t recommission_node_cmd_type = 1;
 static constexpr int8_t finish_reallocations_cmd_type = 2;
 static constexpr int8_t maintenance_mode_cmd_type = 3;
+static constexpr int8_t register_node_uuid_cmd_type = 4;
 
 // cluster config commands
 static constexpr int8_t cluster_config_delta_cmd_type = 0;
@@ -239,6 +240,11 @@ using finish_reallocations_cmd = controller_command<
   finish_reallocations_cmd_type,
   model::record_batch_type::node_management_cmd,
   serde_opts::adl_and_serde>;
+using register_node_uuid_cmd = controller_command<
+  model::node_uuid,
+  std::optional<model::node_id>,
+  register_node_uuid_cmd_type,
+  model::record_batch_type::node_management_cmd>;
 
 using maintenance_mode_cmd = controller_command<
   model::node_id,

--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -28,7 +28,7 @@ config_frontend::config_frontend(
   , _leaders(leaders)
   , _features(features)
   , _as(as)
-  , _self(config::node().node_id()) {}
+  , _self(*config::node().node_id()) {}
 
 /**
  * RPC wrapper on do_patch, to dispatch to the controller leader

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -55,7 +55,7 @@ config_manager::config_manager(
   ss::sharded<partition_leaders_table>& pl,
   ss::sharded<features::feature_table>& ft,
   ss::sharded<ss::abort_source>& as)
-  : _self(config::node().node_id())
+  : _self(*config::node().node_id())
   , _frontend(cf)
   , _connection_cache(cc)
   , _leaders(pl)

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -112,6 +112,8 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
       .then([this] {
           return _members_manager.start_single(
             _raft0,
+            std::ref(_stm),
+            std::ref(_feature_table),
             std::ref(_members_table),
             std::ref(_connections),
             std::ref(_partition_allocator),

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -260,7 +260,7 @@ controller_backend::controller_backend(
   , _partition_leaders_table(leaders)
   , _topics_frontend(frontend)
   , _storage(storage)
-  , _self(model::node_id(config::node().node_id))
+  , _self(*config::node().node_id())
   , _data_directory(config::node().data_directory().as_sstring())
   , _housekeeping_timer_interval(
       config::shard_local_cfg().controller_backend_housekeeping_interval_ms())

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -14,12 +14,13 @@
 #include "cluster/config_manager.h"
 #include "cluster/data_policy_manager.h"
 #include "cluster/feature_backend.h"
-#include "cluster/members_manager.h"
 #include "cluster/security_manager.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/mux_state_machine.h"
 
 namespace cluster {
+
+class members_manager;
 
 // single instance
 using controller_stm = raft::mux_state_machine<

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -45,7 +45,7 @@ feature_manager::feature_manager(
   , _connection_cache(connection_cache)
   , _raft0_group(raft0_group)
   , _barrier_state(
-      config::node().node_id(),
+      *config::node().node_id(),
       members.local(),
       as.local(),
       _gate,
@@ -109,7 +109,7 @@ ss::future<> feature_manager::start() {
 
             vlog(
               clusterlog.debug, "Controller leader notification term {}", term);
-            _am_controller_leader = leader_id == config::node().node_id();
+            _am_controller_leader = leader_id == *config::node().node_id();
 
             // This hook avoids the need for the controller leader to receive
             // its own health report to generate a call to update_node_version.
@@ -128,7 +128,7 @@ ss::future<> feature_manager::start() {
                   leader_id.value(),
                   features::feature_table::get_latest_logical_version());
                 update_node_version(
-                  config::node().node_id,
+                  *config::node().node_id(),
                   features::feature_table::get_latest_logical_version());
             }
         });

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -34,7 +34,7 @@ members_frontend::members_frontend(
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<ss::abort_source>& as)
-  : _self(config::node().node_id())
+  : _self(*config::node().node_id())
   , _node_op_timeout(
       config::shard_local_cfg().node_management_operation_timeout_ms)
   , _stm(stm)

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -12,6 +12,7 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
 #include "cluster/controller_service.h"
+#include "cluster/controller_stm.h"
 #include "cluster/drain_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
@@ -44,6 +45,8 @@ namespace cluster {
 
 members_manager::members_manager(
   consensus_ptr raft0,
+  ss::sharded<controller_stm>& controller_stm,
+  ss::sharded<features::feature_table>& feature_table,
   ss::sharded<members_table>& members_table,
   ss::sharded<rpc::connection_cache>& connections,
   ss::sharded<partition_allocator>& allocator,
@@ -55,6 +58,8 @@ members_manager::members_manager(
   , _join_retry_jitter(config::shard_local_cfg().join_retry_timeout_ms())
   , _join_timeout(std::chrono::seconds(2))
   , _raft0(raft0)
+  , _controller_stm(controller_stm)
+  , _feature_table(feature_table)
   , _members_table(members_table)
   , _connection_cache(connections)
   , _allocator(allocator)
@@ -341,6 +346,14 @@ members_manager::get_node_updates() {
     return ss::make_ready_future<std::vector<node_update>>(std::move(ret));
 }
 
+model::node_id members_manager::get_node_id(const model::node_uuid& node_uuid) {
+    const auto it = _id_by_uuid.find(node_uuid);
+    vassert(
+      it != _id_by_uuid.end(),
+      "Node registration must be completed before calling");
+    return it->second;
+}
+
 template<typename Cmd>
 ss::future<std::error_code> members_manager::dispatch_updates_to_cores(
   model::offset update_offset, Cmd cmd) {
@@ -432,6 +445,7 @@ void members_manager::join_raft0() {
                             std::move(join_node_request{
                               features::feature_table::
                                 get_latest_logical_version(),
+                              _storage.local().node_uuid()().to_vector(),
                               _self}))
                      .then([this](result<join_node_reply> r) {
                          bool success = r && r.value().success;
@@ -575,92 +589,211 @@ auto members_manager::dispatch_rpc_to_leader(
       std::forward<Func>(f));
 }
 
+ss::future<result<join_node_reply>> members_manager::replicate_new_node_uuid(
+  const model::node_uuid& node_uuid,
+  const std::optional<model::node_id>& node_id) {
+    using ret_t = result<join_node_reply>;
+    ss::sstring node_id_str = node_id ? ssx::sformat("node ID {}", *node_id)
+                                      : "no node ID";
+    vlog(
+      clusterlog.debug,
+      "Replicating registration of UUID {} with {}",
+      node_uuid,
+      node_id_str);
+    // Otherwise, replicate a request to register the UUID.
+    auto errc = co_await replicate_and_wait(
+      _controller_stm,
+      _feature_table,
+      _as,
+      register_node_uuid_cmd(node_uuid, node_id),
+      model::timeout_clock::now() + 30s);
+    vlog(
+      clusterlog.debug,
+      "Registration replication completed for UUID '{}': {}",
+      node_uuid,
+      errc);
+    if (errc != errc::success) {
+        co_return errc;
+    }
+    const auto assigned_node_id = get_node_id(node_uuid);
+    if (node_id && assigned_node_id != *node_id) {
+        vlog(
+          clusterlog.warn,
+          "Node registration for UUID {} as {} completed but already already "
+          "assigned as {}",
+          node_uuid,
+          *node_id,
+          assigned_node_id);
+        co_return errc::invalid_request;
+    }
+
+    // On success, return the node ID.
+    co_return ret_t(join_node_reply{true, get_node_id(node_uuid)});
+}
+
 ss::future<result<join_node_reply>>
 members_manager::handle_join_request(join_node_request const req) {
     using ret_t = result<join_node_reply>;
+
+    bool node_id_assignment_supported = _feature_table.local().is_active(
+      features::feature::node_id_assignment);
+    bool req_has_node_uuid = !req.node_uuid.empty();
+    if (node_id_assignment_supported && !req_has_node_uuid) {
+        vlog(
+          clusterlog.warn,
+          "Invalid join request for node ID {}, node UUID is required",
+          req.node.id());
+        co_return errc::invalid_request;
+    }
+    std::optional<model::node_id> req_node_id = std::nullopt;
+    if (req.node.id() >= 0) {
+        req_node_id = req.node.id();
+    }
+    if (!node_id_assignment_supported && !req_node_id) {
+        vlog(
+          clusterlog.warn,
+          "Got request to assign node ID, but feature not active",
+          req.node.id());
+        co_return errc::invalid_request;
+    }
+    if (
+      req_has_node_uuid
+      && req.node_uuid.size() != model::node_uuid::type::length) {
+        vlog(
+          clusterlog.warn,
+          "Invalid join request, expected UUID or empty; got {}-byte value",
+          req.node_uuid.size());
+        co_return errc::invalid_request;
+    }
+    model::node_uuid node_uuid;
+    if (!req_node_id && !req_has_node_uuid) {
+        vlog(clusterlog.warn, "Node ID assignment attempt had no node UUID");
+        co_return errc::invalid_request;
+    }
+
+    ss::sstring node_uuid_str = "no node_uuid";
+    if (req_has_node_uuid) {
+        node_uuid = model::node_uuid(uuid_t(req.node_uuid));
+        node_uuid_str = ssx::sformat("{}", node_uuid);
+    }
     vlog(
       clusterlog.info,
-      "Processing node '{}' join request (version {})",
+      "Processing node '{} ({})' join request (version {})",
       req.node.id(),
+      node_uuid_str,
       req.logical_version);
 
-    // curent node is a leader
-    if (_raft0->is_elected_leader()) {
-        // if configuration contains the broker already just update its config
-        // with data from join request
-
-        if (_raft0->config().contains_broker(req.node.id())) {
-            vlog(
-              clusterlog.info,
-              "Broker {} is already member of a cluster, updating "
-              "configuration",
-              req.node.id());
-            auto node_id = req.node.id();
-            auto update_req = configuration_update_request(
-              req.node, _self.id());
-            co_return co_await handle_configuration_update_request(
-              std::move(update_req))
-              .then([node_id](result<configuration_update_reply> r) {
-                  if (r) {
-                      auto success = r.value().success;
-                      return ret_t(join_node_reply{
-                        success, success ? node_id : model::node_id{-1}});
-                  }
-                  return ret_t(r.error());
-              });
-        }
-
-        if (_raft0->config().contains_address(req.node.rpc_address())) {
-            vlog(
-              clusterlog.info,
-              "Broker {} address ({}) conflicts with the address of another "
-              "node",
-              req.node.id(),
-              req.node.rpc_address());
-            co_return ret_t(join_node_reply{false, model::node_id(-1)});
-        }
-        if (req.node.id() != _self.id()) {
-            co_await update_broker_client(
-              _self.id(),
-              _connection_cache,
-              req.node.id(),
-              req.node.rpc_address(),
-              _rpc_tls_config);
-        }
-        // Just update raft0 configuration
-        // we do not use revisions in raft0 configuration, it is always revision
-        // 0 which is perfectly fine. this will work like revision less raft
-        // protocol.
-        co_return co_await _raft0
-          ->add_group_members({req.node}, model::revision_id(0))
-          .then([broker = req.node](std::error_code ec) {
-              if (!ec) {
-                  return ret_t(join_node_reply{true, broker.id()});
-              }
+    if (!_raft0->is_elected_leader()) {
+        vlog(clusterlog.debug, "Not the leader; dispatching to leader node");
+        // Current node is not the leader have to send an RPC to leader
+        // controller
+        co_return co_await dispatch_rpc_to_leader(
+          _join_timeout,
+          [req, tout = rpc::clock_type::now() + _join_timeout](
+            controller_client_protocol c) mutable {
+              return c.join_node(join_node_request(req), rpc::client_opts(tout))
+                .then(&rpc::get_ctx_data<join_node_reply>);
+          })
+          .handle_exception([](const std::exception_ptr& e) {
               vlog(
                 clusterlog.warn,
-                "Error adding node {} to cluster - {}",
-                broker,
-                ec.message());
-              return ret_t(ec);
+                "Error while dispatching join request to leader node - {}",
+                e);
+              return ss::make_ready_future<ret_t>(
+                errc::join_request_dispatch_error);
           });
     }
-    // Current node is not the leader have to send an RPC to leader
-    // controller
-    co_return co_await dispatch_rpc_to_leader(
-      _join_timeout,
-      [req, tout = rpc::clock_type::now() + _join_timeout](
-        controller_client_protocol c) mutable {
-          return c.join_node(join_node_request(req), rpc::client_opts(tout))
-            .then(&rpc::get_ctx_data<join_node_reply>);
-      })
-      .handle_exception([](const std::exception_ptr& e) {
+
+    if (likely(node_id_assignment_supported && req_has_node_uuid)) {
+        const auto it = _id_by_uuid.find(node_uuid);
+        if (!req_node_id) {
+            if (it == _id_by_uuid.end()) {
+                // The UUID isn't yet in our table. Register it, but return,
+                // expecting the node to come back with another join request
+                // once its Raft subsystems are up.
+                co_return co_await replicate_new_node_uuid(
+                  node_uuid, req_node_id);
+            }
+            // The requested UUID already exists; this is a duplicate request
+            // to assign a node ID. Just return the registered node ID.
+            co_return ret_t(join_node_reply{true, it->second});
+        }
+        // We've been passed a node ID. The caller expects to be added to the
+        // Raft group by the end of this function.
+        if (it == _id_by_uuid.end()) {
+            // The node ID was manually provided and this is a new attempt to
+            // register the UUID.
+            auto r = co_await replicate_new_node_uuid(node_uuid, req_node_id);
+            if (r.has_error() || !r.value().success) {
+                co_return r;
+            }
+        } else {
+            // Validate that the node ID matches the one in our table.
+            if (*req_node_id != it->second) {
+                co_return ret_t(join_node_reply{false, model::node_id(-1)});
+            }
+        }
+        // Proceed to adding the node ID to the controller Raft group.
+        // Presumably the node that made this join request started its Raft
+        // subsystem with the node ID and is waiting to join the group.
+    }
+
+    // if configuration contains the broker already just update its config
+    // with data from join request
+
+    if (_raft0->config().contains_broker(req.node.id())) {
+        vlog(
+          clusterlog.info,
+          "Broker {} is already member of a cluster, updating "
+          "configuration",
+          req.node.id());
+        auto node_id = req.node.id();
+        auto update_req = configuration_update_request(req.node, _self.id());
+        co_return co_await handle_configuration_update_request(
+          std::move(update_req))
+          .then([node_id](result<configuration_update_reply> r) {
+              if (r) {
+                  auto success = r.value().success;
+                  return ret_t(join_node_reply{
+                    success, success ? node_id : model::node_id{-1}});
+              }
+              return ret_t(r.error());
+          });
+    }
+
+    if (_raft0->config().contains_address(req.node.rpc_address())) {
+        vlog(
+          clusterlog.info,
+          "Broker {} address ({}) conflicts with the address of another "
+          "node",
+          req.node.id(),
+          req.node.rpc_address());
+        co_return ret_t(join_node_reply{false, model::node_id(-1)});
+    }
+    if (req.node.id() != _self.id()) {
+        co_await update_broker_client(
+          _self.id(),
+          _connection_cache,
+          req.node.id(),
+          req.node.rpc_address(),
+          _rpc_tls_config);
+    }
+    // Just update raft0 configuration
+    // we do not use revisions in raft0 configuration, it is always revision
+    // 0 which is perfectly fine. this will work like revision less raft
+    // protocol.
+    co_return co_await _raft0
+      ->add_group_members({req.node}, model::revision_id(0))
+      .then([broker = req.node](std::error_code ec) {
+          if (!ec) {
+              return ret_t(join_node_reply{true, broker.id()});
+          }
           vlog(
             clusterlog.warn,
-            "Error while dispatching join request to leader node - {}",
-            e);
-          return ss::make_ready_future<ret_t>(
-            errc::join_request_dispatch_error);
+            "Error adding node {} to cluster - {}",
+            broker,
+            ec.message());
+          return ret_t(ec);
       });
 }
 

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -72,7 +72,8 @@ public:
       int16_t proxy_port,
       int16_t schema_reg_port,
       int16_t coproc_supervisor_port,
-      std::vector<config::seed_server> seeds) {
+      std::vector<config::seed_server> seeds,
+      configure_node_id use_node_id = configure_node_id::yes) {
         _instances.emplace(
           node_id,
           std::make_unique<redpanda_thread_fixture>(
@@ -85,7 +86,11 @@ public:
             seeds,
             ssx::sformat("{}.{}", _base_dir, node_id()),
             _sgroups,
-            false));
+            false,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            use_node_id));
     }
 
     application* get_node_application(model::node_id id) {
@@ -107,11 +112,12 @@ public:
 
     application* create_node_application(
       model::node_id node_id,
-      int kafka_port = 9092,
-      int rpc_port = 11000,
-      int proxy_port = 8082,
-      int schema_reg_port = 8081,
-      int coproc_supervisor_port = 43189) {
+      int kafka_port_base = 9092,
+      int rpc_port_base = 11000,
+      int proxy_port_base = 8082,
+      int schema_reg_port_base = 8081,
+      int coproc_supervisor_port_base = 43189,
+      configure_node_id use_node_id = configure_node_id::yes) {
         std::vector<config::seed_server> seeds = {};
         if (node_id != 0) {
             seeds.push_back(
@@ -119,13 +125,20 @@ public:
         }
         add_node(
           node_id,
-          kafka_port + node_id(),
-          rpc_port + node_id(),
-          proxy_port + node_id(),
-          schema_reg_port + node_id(),
-          coproc_supervisor_port + node_id(),
-          std::move(seeds));
+          kafka_port_base + node_id(),
+          rpc_port_base + node_id(),
+          proxy_port_base + node_id(),
+          schema_reg_port_base + node_id(),
+          coproc_supervisor_port_base + node_id(),
+          std::move(seeds),
+          use_node_id);
         return get_node_application(node_id);
+    }
+
+    application* create_node_application(
+      model::node_id node_id, configure_node_id use_node_id) {
+        return create_node_application(
+          node_id, 9092, 11000, 8082, 8081, 43189, use_node_id);
     }
 
     void remove_node_application(model::node_id node_id) {

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -45,3 +45,46 @@ FIXTURE_TEST(test_three_node_cluster, cluster_test_fixture) {
 
     wait_for_all_members(3s).get();
 }
+
+FIXTURE_TEST(test_auto_assign_node_id, cluster_test_fixture) {
+    create_node_application(model::node_id{0}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
+
+    create_node_application(model::node_id{1}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(1, *config::node().node_id());
+
+    create_node_application(model::node_id{2}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(2, *config::node().node_id());
+
+    wait_for_all_members(3s).get();
+}
+
+FIXTURE_TEST(test_auto_assign_non_seeds, cluster_test_fixture) {
+    create_node_application(model::node_id{0});
+    BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
+
+    create_node_application(model::node_id{1}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(1, *config::node().node_id());
+
+    create_node_application(model::node_id{2}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(2, *config::node().node_id());
+
+    wait_for_all_members(3s).get();
+}
+
+FIXTURE_TEST(test_auto_assign_with_explicit_node_id, cluster_test_fixture) {
+    create_node_application(model::node_id{0});
+    BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
+
+    // Explicitly assign node ID 2. Node ID assignment should assign around it.
+    create_node_application(model::node_id{2});
+    BOOST_REQUIRE_EQUAL(2, *config::node().node_id());
+
+    create_node_application(model::node_id{1}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(1, *config::node().node_id());
+
+    create_node_application(model::node_id{3}, configure_node_id::no);
+    BOOST_REQUIRE_EQUAL(3, *config::node().node_id());
+
+    wait_for_all_members(3s).get();
+}

--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -19,7 +19,7 @@ namespace cluster {
 
 topic_table_probe::topic_table_probe(const topic_table& topic_table)
   : _topic_table(topic_table)
-  , _node_id(config::node().node_id()) {
+  , _node_id(*config::node().node_id()) {
     setup_metrics();
 }
 

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -29,8 +29,10 @@ node_config::node_config() noexcept
   , node_id(
       *this,
       "node_id",
-      "Unique id identifying a node in the cluster",
-      {.required = required::yes, .visibility = visibility::user})
+      "Unique id identifying a node in the cluster. If missing, a unique id "
+      "will be assigned for this node when it joins the cluster",
+      {.visibility = visibility::user},
+      std::nullopt)
   , rack(
       *this,
       "rack",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -26,7 +26,12 @@ struct node_config final : public config_store {
 public:
     property<bool> developer_mode;
     property<data_directory_path> data_directory;
-    property<model::node_id> node_id;
+
+    // NOTE: during the normal runtime of a cluster, it is safe to assume that
+    // the value of the node ID has been determined, and that there is a value
+    // set for this property.
+    property<std::optional<model::node_id>> node_id;
+
     property<std::optional<model::rack_id>> rack;
     property<std::vector<seed_server>> seed_servers;
 

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -79,7 +79,7 @@ reconciliation_backend::reconciliation_backend(
   ss::sharded<partition_manager>& coproc_pm,
   ss::sharded<pacemaker>& pacemaker,
   ss::sharded<wasm::script_database>& sdb) noexcept
-  : _self(model::node_id(config::node().node_id))
+  : _self(model::node_id(*config::node().node_id()))
   , _data_directory(config::node().data_directory().as_sstring())
   , _topics(topics)
   , _shard_table(shard_table)

--- a/src/v/coproc/tests/partition_movement_tests.cc
+++ b/src/v/coproc/tests/partition_movement_tests.cc
@@ -58,7 +58,8 @@ FIXTURE_TEST(test_move_source_topic, coproc_test_fixture) {
     const ss::shard_id next_shard = (*shard + 1) % ss::smp::count;
     info("Current target shard {} and next shard {}", *shard, next_shard);
     model::broker_shard bs{
-      .node_id = model::node_id(config::node().node_id), .shard = next_shard};
+      .node_id = model::node_id(*config::node().node_id()),
+      .shard = next_shard};
 
     /// Move the input onto the new desired target
     auto& topics_fe = root_fixture()->app.controller->get_topics_frontend();

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -45,6 +45,8 @@ std::string_view to_string_view(feature f) {
         return "rpc_v2_by_default";
     case feature::cloud_retention:
         return "cloud_retention";
+    case feature::node_id_assignment:
+        return "node_id_assignment";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -43,6 +43,7 @@ enum class feature : std::uint64_t {
     raftless_node_status = 0x200,
     rpc_v2_by_default = 0x400,
     cloud_retention = 0x800,
+    node_id_assignment = 0x1000,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -165,6 +166,12 @@ constexpr static std::array feature_schema{
     cluster_version{7},
     "cloud_retention",
     feature::cloud_retention,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{7},
+    "node_id_assignment",
+    feature::node_id_assignment,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -294,12 +294,12 @@ static void report_broker_config(
           result.resource_name.data() + result.resource_name.size(), // NOLINT
           broker_id);
         if (res.ec == std::errc()) {
-            if (broker_id != config::node().node_id()) {
+            if (broker_id != *config::node().node_id()) {
                 result.error_code = error_code::invalid_request;
                 result.error_message = ssx::sformat(
                   "Unexpected broker id {} expected {}",
                   broker_id,
-                  config::node().node_id());
+                  *config::node().node_id());
                 return;
             }
         } else {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -83,7 +83,7 @@ std::optional<cluster::leader_term> get_leader_term(
         const auto previous = md_cache.get_previous_leader_id(tp_ns, p_id);
         leader_term->leader = previous;
 
-        if (previous == config::node().node_id()) {
+        if (previous == *config::node().node_id()) {
             auto idx = fast_prng_source() % replicas.size();
             leader_term->leader = replicas[idx];
         }
@@ -333,7 +333,7 @@ guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
             // is not yet consistent with what's in members_table,
             // because a node configuration update didn't propagate
             // via raft0 yet
-            if (broker->id() == config::node().node_id()) {
+            if (broker->id() == *config::node().node_id()) {
                 return l;
             }
         }

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "model/metadata.h"
 #include "net/unresolved_address.h"
 #include "rpc/logger.h"
 #include "rpc/types.h"
@@ -70,6 +71,7 @@ public:
     void setup_metrics(
       ss::metrics::metric_groups& mgs,
       const std::optional<rpc::connection_cache_label>& label,
+      const std::optional<model::node_id>& node_id,
       const net::unresolved_address& target_addr);
 
 private:

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -148,6 +148,7 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
 void client_probe::setup_metrics(
   ss::metrics::metric_groups& mgs,
   const std::optional<rpc::connection_cache_label>& label,
+  const std::optional<model::node_id>& node_id,
   const net::unresolved_address& target_addr) {
     namespace sm = ss::metrics;
     auto target = sm::label("target");
@@ -156,6 +157,16 @@ void client_probe::setup_metrics(
     if (label) {
         labels.push_back(sm::label("connection_cache_label")((*label)()));
     }
+    std::vector<sm::label> aggregate_labels;
+    // Label the metrics for a given server with the node ID so Seastar can
+    // differentiate between them, in case multiple node IDs start at the same
+    // address (e.g. in an ungraceful decommission). Aggregate on node ID so
+    // the user is presented metrics for each server regardless of node ID.
+    if (node_id) {
+        auto node_id_label = sm::label("node_id");
+        labels.push_back(node_id_label(*node_id));
+        aggregate_labels.push_back(node_id_label);
+    }
     mgs.add_group(
       prometheus_sanitize::metrics_name("rpc_client"),
       {
@@ -163,73 +174,87 @@ void client_probe::setup_metrics(
           "active_connections",
           [this] { return _connections; },
           sm::description("Currently active connections"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "connects",
           [this] { return _connects; },
           sm::description("Connection attempts"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "requests",
           [this] { return _requests; },
           sm::description("Number of requests"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_gauge(
           "requests_pending",
           [this] { return _requests_pending; },
           sm::description("Number of requests pending"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "request_errors",
           [this] { return _request_errors; },
           sm::description("Number or requests errors"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "request_timeouts",
           [this] { return _request_timeouts; },
           sm::description("Number or requests timeouts"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_total_bytes(
           "in_bytes",
           [this] { return _out_bytes; },
           sm::description("Total number of bytes sent (including headers)"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_total_bytes(
           "out_bytes",
           [this] { return _in_bytes; },
           sm::description("Total number of bytes received"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "connection_errors",
           [this] { return _connection_errors; },
           sm::description("Number of connection errors"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "read_dispatch_errors",
           [this] { return _read_dispatch_errors; },
           sm::description("Number of errors while dispatching responses"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "corrupted_headers",
           [this] { return _corrupted_headers; },
           sm::description("Number of responses with corrupted headers"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "server_correlation_errors",
           [this] { return _server_correlation_errors; },
           sm::description("Number of responses with wrong correlation id"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "client_correlation_errors",
           [this] { return _client_correlation_errors; },
           sm::description("Number of errors in client correlation id"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
         sm::make_counter(
           "requests_blocked_memory",
           [this] { return _requests_blocked_memory; },
           sm::description("Number of requests that are blocked because"
                           " of insufficient memory"),
-          labels),
+          labels)
+          .aggregate(aggregate_labels),
       });
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -438,7 +438,7 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
           ss::httpd::reply::status_type::service_unavailable);
     }
 
-    if (leader_id_opt.value() == config::node().node_id()) {
+    if (leader_id_opt.value() == *config::node().node_id()) {
         vlog(
           logger.info,
           "Can't redirect to leader from leader node ({})",
@@ -559,7 +559,7 @@ bool need_redirect_to_leader(
           ss::httpd::reply::status_type::service_unavailable);
     }
 
-    return leader_id_opt.value() != config::node().node_id();
+    return leader_id_opt.value() != *config::node().node_id();
 }
 
 model::node_id parse_broker_id(const ss::httpd::request& req) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1390,7 +1390,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     // ID. A valid node ID is required before we can initialize the rest of our
     // subsystems.
     const auto& node_uuid = storage.local().node_uuid();
-    cluster::cluster_discovery cd(node_uuid, app_signal.abort_source());
+    cluster::cluster_discovery cd(
+      node_uuid, storage.local().kvs(), app_signal.abort_source());
     auto node_id = cd.determine_node_id().get();
     if (config::node().node_id() == std::nullopt) {
         // If we previously didn't have a node ID, set it in the config. We

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1389,7 +1389,7 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     // ID. A valid node ID is required before we can initialize the rest of our
     // subsystems.
     const auto& node_uuid = storage.local().node_uuid();
-    cluster::cluster_discovery cd(node_uuid);
+    cluster::cluster_discovery cd(node_uuid, app_signal.abort_source());
     auto node_id = cd.determine_node_id().get();
 
     vlog(_log.info, "Starting Redpanda with node_id {}", node_id);

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -36,7 +36,7 @@ ss::future<> connection_cache::emplace(
         _cache.emplace(
           n,
           ss::make_lw_shared<rpc::reconnect_transport>(
-            std::move(c), std::move(backoff_policy), _label));
+            std::move(c), std::move(backoff_policy), _label, n));
     });
 }
 ss::future<> connection_cache::remove(model::node_id n) {

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "outcome.h"
 #include "rpc/backoff_policy.h"
 #include "rpc/transport.h"
@@ -31,11 +32,15 @@ namespace rpc {
  */
 class reconnect_transport {
 public:
+    // Instantiates an underlying rpc::transport, using the given node ID (if
+    // provided) to distinguish client metrics that target the same server and
+    // to indicate that the client metrics should be aggregated by node ID.
     explicit reconnect_transport(
       rpc::transport_configuration c,
       backoff_policy backoff_policy,
-      std::optional<connection_cache_label> label = std::nullopt)
-      : _transport(std::move(c), std::move(label))
+      const std::optional<connection_cache_label>& label = std::nullopt,
+      const std::optional<model::node_id>& node_id = std::nullopt)
+      : _transport(std::move(c), std::move(label), std::move(node_id))
       , _backoff_policy(std::move(backoff_policy)) {}
 
     bool is_valid() const { return _transport.is_valid(); }

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -52,7 +52,9 @@ struct client_context_impl final : streaming_context {
 };
 
 transport::transport(
-  transport_configuration c, std::optional<connection_cache_label> label)
+  transport_configuration c,
+  std::optional<connection_cache_label> label,
+  std::optional<model::node_id> node_id)
   : base_transport(base_transport::configuration{
     .server_addr = std::move(c.server_addr),
     .credentials = std::move(c.credentials),
@@ -61,7 +63,7 @@ transport::transport(
   , _version(c.version)
   , _default_version(c.version) {
     if (!c.disable_metrics) {
-        setup_metrics(label);
+        setup_metrics(label, node_id);
     }
 }
 
@@ -289,8 +291,9 @@ ss::future<> transport::dispatch(header h) {
 }
 
 void transport::setup_metrics(
-  const std::optional<connection_cache_label>& label) {
-    _probe.setup_metrics(_metrics, label, server_address());
+  const std::optional<connection_cache_label>& label,
+  const std::optional<model::node_id>& node_id) {
+    _probe.setup_metrics(_metrics, label, node_id, server_address());
 }
 
 transport::~transport() {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "net/transport.h"
 #include "outcome.h"
 #include "reflection/async_adl.h"
@@ -56,7 +57,8 @@ class transport final : public net::base_transport {
 public:
     explicit transport(
       transport_configuration c,
-      std::optional<connection_cache_label> label = std::nullopt);
+      std::optional<connection_cache_label> label = std::nullopt,
+      std::optional<model::node_id> node_id = std::nullopt);
     ~transport() override;
     transport(transport&&) noexcept = default;
     // semaphore is not move assignable
@@ -93,7 +95,9 @@ private:
     ss::future<> do_reads();
     ss::future<> dispatch(header);
     void fail_outstanding_futures() noexcept final;
-    void setup_metrics(const std::optional<connection_cache_label>&);
+    void setup_metrics(
+      const std::optional<connection_cache_label>&,
+      const std::optional<model::node_id>&);
 
     ss::future<result<std::unique_ptr<streaming_context>>>
       do_send(sequence_t, netbuf, rpc::client_opts);
@@ -311,9 +315,11 @@ concept RpcClientProtocol = std::constructible_from<Protocol, rpc::transport&>;
 template<typename... Protocol>
 requires(RpcClientProtocol<Protocol>&&...) class client : public Protocol... {
 public:
-    explicit client(transport_configuration cfg)
+    explicit client(
+      transport_configuration cfg,
+      const std::optional<model::node_id>& node_id = std::nullopt)
       : Protocol(_transport)...
-      , _transport(std::move(cfg)) {}
+      , _transport(std::move(cfg), std::nullopt, node_id) {}
 
     ss::future<> connect(rpc::clock_type::time_point connection_timeout) {
         return _transport.connect(connection_timeout);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -383,8 +383,8 @@ class Admin:
     def get_cluster_config_status(self, node: ClusterNode = None):
         return self._request("GET", "cluster_config/status", node=node).json()
 
-    def get_node_config(self):
-        return self._request("GET", "node_config").json()
+    def get_node_config(self, node=None):
+        return self._request("GET", "node_config", node).json()
 
     def get_features(self, node=None):
         return self._request("GET", "features", node=node).json()

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -12,7 +12,9 @@ organization: "vectorized"
 redpanda:
   developer_mode: true
   data_directory: "{{data_dir}}"
+{% if node_id is not none %}
   node_id: {{node_id}}
+{% endif %}
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145
@@ -39,12 +41,11 @@ redpanda:
       port: {{admin_alternate_port}}
 
 
-{% if node_id > 1 %}
+{% if include_seed_servers %}
   seed_servers:
     - host:
         address: {{nodes[1].account.hostname}}
         port: 33145
-      node_id: 1
 {% endif %}
 
 {% if enable_pp %}

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -1,0 +1,112 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.utils.util import wait_until
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda_installer import RedpandaInstaller
+
+
+def wipe_and_restart(redpanda, node):
+    """
+    Stops, clears, and restarts a node, priming it to be assigned a node ID.
+    """
+    redpanda.stop_node(node)
+    redpanda.clean_node(node,
+                        preserve_logs=True,
+                        preserve_current_install=True)
+    redpanda.start_node(node, auto_assign_node_id=True)
+
+
+class NodeIdAssignment(RedpandaTest):
+    """
+    Test that exercises cluster formation when node IDs are automatically
+    assigned by Redpanda.
+    """
+    def __init__(self, test_context):
+        super(NodeIdAssignment, self).__init__(test_context=test_context,
+                                               num_brokers=3)
+        self.admin = self.redpanda._admin
+
+    def setUp(self):
+        self.redpanda.start(auto_assign_node_id=True)
+        self._create_initial_topics()
+
+    def check_node_ids_persist(self):
+        """
+        Checks that all node IDs remain the same after restarting.
+        """
+        original_node_id_by_idx = {}
+        for node in self.redpanda.nodes:
+            original_node_id = self.redpanda.node_id(node)
+            original_node_id_by_idx[self.redpanda.idx(node)] = original_node_id
+
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True)
+        for node in self.redpanda.nodes:
+            original_node_id = original_node_id_by_idx[self.redpanda.idx(node)]
+            new_node_id = self.redpanda.node_id(node)
+            assert new_node_id == original_node_id, f"{new_node_id} vs {original_node_id}"
+
+    @cluster(num_nodes=3)
+    def test_basic_assignment(self):
+        brokers = self.admin.get_brokers()
+        assert 3 == len(brokers), f"Got {len(brokers)} brokers"
+        self.check_node_ids_persist()
+
+    @cluster(num_nodes=3)
+    def test_assign_after_clear(self):
+        brokers = self.admin.get_brokers()
+        assert 3 == len(brokers), f"Got {len(brokers)} brokers"
+
+        clean_node = self.redpanda.nodes[-1]
+        original_node_id = self.redpanda.node_id(clean_node)
+        wipe_and_restart(self.redpanda, clean_node)
+
+        brokers = self.admin.get_brokers()
+        assert 4 == len(brokers), f"Got {len(brokers)} brokers"
+        new_node_id = self.redpanda.node_id(clean_node)
+        assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
+        self.check_node_ids_persist()
+
+
+class NodeIdAssignmentUpgrade(RedpandaTest):
+    """
+    Test that exercises cluster formation when node IDs are automatically
+    assigned by Redpanda after an upgrade.
+    """
+    def __init__(self, test_context):
+        super(NodeIdAssignmentUpgrade,
+              self).__init__(test_context=test_context, num_brokers=3)
+        self.installer = self.redpanda._installer
+        self.admin = self.redpanda._admin
+
+    def setUp(self):
+        self.installer.install(self.redpanda.nodes, (22, 2, 1))
+        super(NodeIdAssignmentUpgrade, self).setUp()
+
+    @cluster(num_nodes=3)
+    def test_assign_after_upgrade(self):
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True)
+        wait_until(
+            lambda: self.admin.supports_feature("node_id_assignment"),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for cluster to support 'license' feature")
+
+        clean_node = self.redpanda.nodes[-1]
+        original_node_id = self.redpanda.node_id(clean_node)
+        wipe_and_restart(self.redpanda, clean_node)
+
+        brokers = self.admin.get_brokers()
+        assert 4 == len(brokers), f"Got {len(brokers)} brokers"
+        new_node_id = self.redpanda.node_id(clean_node)
+        assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"


### PR DESCRIPTION
## Cover letter

This PR contains functionality for automatically assigning a node ID. For details of the startup changes, see the comments in `cluster_discovery.h` and `members_manager.h`.

This PR adds the ability to start a node without explicitly assigning its node ID. When a node starts up, before it can initialize most of its subsystems, it must be made aware of its node ID. It can either get this from its config, the kv-store, or be assigned one by the controller leader. In all cases, the node ID and node UUID must be registered with the controller, after which the node can proceed join the cluster.

The high level steps are as follows:

When the node ID is unknown:
1. Generate or load node UUID
2. Get assigned a node ID by sending a request to the controller leader
3. Start subsystems with our known node ID
4. Join the cluster and get added to the controller Raft group by sending a request to the controller leader
5. Once added to the cluster, open endpoints for user traffic

When the node ID is known:
1. Generate or load node UUID
2. Load node ID from config or kv-store
3. Start subsystems with our known node ID
4. Register our UUID with our node ID and join the cluster by sending a request to the controller leader
5. Once added to the cluster, open endpoints for user traffic

The registration of the UUID is handled by the existing join_node RPC, which has a currently unused field for node UUID. Based on whether the registration has already occurred, the `members_manager` will either register the UUID (potentially assigning a node ID in doing so), persisting it to the controller log, or simply proceed to add the node to the cluster. Node DI assignments are made deterministic by having node ID assignment and registration be done in the apply phase of a new controller command.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Users are no longer required to supply a node ID in each node's node configuration file.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* Users are no longer required to supply a node ID in each node's node configuration file. With such a configuration, Redpanda assigns a node ID to each empty node as it joins the cluster.

### Features

* Users are no longer required to supply a node ID in each node's node configuration file. All nodes must be upgraded before using this feature. Node IDs on existing nodes will be preserved when using this.
