### PR TITLE
bk/pre-exit: invoke ducktape tests cleanup

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,4 +1,7 @@
 #!/bin/bash
-if [[ $ENABLE_STEP_CDT == '1' && -x bin/task ]]; then
-  bin/task ci:cdt-cleanup
+if [[ -x bin/task ]]; then
+  if [[ $ENABLE_STEP_CDT == '1' ]]; then
+    bin/task ci:cdt-cleanup
+  fi
+  bin/task rp:stop-compose-cluster
 fi


### PR DESCRIPTION
Invoke ducktape cluster cleanup from pre-exit hook. When the compose cluster isn't running, this is effectively a no-op

## Release notes

  * none