### PR TITLE
kafka/tests: fix a broken assertion in `list_offsets`

### DIFF
--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -286,7 +286,7 @@ public:
 
 // This is rougly equivalent to
 //   https://github.com/apache/kafka/blob/8e16158/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala#L27
-FIXTURE_TEST_EXPECTED_FAILURES(create_topics, create_topic_fixture, 2) {
+FIXTURE_TEST(create_topics, create_topic_fixture) {
     wait_for_controller_leadership().get();
 
     test_create_topic(make_req({make_topic("topic1")}));


### PR DESCRIPTION
## Cover letter

   The test data generation creates a situation where
    we may not reason robustly about the timestamp
    results at all, because the query time and the
    record batch time are both taken independently
    from the wallclock, and the record batch times
    are rewound to earlier than the wallclock when
    generated.
    
    There will be a followup to fix the test data
    generation.


## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
