### PR TITLE
(PoC) cluster: upgrade compatibility enforcement

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -127,6 +127,7 @@ private:
     friend controller_probe;
 
     ss::future<> cluster_creation_hook();
+    void assert_compatible_version();
     config_manager::preload_result _config_preload;
 
     ss::sharded<ss::abort_source> _as;                     // instance per core

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -109,6 +109,13 @@ node_config::node_config() noexcept
       {.visibility = visibility::user},
       std::nullopt)
   , enable_central_config(*this, "enable_central_config")
+  , upgrade_override_checks(
+      *this,
+      "upgrade_override_checks",
+      "Whether to violate safety checks when starting a redpanda version newer "
+      "than the cluster's consensus version",
+      {.visibility = visibility::tunable},
+      false)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -59,6 +59,10 @@ public:
 
     deprecated_property enable_central_config;
 
+    // If true, permit any version of redpanda to start, even
+    // if potentially incompatible with existing system state.
+    property<bool> upgrade_override_checks;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -73,9 +73,22 @@ std::string_view to_string_view(feature_state::state s) {
     __builtin_unreachable();
 };
 
+// For your convenience, a rough guide to the history of how logical
+// versions mapped to redpanda release versions:
+//  22.1.1 -> 3  (22.1.5 was version 4
+//  22.2.1 -> 5  (22.2.6 later proceeds to version 6)
+//  22.3.1 -> 7
+
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
+// ***Don't forget to update upgradable_version***
 static constexpr cluster_version latest_version = cluster_version{7};
+
+// The "upgradable" version is the cluster logical version from when
+// the last feature release series started.  For example, on redpanda
+// 22.3.1, cluster_version is 7, and previous_version is 5, which was
+// the logical version when 22.2.1 was released
+static constexpr cluster_version upgradable_version = cluster_version{5};
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use
@@ -130,6 +143,10 @@ cluster_version feature_table::get_latest_logical_version() {
     }
 
     return latest_version_cache;
+}
+
+cluster_version feature_table::get_upgradable_logical_version() {
+    return upgradable_version;
 }
 
 void feature_state::transition_active() { _state = state::active; }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -353,6 +353,7 @@ public:
     ss::future<> stop();
 
     static cluster_version get_latest_logical_version();
+    static cluster_version get_upgradable_logical_version();
 
     feature_table();
 

--- a/tests/rptest/trim_results.py
+++ b/tests/rptest/trim_results.py
@@ -70,61 +70,11 @@ class Trimmer:
 
         return log_paths
 
-    def get_saved_executables(self, results: list):
-        EXE_FILENAME = "redpanda.gz"
-
-        exe_paths = []
-        for r in results:
-            results_dir = os.path.join(self.result_path,
-                                       r['relative_results_dir'])
-
-            for service in r['services']:
-                if service['cls_name'] != "RedpandaService":
-                    continue
-
-                service_dir = os.path.join(results_dir, service['service_id'])
-                for node in service['nodes']:
-                    hostname = node.split("@")[-1]
-                    exe_path = os.path.join(service_dir,
-                                            f"{hostname}/{EXE_FILENAME}")
-                    if os.path.exists(exe_path):
-                        exe_paths.append(exe_path)
-
-        return exe_paths
-
-    def deduplicate_executables(self, saved_exes):
-        if len(saved_exes) < 2:
-            return
-
-        by_checksum = defaultdict(list)
-        for e in saved_exes:
-            h = hashlib.sha1()
-            with open(e, 'rb') as f:
-                for chunk in iter(lambda: f.read(16384), b""):
-                    h.update(chunk)
-            hash = h.hexdigest()
-            by_checksum[hash].append(e)
-
-        for hash, filenames in by_checksum.items():
-            keep_file = filenames[0]
-            for f in filenames[1:]:
-                log.info(f"Deleting duplicate executable: {f}")
-                os.unlink(f)
-
-                # Leave a note behind about where to find a copy of the executable
-                note_path = os.path.join(os.path.dirname(f),
-                                         "redpanda.gz.moved")
-                note_message = f"De-duplicated executables in test results: an identical executable is at {keep_file}"
-                open(note_path, "w").write(note_message)
-
     def trim(self):
         results = json.load(open(os.path.join(self.result_path,
                                               "report.json")))['results']
 
         log_paths = self.get_passed_test_logs(results)
-        saved_exes = self.get_saved_executables(results)
-
-        self.deduplicate_executables(saved_exes)
 
         executor = concurrent.futures.ThreadPoolExecutor()
 


### PR DESCRIPTION
## Cover letter

This should cause upgrade tests to fail where they are currently trying to jump straight from 22.1.x to 22.3.x(dev)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
