### PR TITLE
archival: Fix assertion in archival_policy

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -461,7 +461,7 @@ static ss::future<> get_file_range(
       upl);
     upl.content_length = upl.final_file_offset - upl.file_offset;
     vassert(
-      upl.content_length <= fsize,
+      upl.content_length <= segment->reader().file_size(),
       "Incorrect content length in {}, file size {}",
       upl,
       fsize);


### PR DESCRIPTION


## Cover letter

The 'get_file_range' method can scan segments to find the last record batch that should be included into S3 upload. This is done using a file stream that reads directly from disk. The file size is checked in the begining and can change while the scan is perfomed. In this case the file size will be outdated and this will trigger an assertion.

This is fixed by using latest file size value instead of the cached one.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes


* none


### Features

* none

### Improvements

* none

