### PR TITLE
Fix latency on first election

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -455,7 +455,7 @@ private:
 
     void arm_vote_timeout();
     void update_node_append_timestamp(vnode);
-    void update_node_hbeat_timestamp(vnode);
+    void update_node_reply_timestamp(vnode);
 
     void update_follower_stats(const group_configuration&);
     void trigger_leadership_notification();

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -78,6 +78,7 @@ prevote_stm::process_reply(vnode n, ss::future<result<vote_reply>> f) {
                 auto r = f.get0();
                 if (r.has_value()) {
                     auto v = r.value();
+                    _ptr->update_node_reply_timestamp(n);
                     if (v.log_ok) {
                         vlog(
                           _ctxlog.trace,

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -230,7 +230,7 @@ inline bool replicate_entries_stm::should_skip_follower_request(vnode id) {
     if (auto it = _ptr->_fstats.find(id); it != _ptr->_fstats.end()) {
         const auto timeout = clock_type::now()
                              - _ptr->_replicate_append_timeout;
-        if (it->second.last_received_append_entries_reply_timestamp < timeout) {
+        if (it->second.last_received_reply_timestamp < timeout) {
             vlog(
               _ctxlog.trace,
               "Skipping sending append request to {} - didn't receive "

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -99,7 +99,7 @@ struct follower_index_metadata {
     model::offset last_sent_offset;
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_sent_append_entries_req_timestamp;
-    clock_type::time_point last_received_append_entries_reply_timestamp;
+    clock_type::time_point last_received_reply_timestamp;
     uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and
     // received by the follower. Every time append entries request is created

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -75,6 +75,7 @@ ss::future<> vote_stm::dispatch_one(vnode n) {
               try {
                   auto r = f.get0();
                   vlog(_ctxlog.info, "vote reply from {} - {}", n, r.value());
+                  _ptr->update_node_reply_timestamp(n);
                   voter_reply->second.set_value(r);
               } catch (...) {
                   voter_reply->second.set_value(errc::vote_dispatch_error);


### PR DESCRIPTION
## Cover letter

When a raft group member is responsive i.e. it replied to the vote
request we should not skip sending it an append entries request.
Previously we did not updated the last received reply timestamp on vote
replies and thus it may happened that the newly elected leader would
have to skip sending append entries requests to the followers when
replicating configuration. This increased leader election latency as it
required sending the configuration batch to followers via
`recovery_stm`.

Fixes: #6675

Signed-off-by: Michal Maslanka <michal@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
