### PR TITLE
cloud_storage: delete objects from S3 on deletion of tiered storage topics

### DIFF
--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -229,15 +229,15 @@ public:
       const remote_segment_path& path,
       retry_chain_node& parent);
 
-    /// \brief Delete segment from S3
+    /// \brief Delete object from S3
     ///
-    /// The method deletes the segment. It can retry after some errors.
+    /// The method deletes the object. It can retry after some errors.
     ///
-    /// \param segment_path is a segment's name in S3
+    /// \param path is a full S3 object path
     /// \param bucket is a name of the S3 bucket
-    ss::future<upload_result> delete_segment(
+    ss::future<upload_result> delete_object(
       const s3::bucket_name& bucket,
-      const remote_segment_path& segment_path,
+      const s3::object_key& path,
       retry_chain_node& parent);
 
     ss::future<download_result> do_download_manifest(

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -202,6 +202,15 @@ public:
     ss::future<std::vector<model::tx_range>>
     aborted_transactions(offset_range offsets);
 
+    /// Helper for erase()
+    ss::future<bool> tolerant_delete_object(
+      const s3::bucket_name& bucket,
+      const s3::object_key& path,
+      retry_chain_node& parent);
+
+    /// Remove objects from S3
+    ss::future<> erase();
+
 private:
     /// Create new remote_segment instances for all new
     /// items in the manifest.

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -341,7 +341,8 @@ FIXTURE_TEST(test_segment_delete, s3_imposter_fixture) { // NOLINT
     // NOTE: we have to upload something as segment in order for the
     // mock to work correctly.
 
-    auto expected_success = remote.delete_segment(bucket, path, fib).get();
+    auto expected_success
+      = remote.delete_object(bucket, s3::object_key(path), fib).get();
     BOOST_REQUIRE(expected_success == upload_result::success);
 
     auto expected_notfound = remote.segment_exists(bucket, path, fib).get();

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -294,7 +294,8 @@ private:
       model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<>
       remove_from_shard_table(model::ntp, raft::group_id, model::revision_id);
-    ss::future<> delete_partition(model::ntp, model::revision_id);
+    ss::future<> delete_partition(
+      model::ntp, model::revision_id, partition_removal_mode mode);
     template<typename Func>
     ss::future<std::error_code> apply_configuration_change_on_leader(
       const model::ntp&,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -375,8 +375,6 @@ partition::timequery(storage::timequery_config cfg) {
 }
 
 ss::future<> partition::update_configuration(topic_properties properties) {
-    _remote_delete_enabled = properties.remote_delete;
-
     co_await _raft->log().update_configuration(
       properties.get_ntp_cfg_overrides());
 }
@@ -427,7 +425,9 @@ ss::future<> partition::remove_remote_persistent_state() {
         || (config::shard_local_cfg().cloud_storage_enable_remote_write() &&
             config::shard_local_cfg().cloud_storage_enable_remote_read());
 
-    if (_cloud_storage_partition && tiered_storage && _remote_delete_enabled) {
+    if (
+      _cloud_storage_partition && tiered_storage
+      && get_ntp_config().remote_delete()) {
         vlog(
           clusterlog.debug,
           "Erasing S3 objects for partition {} ({} {} {})",

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -400,6 +400,22 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
     // epoch
     return model::next_offset(kafka::offset_cast(*o));
 }
+
+ss::future<> partition::remove_persistent_state() {
+    if (_rm_stm) {
+        co_await _rm_stm->remove_persistent_state();
+    }
+    if (_tm_stm) {
+        co_await _tm_stm->remove_persistent_state();
+    }
+    if (_archival_meta_stm) {
+        co_await _archival_meta_stm->remove_persistent_state();
+    }
+    if (_id_allocator_stm) {
+        co_await _id_allocator_stm->remove_persistent_state();
+    }
+}
+
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -245,6 +245,7 @@ public:
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
     ss::future<> remove_persistent_state();
+    ss::future<> remove_remote_persistent_state();
 
     std::optional<model::offset> get_term_last_offset(model::term_id) const;
 
@@ -283,6 +284,7 @@ private:
     ss::shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     std::optional<s3::bucket_name> _read_replica_bucket{std::nullopt};
+    bool _remote_delete_enabled{topic_properties::default_remote_delete};
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -284,7 +284,7 @@ private:
     ss::shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     std::optional<s3::bucket_name> _read_replica_bucket{std::nullopt};
-    bool _remote_delete_enabled{topic_properties::default_remote_delete};
+    bool _remote_delete_enabled{storage::ntp_config::default_remote_delete};
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -244,20 +244,7 @@ public:
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
-    ss::future<> remove_persistent_state() {
-        if (_rm_stm) {
-            co_await _rm_stm->remove_persistent_state();
-        }
-        if (_tm_stm) {
-            co_await _tm_stm->remove_persistent_state();
-        }
-        if (_archival_meta_stm) {
-            co_await _archival_meta_stm->remove_persistent_state();
-        }
-        if (_id_allocator_stm) {
-            co_await _id_allocator_stm->remove_persistent_state();
-        }
-    }
+    ss::future<> remove_persistent_state();
 
     std::optional<model::offset> get_term_last_offset(model::term_id) const;
 

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -86,7 +86,8 @@ public:
       std::optional<s3::bucket_name> = std::nullopt);
 
     ss::future<> shutdown(const model::ntp& ntp);
-    ss::future<> remove(const model::ntp& ntp);
+
+    ss::future<> remove(const model::ntp& ntp, partition_removal_mode mode);
 
     std::optional<storage::log> log(const model::ntp& ntp) {
         return _storage.log_mgr().get(ntp);

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -592,6 +592,10 @@ cluster::topic_properties old_random_topic_properties() {
       [] { return tests::random_bool(); });
     properties.shadow_indexing = tests::random_optional(
       [] { return model::random_shadow_indexing_mode(); });
+
+    // Always test with remote_delete=false so that we survive
+    // an ADL roundtrip
+    properties.remote_delete = false;
     return properties;
 }
 
@@ -606,6 +610,9 @@ cluster::topic_properties random_topic_properties() {
     });
     properties.remote_topic_properties = tests::random_optional(
       [] { return random_remote_topic_properties(); });
+
+    // Always set remote_delete=false to survive an ADL roundtrip
+    properties.remote_delete = false;
 
     return properties;
 }
@@ -940,7 +947,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             tests::random_tristate([] { return tests::random_duration_ms(); })),
           .shadow_indexing = random_property_update(tests::random_optional(
             [] { return model::random_shadow_indexing_mode(); })),
-        };
+          .remote_delete = random_property_update(tests::random_bool())};
         roundtrip_test(updates);
     }
     { roundtrip_test(old_random_topic_configuration()); }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -509,6 +509,24 @@ void incremental_update(
     }
 }
 
+template<typename T>
+void incremental_update(
+  T& property, property_update<T> override, const T& default_value) {
+    switch (override.op) {
+    case incremental_update_operation::remove:
+        // remove override, fallback to default
+        property = default_value;
+        return;
+    case incremental_update_operation::set:
+        // set new value
+        property = override.value;
+        return;
+    case incremental_update_operation::none:
+        // do nothing
+        return;
+    }
+}
+
 ss::future<std::error_code>
 topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     auto tp = _topics.find(cmd.key);
@@ -540,6 +558,10 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(
       properties.retention_local_target_ms,
       overrides.retention_local_target_ms);
+    incremental_update(
+      properties.remote_delete,
+      overrides.remote_delete,
+      topic_properties::default_remote_delete);
 
     // generate deltas for controller backend
     std::vector<topic_table_delta> deltas;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -17,6 +17,7 @@
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "storage/ntp_config.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -561,7 +562,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(
       properties.remote_delete,
       overrides.remote_delete,
-      topic_properties::default_remote_delete);
+      storage::ntp_config::default_remote_delete);
 
     // generate deltas for controller backend
     std::vector<topic_table_delta> deltas;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -60,7 +60,7 @@ bool topic_properties::has_overrides() const {
            || read_replica.has_value() || batch_max_bytes.has_value()
            || retention_local_target_bytes.has_value()
            || retention_local_target_ms.has_value()
-           || remote_delete != default_remote_delete;
+           || remote_delete != storage::ntp_config::default_remote_delete;
 }
 
 storage::ntp_config::default_overrides
@@ -75,6 +75,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.read_replica = read_replica;
     ret.retention_local_target_bytes = retention_local_target_bytes;
     ret.retention_local_target_ms = retention_local_target_ms;
+    ret.remote_delete = remote_delete;
     return ret;
 }
 
@@ -103,7 +104,8 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .read_replica = properties.read_replica,
             .retention_local_target_bytes
             = properties.retention_local_target_bytes,
-            .retention_local_target_ms = properties.retention_local_target_ms});
+            .retention_local_target_ms = properties.retention_local_target_ms,
+            .remote_delete = properties.remote_delete});
     }
     return {
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),
@@ -974,7 +976,7 @@ adl<cluster::topic_configuration>::from(iobuf_parser& in) {
       cfg.properties.retention_local_target_ms);
 
     // Legacy topics from pre-22.3 get remote delete disabled.
-    cfg.properties.remote_delete = false;
+    cfg.properties.remote_delete = storage::ntp_config::legacy_remote_delete;
 
     return cfg;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1083,9 +1083,7 @@ struct topic_properties
     // is handled during adl/serde decode).
     // This is intentionally not an optional: all topics have a concrete value
     // one way or another.  There is no "use the cluster default".
-    static constexpr bool default_remote_delete{true};
-    static constexpr bool legacy_remote_delete{false};
-    bool remote_delete{default_remote_delete};
+    bool remote_delete{storage::ntp_config::default_remote_delete};
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1378,7 +1376,8 @@ struct topic_configuration
 
             // Legacy tiered storage topics do not delete data on
             // topic deletion.
-            properties.remote_delete = topic_properties::legacy_remote_delete;
+            properties.remote_delete
+              = storage::ntp_config::legacy_remote_delete;
         }
     }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -194,6 +194,20 @@ struct kafka_stages {
     ss::future<result<kafka_result>> replicate_finished;
 };
 
+/**
+ * When we remove a partition in the controller backend, we need to know
+ * whether the action is just for this node, or whether the partition
+ * is being deleted overall.
+ */
+enum class partition_removal_mode : uint8_t {
+    // We are removing a partition from this node only: delete
+    // local data but leave remote data alone.
+    local_only = 0,
+    // The partition is being permanently deleted from all nodes:
+    // remove remote data as well as local data.
+    global = 1
+};
+
 struct try_abort_request
   : serde::envelope<try_abort_request, serde::version<0>> {
     model::partition_id tm;

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -329,6 +329,7 @@ struct compat_check<cluster::topic_properties> {
         json_write(batch_max_bytes);
         json_write(retention_local_target_bytes);
         json_write(retention_local_target_ms);
+        json_write(remote_delete);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -348,6 +349,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(batch_max_bytes);
         json_read(retention_local_target_bytes);
         json_read(retention_local_target_ms);
+        json_read(remote_delete);
         return obj;
     }
 
@@ -431,6 +433,10 @@ struct compat_check<cluster::topic_configuration> {
           std::nullopt};
         obj.properties.retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
+
+        // ADL will always squash remote_delete to false
+        obj.properties.remote_delete = false;
+
         if (cfg != obj) {
             throw compat_error(fmt::format(
               "Verify of {{cluster::topic_property}} decoding "
@@ -590,6 +596,7 @@ GEN_COMPAT_CHECK(
       json_write(retention_bytes);
       json_write(retention_duration);
       json_write(shadow_indexing);
+      json_write(remote_delete);
   },
   {
       json_read(compression);
@@ -600,6 +607,7 @@ GEN_COMPAT_CHECK(
       json_read(retention_bytes);
       json_read(retention_duration);
       json_read(shadow_indexing);
+      json_read(remote_delete);
   })
 
 GEN_COMPAT_CHECK(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -688,7 +688,9 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_tristate(
             [] { return random_generators::get_int<size_t>(); }),
           tests::random_tristate([] { return tests::random_duration_ms(); }),
-        };
+          // Remote delete always false to enable ADL roundtrip (ADL
+          // always decodes to false for legacy topics)
+          false};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }
@@ -830,6 +832,11 @@ struct instance_generator<cluster::incremental_topic_updates> {
                   return instance_generator<
                     model::shadow_indexing_mode>::random();
               });
+          }),
+          .remote_delete = random_property_update([] {
+              // Enable ADL roundtrip, which always decodes as false
+              // for legacy topics
+              return false;
           })};
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -28,9 +28,13 @@ template<typename T>
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const cluster::property_update<T>& pu) {
     w.StartObject();
-    if constexpr (
-      is_exceptional_enum<T> || is_exceptional_enum_wrapped_opt<T>) {
-        write_exceptional_member_type(w, "value", pu.value);
+    if constexpr (std::is_class<T>::value) {
+        if constexpr (
+          is_exceptional_enum<T> || is_exceptional_enum_wrapped_opt<T>) {
+            write_exceptional_member_type(w, "value", pu.value);
+        } else {
+            write_member(w, "value", pu.value);
+        }
     } else {
         write_member(w, "value", pu.value);
     }
@@ -581,6 +585,7 @@ inline void rjson_serialize(
     write_member(
       w, "retention_local_target_bytes", tps.retention_local_target_bytes);
     write_member(w, "retention_local_target_ms", tps.retention_local_target_ms);
+    write_member(w, "remote_delete", tps.remote_delete);
     w.EndObject();
 }
 
@@ -601,6 +606,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(
       rd, "retention_local_target_bytes", obj.retention_local_target_bytes);
     read_member(rd, "retention_local_target_ms", obj.retention_local_target_ms);
+    read_member(rd, "remote_delete", obj.remote_delete);
 }
 
 inline void rjson_serialize(
@@ -660,6 +666,7 @@ inline void rjson_serialize(
     write_member(w, "retention_bytes", itu.retention_bytes);
     write_member(w, "retention_duration", itu.retention_duration);
     write_member(w, "shadow_indexing", itu.shadow_indexing);
+    write_member(w, "remote_delete", itu.remote_delete);
     w.EndObject();
 }
 
@@ -673,6 +680,7 @@ read_value(json::Value const& rd, cluster::incremental_topic_updates& itu) {
     read_member(rd, "retention_bytes", itu.retention_bytes);
     read_member(rd, "retention_duration", itu.retention_duration);
     read_member(rd, "shadow_indexing", itu.shadow_indexing);
+    read_member(rd, "remote_delete", itu.remote_delete);
 }
 
 inline void rjson_serialize(

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -47,6 +47,24 @@ void parse_and_set_optional(
     property_update.value = boost::lexical_cast<T>(*value);
 }
 
+void parse_and_set_bool(
+  cluster::property_update<bool>& property_update,
+  const std::optional<ss::sstring>& value,
+  bool default_value) {
+    if (!value) {
+        property_update.value = default_value;
+    } else {
+        try {
+            property_update.value = string_switch<bool>(*(value))
+                                      .match("true", true)
+                                      .match("false", false);
+        } catch (...) {
+            // Our callers expect this exception type on malformed values
+            throw boost::bad_lexical_cast();
+        }
+    }
+}
+
 template<typename T>
 void parse_and_set_tristate(
   cluster::property_update<tristate<T>>& property_update,
@@ -153,6 +171,12 @@ create_topic_properties_update(alter_configs_resource& resource) {
                 parse_and_set_tristate(
                   update.properties.retention_bytes, cfg.value);
                 continue;
+            }
+            if (cfg.name == topic_property_remote_delete) {
+                parse_and_set_bool(
+                  update.properties.remote_delete,
+                  cfg.value,
+                  cluster::topic_properties::default_remote_delete);
             }
             if (cfg.name == topic_property_remote_write) {
                 auto set_value = update.properties.shadow_indexing.value

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -176,7 +176,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
                 parse_and_set_bool(
                   update.properties.remote_delete,
                   cfg.value,
-                  cluster::topic_properties::default_remote_delete);
+                  storage::ntp_config::default_remote_delete);
             }
             if (cfg.name == topic_property_remote_write) {
                 auto set_value = update.properties.shadow_indexing.value

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -34,7 +34,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 14> supported_configs{
+static constexpr std::array<std::string_view, 15> supported_configs{
   topic_property_compression,
   topic_property_cleanup_policy,
   topic_property_timestamp_type,
@@ -45,6 +45,7 @@ static constexpr std::array<std::string_view, 14> supported_configs{
   topic_property_recovery,
   topic_property_remote_write,
   topic_property_remote_read,
+  topic_property_remote_delete,
   topic_property_read_replica,
   topic_property_max_message_bytes,
   topic_property_retention_local_target_bytes,

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -588,7 +588,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 add_topic_config<bool>(
                   result,
                   topic_property_remote_delete,
-                  cluster::topic_properties::default_remote_delete,
+                  storage::ntp_config::default_remote_delete,
                   topic_property_remote_delete,
                   std::make_optional<bool>(
                     topic_config->properties.remote_delete),

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -583,6 +583,19 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_config->properties.retention_local_target_ms,
               request.data.include_synonyms);
 
+            if (config_property_requested(
+                  resource.configuration_keys, topic_property_remote_delete)) {
+                add_topic_config<bool>(
+                  result,
+                  topic_property_remote_delete,
+                  cluster::topic_properties::default_remote_delete,
+                  topic_property_remote_delete,
+                  std::make_optional<bool>(
+                    topic_config->properties.remote_delete),
+                  true,
+                  [](const bool& b) { return b ? "true" : "false"; });
+            }
+
             // Data-policy property
             ss::sstring property_name = "redpanda.datapolicy";
             add_topic_config_if_requested(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -185,6 +185,10 @@ to_cluster_type(const creatable_topic& t) {
       = get_tristate_value<std::chrono::milliseconds>(
         config_entries, topic_property_retention_local_target_ms);
 
+    cfg.properties.remote_delete
+      = get_bool_value(config_entries, topic_property_remote_delete)
+          .value_or(cluster::topic_properties::default_remote_delete);
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 
@@ -293,6 +297,10 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
         config_entries[topic_property_retention_local_target_ms]
           = from_config_type(*properties.retention_local_target_ms);
     }
+
+    config_entries[topic_property_remote_delete] = from_config_type(
+      properties.remote_delete);
+
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
     return config_entries;

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -187,7 +187,7 @@ to_cluster_type(const creatable_topic& t) {
 
     cfg.properties.remote_delete
       = get_bool_value(config_entries, topic_property_remote_delete)
-          .value_or(cluster::topic_properties::default_remote_delete);
+          .value_or(storage::ntp_config::default_remote_delete);
 
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -63,6 +63,8 @@ static constexpr std::string_view topic_property_retention_local_target_ms
   = "retention.local.target.ms";
 static constexpr std::string_view topic_property_replication_factor
   = "replication.factor";
+static constexpr std::string_view topic_property_remote_delete
+  = "redpanda.remote.delete";
 
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -346,7 +346,8 @@ FIXTURE_TEST(
       "redpanda.remote.write",
       "max.message.bytes",
       "retention.local.target.bytes",
-      "retention.local.target.ms"};
+      "retention.local.target.ms",
+      "redpanda.remote.delete"};
 
     // All properies_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -165,6 +165,17 @@ public:
 
     bool is_internal_topic() const { return _ntp.ns != model::kafka_namespace; }
 
+    /**
+     * True if the topic is configured for "normal" tiered storage, i.e.
+     * both reads and writes to S3, and is not a read replica.
+     */
+    bool is_tiered_storage() const {
+        return _overrides != nullptr
+               && !_overrides->read_replica.value_or(false)
+               && _overrides->shadow_indexing_mode
+                    == model::shadow_indexing_mode::full;
+    }
+
 private:
     model::ntp _ntp;
     /// \brief currently this is the basedir. In the future

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -31,6 +31,7 @@ class TopicSpec:
     PROPERTY_DATA_POLICY_SCRIPT_NAME = "redpanda.datapolicy.script.name"
     PROPERTY_RETENTION_LOCAL_TARGET_BYTES = "retention.local.target.bytes"
     PROPERTY_RETENTION_LOCAL_TARGET_MS = "retention.local.target.ms"
+    PROPERTY_REMOTE_DELETE = "redpanda.remote.delete"
 
     # compression types
     COMPRESSION_NONE = "none"
@@ -57,7 +58,8 @@ class TopicSpec:
                  retention_ms=None,
                  redpanda_datapolicy=None,
                  redpanda_remote_read=None,
-                 redpanda_remote_write=None):
+                 redpanda_remote_write=None,
+                 redpanda_remote_delete=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -70,6 +72,7 @@ class TopicSpec:
         self.redpanda_datapolicy = redpanda_datapolicy
         self.redpanda_remote_read = redpanda_remote_read
         self.redpanda_remote_write = redpanda_remote_write
+        self.redpanda_remote_delete = redpanda_remote_delete
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -175,17 +175,40 @@ class TestReadReplicaService(EndToEndTest):
         else:
             return None
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=7)
     @matrix(partition_count=[10])
-    def test_produce_is_forbidden(self, partition_count: int) -> None:
+    def test_writes_forbidden(self, partition_count: int) -> None:
+        """
+        Verify that the read replica cluster does not permit writes,
+        and does not perform other data-modifying actions such as
+        removing objects from S3 on topic deletion.
+        """
 
-        self._setup_read_replica(partition_count=partition_count)
+        self._setup_read_replica(partition_count=partition_count,
+                                 num_messages=1000)
         second_rpk = RpkTool(self.second_cluster)
         with expect_exception(
                 RpkException, lambda e:
                 "unable to produce record: INVALID_TOPIC_EXCEPTION: The request attempted to perform an operation on an invalid topic."
                 in str(e)):
             second_rpk.produce(self.topic_name, "", "test payload")
+
+        objects_before = set(
+            self.redpanda.s3_client.list_objects(
+                self.si_settings.cloud_storage_bucket))
+        assert len(objects_before) > 0
+        second_rpk.delete_topic(self.topic_name)
+        objects_after = set(
+            self.redpanda.s3_client.list_objects(
+                self.si_settings.cloud_storage_bucket))
+        if len(objects_after) < len(objects_before):
+            deleted = objects_before - objects_after
+            self.logger.error(f"Objects unexpectedly deleted: {deleted}")
+
+            # This is not an exact equality check because the source
+            # cluster might still be uploading segments: the object
+            # count is permitted to increase.
+            assert len(objects_after) >= len(objects_before)
 
     @cluster(num_nodes=9)
     @matrix(partition_count=[10], min_records=[10000])

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -47,9 +47,11 @@ class BaseTimeQuery:
 
         if cloud_storage:
             for k, v in {
-                    'redpanda.remote.read': True,
-                    'redpanda.remote.write': True,
-                    'retention.bytes':
+                    'redpanda.remote.read':
+                    True,
+                    'redpanda.remote.write':
+                    True,
+                    'retention.local.target.bytes':
                     self.log_segment_size * local_retain_segments
             }.items():
                 self.client().alter_topic_config(topic.name, k, v)

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -184,6 +184,8 @@ class CreateTopicsTest(RedpandaTest):
         lambda: random.randint(-1, 10000000),
         'max.message.bytes':
         lambda: random.randint(1024 * 1024, 10 * 1024 * 1024),
+        'redpanda.remote.delete':
+        lambda: "true" if random.randint(0, 1) else "false"
     }
 
     def __init__(self, test_context):

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -23,6 +23,7 @@ from rptest.services.redpanda import ResourceSettings, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import wait_for_segments_removal
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize, ok_to_fail
@@ -425,6 +426,7 @@ class CreateTopicUpgradeTest(RedpandaTest):
     def __init__(self, test_context):
         si_settings = SISettings(cloud_storage_enable_remote_write=False,
                                  cloud_storage_enable_remote_read=False)
+        self._s3_bucket = si_settings.cloud_storage_bucket
 
         super(CreateTopicUpgradeTest, self).__init__(test_context=test_context,
                                                      num_brokers=3,
@@ -439,16 +441,30 @@ class CreateTopicUpgradeTest(RedpandaTest):
         )
         self.redpanda.start()
 
+    def _populate_tiered_storage_topic(self, topic_name):
+        for n in range(0, 8):
+            self.rpk.produce(topic_name, "key", "b" * 512 * 1024)
+        wait_for_segments_removal(self.redpanda, topic_name, 0, 1)
+
     @cluster(num_nodes=3)
     def test_retention_config_on_upgrade_from_v22_2_to_v22_3(self):
         self.rpk.create_topic("test-topic-with-retention",
                               config={"retention.bytes": 10000})
 
-        self.rpk.create_topic("test-si-topic-with-retention",
-                              config={
-                                  "retention.bytes": 10000,
-                                  "redpanda.remote.write": "true"
-                              })
+        self.rpk.create_topic(
+            "test-si-topic-with-retention",
+            config={
+                "retention.bytes": 10000,
+                "redpanda.remote.write": "true",
+                "redpanda.remote.read": "true",
+                # Small segment.bytes so that we can readily
+                # get data into S3 by writing small amounts.
+                "segment.bytes": 1000000
+            })
+
+        # Write a few megabytes of data, enough to spill to S3.  This will be used
+        # later for checking that deletion behavior is correct on legacy topics.
+        self._populate_tiered_storage_topic("test-si-topic-with-retention")
 
         self.installer.install(
             self.redpanda.nodes,
@@ -462,7 +478,7 @@ class CreateTopicUpgradeTest(RedpandaTest):
         si_configs = self.rpk.describe_topic_configs(
             "test-si-topic-with-retention")
 
-        self.logger.debug(f"test-si-topic-with-retention conig: {si_configs}")
+        self.logger.debug(f"test-si-topic-with-retention config: {si_configs}")
         self.logger.debug(f"test-topic-with-retention: {non_si_configs}")
 
         # "test-topic-with-retention" did not have remote write enabled
@@ -477,6 +493,7 @@ class CreateTopicUpgradeTest(RedpandaTest):
             "-1", "DEFAULT_CONFIG")
         assert non_si_configs["retention.local.target.ms"][
             1] == "DEFAULT_CONFIG"
+        assert non_si_configs["redpanda.remote.delete"][0] == "false"
 
         # 'test-si-topic-with-retention' was enabled from remote write
         # at the time of the upgrade, so retention.local.target.* configs
@@ -488,6 +505,89 @@ class CreateTopicUpgradeTest(RedpandaTest):
         assert si_configs["retention.local.target.bytes"] == (
             "10000", "DYNAMIC_TOPIC_CONFIG")
         assert si_configs["retention.local.target.ms"][1] == "DEFAULT_CONFIG"
+        assert si_configs["redpanda.remote.delete"][0] == "false"
+
+        # After upgrade, newly created topics should have remote.delete
+        # enabled by default, and interpret assignments to retention properties
+        # literally (no mapping of retention -> retention.local)
+        for (new_topic_name,
+             enable_si) in [("test-topic-post-upgrade-nosi", False),
+                            ("test-topic-post-upgrade-si", True)]:
+            create_config = {
+                "retention.bytes": 10000,
+                "retention.local.target.bytes": 5000,
+                "segment.bytes": 1000000
+            }
+            if enable_si:
+                create_config['redpanda.remote.write'] = 'true'
+                create_config['redpanda.remote.read'] = 'true'
+
+            self.rpk.create_topic(new_topic_name, config=create_config)
+            new_config = self.rpk.describe_topic_configs(new_topic_name)
+            assert new_config["redpanda.remote.delete"][0] == "true"
+            assert new_config["retention.bytes"] == ("10000",
+                                                     "DYNAMIC_TOPIC_CONFIG")
+            assert new_config["retention.ms"][1] == "DEFAULT_CONFIG"
+            assert new_config["retention.local.target.ms"][
+                1] == "DEFAULT_CONFIG"
+            assert new_config["retention.local.target.bytes"] == (
+                "5000", "DYNAMIC_TOPIC_CONFIG")
+            if enable_si:
+                assert new_config['redpanda.remote.write'][0] == "true"
+                assert new_config['redpanda.remote.read'][0] == "true"
+
+            # The remote.delete property is applied irrespective of whether
+            # the topic is initially tiered storage enabled.
+            assert new_config['redpanda.remote.delete'][0] == "true"
+
+            if enable_si:
+                self._populate_tiered_storage_topic(new_topic_name)
+
+        # A newly created tiered storage topic should have its data deleted
+        # in S3 when the topic is deleted
+        self._delete_tiered_storage_topic("test-topic-post-upgrade-si", True)
+
+        # Ensure that the `redpanda.remote.delete==false` configuration is
+        # really taking effect, by deleting a legacy topic and ensuring data is
+        # left behind in S3
+        self._delete_tiered_storage_topic("test-si-topic-with-retention",
+                                          False)
+
+    def _delete_tiered_storage_topic(self, topic_name: str,
+                                     expect_s3_deletion: bool):
+        self.logger.debug(f"Deleting {topic_name} and checking S3 result")
+
+        before_objects = set(
+            o.Key for o in self.s3_client.list_objects(self._s3_bucket)
+            if topic_name in o.Key)
+
+        # Test is meaningless if there were no objects to start with
+        assert len(before_objects) > 0
+
+        self.rpk.delete_topic(topic_name)
+
+        def is_empty():
+            return sum(1 for o in self.s3_client.list_objects(self._s3_bucket)
+                       if topic_name in o.Key) == 0
+
+        if expect_s3_deletion:
+            wait_until(is_empty, timeout_sec=10, backoff_sec=1)
+        else:
+            # When we expect objects to remain, require that they remain for
+            # at least some time, to avoid false-passing if they were deleted with
+            # some small delay.
+            sleep(10)
+
+        after_objects = set(
+            o.Key for o in self.s3_client.list_objects(self._s3_bucket)
+            if topic_name in o.Key)
+        deleted_objects = before_objects - after_objects
+        if expect_s3_deletion:
+            assert deleted_objects
+        else:
+            self.logger.debug(
+                f"deleted objects (should be empty): {deleted_objects}")
+            assert len(deleted_objects) == 0
 
     # Previous version of Redpanda have a bug due to which the topic
     # level overrides are not applied for remote read/write. This causes


### PR DESCRIPTION
## Cover letter

This behavior mirrors how we handle deletion of local data: each node that has a cluster::partition instance does a simple for loop through the manifest and deletes each segment.

This sends many redundant DELETE operations to S3, but is necessary for safety, as if we tried to e.g. only do this from the leader then we would be dependent on the leader being available at deletion time.

This behavior is _not_ applied to:
- Read replica topics
- Topics without both remote.read and remote.write set to true (i.e. legacy "archival" topics)

Still to add:
- [ ] DeleteObjects S3 API for efficient bulk deletion
- [x] Cover txrange objects

I think we will probably release 22.3 without plugging all the cases that can leave objects behind in S3: this will require implementing scrub of S3 data.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Features

* Topics using Tiered Storage will now clean up objects in S3 when they are deleted.  This may be avoided by disabling tiered storage on the topic before deleting it.
