### PR TITLE
storage: reinstate indexing on non-data batches, for internal topics

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -246,7 +246,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
           batch.last_offset(),
           batch.header().first_timestamp,
           batch.header().max_timestamp,
-          batch.header().type == model::record_batch_type::raft_data)) {
+          _is_internal
+            || batch.header().type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     co_await storage::write(*_appender, batch);

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -109,9 +109,11 @@ private:
 
 class copy_data_segment_reducer : public compaction_reducer {
 public:
-    copy_data_segment_reducer(compacted_offset_list l, segment_appender* a)
+    copy_data_segment_reducer(
+      compacted_offset_list l, segment_appender* a, bool is_internal)
       : _list(std::move(l))
-      , _appender(a) {}
+      , _appender(a)
+      , _is_internal(is_internal) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
     storage::index_state end_of_stream() { return std::move(_idx); }
@@ -130,6 +132,7 @@ private:
     segment_appender* _appender;
     index_state _idx;
     size_t _acc{0};
+    bool _is_internal;
 };
 
 class index_rebuilder_reducer : public compaction_reducer {

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -390,7 +390,8 @@ ss::future<> kvstore::recover() {
               config::shard_local_cfg().storage_read_buffer_size(),
               config::shard_local_cfg().storage_read_readahead_count(),
               std::nullopt,
-              _resources)
+              _resources,
+              true)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -284,7 +284,8 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       config::shard_local_cfg().storage_read_buffer_size(),
       config::shard_local_cfg().storage_read_readahead_count(),
       last_clean_segment,
-      _resources);
+      _resources,
+      cfg.is_internal_topic());
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "ssx/sformat.h"
 #include "tristate.h"
 
@@ -156,6 +157,8 @@ public:
         return _overrides != nullptr && _overrides->read_replica
                && _overrides->read_replica.value();
     }
+
+    bool is_internal_topic() const { return _ntp.ns != model::kafka_namespace; }
 
 private:
     model::ntp _ntp;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -50,7 +50,8 @@ segment::segment(
   std::optional<compacted_index_writer> ci,
   std::optional<batch_cache_index> c,
   storage_resources& resources,
-  segment::generation_id gen) noexcept
+  segment::generation_id gen,
+  bool is_internal) noexcept
   : _resources(resources)
   , _appender_callbacks(this)
   , _generation_id(gen)
@@ -59,7 +60,8 @@ segment::segment(
   , _idx(std::move(i))
   , _appender(std::move(a))
   , _compaction_index(std::move(ci))
-  , _cache(std::move(c)) {
+  , _cache(std::move(c))
+  , _is_internal(is_internal) {
     if (_appender) {
         _appender->set_callbacks(&_appender_callbacks);
     }
@@ -574,7 +576,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources& resources) {
+  storage_resources& resources,
+  bool is_internal) {
     auto const meta = segment_path::parse_segment_filename(
       path.filename().string());
     if (!meta || meta->version != record_version_type::v1) {
@@ -597,7 +600,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
       index_name,
       meta->base_offset,
       segment_index::default_data_buffer_step,
-      sanitize_fileops);
+      sanitize_fileops,
+      is_internal);
 
     co_return ss::make_lw_shared<segment>(
       segment::offset_tracker(meta->term, meta->base_offset),
@@ -622,6 +626,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   storage_resources& resources) {
     auto path = segment_path::make_segment_path(
       ntpc, base_offset, term, version);
+
     vlog(stlog.info, "Creating new segment {}", path.string());
     return open_segment(
              path,
@@ -629,7 +634,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
              std::move(batch_cache),
              buf_size,
              read_ahead,
-             resources)
+             resources,
+             ntpc.is_internal_topic())
       .then([path, &ntpc, sanitize_fileops, pc, &resources](
               ss::lw_shared_ptr<segment> seg) {
           return with_segment(
@@ -654,7 +660,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt,
-                          resources));
+                          resources,
+                          segment::generation_id{},
+                          seg->is_internal_topic()));
                   });
             });
       })
@@ -681,7 +689,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt,
-                          resources));
+                          resources,
+                          segment::generation_id{},
+                          seg->is_internal_topic()));
                   });
             });
       });

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -77,7 +77,8 @@ public:
       std::optional<compacted_index_writer>,
       std::optional<batch_cache_index>,
       storage_resources&,
-      generation_id = generation_id{}) noexcept;
+      generation_id = generation_id{},
+      bool is_internal = false) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -117,6 +118,8 @@ public:
     bool finished_self_compaction() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
+    bool is_internal_topic() { return _is_internal; }
+
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible
     segment_reader& reader();
@@ -214,6 +217,7 @@ private:
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;
     ss::gate _gate;
+    bool _is_internal;
 
     absl::btree_map<size_t, model::offset> _inflight;
 
@@ -241,7 +245,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources&);
+  storage_resources&,
+  bool is_internal);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -42,10 +42,12 @@ segment_index::segment_index(
   ss::sstring filename,
   model::offset base,
   size_t step,
-  debug_sanitize_files sanitize)
+  debug_sanitize_files sanitize,
+  bool is_internal)
   : _name(std::move(filename))
   , _step(step)
-  , _sanitize(sanitize) {
+  , _sanitize(sanitize)
+  , _is_internal(is_internal) {
     _state.base_offset = base;
 }
 

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -96,7 +96,7 @@ void segment_index::maybe_track(
           hdr.last_offset(),
           hdr.first_timestamp,
           hdr.max_timestamp,
-          hdr.type == model::record_batch_type::raft_data)) {
+          _is_internal || hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -53,7 +53,8 @@ public:
       ss::sstring filename,
       model::offset base,
       size_t step,
-      debug_sanitize_files);
+      debug_sanitize_files,
+      bool is_internal = false);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -96,6 +97,12 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
+
+    /** We need to know if it's an internal topic or a user topic, because
+     *  indexing behavior is different (user topics only index user data
+     *  batches)
+     */
+    bool _is_internal;
 
     /** Constructor with mock file content for unit testing */
     segment_index(

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -47,9 +47,8 @@ struct segment_ordering {
     }
 };
 
-segment_set::segment_set(segment_set::underlying_t segs, bool is_internal_topic)
-  : _handles(std::move(segs))
-  , _is_internal_topic(is_internal_topic) {
+segment_set::segment_set(segment_set::underlying_t segs)
+  : _handles(std::move(segs)) {
     std::sort(_handles.begin(), _handles.end(), segment_ordering{});
 }
 
@@ -468,9 +467,9 @@ ss::future<segment_set> recover_segments(
       })
       .then([&as,
              is_compaction_enabled,
-             last_clean_segment = std::move(last_clean_segment),
-             is_internal_topic](segment_set::underlying_t segs) {
-          auto segments = segment_set(std::move(segs), is_internal_topic);
+             last_clean_segment = std::move(last_clean_segment)](
+              segment_set::underlying_t segs) {
+          auto segments = segment_set(std::move(segs));
           // we have to mark compacted segments before recovery to allow reading
           // gaps introduced by compaction
           if (is_compaction_enabled) {

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t, bool is_internal_topic = false);
+    explicit segment_set(underlying_t);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,7 +85,6 @@ public:
 
 private:
     underlying_t _handles;
-    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t);
+    explicit segment_set(underlying_t, bool is_internal_topic = false);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,6 +85,7 @@ public:
 
 private:
     underlying_t _handles;
+    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };
@@ -98,6 +99,7 @@ ss::future<segment_set> recover_segments(
   size_t read_buf_size,
   unsigned read_readahead_count,
   std::optional<ss::sstring> last_clean_segment,
-  storage_resources&);
+  storage_resources&,
+  bool is_internal_topic);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -407,7 +407,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set), s->is_internal_topic()));
+      segment_set(std::move(set)));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -370,7 +370,8 @@ ss::future<storage::index_state> do_copy_segment_data(
             .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
                     segment_appender_ptr w) mutable {
                 auto raw = w.get();
-                auto red = copy_data_segment_reducer(std::move(l), raw);
+                auto red = copy_data_segment_reducer(
+                  std::move(l), raw, s->is_internal_topic());
                 auto r = create_segment_full_reader(s, cfg, pb, std::move(h));
                 vlog(
                   gclog.trace,
@@ -406,7 +407,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set)));
+      segment_set(std::move(set), s->is_internal_topic()));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);


### PR DESCRIPTION
## Cover letter

storage: index internal batches on internal topics
    
Skipping non-data batches in indexing is necessary
for user topics, where non-data batches are not looked
up directly, and may have very distant timestamps compared
with the walltimes used to timestamp non-data batches.
    
However, for internal topics where _all_ the batches are
non-data batches (e.g. transaction coordinator), this effectively
removes all indexing: a performance regression.
    
This commit re-introduces indexing on non-data batches
selectively, for all topics not in the 'kafka' namespace.
    
Fixes: https://github.com/redpanda-data/redpanda/issues/6682


## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
