### PR TITLE
admin: urldecode logger

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -80,6 +80,7 @@
 #include <seastar/http/api_docs.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/reply.hh>
+#include <seastar/http/request.hh>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -894,7 +895,11 @@ void admin_server::register_config_routes() {
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::httpd::request> req)
         -> ss::future<ss::json::json_return_type> {
-          auto name = req->param["name"];
+          ss::sstring name;
+          if (!ss::httpd::connection::url_decode(req->param["name"], name)) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'name' got {{{}}}", req->param["name"]));
+          }
 
           // current level: will be used revert after a timeout (optional)
           ss::log_level cur_level;


### PR DESCRIPTION
## Cover letter

Fix #6561 

It's now possible to set `kafka/client` and `r/heartbeat`

```
rpk redpanda admin config log-level set --host http://localhost:19644 kafka/client -l trace -e 12
```
Now outputs:
```
SUCCESSES
kafka/client
```

Instead of
```
FAILURES
kafka/client: request PUT http://localhost:19644/v1/config/log_level/kafka%2Fclient?level=trace&expires=12 failed: Bad Request, body: "{\"message\": \"Cannot set log level: unknown logger {kafka%2Fclient}\", \"code\": 400}"
```

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

### Improvements

* It's now possible to set the log level for `kafka/client` and `r/heartbeat` through the admin API.
