### PR TITLE
storage: refactor: reinstate indexing on non-data batches, for internal topics

### DIFF
--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -35,6 +35,7 @@ v_cc_library(
     backlog_controller.cc
     compaction_controller.cc
     offset_to_filepos.cc
+    fs_utils.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -33,11 +33,11 @@
 namespace storage::internal {
 
 compacted_index_chunk_reader::compacted_index_chunk_reader(
-  ss::sstring name,
+  segment_full_path path,
   ss::file in,
   ss::io_priority_class pc,
   size_t max_chunk_memory) noexcept
-  : compacted_index_reader::impl(std::move(name))
+  : compacted_index_reader::impl(std::move(path))
   , _handle(std::move(in))
   , _iopc(pc)
   , _max_chunk_memory(max_chunk_memory) {}
@@ -140,8 +140,8 @@ compacted_index_chunk_reader::load_footer() {
           !_file_size || _file_size == 0
           || _file_size < compacted_index::footer_size) {
             return ss::make_exception_future<compacted_index::footer>(
-              std::runtime_error(fmt::format(
-                "Cannot read footer from empty file: {}", filename())));
+              std::runtime_error(
+                fmt::format("Cannot read footer from empty file: {}", path())));
         }
         ss::file_input_stream_options options;
         options.buffer_size = 4096;
@@ -248,13 +248,13 @@ operator<<(std::ostream& o, const compacted_index_chunk_reader& r) {
 
 namespace storage {
 compacted_index_reader make_file_backed_compacted_reader(
-  ss::sstring filename,
+  segment_full_path path,
   ss::file f,
   ss::io_priority_class iopc,
   size_t step_chunk) {
     return compacted_index_reader(
       ss::make_shared<internal::compacted_index_chunk_reader>(
-        std::move(filename), std::move(f), iopc, step_chunk));
+        std::move(path), std::move(f), iopc, step_chunk));
 }
 
 } // namespace storage

--- a/src/v/storage/compacted_index_chunk_reader.h
+++ b/src/v/storage/compacted_index_chunk_reader.h
@@ -25,7 +25,7 @@ using namespace storage; // NOLINT
 class compacted_index_chunk_reader final : public compacted_index_reader::impl {
 public:
     compacted_index_chunk_reader(
-      ss::sstring name,
+      segment_full_path,
       ss::file,
       ss::io_priority_class,
       size_t max_chunk_memory) noexcept;

--- a/src/v/storage/compacted_index_reader.h
+++ b/src/v/storage/compacted_index_reader.h
@@ -13,6 +13,7 @@
 
 #include "model/timeout_clock.h"
 #include "storage/compacted_index.h"
+#include "storage/fs_utils.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/file.hh>
@@ -32,8 +33,8 @@ class compacted_index_reader {
 public:
     class impl {
     public:
-        explicit impl(ss::sstring filename) noexcept
-          : _name(std::move(filename)) {}
+        explicit impl(segment_full_path path) noexcept
+          : _path(std::move(path)) {}
         virtual ~impl() noexcept = default;
         impl(impl&&) noexcept = default;
         impl& operator=(impl&&) noexcept = default;
@@ -50,7 +51,8 @@ public:
 
         virtual void print(std::ostream&) const = 0;
 
-        const ss::sstring& filename() const { return _name; }
+        const ss::sstring filename() const { return path(); }
+        const segment_full_path& path() const { return _path; }
 
         virtual bool is_end_of_stream() const = 0;
 
@@ -99,7 +101,7 @@ public:
               .then([&consumer] { return consumer.end_of_stream(); });
         }
 
-        ss::sstring _name;
+        segment_full_path _path;
         ss::circular_buffer<compacted_index::entry> _slice;
     };
 
@@ -118,7 +120,8 @@ public:
 
     void reset() { _impl->reset(); }
 
-    const ss::sstring& filename() const { return _impl->filename(); }
+    const ss::sstring filename() const { return _impl->filename(); }
+    const segment_full_path& path() const { return _impl->path(); }
 
     template<typename Consumer>
     requires CompactedIndexEntryConsumer<Consumer>
@@ -137,7 +140,10 @@ private:
 };
 
 compacted_index_reader make_file_backed_compacted_reader(
-  ss::sstring filename, ss::file, ss::io_priority_class, size_t step_chunk);
+  segment_full_path filename,
+  ss::file,
+  ss::io_priority_class,
+  size_t step_chunk);
 
 inline ss::future<ss::circular_buffer<compacted_index::entry>>
 compaction_index_reader_to_memory(compacted_index_reader rdr) {

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -269,8 +269,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
           batch.last_offset(),
           batch.header().first_timestamp,
           batch.header().max_timestamp,
-          _is_internal
-            || batch.header().type == model::record_batch_type::raft_data)) {
+          batch.header().type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     co_await storage::write(*_appender, batch);

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -269,7 +269,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
           batch.last_offset(),
           batch.header().first_timestamp,
           batch.header().max_timestamp,
-          batch.header().type == model::record_batch_type::raft_data)) {
+          _internal_topic
+            || batch.header().type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     co_await storage::write(*_appender, batch);

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -109,11 +109,9 @@ private:
 
 class copy_data_segment_reducer : public compaction_reducer {
 public:
-    copy_data_segment_reducer(
-      compacted_offset_list l, segment_appender* a, bool is_internal)
+    copy_data_segment_reducer(compacted_offset_list l, segment_appender* a)
       : _list(std::move(l))
-      , _appender(a)
-      , _is_internal(is_internal) {}
+      , _appender(a) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
     storage::index_state end_of_stream() { return std::move(_idx); }
@@ -132,7 +130,6 @@ private:
     segment_appender* _appender;
     index_state _idx;
     size_t _acc{0};
-    bool _is_internal;
 };
 
 class index_rebuilder_reducer : public compaction_reducer {

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -109,9 +109,11 @@ private:
 
 class copy_data_segment_reducer : public compaction_reducer {
 public:
-    copy_data_segment_reducer(compacted_offset_list l, segment_appender* a)
+    copy_data_segment_reducer(
+      compacted_offset_list l, segment_appender* a, bool internal_topic)
       : _list(std::move(l))
-      , _appender(a) {}
+      , _appender(a)
+      , _internal_topic(internal_topic) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
     storage::index_state end_of_stream() { return std::move(_idx); }
@@ -130,6 +132,10 @@ private:
     segment_appender* _appender;
     index_state _idx;
     size_t _acc{0};
+
+    /// We need to know if this is an internal topic to inform whether to
+    /// index on non-raft-data batches
+    bool _internal_topic;
 };
 
 class index_rebuilder_reducer : public compaction_reducer {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -519,8 +519,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
     // lock on the range, which is then released. the remainder of the
     // compaction process operates on replacement segment, and any conflicting
     // log operations are later identified before committing changes.
-    auto staging_path = std::filesystem::path(
-      fmt::format("{}.compaction.staging", target->reader().filename()));
+    auto staging_path = target->reader().path().to_compaction_staging();
     auto [replacement, generations]
       = co_await storage::internal::make_concatenated_segment(
         staging_path, segments, cfg, _manager.resources());
@@ -548,8 +547,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
         co_await ss::remove_file(target->index().filename());
     }
 
-    auto compact_index = internal::compacted_index_path(
-      target->reader().filename().c_str());
+    auto compact_index = target->reader().path().to_compacted_index();
     if (co_await ss::file_exists(compact_index.string())) {
         co_await ss::remove_file(compact_index.string());
     }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -543,8 +543,8 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
      * remove index files. they will be rebuilt by the single segment compaction
      * operation, and also ensures we examine segments correctly on recovery.
      */
-    if (co_await ss::file_exists(target->index().filename())) {
-        co_await ss::remove_file(target->index().filename());
+    if (co_await ss::file_exists(target->index().path().string())) {
+        co_await ss::remove_file(target->index().path().string());
     }
 
     auto compact_index = target->reader().path().to_compacted_index();

--- a/src/v/storage/fs_utils.cc
+++ b/src/v/storage/fs_utils.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "fs_utils.h"
+
+#include "config/node_config.h"
+#include "model/namespace.h"
+
+namespace storage {
+
+ss::sstring segment_full_path::string() const {
+    if (unlikely(override_path.has_value())) {
+        return *override_path;
+    }
+
+    return ss::format(
+      "{}/{}_{}/{}-{}-{}{}",
+      dir_part.base_dir.value_or(config::node().data_directory().as_sstring()),
+      dir_part.ntp.path(),
+      dir_part.revision_id,
+      file_part.base_offset(),
+      file_part.term(),
+      to_string(file_part.version),
+      extension);
+}
+
+ss::sstring partition_path::make_string() const {
+    return ss::format(
+      "{}/{}_{}",
+      base_dir.value_or(config::node().data_directory().as_sstring()),
+      ntp.path(),
+      revision_id);
+}
+
+partition_path::partition_path(const ntp_config& ntpc)
+  : ntp(ntpc.ntp())
+  , revision_id(ntpc.get_revision()) {
+    /**
+     * We generally avoid storing the base path on every instance:
+     * only use it as an override for unit tests.
+     */
+    if (
+      // Unit tests that set a random directory in the config
+      ntpc.base_directory() != config::node().data_directory().as_sstring()
+      // Unit tests that set a random (relative) config in node_config
+      || (ntpc.base_directory().size() && ntpc.base_directory()[0] != '/')) {
+        base_dir = ntpc.base_directory();
+    }
+}
+
+std::optional<segment_full_path> segment_full_path::parse(
+  partition_path const& dir_part, const ss::sstring& filename) noexcept {
+    std::optional<segment_path::metadata> file_part_opt;
+    try {
+        file_part_opt = segment_path::parse_segment_filename(filename);
+    } catch (...) {
+        return std::nullopt;
+    }
+    if (!file_part_opt) {
+        return std::nullopt;
+    }
+
+    return segment_full_path(
+      partition_path(dir_part), std::move(*file_part_opt));
+}
+
+segment_full_path segment_full_path::mock(ss::sstring str_path) {
+    auto ntp = model::ntp(
+      model::kafka_namespace,
+      model::topic_partition(
+        model::topic{"testtopic"}, model::partition_id{0}));
+
+    auto pp = partition_path(ntp, model::revision_id{123});
+
+    auto sp = segment_path::metadata{
+      .base_offset = model::offset{123},
+      .term = model::term_id{456},
+      .version = record_version_type::v1};
+
+    return segment_full_path(str_path, pp, sp);
+}
+
+bool segment_full_path::is_internal_topic() const {
+    return dir_part.ntp.ns != model::kafka_namespace;
+}
+
+segment_full_path segment_full_path::to_index() const {
+    if (extension == ".log") {
+        return with_extension(".base_index");
+    } else if (extension == ".log.compaction.staging") {
+        return with_extension(".log.compaction.base_index");
+    } else {
+        vassert(false, "Unexpected extension {}", extension);
+    }
+}
+
+segment_full_path segment_full_path::to_compacted_index() const {
+    if (extension == ".log") {
+        return with_extension(".compaction_index");
+    } else if (extension == ".log.compaction.staging") {
+        return with_extension("log.compaction.compaction_index");
+    } else {
+        vassert(false, "Unexpected extension {}", extension);
+    }
+}
+
+segment_full_path segment_full_path::to_compaction_staging() const {
+    vassert(extension == ".log", "Unexpected extension {}", extension);
+    return with_extension(".log.compaction.staging");
+}
+
+segment_full_path segment_full_path::to_staging() const {
+    if (extension == ".log") {
+        return with_extension(".log.staging");
+    } else if (extension == ".log.compaction.staging") {
+        return with_extension(".log.compaction.staging.staging");
+    } else {
+        vassert(false, "Unexpected extension {}", extension);
+    }
+}
+
+std::ostream& operator<<(std::ostream& o, const partition_path& p) {
+    o << ss::format("{}_{}", p.ntp.path(), p.revision_id);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const segment_full_path& p) {
+    o << p.string();
+    return o;
+}
+
+} // namespace storage

--- a/src/v/storage/fs_utils.h
+++ b/src/v/storage/fs_utils.h
@@ -63,4 +63,140 @@ struct segment_path {
     }
 };
 
+class segment_full_path;
+
+class partition_path {
+public:
+    partition_path(const ntp_config& ntpc);
+
+    operator std::filesystem::path() const { return make_path(); }
+    operator ss::sstring() const { return make_string(); }
+
+private:
+    // If base_dir is null, use the global node_config::data_directory: this
+    // enables overriding the dir, while avoiding copying it everywhere in
+    // normal operation.
+    std::optional<ss::sstring> base_dir;
+
+    model::ntp ntp;
+    model::revision_id revision_id;
+
+    // For segment_full_path::mock() in unit tests
+    partition_path(model::ntp ntp, model::revision_id r)
+      : ntp(ntp)
+      , revision_id(r) {}
+
+    std::filesystem::path make_path() const {
+        return std::filesystem::path(make_string());
+    }
+    ss::sstring make_string() const;
+    friend std::ostream& operator<<(std::ostream&, const partition_path&);
+    friend class segment_full_path;
+};
+
+class segment_full_path {
+public:
+    segment_full_path(
+      const ntp_config& ntpc,
+      model::offset o,
+      model::term_id t,
+      record_version_type v)
+      : dir_part(ntpc)
+      , file_part({.base_offset = o, .term = t, .version = v}) {}
+
+    segment_full_path(
+      partition_path&& dir_part, segment_path::metadata&& file_part)
+      : dir_part(std::move(dir_part))
+      , file_part(std::move(file_part)) {}
+
+    /**
+     * Transformations from regular segment paths to the index etc
+     * for that segment.  These are strict: if you try to e.g. make
+     * an index path from an index path, that will assert out.
+     */
+    segment_full_path to_index() const;
+    segment_full_path to_compacted_index() const;
+    segment_full_path to_compaction_staging() const;
+    segment_full_path to_staging() const;
+
+    /**
+     * Hydrate the metadata into a fully qualified filesystem path.
+     */
+    ss::sstring string() const;
+    operator ss::sstring() const { return string(); }
+    operator std::filesystem::path() const {
+        return std::filesystem::path(string());
+    }
+
+    /**
+     * For unit tests: construct a path object that has a raw filename inside
+     * it, and some metadata that doesn't have to match that filename.
+     */
+    static segment_full_path mock(ss::sstring str_path);
+
+    /**
+     * On malformed input, returns nullopt (does not throw)
+     */
+    static std::optional<segment_full_path>
+    parse(const partition_path& dir_part, const ss::sstring& filename) noexcept;
+
+    model::term_id get_term() { return file_part.term; }
+    model::offset get_base_offset() { return file_part.base_offset; }
+    record_version_type get_version() { return file_part.version; };
+    const model::ntp& get_ntp() const { return dir_part.ntp; }
+
+    /**
+     * This is a storage-specific interpretation of 'internal': it means
+     * topics that are not expected to container end user data, and therefore
+     * to have all batches considered for indexing, whereas for user data we
+     * only want to index their raft_data batches (because including other
+     * batches disrupts time indexing when user timestamps diverge from ours).
+     */
+    bool is_internal_topic() const;
+
+private:
+    // This should always point to a compile-time string constant: we do not
+    // use any dynamic extensions, just simple thing like ".index" and
+    // ".log.staging"
+    std::string_view extension{".log"};
+
+    /***
+     * Return a new instance with the extension set to `ext`, replacing
+     * any extension on the current instance.
+     *
+     * `ext` should include a '.' character
+     *
+     * This should always point to a compile-time string constant: we do not
+     * use any dynamic extensions, just simple thing like ".index" and
+     * ".log.staging"
+     */
+    segment_full_path with_extension(std::string_view ext) const {
+        auto copy = *this;
+        copy.extension = ext;
+        return copy;
+    }
+
+    /// For use in unit tests: override the effective path
+    std::optional<ss::sstring> override_path{std::nullopt};
+
+    /// State that gives us the directory (of the partition)
+    partition_path dir_part;
+
+    /// State that gives us the filename (of the segment, within the partition)
+    segment_path::metadata file_part;
+
+    // Private, used by mock() for tests
+    segment_full_path(
+      ss::sstring override_path,
+      partition_path dir_part,
+      segment_path::metadata file_part)
+      : override_path(override_path)
+      , dir_part(dir_part)
+      , file_part(file_part) {}
+
+    friend std::ostream& operator<<(std::ostream&, const segment_full_path&);
+};
+
+std::ostream& operator<<(std::ostream&, const segment_full_path&);
+
 } // namespace storage

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -289,8 +289,8 @@ ss::future<> kvstore::roll() {
                 lg.debug,
                 "Removing old segment with base offset {}",
                 seg->offsets().base_offset);
-              return ss::remove_file(seg->reader().filename()).then([seg] {
-                  return ss::remove_file(seg->index().filename());
+              return ss::remove_file(seg->reader().path().string()).then([seg] {
+                  return ss::remove_file(seg->index().path().string());
               });
           })
           .then([this] {
@@ -535,8 +535,8 @@ void kvstore::replay_segments_in_thread(segment_set segs) {
           "Removing old segment with base offset {}",
           seg->offsets().base_offset);
         seg->close().get();
-        ss::remove_file(seg->reader().filename()).get();
-        ss::remove_file(seg->index().filename()).get();
+        ss::remove_file(seg->reader().path().string()).get();
+        ss::remove_file(seg->index().path().string()).get();
     }
 
     // close the rest

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -391,8 +391,7 @@ ss::future<> kvstore::recover() {
               config::shard_local_cfg().storage_read_buffer_size(),
               config::shard_local_cfg().storage_read_readahead_count(),
               std::nullopt,
-              _resources,
-              true)
+              _resources)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -380,10 +380,9 @@ ss::future<> kvstore::recover() {
          */
         load_snapshot_in_thread();
 
-        auto dir = std::filesystem::path(_ntpc.work_directory());
         auto segments
           = recover_segments(
-              std::move(dir),
+              partition_path(_ntpc),
               debug_sanitize_files::yes,
               _ntpc.is_compacted(),
               [] { return std::nullopt; },

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -349,8 +349,7 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       config::shard_local_cfg().storage_read_buffer_size(),
       config::shard_local_cfg().storage_read_readahead_count(),
       last_clean_segment,
-      _resources,
-      cfg.is_internal_topic());
+      _resources);
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -338,10 +338,9 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
 
     co_await recover_log_state(cfg);
 
-    ss::sstring path = cfg.work_directory();
     with_cache cache_enabled = cfg.cache_enabled();
     auto segments = co_await recover_segments(
-      std::filesystem::path(path),
+      partition_path(cfg),
       _config.sanitize_fileops,
       cfg.is_compacted(),
       [this, cache_enabled] { return create_cache(cache_enabled); },

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -13,7 +13,6 @@
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
-#include "model/namespace.h"
 #include "ssx/sformat.h"
 #include "tristate.h"
 
@@ -188,8 +187,6 @@ public:
         return _overrides != nullptr && _overrides->read_replica
                && _overrides->read_replica.value();
     }
-
-    bool is_internal_topic() const { return _ntp.ns != model::kafka_namespace; }
 
     /**
      * True if the topic is configured for "normal" tiered storage, i.e.

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -102,7 +102,7 @@ ss::future<> segment::remove_persistent_state() {
     std::vector<std::filesystem::path> rm;
     rm.reserve(3);
     rm.emplace_back(reader().filename().c_str());
-    rm.emplace_back(index().filename().c_str());
+    rm.emplace_back(index().path().string());
     if (is_compacted_segment()) {
         rm.push_back(reader().path().to_compacted_index());
     }
@@ -610,12 +610,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
       path, buf_size, read_ahead, sanitize_fileops);
     co_await rdr->load_size();
 
-    auto index_name = std::filesystem::path(rdr->filename().c_str())
-                        .replace_extension("base_index")
-                        .string();
-
     auto idx = segment_index(
-      index_name,
+      rdr->path().to_index(),
       path.get_base_offset(),
       segment_index::default_data_buffer_step,
       sanitize_fileops);

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -13,6 +13,7 @@
 
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/fs_utils.h"
 #include "storage/fwd.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_index.h"
@@ -237,7 +238,7 @@ private:
  * exist
  */
 ss::future<ss::lw_shared_ptr<segment>> open_segment(
-  std::filesystem::path path,
+  segment_full_path path,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -77,8 +77,7 @@ public:
       std::optional<compacted_index_writer>,
       std::optional<batch_cache_index>,
       storage_resources&,
-      generation_id = generation_id{},
-      bool is_internal = false) noexcept;
+      generation_id = generation_id{}) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -119,8 +118,6 @@ public:
     bool finished_self_compaction() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
-    bool is_internal_topic() { return _is_internal; }
-
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible
     segment_reader& reader();
@@ -218,7 +215,6 @@ private:
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;
     ss::gate _gate;
-    bool _is_internal;
 
     absl::btree_map<size_t, model::offset> _inflight;
 
@@ -246,8 +242,7 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources&,
-  bool is_internal);
+  storage_resources&);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -123,7 +123,8 @@ public:
     // please use higher level API's when possible
     segment_reader& reader();
     size_t file_size() const { return _reader.file_size(); }
-    const ss::sstring& filename() const { return _reader.filename(); }
+    const ss::sstring filename() const { return _reader.filename(); }
+    const segment_full_path& path() const { return _reader.path(); }
     segment_index& index();
     const segment_index& index() const;
     segment_appender_ptr release_appender();

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -96,7 +96,7 @@ void segment_index::maybe_track(
           hdr.last_offset(),
           hdr.first_timestamp,
           hdr.max_timestamp,
-          _is_internal || hdr.type == model::record_batch_type::raft_data)) {
+          hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -39,19 +39,19 @@ static inline segment_index::entry translate_index_entry(
 }
 
 segment_index::segment_index(
-  ss::sstring filename,
+  segment_full_path path,
   model::offset base,
   size_t step,
   debug_sanitize_files sanitize)
-  : _name(std::move(filename))
+  : _path(std::move(path))
   , _step(step)
   , _sanitize(sanitize) {
     _state.base_offset = base;
 }
 
 segment_index::segment_index(
-  ss::sstring filename, ss::file mock_file, model::offset base, size_t step)
-  : _name(std::move(filename))
+  segment_full_path path, ss::file mock_file, model::offset base, size_t step)
+  : _path(std::move(path))
   , _step(step)
   , _mock_file(mock_file) {
     _state.base_offset = base;
@@ -64,10 +64,7 @@ ss::future<ss::file> segment_index::open() {
     }
 
     return internal::make_handle(
-      std::filesystem::path{_name},
-      ss::open_flags::create | ss::open_flags::rw,
-      {},
-      _sanitize);
+      _path, ss::open_flags::create | ss::open_flags::rw, {}, _sanitize);
 }
 
 void segment_index::reset() {
@@ -239,7 +236,7 @@ ss::future<> segment_index::flush_to_file(ss::file backing_file) {
 }
 
 std::ostream& operator<<(std::ostream& o, const segment_index& i) {
-    return o << "{file:" << i.filename() << ", offsets:" << i.base_offset()
+    return o << "{file:" << i.path() << ", offsets:" << i.base_offset()
              << ", index:" << i._state << ", step:" << i._step
              << ", needs_persistence:" << i._needs_persistence << "}";
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -42,12 +42,10 @@ segment_index::segment_index(
   ss::sstring filename,
   model::offset base,
   size_t step,
-  debug_sanitize_files sanitize,
-  bool is_internal)
+  debug_sanitize_files sanitize)
   : _name(std::move(filename))
   , _step(step)
-  , _sanitize(sanitize)
-  , _is_internal(is_internal) {
+  , _sanitize(sanitize) {
     _state.base_offset = base;
 }
 

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -91,7 +91,8 @@ void segment_index::maybe_track(
           hdr.last_offset(),
           hdr.first_timestamp,
           hdr.max_timestamp,
-          hdr.type == model::record_batch_type::raft_data)) {
+          path().is_internal_topic()
+            || hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timestamp.h"
+#include "storage/fs_utils.h"
 #include "storage/index_state.h"
 #include "storage/types.h"
 
@@ -50,7 +51,7 @@ public:
     static constexpr size_t default_data_buffer_step = 4096 * 8;
 
     segment_index(
-      ss::sstring filename,
+      segment_full_path path,
       model::offset base,
       size_t step,
       debug_sanitize_files);
@@ -69,13 +70,14 @@ public:
     model::offset max_offset() const { return _state.max_offset; }
     model::timestamp max_timestamp() const { return _state.max_timestamp; }
     model::timestamp base_timestamp() const { return _state.base_timestamp; }
-    const ss::sstring& filename() const { return _name; }
 
     ss::future<bool> materialize_index();
     ss::future<> flush();
     ss::future<> truncate(model::offset);
 
     ss::future<ss::file> open();
+
+    const segment_full_path& path() const { return _path; }
 
     /// \brief erases the underlying file and resets the index
     /// this is used during compacted index recovery, as we must first
@@ -93,7 +95,7 @@ private:
     ss::future<bool> materialize_index_from_file(ss::file);
     ss::future<> flush_to_file(ss::file);
 
-    ss::sstring _name;
+    segment_full_path _path;
     size_t _step;
     size_t _acc{0};
     bool _needs_persistence{false};
@@ -102,7 +104,7 @@ private:
 
     /** Constructor with mock file content for unit testing */
     segment_index(
-      ss::sstring filename,
+      segment_full_path path,
       ss::file mock_file,
       model::offset base,
       size_t step);

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -53,8 +53,7 @@ public:
       ss::sstring filename,
       model::offset base,
       size_t step,
-      debug_sanitize_files,
-      bool is_internal = false);
+      debug_sanitize_files);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -100,12 +99,6 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
-
-    /** We need to know if it's an internal topic or a user topic, because
-     *  indexing behavior is different (user topics only index user data
-     *  batches)
-     */
-    bool _is_internal;
 
     /** Constructor with mock file content for unit testing */
     segment_index(

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -13,6 +13,7 @@
 
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "storage/fs_utils.h"
 #include "storage/types.h"
 #include "utils/intrusive_list_helpers.h"
 #include "utils/mutex.h"
@@ -107,7 +108,7 @@ public:
 class segment_reader {
 public:
     segment_reader(
-      ss::sstring filename,
+      segment_full_path filename,
       size_t buffer_size,
       unsigned read_ahead,
       debug_sanitize_files) noexcept;
@@ -124,7 +125,8 @@ public:
     size_t file_size() const { return _file_size; }
 
     /// file name
-    const ss::sstring& filename() const { return _filename; }
+    const ss::sstring filename() const { return path(); }
+    const segment_full_path& path() const { return _path; }
 
     bool empty() const { return _file_size == 0; }
 
@@ -145,7 +147,7 @@ public:
     data_stream(size_t pos_begin, size_t pos_end, const ss::io_priority_class);
 
 private:
-    ss::sstring _filename;
+    segment_full_path _path;
 
     // Protects open/close of _data_file, to avoid double-opening on
     // concurrent calls to get()

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -218,7 +218,7 @@ static ss::future<segment_set> unsafe_do_recover(
                   stlog.info,
                   "Error materializing index:{}. Recovering parent "
                   "segment:{}. Details:{}",
-                  s.index().filename(),
+                  s.index().path(),
                   s.filename(),
                   std::current_exception());
                 to_recover_set.insert(&s);
@@ -251,9 +251,9 @@ static ss::future<segment_set> unsafe_do_recover(
               }
               vlog(stlog.info, "Removing empty segment: {}", segment);
               segment->close().get();
-              ss::remove_file(segment->reader().filename()).get();
+              ss::remove_file(segment->reader().path().string()).get();
               try {
-                  ss::remove_file(segment->index().filename()).get();
+                  ss::remove_file(segment->index().path().string()).get();
               } catch (const std::filesystem::filesystem_error& e) {
                   // Ignore ENOENT on deletion: segments are allowed to
                   // exist without an index if redpanda shutdown without

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -47,8 +47,9 @@ struct segment_ordering {
     }
 };
 
-segment_set::segment_set(segment_set::underlying_t segs)
-  : _handles(std::move(segs)) {
+segment_set::segment_set(segment_set::underlying_t segs, bool is_internal_topic)
+  : _handles(std::move(segs))
+  , _is_internal_topic(is_internal_topic) {
     std::sort(_handles.begin(), _handles.end(), segment_ordering{});
 }
 
@@ -467,9 +468,9 @@ ss::future<segment_set> recover_segments(
       })
       .then([&as,
              is_compaction_enabled,
-             last_clean_segment = std::move(last_clean_segment)](
-              segment_set::underlying_t segs) {
-          auto segments = segment_set(std::move(segs));
+             last_clean_segment = std::move(last_clean_segment),
+             is_internal_topic](segment_set::underlying_t segs) {
+          auto segments = segment_set(std::move(segs), is_internal_topic);
           // we have to mark compacted segments before recovery to allow reading
           // gaps introduced by compaction
           if (is_compaction_enabled) {

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t);
+    explicit segment_set(underlying_t, bool is_internal_topic = false);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,6 +85,7 @@ public:
 
 private:
     underlying_t _handles;
+    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "storage/fs_utils.h"
 #include "storage/segment.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -90,7 +91,7 @@ private:
 };
 
 ss::future<segment_set> recover_segments(
-  std::filesystem::path path,
+  partition_path path,
   debug_sanitize_files sanitize_fileops,
   bool is_compaction_enabled,
   std::function<std::optional<batch_cache_index>()> batch_cache_factory,

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t, bool is_internal_topic = false);
+    explicit segment_set(underlying_t);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,7 +85,6 @@ public:
 
 private:
     underlying_t _handles;
-    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };
@@ -99,7 +98,6 @@ ss::future<segment_set> recover_segments(
   size_t read_buf_size,
   unsigned read_readahead_count,
   std::optional<ss::sstring> last_clean_segment,
-  storage_resources&,
-  bool is_internal_topic);
+  storage_resources&);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -367,7 +367,8 @@ ss::future<storage::index_state> do_copy_segment_data(
             .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
                     segment_appender_ptr w) mutable {
                 auto raw = w.get();
-                auto red = copy_data_segment_reducer(std::move(l), raw);
+                auto red = copy_data_segment_reducer(
+                  std::move(l), raw, s->path().is_internal_topic());
                 auto r = create_segment_full_reader(s, cfg, pb, std::move(h));
                 vlog(
                   gclog.trace,

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -678,7 +678,7 @@ make_concatenated_segment(
         co_await ss::remove_file(index_name.string());
     }
     segment_index index(
-      index_name.string(),
+      index_name,
       offsets.base_offset,
       segment_index::default_data_buffer_step,
       cfg.sanitize);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -410,7 +410,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set)));
+      segment_set(std::move(set), s->is_internal_topic()));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -373,8 +373,7 @@ ss::future<storage::index_state> do_copy_segment_data(
             .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
                     segment_appender_ptr w) mutable {
                 auto raw = w.get();
-                auto red = copy_data_segment_reducer(
-                  std::move(l), raw, s->is_internal_topic());
+                auto red = copy_data_segment_reducer(std::move(l), raw);
                 auto r = create_segment_full_reader(s, cfg, pb, std::move(h));
                 vlog(
                   gclog.trace,
@@ -410,7 +409,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set), s->is_internal_topic()));
+      segment_set(std::move(set)));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -59,7 +59,7 @@ ss::future<compaction_result> self_compact_segment(
 ss::future<
   std::tuple<ss::lw_shared_ptr<segment>, std::vector<segment::generation_id>>>
 make_concatenated_segment(
-  std::filesystem::path,
+  segment_full_path,
   std::vector<ss::lw_shared_ptr<segment>>,
   compaction_config,
   storage_resources& resources);
@@ -110,7 +110,7 @@ ss::future<compacted_index_writer> make_compacted_index_writer(
   storage_resources& resources);
 
 ss::future<segment_appender_ptr> make_segment_appender(
-  const std::filesystem::path& path,
+  const segment_full_path& path,
   storage::debug_sanitize_files debug,
   size_t number_of_chunks,
   std::optional<uint64_t> segment_size,
@@ -171,8 +171,6 @@ ss::future<> do_swap_data_file_handles(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
   probe&);
-
-std::filesystem::path compacted_index_path(std::filesystem::path segment_path);
 
 // Generates a random jitter percentage [as a fraction] with in the passed
 // percents range.

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -15,6 +15,7 @@
 #include "storage/compacted_index_reader.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
+#include "storage/fs_utils.h"
 #include "storage/segment_utils.h"
 #include "storage/spill_key_index.h"
 #include "test_utils/fixture.h"
@@ -149,7 +150,7 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
     info("{}", idx);
 
     auto rdr = storage::make_file_backed_compacted_reader(
-      "dummy name",
+      storage::segment_full_path::mock("dummy name"),
       ss::file(ss::make_shared(tmpbuf_file(index_data))),
       ss::default_priority_class(),
       32_KiB);
@@ -176,7 +177,7 @@ FIXTURE_TEST(
     info("{}", idx);
 
     auto rdr = storage::make_file_backed_compacted_reader(
-      "dummy name",
+      storage::segment_full_path::mock("dummy name"),
       ss::file(ss::make_shared(tmpbuf_file(index_data))),
       ss::default_priority_class(),
       32_KiB);
@@ -217,7 +218,7 @@ FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
     info("{}", idx);
 
     auto rdr = storage::make_file_backed_compacted_reader(
-      "dummy name",
+      storage::segment_full_path::mock("dummy name"),
       ss::file(ss::make_shared(tmpbuf_file(index_data))),
       ss::default_priority_class(),
       32_KiB);
@@ -258,7 +259,7 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
     info("{}", idx);
 
     auto rdr = storage::make_file_backed_compacted_reader(
-      "dummy name",
+      storage::segment_full_path::mock("dummy name"),
       ss::file(ss::make_shared(tmpbuf_file(index_data))),
       ss::default_priority_class(),
       32_KiB);
@@ -324,7 +325,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
     info("{}", idx);
 
     auto rdr = storage::make_file_backed_compacted_reader(
-      "dummy name",
+      storage::segment_full_path::mock("dummy name"),
       ss::file(ss::make_shared(tmpbuf_file(index_data))),
       ss::default_priority_class(),
       32_KiB);
@@ -355,7 +356,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
     final_idx.close().get();
     {
         auto final_rdr = storage::make_file_backed_compacted_reader(
-          "dummy name - final ",
+          storage::segment_full_path::mock("dummy name - final "),
           ss::file(ss::make_shared(tmpbuf_file(final_data))),
           ss::default_priority_class(),
           32_KiB);

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -53,9 +53,15 @@ public:
           segment_appender::options(
             ss::default_priority_class(), 1, std::nullopt, resources));
         auto indexer = segment_index(
-          base_name + ".index", std::move(fidx), base, 4096);
+          segment_full_path::mock(base_name + ".index"),
+          std::move(fidx),
+          base,
+          4096);
         auto reader = segment_reader(
-          base_name, 128_KiB, 10, debug_sanitize_files::no);
+          segment_full_path::mock(base_name),
+          128_KiB,
+          10,
+          debug_sanitize_files::no);
         reader.load_size().get();
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -27,7 +27,7 @@ public:
         _base_offset = base;
         // index
         _idx = std::unique_ptr<segment_index>(new segment_index(
-          "In memory iobuf",
+          segment_full_path::mock("In memory iobuf"),
           ss::file(ss::make_shared(tmpbuf_file(_data))),
           _base_offset,
           storage::segment_index::default_data_buffer_step));

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -10,6 +10,7 @@
 #include "bytes/bytes.h"
 #include "config/mock_property.h"
 #include "model/fundamental.h"
+#include "model/namespace.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
@@ -2913,10 +2914,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
     // Remove compacted indexes to trigger a full index rebuild.
-    auto seg_path = disk_log->segments()[0]->filename();
-    auto index_path = storage::internal::compacted_index_path(
-      std::filesystem::path(seg_path));
-
+    auto index_path = disk_log->segments()[0]->path().to_compacted_index();
     BOOST_REQUIRE(std::filesystem::remove(index_path));
 
     auto batches = read_and_validate_all_batches(log);


### PR DESCRIPTION
## Cover letter

_This is a cleaner version of https://github.com/redpanda-data/redpanda/pull/6684, where instead of passing an internal flag around everywhere, we replace the existing std::filesystem::path on segments etc with a structured object that can be queried for ntp info._

storage: index internal batches on internal topics
    
Skipping non-data batches in indexing is necessary
for user topics, where non-data batches are not looked
up directly, and may have very distant timestamps compared
with the walltimes used to timestamp non-data batches.
    
However, for internal topics where _all_ the batches are
non-data batches (e.g. transaction coordinator), this effectively
removes all indexing: a performance regression.
    
This commit re-introduces indexing on non-data batches
selectively, for all topics not in the 'kafka' namespace.
    
Fixes: https://github.com/redpanda-data/redpanda/issues/6682

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none