### PR TITLE
archival: Fix off by one error in get_file_range

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -393,7 +393,7 @@ static ss::future<> get_file_range(
         // Subsequent call to segment_reader::data_stream will fail in this
         // case. In order to avoid this we need to make another index lookup
         // to find a lower offset which is committed.
-        while (ix_end && ix_end->filepos > fsize) {
+        while (ix_end && ix_end->filepos >= fsize) {
             vlog(archival_log.debug, "The position is not flushed {}", *ix_end);
             auto lookup_offset = ix_end->offset - model::offset(1);
             ix_end = segment->index().find_nearest(lookup_offset);

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -291,7 +291,8 @@ class ArchivalTest(RedpandaTest):
         validate(self._cross_node_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    def test_timeboxed_uploads(self):
+    @matrix(acks=[-1, 0, 1])
+    def test_timeboxed_uploads(self, acks):
         """This test checks segment upload time limit. The feature is enabled in the
         configuration. The configuration defines maximum time interval between uploads.
         If the option is set then redpanda will start uploading a segment partially if
@@ -311,7 +312,7 @@ class ArchivalTest(RedpandaTest):
         # expect that the bucket won't have 9 segments with 1000 offsets.
         # The actual segments will be larger.
         for _ in range(0, 10):
-            self.kafka_tools.produce(self.topic, 1000, 1024)
+            self.kafka_tools.produce(self.topic, 1000, 1024, acks)
             time.sleep(1)
         time.sleep(5)
 
@@ -358,8 +359,8 @@ class ArchivalTest(RedpandaTest):
                     self.logger.info(
                         f"checking {segment} prev: {prev_committed_offset}")
                     base_offset = segment['base_offset']
-                    assert prev_committed_offset + 1 == base_offset, f"inconsistent segments, " +\
-                        "expected base_offset: {prev_committed_offset + 1}, actual: {base_offset}"
+                    assert prev_committed_offset + 1 == base_offset, "inconsistent segments, " +\
+                        f"expected base_offset: {prev_committed_offset + 1}, actual: {base_offset}"
                     prev_committed_offset = segment['committed_offset']
                     size += segment['size_bytes']
                 assert sizes[ntp] >= size


### PR DESCRIPTION
## Cover letter

Fix off-by-one error and add test that reproduces the problem.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes


* none

### Features

* none

### Improvements

* none