### PR TITLE
archival: Fix off by one error in get_file_range

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -309,7 +309,7 @@ static ss::future<> get_file_range(
         // Subsequent call to segment_reader::data_stream will fail in this
         // case. In order to avoid this we need to make another index lookup
         // to find a lower offset which is committed.
-        while (ix_end && ix_end->filepos > fsize) {
+        while (ix_end && ix_end->filepos >= fsize) {
             vlog(archival_log.debug, "The position is not flushed {}", *ix_end);
             auto lookup_offset = ix_end->offset - model::offset(1);
             ix_end = segment->index().find_nearest(lookup_offset);


### PR DESCRIPTION


## Cover letter

The check before this fix compared the file offset to file size using greater-then operator. This is incorrect since it returns true in case if file offset is equal to file size. This resulted in a situation when we tried to read after EOF. In case of seastar::input_stream this operation is allowed and returns 0 bytes. So the scan operation was considered successful with the offsets from index.

Backport #6698, the second commit with changes to ductape tests is omitted because of merge conflicts.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none


### Features

* none

### Improvements

* none

