### PR TITLE
admin: urldecode logger

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -67,6 +67,8 @@
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/http/httpd.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/http/request.hh>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -668,7 +670,11 @@ void admin_server::register_config_routes() {
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::httpd::request> req)
         -> ss::future<ss::json::json_return_type> {
-          auto name = req->param["name"];
+          ss::sstring name;
+          if (!ss::httpd::connection::url_decode(req->param["name"], name)) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'name' got {{{}}}", req->param["name"]));
+          }
 
           // current level: will be used revert after a timeout (optional)
           ss::log_level cur_level;


### PR DESCRIPTION
## Cover letter

Backport of #6688

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] is a backport

## UX changes

* none

## Release notes

### Improvements

* It's now possible to set the log level for `kafka/client` and `r/heartbeat` through the admin API.
