### PR TITLE
Remap `raft::errc::replicated_entry_truncated` error code to a retry-able kafka one

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2027,13 +2027,13 @@ kafka::error_code map_store_offset_error_code(std::error_code ec) {
         case raft::errc::shutting_down:
             return error_code::request_timed_out;
         case raft::errc::not_leader:
+        case raft::errc::replicated_entry_truncated:
             return error_code::not_coordinator;
         case raft::errc::disconnected_endpoint:
         case raft::errc::exponential_backoff:
         case raft::errc::non_majority_replication:
         case raft::errc::vote_dispatch_error:
         case raft::errc::append_entries_dispatch_error:
-        case raft::errc::replicated_entry_truncated:
         case raft::errc::leader_flush_failed:
         case raft::errc::leader_append_failed:
         case raft::errc::configuration_change_in_progress:


### PR DESCRIPTION
## Cover letter
This specific raft error code is returned a single conditional, which will be returned in the case a term mismatch is observed.
The logic is sound however the error code is mapped to a generic `unknown_server_error` kafka error code, so clients that have made requests that inadvertently hit this situation will not retry.

This commit remaps the `raft::errc::replicated_entry_truncated` error code to a retry-able kafka error code, namely
`kafka::error_code::not_coordinator`. The client will make a metadata refresh request before retrying, this is desired as the entire series of events was most likely triggered by a new raft leadership election having taken place.

Fixes: #6508 

## Backport Required

- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## Release notes

- Returning retryable kafka error code in raft replication failure events that require the client to retry
