### PR TITLE
Treat remote read and write cluster config as defaults

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -325,8 +325,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
           }
           if (
             part->get_ntp_config().is_archival_enabled()
-            || part->get_ntp_config().is_read_replica_mode_enabled()
-            || config::shard_local_cfg().cloud_storage_enable_remote_write()) {
+            || part->get_ntp_config().is_read_replica_mode_enabled()) {
               auto archiver = ss::make_lw_shared<ntp_archiver>(
                 log->config(),
                 _partition_manager.local(),

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -414,9 +414,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {
-    if (
-      !_raft->log_config().is_archival_enabled()
-      && !config::shard_local_cfg().cloud_storage_enable_remote_write.value()) {
+    if (!_raft->log_config().is_archival_enabled()) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
         return model::offset::max();

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -125,9 +125,7 @@ ss::future<std::vector<rm_stm::tx_range>> partition::aborted_transactions_cloud(
 
 bool partition::is_remote_fetch_enabled() const {
     const auto& cfg = _raft->log_config();
-    return cfg.is_remote_fetch_enabled()
-           || config::shard_local_cfg()
-                .cloud_storage_enable_remote_read.value();
+    return cfg.is_remote_fetch_enabled();
 }
 
 bool partition::cloud_data_available() const {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -971,13 +971,13 @@ configuration::configuration()
   , cloud_storage_enable_remote_read(
       *this,
       "cloud_storage_enable_remote_read",
-      "Enable remote read for all topics",
+      "Default remote read config value for new topics",
       {.visibility = visibility::tunable},
       false)
   , cloud_storage_enable_remote_write(
       *this,
       "cloud_storage_enable_remote_write",
-      "Enable remote write for all topics",
+      "Default remote write value for new topics",
       {.visibility = visibility::tunable},
       false)
   , cloud_storage_access_key(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -87,19 +87,12 @@ get_bool_value(const config_map_t& config, std::string_view key) {
     return std::nullopt;
 }
 
-static std::optional<model::shadow_indexing_mode>
+static model::shadow_indexing_mode
 get_shadow_indexing_mode(const config_map_t& config) {
     auto arch_enabled = get_bool_value(config, topic_property_remote_write);
     auto si_enabled = get_bool_value(config, topic_property_remote_read);
 
-    // If the topic creation does not explicitly specify a shadow indexing mode
-    // we should use the default shadow indexing mode.
-    if (!arch_enabled && !si_enabled) {
-        return std::nullopt;
-    }
-
-    // If one of the topic properties is missing, patch it with the cluster
-    // config.
+    // If topic properties are missing, patch them with the cluster config.
     if (!arch_enabled) {
         arch_enabled
           = config::shard_local_cfg().cloud_storage_enable_remote_write();


### PR DESCRIPTION
## Cover letter

This PR changes the behaviour of the remote read and write cluster configs (cloud_storage_enable_remote_write and cloud_storage_enable_remote_read) to act as defaults at the time of topic creation. Previously, they acted as overrides
for the topic remote read and write configs (redpanda.remote.[read|write]). This resulted in confusing scenarios where
remote write was disabled at the topic level, but data was still being archived. It also makes writing code that needs
to know whether remote read/write is enabled for a topic difficult.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [X] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
The remote read/write cluster level configs (cloud_storage_enable_remote_write and cloud_storage_enable_remote_read) are now treated as defaults at the time of topic creation. This is the behaviour that people expect.

## Release notes
* none
