### PR TITLE
tests: skip TimeQueryTest in debug mode

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -30,6 +30,7 @@ from ducktape.mark.resource import cluster as ducktape_cluster
 from kafkatest.version import V_3_0_0
 from ducktape.tests.test import Test
 from rptest.clients.default import DefaultClient
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
@@ -210,6 +211,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
     @parametrize(cloud_storage=True, batch_cache=False)
     @parametrize(cloud_storage=False, batch_cache=True)
     @parametrize(cloud_storage=False, batch_cache=False)
+    @skip_debug_mode
     def test_timequery(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise


### PR DESCRIPTION

## Cover letter

This test relies on reliably producing a burst of messages.

In debug mode docker tests, redpanda doesn't reliably hold leadership, and the client can end up double-transmitting, violating the test's expectation of receiving a set number of messages (nothing to do with time querying, this is just the test's setup).

It's not yet clear if there is an underlying bug in idempotency, or if this is a legitimate behavior.  In any case, stop running this test in debug mode where it's known to be unstable.

Related: https://github.com/redpanda-data/redpanda/issues/6685

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none