### PR TITLE
perf/omb: redefine omb perf run workload

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN apt update && \
 
 # Install the OMB tool
 RUN git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git && \
-    cd /opt/openmessaging-benchmark && git reset --hard 43b737c357cde3b418a6aee4c95107d6ef28b8a2 && mvn package
+    cd /opt/openmessaging-benchmark && git reset --hard 6eba1030cb7c199e03f76676b6c2df9dcc3b219d && mvn clean package -DskipTests
 
 # install kafka binary dependencies, librdkafka dev, kcat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"

--- a/tests/rptest/perf/openmessaging_perf_test.py
+++ b/tests/rptest/perf/openmessaging_perf_test.py
@@ -16,11 +16,8 @@ from ducktape.mark import parametrize
 
 
 class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
-    # We need to be a little generous with the wait time here as the benchmark
-    # run often takes longer than the configured time. This is often the case
-    # when consumers are catching up with the produced data, when
-    # consumerBacklogSizeGB is configured (check OMB documentation for details).
-    BENCHMARK_WAIT_TIME_MIN = 30
+
+    BENCHMARK_WAIT_TIME_MIN = 10
 
     def __init__(self, ctx):
         self._ctx = ctx
@@ -29,16 +26,16 @@ class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
 
     @cluster(num_nodes=6)
     @parametrize(driver_idx="ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT",
-                 workload_idx="TOPIC1_PART100_1KB_4PROD_1250K_RATE")
-    def test_perf_with_idempotence_and_max_in_flight(self, driver_idx,
-                                                     workload_idx):
+                 workload_idx="RELEASE_CERT_SMOKE_LOAD_625k")
+    def test_perf(self, driver_idx, workload_idx):
         """
-        This test runs ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT driver with
-        TOPIC1_PART100_1KB_4PROD_1250K_RATE workload. Has a runtime of ~1hr.
+        This test is run as a part of nightly perf suite to detect
+        regressions.
         """
 
-        # Make sure this is running in a dedicated environment as the perf run
-        # is long running and requires significant resources.
+        # Make sure this is running in a dedicated environment as the perf
+        # run validator metrics are based on a production grade deployment.
+        # Check validator for specifics.
         assert self.redpanda.dedicated_nodes
 
         benchmark = OpenMessagingBenchmark(self._ctx, self.redpanda,

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -230,6 +230,7 @@ class OpenMessagingBenchmark(Service):
                     --workers {worker_nodes} \
                     --output {OpenMessagingBenchmark.RESULT_FILE} \
                     --service-version {rp_version} \
+                    -t swarm \
                     {OpenMessagingBenchmark.WORKLOAD_FILE} >> {OpenMessagingBenchmark.STDOUT_STDERR_CAPTURE} 2>&1 \
                     & disown"
 

--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -15,16 +15,20 @@ class OMBSampleConfigurations:
 
     # These are copied over from OMB/bin/generate_charts.py
     # All metrics are in milliseconds unless specially suffixed.
+    PUB_LATENCY_MIN = "publishLatencyMin"
     PUB_LATENCY_AVG = "aggregatedPublishLatencyAvg"
     PUB_LATENCY_50PCT = "aggregatedPublishLatency50pct"
-    PUB_LATENCY_99PCT = "aggregatedPublishLatency99pct"
+    PUB_LATENCY_75PCT = "aggregatedPublishLatency75pct"
+    PUB_LATENCY_95PCT = "aggregatedPublishLatency95pct"
     PUB_LATENCY_MAX = "aggregatedPublishLatencyMax"
     PUB_DELAY_LATENCY_AVG = "aggregatedPublishDelayLatencyAvg"
     PUB_DELAY_LATENCY_50PCT = "aggregatedPublishDelayLatency50pct"
     PUB_DELAY_LATENCY_99PCT = "aggregatedPublishDelayLatency99pct"
+    E2E_LATENCY_MIN = "endToEndLatencyMin"
     E2E_LATENCY_AVG = "aggregatedEndToEndLatencyAvg"
     E2E_LATENCY_50PCT = "aggregatedEndToEndLatency50pct"
-    E2E_LATENCY_99PCT = "aggregatedEndToEndLatency99pct"
+    E2E_LATENCY_75PCT = "aggregatedEndToEndLatency75pct"
+    E2E_LATENCY_95PCT = "aggregatedEndToEndLatency95pct"
     E2E_LATENCY_MAX = "aggregatedEndToEndLatencyMax"
     AVG_THROUGHPUT_MBPS = "throughputMBps"
 
@@ -54,6 +58,33 @@ class OMBSampleConfigurations:
     UNIT_TEST_LATENCY_VALIDATOR = {
         E2E_LATENCY_50PCT: [lte(30)],
         E2E_LATENCY_AVG: [lte(50)],
+    }
+
+    # As benchmarked on
+    # - i3en.6xlarge for 3 Redpanda;
+    # - c5n.9xlarge for 2 clients
+    #
+    # Publish latencies
+    #   min <= 1ms
+    #   p50 <= 3ms
+    #   p75 <= 4ms
+    #   p95 <= 8ms
+    #
+    # E2E latencies
+    #   min <= 1ms
+    #   p50 <= 4ms
+    #   p75 <= 5ms
+    #   p95 <= 10ms
+    RELEASE_SMOKE_TEST_VALIDATOR = {
+        PUB_LATENCY_MIN: [lte(1)],
+        PUB_LATENCY_50PCT: [lte(3)],
+        PUB_LATENCY_75PCT: [lte(4)],
+        PUB_LATENCY_95PCT: [lte(8)],
+        E2E_LATENCY_MIN: [lte(1)],
+        E2E_LATENCY_50PCT: [lte(4)],
+        E2E_LATENCY_75PCT: [lte(5)],
+        E2E_LATENCY_95PCT: [lte(10)],
+        AVG_THROUGHPUT_MBPS: [gte(600)]
     }
 
     def validate_metrics(metrics, validator):
@@ -201,6 +232,21 @@ class OMBSampleConfigurations:
         "test_duration_minutes": 15,
         "warmup_duration_minutes": 5,
     }
+
+    # Release certifying smoke test we use for perf run.
+    RELEASE_CERT_SMOKE_LOAD_625k = {
+        "name": "SmokeLoad625kReleaseCert",
+        "topics": 1,
+        "partitions_per_topic": 100,
+        "subscriptions_per_topic": 1,
+        "consumer_per_subscription": 8,
+        "producers_per_topic": 16,
+        "producer_rate": 625000,
+        "consumer_backlog_size_GB": 0,
+        "test_duration_minutes": 5,
+        "warmup_duration_minutes": 1,
+    }
+
     # ------- Workload configurations end--------
 
     # We have another level of indirection from name -> driver/workload
@@ -232,5 +278,7 @@ class OMBSampleConfigurations:
         "DEDICATED_NODE_WORKLOAD":
         (DEDICATED_NODE_WORKLOAD, UNIT_TEST_LATENCY_VALIDATOR),
         "TOPIC1_PART100_1KB_4PROD_1250K_RATE":
-        (TOPIC1_PART100_1KB_4PROD_1250K_RATE, PROD_ENV_VALIDATOR)
+        (TOPIC1_PART100_1KB_4PROD_1250K_RATE, PROD_ENV_VALIDATOR),
+        "RELEASE_CERT_SMOKE_LOAD_625k":
+        (RELEASE_CERT_SMOKE_LOAD_625k, RELEASE_SMOKE_TEST_VALIDATOR)
     }


### PR DESCRIPTION
## Cover letter

Adjust the perf baselines and workload based on Denis' recent perf runs. Adds a new workload that was run as a part of release certification.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* none
