### PR TITLE
storage/tests: remove use of walltime from log appender tests

### DIFF
--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -351,7 +351,7 @@ FIXTURE_TEST(
     append_random_batches(log, 10, model::term_id(0));
     append_random_batches(log, 10, model::term_id(0));
     log.flush().get0();
-    auto ts = model::timestamp::now();
+    auto ts = now();
     append_random_batches(log, 10, model::term_id(0));
     log.flush().get0();
     // garbadge collect first append series
@@ -529,7 +529,8 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     append_random_batches(log, 10, model::term_id(1));
     log.flush().get0();
 
-    auto ts = model::timestamp::now();
+    auto ts = now();
+
     auto new_lstats = log.offsets();
     log.set_collectible_offset(new_lstats.dirty_offset);
 

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -293,12 +293,21 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
     auto ntp = model::ntp("default", "test", 0);
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto headers = append_random_batches(log, 15, model::term_id(0), [] {
-        ss::circular_buffer<model::record_batch> ret;
-        ret.push_back(
-          model::test::make_random_batch(model::offset(0), 1, true));
-        return ret;
-    });
+    auto headers = append_random_batches(
+      log,
+      15,
+      model::term_id(0),
+      [](std::optional<model::timestamp> ts = std::nullopt) {
+          ss::circular_buffer<model::record_batch> ret;
+          ret.push_back(model::test::make_random_batch(
+            model::offset(0),
+            1,
+            true,
+            model::record_batch_type::raft_data,
+            std::nullopt,
+            ts));
+          return ret;
+      });
     log.flush().get0();
 
     for (auto lstats = log.offsets(); lstats.dirty_offset > model::offset{};


### PR DESCRIPTION
## Cover letter

These tests were making assumptions about the relationship between timestamps in their batches and the wallclock time.

Fixes https://github.com/redpanda-data/redpanda/issues/6717

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
