### PR TITLE
util: add named_type constructor from args

### DIFF
--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -132,10 +132,11 @@ public:
       = std::is_nothrow_move_constructible<T>::value;
 
     base_named_type() = default;
-    explicit base_named_type(const type& v)
-      : _value(v) {}
-    explicit base_named_type(type&& v)
-      : _value(std::move(v)) {}
+
+    template<typename... Args>
+    requires std::constructible_from<T, Args...>
+    explicit base_named_type(Args&&... args)
+      : _value(std::forward<Args>(args)...) {}
 
     base_named_type(base_named_type&& o) noexcept(move_noexcept) = default;
 

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -27,3 +27,10 @@ SEASTAR_THREAD_TEST_CASE(test_named_uuid_type) {
     auto uuid2 = test_uuid(uuid_t::create());
     BOOST_REQUIRE_NE(uuid1, uuid2);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_to_from_vec) {
+    auto uuid1 = test_uuid(uuid_t::create());
+    auto uuid1_vec = uuid1().to_vector();
+    auto uuid2 = test_uuid(uuid1_vec);
+    BOOST_REQUIRE_EQUAL(uuid1, uuid2);
+}


### PR DESCRIPTION
## Cover letter

It can be convenient to construct a named_type using constructors of the
underlying type.

A simple solution today is to construct the underlying type separately
and then construct the named_type with it, but this spills the
underlying type into call sites. Another approach would be to construct
with the named_type::type constructor, but this can be verbose.

This commit replaces the current constructors with a templatized
constructor that callers can pass constructor args into.

NOTE: some existing message types (e.g. `join_node_request`) use a `vector<uint8_t>` instead of the new `uuid_t` type, hence the focus on improvements to conversions between these types.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes


* none

