### PR TITLE
Increase the verbosity of curl commands

### DIFF
--- a/src/go/k8s/hack/install-cert-manager.sh
+++ b/src/go/k8s/hack/install-cert-manager.sh
@@ -15,9 +15,9 @@ fi
 mkdir -p ./bin
 
 if [ "$(uname)" == 'Darwin' ]; then
-  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf - -C ./bin
+  curl -Lv https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf - -C ./bin
 else
-  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Linux_x86_64.tar.gz | tar -xzvf - -C ./bin
+  curl -Lv https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Linux_x86_64.tar.gz | tar -xzvf - -C ./bin
 fi
 
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.4/cert-manager.yaml


### PR DESCRIPTION
## Cover letter

CI occasionally fails to untar the download. Increase the verbosity of the curl command in order to produce enough information to determine why.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Closes #6699 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none

