### PR TITLE
tests: fix skip_debug_mode

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -583,6 +583,9 @@ class RedpandaService(Service):
         # stash a copy here so that we can quickly look up e.g. addresses later.
         self._node_configs = {}
 
+    def set_skip_if_no_redpanda_log(self, v: bool):
+        self._skip_if_no_redpanda_log = v
+
     def set_environment(self, environment: dict[str, str]):
         self._environment = environment
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -66,6 +66,12 @@ class RedpandaTest(Test):
                                         **kwargs)
         self._client = DefaultClient(self.redpanda)
 
+    def early_exit_hook(self):
+        """
+        Hook for `skip_debug_mode` decorator
+        """
+        self.redpanda.set_skip_if_no_redpanda_log(True)
+
     @property
     def topic(self):
         """

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -26,13 +26,11 @@ def cleanup_on_early_exit(caller):
             hook
         ), f'{name.early_exit_hook} should be a method which can be called to set up early exit from test'
         hook()
-    else:
-        caller.logger.debug(
-            f'{name} does not define action to take when skipping test on debug mode. '
-            f'Cleaning up unused nodes.')
 
-        if test_context := getattr(caller, 'test_context', None):
-            allocate_and_free(test_context.cluster, caller.logger)
+    caller.logger.debug(f'Cleaning up unused nodes.')
+
+    if test_context := getattr(caller, 'test_context', None):
+        allocate_and_free(test_context.cluster, caller.logger)
 
 
 def skip_debug_mode(func):


### PR DESCRIPTION
## Cover letter

This decorator didn't work in practice, because it causes RedpandaTest to fail its log scans on missing logs.

Update it to set a flag on RedpandaTest to tolerate missing logs.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
