### PR TITLE
Revert "tests: skip TimeQueryTest in debug mode"

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -30,7 +30,6 @@ from ducktape.mark.resource import cluster as ducktape_cluster
 from kafkatest.version import V_3_0_0
 from ducktape.tests.test import Test
 from rptest.clients.default import DefaultClient
-from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
@@ -211,7 +210,6 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
     @parametrize(cloud_storage=True, batch_cache=False)
     @parametrize(cloud_storage=False, batch_cache=True)
     @parametrize(cloud_storage=False, batch_cache=False)
-    @skip_debug_mode
     def test_timequery(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise


### PR DESCRIPTION
This reverts commit 062b88785f5b3153cd639da0a3f3fd19b52f420d.

#6722 should fix it too, but this one is a straight revert so can perhaps be merged without waiting another 2 hours for the CI.

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
