### PR TITLE
Remove log4j dependency

### DIFF
--- a/tests/java/e2e-verifiers/pom.xml
+++ b/tests/java/e2e-verifiers/pom.xml
@@ -18,7 +18,6 @@
         <slf4j.version>1.7.36</slf4j.version>
         <buildDir>${project.basedir}/target</buildDir>
         <jackson.version>2.13.1</jackson.version>
-        <log4j.version>1.2.17</log4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -35,11 +34,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Cover letter

log4j is an outdated logger implementation. Looks like slf4j-log4j12 now pulls in another newer transitive dependency that is meant to replace log4j because of the security vulnerabilities. If you run maven, you can see

`[WARNING] The artifact org.slf4j:slf4j-log4j12:jar:1.7.36 has been relocated to org.slf4j:slf4j-reload4j:jar:1.7.36`

Which then points to https://reload4j.qos.ch/:
Initiated by Ceki Gülcü, the original author of Apache log4j 1.x, the reload4j project is a fork of Apache log4j version 1.2.17 with the goal of fixing pressing security issues. It is intended as a drop-in replacement for log4j version 1.2.17. By drop-in, we mean the replacement of log4j.jar with reload4j.jar in your build with no source code changes in .java files being necessary.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## Release notes

* none
