### PR TITLE
r/cosnensus: fixed unconditionally accessing follower state in vote stms

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2382,7 +2382,11 @@ void consensus::update_node_append_timestamp(vnode id) {
         it->second.last_sent_append_entries_req_timestamp = clock_type::now();
     }
 }
-
+void consensus::maybe_update_node_reply_timestamp(vnode id) {
+    if (auto it = _fstats.find(id); it != _fstats.end()) {
+        it->second.last_received_reply_timestamp = clock_type::now();
+    }
+}
 void consensus::update_node_reply_timestamp(vnode id) {
     _fstats.get(id).last_received_reply_timestamp = clock_type::now();
 }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -456,6 +456,7 @@ private:
     void arm_vote_timeout();
     void update_node_append_timestamp(vnode);
     void update_node_reply_timestamp(vnode);
+    void maybe_update_node_reply_timestamp(vnode);
 
     void update_follower_stats(const group_configuration&);
     void trigger_leadership_notification();

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -78,7 +78,7 @@ prevote_stm::process_reply(vnode n, ss::future<result<vote_reply>> f) {
                 auto r = f.get0();
                 if (r.has_value()) {
                     auto v = r.value();
-                    _ptr->update_node_reply_timestamp(n);
+                    _ptr->maybe_update_node_reply_timestamp(n);
                     if (v.log_ok) {
                         vlog(
                           _ctxlog.trace,

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -75,7 +75,7 @@ ss::future<> vote_stm::dispatch_one(vnode n) {
               try {
                   auto r = f.get0();
                   vlog(_ctxlog.info, "vote reply from {} - {}", n, r.value());
-                  _ptr->update_node_reply_timestamp(n);
+                  _ptr->maybe_update_node_reply_timestamp(n);
                   voter_reply->second.set_value(r);
               } catch (...) {
                   voter_reply->second.set_value(errc::vote_dispatch_error);


### PR DESCRIPTION
## Cover letter

Vote stms i.e. `prevote_stm` and `vote_stm` acquire and release consensus lock during operation. This may lead to the situation in which a node set have changed. We need to verify if a node is still a part of follower set before updating its reply timestamp.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
