### PR TITLE
rpc/transport: release caller units when timeout occurs

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -128,7 +128,8 @@ transport::send(netbuf b, rpc::client_opts opts) {
 }
 
 ss::future<result<std::unique_ptr<streaming_context>>>
-transport::make_response_handler(netbuf& b, const rpc::client_opts& opts) {
+transport::make_response_handler(
+  netbuf& b, const rpc::client_opts& opts, sequence_t seq) {
     if (_correlations.find(_correlation_idx + 1) != _correlations.end()) {
         _probe.client_correlation_error();
         vlog(
@@ -151,7 +152,14 @@ transport::make_response_handler(netbuf& b, const rpc::client_opts& opts) {
         throw std::logic_error(
           fmt::format("Tried to reuse correlation id: {}", idx));
     }
-    item_raw_ptr->with_timeout(opts.timeout, [this, idx] {
+    item_raw_ptr->with_timeout(opts.timeout, [this, idx, seq] {
+        /*
+         * remove pending entry from requests queue. If a timeout occurred
+         * before an entry was sent we can not keep the entry alive as it may
+         * contain caller semaphore units, the units must be released when we
+         * notify caller with the result.
+         */
+        _requests_queue.erase(seq);
         auto it = _correlations.find(idx);
         if (likely(it != _correlations.end())) {
             vlog(
@@ -180,7 +188,7 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
     return ss::with_gate(
       _dispatch_gate,
       [this, b = std::move(b), opts = std::move(opts), seq]() mutable {
-          auto f = make_response_handler(b, opts);
+          auto f = make_response_handler(b, opts, seq);
 
           // send
           auto sz = b.buffer().size_bytes();

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -100,7 +100,7 @@ private:
     void dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
-    make_response_handler(netbuf&, const rpc::client_opts&);
+    make_response_handler(netbuf&, const rpc::client_opts&, sequence_t);
 
     ssx::semaphore _memory;
     /**


### PR DESCRIPTION
## Cover letter

When request is completed with timeout we must release request related caller passed semaphore units. Otherwise the units may be held in the requests queue long enough to outlive the caller and cause use after free error when released.

Fixes: #6711
Fixes: #5261 




<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
