### PR TITLE
[v22.2.x] archival: Use archival_metadata_stm manifest

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -114,10 +114,10 @@ public:
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
-    ss::future<cloud_storage::download_result> download_manifest();
-
-    const cloud_storage::partition_manifest& get_remote_manifest() const;
-
+    ss::future<std::pair<
+      cloud_storage::partition_manifest,
+      cloud_storage::download_result>>
+    download_manifest();
     struct batch_result {
         size_t num_succeded;
         size_t num_failed;
@@ -204,6 +204,7 @@ private:
 
     bool upload_loop_can_continue() const;
     bool sync_manifest_loop_can_continue() const;
+    const cloud_storage::partition_manifest& manifest() const;
 
     ntp_level_probe _probe;
     model::ntp _ntp;
@@ -214,16 +215,13 @@ private:
     model::term_id _start_term;
     archival_policy _policy;
     s3::bucket_name _bucket;
-    /// Remote manifest contains representation of the data stored in S3 (it
-    /// gets uploaded to the remote location)
-    cloud_storage::partition_manifest _manifest;
     ss::gate _gate;
     ss::abort_source _as;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
     ss::lowres_clock::duration _cloud_storage_initial_backoff;
     ss::lowres_clock::duration _segment_upload_timeout;
-    ss::lowres_clock::duration _manifest_upload_timeout;
+    ss::lowres_clock::duration _metadata_sync_timeout;
     ssx::semaphore _mutex{1, "archive/ntp"};
     ss::lowres_clock::duration _upload_loop_initial_backoff;
     ss::lowres_clock::duration _upload_loop_max_backoff;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -229,64 +229,28 @@ ss::future<> scheduler_service_impl::add_ntp_archiver(
     ss::gate::holder gh(_gate);
 
     _archivers.emplace(archiver->get_ntp(), archiver);
-    auto result = co_await archiver->download_manifest();
-
     auto ntp = archiver->get_ntp();
     auto part = _partition_manager.local().get(ntp);
     if (!part) {
         co_return;
     }
-    switch (result) {
-    case cloud_storage::download_result::success:
-        vlog(_rtclog.info, "Found manifest for partition {}", ntp);
+    vlog(_rtclog.info, "Starting archiver for partition {}", ntp);
 
-        if (part->get_ntp_config().is_read_replica_mode_enabled()) {
-            archiver->run_sync_manifest_loop();
-        } else {
-            if (ntp.tp.partition == 0) {
-                // Upload manifest once per topic. GCS has strict
-                // limits for single object updates.
-                ssx::background = upload_topic_manifest(
-                  model::topic_namespace(ntp.ns, ntp.tp.topic),
-                  archiver->get_revision_id());
-            }
-            _probe.start_archiving_ntp();
-            archiver->run_upload_loop();
+    if (part->get_ntp_config().is_read_replica_mode_enabled()) {
+        archiver->run_sync_manifest_loop();
+    } else {
+        if (ntp.tp.partition == 0) {
+            // Upload manifest once per topic. GCS has strict
+            // limits for single object updates.
+            ssx::background = upload_topic_manifest(
+              model::topic_namespace(ntp.ns, ntp.tp.topic),
+              archiver->get_revision_id());
         }
-
-        co_return;
-    case cloud_storage::download_result::notfound:
-        if (part->get_ntp_config().is_read_replica_mode_enabled()) {
-            vlog(
-              _rtclog.info,
-              "Couldn't download manifest for partition {} in read replica",
-              ntp);
-            archiver->run_sync_manifest_loop();
-        } else {
-            vlog(_rtclog.info, "Start archiving new partition {}", ntp);
-            // Start topic manifest upload
-            // asynchronously
-            if (ntp.tp.partition == 0) {
-                // Upload manifest once per topic. GCS has strict
-                // limits for single object updates.
-                ssx::background = upload_topic_manifest(
-                  model::topic_namespace(ntp.ns, ntp.tp.topic),
-                  archiver->get_revision_id());
-            }
-            _probe.start_archiving_ntp();
-
-            archiver->run_upload_loop();
-        }
-
-        co_return;
-    case cloud_storage::download_result::failed:
-    case cloud_storage::download_result::timedout:
-        vlog(_rtclog.warn, "Manifest download failed");
-        _archivers.erase(archiver->get_ntp());
-        co_return co_await archiver->stop().finally([archiver]() {
-            return ss::make_exception_future<>(ss::timed_out_error());
-        });
+        _probe.start_archiving_ntp();
+        archiver->run_upload_loop();
     }
+
+    co_return;
 }
 
 ss::future<>
@@ -351,8 +315,13 @@ ss::future<> scheduler_service_impl::reconcile_archivers() {
     std::vector<model::ntp> to_create;
     // find new ntps that present in the snapshot only
     for (const auto& [ntp, p] : pm.partitions()) {
+        // archival_metadata_stm is only created for topics in kafka namespace
+        // if we ever uploaded some topics from kafka_internal by accident these
+        // topics won't have an STM and the snapshot so it's safe to limit
+        // creation of archivers by 'kafka' namespace for now.
+        // we will change this in the future when we will add DR
         if (
-          ntp.ns != model::redpanda_ns && !_archivers.contains(ntp)
+          ntp.ns == model::kafka_namespace && !_archivers.contains(ntp)
           && p->is_elected_leader()) {
             to_create.push_back(ntp);
         }

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -35,10 +35,6 @@ inline seastar::logger arch_svc_log("SVC-TEST");
 static const model::ns test_ns = model::ns("kafka");
 using namespace std::chrono_literals;
 
-static ss::future<> launch_remote(ss::sharded<cloud_storage::remote>& r) {
-    return r.invoke_on(0, [](auto& s) { return s.start(); });
-}
-
 FIXTURE_TEST(test_reconciliation_manifest_download, archiver_fixture) {
     wait_for_controller_leadership().get();
     auto topic1 = model::topic("topic_1");

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -32,7 +32,7 @@
 #include <type_traits>
 
 inline seastar::logger arch_svc_log("SVC-TEST");
-static const model::ns test_ns = model::ns("test-namespace");
+static const model::ns test_ns = model::ns("kafka");
 using namespace std::chrono_literals;
 
 static ss::future<> launch_remote(ss::sharded<cloud_storage::remote>& r) {
@@ -71,30 +71,16 @@ FIXTURE_TEST(test_reconciliation_manifest_download, archiver_fixture) {
       {.url = urls[1], .body = std::nullopt},
       {.url = urls[2], .body = std::nullopt},
     });
-
     add_topic_with_random_data(pid0, 20);
     add_topic_with_random_data(pid1, 20);
     wait_for_partition_leadership(pid0);
     wait_for_partition_leadership(pid1);
 
-    auto [arch_config, remote_config] = get_configurations();
-    auto& pm = app.partition_manager;
-    auto& topics = app.controller->get_topics_state();
-    ss::sharded<cloud_storage::remote> remote;
-    remote
-      .start_single(
-        remote_config.connection_limit,
-        remote_config.client_config,
-        remote_config.cloud_credentials_source)
-      .get();
-    launch_remote(remote).get();
-    archival::internal::scheduler_service_impl service(
-      arch_config, remote, pm, topics);
+    auto& service = get_scheduler_service();
+
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(pid0));
     BOOST_REQUIRE(service.contains(pid1));
-    service.stop().get();
-    remote.stop().get();
 }
 
 FIXTURE_TEST(test_reconciliation_drop_ntp, archiver_fixture) {
@@ -115,20 +101,7 @@ FIXTURE_TEST(test_reconciliation_drop_ntp, archiver_fixture) {
 
     wait_for_partition_leadership(ntp);
 
-    auto [arch_config, remote_config] = get_configurations();
-    auto& pm = app.partition_manager;
-    auto& topics = app.controller->get_topics_state();
-    ss::sharded<cloud_storage::remote> remote;
-    remote
-      .start_single(
-        remote_config.connection_limit,
-        remote_config.client_config,
-        remote_config.cloud_credentials_source)
-      .get();
-    launch_remote(remote).get();
-
-    archival::internal::scheduler_service_impl service(
-      arch_config, remote, pm, topics);
+    auto& service = get_scheduler_service();
 
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(ntp));
@@ -140,8 +113,6 @@ FIXTURE_TEST(test_reconciliation_drop_ntp, archiver_fixture) {
 
     service.reconcile_archivers().get();
     BOOST_REQUIRE(!service.contains(ntp));
-    service.stop().get();
-    remote.stop().get();
 }
 
 FIXTURE_TEST(test_segment_upload, archiver_fixture) {
@@ -153,7 +124,7 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
     model::revision_id partition_rev{get_next_partition_revision_id().get()};
 
     std::string manifest_ntp_path = fmt::format(
-      "test-namespace/topic_3/0_{}", partition_rev);
+      "kafka/topic_3/0_{}", partition_rev);
     uint32_t hash = xxhash_32(
                       manifest_ntp_path.data(), manifest_ntp_path.size())
                     & 0xf0000000;
@@ -184,26 +155,13 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
 
     wait_for_partition_leadership(ntp);
 
-    auto [arch_config, remote_config] = get_configurations();
-    auto& pm = app.partition_manager;
-    auto& topics = app.controller->get_topics_state();
-    ss::sharded<cloud_storage::remote> remote;
-    remote
-      .start_single(
-        remote_config.connection_limit,
-        remote_config.client_config,
-        remote_config.cloud_credentials_source)
-      .get();
-    launch_remote(remote).get();
-
-    archival::internal::scheduler_service_impl service(
-      arch_config, remote, pm, topics);
+    auto& service = get_scheduler_service();
 
     service.reconcile_archivers().get();
     BOOST_REQUIRE(service.contains(ntp));
 
-    // 2 partition manifests, 1 topic manifest, 2 segments
-    const size_t num_requests_expected = 5;
+    // 1 topic manifest, 1 partition manifest, 2 segments
+    const size_t num_requests_expected = 4;
     tests::cooperative_spin_wait_with_timeout(10s, [this] {
         return get_requests().size() == num_requests_expected;
     }).get();
@@ -213,15 +171,10 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
     auto manifest_req = get_targets().equal_range(manifest_path);
     BOOST_REQUIRE(manifest_req.first != manifest_req.second);
     std::exception_ptr ex;
-    for (auto it = manifest_req.first; it != manifest_req.second; it++) {
-        if (it->second._method == "PUT") {
-            BOOST_REQUIRE(it->second._method == "PUT");
-            verify_manifest_content(it->second.content);
-            manifest = load_manifest(it->second.content);
-        } else {
-            BOOST_REQUIRE(it->second._method == "GET");
-        }
-    }
+    auto it = manifest_req.first;
+    BOOST_REQUIRE(it->second._method == "PUT");
+    verify_manifest_content(it->second.content);
+    manifest = load_manifest(it->second.content);
 
     auto seg000_meta = manifest.get(seg000);
     BOOST_REQUIRE(seg000_meta);
@@ -240,6 +193,4 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
     auto put_seg100 = get_targets().find(seg100_url);
     BOOST_REQUIRE(put_seg100->second._method == "PUT");
     verify_segment(ntp, seg100, put_seg100->second.content);
-    service.stop().get();
-    remote.stop().get();
 }

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+#include "archival/types.h"
+#include "cloud_roles/types.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/controller.h"
 #include "cluster/members_table.h"
@@ -35,6 +37,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "redpanda/application.h"
 #include "resource_mgmt/cpu_scheduling.h"
+#include "s3/client.h"
 #include "storage/directories.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"
@@ -45,6 +48,7 @@
 
 #include <fmt/format.h>
 
+#include <chrono>
 #include <filesystem>
 
 class redpanda_thread_fixture {
@@ -61,7 +65,10 @@ public:
       std::vector<config::seed_server> seed_servers,
       ss::sstring base_dir,
       std::optional<scheduling_groups> sch_groups,
-      bool remove_on_shutdown)
+      bool remove_on_shutdown,
+      std::optional<s3::configuration> s3_config = std::nullopt,
+      std::optional<archival::configuration> archival_cfg = std::nullopt,
+      std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt)
       : app(ssx::sformat("redpanda-{}", node_id()))
       , proxy_port(proxy_port)
       , schema_reg_port(schema_reg_port)
@@ -73,7 +80,10 @@ public:
           kafka_port,
           rpc_port,
           coproc_supervisor_port,
-          std::move(seed_servers));
+          std::move(seed_servers),
+          std::move(s3_config),
+          std::move(archival_cfg),
+          std::move(cloud_cfg));
         app.initialize(
           proxy_config(proxy_port),
           proxy_client_config(kafka_port),
@@ -136,6 +146,25 @@ public:
         std::nullopt,
         true) {}
 
+    struct init_cloud_storage_tag {};
+
+    // Start redpanda with shadow indexing enabled
+    explicit redpanda_thread_fixture(init_cloud_storage_tag)
+      : redpanda_thread_fixture(
+        model::node_id(1),
+        9092,
+        33145,
+        8082,
+        8081,
+        43189,
+        {},
+        ssx::sformat("test.dir_{}", time(0)),
+        std::nullopt,
+        true,
+        get_s3_config(),
+        get_archival_config(),
+        get_cloud_config()) {}
+
     ~redpanda_thread_fixture() {
         shutdown();
         if (remove_on_shutdown) {
@@ -152,19 +181,59 @@ public:
 
     config::configuration& lconf() { return config::shard_local_cfg(); }
 
+    static s3::configuration get_s3_config() {
+        net::unresolved_address server_addr("127.0.0.1", 4430);
+        s3::configuration s3conf{
+          .uri = s3::access_point_uri("127.0.0.1"),
+          .access_key = cloud_roles::public_key_str("acess-key"),
+          .secret_key = cloud_roles::private_key_str("secret-key"),
+          .region = cloud_roles::aws_region_name("us-east-1"),
+        };
+        s3conf.server_addr = server_addr;
+        return s3conf;
+    }
+
+    static archival::configuration get_archival_config() {
+        archival::configuration aconf;
+        aconf.bucket_name = s3::bucket_name("test-bucket");
+        aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
+        aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
+        aconf.cloud_storage_initial_backoff = 100ms;
+        aconf.segment_upload_timeout = 1s;
+        aconf.manifest_upload_timeout = 1s;
+        aconf.time_limit = std::nullopt;
+        return aconf;
+    }
+
+    static cloud_storage::configuration get_cloud_config() {
+        auto s3conf = get_s3_config();
+        cloud_storage::configuration cconf;
+        cconf.client_config = s3conf;
+        cconf.bucket_name = s3::bucket_name("test-bucket");
+        cconf.connection_limit = archival::s3_connection_limit(4);
+        cconf.metrics_disabled = cloud_storage::remote_metrics_disabled::yes;
+        return cconf;
+    }
+
     void configure(
       model::node_id node_id,
       int32_t kafka_port,
       int32_t rpc_port,
       int32_t coproc_supervisor_port,
-      std::vector<config::seed_server> seed_servers) {
+      std::vector<config::seed_server> seed_servers,
+      std::optional<s3::configuration> s3_config = std::nullopt,
+      std::optional<archival::configuration> archival_cfg = std::nullopt,
+      std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt) {
         auto base_path = std::filesystem::path(data_dir);
         ss::smp::invoke_on_all([node_id,
                                 kafka_port,
                                 rpc_port,
                                 coproc_supervisor_port,
                                 seed_servers = std::move(seed_servers),
-                                base_path]() mutable {
+                                base_path,
+                                s3_config,
+                                archival_cfg,
+                                cloud_cfg]() mutable {
             auto& config = config::shard_local_cfg();
 
             config.get("enable_pid_file").set_value(false);
@@ -193,6 +262,48 @@ public:
             node_config.get("coproc_supervisor_server")
               .set_value(
                 net::unresolved_address("127.0.0.1", coproc_supervisor_port));
+            if (s3_config) {
+                config.get("cloud_storage_enabled").set_value(true);
+                config.get("cloud_storage_region")
+                  .set_value(std::make_optional(s3_config->region()));
+                config.get("cloud_storage_access_key")
+                  .set_value(std::make_optional((*s3_config->access_key)()));
+                config.get("cloud_storage_secret_key")
+                  .set_value(std::make_optional((*s3_config->secret_key)()));
+                config.get("cloud_storage_api_endpoint")
+                  .set_value(std::make_optional(s3_config->server_addr.host()));
+                config.get("cloud_storage_api_endpoint_port")
+                  .set_value(
+                    static_cast<int16_t>(s3_config->server_addr.port()));
+            }
+            if (archival_cfg) {
+                config.get("cloud_storage_disable_tls").set_value(true);
+                config.get("cloud_storage_bucket")
+                  .set_value(std::make_optional(archival_cfg->bucket_name()));
+                config.get("cloud_storage_initial_backoff_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->cloud_storage_initial_backoff));
+                config.get("cloud_storage_reconciliation_interval_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->reconciliation_interval));
+                config.get("cloud_storage_manifest_upload_timeout_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->manifest_upload_timeout));
+                config.get("cloud_storage_segment_upload_timeout_ms")
+                  .set_value(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                      archival_cfg->segment_upload_timeout));
+            }
+            if (cloud_cfg) {
+                config.get("cloud_storage_enable_remote_read").set_value(true);
+                config.get("cloud_storage_enable_remote_write").set_value(true);
+                config.get("cloud_storage_max_connections")
+                  .set_value(
+                    static_cast<int16_t>(cloud_cfg->connection_limit()));
+            }
         }).get0();
     }
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6558.
