### PR TITLE
bk: delete CI `pre-exit` hook

### DIFF
--- a/.buildkite/hooks/README.md
+++ b/.buildkite/hooks/README.md
@@ -1,0 +1,7 @@
+Hooks in this folder are expected to come from the vtools repo at the 
+time the CI pipeline runs, as these are repository-level hooks. The 
+ones that cannot be shared and need to be copy-pasted (from the vtools 
+repo into this folder) are the `post-checkout` and `pre-command` 
+hooks. See [here][bk-hooks] for more on how hooks work.
+
+[bk-hooks]: https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,4 +1,0 @@
-#!/bin/bash
-if [[ $ENABLE_STEP_CDT == '1' && -x bin/task ]]; then
-  bin/task ci:cdt-cleanup
-fi


### PR DESCRIPTION
this is already contained in vtools. This PR also adds a README to explain how hooks are organized/share between the two repos.

## Backport Required

- [x] not a bug fix

## Release notes

* none
