### PR TITLE
Seeds Driven Cluster Bootstrap

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -122,6 +122,7 @@ v_cc_library(
     node_status_backend.cc
     node_status_rpc_handler.cc
     bootstrap_service.cc
+    bootstrap_backend.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/bootstrap_backend.h"
+
+#include "cluster/cluster_uuid.h"
+#include "cluster/commands.h"
+#include "cluster/logger.h"
+#include "cluster/types.h"
+
+namespace cluster {
+
+bootstrap_backend::bootstrap_backend(ss::sharded<storage::api>& storage)
+  : _storage(storage) {}
+
+ss::future<std::error_code>
+bootstrap_backend::apply_update(model::record_batch b) {
+    vlog(clusterlog.info, "Applying update to bootstrap_manager");
+
+    // handle node managements command
+    static constexpr auto accepted_commands
+      = make_commands_list<bootstrap_cluster_cmd>();
+    auto cmd = co_await cluster::deserialize(std::move(b), accepted_commands);
+
+    co_return co_await ss::visit(
+      cmd, [this](bootstrap_cluster_cmd cmd) -> ss::future<std::error_code> {
+          if (_storage.local().get_cluster_uuid().has_value()) {
+              vlog(
+                clusterlog.debug,
+                "Skipping bootstrap_cluster_cmd {}, current cluster_uuid: {}",
+                cmd.value.uuid,
+                *_storage.local().get_cluster_uuid());
+              co_return errc::cluster_already_exists;
+          }
+
+          co_await _storage.invoke_on_all(
+            [&new_cluster_uuid = cmd.value.uuid](storage::api& storage) {
+                storage.set_cluster_uuid(new_cluster_uuid);
+                return ss::make_ready_future();
+            });
+          co_await _storage.local().kvs().put(
+            cluster_uuid_key_space,
+            cluster_uuid_key,
+            serde::to_iobuf(cmd.value.uuid));
+
+          vlog(clusterlog.info, "Cluster created {}", cmd.value.uuid);
+          co_return errc::success;
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "storage/api.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <optional>
+
+namespace security {
+class credential_store;
+}
+
+namespace cluster {
+
+/**
+ * This class applies the cluster intitalization message to
+ * - itself, storing the cluster UUID value, also duplicating it to the kvstore
+ * - credintial_store, to initialize the bootstrap user
+ * - TODO: apply the initial licence
+ */
+class bootstrap_backend final {
+public:
+    bootstrap_backend(ss::sharded<storage::api>&);
+
+    ss::future<std::error_code> apply_update(model::record_batch);
+
+    bool is_batch_applicable(const model::record_batch& b) {
+        return b.header().type
+               == model::record_batch_type::cluster_bootstrap_cmd;
+    }
+
+private:
+    ss::sharded<storage::api>& _storage;
+};
+
+} // namespace cluster

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -36,7 +36,8 @@ namespace cluster {
  */
 class bootstrap_backend final {
 public:
-    bootstrap_backend(ss::sharded<storage::api>&);
+    bootstrap_backend(
+      ss::sharded<security::credential_store>&, ss::sharded<storage::api>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -46,6 +47,7 @@ public:
     }
 
 private:
+    ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
 };
 

--- a/src/v/cluster/bootstrap_service.cc
+++ b/src/v/cluster/bootstrap_service.cc
@@ -10,6 +10,11 @@
 #include "cluster/bootstrap_service.h"
 
 #include "cluster/bootstrap_types.h"
+#include "cluster/cluster_utils.h"
+#include "cluster/logger.h"
+#include "config/node_config.h"
+#include "features/feature_table.h"
+#include "storage/api.h"
 
 namespace cluster {
 
@@ -17,7 +22,20 @@ ss::future<cluster_bootstrap_info_reply>
 bootstrap_service::cluster_bootstrap_info(
   cluster_bootstrap_info_request&&, rpc::streaming_context&) {
     cluster_bootstrap_info_reply r{};
-    // TODO: add fields!
+    r.broker = make_self_broker(config::node());
+    r.version = features::feature_table::get_latest_logical_version();
+    const std::vector<config::seed_server>& seed_servers
+      = config::node().seed_servers();
+    r.seed_servers.reserve(seed_servers.size());
+    std::transform(
+      seed_servers.cbegin(),
+      seed_servers.cend(),
+      std::back_inserter(r.seed_servers),
+      [](const config::seed_server& seed_server) { return seed_server.addr; });
+    r.empty_seed_starts_cluster = config::node().empty_seed_starts_cluster();
+    r.cluster_uuid = _storage.local().get_cluster_uuid();
+
+    vlog(clusterlog.debug, "Replying cluster_bootstrap_info: {}", r);
     co_return r;
 }
 

--- a/src/v/cluster/bootstrap_service.h
+++ b/src/v/cluster/bootstrap_service.h
@@ -10,20 +10,28 @@
 
 #include "cluster/bootstrap_types.h"
 #include "cluster/cluster_bootstrap_service.h"
+#include "storage/fwd.h"
 
 #include <seastar/core/sharded.hh>
 
 namespace cluster {
 
-// RPC service to be used when initialially bootstrapping a cluster.
-// TODO: talk about how it's a slim service with few dependencies.
+// RPC service used to determine cluster info when bootstrapping a cluster
+// or to discover the existence of an existing cluster.
 class bootstrap_service : public cluster_bootstrap_service {
 public:
-    bootstrap_service(ss::scheduling_group sg, ss::smp_service_group ssg)
-      : cluster_bootstrap_service(sg, ssg) {}
+    bootstrap_service(
+      ss::scheduling_group sg,
+      ss::smp_service_group ssg,
+      ss::sharded<storage::api>& storage)
+      : cluster_bootstrap_service(sg, ssg)
+      , _storage(storage) {}
 
     ss::future<cluster_bootstrap_info_reply> cluster_bootstrap_info(
       cluster_bootstrap_info_request&&, rpc::streaming_context&) override;
+
+private:
+    ss::sharded<storage::api>& _storage;
 };
 
 } // namespace cluster

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "cluster/types.h"
 #include "model/fundamental.h"
 #include "serde/serde.h"
 
@@ -34,11 +35,32 @@ struct cluster_bootstrap_info_reply
   : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>> {
     using rpc_adl_exempt = std::true_type;
 
-    auto serde_fields() { return std::tie(); }
+    model::broker broker;
+    cluster_version version;
+    std::vector<net::unresolved_address> seed_servers;
+    bool empty_seed_starts_cluster;
+    std::optional<model::cluster_uuid> cluster_uuid;
+
+    auto serde_fields() {
+        return std::tie(
+          broker,
+          version,
+          seed_servers,
+          empty_seed_starts_cluster,
+          cluster_uuid);
+    }
 
     friend std::ostream&
-    operator<<(std::ostream& o, const cluster_bootstrap_info_reply&) {
-        fmt::print(o, "{{}}");
+    operator<<(std::ostream& o, const cluster_bootstrap_info_reply& v) {
+        fmt::print(
+          o,
+          "{{broker: {}, version: {}, seed_servers: {}, ESCB: {}, "
+          "cluster_UUID: {}}}",
+          v.broker,
+          v.version,
+          v.seed_servers,
+          v.empty_seed_starts_cluster,
+          v.cluster_uuid);
         return o;
     }
 };

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -34,8 +34,6 @@ struct cluster_bootstrap_info_reply
   : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>> {
     using rpc_adl_exempt = std::true_type;
 
-    // TODO: add fields!
-
     auto serde_fields() { return std::tie(); }
 
     friend std::ostream&

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -88,7 +88,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
     for (const auto& s : seed_servers) {
         vlog(
           clusterlog.info,
-          "Requesting node ID for UUID {} from {}",
+          "Requesting node ID for node UUID {} from {}",
           _node_uuid,
           s.addr);
         result<join_node_reply> r(join_node_reply{});
@@ -110,7 +110,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
         } catch (...) {
             vlog(
               clusterlog.debug,
-              "Error registering UUID {}, retrying: {}",
+              "Error registering node UUID {}, retrying: {}",
               _node_uuid,
               std::current_exception());
             continue;
@@ -126,7 +126,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
         if (!r.has_value() || !r.value().success) {
             vlog(
               clusterlog.debug,
-              "Error registering UUID {}, retrying",
+              "Error registering node UUID {}, retrying",
               _node_uuid);
             continue;
         }

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -80,29 +80,21 @@ public:
     // assignment of node IDs for the seeds.
     ss::future<model::node_id> determine_node_id();
 
-    // If configured as the root, return this broker as the sole initial Raft0
-    // broker.
-    //
-    // TODO: implement the below behavior.
-    //
     // Returns brokers to be used to form a Raft group for a new cluster.
     //
-    // If this node is a seed server, returns all seed servers, assuming seeds
-    // are configured with identical seed servers.
-    //
-    // If this node is not a seed server returns an empty list.
-    std::vector<model::broker> initial_raft0_brokers() const;
+    // If this node is a cluster founder, returns all seed servers, assuming
+    // all founders are configured with identical seed servers list.
+    // If this node is not a cluster founder, returns an empty list.
+    // In case of Emtpy Seed Cluster Bootstrap, that reflects to a list of the
+    // root broker in root if cluster is not there yet, and empty otherwise.
+    std::vector<model::broker> initial_seed_brokers() const;
 
 private:
-    // Returns whether this node is the root node.
-    //
-    // TODO: implement the below behavior.
-    //
-    // Returns true if the local node is a founding member of the cluster, as
-    // indicated by either us having an empty seed server (we are the root node
-    // in a legacy config) or our node UUID matching one of those returned by
-    // the seed servers.
-    bool is_cluster_founder() const;
+    // Returns index-based node_id if the local node is a founding member
+    // of the cluster, as indicated by either us having an empty seed server
+    // (we are the root node in a legacy config), or our node IP listed
+    // as one of the seed servers.
+    static std::optional<model::node_id> get_cluster_founder_node_id();
 
     // Sends requests to each seed server to register the local node UUID until
     // one succeeds. Upon success, sets `node_id` to the assigned node ID and

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -198,7 +198,7 @@ model::broker make_self_broker(const config::node_config& node_cfg) {
     // operation of a broker, and instead should be used to indicate a broker
     // that needs to be assigned a node ID when it first starts up.
     model::node_id node_id = node_cfg.node_id() == std::nullopt
-                               ? model::node_id(-1)
+                               ? model::unassigned_node_id
                                : *node_cfg.node_id();
     return model::broker(
       node_id,

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -244,7 +244,8 @@ ss::future<std::error_code> replicate_and_wait(
           }
           vassert(
             use_serde_serialization,
-            "Requested to ADL serialize a serde-only type");
+            "serde_raft_0 feature not enabled while serializing a serde-only "
+            "controller command");
           auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
           return stm.replicate_and_wait(
             std::move(b), timeout, as.local(), term);

--- a/src/v/cluster/cluster_uuid.h
+++ b/src/v/cluster/cluster_uuid.h
@@ -14,6 +14,8 @@
 #include "bytes/bytes.h"
 #include "storage/kvstore.h"
 
+#include <seastar/core/sharded.hh>
+
 namespace cluster {
 
 constexpr const char* cluster_uuid_key = "cluster_uuid";

--- a/src/v/cluster/cluster_uuid.h
+++ b/src/v/cluster/cluster_uuid.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/bytes.h"
+#include "storage/kvstore.h"
+
+namespace cluster {
+
+constexpr const char* cluster_uuid_key = "cluster_uuid";
+constexpr storage::kvstore::key_space cluster_uuid_key_space
+  = storage::kvstore::key_space::controller;
+
+} // namespace cluster

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -117,6 +117,9 @@ static constexpr int8_t cluster_config_status_cmd_type = 1;
 static constexpr int8_t feature_update_cmd_type = 0;
 static constexpr int8_t feature_update_license_update_cmd_type = 1;
 
+// cluster bootstrap commands
+static constexpr int8_t bootstrap_cluster_cmd_type = 0;
+
 using create_topic_cmd = controller_command<
   model::topic_namespace,
   topic_configuration_assignment,
@@ -281,6 +284,13 @@ using feature_update_license_update_cmd = controller_command<
   feature_update_license_update_cmd_type,
   model::record_batch_type::feature_update,
   serde_opts::serde_only>;
+
+// Cluster bootstrap
+using bootstrap_cluster_cmd = controller_command<
+  int8_t, // unused, always 0
+  bootstrap_cluster_cmd_data,
+  bootstrap_cluster_cmd_type,
+  model::record_batch_type::cluster_bootstrap_cmd>;
 
 // typelist utils
 template<typename T>

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -102,6 +102,7 @@ ss::future<> controller::wire_up() {
 
 ss::future<>
 controller::start(std::vector<model::broker> initial_raft0_brokers) {
+    const bool local_node_is_seed_server = !initial_raft0_brokers.empty();
     return create_raft0(
              _partition_manager,
              _shard_table,
@@ -266,7 +267,9 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
               return stm.wait(stm.bootstrap_last_applied(), model::no_timeout);
           });
       })
-      .then([this] { return cluster_creation_hook(); })
+      .then([this, local_node_is_seed_server] {
+          return cluster_creation_hook(local_node_is_seed_server);
+      })
       .then(
         [this] { return _backend.invoke_on_all(&controller_backend::start); })
       .then([this] {
@@ -451,39 +454,113 @@ ss::future<> controller::stop() {
     });
 }
 
+ss::future<> controller::create_cluster() {
+    vassert(
+      ss::this_shard_id() == controller_stm_shard,
+      "Cluster can only be created from controller_stm_shard");
+    bootstrap_cluster_cmd_data cmd_data;
+    cmd_data.uuid = model::cluster_uuid(uuid_t::create());
+    vlog(clusterlog.info, "Creating cluster {}", cmd_data.uuid);
+
+    for (simple_time_jitter<model::timeout_clock> retry_jitter(1s);;) {
+        model::record_batch b = serde_serialize_cmd(
+          bootstrap_cluster_cmd{0, cmd_data});
+        // cluster::replicate_and_wait() cannot be used here because it checks
+        // for serde_raft_0 feature to be enabled. Before a cluster is here,
+        // no feature is active, however the bootstrap_cluster_cmd is serde-only
+        const std::error_code errc = co_await _stm.local().replicate_and_wait(
+          std::move(b),
+          model::timeout_clock::now() + 30s,
+          _as.local(),
+          std::nullopt);
+        if (errc == errc::success) {
+            co_return;
+        }
+        vlog(
+          clusterlog.warn,
+          "Failed to replicate and wait the cluster bootstrap cmd, {}",
+          errc);
+        if (errc == errc::cluster_already_exists) {
+            co_return;
+        }
+
+        co_await ss::sleep_abortable(retry_jitter.next_duration(), _as.local());
+        vlog(clusterlog.trace, "Retrying to create cluster {}", cmd_data.uuid);
+    }
+}
+
 /**
  * This function provides for writing the controller log immediately
  * after it has been created, before anything else has been written
  * to it, and before we have started communicating with peers.
  */
-ss::future<> controller::cluster_creation_hook() {
-    if (!config::node().seed_servers().empty()) {
-        // We are not on the root node
-        co_return;
-    } else if (
-      _raft0->last_visible_index() > model::offset{}
-      || _raft0->config().brokers().size() > 1) {
-        // The controller log has already been written to
+ss::future<>
+controller::cluster_creation_hook(const bool local_node_is_seed_server) {
+    if (_storage.local().get_cluster_uuid()) {
+        // Cluster already exists
         co_return;
     }
 
-    // Internal RPC does not start until after controller startup
-    // is complete (we are called during controller startup), so
-    // it is guaranteed that if we were single node/empty controller
-    // log at start of this function, we will still be in that state
-    // here.  The wait for leadership is really just a wait for the
-    // consensus object to finish writing its last_voted_for from
-    // its self-vote.
-    while (!_raft0->is_leader()) {
+    if (!local_node_is_seed_server) {
+        // We are not on a seed server / root node
+        co_return;
+    }
+
+    if (config::node().empty_seed_starts_cluster()) {
+        // This is the legacy empty-seed-starts-cluster mode
+        vassert(
+          config::node().seed_servers().empty(), "We are not on the root node");
+
+        if (
+          _raft0->last_visible_index() > model::offset{}
+          || _raft0->config().brokers().size() > 1) {
+            // The controller log has already been written to
+            co_return;
+        }
+
+        // Internal RPC does not start until after controller startup
+        // is complete (we are called during controller startup), so
+        // it is guaranteed that if we were single node/empty controller
+        // log at start of this function, we will still be in that state
+        // here.  The wait for leadership is really just a wait for the
+        // consensus object to finish writing its last_voted_for from
+        // its self-vote.
+        while (!_raft0->is_leader()) {
+            co_await ss::sleep(100ms);
+        }
+
+        auto err
+          = co_await _security_frontend.local().maybe_create_bootstrap_user();
+        vassert(
+          err == errc::success,
+          "Controller write should always succeed in single replica state "
+          "during creation");
+
+        co_return co_await create_cluster();
+    }
+
+    // The new cluster creation is done by the leader of raft0 consisting of
+    // seed servers, once elected
+    while (!_storage.local().get_cluster_uuid() && !_raft0->is_leader()) {
         co_await ss::sleep(100ms);
     }
 
-    auto err
-      = co_await _security_frontend.local().maybe_create_bootstrap_user();
-    vassert(
-      err == errc::success,
-      "Controller write should always succeed in single replica state during "
-      "creation");
+    if (_storage.local().get_cluster_uuid()) {
+        vlog(
+          clusterlog.info,
+          "Cluster is {}",
+          *_storage.local().get_cluster_uuid());
+        co_return;
+    }
+
+    if (
+      _raft0->last_visible_index() > model::offset{}
+      || _raft0->config().brokers().size() > 1) {
+        // The controller log has already been written to
+        // TODO: create_cluster() but use the metrics' cluster_id
+    }
+
+    co_return co_await create_cluster();
 }
 
 /**

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/controller.h"
 
+#include "cluster/bootstrap_backend.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller_api.h"
@@ -129,6 +130,8 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
       .then([this] {
           return _feature_backend.start_single(std::ref(_feature_table));
       })
+      .then(
+        [this] { return _bootstrap_backend.start_single(std::ref(_storage)); })
       .then([this] {
           return _config_frontend.start(
             std::ref(_stm),
@@ -182,7 +185,8 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
             std::ref(_members_manager),
             std::ref(_data_policy_manager),
             std::ref(_config_manager),
-            std::ref(_feature_backend));
+            std::ref(_feature_backend),
+            std::ref(_bootstrap_backend));
       })
       .then([this] {
           return _members_frontend.start(
@@ -433,6 +437,7 @@ ss::future<> controller::stop() {
           .then([this] { return _config_frontend.stop(); })
           .then([this] { return _feature_backend.stop(); })
           .then([this] { return _stm.stop(); })
+          .then([this] { return _bootstrap_backend.stop(); })
           .then([this] { return _authorizer.stop(); })
           .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -103,6 +103,14 @@ ss::future<> controller::wire_up() {
 ss::future<>
 controller::start(std::vector<model::broker> initial_raft0_brokers) {
     const bool local_node_is_seed_server = !initial_raft0_brokers.empty();
+    std::vector<model::node_id> seed_nodes;
+    seed_nodes.reserve(initial_raft0_brokers.size());
+    std::transform(
+      initial_raft0_brokers.cbegin(),
+      initial_raft0_brokers.cend(),
+      std::back_inserter(seed_nodes),
+      [](const model::broker& b) { return b.id(); });
+
     return create_raft0(
              _partition_manager,
              _shard_table,
@@ -359,9 +367,11 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
       .then([this] {
           return _hm_frontend.invoke_on_all(&health_monitor_frontend::start);
       })
-      .then([this] {
+      .then([this, seed_nodes = std::move(seed_nodes)]() mutable {
           return _feature_manager.invoke_on(
-            feature_manager::backend_shard, &feature_manager::start);
+            feature_manager::backend_shard,
+            &feature_manager::start,
+            std::move(seed_nodes));
       })
       .then([this] {
           return _metrics_reporter.start_single(

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -118,7 +118,13 @@ public:
 
     ss::future<> wire_up();
 
-    ss::future<> start(std::vector<model::broker>);
+    /**
+     * Create raft0, and start the services that the \c controller owns.
+     * \param initial_raft0_brokers Brokers to start raft0 with. Empty for
+     *      non-seeds.
+     */
+    ss::future<> start(std::vector<model::broker> initial_raft0_brokers);
+
     // prevents controller from accepting new requests
     ss::future<> shutdown_input();
     ss::future<> stop();

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -132,7 +132,14 @@ public:
 private:
     friend controller_probe;
 
-    ss::future<> cluster_creation_hook();
+    /**
+     * Create a \c bootstrap_cluster_cmd, replicate-and-wait it to the current
+     * quorum, retry infinitely if replicate-and-wait fails.
+     */
+    ss::future<> create_cluster();
+
+    ss::future<> cluster_creation_hook(bool local_node_is_seed_server);
+
     config_manager::preload_result _config_preload;
 
     ss::sharded<ss::abort_source> _as;                     // instance per core

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -177,6 +177,7 @@ private:
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     controller_probe _probe;
+    ss::sharded<bootstrap_backend> _bootstrap_backend; // single instance
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/bootstrap_backend.h"
 #include "cluster/config_manager.h"
 #include "cluster/controller_log_limiter.h"
 #include "cluster/data_policy_manager.h"
@@ -33,7 +34,8 @@ class controller_stm final
       members_manager,
       data_policy_manager,
       config_manager,
-      feature_backend> {
+      feature_backend,
+      bootstrap_backend> {
 public:
     template<typename... Args>
     controller_stm(limiter_configuration limiter_conf, Args&&... stm_args)

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -63,7 +63,8 @@ enum class errc : int16_t {
     no_update_in_progress,
     unknown_update_interruption_error,
     invalid_retention_configuration,
-    throttling_quota_exceeded
+    throttling_quota_exceeded,
+    cluster_already_exists,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -184,6 +185,9 @@ struct errc_category final : public std::error_category {
                    "retention.local.target.ms respectively";
         case errc::throttling_quota_exceeded:
             return "Request declined due to exceeded requests quotas";
+        case errc::cluster_already_exists:
+            return "Node is a part of a cluster already, new cluster is not "
+                   "created";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -66,7 +66,13 @@ public:
       ss::sharded<rpc::connection_cache>& connection_cache,
       raft::group_id raft0_group);
 
-    ss::future<> start();
+    /**
+     * \param cluster_founder_nodes When a new cluster is about to bootstrap,
+     *    this should list all cluster founder nodes. It is assumed that all
+     *    cluster founder nodes are verified to have the same logical version
+     *    as the local node. In all other cases this list will be empty.
+     */
+    ss::future<> start(std::vector<model::node_id>&& cluster_founder_nodes);
     ss::future<> stop();
 
     ss::future<std::error_code> write_action(cluster::feature_update_action);
@@ -93,6 +99,13 @@ public:
 
 private:
     void update_node_version(model::node_id, cluster_version v);
+
+    /**
+     * When cluster discovery has verified seed server latest versions are
+     * the same as local latest version, this function is used to initialize
+     * seed servers versions in feature manager.
+     */
+    void set_node_to_latest_version(model::node_id);
 
     ss::future<> do_maybe_update_active_version();
     ss::future<> maybe_update_active_version();

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -477,7 +477,7 @@ void members_manager::join_raft0() {
 bool members_manager::try_register_node_id(
   const model::node_id& requested_node_id,
   const model::node_uuid& requested_node_uuid) {
-    vassert(requested_node_id != model::node_id(-1), "invalid node ID");
+    vassert(requested_node_id != model::unassigned_node_id, "invalid node ID");
     vlog(
       clusterlog.info,
       "Registering node ID {} as node UUID {}",
@@ -730,7 +730,8 @@ members_manager::handle_join_request(join_node_request const req) {
         } else {
             // Validate that the node ID matches the one in our table.
             if (*req_node_id != it->second) {
-                co_return ret_t(join_node_reply{false, model::node_id(-1)});
+                co_return ret_t(
+                  join_node_reply{false, model::unassigned_node_id});
             }
         }
         // Proceed to adding the node ID to the controller Raft group.
@@ -755,7 +756,7 @@ members_manager::handle_join_request(join_node_request const req) {
               if (r) {
                   auto success = r.value().success;
                   return ret_t(join_node_reply{
-                    success, success ? node_id : model::node_id{-1}});
+                    success, success ? node_id : model::unassigned_node_id});
               }
               return ret_t(r.error());
           });
@@ -772,7 +773,7 @@ members_manager::handle_join_request(join_node_request const req) {
           "node",
           req.node.id(),
           req.node.rpc_address());
-        co_return ret_t(join_node_reply{false, model::node_id(-1)});
+        co_return ret_t(join_node_reply{false, model::unassigned_node_id});
     }
 
     if (req.node.id() != _self.id()) {

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -26,10 +26,13 @@ static ss::future<consensus_ptr> create_raft0(
   ss::sharded<shard_table>& st,
   const ss::sstring& data_directory,
   std::vector<model::broker> initial_brokers) {
-    // root, otherwise it will use one of the seed servers to join the
-    // cluster
-    if (!initial_brokers.empty()) {
+    // non-empty initial_brokers mean root (in root-driven bootstrap) or seed
+    // (in seeds-driven bootstrap), otherwise it will use one of the seed
+    // servers to join the cluster
+    if (initial_brokers.size() == 1) {
         vlog(clusterlog.info, "Current node is cluster root");
+    } else if (!initial_brokers.empty()) {
+        vlog(clusterlog.info, "Current node is a cluster seed broker");
     }
 
     return pm.local()

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -309,22 +309,14 @@ security_frontend::dispatch_delete_acls_to_leader(
       });
 }
 
-/**
- * For use during cluster creation, if RP_BOOTSTRAP_USER is set
- * then write a user creation message to the controller log.
- *
- * @returns an error code if controller log write failed.  If the
- *          environment variable is missing or malformed this is
- *          not considered an error.
- *
- */
-ss::future<std::error_code> security_frontend::maybe_create_bootstrap_user() {
-    static const ss::sstring bootstrap_user_env_key{"RP_BOOTSTRAP_USER"};
+static const ss::sstring bootstrap_user_env_key{"RP_BOOTSTRAP_USER"};
 
+/*static*/ std::optional<user_and_credential>
+security_frontend::get_bootstrap_user_creds_from_env() {
     auto creds_str_ptr = std::getenv(bootstrap_user_env_key.c_str());
     if (creds_str_ptr == nullptr) {
         // Environment variable is not set
-        co_return errc::success;
+        return {};
     }
 
     ss::sstring creds_str = creds_str_ptr;
@@ -336,32 +328,15 @@ ss::future<std::error_code> security_frontend::maybe_create_bootstrap_user() {
           clusterlog.warn,
           "Invalid value of {} (expected \"username:password\")",
           bootstrap_user_env_key);
-        co_return errc::success;
+        return {};
     }
 
     auto username = security::credential_user{creds_str.substr(0, colon)};
     auto password = creds_str.substr(colon + 1);
     auto credentials = security::scram_sha256::make_credentials(
       password, security::scram_sha256::min_iterations);
-
-    auto err = co_await create_user(
-      username, credentials, model::timeout_clock::now() + 5s);
-
-    if (err) {
-        vlog(
-          clusterlog.warn,
-          "Failed to apply {}: {}",
-          bootstrap_user_env_key,
-          err.message());
-    } else {
-        vlog(
-          clusterlog.info,
-          "Created user '{}' via {}",
-          username,
-          bootstrap_user_env_key);
-    }
-
-    co_return err;
+    return std::optional<user_and_credential>(
+      std::in_place, std::move(username), std::move(credentials));
 }
 
 } // namespace cluster

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -54,7 +54,15 @@ public:
       std::vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
-    ss::future<std::error_code> maybe_create_bootstrap_user();
+    /**
+     * For use during cluster creation, if RP_BOOTSTRAP_USER is set
+     * then returns the user creds specified in it
+     *
+     * @returns empty value if RP_BOOTSTRAP_USER is not set or user creds
+     *          cannot be parsed
+     */
+    static std::optional<user_and_credential>
+    get_bootstrap_user_creds_from_env();
 
 private:
     ss::future<std::vector<errc>> do_create_acls(

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -42,8 +42,9 @@ public:
     }
 
 private:
-    template<typename Cmd, typename T>
-    ss::future<std::error_code> dispatch_updates_to_cores(Cmd, ss::sharded<T>&);
+    template<typename Cmd, typename Service>
+    ss::future<std::error_code>
+    dispatch_updates_to_cores(Cmd, ss::sharded<Service>&);
 
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<security::authorizer>& _authorizer;

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -73,7 +73,9 @@ public:
       int16_t schema_reg_port,
       int16_t coproc_supervisor_port,
       std::vector<config::seed_server> seeds,
-      configure_node_id use_node_id = configure_node_id::yes) {
+      configure_node_id use_node_id = configure_node_id::yes,
+      empty_seed_starts_cluster empty_seed_starts_cluster_val
+      = empty_seed_starts_cluster::yes) {
         _instances.emplace(
           node_id,
           std::make_unique<redpanda_thread_fixture>(
@@ -90,7 +92,8 @@ public:
             std::nullopt,
             std::nullopt,
             std::nullopt,
-            use_node_id));
+            use_node_id,
+            empty_seed_starts_cluster_val));
     }
 
     application* get_node_application(model::node_id id) {
@@ -117,9 +120,11 @@ public:
       int proxy_port_base = 8082,
       int schema_reg_port_base = 8081,
       int coproc_supervisor_port_base = 43189,
-      configure_node_id use_node_id = configure_node_id::yes) {
+      configure_node_id use_node_id = configure_node_id::yes,
+      empty_seed_starts_cluster empty_seed_starts_cluster_val
+      = empty_seed_starts_cluster::yes) {
         std::vector<config::seed_server> seeds = {};
-        if (node_id != 0) {
+        if (!empty_seed_starts_cluster_val || node_id != 0) {
             seeds.push_back(
               {.addr = net::unresolved_address("127.0.0.1", 11000)});
         }
@@ -131,14 +136,25 @@ public:
           schema_reg_port_base + node_id(),
           coproc_supervisor_port_base + node_id(),
           std::move(seeds),
-          use_node_id);
+          use_node_id,
+          empty_seed_starts_cluster_val);
         return get_node_application(node_id);
     }
 
     application* create_node_application(
-      model::node_id node_id, configure_node_id use_node_id) {
+      model::node_id node_id,
+      configure_node_id use_node_id,
+      empty_seed_starts_cluster empty_seed_starts_cluster_val
+      = empty_seed_starts_cluster::yes) {
         return create_node_application(
-          node_id, 9092, 11000, 8082, 8081, 43189, use_node_id);
+          node_id,
+          9092,
+          11000,
+          8082,
+          8081,
+          43189,
+          use_node_id,
+          empty_seed_starts_cluster_val);
     }
 
     void remove_node_application(model::node_id node_id) {

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -88,3 +88,18 @@ FIXTURE_TEST(test_auto_assign_with_explicit_node_id, cluster_test_fixture) {
 
     wait_for_all_members(3s).get();
 }
+
+FIXTURE_TEST(
+  test_seed_driven_cluster_bootstrap_single_node, cluster_test_fixture) {
+    const model::node_id id0{0};
+    create_node_application(
+      id0, configure_node_id::no, empty_seed_starts_cluster::no);
+    BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
+    wait_for_controller_leadership(id0).get();
+    wait_for_all_members(3s).get();
+    auto brokers = get_local_cache(id0).all_brokers();
+
+    // single broker
+    BOOST_REQUIRE_EQUAL(brokers.size(), 1);
+    BOOST_REQUIRE_EQUAL(brokers[0]->id(), id0);
+}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1984,6 +1984,19 @@ struct feature_update_license_update_cmd_data
     operator<<(std::ostream&, const feature_update_license_update_cmd_data&);
 };
 
+struct bootstrap_cluster_cmd_data
+  : serde::envelope<bootstrap_cluster_cmd_data, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    friend bool operator==(
+      const bootstrap_cluster_cmd_data&, const bootstrap_cluster_cmd_data&)
+      = default;
+
+    auto serde_fields() { return std::tie(uuid); }
+
+    model::cluster_uuid uuid;
+};
+
 enum class reconciliation_status : int8_t {
     done,
     in_progress,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -22,7 +22,9 @@
 #include "model/timeout_clock.h"
 #include "raft/types.h"
 #include "security/acl.h"
+#include "security/credential_store.h"
 #include "security/license.h"
+#include "security/scram_credential.h"
 #include "serde/envelope.h"
 #include "serde/serde.h"
 #include "storage/ntp_config.h"
@@ -1984,6 +1986,26 @@ struct feature_update_license_update_cmd_data
     operator<<(std::ostream&, const feature_update_license_update_cmd_data&);
 };
 
+struct user_and_credential
+  : serde::envelope<user_and_credential, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    static constexpr int8_t current_version = 0;
+
+    user_and_credential() = default;
+    user_and_credential(
+      security::credential_user&& username_,
+      security::scram_credential&& credential_)
+      : username(std::move(username_))
+      , credential(std::move(credential_)) {}
+    friend bool
+    operator==(const user_and_credential&, const user_and_credential&)
+      = default;
+    auto serde_fields() { return std::tie(username, credential); }
+
+    security::credential_user username;
+    security::scram_credential credential;
+};
+
 struct bootstrap_cluster_cmd_data
   : serde::envelope<bootstrap_cluster_cmd_data, serde::version<0>> {
     using rpc_adl_exempt = std::true_type;
@@ -1992,9 +2014,10 @@ struct bootstrap_cluster_cmd_data
       const bootstrap_cluster_cmd_data&, const bootstrap_cluster_cmd_data&)
       = default;
 
-    auto serde_fields() { return std::tie(uuid); }
+    auto serde_fields() { return std::tie(uuid, bootstrap_user_cred); }
 
     model::cluster_uuid uuid;
+    std::optional<user_and_credential> bootstrap_user_cred;
 };
 
 enum class reconciliation_status : int8_t {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -891,7 +891,7 @@ struct join_node_request
 
 struct join_node_reply : serde::envelope<join_node_reply, serde::version<0>> {
     bool success{false};
-    model::node_id id{-1};
+    model::node_id id{model::unassigned_node_id};
 
     join_node_reply() noexcept = default;
 

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -52,7 +52,16 @@ node_config::node_config() noexcept
       "seed_server list is empty the node will be a cluster root and it will "
       "form a new cluster",
       {.visibility = visibility::user},
-      {})
+      {},
+      [](std::vector<seed_server> s) -> std::optional<ss::sstring> {
+          std::sort(s.begin(), s.end());
+          const auto s_dupe_i = std::adjacent_find(s.cbegin(), s.cend());
+          if (s_dupe_i != s.cend()) {
+              return fmt::format(
+                "Duplicate items in seed_servers: {}", *s_dupe_i);
+          }
+          return std::nullopt;
+      })
   , empty_seed_starts_cluster(
       *this,
       "empty_seed_starts_cluster",

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -32,7 +32,13 @@ node_config::node_config() noexcept
       "Unique id identifying a node in the cluster. If missing, a unique id "
       "will be assigned for this node when it joins the cluster",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      [](std::optional<model::node_id> id) -> std::optional<ss::sstring> {
+          if (id && (*id)() < 0) {
+              return fmt::format("Negative node_id ({}) not allowed", *id);
+          }
+          return std::nullopt;
+      })
   , rack(
       *this,
       "rack",

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -53,6 +53,14 @@ node_config::node_config() noexcept
       "form a new cluster",
       {.visibility = visibility::user},
       {})
+  , empty_seed_starts_cluster(
+      *this,
+      "empty_seed_starts_cluster",
+      "If enabled, requires exactly one node in a cluster-to-be to have its "
+      "seed_servers list empty. Otherwise, seed_servers list cannot be empty, "
+      "and must be the same in each node from that list",
+      {.visibility = visibility::user},
+      true)
   , rpc_server(
       *this,
       "rpc_server",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -34,6 +34,7 @@ public:
 
     property<std::optional<model::rack_id>> rack;
     property<std::vector<seed_server>> seed_servers;
+    property<bool> empty_seed_starts_cluster;
 
     // Internal RPC listener
     property<net::unresolved_address> rpc_server;

--- a/src/v/config/seed_server.h
+++ b/src/v/config/seed_server.h
@@ -25,6 +25,9 @@ struct seed_server {
     net::unresolved_address addr;
 
     bool operator==(const seed_server&) const = default;
+    friend bool operator<(const seed_server& lhs, const seed_server& rhs) {
+        return lhs.addr < rhs.addr;
+    }
 
     friend std::ostream&
     operator<<(std::ostream& o, const config::seed_server& s) {

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -80,6 +80,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::feature_disabled:
     case cluster::errc::no_update_in_progress:
     case cluster::errc::unknown_update_interruption_error:
+    case cluster::errc::cluster_already_exists:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -45,6 +45,7 @@ using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
 namespace model {
 
 using node_uuid = named_type<uuid_t, struct node_uuid_type>;
+using cluster_uuid = named_type<uuid_t, struct cluster_uuid_type>;
 
 // Named after Kafka cleanup.policy topic property
 enum class cleanup_policy_bitflags : uint8_t {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -32,6 +32,14 @@
 
 namespace model {
 using node_id = named_type<int32_t, struct node_id_model_type>;
+
+/**
+ * Reserved to represent the node_id value yet to be assigned
+ * when node is configured for automatic assignment of node_ids.
+ * Never used in node configuration.
+ */
+constexpr node_id unassigned_node_id(-1);
+
 /**
  * We use revision_id to identify entities evolution in time. f.e. NTP that was
  * first created and then removed, raft configuration

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -200,6 +200,13 @@ public:
         _maintenance_state = st;
     }
 
+    void replace_unassigned_node_id(const node_id id) {
+        vassert(
+          _id == unassigned_node_id,
+          "Cannot replace an assigned node_id in model::broker");
+        _id = id;
+    }
+
     bool operator==(const model::broker& other) const = default;
     bool operator<(const model::broker& other) const { return _id < other._id; }
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -352,6 +352,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::cluster_config_cmd";
     case record_batch_type::feature_update:
         return o << "batch_type::feature_update";
+    case record_batch_type::cluster_bootstrap_cmd:
+        return o << "batch_type::cluster_bootstrap_cmd";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -39,6 +39,7 @@ enum class record_batch_type : int8_t {
     archival_metadata = 19,          // archival metadata updates
     cluster_config_cmd = 20,         // cluster config deltas and status
     feature_update = 21,             // Node logical versions updates
+    cluster_bootstrap_cmd = 22,      // cluster bootsrap command
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -43,6 +43,8 @@ public:
     inet_family family() const { return _family; }
 
     bool operator==(const unresolved_address& other) const = default;
+    friend bool operator<(const unresolved_address&, const unresolved_address&)
+      = default;
 
     auto serde_fields() { return std::tie(_host, _port, _family); }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1487,7 +1487,7 @@ void application::start_runtime_services(
     _co_group_manager.invoke_on_all(&kafka::group_manager::start).get();
 
     syschecks::systemd_message("Starting controller").get();
-    controller->start(cluster_discovery.initial_raft0_brokers()).get0();
+    controller->start(cluster_discovery.initial_seed_brokers()).get0();
     kafka_group_migration = ss::make_lw_shared<kafka::group_metadata_migration>(
       *controller, group_router);
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1355,7 +1355,8 @@ void application::start_bootstrap_services() {
           bootstrap_service.push_back(
             std::make_unique<cluster::bootstrap_service>(
               _scheduling_groups.cluster_sg(),
-              smp_service_groups.cluster_smp_sg()));
+              smp_service_groups.cluster_smp_sg(),
+              std::ref(storage)));
           s.add_services(std::move(bootstrap_service));
       })
       .get();
@@ -1507,7 +1508,7 @@ void application::start_runtime_services(
       ->start(
         storage.local().get_cluster_uuid().has_value()
           ? std::vector<model::broker>{}
-          : cd.initial_seed_brokers())
+          : cd.initial_seed_brokers().get())
       .get0();
 
     kafka_group_migration = ss::make_lw_shared<kafka::group_metadata_migration>(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -131,8 +131,7 @@ private:
 
     // Starts the services meant for Redpanda runtime. Must be called after
     // having constructed the subsystems via the corresponding `wire_up` calls.
-    void
-    start_runtime_services(const cluster::cluster_discovery&, ::stop_signal&);
+    void start_runtime_services(cluster::cluster_discovery&, ::stop_signal&);
     void start_kafka(const model::node_id&, ::stop_signal&);
 
     // All methods are calleds from Seastar thread

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -82,6 +82,13 @@ public:
 
     model::node_uuid node_uuid() const { return _node_uuid; }
 
+    void set_cluster_uuid(const model::cluster_uuid& cluster_uuid) {
+        _cluster_uuid = cluster_uuid;
+    }
+    const std::optional<model::cluster_uuid>& get_cluster_uuid() const {
+        return _cluster_uuid;
+    }
+
     kvstore& kvs() { return *_kvstore; }
     log_manager& log_mgr() { return *_log_mgr; }
     storage_resources& resources() { return _resources; }
@@ -99,6 +106,8 @@ private:
     // directory. Should be generated once upon first starting up and
     // immediately persisted into `_kvstore`.
     model::node_uuid _node_uuid;
+
+    std::optional<model::cluster_uuid> _cluster_uuid;
 };
 
 } // namespace storage

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -58,6 +58,10 @@ public:
 
     auto get_units() noexcept { return ss::get_units(_sem, 1); }
 
+    auto get_units(ss::abort_source& as) noexcept {
+        return ss::get_units(_sem, 1, as);
+    }
+
     auto try_get_units() noexcept { return ss::try_get_units(_sem, 1); }
 
     void broken() noexcept { _sem.broken(); }

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -43,9 +43,11 @@ redpanda:
 
 {% if include_seed_servers %}
   seed_servers:
+  {% for node in seed_servers %}
     - host:
-        address: {{nodes[1].account.hostname}}
+        address: {{node.account.hostname}}
         port: 33145
+  {% endfor %}
 {% endif %}
 
 {% if enable_pp %}

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -1,0 +1,51 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark import matrix
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+
+
+class ClusterBootstrapTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(ClusterBootstrapTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_node_conf={
+                                 "empty_seed_starts_cluster": False,
+                             })
+        self.admin = self.redpanda._admin
+
+    def setUp(self):
+        # Defer startup to test body.
+        pass
+
+    @cluster(num_nodes=3)
+    @matrix(num_seeds=[1, 2, 3], auto_assign_node_ids=[False, True])
+    def test_three_node_bootstrap(self, num_seeds, auto_assign_node_ids):
+        seeds = [self.redpanda.nodes[i] for i in range(num_seeds)]
+        self.redpanda.set_seed_servers(seeds)
+        self.redpanda.start(auto_assign_node_id=auto_assign_node_ids,
+                            omit_seeds_on_idx_one=False)
+        node_ids_per_idx = {}
+        for n in self.redpanda.nodes:
+            idx = self.redpanda.idx(n)
+            node_ids_per_idx[idx] = self.redpanda.node_id(n)
+
+        brokers = self.admin.get_brokers()
+        assert 3 == len(brokers), f"Got {len(brokers)} brokers"
+
+        # Restart our nodes and make sure our node IDs persist across restarts.
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=auto_assign_node_ids)
+        for idx in node_ids_per_idx:
+            n = self.redpanda.get_node(idx)
+            expected_node_id = node_ids_per_idx[idx]
+            node_id = self.redpanda.node_id(n)
+            assert expected_node_id == node_id, f"Expected {expected_node_id} but got {node_id}"

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -175,6 +175,34 @@ def decode_feature_command(record):
 
 
 def decode_record(batch, record):
+def decode_cluster_bootstrap_command(record):
+    def decode_user_and_credential(r):
+        user_cred = {}
+        user_cred['username'] = r.read_string()
+        cmd['salt'] = obfuscate_secret(r.read_iobuf().hex())
+        cmd['server_key'] = obfuscate_secret(r.read_iobuf().hex())
+        cmd['stored_key'] = obfuscate_secret(r.read_iobuf().hex())
+
+    rdr = Reader(BytesIO(record.value))
+    k_rdr = Reader(BytesIO(record.key))
+    cmd = {}
+    rdr.read_envelope()
+    cmd['type'] = rdr.read_int8()
+    if cmd['type'] == 0 or cmd['type'] == 5:  # TODO: remove 5
+        cmd['type_name'] = 'bootstrap_cluster'
+        cmd['key'] = k_rdr.read_int8()
+        cmd['v'] = rdr.read_int8()
+        if cmd['v'] == 0:
+            cmd['cluster_uuid'] = ''.join([
+                f'{rdr.read_uint8():02x}' + ('-' if k in [3, 5, 7, 9] else '')
+                for k in range(16)
+            ])
+            cmd['bootstrap_user_cred'] = rdr.read_optional(
+                decode_user_and_credential)
+
+    return cmd
+
+
     ret = {}
     header = batch.header
     ret['type'] = batch.type.name
@@ -196,6 +224,9 @@ def decode_record(batch, record):
         ret['data'] = decode_config_command(record)
     if header.type == BatchType.feature_update:
         ret['data'] = decode_feature_command(record)
+    if batch.type == BatchType.cluster_bootstrap_cmd:
+        ret['data'] = decode_cluster_bootstrap_command(record)
+
     return ret
 
 

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -135,6 +135,7 @@ class BatchType(Enum):
     archival_metadata = 19
     cluster_config_cmd = 20
     feature_update = 21
+    cluster_bootstrap_cmd = 22
     unknown = -1
 
     @classmethod

--- a/tools/offline_log_viewer/viewer.py
+++ b/tools/offline_log_viewer/viewer.py
@@ -26,11 +26,11 @@ def print_kv_store(store):
             logger.info(json.dumps(items, indent=2))
 
 
-def print_controller(store):
+def print_controller(store, bin_dump: bool):
     for ntp in store.ntps:
         if ntp.nspace == "redpanda" and ntp.topic == "controller":
             ctrl = ControllerLog(ntp)
-            ctrl.decode()
+            ctrl.decode(bin_dump)
             logger.info(json.dumps(ctrl.records, indent=2))
 
 
@@ -114,6 +114,10 @@ def main():
             required=False,
             help='for kafka type, if set, parse only this topic')
         parser.add_argument('-v', "--verbose", action="store_true")
+        parser.add_argument(
+            '--dump',
+            action='store_true',
+            help='output binary dumps of keys and values being parsed')
         return parser
 
     parser = generate_options()
@@ -130,7 +134,7 @@ def main():
     if options.type == "kvstore":
         print_kv_store(store)
     elif options.type == "controller":
-        print_controller(store)
+        print_controller(store, options.dump)
     elif options.type == "kafka":
         validate_topic(options.path, options.topic)
         print_kafka(store, options.topic, headers_only=True)


### PR DESCRIPTION
## Cover letter

This PR addresses the second part of the scope of the ["Cluster Bootstrap" project](https://docs.google.com/document/d/1PaCQWgxTwh5f5v5ePkHFQKgOgic8mZpxkbyt8vM9LqY/edit#heading=h.axx8odyp4ut2). The first part was addressed by #6659.

This PR introduces a new node configuration parameter `empty_seed_starts_cluster` that can disable the _Empty Seed Cluster Bootstrap_ AKA _Root Driven Cluster Bootstrap_ (legacy) mode of bootstrapping a cluster, and allows the set of servers listed as seeds in each node configuration to start a cluster together, as soon as they form a raft group and elect a leader. The new bootstrapping mode is referred as _Seeds Driven Cluster Bootstrap_.

In either mode, cluster now gets cluster UUID reflected by a new controller log message, which lands second in the controller log right after the initial raft configuration message. Cluster UUID is also stored in kvstore of shard0 in every node.

In the new Seeds Driven bootstrap mode, all seed servers must be available for a cluster to be created, with identical node configurations. Afterwards, none of seed servers should try to form another new cluster ("split-brain") if their local storage is wiped out, unless all seed nodes are wiped together at the same time.

<!-- Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it. -->

Fixes #333 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

### Node Configuration in redpanda.yaml

* `empty_seed_starts_cluster` (default: true) to switch between the _Empty Seed Cluster Bootstrap_ (legacy) mode, and the _Seeds Driven Cluster Bootstrap_ mode. When disabled, it is required to be disabled in all seed nodes.
* `seed_servers` are required to be identical in every seed node when in the _Seeds Driven Cluster Bootstrap_ mode.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.
-->
### Features

* Seed driven cluster bootstrap mode. Disable `empty_seed_starts_cluster` to use it. That will allow the set of servers listed as seeds to start a cluster together. All seed servers must be available for a cluster to be created, with identical node configurations. Afterwards, none of seed servers will try to form another new cluster if their local storage is wiped out, unless all seed nodes are wiped together at the same time. Cluster now gets cluster UUID reflected by a new controller log message, and stored in kvstore.

<!-- * TODO: Short description of the feature. Explain how to configure the new feature if applicable. -->

### Improvements

<!-- * TODO: Short description of how this PR improves redpanda. -->
* Configurations of all nodes across the cluster can be identical
* Cluster is bootstrapped with all its seed servers
* Wiped out seed cluster members will not start their own new cluster
