### PR TITLE
[v22.2.x] Fix local timequeries, and implement cloud_storage timequeries

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
+#include "cloud_storage/logger.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"
 #include "json/istreamwrapper.h"
@@ -30,6 +31,29 @@
 #include <memory>
 #include <optional>
 #include <utility>
+
+namespace fmt {
+template<>
+struct fmt::formatter<cloud_storage::partition_manifest::segment_meta> {
+    using segment_meta = cloud_storage::partition_manifest::segment_meta;
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(segment_meta const& m, FormatContext& ctx) {
+        return fmt::format_to(
+          ctx.out(),
+          "{{o={}-{} t={}-{}}}",
+          m.base_offset,
+          m.committed_offset,
+          m.base_timestamp,
+          m.max_timestamp);
+    }
+};
+} // namespace fmt
 
 namespace cloud_storage {
 std::ostream&
@@ -833,6 +857,123 @@ bool partition_manifest::delete_permanently(
         return true;
     }
     return false;
+}
+
+/**
+ * Look up the first segment containing timestamps >= the query timestamp.
+ *
+ * We do not keep a direct index of timestamp to segment, because
+ * it is relatively rarely used, and would have a high memory cost.
+ * In the absence of a random-access container of timestamps,
+ * we may use offset as an indirect way of sampling the segments
+ * for a bisection search, and use the total partition min+max
+ * timestamps to establish a good initial guess: for a partition
+ * with evenly spaced messages over time, this will result in very
+ * fast lookup.
+ * The procedure is:
+ * 1. Make an initial guess by interpolating the timestamp between
+ *    the partitions min+max timestamp and mapping that to an offset
+ * 2. Convert offset guess into segment guess.  This is not a strictly
+ *    correct offset lookup, we just want something close.
+ * 3. Do linear search backward or forward from the location
+ *    we probed, to find the right segment.
+ */
+std::optional<std::reference_wrapper<const partition_manifest::segment_meta>>
+partition_manifest::timequery(model::timestamp t) const {
+    if (_segments.empty()) {
+        return std::nullopt;
+    }
+
+    auto base_t = _segments.begin()->second.base_timestamp;
+    auto max_t = _segments.rbegin()->second.max_timestamp;
+    auto base_offset = _segments.begin()->second.base_offset;
+    auto max_offset = _segments.rbegin()->second.committed_offset;
+
+    // Fast handling of bounds/edge cases to simplify subsequent
+    // arithmetic steps
+    if (t < base_t) {
+        return _segments.begin()->second;
+    } else if (t > max_t) {
+        return std::nullopt;
+    } else if (max_t == base_t) {
+        // This is plausible in the case of a single segment with
+        // a single batch using LogAppendTime.
+        return _segments.begin()->second;
+    }
+
+    // Single-offset case should have hit max_t==base_t above
+    vassert(
+      max_offset > base_offset,
+      "Unexpected offsets {} {} (times {} {})",
+      base_offset,
+      max_offset,
+      base_t,
+      max_t);
+
+    // From this point on, we have finite positive differences between
+    // base and max for both offset and time.
+    model::offset interpolated_offset
+      = base_offset
+        + model::offset{
+          (float(t() - base_t()) / float(max_t() - base_t()))
+          * float(max_offset() - base_offset())};
+
+    vlog(
+      cst_log.debug, "timequery t={} offset guess {}", t, interpolated_offset);
+
+    // 2. Convert offset guess into segment guess.  This is not a strictly
+    // correct offset lookup, we just want something close.
+    auto segment_iter = _segments.lower_bound(
+      key{interpolated_offset, model::term_id{-1}});
+    if (segment_iter == _segments.end()) {
+        segment_iter = --_segments.end();
+    }
+    vlog(
+      cst_log.debug,
+      "timequery t={} segment initial guess {}",
+      t,
+      segment_iter->second);
+
+    // 3. Do linear search backward or forward from the location
+    //    we probed, to find the right segment.
+    if (segment_iter->second.base_timestamp < t) {
+        // Our guess's base_timestamp is before the search point, so our
+        // result must be this segment or a later one: search forward
+        for (; segment_iter != _segments.end(); ++segment_iter) {
+            auto base_timestamp = segment_iter->second.base_timestamp;
+            auto max_timestamp = segment_iter->second.max_timestamp;
+            if (max_timestamp >= t) {
+                // We found a segment bounding the search point
+                break;
+            } else if (base_timestamp > t) {
+                // We found the first segment after the search point
+                break;
+            }
+        }
+
+        return segment_iter->second;
+    } else {
+        // Search backwards: we must peek at each preceding segment
+        // to see if its max_timestamp is >= the query t, before
+        // deciding whether to walk back to it.
+        vlog(
+          cst_log.debug, "timequery t={} reverse {}", t, segment_iter->second);
+
+        while (segment_iter != _segments.begin()) {
+            vlog(
+              cst_log.debug,
+              "timequery t={} reverse {}",
+              t,
+              segment_iter->second);
+            auto prev = std::prev(segment_iter);
+            if (prev->second.max_timestamp >= t) {
+                segment_iter = prev;
+            } else {
+                break;
+            }
+        }
+        return segment_iter->second;
+    }
 }
 
 std::ostream& operator<<(std::ostream& o, const partition_manifest::key& k) {

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -110,6 +110,10 @@ public:
     /// Get revision
     model::initial_revision_id get_revision_id() const;
 
+    /// Find the earliest segment that has max timestamp >= t
+    std::optional<std::reference_wrapper<const segment_meta>>
+    timequery(model::timestamp t) const;
+
     remote_segment_path
     generate_segment_path(const key&, const segment_meta&) const;
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -14,6 +14,7 @@
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
+#include "storage/log_reader.h"
 #include "storage/parser_errc.h"
 #include "storage/types.h"
 #include "utils/gate_guard.h"
@@ -248,15 +249,30 @@ private:
         remote_partition::iterator iter;
     };
 
+    /// Find the starting segment for a reader
+    remote_partition::iterator
+    seek_segment(const storage::log_reader_config& config) {
+        if (config.first_timestamp) {
+            // Seek by timestamp
+            return _partition->seek_by_timestamp(*config.first_timestamp);
+        } else {
+            // Seek by offset
+            auto it = _partition->upper_bound(
+              config.start_offset);
+            if (it != _partition->begin()) {
+                it = std::prev(it);
+            }
+            return it;
+        }
+    }
+
     std::optional<cache_reader_lookup_result>
     find_cached_reader(const storage::log_reader_config& config) {
         if (!_partition || _partition->_segments.empty()) {
             return std::nullopt;
         }
-        auto it = _partition->upper_bound(config.start_offset);
-        if (it != _partition->begin()) {
-            it = std::prev(it);
-        }
+
+        auto it = seek_segment(config);
         auto reader = _partition->borrow_reader(config, it->first, it->second);
         // Here we know the exact type of the reader_state because of
         // the invariant of the borrow_reader
@@ -695,6 +711,50 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};
 }
 
+ss::future<std::optional<storage::timequery_result>>
+remote_partition::timequery(storage::timequery_config cfg) {
+    if (static_cast<size_t>(_segments.size()) < _manifest.size()) {
+        update_segments_incrementally();
+    }
+
+    if (_segments.empty()) {
+        vlog(_ctxlog.debug, "timequery: no segments");
+        co_return std::nullopt;
+    }
+
+    auto start_offset = _segments.begin()->first;
+
+    // Synthesize a log_reader_config from our timequery_config
+    storage::log_reader_config config(
+      start_offset,
+      cfg.max_offset,
+      0,
+      2048, // We just need one record batch
+      cfg.prio,
+      cfg.type_filter,
+      cfg.time,
+      cfg.abort_source);
+
+    // Construct a reader that will skip to the requested timestamp
+    // by virtue of log_reader_config::start_timestamp
+    auto translating_reader = co_await make_reader(config);
+    auto ot_state = std::move(translating_reader.ot_state);
+
+    // Read one batch from the reader to learn the offset
+    model::record_batch_reader::storage_t data
+      = co_await model::consume_reader_to_memory(
+        std::move(translating_reader.reader), model::no_timeout);
+
+    auto& batches = std::get<model::record_batch_reader::data_t>(data);
+    vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
+
+    if (batches.size()) {
+        co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+    } else {
+        co_return std::nullopt;
+    }
+}
+
 remote_partition::offloaded_segment_state::offloaded_segment_state(
   model::offset base_offset)
   : base_rp_offset(base_offset) {}
@@ -795,6 +855,27 @@ remote_partition::iterator remote_partition::upper_bound(model::offset o) {
         return iterator(_segments, it->first);
     }
     return end();
+}
+
+remote_partition::iterator
+remote_partition::seek_by_timestamp(model::timestamp t) {
+    auto segment_meta = _manifest.timequery(t);
+
+    if (segment_meta) {
+        model::offset o = get_kafka_base_offset(*segment_meta);
+        auto found = _segments.find(o);
+
+        // Cannot happen because timequery() calls
+        // update_segments_incrementally first.
+        vassert(
+          found != _segments.end(),
+          "Timequery t={} found offset {} in manifest, but no segment "
+          "state found for that offset");
+        return iterator(_segments, found->first);
+    } else {
+        // They queried a time that is later than all our data
+        return end();
+    }
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -187,6 +187,10 @@ public:
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
+    /// Look up offset from timestamp
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg);
+
     /// Return first uploaded kafka offset
     model::offset first_uploaded_offset();
 
@@ -313,6 +317,7 @@ private:
     iterator begin();
     iterator end();
     iterator upper_bound(model::offset);
+    iterator seek_by_timestamp(model::timestamp);
 
     using segment_map_t = absl::btree_map<model::offset, segment_state>;
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -109,8 +109,10 @@ public:
     };
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
-    ss::future<input_stream_with_offsets>
-    offset_data_stream(model::offset kafka_offset, ss::io_priority_class);
+    ss::future<input_stream_with_offsets> offset_data_stream(
+      model::offset kafka_offset,
+      std::optional<model::timestamp>,
+      ss::io_priority_class);
 
     /// Hydrate the segment
     ss::future<> hydrate();

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -237,6 +237,8 @@ replicated_partition::aborted_transactions(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
+    cfg.max_offset = _translator->to_log_offset(cfg.max_offset);
+
     return _partition->timequery(cfg).then(
       [this](std::optional<storage::timequery_result> r) {
           if (r) {

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -237,15 +237,9 @@ replicated_partition::aborted_transactions(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
-    cfg.max_offset = _translator->to_log_offset(cfg.max_offset);
-
-    return _partition->timequery(cfg).then(
-      [this](std::optional<storage::timequery_result> r) {
-          if (r) {
-              r->offset = _translator->from_log_offset(r->offset);
-          }
-          return r;
-      });
+    // cluster::partition::timequery returns a result in Kafka offsets,
+    // no further offset translation is required here.
+    return _partition->timequery(cfg);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -286,7 +286,7 @@ public:
 
 // This is rougly equivalent to
 //   https://github.com/apache/kafka/blob/8e16158/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala#L27
-FIXTURE_TEST_EXPECTED_FAILURES(create_topics, create_topic_fixture, 2) {
+FIXTURE_TEST(create_topics, create_topic_fixture) {
     wait_for_controller_leadership().get();
 
     test_create_topic(make_req({make_topic("topic1")}));

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -87,13 +87,15 @@ model::record_batch make_random_batch(
   int num_records,
   bool allow_compression,
   model::record_batch_type bt,
-  std::optional<std::vector<size_t>> record_sizes) {
+  std::optional<std::vector<size_t>> record_sizes,
+  std::optional<model::timestamp> ts) {
     return make_random_batch(record_batch_spec{
       .offset = o,
       .allow_compression = allow_compression,
       .count = num_records,
       .bt = bt,
-      .record_sizes = std::move(record_sizes)});
+      .record_sizes = std::move(record_sizes),
+      .timestamp = ts});
 }
 
 model::record_batch
@@ -107,10 +109,8 @@ make_random_batch(model::offset o, int num_records, bool allow_compression) {
 }
 
 model::record_batch make_random_batch(record_batch_spec spec) {
-    auto ts = spec.timestamp.value_or(
-      model::timestamp(model::timestamp::now()() - (spec.count - 1)));
-    auto max_ts = spec.timestamp.value_or(
-      model::timestamp(ts.value() + spec.count - 1));
+    auto ts = spec.timestamp.value_or(model::timestamp::now());
+    auto max_ts = model::timestamp(ts() + spec.count - 1);
     auto header = model::record_batch_header{
       .size_bytes = 0, // computed later
       .base_offset = spec.offset,
@@ -171,22 +171,32 @@ model::record_batch make_random_batch(record_batch_spec spec) {
     return batch;
 }
 
-model::record_batch make_random_batch(model::offset o, bool allow_compression) {
+model::record_batch make_random_batch(
+  model::offset o, bool allow_compression, std::optional<model::timestamp> ts) {
     auto num_records = get_int(2, 30);
     return make_random_batch(
-      o, num_records, allow_compression, model::record_batch_type::raft_data);
+      o,
+      num_records,
+      allow_compression,
+      model::record_batch_type::raft_data,
+      std::nullopt,
+      ts);
 }
 
-ss::circular_buffer<model::record_batch>
-make_random_batches(model::offset o, int count, bool allow_compression) {
+ss::circular_buffer<model::record_batch> make_random_batches(
+  model::offset o,
+  int count,
+  bool allow_compression,
+  std::optional<model::timestamp> base_ts) {
     // start offset + count
     ss::circular_buffer<model::record_batch> ret;
     ret.reserve(count);
+    model::timestamp ts = base_ts.value_or(model::timestamp::now());
     for (int i = 0; i < count; i++) {
         // TODO: it looks like a bug: make_random_batch adds
         // random number of records like we increment offset
         // always by one
-        auto b = make_random_batch(o, allow_compression);
+        auto b = make_random_batch(o, allow_compression, ts);
         o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
         ret.push_back(std::move(b));
@@ -205,9 +215,12 @@ make_random_batches(record_batch_spec spec) {
     ret.reserve(spec.count);
     model::offset o = spec.offset;
     int32_t base_sequence = spec.base_sequence;
+    model::timestamp ts = spec.timestamp.value_or(model::timestamp::now());
     for (int i = 0; i < spec.count; i++) {
         auto num_records = spec.records ? *spec.records : get_int(2, 30);
         auto batch_spec = spec;
+        batch_spec.timestamp = ts;
+        ts = model::timestamp(ts() + num_records);
         batch_spec.offset = o;
         batch_spec.count = num_records;
         if (spec.enable_idempotence) {

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -44,18 +44,24 @@ model::record_batch make_random_batch(
   int num_records,
   bool allow_compression,
   model::record_batch_type bt,
-  std::optional<std::vector<size_t>> record_sizes = std::nullopt);
+  std::optional<std::vector<size_t>> record_sizes = std::nullopt,
+  std::optional<model::timestamp> ts = std::nullopt);
 
 model::record_batch
 make_random_batch(model::offset o, int num_records, bool allow_compression);
 
 model::record_batch make_random_batch(record_batch_spec);
 
-model::record_batch
-make_random_batch(model::offset o, bool allow_compression = true);
+model::record_batch make_random_batch(
+  model::offset o,
+  bool allow_compression = true,
+  std::optional<model::timestamp> ts = std::nullopt);
 
-ss::circular_buffer<model::record_batch>
-make_random_batches(model::offset o, int count, bool allow_compression = true);
+ss::circular_buffer<model::record_batch> make_random_batches(
+  model::offset o,
+  int count,
+  bool allow_compression = true,
+  std::optional<model::timestamp> ts = std::nullopt);
 
 ss::circular_buffer<model::record_batch>
 make_random_batches(model::offset o = model::offset(0));

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -498,7 +498,9 @@ public:
           });
     }
 
-    model::ntp make_data(model::revision_id rev) {
+    model::ntp make_data(
+      model::revision_id rev,
+      std::optional<model::timestamp> base_ts = std::nullopt) {
         auto topic_name = ssx::sformat("my_topic_{}", 0);
         model::ntp ntp(
           model::kafka_namespace,
@@ -510,9 +512,18 @@ public:
 
         storage::disk_log_builder builder(make_default_config());
         using namespace storage; // NOLINT
+
         builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
           | add_random_batches(
-            model::offset(0), 20, maybe_compress_batches::yes)
+            model::offset(0),
+            20,
+            maybe_compress_batches::yes,
+            log_append_config{
+              .should_fsync = log_append_config::fsync::yes,
+              .io_priority = ss::default_priority_class(),
+              .timeout = model::no_timeout},
+            disk_log_builder::should_flush_after::yes,
+            base_ts)
           | stop();
 
         add_topic(model::topic_namespace_view(ntp)).get();

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -304,7 +304,7 @@ batch_cache_index::read_result batch_cache_index::read(
         auto batch = it->second.batch();
 
         auto take = !type_filter || type_filter == batch.header().type;
-        take &= !first_ts || batch.header().first_timestamp >= *first_ts;
+        take &= !first_ts || batch.header().max_timestamp >= *first_ts;
         offset = batch.last_offset() + model::offset(1);
         if (take) {
             batch_cache::range::lock_guard g(*it->second.range());

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -246,7 +246,9 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
                     batch.base_offset(),
                     batch.last_offset(),
                     batch.header().first_timestamp,
-                    batch.header().max_timestamp)) {
+                    batch.header().max_timestamp,
+                    batch.header().type
+                    == model::record_batch_type::raft_data)) {
                   _acc = 0;
               }
               return storage::write(*_appender, batch)

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -247,7 +247,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
                     batch.last_offset(),
                     batch.header().first_timestamp,
                     batch.header().max_timestamp,
-                    batch.header().type
+                    _is_internal || batch.header().type
                     == model::record_batch_type::raft_data)) {
                   _acc = 0;
               }

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -109,9 +109,11 @@ private:
 
 class copy_data_segment_reducer : public compaction_reducer {
 public:
-    copy_data_segment_reducer(compacted_offset_list l, segment_appender* a)
+    copy_data_segment_reducer(
+      compacted_offset_list l, segment_appender* a, bool is_internal)
       : _list(std::move(l))
-      , _appender(a) {}
+      , _appender(a)
+      , _is_internal(is_internal) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch&&);
     storage::index_state end_of_stream() { return std::move(_idx); }
@@ -130,6 +132,7 @@ private:
     segment_appender* _appender;
     index_state _idx;
     size_t _acc{0};
+    bool _is_internal;
 };
 
 class index_rebuilder_reducer : public compaction_reducer {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -734,6 +734,15 @@ offset_stats disk_log_impl::offsets() const {
     };
 }
 
+model::timestamp disk_log_impl::start_timestamp() const {
+    if (_segs.empty()) {
+        return model::timestamp{};
+    }
+
+    auto& s = _segs.front();
+    return s->index().base_timestamp();
+}
+
 ss::future<> disk_log_impl::new_segment(
   model::offset o, model::term_id t, ss::io_priority_class pc) {
     vassert(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -982,10 +982,8 @@ disk_log_impl::timequery(timequery_config cfg) {
                   st);
                 if (
                   !batches.empty()
-                  && batches.front().header().first_timestamp >= cfg.time) {
-                    return ret_t(timequery_result(
-                      batches.front().base_offset(),
-                      batches.front().header().first_timestamp));
+                  && batches.front().header().max_timestamp >= cfg.time) {
+                    return ret_t(batch_timequery(batches.front(), cfg.time));
                 }
                 return ret_t();
             });

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -79,6 +79,7 @@ public:
     timequery(timequery_config cfg) final;
     size_t segment_count() const final { return _segs.size(); }
     offset_stats offsets() const final;
+    model::timestamp start_timestamp() const final;
     std::optional<model::term_id> get_term(model::offset) const final;
     std::optional<model::offset>
     get_term_last_offset(model::term_id term) const final;

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -86,7 +86,8 @@ struct index_state
       model::offset base_offset,
       model::offset batch_max_offset,
       model::timestamp first_timestamp,
-      model::timestamp last_timestamp);
+      model::timestamp last_timestamp,
+      bool user_data);
 
     friend bool operator==(const index_state&, const index_state&) = default;
 
@@ -96,6 +97,8 @@ struct index_state
     friend void read_nested(iobuf_parser&, index_state&, const size_t);
 
 private:
+    bool non_data_timestamps{false};
+
     index_state(const index_state& o) noexcept
       : bitflags(o.bitflags)
       , base_offset(o.base_offset)

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -390,7 +390,8 @@ ss::future<> kvstore::recover() {
               config::shard_local_cfg().storage_read_buffer_size(),
               config::shard_local_cfg().storage_read_readahead_count(),
               std::nullopt,
-              _resources)
+              _resources,
+              true)
               .get0();
 
         replay_segments_in_thread(std::move(segments));

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -70,6 +70,7 @@ public:
 
         virtual size_t segment_count() const = 0;
         virtual storage::offset_stats offsets() const = 0;
+        virtual model::timestamp start_timestamp() const = 0;
         virtual std::ostream& print(std::ostream& o) const = 0;
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
         virtual std::optional<model::offset>
@@ -146,6 +147,10 @@ public:
     const ntp_config& config() const { return _impl->config(); }
 
     size_t segment_count() const { return _impl->segment_count(); }
+
+    model::timestamp start_timestamp() const {
+        return _impl->start_timestamp();
+    }
 
     storage::offset_stats offsets() const { return _impl->offsets(); }
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -280,7 +280,8 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
       config::shard_local_cfg().storage_read_buffer_size(),
       config::shard_local_cfg().storage_read_readahead_count(),
       last_clean_segment,
-      _resources);
+      _resources,
+      cfg.is_internal_topic());
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -62,9 +62,9 @@ batch_consumer::consume_result skipping_consumer::accept_batch_start(
         _reader._config.start_offset = header.last_offset() + model::offset(1);
         return batch_consumer::consume_result::skip_batch;
     }
-    if (_reader._config.first_timestamp > header.first_timestamp) {
-        // kakfa needs to guarantee that the returned record is >=
-        // first_timestamp
+    if (_reader._config.first_timestamp > header.max_timestamp) {
+        // kakfa requires that we return messages >= the timestamp, it is
+        // permitted to include a few earlier
         _reader._config.start_offset = header.last_offset() + model::offset(1);
         return batch_consumer::consume_result::skip_batch;
     }

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -353,7 +353,7 @@ batch_timequery(const model::record_batch& b, model::timestamp t) {
     // records in the batch have different timestamps.
     model::offset result_o = b.base_offset();
     model::timestamp result_t = b.header().first_timestamp;
-    if (b.header().first_timestamp < t) {
+    if (b.header().first_timestamp < t && !b.compressed()) {
         b.for_each_record(
           [&result_o, &result_t, t, &b](
             const model::record& r) -> ss::stop_iteration {

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -236,4 +236,16 @@ private:
     ss::abort_source::subscription _as_sub;
 };
 
+/**
+ * Assuming caller has already determined that this batch contains
+ * the record that should be the result to the timequery, traverse
+ * the batch to find which record matches.
+ *
+ * This is used by both storage's disk_log_impl and by cloud_storage's
+ * remote_partition, to seek to their final result after finding
+ * the batch.
+ */
+timequery_result
+batch_timequery(const model::record_batch& b, model::timestamp t);
+
 } // namespace storage

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -208,9 +208,6 @@ private:
     bool is_done();
     ss::future<> find_next_valid_iterator();
 
-    using reader_available = ss::bool_class<struct create_reader_tag>;
-    reader_available maybe_create_segment_reader();
-
 private:
     struct iterator_pair {
         iterator_pair(segment_set::iterator i)

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -412,6 +412,14 @@ struct mem_log_impl final : log::impl {
           .last_term_start_offset = last_term_base_offset};
     }
 
+    model::timestamp start_timestamp() const final {
+        if (_data.size()) {
+            return _data.begin()->header().first_timestamp;
+        } else {
+            return model::timestamp{};
+        }
+    }
+
     size_t size_bytes() const override {
         return std::accumulate(
           _data.cbegin(),

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "ssx/sformat.h"
 #include "tristate.h"
 
@@ -156,6 +157,8 @@ public:
         return _overrides != nullptr && _overrides->read_replica
                && _overrides->read_replica.value();
     }
+
+    bool is_internal_topic() const { return _ntp.ns != model::kafka_namespace; }
 
 private:
     model::ntp _ntp;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -50,7 +50,8 @@ segment::segment(
   std::optional<compacted_index_writer> ci,
   std::optional<batch_cache_index> c,
   storage_resources& resources,
-  segment::generation_id gen) noexcept
+  segment::generation_id gen,
+  bool is_internal) noexcept
   : _resources(resources)
   , _appender_callbacks(this)
   , _generation_id(gen)
@@ -59,7 +60,8 @@ segment::segment(
   , _idx(std::move(i))
   , _appender(std::move(a))
   , _compaction_index(std::move(ci))
-  , _cache(std::move(c)) {
+  , _cache(std::move(c))
+  , _is_internal(is_internal) {
     if (_appender) {
         _appender->set_callbacks(&_appender_callbacks);
     }
@@ -574,7 +576,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources& resources) {
+  storage_resources& resources,
+  bool is_internal) {
     auto const meta = segment_path::parse_segment_filename(
       path.filename().string());
     if (!meta || meta->version != record_version_type::v1) {
@@ -597,7 +600,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
       index_name,
       meta->base_offset,
       segment_index::default_data_buffer_step,
-      sanitize_fileops);
+      sanitize_fileops,
+      is_internal);
 
     co_return ss::make_lw_shared<segment>(
       segment::offset_tracker(meta->term, meta->base_offset),
@@ -622,6 +626,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   storage_resources& resources) {
     auto path = segment_path::make_segment_path(
       ntpc, base_offset, term, version);
+
     vlog(stlog.info, "Creating new segment {}", path.string());
     return open_segment(
              path,
@@ -629,7 +634,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
              std::move(batch_cache),
              buf_size,
              read_ahead,
-             resources)
+             resources,
+             ntpc.is_internal_topic())
       .then([path, &ntpc, sanitize_fileops, pc, &resources](
               ss::lw_shared_ptr<segment> seg) {
           return with_segment(
@@ -654,7 +660,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt,
-                          resources));
+                          resources,
+                          segment::generation_id{},
+                          seg->is_internal_topic()));
                   });
             });
       })
@@ -681,7 +689,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           seg->has_cache()
                             ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt,
-                          resources));
+                          resources,
+                          segment::generation_id{},
+                          seg->is_internal_topic()));
                   });
             });
       });

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -73,7 +73,8 @@ public:
       std::optional<compacted_index_writer>,
       std::optional<batch_cache_index>,
       storage_resources&,
-      generation_id = generation_id{}) noexcept;
+      generation_id = generation_id{},
+      bool is_internal = false) noexcept;
     ~segment() noexcept = default;
     segment(segment&&) noexcept = default;
     // rwlock does not have move-assignment
@@ -113,6 +114,8 @@ public:
     bool finished_self_compaction() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
+    bool is_internal_topic() { return _is_internal; }
+
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible
     segment_reader& reader();
@@ -207,6 +210,7 @@ private:
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;
     ss::gate _gate;
+    bool _is_internal;
 
     absl::btree_map<size_t, model::offset> _inflight;
 
@@ -234,7 +238,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources&);
+  storage_resources&,
+  bool is_internal);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -42,10 +42,12 @@ segment_index::segment_index(
   ss::sstring filename,
   model::offset base,
   size_t step,
-  debug_sanitize_files sanitize)
+  debug_sanitize_files sanitize,
+  bool is_internal)
   : _name(std::move(filename))
   , _step(step)
-  , _sanitize(sanitize) {
+  , _sanitize(sanitize)
+  , _is_internal(is_internal) {
     _state.base_offset = base;
 }
 

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -96,7 +96,7 @@ void segment_index::maybe_track(
           hdr.last_offset(),
           hdr.first_timestamp,
           hdr.max_timestamp,
-          hdr.type == model::record_batch_type::raft_data)) {
+          _is_internal || hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -93,7 +93,8 @@ void segment_index::maybe_track(
           hdr.base_offset,
           hdr.last_offset(),
           hdr.first_timestamp,
-          hdr.max_timestamp)) {
+          hdr.max_timestamp,
+          hdr.type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -53,7 +53,8 @@ public:
       ss::sstring filename,
       model::offset base,
       size_t step,
-      debug_sanitize_files);
+      debug_sanitize_files,
+      bool is_internal = false);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -96,6 +97,12 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
+
+    /** We need to know if it's an internal topic or a user topic, because
+     *  indexing behavior is different (user topics only index user data
+     *  batches)
+     */
+    bool _is_internal;
 
     /** Constructor with mock file content for unit testing */
     segment_index(

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -47,9 +47,8 @@ struct segment_ordering {
     }
 };
 
-segment_set::segment_set(segment_set::underlying_t segs, bool is_internal_topic)
-  : _handles(std::move(segs))
-  , _is_internal_topic(is_internal_topic) {
+segment_set::segment_set(segment_set::underlying_t segs)
+  : _handles(std::move(segs)) {
     std::sort(_handles.begin(), _handles.end(), segment_ordering{});
 }
 
@@ -468,9 +467,9 @@ ss::future<segment_set> recover_segments(
       })
       .then([&as,
              is_compaction_enabled,
-             last_clean_segment = std::move(last_clean_segment),
-             is_internal_topic](segment_set::underlying_t segs) {
-          auto segments = segment_set(std::move(segs), is_internal_topic);
+             last_clean_segment = std::move(last_clean_segment)](
+              segment_set::underlying_t segs) {
+          auto segments = segment_set(std::move(segs));
           // we have to mark compacted segments before recovery to allow reading
           // gaps introduced by compaction
           if (is_compaction_enabled) {

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t, bool is_internal_topic = false);
+    explicit segment_set(underlying_t);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,7 +85,6 @@ public:
 
 private:
     underlying_t _handles;
-    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -44,7 +44,7 @@ public:
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
 
-    explicit segment_set(underlying_t);
+    explicit segment_set(underlying_t, bool is_internal_topic = false);
     ~segment_set() noexcept = default;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
@@ -85,6 +85,7 @@ public:
 
 private:
     underlying_t _handles;
+    [[maybe_unused]] bool _is_internal_topic;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);
 };
@@ -98,6 +99,7 @@ ss::future<segment_set> recover_segments(
   size_t read_buf_size,
   unsigned read_readahead_count,
   std::optional<ss::sstring> last_clean_segment,
-  storage_resources&);
+  storage_resources&,
+  bool is_internal_topic);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -405,7 +405,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set), s->is_internal_topic()));
+      segment_set(std::move(set)));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -368,7 +368,8 @@ ss::future<storage::index_state> do_copy_segment_data(
             .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
                     segment_appender_ptr w) mutable {
                 auto raw = w.get();
-                auto red = copy_data_segment_reducer(std::move(l), raw);
+                auto red = copy_data_segment_reducer(
+                  std::move(l), raw, s->is_internal_topic());
                 auto r = create_segment_full_reader(s, cfg, pb, std::move(h));
                 vlog(
                   gclog.trace,
@@ -404,7 +405,7 @@ model::record_batch_reader create_segment_full_reader(
     set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
-      segment_set(std::move(set)));
+      segment_set(std::move(set), s->is_internal_topic()));
     lease->locks.push_back(std::move(h));
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb);

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -25,6 +25,8 @@ FIXTURE_TEST(empty_log_garbage_collect, gc_fixture) {
 }
 
 FIXTURE_TEST(retention_test_time, gc_fixture) {
+    auto base_ts = model::timestamp{123000};
+    builder.set_time(base_ts);
     builder | storage::start() | storage::add_segment(0)
       | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
       | storage::add_random_batch(100, 2, storage::maybe_compress_batches::yes)
@@ -47,7 +49,9 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
 
     BOOST_TEST_MESSAGE("Should leave one active segment");
-    builder | storage::garbage_collect(model::timestamp::now(), std::nullopt)
+    builder
+      | storage::garbage_collect(
+        model::timestamp{base_ts() + 1000}, std::nullopt)
       | storage::stop();
 
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -351,7 +351,7 @@ FIXTURE_TEST(
     append_random_batches(log, 10, model::term_id(0));
     append_random_batches(log, 10, model::term_id(0));
     log.flush().get0();
-    auto ts = model::timestamp::now();
+    auto ts = now();
     append_random_batches(log, 10, model::term_id(0));
     log.flush().get0();
     // garbadge collect first append series
@@ -525,7 +525,8 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     append_random_batches(log, 10, model::term_id(1));
     log.flush().get0();
 
-    auto ts = model::timestamp::now();
+    auto ts = now();
+
     auto new_lstats = log.offsets();
     log.set_collectible_offset(new_lstats.dirty_offset);
 

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -293,12 +293,21 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
     auto ntp = model::ntp("default", "test", 0);
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto headers = append_random_batches(log, 15, model::term_id(0), [] {
-        ss::circular_buffer<model::record_batch> ret;
-        ret.push_back(
-          model::test::make_random_batch(model::offset(0), 1, true));
-        return ret;
-    });
+    auto headers = append_random_batches(
+      log,
+      15,
+      model::term_id(0),
+      [](std::optional<model::timestamp> ts = std::nullopt) {
+          ss::circular_buffer<model::record_batch> ret;
+          ret.push_back(model::test::make_random_batch(
+            model::offset(0),
+            1,
+            true,
+            model::record_batch_type::raft_data,
+            std::nullopt,
+            ts));
+          return ret;
+      });
     log.flush().get0();
 
     for (auto lstats = log.offsets(); lstats.dirty_offset > model::offset{};

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -35,6 +35,7 @@ public:
 
     const model::record_batch_header
     modify_get(model::offset o, int32_t batch_size) {
+        _base_hdr.type = model::record_batch_type::raft_data;
         _base_hdr.base_offset = o;
         _base_hdr.size_bytes = batch_size;
         return _base_hdr;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -134,12 +134,21 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
     auto ntp = model::ntp("default", "test", 0);
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto headers = append_random_batches(log, 10, model::term_id(1), []() {
-        ss::circular_buffer<model::record_batch> batches;
-        batches.push_back(
-          model::test::make_random_batch(model::offset(0), 1, true));
-        return batches;
-    });
+    auto headers = append_random_batches(
+      log,
+      10,
+      model::term_id(1),
+      [](std::optional<model::timestamp> ts = std::nullopt) {
+          ss::circular_buffer<model::record_batch> batches;
+          batches.push_back(model::test::make_random_batch(
+            model::offset(0),
+            1,
+            true,
+            model::record_batch_type::raft_data,
+            std::nullopt,
+            ts));
+          return batches;
+      });
     log.flush().get0();
     auto batches = read_and_validate_all_batches(log);
     info("Flushed log: {}", log);
@@ -165,10 +174,16 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
       log,
       10,
       model::term_id(1),
-      []() {
+      [](std::optional<model::timestamp> ts = std::nullopt)
+        -> ss::circular_buffer<model::record_batch> {
           ss::circular_buffer<model::record_batch> batches;
-          batches.push_back(
-            model::test::make_random_batch(model::offset(0), 1, true));
+          batches.push_back(model::test::make_random_batch(
+            model::offset(0),
+            1,
+            true,
+            model::record_batch_type::raft_data,
+            std::nullopt,
+            ts));
           return batches;
       },
       storage::log_append_config::fsync::no,
@@ -188,10 +203,15 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
       log,
       10,
       model::term_id(1),
-      []() {
+      [](std::optional<model::timestamp> ts = std::nullopt) {
           ss::circular_buffer<model::record_batch> batches;
-          batches.push_back(
-            model::test::make_random_batch(model::offset(0), 1, true));
+          batches.push_back(model::test::make_random_batch(
+            model::offset(0),
+            1,
+            true,
+            model::record_batch_type::raft_data,
+            std::nullopt,
+            ts));
           return batches;
       },
       storage::log_append_config::fsync::no,
@@ -330,7 +350,9 @@ struct custom_ts_batch_generator {
     explicit custom_ts_batch_generator(model::timestamp start_ts)
       : _start_ts(start_ts) {}
 
-    ss::circular_buffer<model::record_batch> operator()() {
+    ss::circular_buffer<model::record_batch> operator()(
+      [[maybe_unused]] std::optional<model::timestamp> ts = std::nullopt) {
+        // The input timestamp is unused, this class does its own timestamping
         auto batches = model::test::make_random_batches(
           model::offset(0), random_generators::get_int(1, 10));
 

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -36,9 +36,10 @@ using namespace std::chrono_literals; // NOLINT
 inline ss::logger tlog{"test_log"};
 
 struct random_batches_generator {
-    ss::circular_buffer<model::record_batch> operator()() {
+    ss::circular_buffer<model::record_batch>
+    operator()(std::optional<model::timestamp> base_ts = std::nullopt) {
         return model::test::make_random_batches(
-          model::offset(0), random_generators::get_int(1, 10));
+          model::offset(0), random_generators::get_int(1, 10), true, base_ts);
     }
 };
 
@@ -47,6 +48,8 @@ public:
     ss::sstring test_dir;
     storage::kvstore kvstore;
     storage::storage_resources resources;
+
+    std::optional<model::timestamp> ts_cursor;
 
     storage_test_fixture()
       : test_dir("test.data." + random_generators::gen_alphanum_string(10))
@@ -66,6 +69,12 @@ public:
     }
 
     ~storage_test_fixture() { kvstore.stop().get(); }
+
+    /**
+     * Only safe to call if you have generated some batches: this gives you
+     * a timestamp ahead of the most recently appended batch
+     */
+    model::timestamp now() { return *ts_cursor; }
 
     void configure_unit_test_logging() { std::cout.setf(std::ios::unitbuf); }
 
@@ -159,13 +168,17 @@ public:
         // do multiple append calls
 
         for (auto append : boost::irange(0, appends)) {
-            auto batches = batch_generator();
+            auto batches = batch_generator(ts_cursor);
             // Collect batches offsets
             for (auto& b : batches) {
                 headers.push_back(b.header());
                 b.set_term(term);
                 total_records += b.record_count();
             }
+
+            ts_cursor = model::timestamp{
+              batches.back().header().max_timestamp() + 1};
+
             // make expected offset inclusive
             auto reader = model::make_memory_record_batch_reader(
               std::move(batches));

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -184,4 +184,5 @@ operator<<(std::ostream& o, compacted_index::recovery_state state) {
     }
     __builtin_unreachable();
 }
+
 } // namespace storage

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -354,4 +354,5 @@ struct compaction_result {
     size_t size_after;
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
+
 } // namespace storage

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -81,6 +81,12 @@ public:
         return frag.at(index % elems_per_frag);
     }
 
+    T& operator[](size_t index) {
+        vassert(index < _size, "Index out of range {}/{}", index, _size);
+        auto& frag = _frags.at(index / elems_per_frag);
+        return frag.at(index % elems_per_frag);
+    }
+
     const T& back() const { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard c8b057e5e1b7de73b412684edcece87dd2adec8b && \
+    cd /opt/kgo-verifier && git reset --hard cf552ccba1c6a68f53b51bbdbbcdb50c4e2c8cfe && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -10,6 +10,7 @@
 import subprocess
 import time
 import json
+from typing import Optional
 
 from rptest.util import wait_until_result
 
@@ -26,10 +27,23 @@ class KafkaCat:
     def metadata(self):
         return self._cmd(["-L"])
 
-    def consume_one(self, topic, partition, offset):
+    def consume_one(self,
+                    topic,
+                    partition,
+                    offset=None,
+                    *,
+                    first_timestamp: Optional[int] = None):
+        if offset is not None:
+            # <value>  (absolute offset)
+            query = offset
+        else:
+            assert first_timestamp is not None
+            # s@<value> (timestamp in ms to start at)
+            query = f"s@{first_timestamp}"
+
         return self._cmd([
             "-C", "-e", "-t", f"{topic}", "-p", f"{partition}", "-o",
-            f"{offset}", "-c1"
+            f"{query}", "-c1"
         ])
 
     def produce_one(self, topic, msg, tx_id=None):

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -463,12 +463,14 @@ class KgoVerifierProducer(KgoVerifierService):
                  msg_size,
                  msg_count,
                  custom_node=None,
-                 batch_max_bytes=None):
+                 batch_max_bytes=None,
+                 fake_timestamp_ms=None):
         super(KgoVerifierProducer, self).__init__(context, redpanda, topic,
                                                   msg_size, custom_node)
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes
+        self._fake_timestamp_ms = fake_timestamp_ms
         self._remote_port = None
 
     @property
@@ -515,6 +517,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
         if self._batch_max_bytes is not None:
             cmd = cmd + f' --batch_max_bytes {self._batch_max_bytes}'
+
+        if self._fake_timestamp_ms is not None:
+            cmd = cmd + f' --fake-timestamp-ms {self._fake_timestamp_ms}'
 
         self.spawn(cmd, node)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -585,6 +585,9 @@ class RedpandaService(Service):
         # stash a copy here so that we can quickly look up e.g. addresses later.
         self._node_configs = {}
 
+    def set_skip_if_no_redpanda_log(self, v: bool):
+        self._skip_if_no_redpanda_log = v
+
     def set_environment(self, environment: dict[str, str]):
         self._environment = environment
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1775,6 +1775,10 @@ class RedpandaService(Service):
         for ns in listdir(store.data_dir, True):
             if ns == '.coprocessor_offset_checkpoints':
                 continue
+            if ns == 'cloud_storage_cache':
+                # Default cache dir is sub-path of data dir
+                continue
+
             ns = store.add_namespace(ns, os.path.join(store.data_dir, ns))
             for topic in listdir(ns.path):
                 topic = ns.add_topic(topic, os.path.join(ns.path, topic))

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -562,9 +562,10 @@ class RedpandaService(Service):
             f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
 
         if si_settings is not None:
-            self._extra_rp_conf = si_settings.update_rp_conf(
-                self._extra_rp_conf)
-        self._si_settings = si_settings
+            self.set_si_settings(si_settings)
+        else:
+            self._si_settings = None
+
         self.s3_client: Optional[S3Client] = None
 
         if environment is None:
@@ -592,6 +593,14 @@ class RedpandaService(Service):
 
     def set_extra_rp_conf(self, conf):
         self._extra_rp_conf = conf
+        if self._si_settings is not None:
+            self._extra_rp_conf = self._si_settings.update_rp_conf(
+                self._extra_rp_conf)
+
+    def set_si_settings(self, si_settings: SISettings):
+        self._si_settings = si_settings
+        self._extra_rp_conf = self._si_settings.update_rp_conf(
+            self._extra_rp_conf)
 
     def add_extra_rp_conf(self, conf):
         self._extra_rp_conf = {**self._extra_rp_conf, **conf}

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -66,6 +66,12 @@ class RedpandaTest(Test):
                                         **kwargs)
         self._client = DefaultClient(self.redpanda)
 
+    def early_exit_hook(self):
+        """
+        Hook for `skip_debug_mode` decorator
+        """
+        self.redpanda.set_skip_if_no_redpanda_log(True)
+
     @property
     def topic(self):
         """

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -6,13 +6,11 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
-from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import RedpandaService, SISettings
 
 from rptest.services.admin import Admin
-from rptest.archival.s3_client import S3Client
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -21,16 +19,6 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 from ducktape.utils.util import wait_until
-
-import xxhash
-from collections import namedtuple, defaultdict
-import time
-import os
-import json
-import traceback
-import uuid
-import sys
-import re
 
 # Log errors expected when connectivity between redpanda and the S3
 # backend is disrupted

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -7,14 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
+import re
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService, SISettings
+from rptest.services.metrics_check import MetricCheck
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk_remote import RpkRemoteTool
+from rptest.util import (segments_count, wait_for_segments_removal)
 
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
@@ -31,7 +34,8 @@ from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
-    def _test_timequery(self):
+    def _test_timequery(self, cluster, cloud_storage: bool, batch_cache: bool):
+        local_retain_segments = 4
         total_segments = 12
         record_size = 1024
 
@@ -40,6 +44,15 @@ class BaseTimeQuery:
                           replication_factor=3)
 
         self.client().create_topic(topic)
+
+        if cloud_storage:
+            for k, v in {
+                    'redpanda.remote.read': True,
+                    'redpanda.remote.write': True,
+                    'retention.bytes':
+                    self.log_segment_size * local_retain_segments
+            }.items():
+                self.client().alter_topic_config(topic.name, k, v)
 
         # Configure topic to trust client-side timestamps, so that
         # we can generate fake ones for the test
@@ -57,9 +70,10 @@ class BaseTimeQuery:
         # Produce a run of messages with CreateTime-style timestamps, each
         # record having a timestamp 1ms greater than the last.
         msg_count = (self.log_segment_size * total_segments) // record_size
+        base_ts = 1664453149000
         producer = KgoVerifierProducer(
             context=self.test_context,
-            redpanda=self.redpanda,
+            redpanda=cluster,
             topic=topic.name,
             msg_size=record_size,
             msg_count=msg_count,
@@ -70,34 +84,87 @@ class BaseTimeQuery:
             batch_max_bytes=record_size * 10,
 
             # A totally arbitrary artificial timestamp base in milliseconds
-            fake_timestamp_ms=1664453149000)
+            fake_timestamp_ms=base_ts)
         producer.start()
         producer.wait()
 
         # Confirm messages written
-        rpk = RpkTool(self.redpanda)
+        rpk = RpkTool(cluster)
         p = next(rpk.describe_topic(topic.name))
         assert p.high_watermark == msg_count
 
-        # Read back timestamps
-        self.logger.info(f"Retrieving timestamps for {msg_count} messages")
-        rpk_remote = RpkRemoteTool(self.redpanda, self.redpanda.nodes[0])
-        timestamps = dict(
-            rpk_remote.read_timestamps(topic.name,
-                                       0,
-                                       msg_count,
-                                       timeout_sec=30))
+        if cloud_storage:
+            # If using cloud storage, we must wait for some segments
+            # to fall out of local storage, to ensure we are really
+            # hitting the cloud storage read path when querying.
+            wait_for_segments_removal(redpanda=cluster,
+                                      topic=topic.name,
+                                      partition_idx=0,
+                                      count=local_retain_segments)
 
+        # Identify partition leader for use in our metrics checks
+        leader_node = cluster.get_node(
+            next(rpk.describe_topic(topic.name)).leader)
+
+        # We know timestamps, they are generated linearly from the
+        # base we provided to kgo-verifier
+        timestamps = dict((i, base_ts + i) for i in range(0, msg_count))
         for k, v in timestamps.items():
             self.logger.debug(f"  Offset {k} -> Timestamp {v}")
 
-        # Interesting cases
-        offsets = [0, msg_count // 4, msg_count // 2, msg_count - 1]
+        # Class defining expectations of timequery results to be checked
+        class ex:
+            def __init__(self, offset, ts=None, expect_read=True):
+                if ts is None:
+                    ts = timestamps[offset]
+                self.ts = ts
+                self.offset = offset
+                self.expect_read = expect_read
 
-        kcat = KafkaCat(self.redpanda)
-        for o in offsets:
-            # read_timestamps gives values in millis
-            ts = int(timestamps[o])
+        # Selection of interesting cases
+        expectations = [
+            ex(0),  # First message
+            ex(msg_count // 4),  # 25%th message
+            ex(msg_count // 2),  # 50%th message
+            ex(msg_count - 1),  # last message
+            ex(0, timestamps[0] - 1000),
+            ex(-1, timestamps[msg_count - 1] + 1000,
+               False)  # After last message
+        ]
+
+        # For when using cloud storage, we expectr offsets ahead
+        # of this to still hit raft for their timequeries.  This is approximate,
+        # but fine as long as the test cases don't tread too near the gap.
+        local_start_offset = msg_count - (
+            (local_retain_segments * self.log_segment_size) / record_size)
+
+        is_redpanda = isinstance(cluster, RedpandaService)
+
+        # Remember which offsets we already hit, so that we can
+        # make a good guess at whether subsequent hits on the same
+        # offset should cause cloud downloads.
+        hit_offsets = set()
+
+        kcat = KafkaCat(cluster)
+        for e in expectations:
+            ts = e.ts
+            o = e.offset
+
+            if is_redpanda and cloud_storage:
+                cloud_metrics = MetricCheck(
+                    self.logger,
+                    cluster,
+                    leader_node,
+                    re.compile("vectorized_cloud_storage_.*"),
+                    reduce=sum)
+
+            if is_redpanda and not cloud_storage:
+                local_metrics = MetricCheck(
+                    self.logger,
+                    cluster,
+                    leader_node,
+                    re.compile("vectorized_storage_.*"),
+                    reduce=sum)
 
             self.logger.info(
                 f"Attempting time lookup ts={ts} (should be o={o})")
@@ -105,12 +172,28 @@ class BaseTimeQuery:
             self.logger.info(f"Time query returned offset {offset}")
             assert offset == o
 
-            self.logger.info(
-                f"Attempting time-based reader lookup ts={ts} (should be o={o})"
-            )
-            record = kcat.consume_one(topic.name, 0, first_timestamp=ts)
-            self.logger.info(f"Time-based consumer returned record {record}")
-            assert record['offset'] == o
+            if is_redpanda and cloud_storage and o < local_start_offset and o not in hit_offsets and e.expect_read:
+                # We should have hydrated exactly one segment: this shows we are properly
+                # looking up the segment and not e.g. seeking from the start.  We may
+                cloud_metrics.expect([
+                    ("vectorized_cloud_storage_successful_downloads_total",
+                     lambda a, b: b == a + 1)
+                ])
+
+            if is_redpanda and not cloud_storage and not batch_cache and e.expect_read:
+                # Expect to read at most one segment from disk: this validates that
+                # we are correctly looking up the right segment before seeking to
+                # the exact offset, and not e.g. reading from the start of the log.
+                local_metrics.expect([
+                    ("vectorized_storage_log_read_bytes_total",
+                     lambda a, b: b > a and b - a < self.log_segment_size)
+                ])
+
+            hit_offsets.add(o)
+
+        # TODO: do some double-restarts to generate segments with
+        # no user data, to check that their timestamps don't
+        # break out indexing.
 
 
 class TimeQueryTest(RedpandaTest, BaseTimeQuery):
@@ -124,21 +207,39 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         # test parameter to set cluster configs before starting.
         pass
 
-    @cluster(num_nodes=4)
-    @parametrize(batch_cache=True)
-    @parametrize(batch_cache=False)
+    @parametrize(cloud_storage=True, batch_cache=False)
+    @parametrize(cloud_storage=False, batch_cache=True)
+    @parametrize(cloud_storage=False, batch_cache=False)
     @skip_debug_mode
-    def test_timequery(self, batch_cache: bool):
+    def test_timequery(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise
             # we won't touch the path in skipping_consumer that applies
             # timestamp bounds
             'disable_batch_cache': not batch_cache,
+
+            # Our time bounds on segment removal depend on the leadership
+            # staying in one place.
+            'enable_leader_balancer': False,
         })
+
+        if cloud_storage:
+            si_settings = SISettings(
+                cloud_storage_max_connections=5,
+                log_segment_size=self.log_segment_size,
+
+                # Off by default: test is parametrized to turn
+                # on if SI is wanted.
+                cloud_storage_enable_remote_read=True,
+                cloud_storage_enable_remote_write=True,
+            )
+            self.redpanda.set_si_settings(si_settings)
 
         self.redpanda.start()
 
-        return self._test_timequery()
+        return self._test_timequery(cluster=self.redpanda,
+                                    cloud_storage=cloud_storage,
+                                    batch_cache=batch_cache)
 
 
 class TimeQueryKafkaTest(Test, BaseTimeQuery):
@@ -168,14 +269,9 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
     def client(self):
         return self._client
 
-    @property
-    def redpanda(self):
-        return self.kafka
-
     def setUp(self):
         self.zk.start()
         self.kafka.start()
-        time.sleep(5)
 
     def tearDown(self):
         # ducktape handle service teardown automatically, but it is hard
@@ -191,4 +287,6 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
 
     @ducktape_cluster(num_nodes=5)
     def test_timequery(self):
-        self._test_timequery()
+        self._test_timequery(cluster=self.kafka,
+                             cloud_storage=False,
+                             batch_cache=True)

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -27,6 +27,7 @@ from ducktape.mark.resource import cluster as ducktape_cluster
 from kafkatest.version import V_3_0_0
 from ducktape.tests.test import Test
 from rptest.clients.default import DefaultClient
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
@@ -126,6 +127,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
     @cluster(num_nodes=4)
     @parametrize(batch_cache=True)
     @parametrize(batch_cache=False)
+    @skip_debug_mode
     def test_timequery(self, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -45,6 +45,10 @@ class BaseTimeQuery:
         self.client().alter_topic_config(topic.name, 'message.timestamp.type',
                                          "CreateTime")
 
+        # Disable time based retention because we will use synthetic timestamps
+        # that may well fall outside of the default 1 week relative to walltime
+        self.client().alter_topic_config(topic.name, 'retention.ms', "-1")
+
         # Use small segments
         self.client().alter_topic_config(topic.name, 'segment.bytes',
                                          self.log_segment_size)

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -1,0 +1,188 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk_remote import RpkRemoteTool
+
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+
+from ducktape.mark import parametrize
+
+from rptest.services.kafka import KafkaServiceAdapter
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.zookeeper import ZookeeperService
+from ducktape.mark.resource import cluster as ducktape_cluster
+from kafkatest.version import V_3_0_0
+from ducktape.tests.test import Test
+from rptest.clients.default import DefaultClient
+
+
+class BaseTimeQuery:
+    def _test_timequery(self):
+        total_segments = 12
+        record_size = 1024
+
+        topic = TopicSpec(name="tqtopic",
+                          partition_count=1,
+                          replication_factor=3)
+
+        self.client().create_topic(topic)
+
+        # Configure topic to trust client-side timestamps, so that
+        # we can generate fake ones for the test
+        self.client().alter_topic_config(topic.name, 'message.timestamp.type',
+                                         "CreateTime")
+
+        # Use small segments
+        self.client().alter_topic_config(topic.name, 'segment.bytes',
+                                         self.log_segment_size)
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_count = (self.log_segment_size * total_segments) // record_size
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topic=topic.name,
+            msg_size=record_size,
+            msg_count=msg_count,
+
+            # A respectable number of messages per batch so that we are covering
+            # the case of looking up timestamps that fall in the middle of a batch,
+            # but small enough that we are getting plenty of distinct batches.
+            batch_max_bytes=record_size * 10,
+
+            # A totally arbitrary artificial timestamp base in milliseconds
+            fake_timestamp_ms=1664453149000)
+        producer.start()
+        producer.wait()
+
+        # Confirm messages written
+        rpk = RpkTool(self.redpanda)
+        p = next(rpk.describe_topic(topic.name))
+        assert p.high_watermark == msg_count
+
+        # Read back timestamps
+        self.logger.info(f"Retrieving timestamps for {msg_count} messages")
+        rpk_remote = RpkRemoteTool(self.redpanda, self.redpanda.nodes[0])
+        timestamps = dict(
+            rpk_remote.read_timestamps(topic.name,
+                                       0,
+                                       msg_count,
+                                       timeout_sec=30))
+
+        for k, v in timestamps.items():
+            self.logger.debug(f"  Offset {k} -> Timestamp {v}")
+
+        # Interesting cases
+        offsets = [0, msg_count // 4, msg_count // 2, msg_count - 1]
+
+        kcat = KafkaCat(self.redpanda)
+        for o in offsets:
+            # read_timestamps gives values in millis
+            ts = int(timestamps[o])
+
+            self.logger.info(
+                f"Attempting time lookup ts={ts} (should be o={o})")
+            offset = kcat.query_offset(topic.name, 0, ts)
+            self.logger.info(f"Time query returned offset {offset}")
+            assert offset == o
+
+            self.logger.info(
+                f"Attempting time-based reader lookup ts={ts} (should be o={o})"
+            )
+            record = kcat.consume_one(topic.name, 0, first_timestamp=ts)
+            self.logger.info(f"Time-based consumer returned record {record}")
+            assert record['offset'] == o
+
+
+class TimeQueryTest(RedpandaTest, BaseTimeQuery):
+    # We use small segments to enable quickly exercising the
+    # lookup of the proper segment for a time index, as well
+    # as the lookup of the offset within that segment.
+    log_segment_size = 1024 * 1024
+
+    def setUp(self):
+        # Don't start up redpanda yet, because we will need the
+        # test parameter to set cluster configs before starting.
+        pass
+
+    @cluster(num_nodes=4)
+    @parametrize(batch_cache=True)
+    @parametrize(batch_cache=False)
+    def test_timequery(self, batch_cache: bool):
+        self.redpanda.set_extra_rp_conf({
+            # Testing with batch cache disabled is important, because otherwise
+            # we won't touch the path in skipping_consumer that applies
+            # timestamp bounds
+            'disable_batch_cache': not batch_cache,
+        })
+
+        self.redpanda.start()
+
+        return self._test_timequery()
+
+
+class TimeQueryKafkaTest(Test, BaseTimeQuery):
+    """
+    Time queries are one of the less clearly defined aspects of the
+    Kafka protocol, so we run our test procedure against Apache Kafka
+    to establish a baseline behavior to ensure our compatibility.
+    """
+    log_segment_size = 1024 * 1024
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.zk = ZookeeperService(self.test_context,
+                                   num_nodes=1,
+                                   version=V_3_0_0)
+
+        self.kafka = KafkaServiceAdapter(
+            self.test_context,
+            KafkaService(self.test_context,
+                         num_nodes=3,
+                         zk=self.zk,
+                         version=V_3_0_0))
+
+        self._client = DefaultClient(self.kafka)
+
+    def client(self):
+        return self._client
+
+    @property
+    def redpanda(self):
+        return self.kafka
+
+    def setUp(self):
+        self.zk.start()
+        self.kafka.start()
+        time.sleep(5)
+
+    def tearDown(self):
+        # ducktape handle service teardown automatically, but it is hard
+        # to tell what went wrong if one of the services hangs.  Do it
+        # explicitly here with some logging, to enable debugging issues
+        # like https://github.com/redpanda-data/redpanda/issues/4270
+
+        self.logger.info("Stopping Kafka...")
+        self.kafka.stop()
+
+        self.logger.info("Stopping zookeeper...")
+        self.zk.stop()
+
+    @ducktape_cluster(num_nodes=5)
+    def test_timequery(self):
+        self._test_timequery()

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -123,14 +123,19 @@ def segments_count(redpanda, topic, partition_idx):
     )
 
 
-def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
+def produce_until_segments(redpanda,
+                           topic,
+                           partition_idx,
+                           count,
+                           acks=-1,
+                           record_size=1024):
     """
     Produce into the topic until given number of segments will appear
     """
     kafka_tools = KafkaCliTools(redpanda)
 
     def done():
-        kafka_tools.produce(topic, 10000, 1024, acks=acks)
+        kafka_tools.produce(topic, 10000, record_size=record_size, acks=acks)
         topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -26,13 +26,11 @@ def cleanup_on_early_exit(caller):
             hook
         ), f'{name.early_exit_hook} should be a method which can be called to set up early exit from test'
         hook()
-    else:
-        caller.logger.debug(
-            f'{name} does not define action to take when skipping test on debug mode. '
-            f'Cleaning up unused nodes.')
 
-        if test_context := getattr(caller, 'test_context', None):
-            allocate_and_free(test_context.cluster, caller.logger)
+    caller.logger.debug(f'Cleaning up unused nodes.')
+
+    if test_context := getattr(caller, 'test_context', None):
+        allocate_and_free(test_context.cluster, caller.logger)
 
 
 def skip_debug_mode(func):


### PR DESCRIPTION
## Cover letter

This is a backport of:
- https://github.com/redpanda-data/redpanda/pull/6656
- https://github.com/redpanda-data/redpanda/pull/6606
- https://github.com/redpanda-data/redpanda/pull/6654
- https://github.com/redpanda-data/redpanda/pull/6658
- https://github.com/redpanda-data/redpanda/pull/6662
- https://github.com/redpanda-data/redpanda/pull/6684
- https://github.com/redpanda-data/redpanda/pull/6714
- https://github.com/redpanda-data/redpanda/pull/6718
- https://github.com/redpanda-data/redpanda/pull/6722

## UX changes

None

## Release notes

### Improvements

* Time queries are more reliable when using client-side timestamps (CreateTime mode)
* Time queries on topics using tiered storage now cover data in S3 as well as local data
