### PR TITLE
tests/compaction: allow consumer to skip offsets

### DIFF
--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -116,6 +116,6 @@ class CompactionEndToEndTest(EndToEndTest):
                    backoff_sec=2)
 
         # enable consumer and validate consumed records
-        self.start_consumer(num_nodes=1)
+        self.start_consumer(num_nodes=1, verify_offsets=False)
 
         self.run_validation(enable_compaction=True)


### PR DESCRIPTION
## Cover letter

When topic is compacted it is natural that consumer may not consume the offset that was previously committed as there may be gap caused by compaction process. Disabled offset verification on consumer to make sure that the test will not generate spurious failures.

Fixes: #6745




## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
