### PR TITLE
[v22.1.x] Bump log4j dependencies

### DIFF
--- a/tests/java/compacted-log-verifier/pom.xml
+++ b/tests/java/compacted-log-verifier/pom.xml
@@ -15,7 +15,7 @@
         <kafka.clients.version>2.4.1</kafka.clients.version>
         <commons.lang.version>3.9</commons.lang.version>
         <argparse4j.version>0.8.1</argparse4j.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <buildDir>${project.basedir}/target</buildDir>
     </properties>
     <dependencies>

--- a/tests/java/e2e-verifiers/pom.xml
+++ b/tests/java/e2e-verifiers/pom.xml
@@ -15,7 +15,7 @@
         <kafka.clients.version>2.8.0</kafka.clients.version>
         <commons.lang.version>3.9</commons.lang.version>
         <argparse4j.version>0.8.1</argparse4j.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <buildDir>${project.basedir}/target</buildDir>
         <jackson.version>2.13.1</jackson.version>
         <log4j.version>1.2.17</log4j.version>

--- a/tests/java/kafka-verifier/pom.xml
+++ b/tests/java/kafka-verifier/pom.xml
@@ -15,7 +15,7 @@
         <kafka.clients.version>2.4.1</kafka.clients.version>
         <commons.lang.version>3.9</commons.lang.version>
         <argparse4j.version>0.8.1</argparse4j.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <buildDir>${project.basedir}/target</buildDir>
     </properties>
     <dependencies>


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6709.
