### PR TITLE
rptest: Remove TRACE & DEBUG logs after each successful run

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -53,7 +53,8 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                     # TODO: extend this to cover shutdown logging too, and
                     # clean up redpanda to not log so many errors on shutdown.
                     self.redpanda.raise_on_bad_logs(allow_list=log_allow_list)
-                    return r
+                self.redpanda.trim_logs()
+                return r
 
         # Propagate ducktape markers (e.g. parameterize) to our function
         # wrapper

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1532,6 +1532,17 @@ class RedpandaService(Service):
             # installation to preserve!
             self._installer.reset_current_install([node])
 
+    def trim_logs(self):
+        # Excessive logging may cause disks to fill up quickly.
+        # Call this method to removes TRACE and DEBUG log lines from redpanda logs
+        # Ensure this is only done on tests that have passed
+        def prune(node):
+            node.account.ssh(
+                f"sed -i -E -e '/TRACE|DEBUG/d' {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
+            )
+
+        self._for_nodes(self.nodes, prune, parallel=True)
+
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
 


### PR DESCRIPTION
## Cover letter

Currently we have an automated trim tool that prunes TRACE and DEBUG logs from tests that have passed however this tool runs after the entire ducktape test suite finishes, and by that time the disk may have filled up.

This patch has ducktape perform this prune after each successful test run.

## Release notes
* none