### PR TITLE
[transaction] Do not send prepare request to rm_stm

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -858,8 +858,8 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
             //
             // If it happens to be the first case then Redpanda rejects a
             // client's tx.
-            auto expiration_it = _mem_state.expiration.find(pid);
-            if (expiration_it != _mem_state.expiration.end()) {
+            auto expiration_it = _log_state.expiration.find(pid);
+            if (expiration_it != _log_state.expiration.end()) {
                 expiration_it->second.is_expiration_requested = true;
             }
             // spawing abort in the background and returning an error to
@@ -1004,8 +1004,8 @@ rm_stm::get_tx_status(model::producer_identity pid) const {
 
 std::optional<rm_stm::expiration_info>
 rm_stm::get_expiration_info(model::producer_identity pid) const {
-    auto it = _mem_state.expiration.find(pid);
-    if (it == _mem_state.expiration.end()) {
+    auto it = _log_state.expiration.find(pid);
+    if (it == _log_state.expiration.end()) {
         return std::nullopt;
     }
 
@@ -1069,7 +1069,7 @@ rm_stm::do_mark_expired(model::producer_identity pid) {
 
     // We should delete information about expiration for pid, because inside
     // try_abort_old_tx it checks is tx expired or not.
-    _mem_state.expiration.erase(pid);
+    _log_state.expiration.erase(pid);
     co_await do_try_abort_old_tx(pid);
     co_return std::error_code(tx_errc::none);
 }
@@ -1640,14 +1640,16 @@ void rm_stm::track_tx(
     if (_gate.is_closed()) {
         return;
     }
-    _mem_state.expiration[pid] = expiration_info{
-      .timeout = transaction_timeout_ms,
-      .last_update = clock_type::now(),
-      .is_expiration_requested = false};
+    if (!_log_state.expiration.contains(pid)) {
+        _log_state.expiration[pid] = expiration_info{
+          .timeout = transaction_timeout_ms,
+          .last_update = clock_type::now(),
+          .is_expiration_requested = false};
+    }
     if (!_is_autoabort_enabled) {
         return;
     }
-    auto deadline = _mem_state.expiration[pid].deadline();
+    auto deadline = _log_state.expiration[pid].deadline();
     try_arm(deadline);
 }
 
@@ -1680,8 +1682,8 @@ ss::future<> rm_stm::do_abort_old_txes() {
     }
     absl::btree_set<model::producer_identity> expired;
     for (auto pid : pids) {
-        auto expiration_it = _mem_state.expiration.find(pid);
-        if (expiration_it != _mem_state.expiration.end()) {
+        auto expiration_it = _log_state.expiration.find(pid);
+        if (expiration_it != _log_state.expiration.end()) {
             if (!expiration_it->second.is_expired(clock_type::now())) {
                 continue;
             }
@@ -1694,7 +1696,7 @@ ss::future<> rm_stm::do_abort_old_txes() {
     }
 
     std::optional<time_point_type> earliest_deadline;
-    for (auto& [pid, expiration] : _mem_state.expiration) {
+    for (auto& [pid, expiration] : _log_state.expiration) {
         if (!is_known_session(pid)) {
             continue;
         }
@@ -1736,8 +1738,8 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
         co_return;
     }
 
-    auto expiration_it = _mem_state.expiration.find(pid);
-    if (expiration_it != _mem_state.expiration.end()) {
+    auto expiration_it = _log_state.expiration.find(pid);
+    if (expiration_it != _log_state.expiration.end()) {
         if (!expiration_it->second.is_expired(clock_type::now())) {
             co_return;
         }
@@ -1884,8 +1886,10 @@ void rm_stm::apply_fence(model::record_batch&& b) {
     if (fence_it->second <= bid.pid.get_epoch()) {
         fence_it->second = bid.pid.get_epoch();
         _log_state.inflight[bid.pid] = 0;
+        _log_state.expiration.erase(bid.pid);
         if (version == rm_stm::fence_control_record_version) {
             _log_state.tx_seqs[bid.pid] = tx_seq.value();
+            track_tx(bid.pid, transaction_timeout_ms.value());
         }
     }
 }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1935,6 +1935,8 @@ ss::future<> rm_stm::apply_control(
 
     if (crt == model::control_record_type::tx_abort) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
+        _log_state.inflight.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             // make a list
@@ -1944,6 +1946,7 @@ ss::future<> rm_stm::apply_control(
         }
 
         _mem_state.forget(pid);
+        _log_state.expiration.erase(pid);
 
         if (
           _log_state.aborted.size() > _abort_index_segment_size
@@ -1953,6 +1956,8 @@ ss::future<> rm_stm::apply_control(
         }
     } else if (crt == model::control_record_type::tx_commit) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
+        _log_state.inflight.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             _log_state.ongoing_set.erase(offset_it->second.first);
@@ -1960,6 +1965,7 @@ ss::future<> rm_stm::apply_control(
         }
 
         _mem_state.forget(pid);
+        _log_state.expiration.erase(pid);
     }
 
     co_return;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -487,6 +487,18 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
         co_return tx_errc::fenced;
     }
 
+    if (_log_state.tx_seqs.contains(pid)) {
+        if (_log_state.tx_seqs[pid] != tx_seq) {
+            vlog(
+              _ctx_log.warn,
+              "expectd tx_seq {} doesn't match gived {} for pid {}",
+              _log_state.tx_seqs[pid],
+              tx_seq,
+              pid);
+        }
+        co_return errc::invalid_producer_epoch;
+    }
+
     if (synced_term != etag) {
         vlog(
           _ctx_log.warn,
@@ -501,17 +513,18 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
         co_return tx_errc::request_rejected;
     }
 
-    auto expected_it = _mem_state.expected.find(pid);
-    if (expected_it == _mem_state.expected.end()) {
-        // impossible situation, a transaction coordinator tries
-        // to prepare a transaction which wasn't started
-        vlog(_ctx_log.error, "Can't prepare pid:{} - unknown session", pid);
-        co_return tx_errc::request_rejected;
-    }
-
-    if (expected_it->second != tx_seq) {
-        // current prepare_tx call is stale, rejecting
-        co_return tx_errc::request_rejected;
+    if (!is_transaction_ga()) {
+        auto expected_it = _mem_state.expected.find(pid);
+        if (expected_it == _mem_state.expected.end()) {
+            // impossible situation, a transaction coordinator tries
+            // to prepare a transaction which wasn't started
+            vlog(_ctx_log.error, "Can't prepare pid:{} - unknown session", pid);
+            co_return tx_errc::request_rejected;
+        }
+        if (expected_it->second != tx_seq) {
+            // current prepare_tx call is stale, rejecting
+            co_return tx_errc::request_rejected;
+        }
     }
 
     auto marker = prepare_marker{

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -991,6 +991,10 @@ ss::future<> rm_stm::start() {
 
 rm_stm::transaction_info::status_t
 rm_stm::get_tx_status(model::producer_identity pid) const {
+    if (is_transaction_ga()) {
+        return transaction_info::status_t::ongoing;
+    }
+
     if (_mem_state.preparing.contains(pid)) {
         return transaction_info::status_t::preparing;
     }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1158,31 +1158,37 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
         co_return errc::invalid_producer_epoch;
     }
 
-    if (!_mem_state.expected.contains(bid.pid)) {
-        // there is an inflight abort
-        // or this partition lost leadership => can't continue tx since there is
-        //  risk that ack=1 writes are lost
-        // or it's a client bug and it keeps producing after commit / abort
-        // or a replication of the first batch in a transaction has failed
-        vlog(
-          _ctx_log.warn,
-          "Partition doesn't expect record with pid:{}",
-          bid.pid);
-        co_return errc::invalid_producer_epoch;
-    }
+    if (is_transaction_ga()) {
+        if (!_log_state.tx_seqs.contains(bid.pid)) {
+            co_return errc::invalid_producer_epoch;
+        }
+    } else {
+        if (!_mem_state.expected.contains(bid.pid)) {
+            // there is an inflight abort
+            // or this partition lost leadership => can't continue tx since
+            // there is
+            //  risk that ack=1 writes are lost
+            // or it's a client bug and it keeps producing after commit / abort
+            // or a replication of the first batch in a transaction has failed
+            vlog(
+              _ctx_log.warn,
+              "Partition doesn't expect record with pid:{}",
+              bid.pid);
+            co_return errc::invalid_producer_epoch;
+        }
 
-    if (_mem_state.preparing.contains(bid.pid)) {
-        vlog(
-          _ctx_log.warn,
-          "Client keeps producing after initiating a prepare for pid:{}",
-          bid.pid);
-        co_return errc::generic_tx_error;
+        if (_mem_state.preparing.contains(bid.pid)) {
+            vlog(
+              _ctx_log.warn,
+              "Client keeps producing after initiating a prepare for pid:{}",
+              bid.pid);
+            co_return errc::generic_tx_error;
+        }
     }
 
     if (_mem_state.estimated.contains(bid.pid)) {
         // we received second produce request while the first is still
-        // being processed. this is highly unlikely situation because
-        // we replicate with ack=1 and it should be fast
+        // being processed.
         vlog(_ctx_log.warn, "Too frequent produce with same pid:{}", bid.pid);
         co_return errc::generic_tx_error;
     }
@@ -1214,43 +1220,54 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     } else {
         // this is the first attempt in the tx, reset dedupe cache
         reset_seq(bid);
+
+        _mem_state.estimated[bid.pid] = _insync_offset;
     }
 
-    _mem_state.inflight[bid.pid] = _mem_state.inflight[bid.pid] + 1;
-
-    if (!_mem_state.tx_start.contains(bid.pid)) {
-        _mem_state.estimated.emplace(bid.pid, _insync_offset);
+    auto expiration_it = _log_state.expiration.find(bid.pid);
+    if (expiration_it == _log_state.expiration.end()) {
+        vlog(_ctx_log.warn, "Can not find expiration info for pid:{}", bid.pid);
+        co_return errc::generic_tx_error;
     }
+    expiration_it->second.last_update = clock_type::now();
+    expiration_it->second.is_expiration_requested = false;
 
     auto r = co_await _c->replicate(
       synced_term,
       std::move(br),
-      raft::replicate_options(raft::consistency_level::leader_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack));
     if (!r) {
         if (_mem_state.estimated.contains(bid.pid)) {
             // an error during replication, preventin tx from progress
             _mem_state.expected.erase(bid.pid);
         }
+        if (_c->is_leader() && _c->term() == synced_term) {
+            co_await _c->step_down();
+        }
         co_return r.error();
     }
-
-    auto expiration_it = _mem_state.expiration.find(bid.pid);
-    if (expiration_it == _mem_state.expiration.end()) {
-        co_return errc::generic_tx_error;
+    if (!co_await wait_no_throw(
+          model::offset(r.value().last_offset()), _sync_timeout)) {
+        if (_c->is_leader() && _c->term() == synced_term) {
+            co_await _c->step_down();
+        }
+        co_return tx_errc::timeout;
     }
-    expiration_it->second.last_update = clock_type::now();
-    expiration_it->second.is_expiration_requested = false;
 
     auto old_offset = r.value().last_offset;
     auto new_offset = from_log_offset(old_offset);
 
     set_seq(bid, new_offset);
 
-    if (!_mem_state.tx_start.contains(bid.pid)) {
-        auto base_offset = model::offset(old_offset() - (bid.record_count - 1));
-        _mem_state.tx_start.emplace(bid.pid, base_offset);
-        _mem_state.tx_starts.insert(base_offset);
-        _mem_state.estimated.erase(bid.pid);
+    _mem_state.estimated.erase(bid.pid);
+
+    if (!is_transaction_ga()) {
+        if (!_mem_state.tx_start.contains(bid.pid)) {
+            auto base_offset = model::offset(
+              old_offset() - (bid.record_count - 1));
+            _mem_state.tx_start.emplace(bid.pid, base_offset);
+            _mem_state.tx_starts.insert(base_offset);
+        }
     }
 
     co_return kafka_result{.last_offset = new_offset};

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -598,49 +598,84 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
         }
     }
 
-    auto preparing_it = _mem_state.preparing.find(pid);
-
-    if (preparing_it != _mem_state.preparing.end()) {
-        if (preparing_it->second.tx_seq > tx_seq) {
-            // - tm_stm & rm_stm failed during prepare
-            // - during recovery tm_stm recommits its previous tx
-            // - that commit (we're here) collides with "next" failed prepare
-            // it may happen only if the commit passed => acking
-            co_return tx_errc::none;
-        }
-
-        ss::sstring msg;
-        if (preparing_it->second.tx_seq == tx_seq) {
-            msg = ssx::sformat(
-              "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
-              pid,
-              tx_seq);
-        } else {
-            msg = ssx::sformat(
-              "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
-              pid,
-              tx_seq,
-              preparing_it->second.tx_seq);
-        }
-
-        if (_recovery_policy == best_effort) {
-            vlog(_ctx_log.error, "{}", msg);
-            co_return tx_errc::request_rejected;
-        }
-        vassert(false, "{}", msg);
+    auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
+    if (fence_it == _log_state.fence_pid_epoch.end()) {
+        // begin_tx should have set a fence
+        co_return tx_errc::request_rejected;
+    }
+    if (pid.get_epoch() != fence_it->second) {
+        vlog(
+          _ctx_log.error,
+          "Can't commit pid:{} - fenced out by epoch {}",
+          pid,
+          fence_it->second);
+        co_return tx_errc::fenced;
     }
 
-    auto prepare_it = _log_state.prepared.find(pid);
+    std::optional<model::tx_seq> tx_seq_for_pid;
+    if (is_transaction_ga()) {
+        if (_log_state.tx_seqs.contains(pid)) {
+            if (tx_seq != _log_state.tx_seqs[pid]) {
+                co_return tx_errc::request_rejected;
+            }
+        }
+    } else {
+        auto preparing_it = _mem_state.preparing.find(pid);
 
-    if (prepare_it == _log_state.prepared.end()) {
+        if (preparing_it != _mem_state.preparing.end()) {
+            if (preparing_it->second.tx_seq > tx_seq) {
+                // - tm_stm & rm_stm failed during prepare
+                // - during recovery tm_stm recommits its previous tx
+                // - that commit (we're here) collides with "next" failed
+                // prepare it may happen only if the commit passed => acking
+                co_return tx_errc::none;
+            }
+
+            ss::sstring msg;
+            if (preparing_it->second.tx_seq == tx_seq) {
+                msg = ssx::sformat(
+                  "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
+                  pid,
+                  tx_seq);
+            } else {
+                msg = ssx::sformat(
+                  "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
+                  pid,
+                  tx_seq,
+                  preparing_it->second.tx_seq);
+            }
+
+            if (_recovery_policy == best_effort) {
+                vlog(_ctx_log.error, "{}", msg);
+                co_return tx_errc::request_rejected;
+            }
+            vassert(false, "{}", msg);
+        }
+
+        auto prepare_it = _log_state.prepared.find(pid);
+
+        if (prepare_it != _log_state.prepared.end()) {
+            tx_seq_for_pid = prepare_it->second.tx_seq;
+        }
+    }
+
+    if (!tx_seq_for_pid) {
+        tx_seq_for_pid = get_tx_seq(pid);
+    }
+
+    _mem_state.expected.erase(pid);
+    _mem_state.preparing.erase(pid);
+
+    if (!tx_seq_for_pid) {
         vlog(
           _ctx_log.trace,
-          "Can't find prepare for pid:{} => replaying already comitted commit",
+          "Can't find tx_seq for pid:{} => replaying already comitted "
+          "commit",
           pid);
         co_return tx_errc::none;
     }
 
-    if (prepare_it->second.tx_seq > tx_seq) {
+    if (*tx_seq_for_pid > tx_seq) {
         // rare situation:
         //   * tm_stm prepares (tx_seq+1)
         //   * prepare on this rm passes but tm_stm failed to write to disk
@@ -651,15 +686,15 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
           "prepare for pid:{} has higher tx_seq:{} than given: {} => replaying "
           "already comitted commit",
           pid,
-          prepare_it->second.tx_seq,
+          *tx_seq_for_pid,
           tx_seq);
         co_return tx_errc::none;
-    } else if (prepare_it->second.tx_seq < tx_seq) {
+    } else if (*tx_seq_for_pid < tx_seq) {
         std::string msg = fmt::format(
           "Rejecting commit with tx_seq:{} since prepare with lesser tx_seq:{} "
           "exists",
           tx_seq,
-          prepare_it->second.tx_seq);
+          *tx_seq_for_pid);
         if (_recovery_policy == best_effort) {
             vlog(_ctx_log.error, "{}", msg);
             co_return tx_errc::request_rejected;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -13,6 +13,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/protocol/response_writer.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -1774,19 +1775,32 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
 
     _mem_state.expected.erase(pid);
 
-    std::optional<prepare_marker> marker;
-    auto prepare_it = _mem_state.preparing.find(pid);
-    if (prepare_it != _mem_state.preparing.end()) {
-        marker = prepare_it->second;
-    }
-    prepare_it = _log_state.prepared.find(pid);
-    if (prepare_it != _log_state.prepared.end()) {
-        marker = prepare_it->second;
+    std::optional<model::tx_seq> tx_seq;
+    if (!is_transaction_ga()) {
+        auto prepare_it = _mem_state.preparing.find(pid);
+        if (prepare_it != _mem_state.preparing.end()) {
+            tx_seq = prepare_it->second.tx_seq;
+        }
+        prepare_it = _log_state.prepared.find(pid);
+        if (prepare_it != _log_state.prepared.end()) {
+            tx_seq = prepare_it->second.tx_seq;
+        }
     }
 
-    if (marker) {
+    if (!tx_seq) {
+        tx_seq = get_tx_seq(pid);
+    }
+
+    if (is_transaction_ga() && !tx_seq) {
+        vlog(
+          _ctx_log.error,
+          "Can not find tx_seq for pid({}) to expire old tx",
+          pid);
+    }
+
+    if (tx_seq) {
         auto r = co_await _tx_gateway_frontend.local().try_abort(
-          marker->tm_partition, marker->pid, marker->tx_seq, _sync_timeout);
+          model::partition_id(0), pid, *tx_seq, _sync_timeout);
         if (r.ec == tx_errc::none) {
             if (r.commited) {
                 auto batch = make_tx_control_batch(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -731,6 +731,22 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
 
 abort_origin rm_stm::get_abort_origin(
   const model::producer_identity& pid, model::tx_seq tx_seq) const {
+    if (is_transaction_ga()) {
+        auto tx_seq_for_pid = get_tx_seq(pid);
+        if (!tx_seq_for_pid) {
+            return abort_origin::present;
+        }
+
+        if (tx_seq < *tx_seq_for_pid) {
+            return abort_origin::past;
+        }
+        if (*tx_seq_for_pid < tx_seq) {
+            return abort_origin::future;
+        }
+
+        return abort_origin::present;
+    }
+
     auto expected_it = _mem_state.expected.find(pid);
     if (expected_it != _mem_state.expected.end()) {
         if (tx_seq < expected_it->second) {
@@ -759,6 +775,18 @@ abort_origin rm_stm::get_abort_origin(
         if (prepared_it->second.tx_seq < tx_seq) {
             return abort_origin::future;
         }
+    }
+
+    auto tx_seq_for_pid = get_tx_seq(pid);
+    if (!tx_seq_for_pid) {
+        return abort_origin::present;
+    }
+
+    if (tx_seq < *tx_seq_for_pid) {
+        return abort_origin::past;
+    }
+    if (*tx_seq_for_pid < tx_seq) {
+        return abort_origin::future;
     }
 
     return abort_origin::present;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1782,8 +1782,11 @@ void rm_stm::apply_fence(model::record_batch&& b) {
 
     auto [fence_it, _] = _log_state.fence_pid_epoch.try_emplace(
       bid.pid.get_id(), bid.pid.get_epoch());
-    if (fence_it->second < bid.pid.get_epoch()) {
+    if (fence_it->second <= bid.pid.get_epoch()) {
         fence_it->second = bid.pid.get_epoch();
+        if (version == rm_stm::fence_control_record_version) {
+            _log_state.tx_seqs[bid.pid] = tx_seq.value();
+        }
     }
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -344,26 +344,6 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
                 co_return tx_errc::unknown_server_error;
             }
         }
-
-        auto batch = make_fence_batch(
-          rm_stm::fence_control_record_version, pid);
-        auto reader = model::make_memory_record_batch_reader(std::move(batch));
-        auto r = co_await _c->replicate(
-          synced_term,
-          std::move(reader),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
-        if (!r) {
-            vlog(
-              _ctx_log.error,
-              "Error \"{}\" on replicating pid:{} fencing batch",
-              r.error(),
-              pid);
-            co_return tx_errc::unknown_server_error;
-        }
-        if (!co_await wait_no_throw(
-              model::offset(r.value().last_offset()), _sync_timeout)) {
-            co_return tx_errc::unknown_server_error;
-        }
     } else if (pid.get_epoch() < fence_it->second) {
         vlog(
           _ctx_log.error,
@@ -371,6 +351,33 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
           pid,
           fence_it->second);
         co_return tx_errc::fenced;
+    }
+
+    std::optional<model::record_batch> batch;
+    if (is_transaction_ga()) {
+        batch = make_fence_batch(pid, tx_seq, transaction_timeout_ms);
+    } else {
+        batch = make_fence_batch(pid);
+    }
+
+    auto reader = model::make_memory_record_batch_reader(std::move(*batch));
+    auto r = co_await _c->replicate(
+      synced_term,
+      std::move(reader),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+
+    if (!r) {
+        vlog(
+          _ctx_log.error,
+          "Error \"{}\" on replicating pid:{} fencing batch",
+          r.error(),
+          pid);
+        co_return tx_errc::unknown_server_error;
+    }
+
+    if (!co_await wait_no_throw(
+          model::offset(r.value().last_offset()), _sync_timeout)) {
+        co_return tx_errc::unknown_server_error;
     }
 
     auto [_, inserted] = _mem_state.expected.emplace(pid, tx_seq);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2295,7 +2295,31 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
             tx_ss.seqs.push_back(entry.second.copy());
         }
         tx_ss.offset = _insync_offset;
+
+        for (const auto& entry : _log_state.tx_seqs) {
+            tx_ss.tx_seqs.push_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.first, .tx_seq = entry.second});
+        }
+
+        for (const auto& entry : _log_state.inflight) {
+            tx_ss.inflight.push_back(tx_snapshot::inflight_snapshot{
+              .pid = entry.first, .counter = entry.second});
+        }
+
+        for (const auto& entry : _log_state.expiration) {
+            tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
+              .pid = entry.first, .timeout = entry.second.timeout});
+        }
+
         reflection::adl<tx_snapshot>{}.to(tx_ss_buf, std::move(tx_ss));
+    } else if (version == tx_snapshot_v2::version) {
+        tx_snapshot_v2 tx_ss;
+        fill_snapshot_wo_seqs(tx_ss);
+        for (const auto& entry : _log_state.seq_table) {
+            tx_ss.seqs.push_back(entry.second.copy());
+        }
+        tx_ss.offset = _insync_offset;
+        reflection::adl<tx_snapshot_v2>{}.to(tx_ss_buf, std::move(tx_ss));
     } else if (version == tx_snapshot_v1::version) {
         tx_snapshot_v1 tx_ss;
         fill_snapshot_wo_seqs(tx_ss);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -402,6 +402,8 @@ private:
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
 
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
+        // number of batches replicated withing a transaction
+        absl::flat_hash_map<model::producer_identity, int64_t> inflight;
     };
 
     struct mem_state {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -355,6 +355,16 @@ private:
     ss::future<> reduce_aborted_list();
     ss::future<> offload_aborted_txns();
 
+    std::optional<model::tx_seq>
+    get_tx_seq(model::producer_identity pid) const {
+        auto log_it = _log_state.tx_seqs.find(pid);
+        if (log_it != _log_state.tx_seqs.end()) {
+            return log_it->second;
+        }
+
+        return std::nullopt;
+    }
+
     // The state of this state machine maybe change via two paths
     //
     //   - by reading the already replicated commands from raft and

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -122,7 +122,7 @@ public:
     };
 
     struct tx_snapshot {
-        static constexpr uint8_t version = 2;
+        static constexpr uint8_t version = 3;
 
         std::vector<model::producer_identity> fenced;
         std::vector<tx_range> ongoing;
@@ -131,6 +131,25 @@ public:
         std::vector<abort_index> abort_indexes;
         model::offset offset;
         std::vector<seq_entry> seqs;
+
+        struct tx_seqs_snapshot {
+            model::producer_identity pid;
+            model::tx_seq tx_seq;
+        };
+
+        struct inflight_snapshot {
+            model::producer_identity pid;
+            int64_t counter;
+        };
+
+        struct expiration_snapshot {
+            model::producer_identity pid;
+            duration_type timeout;
+        };
+
+        std::vector<tx_seqs_snapshot> tx_seqs;
+        std::vector<inflight_snapshot> inflight;
+        std::vector<expiration_snapshot> expiration;
     };
 
     struct abort_snapshot {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -521,6 +521,11 @@ private:
     template<class T>
     void fill_snapshot_wo_seqs(T&);
 
+    bool is_transaction_ga() const {
+        return _feature_table.local().is_active(
+          features::feature::transaction_ga);
+    }
+
     ss::basic_rwlock<> _state_lock;
     bool _is_abort_idx_reduction_requested{false};
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -144,7 +144,8 @@ public:
     };
 
     static constexpr int8_t prepare_control_record_version{0};
-    static constexpr int8_t fence_control_record_version{0};
+    static constexpr int8_t fence_control_record_v0_version{0};
+    static constexpr int8_t fence_control_record_version{1};
 
     explicit rm_stm(
       ss::logger&,

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -404,6 +404,8 @@ private:
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
         // number of batches replicated withing a transaction
         absl::flat_hash_map<model::producer_identity, int64_t> inflight;
+        absl::flat_hash_map<model::producer_identity, expiration_info>
+          expiration;
     };
 
     struct mem_state {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -390,6 +390,8 @@ private:
         // by spec should be ready for thier commands being rejected so it's
         // ok by design to have false rejects
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
+
+        absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
     };
 
     struct mem_state {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -550,22 +550,25 @@ ss::future<tm_stm::op_status> tm_stm::add_partitions(
     if (ptx->second.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::unknown;
     }
-    bool just_started = ptx->second.partitions.size() == 0
-                        && ptx->second.groups.size() == 0;
 
-    if (just_started) {
-        tm_transaction tx = ptx->second;
-        for (auto& partition : partitions) {
-            tx.partitions.push_back(partition);
-        }
-        tx.last_update_ts = clock_type::now();
-        auto r = co_await update_tx(tx, tx.etag);
+    if (!is_transaction_ga()) {
+        bool just_started = ptx->second.partitions.size() == 0
+                            && ptx->second.groups.size() == 0;
 
-        if (!r.has_value()) {
-            co_return tm_stm::op_status::unknown;
+        if (just_started) {
+            tm_transaction tx = ptx->second;
+            for (auto& partition : partitions) {
+                tx.partitions.push_back(partition);
+            }
+            tx.last_update_ts = clock_type::now();
+            auto r = co_await update_tx(tx, tx.etag);
+
+            if (!r.has_value()) {
+                co_return tm_stm::op_status::unknown;
+            }
+            _mem_txes[tx_id] = tx;
+            co_return tm_stm::op_status::success;
         }
-        _mem_txes[tx_id] = tx;
-        co_return tm_stm::op_status::success;
     }
 
     for (auto& partition : partitions) {
@@ -587,21 +590,24 @@ ss::future<tm_stm::op_status> tm_stm::add_group(
     if (ptx->second.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::unknown;
     }
-    bool just_started = ptx->second.partitions.size() == 0
-                        && ptx->second.groups.size() == 0;
 
-    if (just_started) {
-        tm_transaction tx = ptx->second;
-        tx.groups.push_back(
-          tm_transaction::tx_group{.group_id = group_id, .etag = term});
-        tx.last_update_ts = clock_type::now();
-        auto r = co_await update_tx(tx, tx.etag);
+    if (!is_transaction_ga()) {
+        bool just_started = ptx->second.partitions.size() == 0
+                            && ptx->second.groups.size() == 0;
 
-        if (!r.has_value()) {
-            co_return tm_stm::op_status::unknown;
+        if (just_started) {
+            tm_transaction tx = ptx->second;
+            tx.groups.push_back(
+              tm_transaction::tx_group{.group_id = group_id, .etag = term});
+            tx.last_update_ts = clock_type::now();
+            auto r = co_await update_tx(tx, tx.etag);
+
+            if (!r.has_value()) {
+                co_return tm_stm::op_status::unknown;
+            }
+            _mem_txes[tx_id] = tx;
+            co_return tm_stm::op_status::success;
         }
-        _mem_txes[tx_id] = tx;
-        co_return tm_stm::op_status::success;
     }
 
     ptx->second.groups.push_back(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1480,46 +1480,48 @@ tx_gateway_frontend::do_commit_tm_tx(
             }
         }
 
-        std::vector<ss::future<prepare_tx_reply>> pfs;
-        for (auto rm : tx.partitions) {
-            pfs.push_back(_rm_partition_frontend.local().prepare_tx(
-              rm.ntp,
-              rm.etag,
-              model::tx_manager_ntp.tp.partition,
-              tx.pid,
-              tx.tx_seq,
-              timeout));
-        }
-
         std::vector<ss::future<prepare_group_tx_reply>> pgfs;
         for (auto group : tx.groups) {
             pgfs.push_back(_rm_group_proxy->prepare_group_tx(
               group.group_id, group.etag, tx.pid, tx.tx_seq, timeout));
         }
 
-        if (
-          !is_transaction_ga()
-          && tx.status == tm_transaction::tx_status::ongoing) {
-            auto preparing_tx = co_await stm->mark_tx_preparing(
-              expected_term, tx.id);
-            if (!preparing_tx.has_value()) {
-                if (preparing_tx.error() == tm_stm::op_status::not_leader) {
-                    outcome->set_value(tx_errc::not_coordinator);
-                    co_return tx_errc::not_coordinator;
-                }
-                outcome->set_value(tx_errc::unknown_server_error);
-                co_return tx_errc::unknown_server_error;
-            }
-            tx = preparing_tx.value();
-        }
-
+        std::vector<ss::future<prepare_tx_reply>> pfs;
         auto ok = true;
         auto rejected = false;
-        auto prs = co_await when_all_succeed(pfs.begin(), pfs.end());
-        for (const auto& r : prs) {
-            ok = ok && (r.ec == tx_errc::none);
-            rejected = rejected || (r.ec == tx_errc::request_rejected);
+
+        if (!is_transaction_ga()) {
+            for (auto rm : tx.partitions) {
+                pfs.push_back(_rm_partition_frontend.local().prepare_tx(
+                  rm.ntp,
+                  rm.etag,
+                  model::tx_manager_ntp.tp.partition,
+                  tx.pid,
+                  tx.tx_seq,
+                  timeout));
+            }
+
+            if (tx.status == tm_transaction::tx_status::ongoing) {
+                auto preparing_tx = co_await stm->mark_tx_preparing(
+                  expected_term, tx.id);
+                if (!preparing_tx.has_value()) {
+                    if (preparing_tx.error() == tm_stm::op_status::not_leader) {
+                        outcome->set_value(tx_errc::not_coordinator);
+                        co_return tx_errc::not_coordinator;
+                    }
+                    outcome->set_value(tx_errc::unknown_server_error);
+                    co_return tx_errc::unknown_server_error;
+                }
+                tx = preparing_tx.value();
+            }
+
+            auto prs = co_await when_all_succeed(pfs.begin(), pfs.end());
+            for (const auto& r : prs) {
+                ok = ok && (r.ec == tx_errc::none);
+                rejected = rejected || (r.ec == tx_errc::request_rejected);
+            }
         }
+
         auto pgrs = co_await when_all_succeed(pgfs.begin(), pgfs.end());
         for (const auto& r : pgrs) {
             ok = ok && (r.ec == tx_errc::none);


### PR DESCRIPTION
## Cover letter

Idea is: do not write prepare marker for rm_stm. We did it to sync all prev records for tx. Because we write data_batches with leader ack. And it does not provide that all followers flush this records. Prepare marker was written with quorum_ack. And after we apply it we can be sure that records for transaction is replicated and flushed.

What we wanna do:
- Do not write prepare_marker
- Change leader_ack to quorum_ack for data batches
- Store tx_seq at the begin_tx because we need it on expire old_txs

Fixes #6484 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Do not send prepare state to rm_stm


