### PR TITLE
tests: Fix stale concept check

### DIFF
--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -161,8 +161,8 @@ public:
 
     // clang-format off
     template<typename T = random_batches_generator>
-        requires requires(T generator) {
-            { generator() } -> std::same_as<ss::circular_buffer<model::record_batch>>;
+        requires requires(T generator, std::optional<model::timestamp> ts) {
+            { generator(ts) } -> std::same_as<ss::circular_buffer<model::record_batch>>;
         }
     // clang-format on
     std::vector<model::record_batch_header> append_random_batches(


### PR DESCRIPTION
## Cover letter

After cf2fc2a, existing check does not hold.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none
