### PR TITLE
net: avoid `this` capture in lambda coroutine

### DIFF
--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -19,7 +19,7 @@
 
 namespace net {
 
-conn_quota::units::~units() {
+conn_quota::units::~units() noexcept {
     if (_quotas) {
         (*_quotas).get().put(_addr);
     }

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -52,20 +52,21 @@ public:
      */
     class [[nodiscard]] units {
     public:
-        units() {}
+        units() = default;
 
         units(conn_quota& quotas, ss::net::inet_address const& addr)
           : _quotas(std::ref(quotas))
           , _addr(addr) {}
 
         units(units const&) = delete;
+        units& operator=(units const&) = delete;
         units(units&& rhs) noexcept
-          : _addr(std::move(rhs._addr)) {
+          : _addr(rhs._addr) {
             _quotas = std::exchange(rhs._quotas, std::nullopt);
         }
-        units& operator=(units&& rhs) {
+        units& operator=(units&& rhs) noexcept {
             _quotas = std::exchange(rhs._quotas, std::nullopt);
-            _addr = std::move(rhs._addr);
+            _addr = rhs._addr;
             return *this;
         }
 

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -78,7 +78,7 @@ public:
          * it is constructed with a reference to a `conn_quota`
          * it becomes live.
          */
-        bool live() { return _quotas.has_value(); }
+        bool live() const { return _quotas.has_value(); }
 
     private:
         std::optional<std::reference_wrapper<conn_quota>> _quotas;

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -70,7 +70,7 @@ public:
             return *this;
         }
 
-        ~units();
+        ~units() noexcept;
 
         /**
          * A default-constructed `units` is not live, i.e.

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -177,6 +177,7 @@ private:
 
     friend resources;
     ss::future<> accept(listener&);
+    ss::future<ss::stop_iteration> accept_finish(listener&, ss::future<ss::accept_result>);
     void setup_metrics();
     void setup_public_metrics();
 

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -177,7 +177,7 @@ private:
 
     friend resources;
     ss::future<> accept(listener&);
-    ss::future<ss::stop_iteration> accept_finish(listener&, ss::future<ss::accept_result>);
+    ss::future<ss::stop_iteration> accept_finish(ss::sstring, ss::future<ss::accept_result>);
     void setup_metrics();
     void setup_public_metrics();
 

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -177,7 +177,8 @@ private:
 
     friend resources;
     ss::future<> accept(listener&);
-    ss::future<ss::stop_iteration> accept_finish(ss::sstring, ss::future<ss::accept_result>);
+    ss::future<ss::stop_iteration>
+      accept_finish(ss::sstring, ss::future<ss::accept_result>);
     void setup_metrics();
     void setup_public_metrics();
 


### PR DESCRIPTION
## Cover letter

A shot in the dark for https://github.com/redpanda-data/redpanda/issues/5575

This needs to bake in the tree for a while to be certain because of how rare we see this crash. If we can conclude at some point that the issue is gone, then we might consider backporting / closing the issue.

Also, if we don't find that the issue is resolved, then we might consider looking more closely at the connection_rate_limit feature that is applied in the net connection accept handler.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* None