### PR TITLE
transactions: enable by default

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -192,8 +192,6 @@ public:
 
     void testing_only_disable_auto_abort() { _is_autoabort_enabled = false; }
 
-    void testing_only_enable_transactions() { _is_tx_enabled = true; }
-
     struct expiration_info {
         duration_type timeout;
         time_point_type last_update;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -71,7 +71,6 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -148,7 +147,6 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -227,7 +225,6 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -310,7 +307,6 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -351,7 +347,6 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -412,7 +407,6 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -478,7 +472,6 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     cluster::rm_stm stm(
       logger, _raft.get(), tx_gateway_frontend, feature_table);
     stm.testing_only_disable_auto_abort();
-    stm.testing_only_enable_transactions();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -481,7 +481,7 @@ configuration::configuration()
       "enable_transactions",
       "Enable transactions",
       {.visibility = visibility::user},
-      false)
+      true)
   , abort_index_segment_size(
       *this,
       "abort_index_segment_size",

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -21,8 +21,10 @@ FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
     auto client = make_kafka_client().get0();
     client.connect().get();
 
+    using underlying_t = std::underlying_type_t<kafka::coordinator_type>;
     kafka::find_coordinator_request req("key");
-    req.data.key_type = kafka::coordinator_type::transaction;
+    req.data.key_type = kafka::coordinator_type(
+      std::numeric_limits<underlying_t>::max());
 
     auto resp = client.dispatch(req, kafka::api_version(1)).get0();
     client.stop().then([&client] { client.shutdown(); }).get();

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -27,7 +27,7 @@ from ducktape.utils.util import wait_until
 
 BOOTSTRAP_CONFIG = {
     # A non-default value for checking bootstrap import works
-    'enable_idempotence': True,
+    'enable_idempotence': False,
 }
 
 SECRET_CONFIG_NAMES = frozenset(["cloud_storage_secret_key"])
@@ -160,7 +160,7 @@ class ClusterConfigTest(RedpandaTest):
         for k, v in BOOTSTRAP_CONFIG.items():
             assert config[k] == v
 
-        set_again = {'enable_idempotence': False}
+        set_again = {'enable_idempotence': True}
         assert BOOTSTRAP_CONFIG['enable_idempotence'] != set_again[
             'enable_idempotence']
         self.redpanda.set_extra_rp_conf(set_again)

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -41,8 +41,6 @@ class EndToEndTopicRecovery(RedpandaTest):
 
     def __init__(self, test_context):
         extra_rp_conf = dict(
-            enable_idempotence=True,
-            enable_transactions=True,
             enable_leader_balancer=False,
             partition_autobalancing_mode="off",
             group_initial_rebalance_delay=300,

--- a/tests/rptest/tests/idempotency_test.py
+++ b/tests/rptest/tests/idempotency_test.py
@@ -23,8 +23,6 @@ def on_delivery(err, msg):
 class IdempotencyTest(RedpandaTest):
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "id_allocator_replication": 3,
             "default_topic_replications": 3,
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -42,8 +42,6 @@ class RetentionPolicyTest(RedpandaTest):
         extra_rp_conf = dict(
             log_compaction_interval_ms=5000,
             log_segment_size=1048576,
-            enable_transactions=True,
-            enable_idempotence=True,
         )
 
         super(RetentionPolicyTest, self).__init__(test_context=test_context,

--- a/tests/rptest/tests/scramful_eos_test.py
+++ b/tests/rptest/tests/scramful_eos_test.py
@@ -31,11 +31,6 @@ class ScramfulEosTest(RedpandaTest):
 
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "enable_transactions": True,
-            "id_allocator_replication": 3,
-            "transaction_coordinator_replication": 3,
-            "id_allocator_replication": 3,
             "default_topic_replications": 3,
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,

--- a/tests/rptest/tests/scramless_eos_test.py
+++ b/tests/rptest/tests/scramless_eos_test.py
@@ -23,11 +23,6 @@ def on_delivery(err, msg):
 class ScramlessEosTest(RedpandaTest):
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "enable_transactions": True,
-            "id_allocator_replication": 3,
-            "transaction_coordinator_replication": 3,
-            "id_allocator_replication": 3,
             "default_topic_replications": 3,
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -37,8 +37,6 @@ class ShadowIndexingTxTest(RedpandaTest):
 
     def __init__(self, test_context):
         extra_rp_conf = dict(
-            enable_idempotence=True,
-            enable_transactions=True,
             enable_leader_balancer=False,
             partition_autobalancing_mode="off",
             group_initial_rebalance_delay=300,

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -30,10 +30,6 @@ class TransactionsTest(RedpandaTest):
 
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "enable_transactions": True,
-            "transaction_coordinator_replication": 3,
-            "id_allocator_replication": 3,
             "enable_leader_balancer": False,
             "partition_autobalancing_mode": "off",
         }
@@ -393,10 +389,6 @@ class UpgradeTransactionTest(RedpandaTest):
             self.test_context,
             1,
             extra_rp_conf={
-                "enable_idempotence": True,
-                "enable_transactions": True,
-                "transaction_coordinator_replication": 1,
-                "id_allocator_replication": 1,
                 "enable_leader_balancer": False,
                 "enable_auto_rebalance_on_node_add": False,
             },

--- a/tests/rptest/tests/tx_abort_index_test.py
+++ b/tests/rptest/tests/tx_abort_index_test.py
@@ -41,7 +41,6 @@ class TxAbortSnapshotTest(RedpandaTest):
         extra_rp_conf = {
             "default_topic_replications": 3,
             "default_topic_partitions": 1,
-            "enable_transactions": True,
             "log_segment_size": 1048576,
             "delete_retention_ms": 1,
             "abort_index_segment_size": 2

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -33,8 +33,6 @@ class TxAdminTest(RedpandaTest):
               self).__init__(test_context=test_context,
                              num_brokers=3,
                              extra_rp_conf={
-                                 "enable_idempotence": True,
-                                 "enable_transactions": True,
                                  "tx_timeout_delay_ms": 10000000,
                                  "abort_timed_out_transactions_interval_ms":
                                  10000000,

--- a/tests/rptest/tests/tx_feature_flag_test.py
+++ b/tests/rptest/tests/tx_feature_flag_test.py
@@ -27,10 +27,6 @@ class TxFeatureFlagTest(EndToEndTest):
         # it unavailable when one of the nodes is down,
         self.start_redpanda(num_nodes=3,
                             extra_rp_conf={
-                                "transaction_coordinator_replication": 3,
-                                "id_allocator_replication": 3,
-                                "enable_idempotence": True,
-                                "enable_transactions": True,
                                 "default_topic_replications": 1,
                                 "default_topic_partitions": 1,
                                 "health_manager_tick_interval": 3600000
@@ -52,11 +48,6 @@ class TxFeatureFlagTest(EndToEndTest):
         for n in self.redpanda.nodes:
             self.redpanda.start_node(n,
                                      override_cfg_params={
-                                         "transaction_coordinator_replication":
-                                         3,
-                                         "id_allocator_replication": 3,
-                                         "enable_idempotence": False,
-                                         "enable_transactions": False,
                                          "transactional_id_expiration_ms":
                                          1000,
                                          "default_topic_replications": 3,

--- a/tests/rptest/tests/tx_reads_writes_test.py
+++ b/tests/rptest/tests/tx_reads_writes_test.py
@@ -22,10 +22,6 @@ class TxReadsWritesTest(RedpandaTest):
     """
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "enable_transactions": True,
-            "transaction_coordinator_replication": 1,
-            "id_allocator_replication": 1,
             "default_topic_replications": 1,
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,

--- a/tests/rptest/tests/tx_verifier_test.py
+++ b/tests/rptest/tests/tx_verifier_test.py
@@ -29,10 +29,6 @@ class TxVerifierTest(RedpandaTest):
     """
     def __init__(self, test_context):
         extra_rp_conf = {
-            "enable_idempotence": True,
-            "enable_transactions": True,
-            "transaction_coordinator_replication": 3,
-            "id_allocator_replication": 3,
             "default_topic_replications": 3,
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,


### PR DESCRIPTION
## Cover letter

Enable transactions by default. 

Fixes redpanda-data/core-internal#54

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Enables transactional capabilities on the service side by default.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* Enables transactions feature (enable_transactions=true) by default on the service side.

### Features

* none

### Improvements

* none