### PR TITLE
ducktape: admin_ops_fuzzer use lowercase in topic names

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -62,7 +62,8 @@ class Operation():
 
 def random_string(length):
     return ''.join(
-        [random.choice(string.ascii_letters) for i in range(0, length)])
+        [random.choice(string.ascii_lowercase) for i in range(0, length)]
+    )  # Using only lower case to avoid getting "ERROR" or other string that would be perceived as an error in the log
 
 
 @unique


### PR DESCRIPTION
When we use all the symbols, it is very unlikely, but we can obtain combination of letters that would be perceived as an error in the log (e.c. ERROR)

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6761 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
