### PR TITLE
tests: fix SISettings handling in AWS

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -600,6 +600,7 @@ class RedpandaService(Service):
                 self._extra_rp_conf)
 
     def set_si_settings(self, si_settings: SISettings):
+        si_settings.load_context(self.logger, self._context)
         self._si_settings = si_settings
         self._extra_rp_conf = self._si_settings.update_rp_conf(
             self._extra_rp_conf)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -54,9 +54,6 @@ class RedpandaTest(Test):
             else:
                 num_brokers = 1
 
-        if self.si_settings:
-            self.si_settings.load_context(self.logger, test_context)
-
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,
                                         extra_rp_conf=extra_rp_conf,


### PR DESCRIPTION
## Cover letter

The SISettings object was only getting adjusted for using AWS S3 (via `load_context`) when provided at construction time, not via set_si_settings.

This caused some tests not to work properly
when run on EC2 instances.

Move the call to a location where it'll get hit
in all cases.

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none