### PR TITLE
Automatic Authentication for Schema Registry and HTTP Proxy - part1

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -130,6 +130,7 @@ v_cc_library(
     node_status_rpc_handler.cc
     bootstrap_service.cc
     bootstrap_backend.cc
+    ephemeral_credential_frontend.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -48,6 +48,13 @@ rpcgen(
   INCLUDES ${CMAKE_BINARY_DIR}/src/v
 )
 
+rpcgen(
+  TARGET ephemeral_credential_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/ephemeral_credential_service_impl.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/ephemeral_credential_service_impl.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+
 v_cc_library(
   NAME cluster
   SRCS
@@ -132,6 +139,7 @@ v_cc_library(
     tx_gateway_rpc
     partition_balancer_rpc
     node_status_rpc
+    ephemeral_credential_rpc
     v::raft
     Roaring::roaring
     absl::flat_hash_map

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -131,6 +131,7 @@ v_cc_library(
     bootstrap_service.cc
     bootstrap_backend.cc
     ephemeral_credential_frontend.cc
+    ephemeral_credential_service.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -17,8 +17,7 @@
 #include "cluster/scheduling/leader_balancer.h"
 #include "raft/fwd.h"
 #include "rpc/fwd.h"
-#include "security/authorizer.h"
-#include "security/credential_store.h"
+#include "security/fwd.h"
 #include "storage/api.h"
 #include "storage/fwd.h"
 
@@ -63,6 +62,16 @@ public:
 
     ss::sharded<security::credential_store>& get_credential_store() {
         return _credentials;
+    }
+
+    ss::sharded<security::ephemeral_credential_store>&
+    get_ephemeral_credential_store() {
+        return _ephemeral_credentials;
+    }
+
+    ss::sharded<ephemeral_credential_frontend>&
+    get_ephemeral_credential_frontend() {
+        return _ephemeral_credential_frontend;
     }
 
     ss::sharded<security_frontend>& get_security_frontend() {
@@ -165,9 +174,11 @@ private:
     ss::sharded<storage::node_api>& _storage_node; // single instance
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
+    ss::sharded<security::ephemeral_credential_store> _ephemeral_credentials;
     security_manager _security_manager;
     data_policy_manager _data_policy_manager;
     ss::sharded<security_frontend> _security_frontend;
+    ss::sharded<ephemeral_credential_frontend> _ephemeral_credential_frontend;
     ss::sharded<data_policy_frontend> _data_policy_frontend;
     ss::sharded<security::authorizer> _authorizer;
     ss::sharded<raft::group_manager>& _raft_manager;

--- a/src/v/cluster/ephemeral_credential_frontend.cc
+++ b/src/v/cluster/ephemeral_credential_frontend.cc
@@ -1,0 +1,172 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/ephemeral_credential_frontend.h"
+
+#include "cluster/ephemeral_credential_serde.h"
+#include "cluster/ephemeral_credential_service_impl.h"
+#include "cluster/logger.h"
+#include "features/feature_table.h"
+#include "random/generators.h"
+#include "rpc/connection_cache.h"
+#include "security/acl.h"
+#include "security/credential_store.h"
+#include "security/ephemeral_credential.h"
+#include "security/ephemeral_credential_store.h"
+#include "security/exceptions.h"
+#include "security/scram_authenticator.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
+#include "vformat.h"
+
+#include <seastar/coroutine/exception.hh>
+
+#include <fmt/ranges.h>
+
+// namespace
+
+namespace cluster {
+
+namespace {
+
+constexpr size_t credential_length{32};
+constexpr auto timeout = 5s;
+
+using scram = security::scram_sha512_authenticator::auth::scram;
+
+security::ephemeral_credential
+make_ephemeral_credential(security::acl_principal const& principal) {
+    constexpr auto gen = []() {
+        return random_generators::gen_alphanum_string(credential_length);
+    };
+    return {security::ephemeral_credential{
+      principal,
+      security::credential_user{gen()},
+      security::credential_password{gen()},
+      security::scram_sha512_authenticator::name}};
+}
+
+security::scram_credential
+make_scram_credential(security::ephemeral_credential const& cred) {
+    return scram::make_credentials(
+      cred.principal(), cred.password(), scram::min_iterations);
+}
+
+} // namespace
+
+using namespace std::chrono_literals;
+
+ephemeral_credential_frontend::ephemeral_credential_frontend(
+  model::node_id self,
+  ss::sharded<security::credential_store>& c_store,
+  ss::sharded<security::ephemeral_credential_store>& e_store,
+  ss::sharded<features::feature_table>& feature_table,
+  ss::sharded<rpc::connection_cache>& connections)
+  : _self(self)
+  , _c_store{c_store}
+  , _e_store{e_store}
+  , _feature_table{feature_table}
+  , _connections{connections}
+  , _gate{} {}
+
+ss::future<ephemeral_credential_frontend::get_return>
+ephemeral_credential_frontend::get(security::acl_principal const& principal) {
+    auto guard = _gate.hold();
+    get_return res;
+
+    if (!_feature_table.local().is_active(
+          features::feature::ephemeral_secrets)) {
+        vlog(
+          clusterlog.info,
+          "Ephemeral credentials feature is not active (upgrade in progress?)");
+        res.err = errc::invalid_node_operation;
+        co_return res;
+    }
+
+    if (auto it = _e_store.local().find(principal); !_e_store.local().has(it)) {
+        res.credential = make_ephemeral_credential(principal);
+        co_await put(res.credential);
+    } else {
+        res.credential = *it;
+    }
+
+    co_return res;
+}
+
+ss::future<> ephemeral_credential_frontend::put(
+  security::acl_principal principal,
+  security::credential_user user,
+  security::scram_credential cred) {
+    auto guard = _gate.hold();
+    // Add the principal to the supplied scram_credential
+    cred = {
+      cred.salt(),
+      cred.server_key(),
+      cred.stored_key(),
+      cred.iterations(),
+      std::move(principal)};
+    co_await _c_store.invoke_on_all(
+      [user{std::move(user)}, cred{std::move(cred)}](auto& store) {
+          store.put(user, cred);
+      });
+}
+
+ss::future<>
+ephemeral_credential_frontend::put(security::ephemeral_credential cred) {
+    auto guard = _gate.hold();
+    co_await _e_store.invoke_on_all(
+      [cred](auto& store) { store.insert_or_assign(cred); });
+}
+
+ss::future<std::error_code> ephemeral_credential_frontend::inform(
+  model::node_id node_id, security::acl_principal const& principal) {
+    auto guard = _gate.hold();
+
+    auto e_cred_res = co_await get(principal);
+    auto err = e_cred_res.err;
+    if (err) {
+        co_return err;
+    }
+    auto req = put_ephemeral_credential_request{
+      principal,
+      e_cred_res.credential.user(),
+      make_scram_credential(e_cred_res.credential)};
+    auto res = rpc::get_ctx_data<put_ephemeral_credential_reply>(
+      co_await _connections.local()
+        .with_node_client<impl::ephemeral_credential_client_protocol>(
+          _self,
+          ss::this_shard_id(),
+          node_id,
+          timeout,
+          [req{std::move(req)}](
+            impl::ephemeral_credential_client_protocol proto) mutable {
+              return proto.put_ephemeral_credential(
+                std::move(req), rpc::client_opts{timeout});
+          }));
+
+    if (res.has_value()) {
+        err = res.assume_value().err;
+    } else if (res.has_error()) {
+        err = res.assume_error();
+    }
+    if (err) {
+        vlog(
+          clusterlog.info,
+          "Failed to inform node: {} of ephemeral_credential: {}, error: {}",
+          node_id,
+          e_cred_res.credential,
+          err);
+    }
+    co_return err;
+}
+
+ss::future<> ephemeral_credential_frontend::start() { return ss::now(); }
+ss::future<> ephemeral_credential_frontend::stop() { return _gate.close(); }
+
+} // namespace cluster

--- a/src/v/cluster/ephemeral_credential_frontend.h
+++ b/src/v/cluster/ephemeral_credential_frontend.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/errc.h"
+#include "features/fwd.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "rpc/fwd.h"
+#include "security/ephemeral_credential.h"
+#include "security/fwd.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+/*
+ * ephemeral_credential_frontend manages ephemeral credentials in memory as well
+ * as allowing to propagate them to other nodes.
+ */
+class ephemeral_credential_frontend {
+public:
+    ephemeral_credential_frontend(
+      model::node_id self,
+      ss::sharded<security::credential_store>&,
+      ss::sharded<security::ephemeral_credential_store>&,
+      ss::sharded<features::feature_table>&,
+      ss::sharded<rpc::connection_cache>&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    // Get a credential
+    // Mint one if it doesn't exist
+    struct get_return {
+        security::ephemeral_credential credential;
+        std::error_code err{errc::success};
+    };
+    ss::future<get_return> get(security::acl_principal const&);
+
+    // Insert or update a scram_credential
+    ss::future<> put(
+      security::acl_principal,
+      security::credential_user,
+      security::scram_credential);
+
+    // Insert or update an ephemeral_credential
+    ss::future<> put(security::ephemeral_credential);
+
+    // Inform a node of the credential for the given principal
+    ss::future<std::error_code>
+    inform(model::node_id, security::acl_principal const&);
+
+private:
+    model::node_id _self;
+    ss::sharded<security::credential_store>& _c_store;
+    ss::sharded<security::ephemeral_credential_store>& _e_store;
+    ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<rpc::connection_cache>& _connections;
+    ss::gate _gate;
+};
+
+} // namespace cluster

--- a/src/v/cluster/ephemeral_credential_serde.h
+++ b/src/v/cluster/ephemeral_credential_serde.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/errc.h"
+#include "security/acl.h"
+#include "security/ephemeral_credential.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
+#include "serde/envelope.h"
+
+#include <iosfwd>
+
+namespace cluster {
+
+struct put_ephemeral_credential_request
+  : serde::envelope<put_ephemeral_credential_request, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    put_ephemeral_credential_request() = default;
+    explicit put_ephemeral_credential_request(
+      security::acl_principal principal,
+      security::credential_user user,
+      security::scram_credential cred)
+      : principal{std::move(principal)}
+      , user{std::move(user)}
+      , credential{std::move(cred)} {}
+
+    auto serde_fields() { return std::tie(principal, user, credential); }
+
+    security::acl_principal principal;
+    security::credential_user user;
+    security::scram_credential credential;
+};
+
+struct put_ephemeral_credential_reply
+  : serde::envelope<put_ephemeral_credential_reply, serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    put_ephemeral_credential_reply() = default;
+    explicit put_ephemeral_credential_reply(errc err)
+      : err(err) {}
+
+    auto serde_fields() { return std::tie(err); }
+
+    errc err{errc::success};
+};
+
+} // namespace cluster

--- a/src/v/cluster/ephemeral_credential_service.cc
+++ b/src/v/cluster/ephemeral_credential_service.cc
@@ -1,0 +1,23 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/ephemeral_credential_service.h"
+
+#include "cluster/ephemeral_credential_frontend.h"
+
+namespace cluster {
+
+ss::future<put_ephemeral_credential_reply>
+ephemeral_credential_service::put_ephemeral_credential(
+  put_ephemeral_credential_request&& r, rpc::streaming_context&) {
+    co_await _fe.local().put(r.principal, r.user, r.credential);
+    co_return errc::success;
+}
+
+} // namespace cluster

--- a/src/v/cluster/ephemeral_credential_service.h
+++ b/src/v/cluster/ephemeral_credential_service.h
@@ -1,0 +1,32 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/ephemeral_credential_service_impl.h"
+#include "cluster/fwd.h"
+
+namespace cluster {
+
+class ephemeral_credential_service final
+  : public impl::ephemeral_credential_service {
+public:
+    ephemeral_credential_service(
+      ss::scheduling_group sc,
+      ss::smp_service_group ssg,
+      ss::sharded<cluster::ephemeral_credential_frontend>& fe)
+      : impl::ephemeral_credential_service{sc, ssg}
+      , _fe(fe) {}
+
+    ss::future<put_ephemeral_credential_reply> put_ephemeral_credential(
+      put_ephemeral_credential_request&&, rpc::streaming_context&) override;
+
+private:
+    ss::sharded<ephemeral_credential_frontend>& _fe;
+};
+
+} // namespace cluster

--- a/src/v/cluster/ephemeral_credential_service_impl.json
+++ b/src/v/cluster/ephemeral_credential_service_impl.json
@@ -1,0 +1,14 @@
+{
+    "namespace": "cluster::impl",
+    "service_name": "ephemeral_credential",
+    "includes": [
+        "cluster/ephemeral_credential_serde.h"
+    ],
+    "methods": [
+        {
+            "name": "put_ephemeral_credential",
+            "input_type": "put_ephemeral_credential_request",
+            "output_type": "put_ephemeral_credential_reply"
+        }
+    ]
+}

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -50,5 +50,6 @@ class drain_manager;
 class partition_balancer_backend;
 class node_status_backend;
 class node_status_table;
+class ephemeral_credential_frontend;
 
 } // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -45,7 +45,8 @@ set(srcs
     topic_configuration_compat_test.cc
     local_monitor_test.cc
     tx_compaction_tests.cc
-    archival_metadata_stm_test.cc)
+    archival_metadata_stm_test.cc
+    ephemeral_credential_test.cc)
 
 foreach(cluster_test_src ${srcs})
 get_filename_component(test_name ${cluster_test_src} NAME_WE)

--- a/src/v/cluster/tests/ephemeral_credential_test.cc
+++ b/src/v/cluster/tests/ephemeral_credential_test.cc
@@ -1,0 +1,96 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/ephemeral_credential_frontend.h"
+#include "cluster/feature_manager.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "cluster/types.h"
+#include "features/feature_table.h"
+#include "model/metadata.h"
+#include "security/acl.h"
+#include "security/scram_authenticator.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+
+#include <algorithm>
+#include <iterator>
+#include <system_error>
+#include <vector>
+
+using namespace std::chrono_literals;
+using namespace cluster;
+
+FIXTURE_TEST(test_ephemeral_credential_frontend, cluster_test_fixture) {
+    std::vector<application*> apps{
+      create_node_application(model::node_id{0}),
+      create_node_application(model::node_id{1}),
+      create_node_application(model::node_id{2})};
+
+    wait_for_all_members(3s).get();
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&apps] {
+        return apps.front()->controller->get_feature_table().local().is_active(
+          features::feature::ephemeral_secrets);
+    }).get();
+
+    auto& fe_0
+      = apps[0]->controller->get_ephemeral_credential_frontend().local();
+    auto& fe_1
+      = apps[1]->controller->get_ephemeral_credential_frontend().local();
+    auto& cs_1 = apps[1]->controller->get_credential_store().local();
+
+    security::acl_principal principal{
+      security::principal_type::ephemeral_user, "principal"};
+
+    // Get credentials on broker 0
+    auto cred_0 = fe_0.get(principal).get();
+    BOOST_REQUIRE_EQUAL(cred_0.err, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(cred_0.credential.principal(), principal);
+    auto user_0 = cred_0.credential.user();
+
+    // Get credentials again on broker 0 should return same
+    {
+        auto get_res_0 = fe_0.get(principal).get();
+        BOOST_REQUIRE_EQUAL(errc::success, get_res_0.err);
+        BOOST_REQUIRE_EQUAL(cred_0.credential, get_res_0.credential);
+    }
+
+    // Get credentials from broker 1, expect different to broker 0
+    {
+        auto get_res_1 = fe_1.get(principal).get();
+        BOOST_REQUIRE_EQUAL(errc::success, get_res_1.err);
+        BOOST_REQUIRE_NE(cred_0.credential, get_res_1.credential);
+    }
+
+    // Check inform works
+    {
+        auto res = fe_0.inform(apps[1]->controller->self(), principal).get();
+        BOOST_REQUIRE_EQUAL(res, errc::success);
+    }
+
+    // Check fe_1 has the credential fe_0 sent it
+    {
+        auto cred_1 = cs_1.get<security::scram_credential>(user_0);
+        BOOST_REQUIRE(cred_1.has_value());
+        BOOST_REQUIRE_EQUAL(cred_1->principal(), principal);
+
+        bool check_password = security::scram_sha512::validate_password(
+          cred_0.credential.password(),
+          cred_1->stored_key(),
+          cred_1->salt(),
+          cred_1->iterations());
+        BOOST_REQUIRE(check_password);
+    }
+}

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -49,6 +49,8 @@ std::string_view to_string_view(feature f) {
         return "node_id_assignment";
     case feature::replication_factor_change:
         return "replication_factor_change";
+    case feature::ephemeral_secrets:
+        return "ephemeral_secrets";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -45,6 +45,7 @@ enum class feature : std::uint64_t {
     cloud_retention = 0x800,
     node_id_assignment = 0x1000,
     replication_factor_change = 0x2000,
+    ephemeral_secrets = 0x4000,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -179,6 +180,12 @@ constexpr static std::array feature_schema{
     cluster_version{7},
     "replication_factor_change",
     feature::replication_factor_change,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster_version{7},
+    "ephemeral_secrets",
+    feature::ephemeral_secrets,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/features/fwd.h
+++ b/src/v/features/fwd.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace features {
+
+class feature_table;
+
+} // namespace features

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -125,20 +125,18 @@ public:
             } else if (_sasl) {
                 return _sasl->principal();
             }
-            return ss::sstring{}; // anonymous user
+            // anonymous user
+            return security::acl_principal{security::principal_type::user, {}};
         };
         return authorized_user(get_principal(), operation, name, quiet);
     }
 
     template<typename T>
     bool authorized_user(
-      ss::sstring user,
+      security::acl_principal principal,
       security::acl_operation operation,
       const T& name,
       authz_quiet quiet) {
-        security::acl_principal principal(
-          security::principal_type::user, std::move(user));
-
         bool authorized = _proto.authorizer().authorized(
           name, operation, principal, security::acl_host(_client_addr));
 

--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -301,6 +301,8 @@ inline ss::sstring to_kafka_principal(const security::acl_principal& p) {
     switch (p.type()) {
     case security::principal_type::user:
         return fmt::format("User:{}", p.name());
+    case security::principal_type::ephemeral_user:
+        return fmt::format("Ephemeral user:{}", p.name());
     }
     __builtin_unreachable();
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -21,6 +21,8 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/cluster_uuid.h"
 #include "cluster/controller.h"
+#include "cluster/ephemeral_credential_frontend.h"
+#include "cluster/ephemeral_credential_service.h"
 #include "cluster/fwd.h"
 #include "cluster/id_allocator.h"
 #include "cluster/id_allocator_frontend.h"
@@ -1598,6 +1600,12 @@ void application::start_runtime_services(
               _scheduling_groups.cluster_sg(),
               smp_service_groups.cluster_smp_sg(),
               std::ref(controller->get_partition_balancer())));
+
+          runtime_services.push_back(
+            std::make_unique<cluster::ephemeral_credential_service>(
+              _scheduling_groups.cluster_sg(),
+              smp_service_groups.cluster_smp_sg(),
+              std::ref(controller->get_ephemeral_credential_frontend())));
           s.add_services(std::move(runtime_services));
       })
       .get();

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME security
   SRCS
+    ephemeral_credential.cc
     scram_algorithm.cc
     scram_credential.cc
     scram_authenticator.cc

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -178,6 +178,7 @@ inline std::ostream& operator<<(std::ostream& os, acl_permission perm) {
  */
 enum class principal_type : int8_t {
     user = 0,
+    ephemeral_user = 1,
 };
 
 inline std::ostream& operator<<(std::ostream& os, resource_type type) {
@@ -208,6 +209,8 @@ inline std::ostream& operator<<(std::ostream& os, principal_type type) {
     switch (type) {
     case principal_type::user:
         return os << "user";
+    case principal_type::ephemeral_user:
+        return os << "ephemeral user";
     }
     __builtin_unreachable();
 }

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "bytes/bytes.h"
 #include "security/scram_credential.h"
+#include "security/types.h"
 
 #include <absl/container/node_hash_map.h>
 
@@ -24,10 +25,6 @@ namespace security {
  * process that often spans multiple network round trips and should remain
  * consistent for the duration of that process.
  */
-using credential_user = named_type<ss::sstring, struct credential_user_type>;
-using credential_password
-  = named_type<ss::sstring, struct credential_password_type>;
-
 class credential_store {
 public:
     // when a second type is supported update `credential_store_test` to include

--- a/src/v/security/ephemeral_credential.cc
+++ b/src/v/security/ephemeral_credential.cc
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "security/ephemeral_credential.h"
+
+#include <fmt/ostream.h>
+
+namespace security {
+
+std::ostream& operator<<(std::ostream& os, const ephemeral_credential& c) {
+    fmt::print(os, "principal: {}, user: {}", c.principal(), c.user());
+    return os;
+}
+
+} // namespace security

--- a/src/v/security/ephemeral_credential.h
+++ b/src/v/security/ephemeral_credential.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "security/acl.h"
+#include "security/types.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <iosfwd>
+
+namespace security {
+
+/*
+ * ephemeral_credential is the client side of a scram_credential.
+ *
+ * Since it contains a password it should not be serialized.
+ **/
+class ephemeral_credential {
+public:
+    ephemeral_credential() noexcept = default;
+    ephemeral_credential(
+      acl_principal principal,
+      credential_user user,
+      credential_password password,
+      ss::sstring mechanism) noexcept
+      : _principal(std::move(principal))
+      , _user(std::move(user))
+      , _password(std::move(password))
+      , _mechanism(std::move(mechanism)) {}
+
+    const acl_principal& principal() const { return _principal; }
+    const credential_user& user() const { return _user; }
+    const credential_password& password() const { return _password; }
+    const ss::sstring& mechanism() const { return _mechanism; }
+
+private:
+    friend bool
+    operator==(const ephemeral_credential&, const ephemeral_credential&)
+      = default;
+
+    friend std::ostream& operator<<(std::ostream&, const ephemeral_credential&);
+
+    acl_principal _principal;
+    credential_user _user;
+    credential_password _password;
+    ss::sstring _mechanism;
+};
+
+} // namespace security

--- a/src/v/security/ephemeral_credential_store.h
+++ b/src/v/security/ephemeral_credential_store.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "security/ephemeral_credential.h"
+
+#include <absl/container/flat_hash_set.h>
+
+#include <functional>
+#include <iosfwd>
+
+namespace security {
+
+/*
+ * Store for ephemerable user credentials.
+ */
+class ephemeral_credential_store {
+    using value_type = ephemeral_credential;
+
+    struct get_principal_ref {
+        acl_principal const& operator()(acl_principal const& p) { return p; }
+        acl_principal const& operator()(value_type const& v) {
+            return v.principal();
+        }
+    };
+
+    struct hasher {
+        using is_transparent = void;
+        template<typename T>
+        size_t operator()(T const& t) const {
+            return absl::Hash<acl_principal>()(get_principal_ref{}(t));
+        };
+    };
+
+    struct hash_comp {
+        using is_transparent = void;
+        template<typename L, typename R>
+        bool operator()(L const& l, R const& r) const {
+            return std::equal_to<>()(
+              get_principal_ref{}(l), get_principal_ref{}(r));
+        }
+    };
+
+    using underlying_t = absl::flat_hash_set<value_type, hasher, hash_comp>;
+    using const_iterator = underlying_t::const_iterator;
+
+public:
+    ephemeral_credential_store() = default;
+
+    const_iterator find(acl_principal const& p) const {
+        assert_principal(p);
+        return _credentials.find(p);
+    }
+
+    bool has(const_iterator it) const { return it != _credentials.end(); }
+
+    const_iterator insert_or_assign(value_type s) {
+        assert_principal(s.principal());
+        auto it = _credentials.find(s);
+        if (!has(it)) {
+            return _credentials.insert(std::move(s)).first;
+        }
+        auto n = _credentials.extract(it);
+        n.value() = std::move(s);
+        return _credentials.insert(std::move(n)).position;
+    }
+
+private:
+    static void assert_principal(acl_principal const& p) {
+        vassert(
+          p.type() == principal_type::ephemeral_user,
+          "principal_type expected to be ephemeral: {}",
+          p);
+    }
+
+    underlying_t _credentials;
+};
+
+} // namespace security

--- a/src/v/security/fwd.h
+++ b/src/v/security/fwd.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace security {
+
+class authorizer;
+class credential_store;
+class ephemeral_credential_store;
+
+} // namespace security

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -13,6 +13,7 @@
 
 #include "config/property.h"
 #include "seastarx.h"
+#include "security/acl.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
@@ -72,12 +73,12 @@ private:
 class mtls_state {
 public:
     explicit mtls_state(ss::sstring principal)
-      : _principal{std::move(principal)} {}
+      : _principal{principal_type::user, std::move(principal)} {}
 
-    const ss::sstring& principal() { return _principal; }
+    const acl_principal& principal() { return _principal; }
 
 private:
-    ss::sstring _principal;
+    acl_principal _principal;
 };
 
 std::optional<ss::sstring>

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "bytes/bytes.h"
 #include "outcome.h"
+#include "security/acl.h"
 #include "vassert.h"
 
 #include <memory>
@@ -24,7 +25,7 @@ public:
     virtual ~sasl_mechanism() = default;
     virtual bool complete() const = 0;
     virtual bool failed() const = 0;
-    virtual const ss::sstring& principal() const = 0;
+    virtual const acl_principal& principal() const = 0;
     virtual result<bytes> authenticate(bytes_view) = 0;
 };
 
@@ -61,7 +62,7 @@ public:
         _mechanism = std::move(m);
     }
 
-    const ss::sstring& principal() const { return _mechanism->principal(); }
+    const acl_principal& principal() const { return _mechanism->principal(); }
 
     bool handshake_v0() const { return _handshake_v0; }
     void set_handshake_v0() { _handshake_v0 = true; }

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -247,6 +247,20 @@ public:
           std::move(storedkey),
           iterations);
     }
+    static scram_credential make_credentials(
+      acl_principal principal, const ss::sstring& password, int iterations) {
+        bytes salt = random_generators::get_bytes(SaltSize);
+        bytes salted_password = salt_password(password, salt, iterations);
+        auto clientkey = client_key(salted_password);
+        auto storedkey = stored_key(clientkey);
+        auto serverkey = server_key(salted_password);
+        return scram_credential(
+          std::move(salt),
+          std::move(serverkey),
+          std::move(storedkey),
+          iterations,
+          std::move(principal));
+    }
 
     static bytes client_proof(
       bytes_view salted_password,

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -20,6 +20,8 @@ class scram_authenticator final : public sasl_mechanism {
     static constexpr int nonce_size = 130;
 
 public:
+    using scram = ScramMechanism;
+
     explicit scram_authenticator(credential_store& credentials)
       : _state{state::client_first_message}
       , _credentials(credentials) {}
@@ -39,8 +41,6 @@ public:
     }
 
 private:
-    using scram = ScramMechanism;
-
     enum class state {
         client_first_message,
         client_final_message,

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "security/acl.h"
 #include "security/credential_store.h"
 #include "security/sasl_authentication.h"
 #include "security/scram_algorithm.h"
@@ -31,13 +32,11 @@ public:
     bool complete() const override { return _state == state::complete; }
     bool failed() const override { return _state == state::failed; }
 
-    const ss::sstring& principal() const override { return authid(); }
-
-    const ss::sstring& authid() const {
+    const acl_principal& principal() const override {
         vassert(
           _state == state::complete,
           "Authentication id is not valid until auth process complete");
-        return _authid;
+        return _principal;
     }
 
 private:
@@ -57,7 +56,7 @@ private:
 
     state _state;
     credential_store& _credentials;
-    ss::sstring _authid;
+    acl_principal _principal;
 
     // populated during authentication process
     std::unique_ptr<scram_credential> _credential;

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "bytes/bytes.h"
 #include "reflection/adl.h"
+#include "security/acl.h"
 #include "serde/envelope.h"
 
 #include <iosfwd>
@@ -29,10 +30,23 @@ public:
       , _stored_key(std::move(stored_key))
       , _iterations(iterations) {}
 
+    scram_credential(
+      bytes salt,
+      bytes server_key,
+      bytes stored_key,
+      int iterations,
+      acl_principal principal) noexcept
+      : _salt(std::move(salt))
+      , _server_key(std::move(server_key))
+      , _stored_key(std::move(stored_key))
+      , _iterations(iterations)
+      , _principal(std::move(principal)) {}
+
     const bytes& salt() const { return _salt; }
     const bytes& server_key() const { return _server_key; }
     const bytes& stored_key() const { return _stored_key; }
     int iterations() const { return _iterations; }
+    const std::optional<acl_principal>& principal() { return _principal; }
 
     bool operator==(const scram_credential&) const = default;
 
@@ -47,6 +61,8 @@ private:
     bytes _server_key;
     bytes _stored_key;
     int _iterations{0};
+    // Principal is not serialized on disk, it is sent over internal rpc
+    std::optional<acl_principal> _principal;
 };
 
 } // namespace security

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -11,3 +11,17 @@ rp_test(
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_kafka_security_single_thread
+  SOURCES
+    ephemeral_credential_store_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES
+    v::seastar_testing_main
+    v::security
+  ARGS "-- -c 1"
+  LABELS
+    kafka
+)

--- a/src/v/security/tests/credential_store_test.cc
+++ b/src/v/security/tests/credential_store_test.cc
@@ -9,6 +9,10 @@
 #include "random/generators.h"
 #include "security/acl.h"
 #include "security/credential_store.h"
+#include "security/ephemeral_credential.h"
+#include "security/sasl_authentication.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
 #include "utils/base64.h"
 
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/security/tests/credential_store_test.cc
+++ b/src/v/security/tests/credential_store_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 #include "random/generators.h"
+#include "security/acl.h"
 #include "security/credential_store.h"
 #include "utils/base64.h"
 
@@ -61,6 +62,36 @@ BOOST_AUTO_TEST_CASE(credential_store_test) {
 
     BOOST_REQUIRE(store.get<scram_credential>(copied));
     BOOST_REQUIRE_EQUAL(*store.get<scram_credential>(copied), cred1);
+}
+
+BOOST_AUTO_TEST_CASE(credential_store_test_principal) {
+    const scram_credential cred0(
+      bytes("salty"),
+      bytes("i'm a server key"),
+      bytes("i'm the stored key"),
+      123456);
+
+    const scram_credential cred1(
+      bytes("salty2"),
+      bytes("i'm a server key2"),
+      bytes("i'm the stored key2"),
+      1234567,
+      acl_principal{principal_type::ephemeral_user, "ephemeral"});
+
+    const credential_user user0("user0");
+    const credential_user user1("user1");
+
+    // put new credentials
+    credential_store store;
+    store.put(user0, cred0);
+    store.put(user1, cred1);
+
+    auto r0 = store.get<scram_credential>(user0);
+    auto r1 = store.get<scram_credential>(user1);
+    BOOST_REQUIRE_EQUAL(r0->principal().has_value(), false);
+    BOOST_REQUIRE_EQUAL(
+      r1->principal()->type(), principal_type::ephemeral_user);
+    BOOST_REQUIRE_EQUAL(r1->principal()->name(), "ephemeral");
 }
 
 } // namespace security

--- a/src/v/security/tests/ephemeral_credential_store_test.cc
+++ b/src/v/security/tests/ephemeral_credential_store_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "random/generators.h"
+#include "security/acl.h"
+#include "security/ephemeral_credential.h"
+#include "security/ephemeral_credential_store.h"
+#include "security/scram_authenticator.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
+#include "test_utils/randoms.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace security {
+
+SEASTAR_THREAD_TEST_CASE(test_ephemeral_credential_store_insert) {
+    ephemeral_credential_store store{};
+
+    const auto scram_cred{tests::random_credential()};
+
+    const acl_principal principal{
+      principal_type::ephemeral_user, "ephemeral_user"};
+
+    const ephemeral_credential ephemeral_cred_0{
+      principal,
+      credential_user{"user_0"},
+      credential_password{"password_0"},
+      scram_sha512_authenticator::name};
+
+    const ephemeral_credential ephemeral_cred_1{
+      principal,
+      credential_user{"user_1"},
+      credential_password{"password_1"},
+      scram_sha512_authenticator::name};
+
+    // insert
+    {
+        auto it = store.insert_or_assign(ephemeral_cred_0);
+        BOOST_REQUIRE(store.has(it));
+        BOOST_REQUIRE_EQUAL(*it, ephemeral_cred_0);
+    }
+
+    // assign
+    {
+        auto it = store.insert_or_assign(ephemeral_cred_1);
+        BOOST_REQUIRE(store.has(it));
+        BOOST_REQUIRE_EQUAL(*it, ephemeral_cred_1);
+    }
+}
+
+} // namespace security

--- a/src/v/security/types.h
+++ b/src/v/security/types.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace security {
+
+using credential_user = named_type<ss::sstring, struct credential_user_type>;
+using credential_password
+  = named_type<ss::sstring, struct credential_password_type>;
+
+} // namespace security


### PR DESCRIPTION
## Cover letter

Implement a mechanism to share ephemeral credentials over internal RPC to allow Schema Registry and Pandaproxy to obtain credentials for a sasl enabled endpoint, without explicitly specifying the secret in the configuration file.

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/1209c39e567090535f898082e66575d86610353f..c0b69c561e2e9e3cbabd370951ea1a3c551948b7)

* Reimplementation to avoid a new auth type
* Rebase due to several conflicts

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/c0b69c561e2e9e3cbabd370951ea1a3c551948b7..46e939cbfec7f43c4a0086d02775241a63d85304)
* Rebase over conflict
* Improve error handling in frontend by
  * Moving to `std::error_code`
  * Properly capturing rpc errors
* Fix trailing newlines
* Improve some logging
* Bump the serde version of `scram_credential`

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/46e939cbfec7f43c4a0086d02775241a63d85304..9a89cbd60cd816dda0ab87cfecfea6360d82f7a7)
* Rebase over conflict (again)

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/9a89cbd60cd816dda0ab87cfecfea6360d82f7a7..3cb3969eae7610313b3ad76f1ba43e73a73a6654)
* Initialise `ephemeral_credential_frontend::_self` (fixes CI failure)
* `ephemeral_credential_frontend::get` now returns just the `ephemeral_credential`
* Don't serialise `scram_credential::principal`, don't bump serde::version
* Make `find` and `has` members of `ephemeral_credential_store` `const`
* Don't serialize `ephemeral_credential`
* Remove `entire_credential`
* Have the test rely on fewer implementation details

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
