### PR TITLE
rpk: make node_id optional

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -136,7 +136,8 @@ func main() {
 		}
 	}
 
-	cfg.Redpanda.ID = int(hostIndex)
+	cfg.Redpanda.ID = new(int)
+	*cfg.Redpanda.ID = int(hostIndex)
 
 	// In case of a single seed server, the list should contain the current node itself.
 	// Normally the cluster is able to recognize it's talking to itself, except when the cluster is

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "a3a81f47c734ebcd16ba339c77c7c4c0",
+			expectedHash:            "13b7ea49c811062afe2a6d275604929e",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "cfc65ce54611c67feef7270e8c1d41ba",
+			expectedHash: "4b241955a317f47a6a06960a333ed661",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "791074a427c1b5006459bc466586d1a5",
+			expectedHash: "533227069ff8ee6791b874db60480b40",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -115,7 +115,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 		configPath string
 	)
 	c := &cobra.Command{
-		Use:   "bootstrap --id <id> [--self <ip>] [--ips <ip1,ip2,...>]",
+		Use:   "bootstrap [--self <ip>] [--ips <ip1,ip2,...>]",
 		Short: "Initialize the configuration to bootstrap a cluster",
 		Long:  helpBootstrap,
 		Args:  cobra.ExactArgs(0),
@@ -131,7 +131,9 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 			ownIP, err := parseSelfIP(self)
 			out.MaybeDieErr(err)
 
-			cfg.Redpanda.ID = id
+			if id >= 0 {
+				cfg.Redpanda.ID = &id
+			}
 			cfg.Redpanda.RPCServer.Address = ownIP.String()
 			cfg.Redpanda.KafkaAPI = []config.NamedAuthNSocketAddress{{
 				Address: ownIP.String(),
@@ -171,9 +173,9 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 		&id,
 		"id",
 		-1,
-		"This node's ID (required).",
+		"This node's ID. If unset, Redpanda will assign one automatically.",
 	)
-	cobra.MarkFlagRequired(c.Flags(), "id")
+	c.Flags().MarkHidden("id")
 	return c
 }
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -198,7 +198,6 @@ func TestSetCommand(t *testing.T) {
 			name: "set without config file on disk",
 			exp: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     rack: redpanda-rack
     seed_servers: []
     rpc_server:
@@ -223,7 +222,6 @@ schema_registry: {}
 			name: "set with loaded config",
 			cfgFile: `redpanda:
     data_directory: data/dir
-    node_id: 0
     rack: redpanda-rack
     seed_servers: []
     rpc_server:
@@ -242,7 +240,6 @@ rpk:
 `,
 			exp: `redpanda:
     data_directory: data/dir
-    node_id: 0
     rack: redpanda-rack
     seed_servers: []
     rpc_server:

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -93,7 +93,8 @@ func updateConfigWithFlags(conf *config.Config, flags *pflag.FlagSet) {
 		conf.Rpk.Overprovisioned, _ = flags.GetBool(overprovisionedFlag)
 	}
 	if flags.Changed(nodeIDFlag) {
-		conf.Redpanda.ID, _ = flags.GetInt(nodeIDFlag)
+		conf.Redpanda.ID = new(int)
+		*conf.Redpanda.ID, _ = flags.GetInt(nodeIDFlag)
 	}
 }
 
@@ -377,10 +378,9 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 	command.Flags().IntVar(
 		&nodeID,
 		nodeIDFlag,
-		0,
-		"The node ID. Must be an integer and must be unique"+
-			" within a cluster",
-	)
+		-1,
+		"The node ID. Must be an integer and must be unique within a cluster. If unset, Redpanda will assign one automatically")
+	command.Flags().MarkHidden(nodeIDFlag)
 	command.Flags().StringSliceVarP(
 		&seeds,
 		"seeds",

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -331,7 +331,7 @@ func TestStartCommand(t *testing.T) {
 				Address: "10.21.34.58",
 				Port:    9092,
 			}}
-			require.Exactly(st, 39, conf.Redpanda.ID)
+			require.Exactly(st, 39, *conf.Redpanda.ID)
 			require.Exactly(st, expectedAdmin, conf.Redpanda.AdminAPI)
 			require.Exactly(st, expectedKafkaAPI, conf.Redpanda.KafkaAPI)
 		},
@@ -402,7 +402,7 @@ func TestStartCommand(t *testing.T) {
 				Port:    9092,
 			}}
 			// The value set with --node-id should have been prioritized
-			require.Exactly(st, 42, conf.Redpanda.ID)
+			require.Exactly(st, 42, *conf.Redpanda.ID)
 			require.Exactly(st, expectedAdmin, conf.Redpanda.AdminAPI)
 			require.Exactly(st, expectedKafkaAPI, conf.Redpanda.KafkaAPI)
 			require.Exactly(st, expectedAdvKafkaAPI, conf.Redpanda.AdvertisedKafkaAPI)
@@ -481,7 +481,7 @@ func TestStartCommand(t *testing.T) {
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			require.Exactly(st, 34, conf.Redpanda.ID)
+			require.Exactly(st, 34, *conf.Redpanda.ID)
 		},
 	}, {
 		name: "it should write the default node ID if --node-id isn't passed and the config file doesn't exist",
@@ -523,7 +523,8 @@ func TestStartCommand(t *testing.T) {
 		},
 		before: func(fs afero.Fs) error {
 			conf, _ := new(config.Params).Load(fs)
-			conf.Redpanda.ID = 98
+			conf.Redpanda.ID = new(int)
+			*conf.Redpanda.ID = 98
 			return conf.Write(fs)
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
@@ -532,7 +533,7 @@ func TestStartCommand(t *testing.T) {
 			require.Exactly(
 				st,
 				98,
-				conf.Redpanda.ID,
+				*conf.Redpanda.ID,
 			)
 		},
 	}, {
@@ -1400,7 +1401,7 @@ func TestStartCommand(t *testing.T) {
 			// Config:
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			require.Equal(st, 0, conf.Redpanda.ID)
+			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			expectedClusterFields := map[string]interface{}{
 				"auto_create_topics_enabled": true,
@@ -1428,7 +1429,7 @@ func TestStartCommand(t *testing.T) {
 			require.Equal(st, "true", rpArgs.SeastarFlags["unsafe-bypass-fsync"])
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
-			require.Equal(st, 0, conf.Redpanda.ID)
+			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 		},
 	}, {
@@ -1457,7 +1458,7 @@ func TestStartCommand(t *testing.T) {
 				"storage_min_free_bytes":     10485760,
 				"topic_partitions_per_shard": 1000,
 			}
-			require.Equal(st, 0, conf.Redpanda.ID)
+			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -178,7 +178,7 @@ func checkRedpandaConfig(cfg *Config) []error {
 	if rp.Directory == "" {
 		errs = append(errs, fmt.Errorf("redpanda.data_directory can't be empty"))
 	}
-	if rp.ID < 0 {
+	if rp.ID != nil && *rp.ID < 0 {
 		errs = append(errs, fmt.Errorf("redpanda.node_id can't be a negative integer"))
 	}
 

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -62,7 +62,7 @@ func TestSet(t *testing.T) {
 			key:   "redpanda.node_id",
 			value: "1",
 			check: func(st *testing.T, c *Config) {
-				require.Exactly(st, 1, c.Redpanda.ID)
+				require.Exactly(st, 1, *c.Redpanda.ID)
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestSet(t *testing.T) {
 			key:   "redpanda.node_id",
 			value: "54312",
 			check: func(st *testing.T, c *Config) {
-				require.Exactly(st, 54312, c.Redpanda.ID)
+				require.Exactly(st, 54312, *c.Redpanda.ID)
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestSet(t *testing.T) {
 			key:   "redpanda.node_id",
 			value: "54312",
 			check: func(st *testing.T, c *Config) {
-				require.Exactly(st, 54312, c.Redpanda.ID)
+				require.Exactly(st, 54312, *c.Redpanda.ID)
 			},
 		},
 		{
@@ -458,7 +458,7 @@ func TestDefault(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    9644,
 			}},
-			ID:            0,
+			ID:            nil,
 			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
 		},
@@ -483,7 +483,6 @@ func TestWrite(t *testing.T) {
 			conf: getValidConfig,
 			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers:
         - host:
             address: 127.0.0.1
@@ -534,7 +533,6 @@ schema_registry: {}
 			},
 			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers:
         - host:
             address: 127.0.0.1
@@ -586,7 +584,6 @@ schema_registry: {}
 			wantErr: false,
 			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers:
         - host:
             address: 127.0.0.1
@@ -621,7 +618,6 @@ schema_registry: {}
 			wantErr: false,
 			expected: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers:
         - host:
             address: 127.0.0.1
@@ -825,7 +821,8 @@ func TestCheckConfig(t *testing.T) {
 			name: "shall return an error when id of server is negative",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.ID = -100
+				c.Redpanda.ID = new(int)
+				*c.Redpanda.ID = -100
 				return c
 			},
 			expected: []string{"redpanda.node_id can't be a negative integer"},

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -21,7 +21,6 @@ func TestParams_Write(t *testing.T) {
 			name: "create default config file if there is no config file yet",
 			exp: `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers: []
     rpc_server:
         address: 0.0.0.0
@@ -50,7 +49,8 @@ rpk:
     rack: my_rack
 `,
 			cfgChanges: func(c *Config) *Config {
-				c.Redpanda.ID = 6
+				c.Redpanda.ID = new(int)
+				*c.Redpanda.ID = 6
 				return c
 			},
 			exp: `redpanda:
@@ -140,6 +140,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 		t.Errorf("unexpected error while writing sample config file: %s", err)
 		return
 	}
+	id := 1
 	expCfg := &Config{
 		fileLocation: "/etc/redpanda/redpanda.yaml",
 		Redpanda: RedpandaNodeConfig{
@@ -156,7 +157,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    9644,
 			}},
-			ID:            1,
+			ID:            &id,
 			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
 		},

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -55,7 +55,7 @@ func (c *Config) FileLocation() string {
 // consider it a node property.
 type RedpandaNodeConfig struct {
 	Directory                  string                    `yaml:"data_directory,omitempty" json:"data_directory"`
-	ID                         int                       `yaml:"node_id" json:"node_id"`
+	ID                         *int                      `yaml:"node_id,omitempty" json:"node_id,omitempty"`
 	Rack                       string                    `yaml:"rack,omitempty" json:"rack"`
 	SeedServers                []SeedServer              `yaml:"seed_servers" json:"seed_servers"`
 	RPCServer                  SocketAddress             `yaml:"rpc_server,omitempty" json:"rpc_server"`

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -328,7 +328,7 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
 		Directory                  weakString                `yaml:"data_directory"`
-		ID                         weakInt                   `yaml:"node_id" `
+		ID                         *weakInt                  `yaml:"node_id"`
 		Rack                       weakString                `yaml:"rack"`
 		SeedServers                seedServers               `yaml:"seed_servers"`
 		RPCServer                  SocketAddress             `yaml:"rpc_server"`
@@ -351,7 +351,7 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		return err
 	}
 	rpc.Directory = string(internal.Directory)
-	rpc.ID = int(internal.ID)
+	rpc.ID = (*int)(internal.ID)
 	rpc.Rack = string(internal.Rack)
 	rpc.SeedServers = internal.SeedServers
 	rpc.RPCServer = internal.RPCServer

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -39,7 +39,6 @@ class RpkConfigTest(RedpandaTest):
 pandaproxy: {}
 redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 0
     seed_servers: []
     rpc_server:
         address: 0.0.0.0

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -40,6 +40,24 @@ class RpkRedpandaStartTest(RedpandaTest):
         assert self.redpanda.search_log_any(
             "WARNING: This is a setup for development purposes only")
 
+    @cluster(num_nodes=3)
+    def test_simple_start_three(self):
+        """
+        Validate simple start using rpk with multiple nodes. Node IDs should be
+        assigned automatically by Redpanda.
+        """
+        node_ids = set()
+        seeds_str = ",".join(
+            [f"{n.account.hostname}" for n in self.redpanda.nodes])
+        for node in self.redpanda.nodes:
+            seeds_arg = f"--seeds={seeds_str}"
+            if self.redpanda.idx(node) == 1:
+                seeds_arg = ""
+            args = f"{seeds_arg} --rpc-addr={node.account.hostname}"
+            self.redpanda.start_node_with_rpk(node, args)
+            node_ids.add(self.redpanda.node_id(node))
+        assert len(node_ids) == 3, f"Node IDs: {node_ids}"
+
     @cluster(num_nodes=1)
     def test_container_mode(self):
         """


### PR DESCRIPTION
## Cover letter

This changes `rpk redpanda config` and `rpk redpanda start` to not
require a node ID.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
