### PR TITLE
build: split up test_cluster

### DIFF
--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -45,14 +45,16 @@ set(srcs
     topic_configuration_compat_test.cc
     local_monitor_test.cc)
 
-
+foreach(cluster_test_src ${srcs})
+get_filename_component(test_name ${cluster_test_src} NAME_WE)
 rp_test(
   UNIT_TEST
-  BINARY_NAME test_cluster
-  SOURCES ${srcs}
+  BINARY_NAME test_${test_name}
+  SOURCES ${cluster_test_src}
   LIBRARIES v::seastar_testing_main v::application v::storage_test_utils v::v8_engine v::cluster
   LABELS cluster
 )
+endforeach()
 
 # These 2 files have a `using namespace cluster;` and removing that
 # would require modifying the FIXTURE_TEST and PERF_TEST_F macros.


### PR DESCRIPTION
## Cover letter
This had something like 120 tests baked into one. In particular things like memory leaks become very hard to track down because we can't exactly narrow it down. Also makes logs significantly easier to deal with because now they are on average smaller when a failure occurs.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
