### PR TITLE
Update consumer groups do not depend on txn prepare phase

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1862,7 +1862,7 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                   raft::replicate_options(raft::consistency_level::quorum_ack));
                 if (!cr) {
                     vlog(
-                      _ctx_log.error,
+                      _ctx_log.trace,
                       "Error \"{}\" on replicating pid:{} autoabort/commit "
                       "batch",
                       cr.error(),
@@ -1871,6 +1871,10 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                 }
                 if (_mem_state.last_end_tx < cr.value().last_offset) {
                     _mem_state.last_end_tx = cr.value().last_offset;
+                }
+                if (!co_await wait_no_throw(
+                      cr.value().last_offset, _sync_timeout)) {
+                    co_return;
                 }
             } else if (r.aborted) {
                 auto batch = make_tx_control_batch(
@@ -1883,7 +1887,7 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                   raft::replicate_options(raft::consistency_level::quorum_ack));
                 if (!cr) {
                     vlog(
-                      _ctx_log.error,
+                      _ctx_log.trace,
                       "Error \"{}\" on replicating pid:{} autoabort/abort "
                       "batch",
                       cr.error(),
@@ -1892,6 +1896,10 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                 }
                 if (_mem_state.last_end_tx < cr.value().last_offset) {
                     _mem_state.last_end_tx = cr.value().last_offset;
+                }
+                if (!co_await wait_no_throw(
+                      cr.value().last_offset, _sync_timeout)) {
+                    co_return;
                 }
             }
         }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -750,7 +750,7 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
 
     if (!r) {
         vlog(
-          _ctx_log.error,
+          _ctx_log.warn,
           "Error \"{}\" on replicating pid:{} commit batch",
           r.error(),
           pid);

--- a/src/v/features/migrators/group_metadata.cc
+++ b/src/v/features/migrators/group_metadata.cc
@@ -237,6 +237,11 @@ bool are_stms_equivalent(const group_stm& source, const group_stm& target) {
         return false;
     }
 
+    if (source.tx_seqs() != target.tx_seqs()) {
+        vlog(featureslog.info, "group ongoing txs does not match");
+        return false;
+    }
+
     if (source.prepared_txs().size() != target.prepared_txs().size()) {
         vlog(
           featureslog.info,

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1749,7 +1749,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
         // to prevent being GCed by the compaction
         auto batch = make_tx_batch(
           model::record_batch_type::tx_fence,
-          fence_control_record_version,
+          fence_control_record_v0_version,
           r.pid,
           std::move(fence));
         auto reader = model::make_memory_record_batch_reader(std::move(batch));

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1787,7 +1787,10 @@ group::begin_tx(cluster::begin_group_tx_request r) {
     auto is_txn_ga = is_transaction_ga();
     std::optional<model::record_batch> batch{};
     if (is_txn_ga) {
-        group_log_fencing fence{.group_id = id(), .tx_seq = r.tx_seq};
+        group_log_fencing fence{
+          .group_id = id(),
+          .tx_seq = r.tx_seq,
+          .transaction_timeout_ms = r.timeout};
         batch = make_tx_fence_batch(r.pid, std::move(fence));
     } else {
         group_log_fencing_v0 fence{.group_id = id()};

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1742,7 +1742,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
     if (
       fence_it == _fence_pid_epoch.end()
       || r.pid.get_epoch() > fence_it->second) {
-        group_log_fencing fence{.group_id = id()};
+        group_log_fencing_v0 fence{.group_id = id()};
 
         // TODO: https://app.clubhouse.io/vectorized/story/2200
         // include producer_id into key to make it unique-ish

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -52,6 +52,7 @@ group::group(
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+  ss::sharded<features::feature_table>& feature_table,
   group_metadata_serializer serializer,
   enable_group_metrics group_metrics)
   : _id(std::move(id))
@@ -71,7 +72,8 @@ group::group(
   , _enable_group_metrics(group_metrics)
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
-  , _tx_frontend(tx_frontend) {
+  , _tx_frontend(tx_frontend)
+  , _feature_table(feature_table) {
     if (_enable_group_metrics) {
         _probe.setup_public_metrics(_id);
     }
@@ -85,6 +87,7 @@ group::group(
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+  ss::sharded<features::feature_table>& feature_table,
   group_metadata_serializer serializer,
   enable_group_metrics group_metrics)
   : _id(std::move(id))
@@ -101,7 +104,8 @@ group::group(
   , _enable_group_metrics(group_metrics)
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
-  , _tx_frontend(tx_frontend) {
+  , _tx_frontend(tx_frontend)
+  , _feature_table(feature_table) {
     _state = md.members.empty() ? group_state::empty : group_state::stable;
     _generation = md.generation;
     _protocol_type = md.protocol_type;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -121,7 +121,7 @@ public:
     using duration_type = clock_type::duration;
     using time_point_type = clock_type::time_point;
 
-    static constexpr int8_t fence_control_record_version{0};
+    static constexpr int8_t fence_control_record_v0_version{0};
     static constexpr int8_t prepared_tx_record_version{0};
     static constexpr int8_t commit_tx_record_version{0};
     static constexpr int8_t aborted_tx_record_version{0};

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -805,7 +805,7 @@ private:
 
     void start_abort_timer() {
         _auto_abort_timer.set_callback([this] { abort_old_txes(); });
-        try_arm(clock_type::now() + _transactional_id_expiration);
+        try_arm(clock_type::now() + _abort_interval_ms);
     }
 
     void abort_old_txes();
@@ -906,7 +906,7 @@ private:
 
     ss::gate _gate;
     ss::timer<clock_type> _auto_abort_timer;
-    std::chrono::milliseconds _transactional_id_expiration;
+    std::chrono::milliseconds _abort_interval_ms;
 
     ss::sharded<cluster::tx_gateway_frontend>& _tx_frontend;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -815,8 +815,8 @@ private:
     void try_arm(time_point_type);
     void maybe_rearm_timer();
 
-    bool is_transaction_ga() const { 
-      return _feature_table.local().is_active(
+    bool is_transaction_ga() const {
+        return _feature_table.local().is_active(
           features::feature::transaction_ga);
     }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -188,6 +188,7 @@ public:
       config::configuration& conf,
       ss::lw_shared_ptr<cluster::partition> partition,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+      ss::sharded<features::feature_table>&,
       group_metadata_serializer,
       enable_group_metrics);
 
@@ -198,6 +199,7 @@ public:
       config::configuration& conf,
       ss::lw_shared_ptr<cluster::partition> partition,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+      ss::sharded<features::feature_table>&,
       group_metadata_serializer,
       enable_group_metrics);
 
@@ -781,6 +783,11 @@ private:
     void try_arm(time_point_type);
     void maybe_rearm_timer();
 
+    bool is_transaction_ga() const { 
+      return _feature_table.local().is_active(
+          features::feature::transaction_ga);
+    }
+
     kafka::group_id _id;
     group_state _state;
     model::timestamp _state_timestamp;
@@ -869,6 +876,7 @@ private:
     std::chrono::milliseconds _transactional_id_expiration;
 
     ss::sharded<cluster::tx_gateway_frontend>& _tx_frontend;
+    ss::sharded<features::feature_table>& _feature_table;
 };
 
 using group_ptr = ss::lw_shared_ptr<group>;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -455,6 +455,10 @@ ss::future<> group_manager::recover_partition(
             for (auto& [id, epoch] : group_stm.fences()) {
                 group->try_set_fence(id, epoch);
             }
+
+            for (auto& [id, txseq] : group_stm.tx_seqs()) {
+                group->try_set_tx_seq(id, txseq);
+            }
         }
     }
 
@@ -481,6 +485,9 @@ ss::future<> group_manager::recover_partition(
         }
         for (auto& [id, epoch] : group_stm.fences()) {
             group->try_set_fence(id, epoch);
+        }
+        for (auto& [id, txseq] : group_stm.tx_seqs()) {
+            group->try_set_tx_seq(id, txseq);
         }
     }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -459,6 +459,10 @@ ss::future<> group_manager::recover_partition(
             for (auto& [id, txseq] : group_stm.tx_seqs()) {
                 group->try_set_tx_seq(id, txseq);
             }
+
+            for (auto& [id, timeout] : group_stm.timeouts()) {
+                group->try_set_timeout(id, timeout);
+            }
         }
     }
 
@@ -488,6 +492,9 @@ ss::future<> group_manager::recover_partition(
         }
         for (auto& [id, txseq] : group_stm.tx_seqs()) {
             group->try_set_tx_seq(id, txseq);
+        }
+        for (auto& [id, timeout] : group_stm.timeouts()) {
+            group->try_set_timeout(id, timeout);
         }
     }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -38,6 +38,7 @@ group_manager::group_manager(
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<cluster::topic_table>& topic_table,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+  ss::sharded<features::feature_table>& feature_table,
   group_metadata_serializer_factory serializer_factory,
   config::configuration& conf,
   enable_group_metrics enable_metrics)
@@ -46,6 +47,7 @@ group_manager::group_manager(
   , _pm(pm)
   , _topic_table(topic_table)
   , _tx_frontend(tx_frontend)
+  , _feature_table(feature_table)
   , _serializer_factory(std::move(serializer_factory))
   , _conf(conf)
   , _self(cluster::make_self_broker(config::node()))
@@ -432,6 +434,7 @@ ss::future<> group_manager::recover_partition(
                   _conf,
                   p->partition,
                   _tx_frontend,
+                  _feature_table,
                   _serializer_factory(),
                   _enable_group_metrics);
                 group->reset_tx_state(term);
@@ -467,6 +470,7 @@ ss::future<> group_manager::recover_partition(
               _conf,
               p->partition,
               _tx_frontend,
+              _feature_table,
               _serializer_factory(),
               _enable_group_metrics);
             group->reset_tx_state(term);
@@ -566,6 +570,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
           _conf,
           p,
           _tx_frontend,
+          _feature_table,
           _serializer_factory(),
           _enable_group_metrics);
         group->reset_tx_state(it->second->term);
@@ -713,6 +718,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 _conf,
                 p->partition,
                 _tx_frontend,
+                _feature_table,
                 _serializer_factory(),
                 _enable_group_metrics);
               group->reset_tx_state(p->term);
@@ -798,6 +804,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 _conf,
                 p->partition,
                 _tx_frontend,
+                _feature_table,
                 _serializer_factory(),
                 _enable_group_metrics);
               group->reset_tx_state(p->term);
@@ -905,6 +912,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               _conf,
               p->partition,
               _tx_frontend,
+              _feature_table,
               _serializer_factory(),
               _enable_group_metrics);
             group->reset_tx_state(p->term);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -120,6 +120,7 @@ public:
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
+      ss::sharded<features::feature_table>&,
       group_metadata_serializer_factory,
       config::configuration& conf,
       enable_group_metrics group_metrics);
@@ -256,6 +257,7 @@ private:
     ss::sharded<cluster::partition_manager>& _pm;
     ss::sharded<cluster::topic_table>& _topic_table;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_frontend;
+    ss::sharded<features::feature_table>& _feature_table;
     group_metadata_serializer_factory _serializer_factory;
     config::configuration& _conf;
     absl::node_hash_map<group_id, group_ptr> _groups;

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -110,7 +110,7 @@ group_recovery_consumer::operator()(model::record_batch batch) {
         co_return ss::stop_iteration::no;
     } else if (batch.header().type == model::record_batch_type::tx_fence) {
         auto cmd = parse_tx_batch<group_log_fencing>(
-          batch, group::fence_control_record_version);
+          batch, group::fence_control_record_v0_version);
 
         auto [group_it, _] = _state.groups.try_emplace(cmd.cmd.group_id);
         group_it->second.try_set_fence(cmd.pid.get_id(), cmd.pid.get_epoch());

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -109,7 +109,7 @@ group_recovery_consumer::operator()(model::record_batch batch) {
 
         co_return ss::stop_iteration::no;
     } else if (batch.header().type == model::record_batch_type::tx_fence) {
-        auto cmd = parse_tx_batch<group_log_fencing>(
+        auto cmd = parse_tx_batch<group_log_fencing_v0>(
           batch, group::fence_control_record_v0_version);
 
         auto [group_it, _] = _state.groups.try_emplace(cmd.cmd.group_id);

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -109,15 +109,57 @@ group_recovery_consumer::operator()(model::record_batch batch) {
 
         co_return ss::stop_iteration::no;
     } else if (batch.header().type == model::record_batch_type::tx_fence) {
-        auto cmd = parse_tx_batch<group_log_fencing_v0>(
-          batch, group::fence_control_record_v0_version);
-
-        auto [group_it, _] = _state.groups.try_emplace(cmd.cmd.group_id);
-        group_it->second.try_set_fence(cmd.pid.get_id(), cmd.pid.get_epoch());
+        apply_tx_fence(std::move(batch));
         co_return ss::stop_iteration::no;
     } else {
         vlog(klog.trace, "ignoring batch with type {}", batch.header().type);
         co_return ss::stop_iteration::no;
+    }
+}
+
+void group_recovery_consumer::apply_tx_fence(model::record_batch&& batch) {
+    vassert(
+      batch.record_count() == 1, "tx fence batch must contain a single record");
+    auto r = batch.copy_records();
+    auto& record = *r.begin();
+    auto key_buf = record.release_key();
+    auto val_buf = record.release_value();
+
+    iobuf_parser key_reader(std::move(key_buf));
+    auto batch_type = reflection::adl<model::record_batch_type>{}.from(
+      key_reader);
+    const auto& hdr = batch.header();
+    vassert(
+      hdr.type == batch_type,
+      "broken tx group message. expected batch type {} got: {}",
+      hdr.type,
+      batch_type);
+    auto p_id = model::producer_id(reflection::adl<int64_t>{}.from(key_reader));
+    auto bid = model::batch_identity::from(hdr);
+    vassert(
+      p_id == bid.pid.id,
+      "broken tx group message. expected pid/id {} got: {}",
+      bid.pid.id,
+      p_id);
+
+    iobuf_parser val_reader(std::move(val_buf));
+    auto fence_version = reflection::adl<int8_t>{}.from(val_reader);
+
+    if (fence_version == group::fence_control_record_v0_version) {
+        auto cmd = reflection::adl<group_log_fencing_v0>{}.from(val_reader);
+        auto [group_it, _] = _state.groups.try_emplace(cmd.group_id);
+        group_it->second.try_set_fence(bid.pid.get_id(), bid.pid.get_epoch());
+    } else if (fence_version == group::fence_control_record_version) {
+        auto cmd = reflection::adl<group_log_fencing>{}.from(val_reader);
+        auto [group_it, _] = _state.groups.try_emplace(cmd.group_id);
+        group_it->second.try_set_fence(
+          bid.pid.get_id(), bid.pid.get_epoch(), cmd.tx_seq);
+    } else {
+        vassert(
+          false,
+          "unknown group fence record version: {} expected at most: {}",
+          fence_version,
+          group::fence_control_record_version);
     }
 }
 

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -153,7 +153,10 @@ void group_recovery_consumer::apply_tx_fence(model::record_batch&& batch) {
         auto cmd = reflection::adl<group_log_fencing>{}.from(val_reader);
         auto [group_it, _] = _state.groups.try_emplace(cmd.group_id);
         group_it->second.try_set_fence(
-          bid.pid.get_id(), bid.pid.get_epoch(), cmd.tx_seq);
+          bid.pid.get_id(),
+          bid.pid.get_epoch(),
+          cmd.tx_seq,
+          cmd.transaction_timeout_ms);
     } else {
         vassert(
           false,

--- a/src/v/kafka/server/group_recovery_consumer.h
+++ b/src/v/kafka/server/group_recovery_consumer.h
@@ -42,6 +42,7 @@ public:
     group_recovery_consumer_state end_of_stream() { return std::move(_state); }
 
 private:
+    void apply_tx_fence(model::record_batch&&);
     void handle_record(model::record);
     void handle_group_metadata(group_metadata_kv);
     void handle_offset_metadata(offset_metadata_kv);

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -84,6 +84,7 @@ void group_stm::commit(model::producer_identity pid) {
     }
 
     _prepared_txs.erase(prepared_it);
+    _tx_seqs.erase(pid.get_id());
 }
 
 void group_stm::abort(
@@ -95,6 +96,7 @@ void group_stm::abort(
         return;
     }
     _prepared_txs.erase(prepared_it);
+    _tx_seqs.erase(pid.get_id());
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -84,7 +84,8 @@ void group_stm::commit(model::producer_identity pid) {
     }
 
     _prepared_txs.erase(prepared_it);
-    _tx_seqs.erase(pid.get_id());
+    _tx_seqs.erase(pid);
+    _timeouts.erase(pid);
 }
 
 void group_stm::abort(
@@ -96,7 +97,8 @@ void group_stm::abort(
         return;
     }
     _prepared_txs.erase(prepared_it);
-    _tx_seqs.erase(pid.get_id());
+    _tx_seqs.erase(pid);
+    _timeouts.erase(pid);
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -35,6 +35,11 @@ struct group_log_fencing_v0 {
     kafka::group_id group_id;
 };
 
+struct group_log_fencing {
+    kafka::group_id group_id;
+    model::tx_seq tx_seq;
+};
+
 struct group_log_prepared_tx {
     kafka::group_id group_id;
     // TODO: get rid of pid, we have it in the headers
@@ -78,6 +83,15 @@ public:
             fence_it->second = epoch;
         }
     }
+    void try_set_fence(
+      model::producer_id id, model::producer_epoch epoch, model::tx_seq txseq) {
+        auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);
+        if (fence_it->second <= epoch) {
+            fence_it->second = epoch;
+            auto [ongoing_it, _] = _tx_seqs.try_emplace(id, txseq);
+            ongoing_it->second = txseq;
+        }
+    }
     bool has_data() const {
         return !_is_removed && (_is_loaded || _offsets.size() > 0);
     }
@@ -98,6 +112,11 @@ public:
         return _fence_pid_epoch;
     }
 
+    const absl::node_hash_map<model::producer_id, model::tx_seq>&
+    tx_seqs() const {
+        return _tx_seqs;
+    }
+
     group_metadata_value& get_metadata() { return _metadata; }
 
     const group_metadata_value& get_metadata() const { return _metadata; }
@@ -107,6 +126,7 @@ private:
     absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;
     absl::node_hash_map<model::producer_id, model::producer_epoch>
       _fence_pid_epoch;
+    absl::node_hash_map<model::producer_id, model::tx_seq> _tx_seqs;
     group_metadata_value _metadata;
     bool _is_loaded{false};
     bool _is_removed{false};

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -31,7 +31,7 @@ struct group_log_prepared_tx_offset {
     std::optional<ss::sstring> metadata;
 };
 
-struct group_log_fencing {
+struct group_log_fencing_v0 {
     kafka::group_id group_id;
 };
 

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -46,12 +46,14 @@ static bool is_uuid(const ss::sstring& uuid) {
 static group get() {
     static config::configuration conf;
     ss::sharded<cluster::tx_gateway_frontend> fr;
+    ss::sharded<features::feature_table> feature_table;
     return group(
       kafka::group_id("g"),
       group_state::empty,
       conf,
       nullptr,
       fr,
+      feature_table,
       make_backward_compatible_serializer(),
       enable_group_metrics::no);
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -975,6 +975,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(partition_manager),
       std::ref(controller->get_topics_state()),
       std::ref(tx_gateway_frontend),
+      std::ref(controller->get_feature_table()),
       &kafka::make_backward_compatible_serializer,
       std::ref(config::shard_local_cfg()),
       kafka::enable_group_metrics::no)
@@ -986,6 +987,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(partition_manager),
       std::ref(controller->get_topics_state()),
       std::ref(tx_gateway_frontend),
+      std::ref(controller->get_feature_table()),
       &kafka::make_consumer_offsets_serializer,
       std::ref(config::shard_local_cfg()),
       kafka::enable_group_metrics::yes)


### PR DESCRIPTION
## Cover letter

Consumer groups used to store txn offsets in memory and flush them to log only during the prepare phase. This PR updates consume groups to write the offsets to disk every time and eliminates the need for the prepare phase. Also it makes Redpanda more robust because a restart doesn't wipe already accepted offsets.

Fixes #6326

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none