### PR TITLE
Add configuration option to check for magic file in data dir on startup 

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1374,6 +1374,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB,
       {.min = 10_MiB})
+  , storage_strict_data_init(
+      *this,
+      "storage_strict_data_init",
+      "Requires that an empty file named `.redpanda_data_dir` be present in "
+      "the data directory. Redpanda will refuse to start if it is not found.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -291,6 +291,7 @@ struct configuration final : public config_store {
     bounded_property<unsigned> storage_space_alert_free_threshold_percent;
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;
+    property<bool> storage_strict_data_init;
     // metrics reporter
     property<bool> enable_metrics_reporter;
     property<std::chrono::milliseconds> metrics_reporter_tick_interval;

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -59,6 +59,10 @@ public:
         return data_directory().path / "pid.lock";
     }
 
+    std::filesystem::path strict_data_dir_file_path() const {
+        return data_directory().path / ".redpanda_data_dir";
+    }
+
     std::vector<model::broker_endpoint> advertised_kafka_api() const {
         if (_advertised_kafka_api().empty()) {
             std::vector<model::broker_endpoint> eps;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -559,6 +559,21 @@ void application::check_environment() {
     storage::directories::initialize(
       config::node().data_directory().as_sstring())
       .get();
+
+    if (config::shard_local_cfg().storage_strict_data_init()) {
+        // Look for the special file that indicates a user intends
+        // for the found data directory to be the one we use.
+        auto strict_data_dir_file
+          = config::node().strict_data_dir_file_path().string();
+        auto file_exists = ss::file_exists(strict_data_dir_file).get();
+
+        if (!file_exists) {
+            throw std::invalid_argument(ssx::sformat(
+              "Data directory not in expected state: {} not found, is the "
+              "expected filesystem mounted?",
+              strict_data_dir_file));
+        }
+    }
 }
 
 static admin_server_cfg

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -564,6 +564,11 @@ class ClusterConfigTest(RedpandaTest):
                 # Enabling cloud storage requires setting other properties too
                 continue
 
+            if name == 'storage_strict_data_init':
+                # Enabling this property requires a file be manually added
+                # to RP's data dir for it to start
+                continue
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,

--- a/tests/rptest/tests/strict_data_init_test.py
+++ b/tests/rptest/tests/strict_data_init_test.py
@@ -1,0 +1,45 @@
+import re
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService, RESTART_LOG_ALLOW_LIST
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.utils import BadLogLines
+
+STRICT_DATA_ERR_MSG_SUFFIX = "not found, is the expected filesystem mounted?"
+
+STRICT_DATA_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
+    re.compile(STRICT_DATA_ERR_MSG_SUFFIX),
+]
+
+
+class StrictDataInitTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, extra_rp_conf={}, **kwargs)
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1, log_allow_list=STRICT_DATA_LOG_ALLOW_LIST)
+    def test_strict_data_init_enabled(self):
+        target_node = self.redpanda.nodes[0]
+
+        # Enable the `storage_strict_data_init` property
+        # the node should fail to restart with it enabled.
+        self.rpk.cluster_config_set("storage_strict_data_init", "true")
+        self.redpanda.stop_node(target_node)
+        self.redpanda.start_node(target_node, expect_fail=True)
+
+        # Verify the reason for the node not starting is what
+        # we expect it to be.
+        try:
+            self.redpanda.raise_on_bad_logs()
+        except BadLogLines as b:
+            bad_lines = b.node_to_lines[target_node]
+            assert any(STRICT_DATA_ERR_MSG_SUFFIX in b for b in bad_lines)
+        else:
+            assert False, "The reason why redpanda failed to start isn't due to a nonexistent magic file"
+
+        # Write the empty `.redpanda_data_dir` file then start
+        # the node once more. It should start this time.
+        file_path = f"{RedpandaService.DATA_DIR}/.redpanda_data_dir"
+        target_node.account.ssh(f"touch {file_path}")
+        self.redpanda.start_node(target_node)


### PR DESCRIPTION
## Cover letter

This PR adds a new configuration property `storage_strict_data_init`. When the `storage_strict_data_init` property is enabled a user will have to manually add an empty magic file called `.redpanda_data_dir` to Redpanda's data directory for RP to start. 

RP currently has no way of telling if it's data directory is purposely or accidentally empty. Hence if an incorrect volume or filesystem is mounted RP will initialize a data dir in it incorrectly. With `store_strict_data_init` enabled RP will instead look for the magic file on start and exit if it's not there.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/core-internal/issues/66

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* adds a new configuration property `storage_strict_data_init`.

## Release notes

* none