### PR TITLE
tests: remove code for saving executables on failure

### DIFF
--- a/tests/rptest/trim_results.py
+++ b/tests/rptest/trim_results.py
@@ -70,61 +70,11 @@ class Trimmer:
 
         return log_paths
 
-    def get_saved_executables(self, results: list):
-        EXE_FILENAME = "redpanda.gz"
-
-        exe_paths = []
-        for r in results:
-            results_dir = os.path.join(self.result_path,
-                                       r['relative_results_dir'])
-
-            for service in r['services']:
-                if service['cls_name'] != "RedpandaService":
-                    continue
-
-                service_dir = os.path.join(results_dir, service['service_id'])
-                for node in service['nodes']:
-                    hostname = node.split("@")[-1]
-                    exe_path = os.path.join(service_dir,
-                                            f"{hostname}/{EXE_FILENAME}")
-                    if os.path.exists(exe_path):
-                        exe_paths.append(exe_path)
-
-        return exe_paths
-
-    def deduplicate_executables(self, saved_exes):
-        if len(saved_exes) < 2:
-            return
-
-        by_checksum = defaultdict(list)
-        for e in saved_exes:
-            h = hashlib.sha1()
-            with open(e, 'rb') as f:
-                for chunk in iter(lambda: f.read(16384), b""):
-                    h.update(chunk)
-            hash = h.hexdigest()
-            by_checksum[hash].append(e)
-
-        for hash, filenames in by_checksum.items():
-            keep_file = filenames[0]
-            for f in filenames[1:]:
-                log.info(f"Deleting duplicate executable: {f}")
-                os.unlink(f)
-
-                # Leave a note behind about where to find a copy of the executable
-                note_path = os.path.join(os.path.dirname(f),
-                                         "redpanda.gz.moved")
-                note_message = f"De-duplicated executables in test results: an identical executable is at {keep_file}"
-                open(note_path, "w").write(note_message)
-
     def trim(self):
         results = json.load(open(os.path.join(self.result_path,
                                               "report.json")))['results']
 
         log_paths = self.get_passed_test_logs(results)
-        saved_exes = self.get_saved_executables(results)
-
-        self.deduplicate_executables(saved_exes)
 
         executor = concurrent.futures.ThreadPoolExecutor()
 


### PR DESCRIPTION
## Cover letter

Buildkite jobs used to throw away packages after tests ran, which made it hard to decode backtraces after the fact.

Recently the jobs were improved to save packages as artifacts, so we don't need to do this any more.

As well as removing some effectively dead code, this also helps to avoid bloating out results tarballs with redundant copies of executables when a crash happens.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
