### PR TITLE
Controller log rate limiting -  not throttle cluster_config_status_cmd

### DIFF
--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -92,11 +92,9 @@ public:
           std::is_same_v<Cmd, delete_acls_cmd>) {
             return _acls_and_users_operations_limiter.try_throttle();
         } else if constexpr (
-          std::is_same_v<Cmd, create_data_policy_cmd> ||    //
-          std::is_same_v<Cmd, delete_data_policy_cmd> ||    //
-          std::is_same_v<Cmd, cluster_config_delta_cmd> ||  //
-          std::is_same_v<Cmd, cluster_config_status_cmd> || //
-          std::is_same_v<Cmd, feature_update_cmd> ||        //
+          std::is_same_v<Cmd, create_data_policy_cmd> ||   //
+          std::is_same_v<Cmd, delete_data_policy_cmd> ||   //
+          std::is_same_v<Cmd, cluster_config_delta_cmd> || //
           std::is_same_v<Cmd, feature_update_license_update_cmd>) {
             return _configuration_operations_limiter.try_throttle();
         } else if constexpr (

--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -194,21 +194,19 @@ class ControllerConfigLimitTest(RedpandaTest):
         return get_metric(self.redpanda, "requests_available_rps",
                           "configuration_operations") == capacity
 
-    @ok_to_fail
     @cluster(num_nodes=3)
     def test_alter_configs_limit_accumulate(self):
         requests_amount = OPERATIONS_LIMIT * 2
-        capacity = requests_amount * 2
         self.client().alter_broker_config(
             {
                 "controller_log_accummulation_rps_capacity_configuration_operations":
-                capacity
+                requests_amount
             },
             incremental=True)
         success_amount = 0
         quota_error_amount = 0
 
-        wait_until(lambda: self.check_capcity_is_full(capacity),
+        wait_until(lambda: self.check_capcity_is_full(requests_amount),
                    timeout_sec=10,
                    backoff_sec=1)
         for i in range(requests_amount):


### PR DESCRIPTION
## Cover letter

cluster_config_status_cmd is internal command, so we don't need to throttle it

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
