### PR TITLE
v/cloud_storage/cache_service.cc: fix a potential race condition

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -451,10 +451,12 @@ ss::future<> cache::put(
       .finally([&out]() { return out.close(); });
 
     // commit write transaction
+    auto src = (dir_path / tmp_filename).native();
     auto dest = (dir_path / filename).native();
-    co_await ss::rename_file((dir_path / tmp_filename).native(), dest);
 
-    auto put_size = co_await ss::file_size(dest);
+    auto put_size = co_await ss::file_size(src);
+
+    co_await ss::rename_file(src, dest);
 
     // Bump access time of the file
     if (ss::this_shard_id() == 0) {


### PR DESCRIPTION
## Cover letter

liked to [issue 6601](https://github.com/redpanda-data/redpanda/issues/6601)
 
fix a potential race condition,
whereby a file becomes a candidate for deletion and stat is requested for it.

Under normal operations, deletion would occur sometime after stat is requested.
But if a lot of these files are generated closely in time, the deletion could happen for a file before stat is requested for it.

This change request stat before making the file a candidate for deletion, removing this potential race.

Not handled: if indeed the new file is deleted too soon, its size will be still [counted towards total cache usage](https://github.com/andijcr/redpanda/blob/issue/6601/src/v/cloud_storage/cache_service.cc#L474) 

Fixes #6601

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none