### PR TITLE
r/consensus: do not require learner promotion to leave joint consensus

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2470,18 +2470,20 @@ ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
 
     auto latest_cfg = _configuration_manager.get_latest();
 
-    /**
-     * current config still contains learners, do nothing
-     */
-    if (unlikely(!latest_cfg.current_config().learners.empty())) {
-        co_return;
-    }
     switch (latest_cfg.get_state()) {
     case configuration_state::simple:
         co_return;
     case configuration_state::transitional:
         vlog(
           _ctxlog.info, "finishing transition of configuration {}", latest_cfg);
+
+        /**
+         * current config still contains learners, do nothing
+         */
+        if (unlikely(!latest_cfg.current_config().learners.empty())) {
+            co_return;
+        }
+
         latest_cfg.finish_configuration_transition();
         break;
     case configuration_state::joint:


### PR DESCRIPTION
## Cover letter

In redpanda Raft implementation reconfiguration cancellation is done by reversing the direction of configuration change. When Raft group configuration change is in first phase i.e. new nodes are added as learners to current configuration then they are simply removed. Cancellation of change when reconfiguration entered a Joint state requires swapping old and new configurations in Joint raft group configuration. It may be the case that cancellation will never finish even if only one node is unavailable as the node may be a voter that was demoted to learner in the last step before its removal. 

In order to allow the configuration change to finish we allow Raft to leave joint consensus before all learners are promoted to voters. This change is safe as learners does not change the safety guarantees but enables us to reliably cancel partition movement when one of the nodes is down.

Fixes #6869 


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
