### PR TITLE
operator: allow to use alternative credentials sources and skip valid…

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -237,6 +237,24 @@ type CloudStorageConfig struct {
 	APIEndpointPort int `json:"apiEndpointPort,omitempty"`
 	// Cache directory that will be mounted for Redpanda
 	CacheStorage *StorageSpec `json:"cacheStorage,omitempty"`
+	// Determines how to load credentials for archival storage. Supported values
+	// are config_file (default), aws_instance_metadata, sts, gcp_instance_metadata
+	// (see the cloud_storage_credentials_source property at
+	// https://docs.redpanda.com/docs/reference/cluster-properties/).
+	// When using config_file then accessKey and secretKeyRef are mandatory.
+	CredentialsSource CredentialsSource `json:"credentialsSource,omitempty"`
+}
+
+// CredentialsSource represents a mechanism for loading credentials for archival storage
+type CredentialsSource string
+
+const (
+	// credentialsSourceConfigFile is the default options for credentials source
+	CredentialsSourceConfigFile CredentialsSource = "config_file"
+)
+
+func (c CredentialsSource) IsDefault() bool {
+	return c == "" || c == CredentialsSourceConfigFile
 }
 
 // StorageSpec defines the storage specification of the Cluster

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -804,12 +804,12 @@ func (r *Cluster) validateArchivalStorage() field.ErrorList {
 	if !r.Spec.CloudStorage.Enabled {
 		return allErrs
 	}
-	if r.Spec.CloudStorage.AccessKey == "" {
+	if r.Spec.CloudStorage.CredentialsSource.IsDefault() && r.Spec.CloudStorage.AccessKey == "" {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec").Child("configuration").Child("cloudStorage").Child("accessKey"),
 				r.Spec.CloudStorage.AccessKey,
-				"AccessKey has to be provided for cloud storage to be enabled"))
+				"AccessKey has to be provided for cloud storage to be enabled using default credentials source"))
 	}
 	if r.Spec.CloudStorage.Bucket == "" {
 		allErrs = append(allErrs,
@@ -825,19 +825,19 @@ func (r *Cluster) validateArchivalStorage() field.ErrorList {
 				r.Spec.CloudStorage.Region,
 				"Region has to be provided for cloud storage to be enabled"))
 	}
-	if r.Spec.CloudStorage.SecretKeyRef.Name == "" {
+	if r.Spec.CloudStorage.CredentialsSource.IsDefault() && r.Spec.CloudStorage.SecretKeyRef.Name == "" {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec").Child("configuration").Child("cloudStorage").Child("secretKeyRef").Child("name"),
 				r.Spec.CloudStorage.SecretKeyRef.Name,
-				"SecretKeyRef name has to be provided for cloud storage to be enabled"))
+				"SecretKeyRef name has to be provided for cloud storage to be enabled using default credentials source"))
 	}
-	if r.Spec.CloudStorage.SecretKeyRef.Namespace == "" {
+	if r.Spec.CloudStorage.SecretKeyRef.Name != "" && r.Spec.CloudStorage.SecretKeyRef.Namespace == "" {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec").Child("configuration").Child("cloudStorage").Child("secretKeyRef").Child("namespace"),
 				r.Spec.CloudStorage.SecretKeyRef.Namespace,
-				"SecretKeyRef namespace has to be provided for cloud storage to be enabled"))
+				"SecretKeyRef namespace has to be defined when name is provided"))
 	}
 	return allErrs
 }

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -87,6 +87,13 @@ spec:
                         description: Storage class name - https://kubernetes.io/docs/concepts/storage/storage-classes/
                         type: string
                     type: object
+                  credentialsSource:
+                    description: Determines how to load credentials for archival storage.
+                      Supported values are config_file (default), aws_instance_metadata,
+                      sts, gcp_instance_metadata (see the cloud_storage_credentials_source
+                      property at https://docs.redpanda.com/docs/reference/cluster-properties/).
+                      When using config_file then accessKey and secretKeyRef are mandatory.
+                    type: string
                   disableTLS:
                     description: Disable TLS (can be used in tests)
                     type: boolean


### PR DESCRIPTION
…ation of access and secret keys in cloud storage

## Cover letter

This adds support for alternative authn methods for cloud storage, as defined in https://github.com/redpanda-data/redpanda/pull/5309.

In particular, when using one of the new IAM authn methods, access_key and secret_key will not be required by the webhook.
The credentials source field will also be injected in cluster configuration.
