### PR TITLE
tests/debug: Add debug logs to TxAbortSnapshotTest

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2067,6 +2067,12 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     }
     _log_state.abort_indexes = std::move(abort_indexes);
 
+    vlog(
+      _ctx_log.debug,
+      "Removing abort indexes {} with offset < {}",
+      expired_abort_indexes.size(),
+      start_offset);
+
     for (const auto& idx : expired_abort_indexes) {
         auto filename = abort_idx_name(idx.first, idx.last);
         co_await _abort_snapshot_mgr.remove_snapshot(filename);


### PR DESCRIPTION
## Cover letter

Only fails in ARM builds, not totally obvious why the snapshotting doesn't kickin after restart.

Also not obvious if it is a specific node or bunch of them.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none
