### PR TITLE
test: re-enable previously failing ducktape test

### DIFF
--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -198,8 +198,6 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
                 min_records=self.min_records,
                 enable_compaction=compacted)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5608
-    # https://github.com/redpanda-data/redpanda/issues/6020
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(replication_factor=[1, 3],
             unclean_abort=[True, False],


### PR DESCRIPTION
## Cover letter

See discussion here
https://github.com/redpanda-data/redpanda/issues/5608#issuecomment-1279461938 for analysis on this test likely being fixed.

Fixes: https://github.com/redpanda-data/redpanda/issues/5608
Fixes: https://github.com/redpanda-data/redpanda/issues/6020

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
