### PR TITLE
tests: mark PartitionBalancerTest.test_full_nodes ok_to_fail

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -437,6 +437,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             ns.make_available()
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6810
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_full_nodes(self):
         """


### PR DESCRIPTION
## Cover letter

This is too frequent of a failure to tolerate on the tip of dev.

It was recently re-enabled in https://github.com/redpanda-data/redpanda/pull/6653

Related: https://github.com/redpanda-data/redpanda/issues/6810

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none