### PR TITLE
tests: remove stale ok_to_fail markers on cloud storage tests

### DIFF
--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -9,7 +9,6 @@
 
 import random
 
-from ducktape.mark import ok_to_fail
 from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -8,15 +8,10 @@
 # by the Apache License, Version 2.0
 
 from ducktape.mark.resource import cluster
-from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
-from ducktape.cluster.cluster_spec import ClusterSpec
-from ducktape.mark import ok_to_fail
 
-import os
 import time
 
-from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.redpanda import ResourceSettings

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -11,7 +11,6 @@ import json
 import os
 import random
 
-from ducktape.mark import ok_to_fail
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -228,7 +227,6 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                              'default_topic_replications': self.num_brokers,
                          })
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4639
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_write_with_node_failures(self):
         self.start_producer()
@@ -307,7 +305,6 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         rpk.alter_topic_config(self.topic, 'retention.bytes',
                                str(self.segment_size))
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6111
     @cluster(num_nodes=8)
     def test_create_or_delete_topics_while_busy(self):
         self.logger.info(f"Environment: {os.environ}")

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -12,7 +12,6 @@ import json
 import uuid
 import requests
 from rptest.services.cluster import cluster
-from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -24,7 +24,6 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool, RpkException
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.mark import matrix
-from ducktape.mark import ok_to_fail
 
 # We inject failures which might cause consumer groups
 # to re-negotiate, so it is necessary to have a longer

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -9,13 +9,12 @@
 
 import random
 import time
-from numpy import record
 import requests
 
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -21,7 +21,6 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 
 from rptest.util import wait_until
-from ducktape.mark import ok_to_fail
 
 
 class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -11,7 +11,6 @@ from rptest.services.cluster import cluster
 
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
-from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -6,7 +6,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-import time
 from typing import NamedTuple, Optional
 from rptest.services.cluster import cluster
 
@@ -18,9 +17,6 @@ from rptest.util import expect_exception
 
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
-from ducktape.mark import ok_to_fail
-
-import json
 
 from rptest.services.redpanda import RedpandaService
 from rptest.tests.end_to_end import EndToEndTest

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -20,7 +20,6 @@ from rptest.util import (
 from rptest.utils.si_utils import Producer
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import ok_to_fail
 
 import confluent_kafka as ck
 
@@ -57,7 +56,6 @@ class ShadowIndexingTxTest(RedpandaTest):
             rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
             rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/5651
     @cluster(num_nodes=3)
     def test_shadow_indexing_aborted_txs(self):
         """Check that messages belonging to aborted transaction are not seen by clients


### PR DESCRIPTION
## Cover letter

https://github.com/redpanda-data/redpanda/issues/5651 test_shadow_indexing_aborted_txs is still occasionally failing (1 in last 600 runs) but so rarely that it's better to have the coverage by re-enabling it.

https://github.com/redpanda-data/redpanda/issues/4639 test_write_with_node_failures is fixed

https://github.com/redpanda-data/redpanda/issues/6111 test_create_or_delete_topics_while_busy has a workaround inside the test already and didn't require ok_to_fail.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none