### PR TITLE
rptest: Don't start async jobs when max_workers==0

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -735,11 +735,13 @@ class RedpandaService(Service):
                 cb(n)
             return
 
-        with concurrent.futures.ThreadPoolExecutor(
-                max_workers=len(nodes)) as executor:
-            # The list() wrapper is to cause futures to be evaluated here+now
-            # (including throwing any exceptions) and not just spawned in background.
-            list(executor.map(cb, nodes))
+        n_workers = len(nodes)
+        if n_workers > 0:
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=n_workers) as executor:
+                # The list() wrapper is to cause futures to be evaluated here+now
+                # (including throwing any exceptions) and not just spawned in background.
+                list(executor.map(cb, nodes))
 
     def _startup_poll_interval(self, first_start):
         """


### PR DESCRIPTION
## Cover Letter

redpanda.py will throw if `_for_nodes` is called and there are no nodes and parallel=True has been set. Solution is to exit early in the case the number of nodes is 0.

Currently this only happens in a single test `PartitionBalancerTest::test_full_nodes` which exits early and clears out the node list on certain skip conditions.

## Release notes
- none