### PR TITLE
cloud_storage: implement retention.ms/bytes for remote data

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     types.cc
     upload_controller.cc
     segment_reupload.cc
+    retention_calculator.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/probe.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -32,6 +33,10 @@ class ntp_level_probe {
 public:
     ntp_level_probe(per_ntp_metrics_disabled disabled, const model::ntp& ntp);
 
+    void setup_ntp_metrics(const model::ntp& ntp);
+
+    void setup_public_metrics(const model::ntp& ntp);
+
     /// Register log-segment upload
     void uploaded(model::offset offset_delta) { _uploaded += offset_delta; }
 
@@ -43,6 +48,10 @@ public:
     /// Register the offset the ought to be uploaded
     void upload_lag(model::offset offset_delta) { _pending = offset_delta; }
 
+    void segments_deleted(int64_t deleted_count) {
+        _segments_deleted += deleted_count;
+    };
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;
@@ -52,8 +61,12 @@ private:
     int64_t _missing = 0;
     /// Width of the offset range yet to be uploaded
     int64_t _pending = 0;
+    /// Number of segments deleted by garbage collection
+    int64_t _segments_deleted = 0;
 
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
 };
 
 /// Service level probe

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/retention_calculator.h"
+
+namespace archival {
+/*
+ * Retention strategy for use with 'retention_calculator'.
+ * Segments are accumulated until a segment with a new enough
+ * timestamp is met. This is a naive approach that assumes
+ * that timestamps are monotonically increasing. That's not always
+ * the case, but treating them as such works well enough in most cases.
+ */
+class time_based_strategy final : public retention_strategy {
+public:
+    static constexpr auto strat_name = "size_based_retention";
+
+    explicit time_based_strategy(model::timestamp);
+
+    bool done(const cloud_storage::partition_manifest::segment_meta&) override;
+
+    ss::sstring name() const override;
+
+private:
+    model::timestamp _oldest_allowed_timestamp;
+};
+
+/*
+ * Retention strategy for use with 'retention_calculator'.
+ * Segments are accumulated from the beggining of the "log" (read as manifest)
+ * until enough has been reclaimed to cover for the provided overshoot.
+ */
+class size_based_strategy final : public retention_strategy {
+public:
+    static constexpr auto strat_name = "size_based_retention";
+
+    explicit size_based_strategy(uint64_t);
+
+    bool done(const cloud_storage::partition_manifest::segment_meta&) override;
+
+    ss::sstring name() const override;
+
+private:
+    const uint64_t _overshot_by;
+    size_t _reclaimed{0};
+};
+
+std::optional<retention_calculator> retention_calculator::factory(
+  const cloud_storage::partition_manifest& manifest,
+  const storage::ntp_config& ntp_config) {
+    if (!ntp_config.is_collectable()) {
+        return std::nullopt;
+    }
+
+    std::vector<std::unique_ptr<retention_strategy>> strats;
+    strats.reserve(2);
+
+    if (ntp_config.retention_bytes()) {
+        auto total_retention_bytes = ntp_config.retention_bytes();
+
+        auto cloud_log_size = manifest.cloud_log_size();
+        if (cloud_log_size > *total_retention_bytes) {
+            auto overshot_by = cloud_log_size - *total_retention_bytes;
+            strats.push_back(
+              std::make_unique<size_based_strategy>(overshot_by));
+        }
+    }
+
+    if (ntp_config.retention_duration()) {
+        model::timestamp oldest_allowed_timestamp{
+          model::timestamp::now().value()
+          - ntp_config.retention_duration()->count()};
+
+        if (
+          manifest.size() > 0
+          && manifest.begin()->second.max_timestamp
+               < oldest_allowed_timestamp) {
+            strats.push_back(
+              std::make_unique<time_based_strategy>(oldest_allowed_timestamp));
+        }
+    }
+
+    if (strats.empty()) {
+        return std::nullopt;
+    }
+
+    return retention_calculator{manifest, std::move(strats)};
+}
+
+retention_calculator::retention_calculator(
+  const cloud_storage::partition_manifest& manifest,
+  std::vector<std::unique_ptr<retention_strategy>> strategies)
+  : _manifest(manifest)
+  , _strategies(std::move(strategies)) {}
+
+std::optional<model::offset> retention_calculator::next_start_offset() {
+    auto it = std::find_if(
+      _manifest.begin(), _manifest.end(), [this](const auto& entry) -> bool {
+          return std::all_of(
+            _strategies.begin(), _strategies.end(), [&](auto& strat) {
+                return strat->done(entry.second);
+            });
+      });
+
+    if (it == _manifest.end()) {
+        return model::next_offset(std::prev(it)->second.committed_offset);
+    }
+
+    return it->second.base_offset;
+}
+
+std::optional<ss::sstring> retention_calculator::strategy_name() const {
+    if (_strategies.size() == 1) {
+        return fmt::format("[{}]", _strategies[0]->name());
+    }
+
+    if (_strategies.size() == 2) {
+        return fmt::format(
+          "[{}]", _strategies[0]->name(), _strategies[1]->name());
+    }
+
+    return std::nullopt;
+}
+
+size_based_strategy::size_based_strategy(uint64_t overshot_by)
+  : _overshot_by{overshot_by} {}
+
+bool size_based_strategy::done(
+  const cloud_storage::partition_manifest::segment_meta& current_segment_meta) {
+    if (_reclaimed >= _overshot_by) {
+        return true;
+    } else {
+        _reclaimed += current_segment_meta.size_bytes;
+        return false;
+    }
+}
+
+ss::sstring size_based_strategy::name() const { return strat_name; }
+
+time_based_strategy::time_based_strategy(
+  model::timestamp oldest_allowed_timestamp)
+  : _oldest_allowed_timestamp(oldest_allowed_timestamp) {}
+
+bool time_based_strategy::done(
+  const cloud_storage::partition_manifest::segment_meta& current_segment_meta) {
+    return current_segment_meta.max_timestamp >= _oldest_allowed_timestamp;
+};
+
+ss::sstring time_based_strategy::name() const { return strat_name; }
+
+} // namespace archival

--- a/src/v/archival/retention_calculator.h
+++ b/src/v/archival/retention_calculator.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/partition_manifest.h"
+#include "model/fundamental.h"
+#include "storage/log.h"
+#include "storage/ntp_config.h"
+
+namespace archival {
+
+class retention_strategy {
+public:
+    virtual bool done(const cloud_storage::partition_manifest::segment_meta&)
+      = 0;
+
+    virtual ss::sstring name() const = 0;
+
+    virtual ~retention_strategy() = default;
+};
+
+/*
+ * Helper class for computing the next start offset for
+ * the cloud log according to the retention policies of
+ * the partition.
+ */
+class retention_calculator {
+public:
+    static std::optional<retention_calculator> factory(
+      const cloud_storage::partition_manifest&, const storage::ntp_config&);
+
+    std::optional<model::offset> next_start_offset();
+
+    std::optional<ss::sstring> strategy_name() const;
+
+private:
+    retention_calculator(
+      const cloud_storage::partition_manifest&,
+      std::vector<std::unique_ptr<retention_strategy>>);
+
+    const cloud_storage::partition_manifest& _manifest;
+    std::vector<std::unique_ptr<retention_strategy>> _strategies;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 rp_test(
   UNIT_TEST
   BINARY_NAME test_archival_service
-  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc
+  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc retention_strategy_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/archival/tests/retention_strategy_test.cc
+++ b/src/v/archival/tests/retention_strategy_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/retention_calculator.h"
+#include "archival/tests/service_fixture.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/archival.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+using namespace storage;
+using namespace archival;
+using namespace std::chrono_literals;
+
+inline ss::logger test_log("test"); // NOLINT
+
+struct size_based_retention_test_spec {
+    std::vector<segment_spec> remote_segments;
+    tristate<size_t> retention_bytes;
+    tristate<std::chrono::milliseconds> retention_duration;
+    std::optional<model::offset> next_start_offset;
+};
+
+const auto delta_10_min = model::timestamp{
+  model::timestamp::now().value() - std::chrono::milliseconds{10min}.count()};
+
+const std::vector<size_based_retention_test_spec> retention_tests{
+  // retention disabled
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024}, {10, 19, 1024}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{},
+    .retention_duration = tristate<std::chrono::milliseconds>{},
+    .next_start_offset = std::nullopt},
+
+  // retention limit is already met
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024}, {10, 19, 1024}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 5},
+    .retention_duration = tristate<std::chrono::milliseconds>{},
+    .next_start_offset = std::nullopt},
+
+  // retention limit lines up with segment end
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024}, {10, 19, 1024}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2},
+    .retention_duration = tristate<std::chrono::milliseconds>{},
+    .next_start_offset = model::offset{20}},
+
+  // retention limit does not line up with segment end
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024}, {10, 19, 1024}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{},
+    .next_start_offset = model::offset{30}},
+
+  // only collect the first segment based on size
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024}, {10, 19, 1024}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 3 + 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{},
+    .next_start_offset = model::offset{10}},
+
+  // time based retention
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .next_start_offset = model::offset{20}},
+
+  // mixed retention
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .next_start_offset = model::offset{30}},
+};
+
+SEASTAR_THREAD_TEST_CASE(test_retention_strategies) {
+    temporary_dir tmp_dir("retention_strategy_test");
+    auto data_path = tmp_dir.get_path();
+
+    for (const auto& test : retention_tests) {
+        // clang-format off
+        const auto& [remote_segments, retention_bytes,
+                     retention_duration, next_start_offset] = test;
+        // clang-format on
+
+        vlog(
+          test_log.info,
+          "Running test case: segments={}, retention_bytes={}, "
+          "retention_duration={}, next_start_offset={}",
+          remote_segments,
+          retention_bytes,
+          retention_duration,
+          next_start_offset);
+
+        ntp_config config{{"test_ns", "test_topic", 0}, {data_path}};
+        config.set_overrides(
+          {.retention_bytes = retention_bytes,
+           .retention_time = retention_duration});
+
+        cloud_storage::partition_manifest m;
+        populate_manifest(m, remote_segments);
+
+        auto retention_calculator = retention_calculator::factory(m, config);
+        if (next_start_offset.has_value()) {
+            BOOST_REQUIRE(retention_calculator.has_value());
+            auto next_so = retention_calculator->next_start_offset();
+            BOOST_REQUIRE(next_so.has_value());
+            BOOST_REQUIRE(next_so == next_start_offset);
+        } else {
+            BOOST_REQUIRE(
+              !retention_calculator
+              || !retention_calculator->next_start_offset());
+        }
+    };
+}

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage/partition_manifest.h"
 #include "storage/log_manager.h"
 #include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/archival.h"
 #include "test_utils/tmp_dir.h"
 
 #include <seastar/testing/thread_test_case.hh>
@@ -81,12 +82,6 @@ static constexpr std::string_view manifest_with_gaps = R"json({
 })json";
 
 static constexpr size_t max_upload_size{4096_KiB};
-
-ss::input_stream<char> make_manifest_stream(std::string_view json) {
-    iobuf i;
-    i.append(json.data(), json.size());
-    return make_iobuf_input_stream(std::move(i));
-}
 
 SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
     cloud_storage::partition_manifest m;

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -38,6 +38,7 @@ struct segment_desc {
     model::offset base_offset;
     model::term_id term;
     std::optional<size_t> num_batches;
+    std::optional<model::timestamp> timestamp;
 };
 
 struct offset_range {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -301,6 +301,20 @@ partition_manifest::const_reverse_iterator partition_manifest::rend() const {
 
 size_t partition_manifest::size() const { return _segments.size(); }
 
+uint64_t partition_manifest::cloud_log_size() const {
+    auto start_iter = find(_start_offset);
+
+    // No addresable segments
+    if (start_iter == end()) {
+        return 0;
+    }
+
+    return std::transform_reduce(
+      start_iter, end(), uint64_t{0}, std::plus{}, [](const auto& seg) {
+          return seg.second.size_bytes;
+      });
+}
+
 bool partition_manifest::contains(const partition_manifest::key& key) const {
     return _segments.contains(key);
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -172,6 +172,11 @@ public:
     const_reverse_iterator rend() const;
     size_t size() const;
 
+    // Computes the size in bytes of all segments available to clients
+    // (i.e. all segments after and including the segment that starts at
+    // the current _start_offset).
+    uint64_t cloud_log_size() const;
+
     /// Check if the manifest contains particular segment
     bool contains(const key& key) const;
     bool contains(const segment_name& name) const;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -277,7 +277,7 @@ ss::future<std::error_code> archival_metadata_stm::do_truncate(
     auto batch = std::move(b).build();
 
     auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
-    if (!ec) {
+    if (ec) {
         co_return ec;
     }
 
@@ -323,7 +323,7 @@ ss::future<std::error_code> archival_metadata_stm::do_cleanup_metadata(
     auto batch = std::move(b).build();
 
     auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
-    if (!ec) {
+    if (ec) {
         co_return ec;
     }
 

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -308,9 +308,15 @@ ss::future<std::error_code> archival_metadata_stm::do_cleanup_metadata(
         as->get().check();
     }
 
-    auto segments_to_remove = _manifest->replaced_segments();
+    auto has_replaced_segments = !_manifest->replaced_segments().empty();
+    auto has_trailing_segments = (_manifest->size() > 0
+                                  && _manifest->get_start_offset())
+                                   ? _manifest->begin()->first.base_offset
+                                       < _manifest->get_start_offset()
+                                   : false;
 
-    if (segments_to_remove.empty()) {
+    if (!has_replaced_segments && !has_trailing_segments) {
+        vlog(_logger.debug, "no metadata to clean up");
         co_return errc::success;
     }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1112,6 +1112,12 @@ configuration::configuration()
       "Timeout for SI metadata synchronization",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , cloud_storage_housekeeping_interval_ms(
+      *this,
+      "cloud_storage_housekeeping_interval_ms",
+      "Interval for cloud storage housekeeping tasks",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5min)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -231,6 +231,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_readreplica_manifest_sync_timeout_ms;
     property<std::chrono::milliseconds> cloud_storage_metadata_sync_timeout_ms;
+    property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -153,6 +154,22 @@ public:
 
     void set_overrides(default_overrides o) {
         _overrides = std::make_unique<default_overrides>(o);
+    }
+
+    std::optional<size_t> retention_bytes() const {
+        if (!_overrides || !_overrides->retention_bytes.has_value()) {
+            return config::shard_local_cfg().retention_bytes();
+        }
+
+        return _overrides->retention_bytes.value();
+    }
+
+    std::optional<std::chrono::milliseconds> retention_duration() const {
+        if (!_overrides || !_overrides->retention_time.has_value()) {
+            return config::shard_local_cfg().delete_retention_ms();
+        }
+
+        return _overrides->retention_time.value();
     }
 
     bool is_archival_enabled() const {

--- a/src/v/test_utils/archival.h
+++ b/src/v/test_utils/archival.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "cloud_storage/partition_manifest.h"
+#include "model/tests/random_batch.h"
+#include "storage/tests/utils/disk_log_builder.h"
+
+inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+inline storage::disk_log_builder make_log_builder(std::string_view data_path) {
+    return storage::disk_log_builder{storage::log_config{
+      storage::log_config::storage_type::disk,
+      {data_path.data(), data_path.size()},
+      4_KiB,
+      storage::debug_sanitize_files::yes,
+    }};
+}
+
+struct segment_spec {
+    size_t start_offset;
+    size_t end_offset;
+    size_t size_bytes;
+    std::optional<model::timestamp> timestamp{std::nullopt};
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const segment_spec& spec) {
+        fmt::print(
+          os,
+          "{{ start_offset={}, end_offset={}, size_bytes={}, timestamp={} }}",
+          spec.start_offset,
+          spec.end_offset,
+          spec.size_bytes,
+          spec.timestamp);
+        return os;
+    }
+};
+
+inline void populate_local_log(
+  storage::disk_log_builder& b, const std::vector<segment_spec>& segs) {
+    for (const auto& spec : segs) {
+        auto record_batch = make_random_batch(model::test::record_batch_spec{
+          .offset = model::offset{spec.start_offset},
+          .allow_compression = false,
+          .count = 1,
+          .record_sizes = std::vector<size_t>{spec.size_bytes},
+          .timestamp = spec.timestamp});
+
+        b | storage::add_segment(spec.start_offset)
+          | storage::add_batch(std::move(record_batch));
+    }
+}
+
+inline void populate_manifest(
+  cloud_storage::partition_manifest& m, const std::vector<segment_spec>& segs) {
+    for (const auto& spec : segs) {
+        cloud_storage::partition_manifest::key key{
+          .base_offset = model::offset{spec.start_offset},
+          .term = model::term_id{0}};
+
+        cloud_storage::partition_manifest::value value{
+          .size_bytes = spec.size_bytes,
+          .base_offset = model::offset{spec.start_offset},
+          .committed_offset = model::offset{spec.end_offset},
+          .max_timestamp = spec.timestamp ? *spec.timestamp
+                                          : model::timestamp::now()};
+        m.add(key, value);
+    }
+}

--- a/src/v/test_utils/http_imposter.cc
+++ b/src/v/test_utils/http_imposter.cc
@@ -100,6 +100,10 @@ void http_imposter_fixture::set_routes(ss::httpd::routes& r) {
               when().request(req._url).then_reply_with(req.content);
               repl.set_status(ss::httpd::reply::status_type::ok);
               return "";
+          }
+          if (req._method == "DELETE") {
+              repl.set_status(reply::status_type::no_content);
+              return "";
           } else {
               ss::httpd::request lookup_r{req};
               lookup_r._url = remove_query_params(req._url);


### PR DESCRIPTION
## Cover letter
This PR introduces retention for cloud storage data. This implemented via a periodic house-keeping job that runs within
every `ntp_archiver` instance. The housekeeping job performs two task sequentially:
1. Advances the start offset of all manifests such that the remaining segments meet the retention policy specified for the partition.
`ntp_archiver` simply computes the offset and then issues a command to the archival STM to persist and replicate the new offset.
2. Run garbage collection. This removes all the segments that can be no longer queried by clients from cloud storage: segments below the current start offset in the manifest and segments that have been replaced with their compacted equivalent.

Once deletion from cloud storage is done, the metadata for the partition is updated and replicated.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
Partitions of topics enabled for remote storage now follow the topic's retention policy specified via retention.bytes and retention.ms. If those are unspecified, cluster level defaults are used. The migrations of existing topics are done in such a way that they preserve the previous behaviour (i.e. data will not be deleted from cloud storage for topics created before v22.3). However, note that for new topics retention is applied and data can be removed from cloud storage.

## Release notes
* Partitions of topics enabled for remote storage now follow the topic's retention policy specified via retention.bytes and retention.ms. If those are unspecified, cluster level defaults are used. The migrations of existing topics are done in such a way that they preserve the previous behaviour (i.e. data will not be deleted from cloud storage for topics created before v22.3). However, note that for new topics retention is applied and data can be removed from cloud storage.
