### PR TITLE
k/client/tests: test passwd change on live client

### DIFF
--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -19,7 +19,7 @@ namespace kc = kafka::client;
 
 class kafka_client_fixture : public redpanda_thread_fixture {
 public:
-    void restart() {
+    void restart(bool test_mode = false) {
         shutdown();
         app_signal = std::make_unique<::stop_signal>();
         ss::smp::invoke_on_all([] {
@@ -28,7 +28,7 @@ public:
         }).get0();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
-        app.wire_up_and_start(*app_signal);
+        app.wire_up_and_start(*app_signal, test_mode);
     }
 
     kc::client make_client() { return kc::client{proxy_client_config()}; }
@@ -73,5 +73,52 @@ public:
           model::kafka_namespace, model::topic{topic_name});
         add_topic(tp_ns, partitions).get();
         return tp_ns;
+    }
+
+    void enable_sasl_and_restart(ss::sstring username) {
+        ss::smp::invoke_on_all([username]() mutable {
+            auto& config = config::shard_local_cfg();
+
+            config.get("enable_sasl").set_value(true);
+            config.get("superusers")
+              .set_value(std::vector<ss::sstring>{username});
+
+            auto& node_config = config::node();
+            int32_t kafka_port
+              = node_config.kafka_api.value()[0].address.port();
+            node_config.get("kafka_api")
+              .set_value(std::vector<config::broker_authn_endpoint>{
+                config::broker_authn_endpoint{
+                  .address = net::unresolved_address("127.0.0.1", kafka_port),
+                  .authn_method = config::broker_authn_method::sasl}});
+
+            node_config.get("admin").set_value(
+              std::vector<model::broker_endpoint>{model::broker_endpoint(
+                net::unresolved_address("127.0.0.1", 9644))});
+        }).get();
+
+        restart(true);
+    }
+
+    void disable_sasl_and_restart() {
+        ss::smp::invoke_on_all([]() mutable {
+            auto& config = config::shard_local_cfg();
+
+            config.get("enable_sasl").reset();
+            config.get("superusers").reset();
+
+            auto& node_config = config::node();
+            int32_t kafka_port
+              = node_config.kafka_api.value()[0].address.port();
+            node_config.get("kafka_api")
+              .set_value(std::vector<config::broker_authn_endpoint>{
+                config::broker_authn_endpoint{
+                  .address = net::unresolved_address("127.0.0.1", kafka_port),
+                  .authn_method = std::nullopt}});
+            node_config.get("admin").set_value(
+              std::vector<model::broker_endpoint>{});
+        }).get();
+
+        restart(true);
     }
 };

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "http/client.h"
 #include "kafka/client/client.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/test/fixture.h"
@@ -17,6 +18,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
+#include "pandaproxy/test/utils.h"
 
 #include <chrono>
 
@@ -73,4 +75,79 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
 
     info("Stopping client");
     client.stop().get();
+}
+inline http::client make_admin_client() {
+    net::base_transport::configuration transport_cfg;
+    transport_cfg.server_addr = net::unresolved_address{"127.0.0.1", 9644};
+    return http::client(transport_cfg);
+}
+
+FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
+    ss::sstring username{"admin"};
+    ss::sstring userpass{"foopar"};
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    info("Enable SASL and restart");
+    enable_sasl_and_restart(username);
+
+    ss::sstring user_body = fmt::format(
+      R"({{"username": "{}", "password": "{}","algorithm": "SCRAM-SHA-256"}})",
+      username,
+      userpass);
+    auto body = iobuf();
+    body.append(user_body.data(), user_body.size());
+
+    info("Create superuser");
+    auto admin_client = make_admin_client();
+    auto res = http_request(
+      admin_client,
+      "/v1/security/users",
+      std::move(body),
+      boost::beast::http::verb::post);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), boost::beast::http::status::ok);
+
+    auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
+    auto kafka_client = make_client();
+    kafka_client.config().sasl_mechanism.set_value(
+      ss::sstring{"SCRAM-SHA-256"});
+    kafka_client.config().scram_username.set_value(username);
+    kafka_client.config().scram_password.set_value(userpass);
+    kafka_client.connect().get();
+
+    {
+        info("Adding known topic");
+        auto ntp = make_default_ntp(tp.topic, tp.partition);
+        add_topic(model::topic_namespace_view(ntp)).get();
+    }
+
+    {
+        info("Checking for known topic");
+        auto res = kafka_client.dispatch(make_list_topics_req()).get();
+        BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+    }
+
+    {
+        // Setting the password has no effect until the client disconnects
+        info("Changing password");
+        userpass = "foobar";
+        kafka_client.config().scram_password.set_value(userpass);
+    }
+
+    {
+        info("Recheck for known topic");
+        auto res = kafka_client.dispatch(make_list_topics_req()).get();
+        BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+    }
+
+    info("Stopping kafka client");
+    kafka_client.stop().get();
+
+    // This is necessary or else subsequent fixture tests will also have SASL
+    // enabled
+    info("Disable SASL and restart");
+    disable_sasl_and_restart();
 }


### PR DESCRIPTION
## Cover letter

Recent changes to the Pandaproxy involved containing kafka clients in a cache. It is, however, possible to trigger a password change on the client. This occurs when a user issues a REST request with their original password and then issues another request with a new password. In this situation, the kafka client will update it's password to the newer version.

This PR adds a fixture test to check what happens when the password changes on a live kafka client. 

Closes #6593 

Changes from force-push  `794ee98`:
- Use `.get()` instead of `.get0()`
- Reformat user body
- Comments

Changes from force-push `1a187d9` and `255ad45`:
- Use `.get()` instead of `.get0()`
- Clear feature migrators vector during test fixture restart

Changes from force-push `9f7bbe2`:
- Pass `test_mode=true` to `restart()`

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Adds a unit test to check what happens when the password changes on a live kafka client

