### PR TITLE
tests: cloud storage upgrade test 

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -171,6 +171,8 @@ public:
     const_iterator cbegin() const;
     const_iterator cend() const;
 
+    std::string hexdump(size_t) const;
+
 private:
     /// \brief trims the back, and appends direct.
     void prepend_take_ownership(fragment*);

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -743,6 +743,8 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
+        vlog(
+          cst_log.debug, "Failed to parse manifest: {}", result.hexdump(2048));
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "Failed to parse topic manifest {}: {} at offset {}",

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -42,6 +42,9 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                 # self.redpanda.decode_backtraces()
 
                 self.redpanda.raise_on_crash()
+
+                self.redpanda.cloud_storage_diagnostics()
+
                 raise
             else:
                 self.redpanda.logger.info("Test passed, doing log checks...")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1341,6 +1341,8 @@ class RedpandaService(Service):
                 allowed = False
                 for a in allow_list:
                     if a.search(line) is not None:
+                        self.logger.warn(
+                            f"Ignoring allow-listed log line '{line}'")
                         allowed = True
                         break
 

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -298,11 +298,17 @@ class RedpandaInstaller:
         if version == RedpandaInstaller.HEAD:
             version = self._head_version
         # NOTE: the released versions are sorted highest first.
+        result = None
         for v in self._released_versions:
             if (v[0] == version[0]
                     and v[1] < version[1]) or (v[0] < version[0]):
-                return v
-        return None
+                result = v
+                break
+
+        self._redpanda.logger.info(
+            f"Selected prior feature version {result}, from my version {version}, from available versions {self._released_versions}"
+        )
+        return result
 
     def install(self, nodes, version):
         """

--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -19,7 +19,9 @@ class RpkProducer(BackgroundThreadService):
                  acks: Optional[int] = None,
                  printable=False,
                  quiet: bool = False,
-                 produce_timeout: Optional[int] = None):
+                 produce_timeout: Optional[int] = None,
+                 *,
+                 partition: Optional[int] = None):
         super(RpkProducer, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
@@ -30,6 +32,7 @@ class RpkProducer(BackgroundThreadService):
         self._stopping = Event()
         self._quiet = quiet
         self._output_line_count = 0
+        self._partition = partition
 
         if produce_timeout is None:
             produce_timeout = 10
@@ -56,6 +59,9 @@ class RpkProducer(BackgroundThreadService):
         if self._quiet:
             # Suppress default "Produced to..." output lines by setting output template to empty string
             cmd += " -o \"\""
+
+        if self._partition is not None:
+            cmd += f" -p {self._partition}"
 
         self._stopping.clear()
         try:

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -8,16 +8,20 @@
 # by the Apache License, Version 2.0
 
 import re
+from collections import defaultdict
 from packaging.version import Version
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
+from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.end_to_end import EndToEndTest
+from rptest.util import wait_for_segments_removal
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings
 from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
@@ -323,3 +327,158 @@ class UpgradeWithWorkloadTest(EndToEndTest):
         self.run_validation(min_records=post_rollback_num_msgs +
                             (self.producer_msgs_per_sec * 3),
                             enable_idempotence=True)
+
+
+class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
+    """
+    Check that a mixed-version cluster does not run into issues with
+    an older node trying to read cloud storage data from a newer node.
+    """
+    def __init__(self, test_context):
+
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=SISettings(),
+            extra_rp_conf={
+                # We will exercise storage/cloud_storage read paths, get the
+                # batch cache out of the way to ensure reads hit storage layer.
+                "disable_batch_cache": True,
+                # We will manually manipulate leaderships, do not want to fight
+                # with the leader balancer
+                "enable_leader_balancer": False,
+            })
+        self.installer = self.redpanda._installer
+        self.rpk = RpkTool(self.redpanda)
+
+    def setUp(self):
+        self.prev_version = \
+            self.installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+        self.installer.install(self.redpanda.nodes, self.prev_version)
+        super().setUp()
+
+    @cluster(
+        num_nodes=4,
+        log_allow_list=RESTART_LOG_ALLOW_LIST +
+        # FIXME: 22.2->22.3 manifests are incompatible and not feature-gated currently:
+        # https://github.com/redpanda-data/redpanda/issues/6837
+        ["partition_manifest.cc.*Failed to parse topic manifest"])
+    def test_rolling_upgrade(self):
+        initial_version = Version(
+            self.redpanda.get_version(self.redpanda.nodes[0]))
+
+        admin = Admin(self.redpanda)
+
+        topic_config = {
+            # Tiny segments
+            'segment.bytes': 512 * 1024,
+            'retention.local.target.bytes': 5 * 512 * 1024,
+        }
+
+        if initial_version < Version("22.3.0"):
+            # We are starting with Redpanda <=22.2, so much use old style declaration of local retention
+            topic_config['retention.bytes'] = topic_config[
+                'retention.local.target.bytes']
+            del topic_config['retention.local.target.bytes']
+
+        # Create a topic with small local retention
+        topic = "cipot"
+        n_partitions = 1
+        self.rpk.create_topic(topic,
+                              partitions=n_partitions,
+                              replicas=3,
+                              config=topic_config)
+
+        # For convenience, write records about the size of a segment
+        record_size = topic_config['segment.bytes']
+
+        # Track how many records we produced, so that we can validate consume afterward
+        expect_records = defaultdict(int)
+
+        def produce(partition, n_records):
+            producer = KgoVerifierProducer(self.test_context,
+                                           self.redpanda,
+                                           topic,
+                                           record_size,
+                                           n_records,
+                                           batch_max_bytes=int(record_size *
+                                                               2))
+            producer.start()
+            producer.wait()
+            producer.free()
+            expect_records[partition] += n_records
+
+        def verify():
+            for p in range(0, n_partitions):
+                self.rpk.consume(topic,
+                                 n=expect_records[p],
+                                 partition=p,
+                                 quiet=True)
+
+        # Ensure some manifests + segments are written from the original version (old feature release)
+        for p in range(0, n_partitions):
+            n_records = 10
+            produce(p, n_records)
+
+        # Wait for archiver to upload to S3
+        for p in range(0, n_partitions):
+            wait_for_segments_removal(self.redpanda,
+                                      topic,
+                                      p,
+                                      6,
+                                      timeout_sec=30)
+
+        # Restart 2/3 nodes, leave last node on old version
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes[:-1],
+                                            start_timeout=90,
+                                            stop_timeout=90)
+
+        # Verify all data readable
+        verify()
+
+        # Pick some arbitrary partition to write data to via a new-verison node
+        newdata_p = 0
+
+        # There might not be any partitions with leadership on new version
+        # node yet, so just transfer one there.
+        new_version_node = self.redpanda.nodes[0]
+        admin.transfer_leadership_to(
+            namespace="kafka",
+            topic=topic,
+            partition=newdata_p,
+            target_id=self.redpanda.idx(new_version_node))
+
+        # Create some new segments in S3 from a new-version node: later we will
+        # cause the old node to try and read them to check that compatibility.
+        n_records = 10
+        produce(newdata_p, n_records)
+        wait_for_segments_removal(self.redpanda,
+                                  topic,
+                                  newdata_p,
+                                  6,
+                                  timeout_sec=30)
+
+        # Move leadership to the old version node and check the partition is readable
+        # from there.
+        old_node = self.redpanda.nodes[-1]
+        admin.transfer_leadership_to(namespace="kafka",
+                                     topic=topic,
+                                     partition=newdata_p,
+                                     target_id=self.redpanda.idx(old_node))
+
+        # Verify all data readable
+        verify()
+
+        # Finish the upgrade
+        self.redpanda.rolling_restart_nodes([self.redpanda.nodes[-1]],
+                                            start_timeout=90,
+                                            stop_timeout=90)
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        head_version_str = self.redpanda.get_version(self.redpanda.nodes[0])
+        head_version = Version(head_version_str)
+        assert initial_version < head_version, f"{initial_version} vs {head_version}"
+        assert head_version_str in unique_versions, unique_versions
+
+        # Verify all data readable
+        verify()

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -8,6 +8,9 @@
 # by the Apache License, Version 2.0
 
 import os
+import time
+from typing import Optional
+
 from contextlib import contextmanager
 from requests.exceptions import HTTPError
 
@@ -15,7 +18,6 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.storage import Segment
 
 from ducktape.errors import TimeoutError
-import time
 
 
 class Scale:
@@ -211,7 +213,11 @@ def wait_for_removal_of_n_segments(redpanda, topic: str, partition_idx: int,
                err_msg="Segments were not removed from all nodes")
 
 
-def wait_for_segments_removal(redpanda, topic, partition_idx, count):
+def wait_for_segments_removal(redpanda,
+                              topic,
+                              partition_idx,
+                              count,
+                              timeout_sec: Optional[int] = None):
     """
     Wait until only given number of segments will left in a partitions
     """
@@ -222,9 +228,12 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
             partitions.append(p <= count)
         return all(partitions)
 
+    if timeout_sec is None:
+        timeout_sec = 120
+
     try:
         wait_until(done,
-                   timeout_sec=120,
+                   timeout_sec=timeout_sec,
                    backoff_sec=5,
                    err_msg="Segments were not removed")
     except Exception as e:


### PR DESCRIPTION
## Cover letter

There was some coverage via `SIPartitionMovementTest`, but it had low probability of detecting manifest decode failures: when https://github.com/redpanda-data/redpanda/pull/6387 changed the manifest format, this wasn't reliably detected by the test.

This test will fail when #6387 merges, until we address the question of how to handle the format changes without breaking 22.2 access to data in https://github.com/redpanda-data/redpanda/pull/6836

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
