### PR TITLE
topic_table: add metric for partition count

### DIFF
--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -157,6 +157,19 @@ void topic_table_probe::handle_topic_creation(
          },
          sm::description("Configured number of replicas for the topic"),
          labels)
+         .aggregate({sm::shard_label}),
+       sm::make_gauge(
+         "partitions",
+         [this, topic_namespace] {
+             auto md = _topic_table.get_topic_metadata_ref(topic_namespace);
+             if (md) {
+                 return md.value().get().get_configuration().partition_count;
+             }
+
+             return int32_t{0};
+         },
+         sm::description("Configured number of partitions for the topic"),
+         labels)
          .aggregate({sm::shard_label})});
 
     _topics_metrics.emplace(


### PR DESCRIPTION
## Cover letter
This PR introduces a new topic level metric that track the number of partitions configured for a topic:
redpanda_kafka_partitions{redpanda_namespace, redpanda_topic}.

This metric was requested by product in order to display the total replica count in our UIs.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
