### PR TITLE
Partition balancer: rack awareness constraint repair

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -118,6 +118,7 @@ v_cc_library(
     remote_topic_configuration_source.cc
     partition_balancer_planner.cc
     partition_balancer_backend.cc
+    partition_balancer_state.cc
     partition_balancer_rpc_handler.cc
     node_status_backend.cc
     node_status_rpc_handler.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -29,6 +29,7 @@
 #include "cluster/metadata_dissemination_service.h"
 #include "cluster/metrics_reporter.h"
 #include "cluster/partition_balancer_backend.h"
+#include "cluster/partition_balancer_state.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
 #include "cluster/raft0_utils.h"
@@ -70,7 +71,11 @@ controller::controller(
   , _shard_table(st)
   , _storage(storage)
   , _storage_node(storage_node)
-  , _tp_updates_dispatcher(_partition_allocator, _tp_state, _partition_leaders)
+  , _tp_updates_dispatcher(
+      _partition_allocator,
+      _tp_state,
+      _partition_leaders,
+      _partition_balancer_state)
   , _security_manager(_credentials, _authorizer)
   , _data_policy_manager(data_policy_table)
   , _raft_manager(raft_manager)
@@ -96,6 +101,12 @@ ss::future<> controller::wire_up() {
             []() { return config::shard_local_cfg().superusers.bind(); });
       })
       .then([this] { return _tp_state.start(); })
+      .then([this] {
+          return _partition_balancer_state.start_single(
+            std::ref(_tp_state),
+            std::ref(_members_table),
+            std::ref(_partition_allocator));
+      })
       .then([this] { _probe.start(); });
 }
 
@@ -375,9 +386,8 @@ controller::start(std::vector<model::broker> initial_raft0_brokers) {
           return _partition_balancer.start_single(
             _raft0,
             std::ref(_stm),
-            std::ref(_tp_state),
+            std::ref(_partition_balancer_state),
             std::ref(_hm_frontend),
-            std::ref(_members_table),
             std::ref(_partition_allocator),
             std::ref(_tp_frontend),
             config::shard_local_cfg().partition_autobalancing_mode.bind(),
@@ -443,6 +453,7 @@ ss::future<> controller::stop() {
           .then([this] { return _tp_state.stop(); })
           .then([this] { return _members_manager.stop(); })
           .then([this] { return _drain_manager.stop(); })
+          .then([this] { return _partition_balancer_state.stop(); })
           .then([this] { return _partition_allocator.stop(); })
           .then([this] { return _partition_leaders.stop(); })
           .then([this] { return _members_table.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -133,6 +133,8 @@ private:
     ss::sharded<partition_allocator> _partition_allocator; // single instance
     ss::sharded<topic_table> _tp_state;                    // instance per core
     ss::sharded<members_table> _members_table;             // instance per core
+    ss::sharded<partition_balancer_state>
+      _partition_balancer_state; // single instance
     ss::sharded<partition_leaders_table>
       _partition_leaders;                            // instance per core
     ss::sharded<drain_manager> _drain_manager;       // instance per core

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -48,6 +48,7 @@ class feature_frontend;
 class feature_manager;
 class drain_manager;
 class partition_balancer_backend;
+class partition_balancer_state;
 class node_status_backend;
 class node_status_table;
 

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -29,9 +29,8 @@ public:
     partition_balancer_backend(
       consensus_ptr raft0,
       ss::sharded<controller_stm>&,
-      ss::sharded<topic_table>&,
+      ss::sharded<partition_balancer_state>&,
       ss::sharded<health_monitor_frontend>&,
-      ss::sharded<members_table>&,
       ss::sharded<partition_allocator>&,
       ss::sharded<topics_frontend>&,
       config::binding<model::partition_autobalancing_mode>&& mode,
@@ -70,9 +69,8 @@ private:
     consensus_ptr _raft0;
 
     controller_stm& _controller_stm;
-    topic_table& _topic_table;
+    partition_balancer_state& _state;
     health_monitor_frontend& _health_monitor;
-    members_table& _members_table;
     partition_allocator& _partition_allocator;
     topics_frontend& _topics_frontend;
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -720,17 +720,20 @@ partition_balancer_planner::plan_reassignments(
     }
 
     if (
-      !result.violations.is_empty()
-      || !_state.ntps_with_broken_rack_constraint().empty()) {
-        init_ntp_sizes_from_health_report(health_report, rrs);
-        get_unavailable_nodes_reassignments(result, rrs);
-        get_rack_constraint_repair_reassignments(result, rrs);
-        get_full_node_reassignments(result, rrs);
-        if (!result.reassignments.empty()) {
-            result.status = status::movement_planned;
-        }
-
+      result.violations.is_empty()
+      && _state.ntps_with_broken_rack_constraint().empty()) {
+        result.status = status::empty;
         return result;
+    }
+
+    init_ntp_sizes_from_health_report(health_report, rrs);
+
+    get_unavailable_nodes_reassignments(result, rrs);
+    get_rack_constraint_repair_reassignments(result, rrs);
+    get_full_node_reassignments(result, rrs);
+
+    if (!result.reassignments.empty()) {
+        result.status = status::movement_planned;
     }
 
     return result;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -201,7 +201,6 @@ std::optional<size_t> partition_balancer_planner::get_partition_size(
 
 partition_constraints partition_balancer_planner::get_partition_constraints(
   const partition_assignment& assignments,
-  const topic_metadata& topic_metadata,
   size_t partition_size,
   double max_disk_usage_ratio,
   reallocation_request_state& rrs) const {
@@ -232,7 +231,7 @@ partition_constraints partition_balancer_planner::get_partition_constraints(
 
     return partition_constraints(
       assignments.id,
-      topic_metadata.get_replication_factor(),
+      assignments.replicas.size(),
       std::move(allocation_constraints));
 }
 
@@ -337,7 +336,6 @@ void partition_balancer_planner::get_unavailable_nodes_reassignments(
 
             auto constraints = get_partition_constraints(
               a,
-              t.second.metadata,
               partition_size.value(),
               _config.hard_max_disk_usage_ratio,
               rrs);
@@ -443,7 +441,6 @@ void partition_balancer_planner::get_full_node_reassignments(
 
             auto constraints = get_partition_constraints(
               *current_assignments,
-              topic_metadata.metadata,
               ntp_size_it->first,
               _config.soft_max_disk_usage_ratio,
               rrs);

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -57,6 +57,12 @@ public:
         std::vector<model::ntp> cancellations;
         size_t failed_reassignments_count = 0;
         status status = status::empty;
+
+        void add_reassignment(
+          model::ntp,
+          const std::vector<model::broker_shard>& orig_replicas,
+          allocation_units,
+          std::string_view reason);
     };
 
     plan_data plan_reassignments(

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -80,7 +80,6 @@ private:
 
     partition_constraints get_partition_constraints(
       const partition_assignment& assignments,
-      const topic_metadata& topic_metadata,
       size_t partition_size,
       double max_disk_usage_ratio,
       reallocation_request_state&) const;

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -40,8 +40,7 @@ class partition_balancer_planner {
 public:
     partition_balancer_planner(
       planner_config config,
-      topic_table& topic_table,
-      members_table& members_table,
+      partition_balancer_state& state,
       partition_allocator& partition_allocator);
 
     enum class status {
@@ -121,8 +120,7 @@ private:
     bool all_reports_received(const reallocation_request_state&);
 
     planner_config _config;
-    topic_table& _topic_table;
-    members_table& _members_table;
+    partition_balancer_state& _state;
     partition_allocator& _partition_allocator;
 };
 

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -95,6 +95,9 @@ private:
     void get_unavailable_nodes_reassignments(
       plan_data&, reallocation_request_state&);
 
+    void get_rack_constraint_repair_reassignments(
+      plan_data&, reallocation_request_state&);
+
     void get_full_node_reassignments(plan_data&, reallocation_request_state&);
 
     void init_per_node_state(

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster/partition_balancer_state.h"
+
+#include "cluster/logger.h"
+#include "cluster/scheduling/partition_allocator.h"
+
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster {
+
+partition_balancer_state::partition_balancer_state(
+  ss::sharded<topic_table>& topic_table,
+  ss::sharded<members_table>& members_table,
+  ss::sharded<partition_allocator>& pa)
+  : _topic_table(topic_table.local())
+  , _members_table(members_table.local())
+  , _partition_allocator(pa.local()) {}
+
+void partition_balancer_state::handle_ntp_update(
+  const model::ns& ns,
+  const model::topic& tp,
+  model::partition_id p_id,
+  const std::vector<model::broker_shard>& prev,
+  const std::vector<model::broker_shard>& next) {
+    if (_partition_allocator.is_rack_awareness_enabled()) {
+        absl::flat_hash_set<model::rack_id> racks;
+        bool is_rack_constraint_violated = false;
+        for (const auto& bs : next) {
+            auto rack = _partition_allocator.state().get_rack_id(bs.node_id);
+            if (rack) {
+                auto res = racks.insert(std::move(*rack));
+                if (!res.second) {
+                    is_rack_constraint_violated = true;
+                    break;
+                }
+            }
+        }
+
+        model::ntp ntp(ns, tp, p_id);
+        if (is_rack_constraint_violated) {
+            auto res = _ntps_with_broken_rack_constraint.insert(std::move(ntp));
+            if (res.second) {
+                vlog(
+                  clusterlog.debug,
+                  "rack constraint violated for ntp: {}, "
+                  "replica set change: {} -> {}",
+                  ntp,
+                  prev,
+                  next);
+            }
+        } else {
+            auto erased = _ntps_with_broken_rack_constraint.erase(ntp);
+            if (erased > 0) {
+                vlog(
+                  clusterlog.debug,
+                  "rack constraint restored for ntp: {}, "
+                  "replica set change: {} -> {}",
+                  ntp,
+                  prev,
+                  next);
+            }
+        }
+    }
+}
+
+} // namespace cluster

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+/// Class that stores state that is needed for functioning of the partition
+/// balancer. It is updated from the controller log (via
+/// topic_updates_dispatcher)
+class partition_balancer_state {
+public:
+    partition_balancer_state(
+      ss::sharded<topic_table>&,
+      ss::sharded<members_table>&,
+      ss::sharded<partition_allocator>&);
+
+    const topic_table& topics() const { return _topic_table; }
+
+    const members_table& members() const { return _members_table; }
+
+    const absl::btree_set<model::ntp>&
+    ntps_with_broken_rack_constraint() const {
+        return _ntps_with_broken_rack_constraint;
+    }
+
+    /// Called when the replica set of an ntp changes. Note that this doesn't
+    /// account for in-progress moves - the function is called only once when
+    /// the move is started.
+    void handle_ntp_update(
+      const model::ns&,
+      const model::topic&,
+      model::partition_id,
+      const std::vector<model::broker_shard>& prev,
+      const std::vector<model::broker_shard>& next);
+
+private:
+    topic_table& _topic_table;
+    members_table& _members_table;
+    partition_allocator& _partition_allocator;
+    absl::btree_set<model::ntp> _ntps_with_broken_rack_constraint;
+};
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -86,6 +86,8 @@ public:
     void remove_allocations(
       const std::vector<model::broker_shard>&, partition_allocation_domain);
 
+    bool is_rack_awareness_enabled() const { return _enable_rack_awareness(); }
+
     allocation_state& state() { return *_state; }
 
 private:

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -699,12 +699,9 @@ FIXTURE_TEST(test_node_cancelation, partition_balancer_planner_fixture) {
  */
 FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
     vlog(logger.debug, "test_rack_awareness");
-    allocator_register_nodes(1, model::rack_id("rack_1"));
-    allocator_register_nodes(1, model::rack_id("rack_2"));
-    allocator_register_nodes(1, model::rack_id("rack_3"));
+    allocator_register_nodes(3, {"rack_1", "rack_2", "rack_3"});
     create_topic("topic-1", 1, 3);
-    allocator_register_nodes(1, model::rack_id("rack_3"));
-    allocator_register_nodes(1, model::rack_id("rack_4"));
+    allocator_register_nodes(2, {"rack_3", "rack_4"});
 
     auto hr = create_health_report();
     // Make node_4 disk free size less to make partition allocator disk usage

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -14,6 +14,9 @@
 
 static ss::logger logger("partition_balancer_planner");
 
+// a shorthand to avoid spelling out model::node_id
+static model::node_id n(int64_t id) { return model::node_id{id}; };
+
 using namespace std::chrono_literals;
 
 void check_violations(
@@ -819,6 +822,45 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
     BOOST_REQUIRE_EQUAL(plan_data.cancellations.size(), 0);
     BOOST_REQUIRE_EQUAL(plan_data.failed_reassignments_count, 1);
+}
+
+FIXTURE_TEST(
+  test_state_ntps_with_broken_rack_constraint,
+  partition_balancer_planner_fixture) {
+    allocator_register_nodes(4, {"rack_A", "rack_B", "rack_B", "rack_C"});
+
+    model::topic topic{"topic-1"};
+    model::ntp ntp0{test_ns, topic, 0};
+    model::ntp ntp1{test_ns, topic, 1};
+
+    auto check_ntps = [&](absl::btree_set<model::ntp> expected) {
+        const auto& ntps
+          = workers.state.local().ntps_with_broken_rack_constraint();
+        BOOST_REQUIRE_EQUAL(
+          std::vector(ntps.begin(), ntps.end()),
+          std::vector(expected.begin(), expected.end()));
+    };
+
+    create_topic(topic(), {{n(0), n(1), n(2)}, {n(0), n(1), n(3)}});
+    check_ntps({ntp0});
+
+    move_partition_replicas(ntp1, {n(0), n(1), n(2)});
+    check_ntps({ntp0, ntp1});
+
+    move_partition_replicas(ntp0, {n(0), n(3), n(2)});
+    check_ntps({ntp1});
+
+    cancel_partition_move(ntp0);
+    check_ntps({ntp0, ntp1});
+
+    finish_partition_move(ntp1);
+    check_ntps({ntp0, ntp1});
+
+    move_partition_replicas(ntp1, {n(0), n(2), n(3)});
+    check_ntps({ntp0});
+
+    delete_topic(topic);
+    check_ntps({});
 }
 
 /*

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/members_table.h"
+#include "cluster/partition_balancer_state.h"
 #include "cluster/scheduling/allocation_node.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/tests/utils.h"
@@ -58,9 +59,13 @@ struct topic_table_fixture {
           create_allocation_node(model::node_id(2), 12));
         allocator.local().register_node(
           create_allocation_node(model::node_id(3), 4));
+        pb_state
+          .start_single(std::ref(table), std::ref(members), std::ref(allocator))
+          .get();
     }
 
     ~topic_table_fixture() {
+        pb_state.stop().get();
         table.stop().get0();
         allocator.stop().get0();
         members.stop().get0();
@@ -149,5 +154,6 @@ struct topic_table_fixture {
     ss::sharded<cluster::partition_allocator> allocator;
     ss::sharded<cluster::topic_table> table;
     ss::sharded<cluster::partition_leaders_table> leaders;
+    ss::sharded<cluster::partition_balancer_state> pb_state;
     ss::abort_source as;
 };

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -21,7 +21,7 @@ using namespace std::chrono_literals;
 
 struct topic_table_updates_dispatcher_fixture : topic_table_fixture {
     topic_table_updates_dispatcher_fixture()
-      : dispatcher(allocator, table, leaders) {}
+      : dispatcher(allocator, table, leaders, pb_state) {}
 
     void create_topics() {
         auto cmd_1 = make_create_topic_cmd("test_tp_1", 1, 3);

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/commands.h"
+#include "cluster/fwd.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
@@ -23,9 +24,9 @@ namespace cluster {
 
 // The topic updates dispatcher is responsible for receiving update_apply
 // upcalls from controller state machine and propagating updates to topic state
-// core local copies. The dispatcher handles partition_allocator updates. The
-// partition allocator exists only on core 0 hence the updates have to be
-// executed at the same core.
+// core local copies. The dispatcher also handles partition_allocator and
+// partition_balancer_state updates. Those services exist only on core 0 hence
+// the updates have to be executed at the same core.
 //
 //
 //                                  +----------------+        +------------+
@@ -53,7 +54,8 @@ public:
     topic_updates_dispatcher(
       ss::sharded<partition_allocator>&,
       ss::sharded<topic_table>&,
-      ss::sharded<partition_leaders_table>&);
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<partition_balancer_state>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -96,6 +98,7 @@ private:
     ss::sharded<partition_allocator>& _partition_allocator;
     ss::sharded<topic_table>& _topic_table;
     ss::sharded<partition_leaders_table>& _partition_leaders_table;
+    ss::sharded<partition_balancer_state>& _partition_balancer_state;
 };
 
 } // namespace cluster


### PR DESCRIPTION
## Cover letter

Add rack awareness repair to the partition balancer.

Add the `partition_balancer_state` class that captures the controller state needed for the balancer. This class maintains a set of ntps that have rack awareness constraint violated (i.e. more than one replica in a rack). In the balancer we go over this set and (if there are suitable racks) try to schedule repairing moves.

Fixes #6355 

TODO: add a "number of ntps with violated constraint" metric

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix

## UX changes

Rack awareness constraint repair is added to partition balancing in the `continuous` mode. For a given partition balancer will try to move excess replicas from racks that have more than one replica to racks where there are none.

## Release notes
### Features
* Added rack awareness constraint repair in the `continuous` partition balancing mode.
