### PR TITLE
rpk: updates for bootstrapping

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -162,7 +162,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 		&ips,
 		"ips",
 		[]string{},
-		"The list of known node addresses or hostnames",
+		"Comma-separated list of the seed node addresses or hostnames. It is strongly recommended that this refers to at least three nodes",
 	)
 	c.Flags().StringVar(
 		&configPath,
@@ -253,6 +253,9 @@ func parseSeedIPs(ips []string) ([]config.SeedServer, error) {
 		}
 		seeds = append(seeds, seed)
 	}
+	if len(seeds) == 0 {
+		return nil, errors.New("must provide seed servers in --ips")
+	}
 	return seeds, nil
 }
 
@@ -313,9 +316,9 @@ func isPrivate(ip net.IP) (bool, error) {
 
 const helpBootstrap = `Initialize the configuration to bootstrap a cluster.
 
---id is mandatory. bootstrap will expect the machine it's running on
-to have only one private non-loopback IP address associated to it,
-and use it in the configuration as the node's address.
+bootstrap will expect the machine it's running on to have only one private
+non-loopback IP address associated to it, and use it in the configuration as
+the node's address.
 
 If it has multiple IPs, --self must be specified.
 In that case, the given IP will be used without checking whether it's

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -147,6 +147,13 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 			cfg.Redpanda.SeedServers = []config.SeedServer{}
 			cfg.Redpanda.SeedServers = seeds
 
+			// In bootstrapping a new cluster, use seeds-driven cluster
+			// formation.
+			if cfg.Redpanda.Other == nil {
+				cfg.Redpanda.Other = make(map[string]interface{})
+			}
+			cfg.Redpanda.Other["empty_seed_starts_cluster"] = false
+
 			err = cfg.Write(fs)
 			out.MaybeDie(err, "error writing config file: %v", err)
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -25,6 +25,27 @@ import (
 
 func TestBootstrap(t *testing.T) {
 	defaultRPCPort := config.DevDefault().Redpanda.RPCServer.Port
+	simpleIps := []string{"187.89.76.3", "192.168.34.5", "192.168.45.8"}
+	simpleSeeds := []config.SeedServer{
+		{
+			Host: config.SocketAddress{
+				Address: "187.89.76.3",
+				Port:    defaultRPCPort,
+			},
+		},
+		{
+			Host: config.SocketAddress{
+				Address: "192.168.34.5",
+				Port:    defaultRPCPort,
+			},
+		},
+		{
+			Host: config.SocketAddress{
+				Address: "192.168.45.8",
+				Port:    defaultRPCPort,
+			},
+		},
+	}
 	tests := []struct {
 		name           string
 		ips            []string
@@ -34,39 +55,24 @@ func TestBootstrap(t *testing.T) {
 		expectedErr    string
 	}{
 		{
-			name: "it should omit node id without errors",
-			self: "192.168.34.5",
+			name:           "it should omit node id without errors",
+			ips:            simpleIps,
+			self:           "192.168.34.5",
+			expSeedServers: simpleSeeds,
 		},
 		{
-			name: "it should set the root node config for a single node",
-			id:   "1",
-			self: "192.168.34.5",
+			name:           "it should set the root node config for a single node",
+			ips:            simpleIps,
+			id:             "1",
+			self:           "192.168.34.5",
+			expSeedServers: simpleSeeds,
 		},
 		{
-			name: "it should fill the seed servers",
-			ips:  []string{"187.89.76.3", "192.168.34.5", "192.168.45.8"},
-			expSeedServers: []config.SeedServer{
-				{
-					Host: config.SocketAddress{
-						Address: "187.89.76.3",
-						Port:    defaultRPCPort,
-					},
-				},
-				{
-					Host: config.SocketAddress{
-						Address: "192.168.34.5",
-						Port:    defaultRPCPort,
-					},
-				},
-				{
-					Host: config.SocketAddress{
-						Address: "192.168.45.8",
-						Port:    defaultRPCPort,
-					},
-				},
-			},
-			self: "192.168.34.5",
-			id:   "1",
+			name:           "it should fill the seed servers",
+			ips:            simpleIps,
+			expSeedServers: simpleSeeds,
+			self:           "192.168.34.5",
+			id:             "1",
 		},
 		{
 			name: "it should fill the seed servers with hostnames",

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -33,6 +33,10 @@ func TestBootstrap(t *testing.T) {
 		expectedErr    string
 	}{
 		{
+			name: "it should omit node id without errors",
+			self: "192.168.34.5",
+		},
+		{
 			name: "it should set the root node config for a single node",
 			id:   "1",
 			self: "192.168.34.5",
@@ -132,6 +136,13 @@ func TestBootstrap(t *testing.T) {
 			require.NoError(t, err)
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(t, err)
+
+			if tt.id != "" {
+				require.NotNil(t, conf.Redpanda.ID)
+				require.Equal(t, 1, *conf.Redpanda.ID)
+			} else {
+				require.Nil(t, conf.Redpanda.ID)
+			}
 
 			require.Equal(t, tt.self, conf.Redpanda.RPCServer.Address)
 			require.Equal(t, tt.self, conf.Redpanda.KafkaAPI[0].Address)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -13,6 +13,7 @@
 package redpanda
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -139,7 +140,9 @@ func TestBootstrap(t *testing.T) {
 
 			if tt.id != "" {
 				require.NotNil(t, conf.Redpanda.ID)
-				require.Equal(t, 1, *conf.Redpanda.ID)
+				id, err := strconv.Atoi(tt.id)
+				require.Nil(t, err)
+				require.Equal(t, id, *conf.Redpanda.ID)
 			} else {
 				require.Nil(t, conf.Redpanda.ID)
 			}
@@ -156,6 +159,8 @@ func TestBootstrap(t *testing.T) {
 				return
 			}
 			require.ElementsMatch(t, tt.expSeedServers, conf.Redpanda.SeedServers)
+			require.Contains(t, conf.Redpanda.Other, "empty_seed_starts_cluster")
+			require.Equal(t, false, conf.Redpanda.Other["empty_seed_starts_cluster"])
 		})
 	}
 }


### PR DESCRIPTION
## Cover letter

For backwards compatibility, Redpanda's default is to continue to use
the old style of startup. New clusters should should use the new style
of bootstrapping, where all nodes are provided the same set of seed
servers. To that end, this updates the bootstrap command to set the
`empty_seed_starts_cluster` node config to false.

Also added to the existing bootstrap a test case to omit node ID.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
