### PR TITLE
tests: set HEAP_ARGS=" " in OMB worker

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -58,6 +58,7 @@ class OpenMessagingBenchmarkWorkers(Service):
         node.account.mkdirs(OpenMessagingBenchmarkWorkers.PERSISTENT_ROOT)
 
         start_cmd = f"cd /opt/openmessaging-benchmark; \
+                      HEAP_OPTS=\" \" \
                       bin/benchmark-worker \
                       --port {OpenMessagingBenchmarkWorkers.PORT} \
                       --stats-port {OpenMessagingBenchmarkWorkers.STATS_PORT} \


### PR DESCRIPTION
## Cover letter

The default bash script that starts OMB worker
has a default heap size limit of 8GB.  This is
too small for testing with >10k partitions.

Instead, set it to an empty string and let Java
use its defaults.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
None

## Release notes


* none
