### PR TITLE
test: stress test client shutdown in the proxy client cache

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -532,12 +532,16 @@ class RedpandaService(Service):
                  security: SecurityConfig = SecurityConfig(),
                  node_ready_timeout_s=None,
                  superuser: Optional[SaslCredentials] = None,
-                 skip_if_no_redpanda_log: bool = False):
+                 skip_if_no_redpanda_log: bool = False,
+                 pp_keep_alive: Optional[int] = None,
+                 pp_cache_max_size: Optional[int] = None):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._extra_rp_conf = extra_rp_conf or dict()
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
+        self._pp_keep_alive = pp_keep_alive
+        self._pp_cache_max_size = pp_cache_max_size
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
 
@@ -1747,7 +1751,9 @@ class RedpandaService(Service):
                            endpoint_authn_method=self.endpoint_authn_method(),
                            pp_authn_method=self._security.pp_authn_method,
                            sr_authn_method=self._security.sr_authn_method,
-                           auto_auth=self._security.auto_auth)
+                           auto_auth=self._security.auto_auth,
+                           pp_keep_alive=self._pp_keep_alive,
+                           pp_cache_max_size=self._pp_cache_max_size)
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -60,6 +60,14 @@ pandaproxy:
     authentication_method: {{ pp_authn_method }}
     {% endif %}
 
+  {% if pp_keep_alive %}
+  client_keep_alive: {{ pp_keep_alive }}
+  {% endif %}
+
+  {% if pp_cache_max_size %}
+  client_cache_max_size: {{ pp_cache_max_size }}
+  {% endif %}
+
   advertised_pandaproxy_api:
     address: "{{node.account.hostname}}"
     port: 8082


### PR DESCRIPTION
## Cover letter

Recent changes to the Pandaproxy involved creating a kafka client cache to support multiple authenticated connections. The client connection is closed when a client is evicted from the cache. Therefore, this PR adds a concurrency test that issues many requests to the proxy such that a client connection should be closed while other requests are still running.

Closes #6595 

Changes from force-push `4067481`:
- Refactor error checking in the ducktape test
- Describe how the new test adds stress to the commit message
- Dropped the commits that made fetch_or_insert async
- Dropped the commits that brought client stop() inline

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Add a ducktape test that checks client shutdown when there are ongoing requests