### PR TITLE
txns/compaction: short circuit tx_reducer for non tx topics

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -379,6 +379,10 @@ bool tx_reducer::handle_non_tx_control_batch(const model::record_batch& b) {
 }
 
 ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
+    if (unlikely(_non_transactional)) {
+        co_return co_await _delegate(std::move(b));
+    }
+
     _stats._all_batches++;
     consume_aborted_txs(b.last_offset());
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -159,6 +159,8 @@ public:
         return _tx_stm->parse_tx_control_batch(b);
     }
 
+    bool has_tx_stm() { return _tx_stm.get(); }
+
 private:
     ss::shared_ptr<snapshotable_stm> _tx_stm;
     std::vector<ss::shared_ptr<snapshotable_stm>> _stms;


### PR DESCRIPTION
## Cover letter

For non transaction topics (no rm_stm attached), it does not make sense to run tx_reducer logic as we won't find any batches of interest. While these topics typically build their compaction index along with the data segment writes, in certain rare cases the index can go missing/ corrupt and requires a rebuild. In such cases we can short circuit tx_reducer and delegate it to the underlying reducer.
We found this issue when __consumer_offsets topic was trying to rebuild it's index (probably after a crash) and the reducer came across some unexpected batches that triggered an assert.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none
