### PR TITLE
Fix cloud storage auth validation

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -779,22 +779,27 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
     } else {
         // Create an implementation of refresh_credentials based on the setting
         // cloud_credentials_source.
-        _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
-          _cloud_credentials_source,
-          _gate,
-          _as,
-          std::move(credentials_update_cb),
-          _region_name));
+        try {
+            _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
+              _cloud_credentials_source,
+              _gate,
+              _as,
+              std::move(credentials_update_cb),
+              _region_name));
 
-        vlog(
-          cst_log.info,
-          "created credentials refresh implementation based on credentials "
-          "source "
-          "{}: {}",
-          _cloud_credentials_source,
-          *_refresh_credentials);
-
-        _refresh_credentials->start();
+            vlog(
+              cst_log.info,
+              "created credentials refresh implementation based on credentials "
+              "source {}: {}",
+              _cloud_credentials_source,
+              *_refresh_credentials);
+            _refresh_credentials->start();
+        } catch (const std::exception& ex) {
+            vlog(
+              cst_log.error,
+              "failed to initialize cloud storage authentication system: {}",
+              ex.what());
+        }
     }
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1045,13 +1045,27 @@ void config_multi_property_validation(
     if (updated_config.cloud_storage_enabled()) {
         // The properties that cloud_storage::configuration requires
         // to be set if cloud storage is enabled.
-        std::vector<std::reference_wrapper<
-          const config::property<std::optional<ss::sstring>>>>
-          properties{
-            std::ref(updated_config.cloud_storage_secret_key),
-            std::ref(updated_config.cloud_storage_access_key),
-            std::ref(updated_config.cloud_storage_region),
-            std::ref(updated_config.cloud_storage_bucket)};
+        using config_properties_seq = std::vector<std::reference_wrapper<
+          const config::property<std::optional<ss::sstring>>>>;
+
+        config_properties_seq properties{};
+
+        if (
+          updated_config.cloud_storage_credentials_source
+          == model::cloud_credentials_source::config_file) {
+            properties = {
+              std::ref(updated_config.cloud_storage_region),
+              std::ref(updated_config.cloud_storage_bucket),
+              std::ref(updated_config.cloud_storage_access_key),
+              std::ref(updated_config.cloud_storage_secret_key),
+            };
+        } else {
+            properties = {
+              std::ref(updated_config.cloud_storage_region),
+              std::ref(updated_config.cloud_storage_bucket),
+            };
+        }
+
         for (auto& p : properties) {
             if (p() == std::nullopt) {
                 errors[ss::sstring(p.get().name())]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -106,6 +106,12 @@ CHANGE_REPLICATION_FACTOR_ALLOW_LIST = [
         "cluster - .*Unable to allocate topic with given replication factor"),
 ]
 
+# Log errors emitted by refresh credentials system when cloud storage is enabled with IAM roles
+# without a corresponding mock service set up to return credentials
+IAM_ROLES_API_CALL_ALLOW_LIST = [
+    re.compile(r'cloud_roles - .*api request failed')
+]
+
 
 class MetricSamples:
     def __init__(self, samples: list[MetricSample]):


### PR DESCRIPTION
## Cover letter

When redpanda is configured with IAM roles, it is not expected that secrets will be supplied as these are sourced at runtime. This change adjusts the admin server validation to allow a cluster config edit without requiring the presence secrets when IAM roles are used.

It also makes sure that when IAM roles are used, secrets cannot be supplied as part of the cluster config edit.

fixes #6795  
fixes #5507

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

It is now invalid to add secrets when IAM roles are set as the credentials source when editing cluster config.

## Release notes

* none

### Improvements

* Enables cluster config editing when IAM roles are used
* extends validation to make sure secrets are not supplied when they are not used by redpanda.



A follow up issue #6865 is created for validating the presence of keys at startup when IAM roles are configured, and exit with error.