### PR TITLE
[v22.2.x] Fixed spurious log entry emitted on heartbeat timeout

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -315,6 +315,15 @@ void heartbeat_manager::process_reply(
         auto consensus = *it;
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);
 
+        if (unlikely(m.result == append_entries_reply::status::timeout)) {
+            vlog(
+              hbeatlog.debug,
+              "Heartbeat request for group {} timed out on the node {}",
+              m.group,
+              n);
+            continue;
+        }
+
         if (unlikely(m.target_node_id != consensus->self())) {
             vlog(
               hbeatlog.warn,


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6412.
Fixes https://github.com/redpanda-data/redpanda/issues/6866,