### PR TITLE
cloud_storage: refactor s3/client.h header #includes from other namespaces

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -19,7 +19,7 @@
 #include "cluster/partition.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 #include "storage/fwd.h"
 #include "storage/segment.h"
 #include "utils/retry_chain_node.h"

--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -10,6 +10,9 @@
 
 #include "cloud_roles/aws_refresh_impl.h"
 
+#include "cloud_roles/logger.h"
+#include "cloud_roles/request_response_helpers.h"
+
 namespace cloud_roles {
 
 struct ec2_response_schema {

--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -11,6 +11,8 @@
 #include "cloud_roles/aws_sts_refresh_impl.h"
 
 #include "bytes/iobuf_istreambuf.h"
+#include "cloud_roles/logger.h"
+#include "cloud_roles/request_response_helpers.h"
 #include "utils/file_io.h"
 
 #include <boost/algorithm/string/trim.hpp>

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -14,6 +14,7 @@
 #include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/gcp_refresh_impl.h"
 #include "cloud_roles/logger.h"
+#include "cloud_roles/request_response_helpers.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "model/metadata.h"
@@ -209,6 +210,22 @@ void refresh_credentials::impl::increment_retries() {
     auto sleep_ms = _retry_params.backoff_ms * (2 * _retries);
     vlog(clrl_log.info, "retry after {} ms", sleep_ms);
     _sleep_duration = sleep_ms;
+}
+
+void refresh_credentials::impl::reset_retries() {
+    if (unlikely(_retries != 0)) {
+        vlog(clrl_log.info, "resetting retry counter from {} to 0", _retries);
+        _retries = 0;
+    }
+}
+
+void refresh_credentials::impl::next_sleep_duration(
+  std::chrono::milliseconds sd) {
+    vlog(
+      clrl_log.trace,
+      "setting next sleep duration to {} seconds",
+      std::chrono::duration_cast<std::chrono::seconds>(sd).count());
+    _sleep_duration = sd;
 }
 
 api_response_parse_result

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -10,9 +10,7 @@
 
 #pragma once
 
-#include "cloud_roles/logger.h"
 #include "cloud_roles/probe.h"
-#include "cloud_roles/request_response_helpers.h"
 #include "cloud_roles/signature.h"
 #include "model/metadata.h"
 #include "seastarx.h"
@@ -72,15 +70,7 @@ public:
         /// go over the max limit, abort the operation by throwing an exception.
         void increment_retries();
 
-        void reset_retries() {
-            if (unlikely(_retries != 0)) {
-                vlog(
-                  clrl_log.info,
-                  "resetting retry counter from {} to 0",
-                  _retries);
-                _retries = 0;
-            }
-        }
+        void reset_retries();
 
     protected:
         /// Returns an http client with the API host and port applied
@@ -94,13 +84,7 @@ public:
         /// Sets the amount of seconds to sleep before making the next API call
         /// to fetch credentials. Depends on expiry time of current set of
         /// credentials.
-        void next_sleep_duration(std::chrono::milliseconds sd) {
-            vlog(
-              clrl_log.trace,
-              "setting next sleep duration to {} seconds",
-              std::chrono::duration_cast<std::chrono::seconds>(sd).count());
-            _sleep_duration = sd;
-        }
+        void next_sleep_duration(std::chrono::milliseconds sd);
 
         /// Calculates sleep duration given a time point in future where the
         /// credentials will expire. Keeps a small buffer to allow for network

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -13,6 +13,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "cloud_storage/types.h"
+#include "s3/client_probe.h"
 #include "seastarx.h"
 #include "test_utils/async.h"
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -14,7 +14,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
 

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -9,8 +9,10 @@
 
 #include "cluster/partition_manager.h"
 
+#include "cloud_storage/cache_service.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/partition_recovery_manager.h"
+#include "cloud_storage/remote.h"
 #include "cluster/archival_metadata_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -11,10 +11,7 @@
 
 #pragma once
 
-#include "cloud_storage/cache_service.h"
 #include "cloud_storage/fwd.h"
-#include "cloud_storage/partition_recovery_manager.h"
-#include "cloud_storage/remote.h"
 #include "cluster/fwd.h"
 #include "cluster/ntp_callbacks.h"
 #include "cluster/partition.h"

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -17,7 +17,7 @@
 #include "cluster/logger.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 
 namespace cluster {
 

--- a/src/v/cluster/remote_topic_configuration_source.h
+++ b/src/v/cluster/remote_topic_configuration_source.h
@@ -14,7 +14,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/errc.h"
 #include "cluster/types.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 
 #include <seastar/core/abort_source.hh>
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -34,7 +34,7 @@
 #include "random/generators.h"
 #include "rpc/errc.h"
 #include "rpc/types.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 #include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -27,6 +27,7 @@
 #include "model/record.h"
 #include "rpc/connection_cache.h"
 #include "types.h"
+#include "utils/gate_guard.h"
 
 #include <seastar/core/coroutine.hh>
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -38,7 +38,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "redpanda/application.h"
 #include "resource_mgmt/cpu_scheduling.h"
-#include "s3/client.h"
+#include "s3/configuration.h"
 #include "storage/directories.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -17,6 +17,7 @@
 #include "net/types.h"
 #include "outcome.h"
 #include "s3/client_probe.h"
+#include "s3/configuration.h"
 #include "utils/gate_guard.h"
 #include "utils/intrusive_list_helpers.h"
 
@@ -34,65 +35,9 @@
 
 namespace s3 {
 
-using access_point_uri = named_type<ss::sstring, struct s3_access_point_uri>;
-using object_key = named_type<std::filesystem::path, struct s3_object_key>;
-using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
-using ca_trust_file
-  = named_type<std::filesystem::path, struct s3_ca_trust_file>;
-
 struct object_tag {
     ss::sstring key;
     ss::sstring value;
-};
-
-/// List of default overrides that can be used to workaround issues
-/// that can arise when we want to deal with different S3 API implementations
-/// and different OS issues (like different truststore locations on different
-/// Linux distributions).
-struct default_overrides {
-    std::optional<endpoint_url> endpoint = std::nullopt;
-    std::optional<uint16_t> port = std::nullopt;
-    std::optional<ca_trust_file> trust_file = std::nullopt;
-    std::optional<ss::lowres_clock::duration> max_idle_time = std::nullopt;
-    bool disable_tls = false;
-};
-
-/// S3 client configuration
-struct configuration : net::base_transport::configuration {
-    /// URI of the S3 access point
-    access_point_uri uri;
-    /// AWS access key, optional if configuration uses temporary credentials
-    std::optional<cloud_roles::public_key_str> access_key;
-    /// AWS secret key, optional if configuration uses temporary credentials
-    std::optional<cloud_roles::private_key_str> secret_key;
-    /// AWS region
-    cloud_roles::aws_region_name region;
-    /// Max time that connection can spend idle
-    ss::lowres_clock::duration max_idle_time;
-    /// Metrics probe (should be created for every aws account on every shard)
-    ss::shared_ptr<client_probe> _probe;
-
-    /// \brief opinionated configuraiton initialization
-    /// Generates uri field from region, initializes credentials for the
-    /// transport, resolves the uri to get the server_addr.
-    ///
-    /// \param pkey is an AWS access key
-    /// \param skey is an AWS secret key
-    /// \param region is an AWS region code
-    /// \param overrides contains a bunch of property overrides like
-    ///        non-standard SSL port and alternative location of the
-    ///        truststore
-    /// \return future that returns initialized configuration
-    static ss::future<configuration> make_configuration(
-      const std::optional<cloud_roles::public_key_str>& pkey,
-      const std::optional<cloud_roles::private_key_str>& skey,
-      const cloud_roles::aws_region_name& region,
-      const default_overrides& overrides = {},
-      net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
-      net::public_metrics_disabled disable_public_metrics
-      = net::public_metrics_disabled::yes);
-
-    friend std::ostream& operator<<(std::ostream& o, const configuration& c);
 };
 
 /// Request formatter for AWS S3

--- a/src/v/s3/configuration.h
+++ b/src/v/s3/configuration.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/types.h"
+#include "model/fundamental.h"
+#include "net/transport.h"
+#include "net/types.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace s3 {
+
+class client_probe;
+
+using access_point_uri = named_type<ss::sstring, struct s3_access_point_uri>;
+using object_key = named_type<std::filesystem::path, struct s3_object_key>;
+using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
+using ca_trust_file
+  = named_type<std::filesystem::path, struct s3_ca_trust_file>;
+
+/// List of default overrides that can be used to workaround issues
+/// that can arise when we want to deal with different S3 API implementations
+/// and different OS issues (like different truststore locations on different
+/// Linux distributions).
+struct default_overrides {
+    std::optional<endpoint_url> endpoint = std::nullopt;
+    std::optional<uint16_t> port = std::nullopt;
+    std::optional<ca_trust_file> trust_file = std::nullopt;
+    std::optional<ss::lowres_clock::duration> max_idle_time = std::nullopt;
+    bool disable_tls = false;
+};
+
+/// S3 client configuration
+struct configuration : net::base_transport::configuration {
+    /// URI of the S3 access point
+    access_point_uri uri;
+    /// AWS access key, optional if configuration uses temporary credentials
+    std::optional<cloud_roles::public_key_str> access_key;
+    /// AWS secret key, optional if configuration uses temporary credentials
+    std::optional<cloud_roles::private_key_str> secret_key;
+    /// AWS region
+    cloud_roles::aws_region_name region;
+    /// Max time that connection can spend idle
+    ss::lowres_clock::duration max_idle_time;
+    /// Metrics probe (should be created for every aws account on every shard)
+    ss::shared_ptr<client_probe> _probe;
+
+    /// \brief opinionated configuraiton initialization
+    /// Generates uri field from region, initializes credentials for the
+    /// transport, resolves the uri to get the server_addr.
+    ///
+    /// \param pkey is an AWS access key
+    /// \param skey is an AWS secret key
+    /// \param region is an AWS region code
+    /// \param overrides contains a bunch of property overrides like
+    ///        non-standard SSL port and alternative location of the
+    ///        truststore
+    /// \return future that returns initialized configuration
+    static ss::future<configuration> make_configuration(
+      const std::optional<cloud_roles::public_key_str>& pkey,
+      const std::optional<cloud_roles::private_key_str>& skey,
+      const cloud_roles::aws_region_name& region,
+      const default_overrides& overrides = {},
+      net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
+      net::public_metrics_disabled disable_public_metrics
+      = net::public_metrics_disabled::yes);
+
+    friend std::ostream& operator<<(std::ostream& o, const configuration& c);
+};
+} // namespace s3


### PR DESCRIPTION
## Cover letter

I noticed while doing other work that including some headers in the controller would result in including many headers via s3/client, all the way down the http clients.

    s3: split out config types into separate header
    
    This is to reduce other modules pulling in whole
    trees of http client headers because they needed
    a simple thing like s3::bucket name in their config
    structure.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none