### PR TITLE
[transaction] Avoid txn coordinator <-> rm_stm prepare RPC

### DIFF
--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -485,7 +485,7 @@ ss::future<commit_tx_reply> rm_partition_frontend::commit_tx(
 
     auto leader = _leaders.local().get_leader(ntp);
     if (!leader) {
-        vlog(txlog.warn, "can't find a leader for {}", ntp);
+        vlog(txlog.warn, "can't find a leader for {} pid:{}", ntp, pid);
         return ss::make_ready_future<commit_tx_reply>(
           commit_tx_reply{tx_errc::leader_not_found});
     }

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -125,17 +125,22 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
         if (leader == _self) {
             result = co_await begin_tx_locally(
               ntp, pid, tx_seq, transaction_timeout_ms);
-            if (result.ec == tx_errc::leader_not_found) {
+            if (
+              result.ec == tx_errc::leader_not_found
+              || result.ec == tx_errc::shard_not_found) {
                 error = vformat(
-                  fmt::runtime(
-                    "local execution of begin_tx({},...) failed with 'not a "
-                    "leader'"),
-                  ntp);
+                  fmt::runtime("local execution of begin_tx pid:{} tx_seq:{} "
+                               "failed with {}"),
+                  pid,
+                  tx_seq,
+                  result.ec);
                 vlog(
                   txlog.trace,
-                  "local execution of begin_tx({},...) failed with 'not a "
-                  "leader', retries left: {}",
-                  ntp,
+                  "local execution of begin_tx pid:{} tx_seq:{} failed with "
+                  "{}, retries left: {}",
+                  pid,
+                  tx_seq,
+                  result.ec,
                   retries);
                 aborted = !co_await sleep_abortable(delay_ms, _as);
                 leader_opt = _leaders.local().get_leader(ntp);
@@ -144,8 +149,9 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
             if (result.ec != tx_errc::none) {
                 vlog(
                   txlog.warn,
-                  "local execution of begin_tx({},...) failed with {}",
-                  ntp,
+                  "local execution of begin_tx pid:{} tx_seq:{} failed with {}",
+                  pid,
+                  tx_seq,
                   result.ec);
             }
             co_return result;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1034,12 +1034,14 @@ ss::future<result<rm_stm::transaction_set>> rm_stm::get_transactions() {
         ans.emplace(id, tx_info);
     }
 
-    for (auto& [id, offset] : _mem_state.tx_start) {
-        transaction_info tx_info;
-        tx_info.lso_bound = offset;
-        tx_info.status = get_tx_status(id);
-        tx_info.info = get_expiration_info(id);
-        ans.emplace(id, tx_info);
+    if (!is_transaction_ga()) {
+        for (auto& [id, offset] : _mem_state.tx_start) {
+            transaction_info tx_info;
+            tx_info.lso_bound = offset;
+            tx_info.status = get_tx_status(id);
+            tx_info.info = get_expiration_info(id);
+            ans.emplace(id, tx_info);
+        }
     }
 
     for (auto& [id, offset] : _log_state.ongoing_map) {
@@ -1520,9 +1522,11 @@ model::offset rm_stm::last_stable_offset() {
             first_tx_start = *_log_state.ongoing_set.begin();
         }
 
-        if (!_mem_state.tx_starts.empty()) {
-            first_tx_start = std::min(
-              first_tx_start, *_mem_state.tx_starts.begin());
+        if (!is_transaction_ga()) {
+            if (!_mem_state.tx_starts.empty()) {
+                first_tx_start = std::min(
+                  first_tx_start, *_mem_state.tx_starts.begin());
+            }
         }
 
         for (auto& entry : _mem_state.estimated) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -13,6 +13,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/protocol/response_writer.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -1772,20 +1773,40 @@ ss::future<> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
     }
 
     _mem_state.expected.erase(pid);
+    auto is_txn_ga = is_transaction_ga();
 
-    std::optional<prepare_marker> marker;
-    auto prepare_it = _mem_state.preparing.find(pid);
-    if (prepare_it != _mem_state.preparing.end()) {
-        marker = prepare_it->second;
-    }
-    prepare_it = _log_state.prepared.find(pid);
-    if (prepare_it != _log_state.prepared.end()) {
-        marker = prepare_it->second;
+    std::optional<model::tx_seq> tx_seq;
+    if (!is_txn_ga) {
+        auto prepare_it = _log_state.prepared.find(pid);
+        if (prepare_it != _log_state.prepared.end()) {
+            tx_seq = prepare_it->second.tx_seq;
+        } else {
+            prepare_it = _mem_state.preparing.find(pid);
+            if (prepare_it != _mem_state.preparing.end()) {
+                tx_seq = prepare_it->second.tx_seq;
+            }
+        }
     }
 
-    if (marker) {
+    if (!tx_seq) {
+        tx_seq = get_tx_seq(pid);
+    }
+
+    if (is_txn_ga && !tx_seq) {
+        vlog(
+          _ctx_log.error,
+          "Can not find tx_seq for pid({}) to expire old tx",
+          pid);
+    }
+
+    if (tx_seq) {
+        // It looks like a partition is fixed now but actually partitioning
+        // of the tx coordinator isn't support yet so it doesn't matter see
+        // https://github.com/redpanda-data/redpanda/issues/6137
+        // In order to support it we ned to update begin_tx to accept the id
+        // and use the true partition_id here
         auto r = co_await _tx_gateway_frontend.local().try_abort(
-          marker->tm_partition, marker->pid, marker->tx_seq, _sync_timeout);
+          model::partition_id(0), pid, *tx_seq, _sync_timeout);
         if (r.ec == tx_errc::none) {
             if (r.commited) {
                 auto batch = make_tx_control_batch(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1781,8 +1781,12 @@ void rm_stm::apply_fence(model::record_batch&& b) {
 
     auto [fence_it, _] = _log_state.fence_pid_epoch.try_emplace(
       bid.pid.get_id(), bid.pid.get_epoch());
-    if (fence_it->second < bid.pid.get_epoch()) {
+    // using less-or-equal to update tx_seqs on every transaction
+    if (fence_it->second <= bid.pid.get_epoch()) {
         fence_it->second = bid.pid.get_epoch();
+        if (tx_seq.has_value()) {
+            _log_state.tx_seqs[bid.pid] = tx_seq.value();
+        }
     }
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -488,6 +488,18 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
         co_return tx_errc::fenced;
     }
 
+    if (_log_state.tx_seqs.contains(pid)) {
+        if (_log_state.tx_seqs[pid] != tx_seq) {
+            vlog(
+              _ctx_log.warn,
+              "expectd tx_seq {} doesn't match gived {} for pid {}",
+              _log_state.tx_seqs[pid],
+              tx_seq,
+              pid);
+        }
+        co_return errc::invalid_producer_epoch;
+    }
+
     if (synced_term != etag) {
         vlog(
           _ctx_log.warn,
@@ -502,17 +514,18 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
         co_return tx_errc::request_rejected;
     }
 
-    auto expected_it = _mem_state.expected.find(pid);
-    if (expected_it == _mem_state.expected.end()) {
-        // impossible situation, a transaction coordinator tries
-        // to prepare a transaction which wasn't started
-        vlog(_ctx_log.error, "Can't prepare pid:{} - unknown session", pid);
-        co_return tx_errc::request_rejected;
-    }
-
-    if (expected_it->second != tx_seq) {
-        // current prepare_tx call is stale, rejecting
-        co_return tx_errc::request_rejected;
+    if (!is_transaction_ga()) {
+        auto expected_it = _mem_state.expected.find(pid);
+        if (expected_it == _mem_state.expected.end()) {
+            // impossible situation, a transaction coordinator tries
+            // to prepare a transaction which wasn't started
+            vlog(_ctx_log.error, "Can't prepare pid:{} - unknown session", pid);
+            co_return tx_errc::request_rejected;
+        }
+        if (expected_it->second != tx_seq) {
+            // current prepare_tx call is stale, rejecting
+            co_return tx_errc::request_rejected;
+        }
     }
 
     auto marker = prepare_marker{

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1938,6 +1938,8 @@ ss::future<> rm_stm::apply_control(
 
     if (crt == model::control_record_type::tx_abort) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
+        _log_state.inflight.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             // make a list
@@ -1947,6 +1949,7 @@ ss::future<> rm_stm::apply_control(
         }
 
         _mem_state.forget(pid);
+        _log_state.expiration.erase(pid);
 
         if (
           _log_state.aborted.size() > _abort_index_segment_size
@@ -1956,6 +1959,8 @@ ss::future<> rm_stm::apply_control(
         }
     } else if (crt == model::control_record_type::tx_commit) {
         _log_state.prepared.erase(pid);
+        _log_state.tx_seqs.erase(pid);
+        _log_state.inflight.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
         if (offset_it != _log_state.ongoing_map.end()) {
             _log_state.ongoing_set.erase(offset_it->second.first);
@@ -1963,6 +1968,7 @@ ss::future<> rm_stm::apply_control(
         }
 
         _mem_state.forget(pid);
+        _log_state.expiration.erase(pid);
     }
 
     co_return;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -241,6 +241,18 @@ struct tx_snapshot_v1 {
     std::vector<seq_entry_v1> seqs;
 };
 
+struct tx_snapshot_v2 {
+    static constexpr uint8_t version = 2;
+
+    std::vector<model::producer_identity> fenced;
+    std::vector<rm_stm::tx_range> ongoing;
+    std::vector<rm_stm::prepare_marker> prepared;
+    std::vector<rm_stm::tx_range> aborted;
+    std::vector<rm_stm::abort_index> abort_indexes;
+    model::offset offset;
+    std::vector<rm_stm::seq_entry> seqs;
+};
+
 rm_stm::rm_stm(
   ss::logger& logger,
   raft::consensus* c,
@@ -2174,9 +2186,13 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
 }
 
 uint8_t rm_stm::active_snapshot_version() {
+    if (is_transaction_ga()) {
+        return tx_snapshot::version;
+    }
+
     if (_feature_table.local().is_active(
           features::feature::rm_stm_kafka_cache)) {
-        return tx_snapshot::version;
+        return tx_snapshot_v2::version;
     }
     return tx_snapshot_v1::version;
 }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -732,6 +732,22 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
 
 abort_origin rm_stm::get_abort_origin(
   const model::producer_identity& pid, model::tx_seq tx_seq) const {
+    if (is_transaction_ga()) {
+        auto tx_seq_for_pid = get_tx_seq(pid);
+        if (!tx_seq_for_pid) {
+            return abort_origin::present;
+        }
+
+        if (tx_seq < *tx_seq_for_pid) {
+            return abort_origin::past;
+        }
+        if (*tx_seq_for_pid < tx_seq) {
+            return abort_origin::future;
+        }
+
+        return abort_origin::present;
+    }
+
     auto expected_it = _mem_state.expected.find(pid);
     if (expected_it != _mem_state.expected.end()) {
         if (tx_seq < expected_it->second) {
@@ -760,6 +776,18 @@ abort_origin rm_stm::get_abort_origin(
         if (prepared_it->second.tx_seq < tx_seq) {
             return abort_origin::future;
         }
+    }
+
+    auto tx_seq_for_pid = get_tx_seq(pid);
+    if (!tx_seq_for_pid) {
+        return abort_origin::present;
+    }
+
+    if (tx_seq < *tx_seq_for_pid) {
+        return abort_origin::past;
+    }
+    if (*tx_seq_for_pid < tx_seq) {
+        return abort_origin::future;
     }
 
     return abort_origin::present;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -426,7 +426,6 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
     // strictly after all records are written it means that it
     // won't be retrying old writes and we may reset the seq cache
     _log_state.seq_table.erase(pid);
-    _mem_state.inflight[pid] = 0;
 
     co_return synced_term;
 }
@@ -1189,7 +1188,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
         co_return errc::generic_tx_error;
     }
 
-    if (_mem_state.inflight[bid.pid] > 0) {
+    if (_log_state.inflight[bid.pid] > 0) {
         // this isn't the first attempt in the tx we should try dedupe
         auto cached_offset = known_seq(bid);
         if (cached_offset) {
@@ -1886,6 +1885,7 @@ void rm_stm::apply_fence(model::record_batch&& b) {
     // using less-or-equal to update tx_seqs on every transaction
     if (fence_it->second <= bid.pid.get_epoch()) {
         fence_it->second = bid.pid.get_epoch();
+        _log_state.inflight[bid.pid] = 0;
         if (tx_seq.has_value()) {
             _log_state.tx_seqs[bid.pid] = tx_seq.value();
         }
@@ -2022,6 +2022,11 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
             _log_state.ongoing_set.insert(base_offset);
             _mem_state.estimated.erase(bid.pid);
         }
+
+        if (!_log_state.inflight.contains(bid.pid)) {
+            _log_state.inflight[bid.pid] = 0;
+        }
+        _log_state.inflight[bid.pid]++;
     }
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -992,6 +992,10 @@ ss::future<> rm_stm::start() {
 
 rm_stm::transaction_info::status_t
 rm_stm::get_tx_status(model::producer_identity pid) const {
+    if (is_transaction_ga()) {
+        return transaction_info::status_t::ongoing;
+    }
+
     if (_mem_state.preparing.contains(pid)) {
         return transaction_info::status_t::preparing;
     }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -599,49 +599,84 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
         }
     }
 
-    auto preparing_it = _mem_state.preparing.find(pid);
-
-    if (preparing_it != _mem_state.preparing.end()) {
-        if (preparing_it->second.tx_seq > tx_seq) {
-            // - tm_stm & rm_stm failed during prepare
-            // - during recovery tm_stm recommits its previous tx
-            // - that commit (we're here) collides with "next" failed prepare
-            // it may happen only if the commit passed => acking
-            co_return tx_errc::none;
-        }
-
-        ss::sstring msg;
-        if (preparing_it->second.tx_seq == tx_seq) {
-            msg = ssx::sformat(
-              "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
-              pid,
-              tx_seq);
-        } else {
-            msg = ssx::sformat(
-              "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
-              pid,
-              tx_seq,
-              preparing_it->second.tx_seq);
-        }
-
-        if (_recovery_policy == best_effort) {
-            vlog(_ctx_log.error, "{}", msg);
-            co_return tx_errc::request_rejected;
-        }
-        vassert(false, "{}", msg);
+    auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
+    if (fence_it == _log_state.fence_pid_epoch.end()) {
+        // begin_tx should have set a fence
+        co_return tx_errc::request_rejected;
+    }
+    if (pid.get_epoch() != fence_it->second) {
+        vlog(
+          _ctx_log.error,
+          "Can't commit pid:{} - fenced out by epoch {}",
+          pid,
+          fence_it->second);
+        co_return tx_errc::fenced;
     }
 
-    auto prepare_it = _log_state.prepared.find(pid);
+    std::optional<model::tx_seq> tx_seq_for_pid;
+    if (is_transaction_ga()) {
+        if (_log_state.tx_seqs.contains(pid)) {
+            if (tx_seq != _log_state.tx_seqs[pid]) {
+                co_return tx_errc::request_rejected;
+            }
+        }
+    } else {
+        auto preparing_it = _mem_state.preparing.find(pid);
 
-    if (prepare_it == _log_state.prepared.end()) {
+        if (preparing_it != _mem_state.preparing.end()) {
+            if (preparing_it->second.tx_seq > tx_seq) {
+                // - tm_stm & rm_stm failed during prepare
+                // - during recovery tm_stm recommits its previous tx
+                // - that commit (we're here) collides with "next" failed
+                // prepare it may happen only if the commit passed => acking
+                co_return tx_errc::none;
+            }
+
+            ss::sstring msg;
+            if (preparing_it->second.tx_seq == tx_seq) {
+                msg = ssx::sformat(
+                  "Prepare hasn't completed => can't commit pid:{} tx_seq:{}",
+                  pid,
+                  tx_seq);
+            } else {
+                msg = ssx::sformat(
+                  "Commit pid:{} tx_seq:{} conflicts with preparing tx_seq:{}",
+                  pid,
+                  tx_seq,
+                  preparing_it->second.tx_seq);
+            }
+
+            if (_recovery_policy == best_effort) {
+                vlog(_ctx_log.error, "{}", msg);
+                co_return tx_errc::request_rejected;
+            }
+            vassert(false, "{}", msg);
+        }
+
+        auto prepare_it = _log_state.prepared.find(pid);
+
+        if (prepare_it != _log_state.prepared.end()) {
+            tx_seq_for_pid = prepare_it->second.tx_seq;
+        }
+    }
+
+    if (!tx_seq_for_pid) {
+        tx_seq_for_pid = get_tx_seq(pid);
+    }
+
+    _mem_state.expected.erase(pid);
+    _mem_state.preparing.erase(pid);
+
+    if (!tx_seq_for_pid) {
         vlog(
           _ctx_log.trace,
-          "Can't find prepare for pid:{} => replaying already comitted commit",
+          "Can't find tx_seq for pid:{} => replaying already comitted "
+          "commit",
           pid);
         co_return tx_errc::none;
     }
 
-    if (prepare_it->second.tx_seq > tx_seq) {
+    if (*tx_seq_for_pid > tx_seq) {
         // rare situation:
         //   * tm_stm prepares (tx_seq+1)
         //   * prepare on this rm passes but tm_stm failed to write to disk
@@ -652,15 +687,15 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
           "prepare for pid:{} has higher tx_seq:{} than given: {} => replaying "
           "already comitted commit",
           pid,
-          prepare_it->second.tx_seq,
+          *tx_seq_for_pid,
           tx_seq);
         co_return tx_errc::none;
-    } else if (prepare_it->second.tx_seq < tx_seq) {
+    } else if (*tx_seq_for_pid < tx_seq) {
         std::string msg = fmt::format(
           "Rejecting commit with tx_seq:{} since prepare with lesser tx_seq:{} "
           "exists",
           tx_seq,
-          prepare_it->second.tx_seq);
+          *tx_seq_for_pid);
         if (_recovery_policy == best_effort) {
             vlog(_ctx_log.error, "{}", msg);
             co_return tx_errc::request_rejected;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2305,7 +2305,31 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
             tx_ss.seqs.push_back(entry.second.copy());
         }
         tx_ss.offset = _insync_offset;
+
+        for (const auto& entry : _log_state.tx_seqs) {
+            tx_ss.tx_seqs.push_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.first, .tx_seq = entry.second});
+        }
+
+        for (const auto& entry : _log_state.inflight) {
+            tx_ss.inflight.push_back(tx_snapshot::inflight_snapshot{
+              .pid = entry.first, .counter = entry.second});
+        }
+
+        for (const auto& entry : _log_state.expiration) {
+            tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
+              .pid = entry.first, .timeout = entry.second.timeout});
+        }
+
         reflection::adl<tx_snapshot>{}.to(tx_ss_buf, std::move(tx_ss));
+    } else if (version == tx_snapshot_v2::version) {
+        tx_snapshot_v2 tx_ss;
+        fill_snapshot_wo_seqs(tx_ss);
+        for (const auto& entry : _log_state.seq_table) {
+            tx_ss.seqs.push_back(entry.second.copy());
+        }
+        tx_ss.offset = _insync_offset;
+        reflection::adl<tx_snapshot_v2>{}.to(tx_ss_buf, std::move(tx_ss));
     } else if (version == tx_snapshot_v1::version) {
         tx_snapshot_v1 tx_ss;
         fill_snapshot_wo_seqs(tx_ss);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -34,11 +34,6 @@ static ss::sstring abort_idx_name(model::offset first, model::offset last) {
     return fmt::format("abort.idx.{}.{}", first, last);
 }
 
-static const model::violation_recovery_policy crash{
-  model::violation_recovery_policy::crash};
-static const model::violation_recovery_policy best_effort{
-  model::violation_recovery_policy::best_effort};
-
 static bool is_sequence(int32_t last_seq, int32_t next_seq) {
     return (last_seq + 1 == next_seq)
            || (next_seq == 0 && last_seq == std::numeric_limits<int32_t>::max());
@@ -274,9 +269,6 @@ rm_stm::rm_stm(
   , _ctx_log(txlog, ssx::sformat("[{}]", c->ntp())) {
     if (!_is_tx_enabled) {
         _is_autoabort_enabled = false;
-    }
-    if (_recovery_policy != crash && _recovery_policy != best_effort) {
-        vassert(false, "Unknown recovery policy: {}", _recovery_policy);
     }
     auto_abort_timer.set_callback([this] { abort_old_txes(); });
 }
@@ -646,11 +638,8 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
                   preparing_it->second.tx_seq);
             }
 
-            if (_recovery_policy == best_effort) {
-                vlog(_ctx_log.error, "{}", msg);
-                co_return tx_errc::request_rejected;
-            }
-            vassert(false, "{}", msg);
+            vlog(_ctx_log.error, "{}", msg);
+            co_return tx_errc::request_rejected;
         }
 
         auto prepare_it = _log_state.prepared.find(pid);
@@ -696,11 +685,8 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
           "exists",
           tx_seq,
           *tx_seq_for_pid);
-        if (_recovery_policy == best_effort) {
-            vlog(_ctx_log.error, "{}", msg);
-            co_return tx_errc::request_rejected;
-        }
-        vassert(false, "{}", msg);
+        vlog(_ctx_log.error, "{}", msg);
+        co_return tx_errc::request_rejected;
     }
 
     // we commit only if a provided tx_seq matches prepared tx_seq
@@ -2055,12 +2041,6 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
               _ctx_log.error,
               "Adding a record with pid:{} to a tx after it was prepared",
               bid.pid);
-            if (_recovery_policy != best_effort) {
-                vassert(
-                  false,
-                  "Adding a record with pid:{} to a tx after it was prepared",
-                  bid.pid);
-            }
             return;
         }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -314,35 +314,32 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
 
     // checking / setting pid fencing
     auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
-    auto is_new_pid = fence_it == _log_state.fence_pid_epoch.end();
-    if (is_new_pid || pid.get_epoch() > fence_it->second) {
-        if (!is_new_pid) {
-            auto old_pid = model::producer_identity{
-              pid.get_id(), fence_it->second};
-            // there is a fence, it might be that tm_stm failed, forget about
-            // an ongoing transaction, assigned next pid for the same tx.id and
-            // started a new transaction without aborting the previous one.
-            //
-            // at the same time it's possible that it already aborted the old
-            // tx before starting this. do_abort_tx is idempotent so calling it
-            // just in case to proactivly abort the tx instead of waiting for
-            // the timeout
-            //
-            // moreover do_abort_tx is co-idempotent with do_commit_tx so if a
-            // tx was committed calling do_abort_tx will do nothing
-            auto ar = co_await do_abort_tx(
-              old_pid, std::nullopt, _sync_timeout);
-            if (ar == tx_errc::stale) {
-                co_return tx_errc::stale;
-            }
-            if (ar != tx_errc::none) {
-                co_return tx_errc::unknown_server_error;
-            }
+    if (fence_it == _log_state.fence_pid_epoch.end()) {
+        // intentionally empty
+    } else if (pid.get_epoch() > fence_it->second) {
+        auto old_pid = model::producer_identity{pid.get_id(), fence_it->second};
+        // there is a fence, it might be that tm_stm failed, forget about
+        // an ongoing transaction, assigned next pid for the same tx.id and
+        // started a new transaction without aborting the previous one.
+        //
+        // at the same time it's possible that it already aborted the old
+        // tx before starting this. do_abort_tx is idempotent so calling it
+        // just in case to proactivly abort the tx instead of waiting for
+        // the timeout
+        //
+        // moreover do_abort_tx is co-idempotent with do_commit_tx so if a
+        // tx was committed calling do_abort_tx will do nothing
+        auto ar = co_await do_abort_tx(old_pid, std::nullopt, _sync_timeout);
+        if (ar == tx_errc::stale) {
+            co_return tx_errc::stale;
+        }
+        if (ar != tx_errc::none) {
+            co_return tx_errc::unknown_server_error;
+        }
 
-            if (is_known_session(old_pid)) {
-                // can't begin a transaction while previous tx is in progress
-                co_return tx_errc::unknown_server_error;
-            }
+        if (is_known_session(old_pid)) {
+            // can't begin a transaction while previous tx is in progress
+            co_return tx_errc::unknown_server_error;
         }
         // we want to replicate tx_fence batch on every transaction so
         // intentionally dropping through
@@ -355,7 +352,9 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
         co_return tx_errc::fenced;
     }
 
-    auto batch = is_transaction_ga()
+    auto is_txn_ga = is_transaction_ga();
+
+    auto batch = is_txn_ga
                    ? make_fence_batch(pid, tx_seq, transaction_timeout_ms)
                    : make_fence_batch(pid);
 
@@ -379,21 +378,48 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
         co_return tx_errc::unknown_server_error;
     }
 
-    auto [_, inserted] = _mem_state.expected.emplace(pid, tx_seq);
-    if (!inserted) {
-        // TODO: https://app.clubhouse.io/vectorized/story/2194
-        // tm_stm forgot that it had already begun a transaction
-        // (it may happen when it crashes)
-        // it's ok we fail this request, a client will abort a
-        // tx bumping its producer id's epoch
+    if (_c->term() != synced_term) {
         vlog(
-          _ctx_log.error,
-          "there is already an ongoing transaction within {} session",
+          _ctx_log.warn,
+          "term changeg from {} to {} during fencing pid {}",
+          synced_term,
+          _c->term(),
           pid);
         co_return tx_errc::unknown_server_error;
     }
 
-    track_tx(pid, transaction_timeout_ms);
+    if (is_txn_ga) {
+        auto tx_seq_it = _log_state.tx_seqs.find(pid);
+        if (tx_seq_it == _log_state.tx_seqs.end()) {
+            vlog(
+              _ctx_log.error,
+              "tx_seqs should be updated after fencing pid {}",
+              pid);
+            co_return tx_errc::unknown_server_error;
+        }
+        if (tx_seq_it->second != tx_seq) {
+            vlog(
+              _ctx_log.error,
+              "expected tx_seq={} for pid {} got {}",
+              tx_seq,
+              pid,
+              tx_seq_it->second);
+            co_return tx_errc::unknown_server_error;
+        }
+    } else {
+        auto [_, inserted] = _mem_state.expected.emplace(pid, tx_seq);
+        if (!inserted) {
+            vlog(
+              _ctx_log.error,
+              "there is already an ongoing transaction with tx_seq:{} within "
+              "{} session",
+              tx_seq,
+              pid);
+            co_return tx_errc::unknown_server_error;
+        }
+
+        track_tx(pid, transaction_timeout_ms);
+    }
 
     // a client may start new transaction only when the previous
     // tx is committed. since a client commits a transacitons

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2087,6 +2087,31 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
     iobuf_parser data_parser(std::move(tx_ss_buf));
     if (hdr.version == tx_snapshot::version) {
         data = reflection::adl<tx_snapshot>{}.from(data_parser);
+    } else if (hdr.version == tx_snapshot_v2::version) {
+        auto data_v2 = reflection::adl<tx_snapshot_v2>{}.from(data_parser);
+        data.fenced = std::move(data_v2.fenced);
+        data.ongoing = std::move(data_v2.ongoing);
+        data.prepared = std::move(data_v2.prepared);
+        data.aborted = std::move(data_v2.aborted);
+        data.abort_indexes = std::move(data_v2.abort_indexes);
+        data.offset = std::move(data_v2.offset);
+        data.seqs = std::move(data_v2.seqs);
+
+        for (auto& entry : data_v2.ongoing) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+        }
+        for (auto& entry : data_v2.prepared) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+            data.tx_seqs.emplace_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.pid, .tx_seq = entry.tx_seq});
+        }
+
+        for (auto& entry : data_v2.seqs) {
+            data.tx_seqs.emplace_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.pid, .tx_seq = model::tx_seq(entry.seq)});
+        }
     } else if (hdr.version == tx_snapshot_v1::version) {
         auto data_v1 = reflection::adl<tx_snapshot_v1>{}.from(data_parser);
         data.fenced = std::move(data_v1.fenced);
@@ -2118,6 +2143,17 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
             seq.last_write_timestamp = seq_v1.last_write_timestamp;
             data.seqs.push_back(std::move(seq));
         }
+
+        for (auto& entry : data_v1.ongoing) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+        }
+        for (auto& entry : data_v1.prepared) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+            data.tx_seqs.emplace_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.pid, .tx_seq = entry.tx_seq});
+        }
     } else if (hdr.version == tx_snapshot_v0::version) {
         auto data_v0 = reflection::adl<tx_snapshot_v0>{}.from(data_parser);
         data.fenced = std::move(data_v0.fenced);
@@ -2133,6 +2169,16 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
               .last_offset = kafka::offset{-1},
               .last_write_timestamp = seq_v0.last_write_timestamp};
             data.seqs.push_back(std::move(seq));
+        }
+        for (auto& entry : data_v0.ongoing) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+        }
+        for (auto& entry : data_v0.prepared) {
+            data.inflight.emplace_back(
+              tx_snapshot::inflight_snapshot{.pid = entry.pid, .counter = 1});
+            data.tx_seqs.emplace_back(tx_snapshot::tx_seqs_snapshot{
+              .pid = entry.pid, .tx_seq = entry.tx_seq});
         }
     } else {
         vassert(
@@ -2179,6 +2225,23 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
         if (snapshot_opt) {
             _log_state.last_abort_snapshot = snapshot_opt.value();
         }
+    }
+
+    for (auto& entry : data.tx_seqs) {
+        _log_state.tx_seqs.emplace(entry.pid, entry.tx_seq);
+    }
+
+    for (auto& entry : data.inflight) {
+        _log_state.inflight.emplace(entry.pid, entry.counter);
+    }
+
+    for (auto& entry : data.expiration) {
+        _log_state.expiration.emplace(
+          entry.pid,
+          expiration_info{
+            .timeout = entry.timeout,
+            .last_update = clock_type::now(),
+            .is_expiration_requested = false});
     }
 
     _last_snapshot_offset = data.offset;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -137,18 +137,12 @@ public:
             model::tx_seq tx_seq;
         };
 
-        struct inflight_snapshot {
-            model::producer_identity pid;
-            int64_t counter;
-        };
-
         struct expiration_snapshot {
             model::producer_identity pid;
             duration_type timeout;
         };
 
         std::vector<tx_seqs_snapshot> tx_seqs;
-        std::vector<inflight_snapshot> inflight;
         std::vector<expiration_snapshot> expiration;
     };
 
@@ -421,8 +415,6 @@ private:
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
 
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
-        // number of batches replicated within a transaction
-        absl::flat_hash_map<model::producer_identity, int64_t> inflight;
         absl::flat_hash_map<model::producer_identity, expiration_info>
           expiration;
     };

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -355,6 +355,16 @@ private:
     ss::future<> reduce_aborted_list();
     ss::future<> offload_aborted_txns();
 
+    std::optional<model::tx_seq>
+    get_tx_seq(model::producer_identity pid) const {
+        auto log_it = _log_state.tx_seqs.find(pid);
+        if (log_it != _log_state.tx_seqs.end()) {
+            return log_it->second;
+        }
+
+        return std::nullopt;
+    }
+
     // The state of this state machine maybe change via two paths
     //
     //   - by reading the already replicated commands from raft and

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -122,7 +122,7 @@ public:
     };
 
     struct tx_snapshot {
-        static constexpr uint8_t version = 2;
+        static constexpr uint8_t version = 3;
 
         std::vector<model::producer_identity> fenced;
         std::vector<tx_range> ongoing;
@@ -131,6 +131,25 @@ public:
         std::vector<abort_index> abort_indexes;
         model::offset offset;
         std::vector<seq_entry> seqs;
+
+        struct tx_seqs_snapshot {
+            model::producer_identity pid;
+            model::tx_seq tx_seq;
+        };
+
+        struct inflight_snapshot {
+            model::producer_identity pid;
+            int64_t counter;
+        };
+
+        struct expiration_snapshot {
+            model::producer_identity pid;
+            duration_type timeout;
+        };
+
+        std::vector<tx_seqs_snapshot> tx_seqs;
+        std::vector<inflight_snapshot> inflight;
+        std::vector<expiration_snapshot> expiration;
     };
 
     struct abort_snapshot {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -402,6 +402,8 @@ private:
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
 
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
+        // number of batches replicated within a transaction
+        absl::flat_hash_map<model::producer_identity, int64_t> inflight;
     };
 
     struct mem_state {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -521,6 +521,11 @@ private:
     template<class T>
     void fill_snapshot_wo_seqs(T&);
 
+    bool is_transaction_ga() const {
+        return _feature_table.local().is_active(
+          features::feature::transaction_ga);
+    }
+
     ss::basic_rwlock<> _state_lock;
     bool _is_abort_idx_reduction_requested{false};
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -144,7 +144,8 @@ public:
     };
 
     static constexpr int8_t prepare_control_record_version{0};
-    static constexpr int8_t fence_control_record_version{0};
+    static constexpr int8_t fence_control_record_v0_version{0};
+    static constexpr int8_t fence_control_record_version{1};
 
     explicit rm_stm(
       ss::logger&,

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -390,6 +390,8 @@ private:
         // by spec should be ready for thier commands being rejected so it's
         // ok by design to have false rejects
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
+
+        absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
     };
 
     struct mem_state {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -404,6 +404,8 @@ private:
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
         // number of batches replicated within a transaction
         absl::flat_hash_map<model::producer_identity, int64_t> inflight;
+        absl::flat_hash_map<model::producer_identity, expiration_info>
+          expiration;
     };
 
     struct mem_state {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -310,6 +310,9 @@ tm_stm::do_update_tx(tm_transaction tx, model::term_id term) {
 
     auto r = co_await replicate_quorum_ack(term, std::move(batch));
     if (!r) {
+        if (r.error() == raft::errc::shutting_down) {
+            co_return tm_stm::op_status::timeout;
+        }
         co_return tm_stm::op_status::unknown;
     }
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -550,22 +550,25 @@ ss::future<tm_stm::op_status> tm_stm::add_partitions(
     if (ptx->second.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::unknown;
     }
-    bool just_started = ptx->second.partitions.size() == 0
-                        && ptx->second.groups.size() == 0;
 
-    if (just_started) {
-        tm_transaction tx = ptx->second;
-        for (auto& partition : partitions) {
-            tx.partitions.push_back(partition);
-        }
-        tx.last_update_ts = clock_type::now();
-        auto r = co_await update_tx(tx, tx.etag);
+    if (!is_transaction_ga()) {
+        bool just_started = ptx->second.partitions.size() == 0
+                            && ptx->second.groups.size() == 0;
 
-        if (!r.has_value()) {
-            co_return tm_stm::op_status::unknown;
+        if (just_started) {
+            tm_transaction tx = ptx->second;
+            for (auto& partition : partitions) {
+                tx.partitions.push_back(partition);
+            }
+            tx.last_update_ts = clock_type::now();
+            auto r = co_await update_tx(tx, tx.etag);
+
+            if (!r.has_value()) {
+                co_return tm_stm::op_status::unknown;
+            }
+            _mem_txes[tx_id] = tx;
+            co_return tm_stm::op_status::success;
         }
-        _mem_txes[tx_id] = tx;
-        co_return tm_stm::op_status::success;
     }
 
     for (auto& partition : partitions) {
@@ -587,21 +590,24 @@ ss::future<tm_stm::op_status> tm_stm::add_group(
     if (ptx->second.status != tm_transaction::tx_status::ongoing) {
         co_return tm_stm::op_status::unknown;
     }
-    bool just_started = ptx->second.partitions.size() == 0
-                        && ptx->second.groups.size() == 0;
 
-    if (just_started) {
-        tm_transaction tx = ptx->second;
-        tx.groups.push_back(
-          tm_transaction::tx_group{.group_id = group_id, .etag = term});
-        tx.last_update_ts = clock_type::now();
-        auto r = co_await update_tx(tx, tx.etag);
+    if (!is_transaction_ga()) {
+        bool just_started = ptx->second.partitions.size() == 0
+                            && ptx->second.groups.size() == 0;
 
-        if (!r.has_value()) {
-            co_return tm_stm::op_status::unknown;
+        if (just_started) {
+            tm_transaction tx = ptx->second;
+            tx.groups.push_back(
+              tm_transaction::tx_group{.group_id = group_id, .etag = term});
+            tx.last_update_ts = clock_type::now();
+            auto r = co_await update_tx(tx, tx.etag);
+
+            if (!r.has_value()) {
+                co_return tm_stm::op_status::unknown;
+            }
+            _mem_txes[tx_id] = tx;
+            co_return tm_stm::op_status::success;
         }
-        _mem_txes[tx_id] = tx;
-        co_return tm_stm::op_status::success;
     }
 
     ptx->second.groups.push_back(

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -158,7 +158,8 @@ public:
         conflict,
         unknown,
         not_leader,
-        partition_not_found
+        partition_not_found,
+        timeout
     };
 
     explicit tm_stm(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1606,26 +1606,40 @@ tx_gateway_frontend::do_commit_tm_tx(
     outcome->set_value(tx_errc::none);
     tx = changed_tx.value();
 
-    std::vector<ss::future<commit_group_tx_reply>> gfs;
-    for (auto group : tx.groups) {
-        gfs.push_back(_rm_group_proxy->commit_group_tx(
-          group.group_id, tx.pid, tx.tx_seq, timeout));
+    auto retries = _metadata_dissemination_retries;
+    auto delay_ms = _metadata_dissemination_retry_delay_ms;
+    auto done = false;
+    while (0 < retries--) {
+        std::vector<ss::future<commit_group_tx_reply>> gfs;
+        gfs.reserve(tx.groups.size());
+        for (auto group : tx.groups) {
+            gfs.push_back(_rm_group_proxy->commit_group_tx(
+              group.group_id, tx.pid, tx.tx_seq, timeout));
+        }
+        std::vector<ss::future<commit_tx_reply>> cfs;
+        cfs.reserve(tx.partitions.size());
+        for (auto rm : tx.partitions) {
+            cfs.push_back(_rm_partition_frontend.local().commit_tx(
+              rm.ntp, tx.pid, tx.tx_seq, timeout));
+        }
+        auto ok = true;
+        auto grs = co_await when_all_succeed(gfs.begin(), gfs.end());
+        for (const auto& r : grs) {
+            ok = ok && (r.ec == tx_errc::none);
+        }
+        auto crs = co_await when_all_succeed(cfs.begin(), cfs.end());
+        for (const auto& r : crs) {
+            ok = ok && (r.ec == tx_errc::none);
+        }
+        if (ok) {
+            done = true;
+            break;
+        }
+        if (!co_await sleep_abortable(delay_ms, _as)) {
+            break;
+        }
     }
-    std::vector<ss::future<commit_tx_reply>> cfs;
-    for (auto rm : tx.partitions) {
-        cfs.push_back(_rm_partition_frontend.local().commit_tx(
-          rm.ntp, tx.pid, tx.tx_seq, timeout));
-    }
-    auto ok = true;
-    auto grs = co_await when_all_succeed(gfs.begin(), gfs.end());
-    for (const auto& r : grs) {
-        ok = ok && (r.ec == tx_errc::none);
-    }
-    auto crs = co_await when_all_succeed(cfs.begin(), cfs.end());
-    for (const auto& r : crs) {
-        ok = ok && (r.ec == tx_errc::none);
-    }
-    if (!ok) {
+    if (!done) {
         co_return tx_errc::unknown_server_error;
     }
     co_return tx;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1480,46 +1480,49 @@ tx_gateway_frontend::do_commit_tm_tx(
             }
         }
 
-        std::vector<ss::future<prepare_tx_reply>> pfs;
-        for (auto rm : tx.partitions) {
-            pfs.push_back(_rm_partition_frontend.local().prepare_tx(
-              rm.ntp,
-              rm.etag,
-              model::tx_manager_ntp.tp.partition,
-              tx.pid,
-              tx.tx_seq,
-              timeout));
-        }
-
         std::vector<ss::future<prepare_group_tx_reply>> pgfs;
         for (auto group : tx.groups) {
             pgfs.push_back(_rm_group_proxy->prepare_group_tx(
               group.group_id, group.etag, tx.pid, tx.tx_seq, timeout));
         }
 
-        if (
-          !is_transaction_ga()
-          && tx.status == tm_transaction::tx_status::ongoing) {
-            auto preparing_tx = co_await stm->mark_tx_preparing(
-              expected_term, tx.id);
-            if (!preparing_tx.has_value()) {
-                if (preparing_tx.error() == tm_stm::op_status::not_leader) {
-                    outcome->set_value(tx_errc::not_coordinator);
-                    co_return tx_errc::not_coordinator;
-                }
-                outcome->set_value(tx_errc::unknown_server_error);
-                co_return tx_errc::unknown_server_error;
-            }
-            tx = preparing_tx.value();
-        }
-
+        std::vector<ss::future<prepare_tx_reply>> pfs;
+        pfs.reserve(tx.partitions.size());
         auto ok = true;
         auto rejected = false;
-        auto prs = co_await when_all_succeed(pfs.begin(), pfs.end());
-        for (const auto& r : prs) {
-            ok = ok && (r.ec == tx_errc::none);
-            rejected = rejected || (r.ec == tx_errc::request_rejected);
+
+        if (!is_transaction_ga()) {
+            for (auto rm : tx.partitions) {
+                pfs.push_back(_rm_partition_frontend.local().prepare_tx(
+                  rm.ntp,
+                  rm.etag,
+                  model::tx_manager_ntp.tp.partition,
+                  tx.pid,
+                  tx.tx_seq,
+                  timeout));
+            }
+
+            if (tx.status == tm_transaction::tx_status::ongoing) {
+                auto preparing_tx = co_await stm->mark_tx_preparing(
+                  expected_term, tx.id);
+                if (!preparing_tx.has_value()) {
+                    if (preparing_tx.error() == tm_stm::op_status::not_leader) {
+                        outcome->set_value(tx_errc::not_coordinator);
+                        co_return tx_errc::not_coordinator;
+                    }
+                    outcome->set_value(tx_errc::unknown_server_error);
+                    co_return tx_errc::unknown_server_error;
+                }
+                tx = preparing_tx.value();
+            }
+
+            auto prs = co_await when_all_succeed(pfs.begin(), pfs.end());
+            for (const auto& r : prs) {
+                ok = ok && (r.ec == tx_errc::none);
+                rejected = rejected || (r.ec == tx_errc::request_rejected);
+            }
         }
+
         auto pgrs = co_await when_all_succeed(pgfs.begin(), pgfs.end());
         for (const auto& r : pgrs) {
             ok = ok && (r.ec == tx_errc::none);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1003,7 +1003,7 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
 
     add_paritions_tx_reply response;
 
-    std::vector<ss::future<begin_tx_reply>> bfs;
+    std::vector<model::ntp> new_partitions;
 
     for (auto& req_topic : request.topics) {
         add_paritions_tx_reply::topic_result res_topic;
@@ -1024,43 +1024,74 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
                 res_partition.error_code = tx_errc::none;
                 res_topic.results.push_back(res_partition);
             } else {
-                bfs.push_back(_rm_partition_frontend.local().begin_tx(
-                  ntp, tx.pid, tx.tx_seq, tx.timeout_ms, timeout));
+                new_partitions.push_back(ntp);
             }
         }
         response.results.push_back(res_topic);
     }
 
-    auto brs = co_await when_all_succeed(bfs.begin(), bfs.end());
-
     std::vector<tm_transaction::tx_partition> partitions;
-    for (auto& br : brs) {
-        auto topic_it = std::find_if(
-          response.results.begin(),
-          response.results.end(),
-          [&br](const auto& r) { return r.name == br.ntp.tp.topic(); });
-        vassert(
-          topic_it != response.results.end(),
-          "can't find expected topic {}",
-          br.ntp.tp.topic());
-        vassert(
-          std::none_of(
-            topic_it->results.begin(),
-            topic_it->results.end(),
-            [&br](const auto& r) {
-                return r.partition_index == br.ntp.tp.partition();
-            }),
-          "partition {} is already part of the response",
-          br.ntp.tp.partition());
-        if (br.ec == tx_errc::none) {
-            partitions.push_back(
-              tm_transaction::tx_partition{.ntp = br.ntp, .etag = br.etag});
+    std::vector<begin_tx_reply> brs;
+    auto retries = _metadata_dissemination_retries;
+    auto delay_ms = _metadata_dissemination_retry_delay_ms;
+    while (0 < retries--) {
+        partitions.clear();
+        brs.clear();
+        bool should_retry = false;
+        bool should_abort = false;
+        std::vector<ss::future<begin_tx_reply>> bfs;
+        bfs.reserve(new_partitions.size());
+        for (auto& ntp : new_partitions) {
+            bfs.push_back(_rm_partition_frontend.local().begin_tx(
+              ntp, tx.pid, tx.tx_seq, tx.timeout_ms, timeout));
         }
+        brs = co_await when_all_succeed(bfs.begin(), bfs.end());
+        for (auto& br : brs) {
+            auto topic_it = std::find_if(
+              response.results.begin(),
+              response.results.end(),
+              [&br](const auto& r) { return r.name == br.ntp.tp.topic(); });
+            vassert(
+              topic_it != response.results.end(),
+              "can't find expected topic {}",
+              br.ntp.tp.topic());
+            vassert(
+              std::none_of(
+                topic_it->results.begin(),
+                topic_it->results.end(),
+                [&br](const auto& r) {
+                    return r.partition_index == br.ntp.tp.partition();
+                }),
+              "partition {} is already part of the response",
+              br.ntp.tp.partition());
+
+            bool expected_ec = br.ec == tx_errc::leader_not_found
+                               || br.ec == tx_errc::shard_not_found;
+            should_abort = should_abort
+                           || (br.ec != tx_errc::none && !expected_ec);
+            should_retry = should_retry || expected_ec;
+
+            if (br.ec == tx_errc::none) {
+                partitions.push_back(
+                  tm_transaction::tx_partition{.ntp = br.ntp, .etag = br.etag});
+            }
+        }
+        if (should_abort) {
+            break;
+        }
+        if (should_retry) {
+            if (!co_await sleep_abortable(delay_ms, _as)) {
+                break;
+            }
+            continue;
+        }
+        break;
     }
+
     auto status = co_await stm->add_partitions(tx.id, partitions);
     auto has_added = status == tm_stm::op_status::success;
     if (!has_added) {
-        vlog(txlog.warn, "can't add partitions: {}", status);
+        vlog(txlog.warn, "adding partitions failed with {}", status);
     }
     for (auto& br : brs) {
         auto topic_it = std::find_if(
@@ -1075,7 +1106,10 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
         } else {
             if (br.ec != tx_errc::none) {
                 vlog(
-                  txlog.warn, "begin_tx({},...) failed with {}", br.ntp, br.ec);
+                  txlog.warn,
+                  "begin_tx request to {} failed with {}",
+                  br.ntp,
+                  br.ec);
             }
             res_partition.error_code = tx_errc::invalid_txn_state;
         }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -782,7 +782,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
           "got error {} on loading tx.id={}",
           term_opt.error(),
           tx_id);
-        co_return init_tm_tx_reply{tx_errc::invalid_txn_state};
+        co_return init_tm_tx_reply{tx_errc::not_coordinator};
     }
     auto term = term_opt.value();
     auto tx_opt = co_await stm->get_tx(tx_id);
@@ -801,7 +801,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
           = co_await _id_allocator_frontend.local().allocate_id(timeout);
         if (pid_reply.ec != errc::success) {
             vlog(txlog.warn, "allocate_id failed with {}", pid_reply.ec);
-            co_return init_tm_tx_reply{tx_errc::invalid_txn_state};
+            co_return init_tm_tx_reply{tx_errc::not_coordinator};
         }
 
         model::producer_identity pid{pid_reply.id, 0};
@@ -940,10 +940,10 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
     auto shard = _shard_table.local().shard_for(model::tx_manager_ntp);
 
     if (shard == std::nullopt) {
-        vlog(txlog.warn, "can't find a shard for {}", model::tx_manager_ntp);
+        vlog(txlog.trace, "can't find a shard for {}", model::tx_manager_ntp);
         return ss::make_ready_future<add_paritions_tx_reply>(
           make_add_partitions_error_response(
-            request, tx_errc::invalid_txn_state));
+            request, tx_errc::not_coordinator));
     }
 
     return container().invoke_on(
@@ -1005,6 +1005,12 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
       term, stm, pid, request.transactional_id, timeout);
 
     if (!r.has_value()) {
+        vlog(
+          txlog.trace,
+          "got {} on getting ongoing tx for pid:{} {}",
+          r.error(),
+          pid,
+          request.transactional_id);
         co_return make_add_partitions_error_response(request, r.error());
     }
     auto tx = r.value();
@@ -1806,10 +1812,19 @@ tx_gateway_frontend::get_ongoing_tx(
         }
 
         if (ec != tx_errc::none) {
+            vlog(
+              txlog.trace,
+              "rolling previous tx failed with {}; pid:{}",
+              ec,
+              pid);
             co_return ec;
         }
 
         if (expected_term != tx.etag) {
+            vlog(
+              txlog.trace,
+              "failing a tx initiated on the previous tx coordinator pid:{}",
+              pid);
             // The tx has started on the previous term. Even though we rolled it
             // forward there is a possibility that a previous leader did the
             // same and already started the current transaction.
@@ -1819,14 +1834,26 @@ tx_gateway_frontend::get_ongoing_tx(
             // So marking it as ready. We use previous term because aborting a
             // tx in current ready state with current term means we abort a tx
             // which wasn't started and it leads to an error.
-            std::ignore = co_await stm->reset_tx_ready(
+            auto c = co_await stm->reset_tx_ready(
               expected_term, tx.id, tx.etag);
+            if (!c) {
+                vlog(
+                  txlog.trace,
+                  "resetting tx as ready failed with {} pid:{}",
+                  c.error(),
+                  pid);
+            }
             co_return tx_errc::invalid_txn_state;
         }
     }
 
     auto ongoing_tx = co_await stm->reset_tx_ongoing(tx.id, expected_term);
     if (!ongoing_tx.has_value()) {
+        vlog(
+          txlog.trace,
+          "resetting tx as ongoing failed with {} pid:{}",
+          ongoing_tx.error(),
+          pid);
         co_return tx_errc::invalid_txn_state;
     }
     co_return ongoing_tx.value();

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1879,6 +1879,9 @@ ss::future<bool> tx_gateway_frontend::try_create_tx_topic() {
         {std::move(topic)}, config::shard_local_cfg().create_topic_timeout_ms())
       .then([](std::vector<cluster::topic_result> res) {
           vassert(res.size() == 1, "expected exactly one result");
+          if (res[0].ec == cluster::errc::topic_already_exists) {
+              return true;
+          }
           if (res[0].ec != cluster::errc::success) {
               vlog(
                 clusterlog.warn,

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.cc
@@ -73,6 +73,9 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
                       case cluster::tx_errc::invalid_txn_state:
                           partition.error_code = error_code::invalid_txn_state;
                           break;
+                      case cluster::tx_errc::timeout:
+                          partition.error_code = error_code::request_timed_out;
+                          break;
                       default:
                           partition.error_code
                             = error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/end_txn.cc
+++ b/src/v/kafka/server/handlers/end_txn.cc
@@ -56,6 +56,9 @@ ss::future<response_ptr> end_txn_handler::handle(
               case cluster::tx_errc::invalid_txn_state:
                   data.error_code = error_code::invalid_txn_state;
                   break;
+              case cluster::tx_errc::timeout:
+                  data.error_code = error_code::request_timed_out;
+                  break;
               default:
                   data.error_code = error_code::unknown_server_error;
                   break;

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -99,6 +99,9 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                       reply.data.error_code
                         = error_code::invalid_producer_epoch;
                       break;
+                  case cluster::tx_errc::timeout:
+                      reply.data.error_code = error_code::request_timed_out;
+                      break;
                   default:
                       vlog(klog.warn, "failed to allocate pid, ec: {}", r.ec);
                       reply.data.error_code = error_code::broker_not_available;

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -102,6 +102,9 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                   case cluster::tx_errc::timeout:
                       reply.data.error_code = error_code::request_timed_out;
                       break;
+                  case cluster::tx_errc::shard_not_found:
+                      reply.data.error_code = error_code::not_coordinator;
+                      break;
                   default:
                       vlog(klog.warn, "failed to allocate pid, ec: {}", r.ec);
                       reply.data.error_code = error_code::broker_not_available;

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -87,81 +87,6 @@ class TxAdminTest(RedpandaTest):
                     assert (tx['timeout_ms'] == 60000)
 
     @cluster(num_nodes=3)
-    def test_expired_transaction(self):
-        '''
-        Problem: rm_stm contains timer to run try_abort_old_txs.
-        This timer rearm on begin_tx to smallest transaction deadline,
-        and after try_abort_old_txs to one of settings 
-        abort_timed_out_transactions_interval_ms or tx_timeout_delay_ms.
-        If we do sleep to transaction timeout and try to get expired 
-        transaction, timer can be signal before our request and after clean
-        expire transactions.
-
-        How to solve:
-        0) Run transaction
-        1) Change leader for parititons 
-        (New leader did not get requests for begin_txs,
-        so his timer is armed on one of settings)
-        2) Get expired transactions
-        '''
-        assert (len(self.redpanda.nodes) >= 2)
-
-        producer1 = ck.Producer({
-            'bootstrap.servers': self.redpanda.brokers(),
-            'transactional.id': '0',
-            'transaction.timeout.ms': '900000'
-        })
-        producer1.init_transactions()
-        producer1.begin_transaction()
-
-        for topic in self.topics:
-            for partition in range(topic.partition_count):
-                producer1.produce(topic.name, '0', '0', partition)
-
-        producer1.flush()
-
-        # We need to change leader for all partition to another node
-        for topic in self.topics:
-            for partition in range(topic.partition_count):
-                old_leader = self.admin.get_partition_leader(
-                    namespace="kafka", topic=topic, partition=partition)
-
-                self.admin.transfer_leadership_to(namespace="kafka",
-                                                  topic=topic,
-                                                  partition=partition,
-                                                  target_id=None)
-
-                def leader_is_changed():
-                    new_leader = self.admin.get_partition_leader(
-                        namespace="kafka", topic=topic, partition=partition)
-                    return (new_leader != -1) and (new_leader != old_leader)
-
-                wait_until(leader_is_changed,
-                           timeout_sec=30,
-                           backoff_sec=2,
-                           err_msg="Failed to establish current leader")
-
-        expected_pids = None
-
-        for topic in self.topics:
-            for partition in range(topic.partition_count):
-                txs_info = self.admin.get_transactions(topic.name, partition,
-                                                       "kafka")
-                assert ('active_transactions' not in txs_info)
-                if expected_pids == None:
-                    expected_pids = set(
-                        map(self.extract_pid,
-                            txs_info['expired_transactions']))
-                    assert (len(expected_pids) == 1)
-
-                assert (len(expected_pids) == len(
-                    txs_info['expired_transactions']))
-                for tx in txs_info['expired_transactions']:
-                    assert (self.extract_pid(tx) in expected_pids)
-                    assert (tx['status'] == 'ongoing')
-                    assert (tx['timeout_ms'] == -1)
-
-    @cluster(num_nodes=3)
     def test_mark_transaction_expired(self):
         producer1 = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
@@ -322,13 +247,6 @@ class TxAdminTest(RedpandaTest):
         rpk = RpkTool(self.redpanda)
         topic_name = self.topics[0].name
         rpk.delete_topic(topic_name)
-
-        try:
-            producer.commit_transaction()
-            raise Exception("commit_transaction should fail")
-        except ck.cimpl.KafkaException as e:
-            kafka_error = e.args[0]
-            assert kafka_error.code() == ck.cimpl.KafkaError.UNKNOWN
 
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -257,7 +257,7 @@ class TxAdminTest(RedpandaTest):
             raise Exception("init_transaction should fail")
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
-            assert kafka_error.code() == ck.cimpl.KafkaError.INVALID_TXN_STATE
+            assert kafka_error.code() == ck.cimpl.KafkaError.REQUEST_TIMED_OUT
 
         txs_info = self.admin.get_all_transactions()
         assert len(


### PR DESCRIPTION
## Cover letter

Several major ideas behind the PR:

  - switch from the parallel commits to a reduced 2PC
  - avoid the prepare RPC and the associated network costs
  - use acks=all instead of acks=1 to tolerate leadership changes without impacting the customer's workload

Fixes #6484

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none