### PR TITLE
cloud_storage: Remote partition compaction improvements

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -952,8 +952,7 @@ ntp_archiver::maybe_truncate_manifest(retry_chain_node& rtc) {
           _metadata_sync_timeout, _upload_loop_initial_backoff, &rtc);
         auto sname = cloud_storage::generate_local_segment_name(
           meta.base_offset, meta.segment_term);
-        auto spath = cloud_storage::generate_remote_segment_path(
-          _ntp, _rev, sname, meta.archiver_term);
+        auto spath = m.generate_segment_path(meta);
         auto result = co_await _remote.segment_exists(_bucket, spath, fib);
         if (result == cloud_storage::download_result::notfound) {
             vlog(

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -118,11 +118,11 @@ model::offset segment_collector::find_replacement_boundary() const {
         // first segment after gap: 25-29
         it = std::find_if(
           _manifest.begin(), _manifest.end(), [this](const auto& entry) {
-              return entry.first.base_offset > _begin_inclusive;
+              return entry.second.base_offset > _begin_inclusive;
           });
 
         // The collection is valid if it can reach the end of the gap: 24
-        replace_boundary = it->first.base_offset - model::offset{1};
+        replace_boundary = it->second.base_offset - model::offset{1};
     } else {
         replace_boundary = it->second.committed_offset;
     }
@@ -167,7 +167,7 @@ void segment_collector::align_end_offset_to_manifest(
         if (it->second.committed_offset == compacted_segment_end) {
             _end_inclusive = compacted_segment_end;
         } else {
-            _end_inclusive = it->first.base_offset - model::offset{1};
+            _end_inclusive = it->second.base_offset - model::offset{1};
         }
     }
 }

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -224,10 +224,7 @@ struct reupload_fixture : public archiver_fixture {
           });
         composite_meta.size_bytes = total_size;
 
-        auto s_url = m.generate_segment_path(
-          {.base_offset = composite_meta.base_offset,
-           .term = composite_meta.segment_term},
-          composite_meta);
+        auto s_url = m.generate_segment_path(composite_meta);
 
         vlog(test_log.info, "searching for target: {}", s_url);
         auto it = get_targets().find("/" + s_url().string());

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -538,13 +538,9 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     ss::sstring segment3_url = "/dfee62b1/kafka/test-topic/42_0/2-2-v1.log";
 
     // Simulate pre-existing state in the snapshot
-    cloud_storage::partition_manifest old_segments(
-      manifest_ntp, manifest_revision);
+    std::vector<cloud_storage::segment_meta> old_segments;
     for (const auto& s : old_manifest) {
-        old_segments.add(
-          segment_name(cloud_storage::generate_local_segment_name(
-            s.first.base_offset, s.first.term)),
-          s.second);
+        old_segments.push_back(s.second);
     }
     part->archival_meta_stm()
       ->add_segments(old_segments, ss::lowres_clock::now() + 1s)
@@ -748,13 +744,9 @@ static void test_partial_upload_impl(
       .ntp_revision = manifest.get_revision_id()};
 
     manifest.add(s1name, segment_meta);
-    cloud_storage::partition_manifest all_segments(
-      manifest_ntp, manifest_revision);
+    std::vector<cloud_storage::segment_meta> all_segments;
     for (const auto& s : manifest) {
-        all_segments.add(
-          segment_name(cloud_storage::generate_local_segment_name(
-            s.first.base_offset, s.first.term)),
-          s.second);
+        all_segments.push_back(s.second);
     }
     part->archival_meta_stm()
       ->add_segments(all_segments, ss::lowres_clock::now() + 1s)

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -532,7 +532,9 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       .is_compacted = false,
       .size_bytes = 100,
       .base_offset = model::offset(2),
-      .committed_offset = segment1->offsets().dirty_offset - model::offset(1)};
+      .committed_offset = segment1->offsets().dirty_offset - model::offset(1),
+      .segment_term = model::term_id{2},
+    };
     auto oldname = archival::segment_name("2-2-v1.log");
     old_manifest.add(oldname, old_meta);
     ss::sstring segment3_url = "/dfee62b1/kafka/test-topic/42_0/2-2-v1.log";

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -479,7 +479,7 @@ archival::remote_segment_path get_segment_path(
     BOOST_REQUIRE(meta);
     auto key = cloud_storage::parse_segment_name(name);
     BOOST_REQUIRE(key);
-    return manifest.generate_segment_path(*key, *meta);
+    return manifest.generate_segment_path(*meta);
 }
 
 void populate_log(storage::disk_log_builder& b, const log_spec& spec) {

--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -78,10 +78,10 @@ ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
 }
 
 segment_name offset_translator::get_adjusted_segment_name(
-  const partition_manifest::key& key, retry_chain_node& fib) const {
+  const segment_meta& meta, retry_chain_node& fib) const {
     retry_chain_logger ctxlog(cst_log, fib);
-    auto base_offset = key.base_offset;
-    auto term_id = key.term;
+    auto base_offset = meta.base_offset;
+    auto term_id = meta.segment_term;
     auto new_base = base_offset - _initial_delta;
     auto new_name = segment_name{
       ssx::sformat("{}-{}-v1.log", new_base(), term_id())};
@@ -89,8 +89,8 @@ segment_name offset_translator::get_adjusted_segment_name(
       ctxlog.debug,
       "Segment: {}-{}-v1.log, base-offset: {}, term-id: {}, "
       "adjusted-base-offset: {}, adjusted-name: {}",
-      key.base_offset,
-      key.term,
+      base_offset,
+      term_id,
       base_offset,
       term_id,
       new_base,

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -52,7 +52,7 @@ public:
 
     /// Get segment name adjusted for all removed offsets
     segment_name get_adjusted_segment_name(
-      const partition_manifest::key& s, retry_chain_node& fib) const;
+      const segment_meta& s, retry_chain_node& fib) const;
 
 private:
     model::offset_delta _initial_delta;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -171,6 +171,7 @@ remote_segment_path generate_remote_segment_path(
 }
 
 segment_name generate_local_segment_name(model::offset o, model::term_id t) {
+    vassert(t != model::term_id{}, "Invalid term id");
     return segment_name(ssx::sformat("{}-{}-v1.log", o(), t()));
 }
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -99,7 +99,7 @@ public:
     };
 
     /// Segment key in the maifest
-    using key = segment_name_components;
+    using key = model::offset;
     using value = segment_meta;
     using segment_map = absl::btree_map<key, value>;
     using replaced_segments_list = std::vector<lw_segment_meta>;
@@ -107,14 +107,13 @@ public:
     using const_reverse_iterator = segment_map::const_reverse_iterator;
 
     /// Generate segment name to use in the cloud
-    static segment_name
-    generate_remote_segment_name(const key& k, const value& val);
+    static segment_name generate_remote_segment_name(const value& val);
     /// Generate segment path to use in the cloud
-    static remote_segment_path generate_remote_segment_path(
-      const model::ntp& ntp, const key& k, const value& val);
+    static remote_segment_path
+    generate_remote_segment_path(const model::ntp& ntp, const value& val);
     /// Generate segment path to use locally
-    static local_segment_path generate_local_segment_path(
-      const model::ntp& ntp, const key& k, const value& val);
+    static local_segment_path
+    generate_local_segment_path(const model::ntp& ntp, const value& val);
 
     /// Create empty manifest that supposed to be updated later
     partition_manifest();
@@ -154,7 +153,7 @@ public:
               "can't parse name of the segment in the manifest '{}'",
               nm.name);
             nm.meta.segment_term = maybe_key->term;
-            _segments.insert(std::make_pair(*maybe_key, nm.meta));
+            _segments.insert(std::make_pair(nm.meta.base_offset, nm.meta));
         }
     }
 
@@ -192,9 +191,6 @@ public:
     timequery(model::timestamp t) const;
 
     remote_segment_path generate_segment_path(const segment_meta&) const;
-
-    remote_segment_path
-    generate_segment_path(const key&, const segment_meta&) const;
 
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -17,6 +17,8 @@
 #include "model/timestamp.h"
 #include "serde/serde.h"
 
+#include <deque>
+
 namespace cloud_storage {
 
 struct partition_manifest_handler;
@@ -78,7 +80,7 @@ public:
     using key = segment_name_components;
     using value = segment_meta;
     using segment_map = absl::btree_map<key, value>;
-    using segment_multimap = absl::btree_multimap<key, value>;
+    using replaced_segments_list = std::vector<segment_meta>;
     using const_iterator = segment_map::const_iterator;
     using const_reverse_iterator = segment_map::const_reverse_iterator;
 
@@ -121,7 +123,7 @@ public:
               "can't parse name of the replaced segment in the manifest '{}'",
               nm.name);
             nm.meta.segment_term = key->term;
-            _replaced.insert(std::make_pair(key.value(), nm.meta));
+            _replaced.push_back(nm.meta);
         }
         for (auto nm : segments) {
             auto maybe_key = parse_segment_name(nm.name);
@@ -270,7 +272,7 @@ private:
     model::initial_revision_id _rev;
     segment_map _segments;
     /// Collection of replaced but not yet removed segments
-    segment_multimap _replaced;
+    replaced_segments_list _replaced;
     model::offset _last_offset;
     model::offset _start_offset;
     model::offset _last_uploaded_compacted_offset;

--- a/src/v/cloud_storage/partition_probe.cc
+++ b/src/v/cloud_storage/partition_probe.cc
@@ -44,11 +44,6 @@ partition_probe::partition_probe(const model::ntp& ntp) {
           labels),
 
         sm::make_gauge(
-          "segments",
-          [this] { return _cur_segments; },
-          sm::description("Current number of remote segments"),
-          labels),
-        sm::make_gauge(
           "materialized_segments",
           [this] { return _cur_materialized_segments; },
           sm::description("Current number of materialized remote segments"),

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -18,12 +18,11 @@ namespace cloud_storage {
 
 class partition_probe {
 public:
-    partition_probe(const model::ntp& ntp);
+    explicit partition_probe(const model::ntp& ntp);
 
     void add_bytes_read(uint64_t read) { _bytes_read += read; }
     void add_records_read(uint64_t read) { _records_read += read; }
 
-    void segment_added() { ++_cur_segments; }
     void segment_materialized() { ++_cur_materialized_segments; }
     void segment_offloaded() { --_cur_materialized_segments; }
 
@@ -36,7 +35,6 @@ private:
     uint64_t _bytes_read = 0;
     uint64_t _records_read = 0;
 
-    int32_t _cur_segments = 0;
     int32_t _cur_materialized_segments = 0;
 
     int32_t _cur_readers = 0;

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -158,22 +158,15 @@ private:
       std::vector<partition_downloader::offset_range> dloffsets,
       partition_downloader::download_part& dlpart);
 
-    struct segment {
-        partition_manifest::key manifest_key;
-        partition_manifest::segment_meta meta;
-    };
-
     /// Download segment file to the target location
     ///
     /// The downloaded file will have a custom suffix
     /// which has to be changed. The downloaded file path
     /// is returned by the futue.
-    ss::future<std::optional<offset_range>> download_segment_file(
-      const segment& segm,
-      const download_part& part,
-      remote_segment_path remote_path);
+    ss::future<std::optional<offset_range>>
+    download_segment_file(const segment_meta& segm, const download_part& part);
 
-    using offset_map_t = absl::btree_map<model::offset, segment>;
+    using offset_map_t = absl::btree_map<model::offset, segment_meta>;
 
     ss::future<offset_map_t> build_offset_map(const recovery_material& mat);
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -822,9 +822,7 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
 
 ss::future<std::optional<storage::timequery_result>>
 remote_partition::timequery(storage::timequery_config cfg) {
-    if (_segments.size() < _manifest.size()) {
-        maybe_sync_with_manifest();
-    }
+    maybe_sync_with_manifest();
 
     if (_segments.empty()) {
         vlog(_ctxlog.debug, "timequery: no segments");

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -758,17 +758,8 @@ void remote_partition::maybe_sync_with_manifest() {
             _segments.insert_or_assign(o, std::move(ms));
             materialized_segments.erase(it);
         } else {
-            auto res = _segments.insert_or_assign(
+            _segments.insert_or_assign(
               o, offloaded_segment_state(meta.second.base_offset));
-            // With offloaded segments we can't distinguish between compacted
-            // and non compacted segments with the same base offset. Because of
-            // that all offloaded segments has to be recreated every time. It
-            // makes this metric useless but future update will make it
-            // completely obsolete since we will no longer have segments in
-            // offloaded state.
-            if (res.second) {
-                _probe.segment_added();
-            }
         }
     }
     _insync_offset = _manifest.get_insync_offset();

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -119,6 +119,10 @@ public:
     ss::future<std::vector<model::tx_range>>
     aborted_transactions(model::offset from, model::offset to);
 
+    const remote_segment_path& get_segment_path() const noexcept {
+        return _path;
+    }
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -60,14 +60,6 @@ public:
       cache& cache,
       s3::bucket_name bucket,
       const partition_manifest& m,
-      const partition_manifest::key& name,
-      retry_chain_node& parent);
-
-    remote_segment(
-      remote& r,
-      cache& cache,
-      s3::bucket_name bucket,
-      const partition_manifest& m,
       model::offset base_offset,
       retry_chain_node& parent);
 

--- a/src/v/cloud_storage/tests/offset_translation_layer_test.cc
+++ b/src/v/cloud_storage/tests/offset_translation_layer_test.cc
@@ -90,10 +90,10 @@ SEASTAR_THREAD_TEST_CASE(test_name_translation) {
 
     for (const auto& [orig, expected] : orig2expected) {
         segment_name orig_name{orig};
-        segment_name_components key = parse_segment_name(orig_name).value();
         auto meta = m.get(orig_name);
         BOOST_REQUIRE(meta);
         offset_translator otl(meta->delta_offset);
-        BOOST_REQUIRE_EQUAL(otl.get_adjusted_segment_name(key, fib), expected);
+        BOOST_REQUIRE_EQUAL(
+          otl.get_adjusted_segment_name(*meta, fib), expected);
     }
 }

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -740,7 +740,8 @@ struct partition_manifest_accessor {
       partition_manifest* m,
       const segment_name& key,
       const partition_manifest::segment_meta& meta) {
-        m->_replaced.push_back(meta);
+        m->_replaced.push_back(
+          partition_manifest::lw_segment_meta::convert(meta));
     }
     static auto find(segment_name n, const partition_manifest& m) {
         auto key = parse_segment_name(n);
@@ -925,7 +926,9 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_serialization_roundtrip) {
         auto actual = accessor::find(segment_name(expected.first), restored);
         auto res = std::any_of(
           actual.first, actual.second, [&expected](const auto& a) {
-              return expected.second == a;
+              return partition_manifest::lw_segment_meta::convert(
+                       expected.second)
+                     == a;
           });
         BOOST_REQUIRE(res);
     }

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -68,7 +68,7 @@ static constexpr std::string_view complete_manifest_json = R"json({
             "max_timestamp": 123029,
             "delta_offset": 1
         },
-        "40-1-v1.log": {
+        "40-11-v1.log": {
             "is_compacted": false,
             "size_bytes": 4096,
             "base_offset": 40,
@@ -449,7 +449,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          .segment_term = model::term_id(
            1), // segment_term is propagated from manifest
        }},
-      {"40-1-v1.log",
+      {"40-11-v1.log",
        partition_manifest::segment_meta{
          .is_compacted = false,
          .size_bytes = 4096,
@@ -468,7 +468,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
     };
     for (const auto& actual : m) {
         auto sn = generate_local_segment_name(
-          actual.first.base_offset, actual.first.term);
+          actual.second.base_offset, actual.second.segment_term);
         auto it = expected.find(sn());
         BOOST_REQUIRE(it != expected.end());
         require_equal_segment_meta(it->second, actual.second);
@@ -499,7 +499,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_segment_meta_update) {
 
     for (const auto& actual : m) {
         auto sn = generate_local_segment_name(
-          actual.first.base_offset, actual.first.term);
+          actual.second.base_offset, actual.second.segment_term);
         auto it = expected.find(sn());
         BOOST_REQUIRE(it != expected.end());
         require_equal_segment_meta(it->second, actual.second);
@@ -572,7 +572,7 @@ SEASTAR_THREAD_TEST_CASE(test_metas_get_smaller) {
     };
     for (const auto& actual : m) {
         auto sn = generate_local_segment_name(
-          actual.first.base_offset, actual.first.term);
+          actual.second.base_offset, actual.second.segment_term);
         auto it = expected.find(sn());
         BOOST_REQUIRE(it != expected.end());
         require_equal_segment_meta(it->second, actual.second);
@@ -612,7 +612,7 @@ SEASTAR_THREAD_TEST_CASE(test_fields_after_segments) {
 
     for (const auto& actual : m) {
         auto sn = generate_local_segment_name(
-          actual.first.base_offset, actual.first.term);
+          actual.second.base_offset, actual.second.segment_term);
         auto it = expected.find(sn());
         BOOST_REQUIRE(it != expected.end());
         require_equal_segment_meta(it->second, actual.second);
@@ -1628,8 +1628,8 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
         auto expected = remote_segment_path(
           "9b367cb7/test-ns/test-topic/42_1/10-1-v1.log.1");
         auto actual1 = partition_manifest::generate_remote_segment_path(
-          m.get_ntp(), s->first, s->second);
-        auto actual2 = m.generate_segment_path(s->first, s->second);
+          m.get_ntp(), s->second);
+        auto actual2 = m.generate_segment_path(s->second);
         BOOST_REQUIRE_EQUAL(expected, actual1);
         BOOST_REQUIRE_EQUAL(expected, actual2);
     }
@@ -1640,8 +1640,8 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
         auto expected = remote_segment_path(
           "96c6b7a9/test-ns/test-topic/42_1/20-29-2048-1-v1.log.2");
         auto actual1 = partition_manifest::generate_remote_segment_path(
-          m.get_ntp(), s->first, s->second);
-        auto actual2 = m.generate_segment_path(s->first, s->second);
+          m.get_ntp(), s->second);
+        auto actual2 = m.generate_segment_path(s->second);
         BOOST_REQUIRE_EQUAL(expected, actual1);
         BOOST_REQUIRE_EQUAL(expected, actual2);
     }
@@ -1652,8 +1652,8 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
         auto expected = remote_segment_path(
           "df1262f5/test-ns/test-topic/42_1/30-1-v1.log");
         auto actual1 = partition_manifest::generate_remote_segment_path(
-          m.get_ntp(), s->first, s->second);
-        auto actual2 = m.generate_segment_path(s->first, s->second);
+          m.get_ntp(), s->second);
+        auto actual2 = m.generate_segment_path(s->second);
         BOOST_REQUIRE_EQUAL(expected, actual1);
         BOOST_REQUIRE_EQUAL(expected, actual2);
     }
@@ -1664,8 +1664,8 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
         auto expected = remote_segment_path(
           "e44e8104/test-ns/test-topic/42_1/40-42-4096-2-v1.log");
         auto actual1 = partition_manifest::generate_remote_segment_path(
-          m.get_ntp(), s->first, s->second);
-        auto actual2 = m.generate_segment_path(s->first, s->second);
+          m.get_ntp(), s->second);
+        auto actual2 = m.generate_segment_path(s->second);
         BOOST_REQUIRE_EQUAL(expected, actual1);
         BOOST_REQUIRE_EQUAL(expected, actual2);
     }

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -217,8 +217,7 @@ make_imposter_expectations(
         m.add(s.sname, meta);
 
         delta = delta + model::offset(s.num_config_records);
-        auto res = parse_segment_name(s.sname);
-        auto url = m.generate_segment_path(*res, meta);
+        auto url = m.generate_segment_path(*m.get(meta.base_offset));
         results.push_back(cloud_storage_fixture::expectation{
           .url = "/" + url().string(), .body = body});
     }

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -82,8 +82,7 @@ FIXTURE_TEST(
     auto bucket = s3::bucket_name("bucket");
     remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
-    auto key = partition_manifest::key{
-      .base_offset = model::offset(1), .term = model::term_id(2)};
+    auto key = model::offset(1);
     model::initial_revision_id segment_ntp_revision{777};
     iobuf segment_bytes = generate_segment(model::offset(1), 20);
     uint64_t clen = segment_bytes.size_bytes();
@@ -99,7 +98,7 @@ FIXTURE_TEST(
       .max_timestamp = {},
       .delta_offset = model::offset_delta(0),
       .ntp_revision = segment_ntp_revision};
-    auto path = m.generate_segment_path(key, meta);
+    auto path = m.generate_segment_path(meta);
     auto upl_res = remote
                      .upload_segment(
                        bucket, path, clen, reset_stream, fib, always_continue)
@@ -128,7 +127,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
     remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
     auto name = segment_name("7-8-v1.log");
-    partition_manifest::key key = parse_segment_name(name).value();
+    auto key = parse_segment_name(name).value();
     m.add(
       name,
       partition_manifest::segment_meta{
@@ -142,7 +141,8 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
         .ntp_revision = manifest_revision});
 
     retry_chain_node fib(100ms, 20ms);
-    remote_segment segment(remote, cache.local(), bucket, m, key, fib);
+    remote_segment segment(
+      remote, cache.local(), bucket, m, key.base_offset, fib);
     BOOST_REQUIRE_THROW(
       segment.data_stream(0, ss::default_priority_class()).get(),
       download_exception);
@@ -157,8 +157,7 @@ FIXTURE_TEST(
     auto bucket = s3::bucket_name("bucket");
     remote remote(s3_connection_limit(10), conf, config_file);
     partition_manifest m(manifest_ntp, manifest_revision);
-    auto key = partition_manifest::key{
-      .base_offset = model::offset(1), .term = model::term_id(2)};
+    auto key = model::offset(1);
     iobuf segment_bytes = generate_segment(model::offset(1), 100);
     partition_manifest::segment_meta meta{
       .is_compacted = false,
@@ -169,7 +168,7 @@ FIXTURE_TEST(
       .max_timestamp = {},
       .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
-    auto path = m.generate_segment_path(key, meta);
+    auto path = m.generate_segment_path(meta);
     uint64_t clen = segment_bytes.size_bytes();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream = make_reset_fn(segment_bytes);
@@ -245,8 +244,7 @@ void test_remote_segment_batch_reader(
     auto action = ss::defer([&remote] { remote.stop().get(); });
 
     partition_manifest m(manifest_ntp, manifest_revision);
-    auto key = partition_manifest::key{
-      .base_offset = model::offset(1), .term = model::term_id(2)};
+    auto key = model::offset(1);
     uint64_t clen = segment_bytes.size_bytes();
     partition_manifest::segment_meta meta{
       .is_compacted = false,
@@ -257,7 +255,7 @@ void test_remote_segment_batch_reader(
       .max_timestamp = {},
       .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
-    auto path = m.generate_segment_path(key, meta);
+    auto path = m.generate_segment_path(meta);
     auto reset_stream = make_reset_fn(segment_bytes);
     retry_chain_node fib(1000ms, 200ms);
     auto upl_res = remote
@@ -357,8 +355,7 @@ FIXTURE_TEST(
     auto action = ss::defer([&remote] { remote.stop().get(); });
 
     partition_manifest m(manifest_ntp, manifest_revision);
-    auto key = partition_manifest::key{
-      .base_offset = model::offset(1), .term = model::term_id(2)};
+    auto key = model::offset(1);
     uint64_t clen = segment_bytes.size_bytes();
     partition_manifest::segment_meta meta{
       .is_compacted = false,
@@ -369,7 +366,7 @@ FIXTURE_TEST(
       .max_timestamp = {},
       .delta_offset = model::offset_delta(0),
       .ntp_revision = manifest_revision};
-    auto path = m.generate_segment_path(key, meta);
+    auto path = m.generate_segment_path(meta);
     auto reset_stream = make_reset_fn(segment_bytes);
     retry_chain_node fib(1000ms, 200ms);
     auto upl_res = remote

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -122,6 +122,8 @@ private:
     struct cleanup_metadata_cmd;
     struct snapshot;
 
+    friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
+
     static std::vector<segment>
     segments_from_manifest(const cloud_storage::partition_manifest& manifest);
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -45,7 +45,7 @@ public:
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.
     ss::future<std::error_code> add_segments(
-      const cloud_storage::partition_manifest&,
+      std::vector<cloud_storage::segment_meta>,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
 
@@ -89,7 +89,7 @@ public:
 
 private:
     ss::future<std::error_code> do_add_segments(
-      const cloud_storage::partition_manifest&,
+      std::vector<cloud_storage::segment_meta>,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>>);
 

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -201,6 +201,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(0),
         .committed_offset = model::offset(99),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.add(
       segment_name("100-1-v1.log"),
@@ -208,6 +209,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(100),
         .committed_offset = model::offset(199),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.add(
       segment_name("200-1-v1.log"),
@@ -215,6 +217,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(200),
         .committed_offset = model::offset(299),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.add(
       segment_name("100-1-v1.log"),
@@ -223,6 +226,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(100),
         .committed_offset = model::offset(299),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
         .sname_format = cloud_storage::segment_name_format::v2,
       });
     m.advance_insync_offset(model::offset{42});
@@ -353,7 +357,7 @@ old_segments_from_manifest(const cloud_storage::partition_manifest& m) {
             meta.ntp_revision = m.get_revision_id();
         }
         auto name = cloud_storage::generate_local_segment_name(
-          key.base_offset, key.term);
+          meta.base_offset, meta.segment_term);
         segments.push_back(old::segment{
           .ntp_revision_deprecated = meta.ntp_revision,
           .name = std::move(name),
@@ -412,6 +416,7 @@ FIXTURE_TEST(
         .base_offset = model::offset(0),
         .committed_offset = model::offset(99),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.add(
       segment_name("100-1-v1.log"),
@@ -419,6 +424,7 @@ FIXTURE_TEST(
         .base_offset = model::offset(100),
         .committed_offset = model::offset(199),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.add(
       segment_name("200-1-v1.log"),
@@ -426,6 +432,7 @@ FIXTURE_TEST(
         .base_offset = model::offset(200),
         .committed_offset = model::offset(299),
         .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
       });
     m.advance_insync_offset(model::offset(3));
 

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -125,7 +125,7 @@ FIXTURE_TEST(test_archival_stm_happy_path, archival_metadata_stm_fixture) {
       .base_offset = model::offset(0),
       .committed_offset = model::offset(99),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     // Replicate add_segment_cmd command that adds segment with offset 0
     archival_stm->add_segments(m, ss::lowres_clock::now() + 10s).get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 1);
@@ -165,12 +165,12 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     m1.push_back(segment_meta{
       .base_offset = model::offset(1000),
       .committed_offset = model::offset(1999),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     // Replicate add_segment_cmd command that adds segment with offset 0
     archival_stm->add_segments(m1, ss::lowres_clock::now() + 10s).get();
     archival_stm->sync(10s).get();
@@ -183,7 +183,7 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     archival_stm->add_segments(m2, ss::lowres_clock::now() + 10s).get();
     archival_stm->sync(10s).get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 2);
@@ -264,22 +264,22 @@ FIXTURE_TEST(
       .base_offset = model::offset(0),
       .committed_offset = model::offset(99),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     m.push_back(segment_meta{
       .base_offset = model::offset(100),
       .committed_offset = model::offset(199),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     m.push_back(segment_meta{
       .base_offset = model::offset(200),
       .committed_offset = model::offset(299),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     m.push_back(segment_meta{
       .base_offset = model::offset(300),
       .committed_offset = model::offset(399),
       .archiver_term = model::term_id(1),
-    });
+      .segment_term = model::term_id(1)});
     partition_manifest pm(ntp_cfg.ntp(), ntp_cfg.get_initial_revision());
     for (const auto& s : m) {
         auto name = cloud_storage::generate_local_segment_name(

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -34,6 +34,13 @@ namespace kafka {
 
 using offset = named_type<int64_t, struct kafka_offset_type>;
 
+inline offset next_offset(offset p) {
+    if (p < offset{0}) {
+        return offset{0};
+    }
+    return p + offset{1};
+}
+
 } // namespace kafka
 
 namespace s3 {

--- a/src/v/test_utils/archival.h
+++ b/src/v/test_utils/archival.h
@@ -68,9 +68,8 @@ inline void populate_local_log(
 inline void populate_manifest(
   cloud_storage::partition_manifest& m, const std::vector<segment_spec>& segs) {
     for (const auto& spec : segs) {
-        cloud_storage::partition_manifest::key key{
-          .base_offset = model::offset{spec.start_offset},
-          .term = model::term_id{0}};
+        cloud_storage::partition_manifest::key key = model::offset{
+          spec.start_offset};
 
         cloud_storage::partition_manifest::value value{
           .size_bytes = spec.size_bytes,


### PR DESCRIPTION
## Cover letter

Store replaced segments in the manifest in a more efficient way. 
Change signature of the `archival_metadata_stm::add_segments` method.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
* 
## Release notes

* none

### Features

* none

### Improvements

* none

-->
