### PR TITLE
r/heartbeat_manager: spurious log entry when group unavailable

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -315,6 +315,18 @@ void heartbeat_manager::process_reply(
         auto consensus = *it;
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);
 
+        if (unlikely(
+              m.result == append_entries_reply::status::group_unavailable)) {
+            // We may see these if the responding node is still starting up and
+            // the replica has yet to bootstrap.
+            vlog(
+              hbeatlog.debug,
+              "Heartbeat request for group {} was unavailable on node {}",
+              m.group,
+              n);
+            continue;
+        }
+
         if (unlikely(m.result == append_entries_reply::status::timeout)) {
             vlog(
               hbeatlog.debug,


### PR DESCRIPTION
## Cover letter

When heartbeat requests are received by nodes that don't yet have the group registered, we occassionally see a very scary warning:

```2022-10-21 18:29:05,472 [shard 1] r/heartbeat - heartbeat_manager.cc:325 - Heartbeat response addressed to different node: {id: {2}, revision: {-9223372036854775808}}, current node: {id: {2}, revision: {606621}}, response: {node_id: {id: {4}, revision: {-9223372036854775808}}, target_node_id{id: {2}, revision: {-9223372036854775808}}, group: {8402}, term:{-1}, last_dirty_log_index:{-9223372036854775808}, last_flushed_log_index:{-9223372036854775808}, last_term_base_offset:{-9223372036854775808}, result: group_unavailable}```


This is ultimately harmless and expected during the normal operation of a cluster (assuming node restarts are a fact of life). This commit draws inspiration from 2f8275917c5015a29ae9f8fea8fb67765a0052a0 and #6412 to ignore such errors.


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
