### PR TITLE
operator: support for rack awareness

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -157,3 +157,16 @@ $(ENVTEST): $(LOCALBIN)
 kuttl: $(KUTTL)
 $(KUTTL): $(LOCALBIN)
 	test -s $(LOCALBIN)/kubectl-kuttl || GOBIN=$(LOCALBIN) go install github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@$(KUTTL_VERSION)
+# go-get-tool will 'go get' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-get-tool
+@[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef

--- a/src/go/k8s/cmd/configurator/main_test.go
+++ b/src/go/k8s/cmd/configurator/main_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPopulateRack(t *testing.T) {
+	fs := afero.NewOsFs()
+	p := config.Params{ConfigPath: ""}
+	cfg, err := p.Load(fs)
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to read the redpanda configuration file: %w", err))
+	}
+	tests := []struct {
+		Zone         string
+		ZoneID       string
+		ExpectedRack string
+	}{
+		{Zone: "", ZoneID: "", ExpectedRack: ""},
+		{Zone: "zone", ZoneID: "", ExpectedRack: "zone"},
+		{Zone: "", ZoneID: "zoneid", ExpectedRack: "zoneid"},
+		{Zone: "zone", ZoneID: "zoneid", ExpectedRack: "zoneid"},
+	}
+	for _, tt := range tests {
+		populateRack(cfg, tt.Zone, tt.ZoneID)
+		assert.Equal(t, tt.ExpectedRack, cfg.Redpanda.Rack)
+	}
+}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -227,11 +227,16 @@ var _ = Describe("RedPandaCluster controller", func() {
 			var crb v1.ClusterRoleBinding
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), clusterRoleKey, &crb)
+				found := false
+				for _, s := range crb.Subjects {
+					if key.Name == s.Name && s.Kind == "ServiceAccount" {
+						found = true
+					}
+				}
 				return err == nil &&
 					crb.RoleRef.Name == clusterRoleKey.Name &&
 					crb.RoleRef.Kind == "ClusterRole" &&
-					crb.Subjects[0].Name == key.Name &&
-					crb.Subjects[0].Kind == "ServiceAccount"
+					found
 			}, timeout, interval).Should(BeTrue())
 
 			By("Creating StatefulSet")

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -167,12 +167,14 @@ var _ = BeforeEach(func() {
 	testAdminAPI.RegisterPropertySchema("auto_create_topics_enabled", admin.ConfigPropertyMetadata{NeedsRestart: false})
 	testAdminAPI.RegisterPropertySchema("cloud_storage_segment_max_upload_interval_sec", admin.ConfigPropertyMetadata{NeedsRestart: true})
 	testAdminAPI.RegisterPropertySchema("log_segment_size", admin.ConfigPropertyMetadata{NeedsRestart: true})
+	testAdminAPI.RegisterPropertySchema("enable_rack_awareness", admin.ConfigPropertyMetadata{NeedsRestart: false})
 
 	// By default we set the following properties and they'll be loaded by redpanda from the .bootstrap.yaml
 	// So we initialize the test admin API with those
 	testAdminAPI.SetProperty("auto_create_topics_enabled", false)
 	testAdminAPI.SetProperty("cloud_storage_segment_max_upload_interval_sec", 1800)
 	testAdminAPI.SetProperty("log_segment_size", 536870912)
+	testAdminAPI.SetProperty("enable_rack_awareness", true)
 })
 
 var _ = AfterSuite(func() {

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -51,10 +51,6 @@ func NewClusterRole(
 
 // Ensure manages v1.ClusterRole that is assigned to v1.ServiceAccount used in initContainer
 func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
-	if r.pandaCluster.ExternalListener() == nil {
-		return nil
-	}
-
 	obj := r.obj()
 	created, err := CreateIfNotExists(ctx, r, obj, r.logger)
 	if err != nil || created {

--- a/src/go/k8s/pkg/resources/cluster_role_binding.go
+++ b/src/go/k8s/pkg/resources/cluster_role_binding.go
@@ -51,10 +51,6 @@ func NewClusterRoleBinding(
 
 // Ensure manages v1.ClusterRoleBinding that is assigned to v1.ServiceAccount used in initContainer
 func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
-	if r.pandaCluster.ExternalListener() == nil {
-		return nil
-	}
-
 	var crb v1.ClusterRoleBinding
 
 	err := r.Get(ctx, r.Key(), &crb)

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -375,6 +375,10 @@ func (r *ConfigMapResource) CreateConfiguration(
 		return nil, err
 	}
 
+	if featuregates.RackAwareness(r.pandaCluster.Spec.Version) {
+		cfg.SetAdditionalRedpandaProperty("enable_rack_awareness", true)
+	}
+
 	if err := cfg.SetAdditionalFlatProperties(r.pandaCluster.Spec.AdditionalConfiguration); err != nil {
 		return nil, err
 	}

--- a/src/go/k8s/pkg/resources/featuregates/featuregates.go
+++ b/src/go/k8s/pkg/resources/featuregates/featuregates.go
@@ -48,6 +48,12 @@ func PerListenerAuthorization(version string) bool {
 	return atLeastVersion(v22_2_1, version)
 }
 
+// RackAwareness feature gate prevents enabling rack awareness
+// or setting the rack id on redpanda versions older than 22.1
+func RackAwareness(version string) bool {
+	return atLeastVersion(v22_1, version)
+}
+
 // atLeastVersion tells if the given version is greater or equal than the
 // minVersion.
 // All semver incompatible versions (such as "dev" or "latest") and non-version

--- a/src/go/k8s/pkg/resources/featuregates/featuregates_test.go
+++ b/src/go/k8s/pkg/resources/featuregates/featuregates_test.go
@@ -23,6 +23,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 		centralizedConfiguration bool
 		maintenanceMode          bool
 		perListenerAuthorization bool
+		rackAwareness            bool
 	}{
 		{
 			version:                  "v21.1.1",
@@ -30,6 +31,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: false,
 			maintenanceMode:          false,
 			perListenerAuthorization: false,
+			rackAwareness:            false,
 		},
 		{
 			version:                  "v21.11.1",
@@ -37,6 +39,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: false,
 			maintenanceMode:          false,
 			perListenerAuthorization: false,
+			rackAwareness:            false,
 		},
 		{
 			version:                  "v21.12.1",
@@ -44,6 +47,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: false,
 			maintenanceMode:          false,
 			perListenerAuthorization: false,
+			rackAwareness:            false,
 		},
 		{
 			version:                  "v22.1.1",
@@ -51,6 +55,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: false,
+			rackAwareness:            true,
 		},
 		{
 			version:                  "v22.1.2",
@@ -58,6 +63,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: false,
+			rackAwareness:            true,
 		},
 		{
 			version:                  "v22.2.1",
@@ -65,6 +71,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: true,
+			rackAwareness:            true,
 		},
 		{
 			version:                  "dev",
@@ -72,6 +79,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: true,
+			rackAwareness:            true,
 		},
 		// Versions from: https://hub.docker.com/r/vectorized/redpanda/tags
 		{
@@ -80,6 +88,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: true,
+			rackAwareness:            true,
 		},
 		{
 			version:                  "v21.11.20-beta2",
@@ -87,6 +96,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: false,
 			maintenanceMode:          false,
 			perListenerAuthorization: false,
+			rackAwareness:            false,
 		},
 		{
 			version:                  "v21.11.20-beta2-amd64",
@@ -94,6 +104,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: false,
 			maintenanceMode:          false,
 			perListenerAuthorization: false,
+			rackAwareness:            false,
 		},
 		{
 			version:                  "v22.2.3-arm64",
@@ -101,6 +112,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: true,
+			rackAwareness:            true,
 		},
 		// Versions from: https://hub.docker.com/r/vectorized/redpanda-nightly/tags
 		{
@@ -109,6 +121,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			centralizedConfiguration: true,
 			maintenanceMode:          true,
 			perListenerAuthorization: true,
+			rackAwareness:            true,
 		},
 	}
 

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -51,10 +51,6 @@ func NewServiceAccount(
 
 // Ensure manages ServiceAccount that is used in initContainer
 func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
-	if s.pandaCluster.ExternalListener() == nil {
-		return nil
-	}
-
 	obj, err := s.obj()
 	if err != nil {
 		return fmt.Errorf("unable to construct ServiceAccount object: %w", err)

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -794,10 +794,7 @@ func (r *StatefulSetResource) getNodePort(name string) string {
 }
 
 func (r *StatefulSetResource) getServiceAccountName() string {
-	if r.pandaCluster.ExternalListener() != nil {
-		return r.serviceAccountName
-	}
-	return ""
+	return r.serviceAccountName
 }
 
 // Key returns namespace/name object that is used to identify object.

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -418,6 +418,10 @@ func (r *StatefulSetResource) obj(
 									Name:  "HOST_PORT",
 									Value: r.getNodePort(ExternalListenerName),
 								},
+								{
+									Name:  "RACK_AWARENESS",
+									Value: strconv.FormatBool(featuregates.RackAwareness(r.pandaCluster.Spec.Version)),
+								},
 							}, r.pandaproxyEnvVars()...),
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  pointer.Int64Ptr(userID),


### PR DESCRIPTION
## Cover letter

This PR enables rack awareness by default when deploying through the operator. To set the rack id in the redpanda configuration of each node, the configurator (init container) retrieves the zone id of the current node and writes it in redpanda.yaml

The node labels are considered in the following order
1. `topology.cloud.redpanda.com/zone-id`
2. `topology.kubernetes.io/zone`

If the annotations are empty or missing, the redpanda.yaml will not include the `rack_id` key.

Note that the operator will only enable rack awareness when running redpanda version v22.1 or higher, and similarly the rack id will not be set otherwise.