### PR TITLE
kafka/client: Mitigate std::errc::timed_out

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -196,7 +196,9 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     } catch (const ss::gate_closed_exception&) {
         vlog(kclog.debug, "gate_closed_exception");
     } catch (const std::system_error& ex) {
-        if (ex.code() == std::errc::broken_pipe) {
+        if (
+          ex.code() == std::errc::broken_pipe
+          || ex.code() == std::errc::timed_out) {
             vlog(kclog.debug, "system_error: {}", ex);
             return _wait_or_start_update_metadata();
         } else {


### PR DESCRIPTION
## Cover letter

If a connection times out, this will now result in the client reconnecting, rather than getting stuck in a broken state.

The error message that drove this fix:
```
2022-10-21T22:42:46.777790351Z stderr F ERROR 2022-10-21 22:42:46,777 [shard 0] pandaproxy - reply.h:109 - exception_reply: std::__1::system_error (error system:110, sendmsg: Connection timed out)
```
Which leads to a response of:
```
{"error_code":500,"message":"HTTP 500 Internal Server Error"}
```

This is related: https://github.com/redpanda-data/redpanda/pull/6687

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

### Improvements

* Improve rebustness of Schema Registry and HTTP Proxy under `std::errc::timed_out`.