### PR TITLE
[v22.1.x] redpanda: Explicitly cast `YAML::Node` to `bool`

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -324,7 +324,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
             vlog(_log.info, "{}.{}\t- {}", service, val.str(), item.desc());
         };
     };
-    _redpanda_enabled = config["redpanda"];
+    _redpanda_enabled = bool(config["redpanda"]);
     if (_redpanda_enabled) {
         ss::smp::invoke_on_all([&config, cfg_path] {
             config::node().load(cfg_path, config);


### PR DESCRIPTION
## Cover letter

This is required for yaml-cpp upgrade.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [x] v21.11.x (done manually https://github.com/redpanda-data/redpanda/pull/6891)

## UX changes

* none

## Release notes

* none
