### PR TITLE
HTTP imposter enhancements

### DIFF
--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -20,6 +20,7 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "redpanda/tests/fixture.h"
+#include "test_utils/http_imposter.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -31,63 +32,6 @@
 #include <exception>
 #include <map>
 #include <vector>
-
-/// Emulates S3 REST API for testing purposes.
-/// The imposter is a simple KV-store that contains a set of expectations.
-/// Expectations are accessible by url via GET, PUT, and DELETE http calls.
-/// Expectations are provided before impster starts to listen. They have
-/// two field - url and optional body. If body is set to nullopt, attemtp
-/// to read it using GET or delete it using DELETE requests will trigger an
-/// http response with error code 404 and xml formatted error message.
-/// If the body of the expectation is set by the user or PUT request it can
-/// be retrieved using the GET request or deleted using the DELETE request.
-class s3_imposter_fixture {
-public:
-    s3_imposter_fixture();
-    ~s3_imposter_fixture();
-
-    s3_imposter_fixture(const s3_imposter_fixture&) = delete;
-    s3_imposter_fixture& operator=(const s3_imposter_fixture&) = delete;
-    s3_imposter_fixture(s3_imposter_fixture&&) = delete;
-    s3_imposter_fixture& operator=(s3_imposter_fixture&&) = delete;
-
-    struct expectation {
-        ss::sstring url;
-        std::optional<ss::sstring> body;
-    };
-
-    /// Set expectaitions on REST API calls that supposed to be made
-    /// Only the requests that described in this call will be possible
-    /// to make. This method can only be called once per test run.
-    ///
-    /// \param expectations is a collection of access points that allow GET,
-    /// PUT, and DELETE requests, each expectation has url and body. The body
-    /// will be returned by GET call if it's set or trigger error if its null.
-    /// The expectations are statefull. If the body of the expectation was set
-    /// to null but there was PUT call that sent some data, subsequent GET call
-    /// will retrieve this data.
-    void
-    set_expectations_and_listen(const std::vector<expectation>& expectations);
-
-    /// Access all http requests ordered by time
-    const std::vector<ss::httpd::request>& get_requests() const;
-
-    /// Access all http requests ordered by target url
-    const std::multimap<ss::sstring, ss::httpd::request>& get_targets() const;
-
-private:
-    void set_routes(
-      ss::httpd::routes& r, const std::vector<expectation>& expectations);
-
-    ss::socket_address _server_addr;
-    ss::shared_ptr<ss::httpd::http_server_control> _server;
-
-    std::unique_ptr<ss::httpd::handler_base> _handler;
-    /// Contains saved requests
-    std::vector<ss::httpd::request> _requests;
-    /// Contains all accessed target urls
-    std::multimap<ss::sstring, ss::httpd::request> _targets;
-};
 
 struct segment_desc {
     model::ntp ntp;
@@ -157,7 +101,7 @@ public:
 
 /// Archiver fixture that contains S3 mock and full redpanda stack.
 class archiver_fixture
-  : public s3_imposter_fixture
+  : public http_imposter_fixture
   , public enable_cloud_storage_fixture
   , public redpanda_thread_fixture
   , public segment_matcher<archiver_fixture> {
@@ -222,3 +166,27 @@ cloud_storage::partition_manifest load_manifest(std::string_view v);
 
 archival::remote_segment_path get_segment_path(
   const cloud_storage::partition_manifest&, const archival::segment_name&);
+
+/// Specification for the segments and data to go into the log for a test
+struct log_spec {
+    // The base offsets for all segments. The difference in adjacent base
+    // offsets is converted to how many records we will write into each segment
+    // (as a single batch)
+    std::vector<size_t> segment_starts;
+    // The indices of the segments which will be marked as compacted for the
+    // test. The segments are not actually compacted, only marked as such.
+    std::vector<size_t> compacted_segment_indices;
+    // The number of records in the final segment, required separately because
+    // there is no delta to use for the last segment.
+    size_t last_segment_num_records;
+};
+
+storage::disk_log_builder make_log_builder(std::string_view data_path);
+
+void populate_log(storage::disk_log_builder& b, const log_spec& spec);
+
+void manage_ntp(
+  archiver_fixture& a,
+  ss::sstring data_path,
+  model::ntp ntp,
+  std::optional<storage::ntp_config::default_overrides> overrides);

--- a/src/v/test_utils/http_imposter.cc
+++ b/src/v/test_utils/http_imposter.cc
@@ -46,54 +46,41 @@ static ss::sstring remove_query_params(std::string_view url) {
                                            : ss::sstring{url.substr(0, q_pos)};
 }
 
-struct content_handler {
-    explicit content_handler(http_imposter_fixture& imp)
-      : fixture(imp) {}
-
-    ss::sstring
-    handle(ss::httpd::const_req request, ss::httpd::reply& repl) const {
-        size_t num_requests = fixture.requests().size();
-
-        fixture.requests().push_back(request);
-        fixture.targets().insert(std::make_pair(request._url, request));
-
-        if (auto it = fixture.indexed_requests_to_fail().find(num_requests);
-            it != fixture.indexed_requests_to_fail().end()) {
-            repl.set_status(it->second.status);
-            return it->second.body;
-        }
-
-        vlog(
-          http_imposter_log.trace,
-          "S3 imposter request {} - {} - {}",
-          request._url,
-          request.content_length,
-          request._method);
-
-        if (request._method == "PUT") {
-            fixture.when()
-              .request(request._url)
-              .then_reply_with(request.content);
-            repl.set_status(ss::httpd::reply::status_type::ok);
-            return "";
-        } else {
-            ss::httpd::request lookup_r{request};
-            lookup_r._url = remove_query_params(request._url);
-
-            auto response = fixture.lookup(lookup_r);
-            repl.set_status(response.status);
-            return response.body;
-        }
-    }
-
-    http_imposter_fixture& fixture;
-};
-
 void http_imposter_fixture::set_routes(ss::httpd::routes& r) {
     using namespace ss::httpd;
     _handler = std::make_unique<function_handler>(
-      [this](const_req req, reply& repl) {
-          return content_handler(*this).handle(req, repl);
+      [this](const_req req, reply& repl) -> ss::sstring {
+          _requests.push_back(req);
+          _targets.insert(std::make_pair(req._url, req));
+
+          const auto& fp = _fail_requests_when;
+          for (size_t i = 0; i < fp.size(); ++i) {
+              if (fp[i](req)) {
+                  auto response = _fail_responses[i];
+                  repl.set_status(response.status);
+                  return response.body;
+              }
+          }
+
+          vlog(
+            http_imposter_log.trace,
+            "HTTP imposter request {} - {} - {}",
+            req._url,
+            req.content_length,
+            req._method);
+
+          if (req._method == "PUT") {
+              when().request(req._url).then_reply_with(req.content);
+              repl.set_status(ss::httpd::reply::status_type::ok);
+              return "";
+          } else {
+              ss::httpd::request lookup_r{req};
+              lookup_r._url = remove_query_params(req._url);
+
+              auto response = lookup(lookup_r);
+              repl.set_status(response.status);
+              return response.body;
+          }
       },
       "txt");
     r.add_default_handler(_handler.get());
@@ -107,9 +94,11 @@ bool http_imposter_fixture::has_call(std::string_view url) const {
            != _requests.cend();
 }
 
-void http_imposter_fixture::fail_nth_request_with(
-  size_t n, http_test_utils::response response) {
-    _fail_requests_at_index[n] = std::move(response);
+void http_imposter_fixture::fail_request_if(
+  http_imposter_fixture::request_predicate predicate,
+  http_test_utils::response response) {
+    _fail_requests_when.push_back(std::move(predicate));
+    _fail_responses[_fail_requests_when.size()] = std::move(response);
 }
 
 void http_imposter_fixture::reset_http_call_state() {


### PR DESCRIPTION
## Cover letter

Allows the HTTP imposter to handle PUT requests, and conditionally fail incoming requests. 

These changes are useful for tests where failure handling is required as well as for testing PUT request content.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* None
