### PR TITLE
Fix flaky failure in `ResourceLimitsTest.test_cpu_limited` ducktape test

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -15,6 +15,7 @@ from typing import Optional
 from ducktape.cluster.cluster import ClusterNode
 from rptest.util import wait_until_result
 from rptest.services import tls
+from ducktape.errors import TimeoutError
 
 DEFAULT_TIMEOUT = 30
 
@@ -143,10 +144,13 @@ class RpkTool:
                     return False
                 raise e
 
-        wait_until_result(create_topic,
-                          10,
-                          0.1,
-                          err_msg="Can't create a topic within 10s")
+        try:
+            wait_until_result(create_topic,
+                              10,
+                              0.1,
+                              err_msg="Can't create a topic within 10s")
+        except TimeoutError:
+            raise RpkException("rpk couldn't create topic within 10s timeout")
 
     def add_partitions(self, topic, partitions):
         cmd = ["add-partitions", topic, "-n", str(partitions)]

--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -11,6 +11,7 @@ from rptest.clients.rpk import RpkTool, RpkException
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import ResourceSettings
 from rptest.services.cluster import cluster
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class ResourceLimitsTest(RedpandaTest):
@@ -67,6 +68,7 @@ class ResourceLimitsTest(RedpandaTest):
         # Growing the partition count within the limit should succeed
         rpk.add_topic_partitions("okay", 10)
 
+    @skip_debug_mode
     @cluster(num_nodes=3)
     def test_cpu_limited(self):
         """
@@ -95,16 +97,7 @@ class ResourceLimitsTest(RedpandaTest):
         else:
             assert False
 
-        try:
-            rpk.create_topic("okay", partitions=6000, replicas=3)
-        except RpkException as e:
-            # Because this many partitions will overwhelm a debug build
-            # of redpanda, we tolerate exceptions, as long as the exception
-            # isn't about the partition count specifically.
-            #
-            # It would be better to execute this part of the test conditionally
-            # on release builds only.
-            assert 'INVALID_PARTITIONS' not in e.msg
+        rpk.create_topic("okay", partitions=6000, replicas=3)
 
     @cluster(num_nodes=3)
     def test_fd_limited(self):


### PR DESCRIPTION
Fixing flaky test that fails due to another commit modifying what exceptions `rpk.create_topic` may throw. A `10s` timeout was introduced in the aformentioned commit which makes create_topic throw `TimeoutError` on expiration of timeout. Existing tests do not expect that `TimeoutError` may be thrown from invocation of create topic and may fail.

Fix is to remap `TimeoutError` exception (when thrown from `rpk.create_topic`) to `RpkException`

## Release notes
- none