### PR TITLE
[v22.1.x] kafka/client: Mitigate std::errc::timed_out

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -196,7 +196,9 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     } catch (const ss::gate_closed_exception&) {
         vlog(kclog.debug, "gate_closed_exception");
     } catch (const std::system_error& ex) {
-        if (ex.code() == std::errc::broken_pipe) {
+        if (
+          ex.code() == std::errc::broken_pipe
+          || ex.code() == std::errc::timed_out) {
             vlog(kclog.debug, "system_error: {}", ex);
             return _wait_or_start_update_metadata();
         } else {


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6885.
