### PR TITLE
Realocate partitions in steps

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -294,6 +294,18 @@ void members_backend::calculate_reallocations_after_node_added(
         return lhs.left_to_move < rhs.left_to_move;
     };
 
+    if (clusterlog.is_enabled(ss::log_level::info)) {
+        for (const auto& [id, cnt] : to_move_from_node) {
+            vlog(
+              clusterlog.info,
+              "[update: {}] there are {} replicas to move from node {} in "
+              "domain {}",
+              meta.update,
+              cnt,
+              id,
+              domain);
+        }
+    }
     // 4. Pass over all partition metadata once, try to move until we reach even
     // number of partitions per core on each node
     for (auto& [tp_ns, metadata] : topics) {

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -484,9 +484,10 @@ ss::future<> members_backend::reconcile() {
 
     vlog(
       clusterlog.info,
-      "[update: {}] reconciliation loop - reallocations: {}, finished: {}",
+      "[update: {}] reconciliation loop - pending reallocation count: {}, "
+      "finished: {}",
       meta.update,
-      meta.partition_reallocations,
+      meta.partition_reallocations.size(),
       meta.finished);
 
     // calculate necessary reallocations

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -97,7 +97,8 @@ private:
     void stop_node_addition(model::node_id id);
     void handle_reallocation_finished(model::node_id);
     void reassign_replicas(partition_assignment&, partition_reallocation&);
-    void calculate_reallocations_after_node_added(update_meta&) const;
+    void calculate_reallocations_after_node_added(
+      update_meta&, partition_allocation_domain) const;
     void calculate_reallocations_after_decommissioned(update_meta&) const;
     void calculate_reallocations_after_recommissioned(update_meta&) const;
     std::vector<model::ntp> ntps_moving_from_node_older_than(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -88,7 +88,7 @@ private:
     ss::future<> reallocate_replica_set(partition_reallocation&);
 
     ss::future<> try_to_finish_update(update_meta&);
-    void calculate_reallocations(update_meta&);
+    ss::future<> calculate_reallocations(update_meta&);
 
     ss::future<> handle_updates();
     void handle_single_update(members_manager::node_update);
@@ -97,10 +97,10 @@ private:
     void stop_node_addition(model::node_id id);
     void handle_reallocation_finished(model::node_id);
     void reassign_replicas(partition_assignment&, partition_reallocation&);
-    void calculate_reallocations_after_node_added(
-      update_meta&, partition_allocation_domain) const;
-    void calculate_reallocations_after_decommissioned(update_meta&) const;
-    void calculate_reallocations_after_recommissioned(update_meta&) const;
+    ss::future<> calculate_reallocations_after_node_added(
+      update_meta&, partition_allocation_domain);
+    ss::future<> calculate_reallocations_after_decommissioned(update_meta&);
+    ss::future<> calculate_reallocations_after_recommissioned(update_meta&);
     std::vector<model::ntp> ntps_moving_from_node_older_than(
       model::node_id, model::revision_id) const;
     void setup_metrics();
@@ -123,6 +123,7 @@ private:
     ss::timer<> _retry_timer;
     ss::condition_variable _new_updates;
     ss::metrics::metric_groups _metrics;
+    config::binding<size_t> _max_concurrent_reallocations;
     /**
      * store revision of node decommissioning update, decommissioning command
      * revision is stored when node is being decommissioned, it is used to

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -102,6 +102,15 @@ public:
         return _allocated_partitions;
     }
 
+    allocation_capacity
+    domain_allocated_partitions(partition_allocation_domain domain) const {
+        if (auto it = _allocated_domain_partitions.find(domain);
+            it != _allocated_domain_partitions.end()) {
+            return it->second;
+        }
+        return allocation_capacity{0};
+    }
+
     bool empty() const {
         return _allocated_partitions == allocation_capacity{0};
     }

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -95,7 +95,14 @@ model::node_id find_best_fit(
           [&node = it->second](
             uint32_t score,
             const allocation_constraints::soft_constraint_ev_ptr& ev) {
-              return score + ev->score(*node);
+              const auto current_score = ev->score(*node);
+              vlog(
+                clusterlog.trace,
+                "constraint: {}, node: {}, score: {}",
+                *ev,
+                node->id(),
+                current_score);
+              return score + current_score;
           });
 
         if (score >= best_score) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1294,7 +1294,12 @@ configuration::configuration()
       "batch",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB)
-
+  , partition_autobalancing_concurrent_moves(
+      *this,
+      "partition_autobalancing_concurrent_moves",
+      "Number of partitions that can be reassigned at once",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      50)
   , enable_leader_balancer(
       *this,
       "enable_leader_balancer",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -276,6 +276,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       partition_autobalancing_tick_interval_ms;
     property<size_t> partition_autobalancing_movement_batch_size_bytes;
+    property<size_t> partition_autobalancing_concurrent_moves;
 
     property<bool> enable_leader_balancer;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import random
+from rptest.services import redpanda
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
@@ -33,6 +34,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                 "partition_autobalancing_node_availability_timeout_sec":
                 self.NODE_AVAILABILITY_TIMEOUT,
                 "partition_autobalancing_tick_interval_ms": 5000,
+                "members_backend_retry_ms": 1000,
                 "raft_learner_recovery_rate": 1073741824,
             },
             *args,
@@ -159,5 +161,130 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             return len(ongoing) == 0
 
         wait_until(all_reconfigurations_done, 300, 5)
+
+        self.verify(topic.name, message_size, consumers)
+
+    @cluster(num_nodes=6)
+    @parametrize(type=MANY_PARTITIONS)
+    @parametrize(type=BIG_PARTITIONS)
+    def test_node_operations_at_scale(self, type):
+        replication_factor = 3
+        if not self.redpanda.dedicated_nodes:
+            # Mini mode, for developers working on the test on their workstation.
+            # (not for use in CI)
+            message_size = 16384
+            message_cnt = 64000
+            consumers = 1
+            partitions_count = 40
+            max_concurrent_moves = 5
+        elif type == self.MANY_PARTITIONS:
+            message_size = 128 * (2 ^ 10)
+            message_cnt = 2000000
+            consumers = 8
+            partitions_count = 18000
+            max_concurrent_moves = 400
+            timeout = 300
+        else:
+            message_size = 512 * (2 ^ 10)
+            message_cnt = 5000000
+            consumers = 8
+            partitions_count = 200
+            max_concurrent_moves = 200
+            timeout = 300
+
+        # set max number of concurrent moves
+        self.redpanda.set_cluster_config(
+            {"partition_autobalancing_concurrent_moves": max_concurrent_moves})
+
+        topic = TopicSpec(partition_count=partitions_count,
+                          replication_factor=replication_factor)
+        self.client().create_topic(topic)
+
+        self._start_producer(topic.name, message_cnt, message_size)
+        self._start_consumer(topic.name, message_size, consumers=consumers)
+        mb = 1024 * 1024
+        self.logger.info(
+            f"waiting for {(message_size*message_cnt) / mb} MB to be produced to "
+            f"{partitions_count} partitions ({((message_size*message_cnt) / mb) / partitions_count} MB per partition"
+        )
+        # wait for the partitions to be filled with data
+        self.producer.wait_for_acks(message_cnt // 2,
+                                    timeout_sec=timeout,
+                                    backoff_sec=5)
+
+        admin = Admin(self.redpanda)
+        brokers = admin.get_brokers()
+        # decommission one of the nodes
+        decommissioned_id = random.choice(brokers)['node_id']
+        self.logger.info(
+            f"cluster brokers: {brokers}, decommissioning: {decommissioned_id}"
+        )
+        admin.decommission_broker(decommissioned_id)
+
+        def decommission_ended():
+            replicas = self.node_replicas([topic.name], decommissioned_id)
+            self.logger.debug(
+                f"decommissioned node {decommissioned_id} hosts {len(replicas)} replicas"
+            )
+            if len(replicas) != 0:
+                return False
+            all_brokers = set()
+            for n in self.redpanda.nodes:
+                current_id = self.redpanda.node_id(n)
+                if current_id == decommissioned_id:
+                    continue
+                brokers = admin.get_brokers(node=n)
+                for i in [b['node_id'] for b in brokers]:
+                    all_brokers.add(i)
+            return decommissioned_id not in all_brokers
+
+        wait_until(decommission_ended, timeout, 5)
+        # restart node
+        to_restart = None
+        for n in self.redpanda.nodes:
+            current_id = self.redpanda.node_id(n)
+            if current_id == decommissioned_id:
+                to_restart = n
+                break
+
+        def seed_servers_for(node):
+            seeds = map(
+                lambda n: {
+                    "address": n.account.hostname,
+                    "port": 33145
+                }, self.redpanda.nodes)
+
+            return list(
+                filter(lambda n: n['address'] != node.account.hostname, seeds))
+
+        self.redpanda.stop_node(to_restart)
+        self.redpanda.clean_node(to_restart)
+        self.redpanda.start_node(to_restart,
+                                 override_cfg_params={
+                                     "node_id": 10,
+                                     "seed_servers":
+                                     seed_servers_for(to_restart)
+                                 })
+        new_node_id = self.redpanda.node_id(to_restart)
+        expected_per_node = partitions_count * replication_factor / len(
+            self.redpanda.nodes)
+
+        def partitions_moved_to_new_node():
+            replicas = self.node_replicas([topic.name], new_node_id)
+            self.logger.info(
+                f"broker {new_node_id} is a host for {len(replicas)} replicas")
+            return len(replicas) > 0.9 * expected_per_node
+
+        wait_until(partitions_moved_to_new_node, timeout, 5)
+
+        def all_reconfigurations_done():
+            ongoing = admin.list_reconfigurations()
+            self.logger.debug(
+                f"Waiting for partition reconfigurations to finish. "
+                f"Currently reconfiguring partitions: {len(ongoing)}")
+
+            return len(ongoing) == 0
+
+        wait_until(all_reconfigurations_done, timeout, 5)
 
         self.verify(topic.name, message_size, consumers)


### PR DESCRIPTION
## Cover letter

Changed the `cluster::members_backend` partition reallocation logic to reallocate partitions in batches instead of requesting all necessary reallocations at once. The incremental approach allows cluster to move large number of partitions without consuming all computational  resources (especially memory). 

With the new implementation both decommissioning and reallocation on node addition are executed incrementally.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
### Improvements

* Improves moving partitions at scale
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
