### PR TITLE
[v22.2.x] rpc/transport: Release resource units right after dispatching send

### DIFF
--- a/src/v/rpc/test/echo_service.json
+++ b/src/v/rpc/test/echo_service.json
@@ -21,9 +21,9 @@
             "output_type": "echo_resp"
         },
         {
-            "name": "sleep_1s",
-            "input_type": "echo_req",
-            "output_type": "echo_resp"
+            "name": "sleep_for",
+            "input_type": "sleep_req",
+            "output_type": "sleep_resp"
         },
         {
             "name": "counter",

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -62,6 +62,16 @@ struct cnt_resp {
     uint64_t current;
 };
 
+struct sleep_req {
+    using rpc_serde_exempt = std::true_type;
+    uint64_t secs;
+};
+
+struct sleep_resp {
+    using rpc_serde_exempt = std::true_type;
+    ss::sstring str;
+};
+
 enum class failure_type { throw_exception, exceptional_future, none };
 
 struct throw_req {

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -222,14 +222,18 @@ void transport::dispatch_send() {
                   auto it = _requests_queue.begin();
                   _last_seq = it->first;
                   auto buffer = std::move(it->second->buffer).get();
+                  // These units are released once we are out of scope here
+                  // and that is intentional because the underlying write call
+                  // to the batched output stream guarantees us the in-order
+                  // delivery of the dispatched write calls, which is the intent
+                  // of holding on to the units up until this point.
                   auto units = std::move(it->second->resource_units);
                   auto v = std::move(*buffer).as_scattered();
                   auto msg_size = v.size();
                   _requests_queue.erase(it->first);
-                  return _out.write(std::move(v))
-                    .finally([this, msg_size, units = std::move(units)] {
-                        _probe.add_bytes_sent(msg_size);
-                    });
+                  auto f = _out.write(std::move(v));
+                  return std::move(f).finally(
+                    [this, msg_size] { _probe.add_bytes_sent(msg_size); });
               });
         }).handle_exception([this](std::exception_ptr e) {
             vlog(rpclog.info, "Error dispatching socket write:{}", e);

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -1,0 +1,98 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import threading
+from ducktape.utils.util import wait_until
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.admin import Admin
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+
+
+class ShutdownTest(EndToEndTest):
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_timely_shutdown_with_failures(self):
+        '''
+        Validates that a leader node can shutdown in a timely manner when
+        a follower node is unresponsive. Specifically the test targets
+        timely cleanup of the consensus class in flaky conditions.
+        '''
+        self.topic = TopicSpec(partition_count=1, replication_factor=3)
+        rp_conf = {
+            'enable_leader_balancer': False,
+            'auto_create_topics_enabled': True
+        }
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        extra_rp_conf=rp_conf)
+        admin = Admin(self.redpanda)
+
+        def checked_get_leader():
+            try:
+                leader = admin.get_partition_leader(namespace="kafka",
+                                                    topic=self.topic.name,
+                                                    partition=0)
+                return next(
+                    filter(lambda n: self.redpanda.idx(n) == leader,
+                           self.redpanda.nodes))
+            except:
+                return None
+
+        self.redpanda.start()
+        # Background load generation
+        self.start_producer(2)
+        # Wait until a leader is available.
+        wait_until(lambda: checked_get_leader(),
+                   timeout_sec=10,
+                   backoff_sec=2,
+                   err_msg=f"Leader not found for ntp: {self.topic}/0")
+
+        stopped = False
+
+        def pause_non_leader_node():
+            """Picks a non leader node for the ntp and isolates it repeatedly"""
+            with FailureInjector(self.redpanda) as finjector:
+                timeout_s = 5
+                failure = FailureSpec.FAILURE_ISOLATE
+                while not stopped:
+                    node = random.choice(self.redpanda.nodes)
+                    assert node
+                    if node == checked_get_leader():
+                        continue
+                    # Suspend for longer than send timeouts
+                    finjector.inject_failure(
+                        FailureSpec(node=node, type=failure, length=timeout_s))
+
+        # Inject failures in the background.
+        background_failures = threading.Thread(target=pause_non_leader_node,
+                                               args=(),
+                                               daemon=True)
+        background_failures.start()
+        pending_attempts = 5
+        while pending_attempts != 0:
+            # Pick the current leader and restart it, repeat
+            wait_until(lambda: checked_get_leader,
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       err_msg=f"Leader not found for ntp: {self.topic}/0")
+            leader = checked_get_leader()
+            assert leader
+            self.redpanda.logger.info(
+                f"Restarting leader node {leader.account.hostname}")
+            self.redpanda.restart_nodes(leader)
+            pending_attempts -= 1
+
+        # Stop the finjector
+        stopped = True
+        background_failures.join()  # Wait for ip tables rules reset.
+        assert not background_failures.is_alive()
+        self.producer.stop()


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/5730.
Fixes https://github.com/redpanda-data/redpanda/issues/6907,