### PR TITLE
cloud_storage: stop uploads to S3 during upgrade from 22.2 to 22.3

### DIFF
--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "archival/ntp_archiver_service.h"
 #include "cluster/fwd.h"
+#include "features/fwd.h"
 #include "model/fundamental.h"
 #include "s3/client.h"
 #include "storage/ntp_config.h"
@@ -55,12 +56,14 @@ public:
       const configuration& conf,
       ss::sharded<cloud_storage::remote>& remote,
       ss::sharded<cluster::partition_manager>& pm,
-      ss::sharded<cluster::topic_table>& tt);
+      ss::sharded<cluster::topic_table>& tt,
+      ss::sharded<features::feature_table>& ft);
     scheduler_service_impl(
       ss::sharded<cloud_storage::remote>& remote,
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::topic_table>& tt,
-      ss::sharded<archival::configuration>& configs);
+      ss::sharded<archival::configuration>& configs,
+      ss::sharded<features::feature_table>& ft);
 
     /// \brief Configure scheduler service
     ///
@@ -125,6 +128,7 @@ private:
     configuration _conf;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::topic_table>& _topic_table;
+    ss::sharded<features::feature_table>& _feature_table;
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _timer;
     ss::gate _gate;

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -233,10 +233,10 @@ bool iobuf::operator==(std::string_view o) const {
  * @param limit maximum number of bytes to read.
  * @return a string populated with the following format:
  *
-00000000 | 7b 22 76 65 72 73 69 6f 6e  22 3a 31 2c 22 6e 61  | {"version":1,"na
-00000010 | 6d 65 73 70 61 63 65 22 3a  22 74 65 73 74 2d 6e  | mespace":"test-n
-00000020 | 73 22 2c 22 74 6f 70 69 63  22 3a 22 74 65 73 74  | s","topic":"test
-00000030 | 2d 74 6f 70 69 63 22 2c 22  70 61 72 74 69 74 69  | -topic","partiti
+00000000 | 7b 22 76 65 72 73 69 6f  6e 22 3a 31 2c 22 6e 61  | {"version":1,"na
+00000010 | 6d 65 73 70 61 63 65 22  3a 22 74 65 73 74 2d 6e  | mespace":"test-n
+00000020 | 73 22 2c 22 74 6f 70 69  63 22 3a 22 74 65 73 74  | s","topic":"test
+00000030 | 2d 74 6f 70 69 63 22 2c  22 70 61 72 74 69 74 69  | -topic","partiti
  */
 std::string iobuf::hexdump(size_t limit) const {
     constexpr size_t line_length = 16;
@@ -256,14 +256,15 @@ std::string iobuf::hexdump(size_t limit) const {
 
             auto c = data[i];
             result << fmt::format("{:02x} ", int(c));
-            if (trail.size() == 8) {
-                result << " ";
-            }
 
             if (std::isprint(c) && c != '\n') {
                 trail.push_back(c);
             } else {
                 trail.push_back('.');
+            }
+
+            if (trail.size() == 8) {
+                result << " ";
             }
 
             if (total >= limit) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -957,7 +957,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
           std::ref(cloud_storage_api),
           std::ref(partition_manager),
           std::ref(controller->get_topics_state()),
-          std::ref(arch_configs))
+          std::ref(arch_configs),
+          std::ref(_feature_table))
           .get();
         arch_configs.stop().get();
 

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -34,6 +34,10 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             try:
                 r = f(self, *args, **kwargs)
             except:
+                if not hasattr(self, 'redpanda') or self.redpanda is None:
+                    # We failed so early there isn't even a RedpandaService instantiated
+                    raise
+
                 self.redpanda.logger.exception(
                     "Test failed, doing failure checks...")
 
@@ -47,6 +51,11 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
 
                 raise
             else:
+                if not hasattr(self, 'redpanda') or self.redpanda is None:
+                    # We passed without instantiating a RedpandaService, for example
+                    # in a skipped test
+                    return r
+
                 self.redpanda.logger.info("Test passed, doing log checks...")
                 if check_allowed_error_logs:
                     # Only do log inspections on tests that are otherwise

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -20,6 +20,7 @@ class Segment:
         self.data_file = None
         self.base_index = None
         self.compaction_index = None
+        self.size = None
 
     def add_file(self, fn, ext):
         assert fn
@@ -43,6 +44,9 @@ class Segment:
         paths = map(lambda fn: os.path.join(self.partition.path, fn), files)
         return all(
             map(lambda path: self.partition.node.account.isfile(path), paths))
+
+    def set_size(self, s: int):
+        self.size = s
 
     def __repr__(self):
         return "{}:{}{}{}".format(self.name, "D" if self.data_file else "d",
@@ -69,6 +73,12 @@ class Partition:
                 self.segments[seg] = Segment(self, seg)
             seg = self.segments[seg]
             seg.add_file(fn, ext)
+
+    def set_segment_size(self, segment_name: str, size: int):
+        seg, _ = os.path.splitext(segment_name)
+        if not re.match(r"^\d+\-\d+\-v\d+$", seg):
+            return
+        self.segments[seg].set_size(size)
 
     def delete_indices(self, allow_fail=False):
         for _, segment in self.segments.items():

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -14,7 +14,7 @@ import requests
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -816,7 +816,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         partitions = 1 if self.debug_mode else 10
         return throughput, records, moves, partitions
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6837
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
     def test_shadow_indexing(self, num_to_upgrade):
@@ -847,7 +846,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             consumer_timeout_sec=45,
                             min_records=records)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6837
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
     def test_cross_shard(self, num_to_upgrade):

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -16,6 +16,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 from ducktape.mark import matrix
 
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
@@ -826,6 +827,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
+    @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_shadow_indexing(self, num_to_upgrade):
         """
         Test interaction between the shadow indexing and the partition movement.
@@ -868,6 +870,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
+    @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_cross_shard(self, num_to_upgrade):
         """
         Test interaction between the shadow indexing and the partition movement.

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -213,6 +213,30 @@ def wait_for_removal_of_n_segments(redpanda, topic: str, partition_idx: int,
                err_msg="Segments were not removed from all nodes")
 
 
+def wait_for_local_storage_truncate(redpanda,
+                                    topic: str,
+                                    partition_idx: int,
+                                    target_bytes: int,
+                                    timeout_sec: Optional[int] = None):
+    """
+    For use in tiered storage tests: wait until the locally retained data
+    size for this partition is below a threshold on all nodes.
+    """
+    def is_truncated():
+        storage = redpanda.storage(sizes=True)
+        sizes = []
+        for node_partition in storage.partitions("kafka", topic):
+            total_size = sum(s.size for s in node_partition.segments.values())
+            redpanda.logger.debug(
+                f"  {topic}/{partition_idx} node {node_partition.node.name} local size {total_size} ({len(node_partition.segments)} segments)"
+            )
+            sizes.append(total_size)
+
+        return all(s <= target_bytes for s in sizes)
+
+    wait_until(is_truncated, timeout_sec=timeout_sec, backoff_sec=1)
+
+
 def wait_for_segments_removal(redpanda,
                               topic,
                               partition_idx,


### PR DESCRIPTION
## Cover letter

In Redpanda 22.3 (cluster logical version 7), S3 segment naming
and partition manifest format change.  Therefore we must not
write anything into the new format while any nodes are still
on the old version (i.e. before feature is active).  This is
a simpler alternative than teaching Redpanda to conditionally
write the old format.

Fixes https://github.com/redpanda-data/redpanda/issues/6837

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none