### PR TITLE
Backports 6864 to v22.2.x

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -651,22 +651,27 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
     } else {
         // Create an implementation of refresh_credentials based on the setting
         // cloud_credentials_source.
-        _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
-          _cloud_credentials_source,
-          _gate,
-          _as,
-          std::move(credentials_update_cb),
-          _region_name));
+        try {
+            _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
+              _cloud_credentials_source,
+              _gate,
+              _as,
+              std::move(credentials_update_cb),
+              _region_name));
 
-        vlog(
-          cst_log.info,
-          "created credentials refresh implementation based on credentials "
-          "source "
-          "{}: {}",
-          _cloud_credentials_source,
-          *_refresh_credentials);
-
-        _refresh_credentials->start();
+            vlog(
+              cst_log.info,
+              "created credentials refresh implementation based on credentials "
+              "source {}: {}",
+              _cloud_credentials_source,
+              *_refresh_credentials);
+            _refresh_credentials->start();
+        } catch (const std::exception& ex) {
+            vlog(
+              cst_log.error,
+              "failed to initialize cloud storage authentication system: {}",
+              ex.what());
+        }
     }
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -986,13 +986,27 @@ void config_multi_property_validation(
     if (updated_config.cloud_storage_enabled()) {
         // The properties that cloud_storage::configuration requires
         // to be set if cloud storage is enabled.
-        std::vector<std::reference_wrapper<
-          const config::property<std::optional<ss::sstring>>>>
-          properties{
-            std::ref(updated_config.cloud_storage_secret_key),
-            std::ref(updated_config.cloud_storage_access_key),
-            std::ref(updated_config.cloud_storage_region),
-            std::ref(updated_config.cloud_storage_bucket)};
+        using config_properties_seq = std::vector<std::reference_wrapper<
+          const config::property<std::optional<ss::sstring>>>>;
+
+        config_properties_seq properties{};
+
+        if (
+          updated_config.cloud_storage_credentials_source
+          == model::cloud_credentials_source::config_file) {
+            properties = {
+              std::ref(updated_config.cloud_storage_region),
+              std::ref(updated_config.cloud_storage_bucket),
+              std::ref(updated_config.cloud_storage_access_key),
+              std::ref(updated_config.cloud_storage_secret_key),
+            };
+        } else {
+            properties = {
+              std::ref(updated_config.cloud_storage_region),
+              std::ref(updated_config.cloud_storage_bucket),
+            };
+        }
+
         for (auto& p : properties) {
             if (p() == std::nullopt) {
                 errors[ss::sstring(p.get().name())]

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -6,24 +6,25 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
+import json
+import pprint
+import re
+import tempfile
 import time
 from typing import Any, NamedTuple
-import requests
-import json
-import re
-import yaml
-import tempfile
 
-from rptest.services.admin import Admin
-from rptest.tests.redpanda_test import RedpandaTest
-from rptest.clients.rpk import RpkTool, RpkException
-from rptest.clients.rpk_remote import RpkRemoteTool
-from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.util import expect_exception, expect_http_error
+import requests
+import yaml
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.rpk_remote import RpkRemoteTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, IAM_ROLES_API_CALL_ALLOW_LIST
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_http_error
 
 BOOTSTRAP_CONFIG = {
     # A non-default value for checking bootstrap import works
@@ -1064,7 +1065,7 @@ class ClusterConfigTest(RedpandaTest):
         assert 'INVALID_CONFIG' in out
         assert "changing broker properties isn't supported via this API" in out
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=IAM_ROLES_API_CALL_ALLOW_LIST)
     def test_cloud_validation(self):
         """
         Cloud storage configuration has special multi-property rules, check
@@ -1076,25 +1077,78 @@ class ClusterConfigTest(RedpandaTest):
         with expect_http_error(400):
             self.admin.patch_cluster_config(upsert=invalid_update, remove=[])
 
-        # It is valid to enable cloud storage along with its accompanying properties
-        valid_update = {
+        # Required for STS to function correctly, the token file is just a placeholder
+        # to make the refresh credentials system boot up.
+        self.redpanda.set_environment({
+            'AWS_ROLE_ARN':
+            'role',
+            'AWS_WEB_IDENTITY_TOKEN_FILE':
+            '/etc/hosts'
+        })
+
+        # Exercise a set of valid combinations of access+secret keys and credentials sources
+        valid_updates = [
+            {
+                'cloud_storage_enabled': True,
+                'cloud_storage_credentials_source': 'aws_instance_metadata',
+                'cloud_storage_region': 'us-east-1',
+                'cloud_storage_bucket': 'dearliza'
+            },
+            {
+                'cloud_storage_enabled': True,
+                'cloud_storage_credentials_source': 'gcp_instance_metadata',
+                'cloud_storage_region': 'us-east-1',
+                'cloud_storage_bucket': 'dearliza'
+            },
+            {
+                'cloud_storage_enabled': True,
+                'cloud_storage_credentials_source': 'sts',
+                'cloud_storage_region': 'us-east-1',
+                'cloud_storage_bucket': 'dearliza'
+            },
+            {
+                'cloud_storage_enabled': True,
+                'cloud_storage_secret_key': 'open',
+                'cloud_storage_access_key': 'sesame',
+                'cloud_storage_credentials_source': 'config_file',
+                'cloud_storage_region': 'us-east-1',
+                'cloud_storage_bucket': 'dearliza'
+            },
+        ]
+        for payload in valid_updates:
+            # It is valid to remove keys from config when the credentials source is dynamic
+            removed = []
+            if 'cloud_storage_access_key' not in payload:
+                removed.append('cloud_storage_access_key')
+            if 'cloud_storage_secret_key' not in payload:
+                removed.append('cloud_storage_secret_key')
+            self.logger.debug(
+                f'patching with {pprint.pformat(payload, indent=1)}, removed keys: {removed}'
+            )
+            patch_result = self.admin.patch_cluster_config(upsert=payload,
+                                                           remove=removed)
+            self._wait_for_version_sync(patch_result['config_version'])
+
+            # Check we really set it properly, and Redpanda can restart without
+            # hitting a validation issue on startup (this is what would happen
+            # if the API validation wasn't working properly)
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Set the config to static for the next set of checks
+        static_config = {
             'cloud_storage_enabled': True,
             'cloud_storage_secret_key': 'open',
             'cloud_storage_access_key': 'sesame',
             'cloud_storage_region': 'us-east-1',
             'cloud_storage_bucket': 'dearliza'
         }
-        patch_result = self.admin.patch_cluster_config(upsert=valid_update,
+        patch_result = self.admin.patch_cluster_config(upsert=static_config,
                                                        remove=[])
         self._wait_for_version_sync(patch_result['config_version'])
-
-        # Check we really set it properly, and Redpanda can restart without
-        # hitting a validation issue on startup (this is what would happen
-        # if the API validation wasn't working properly)
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         # It is invalid to clear any required cloud storage properties while
-        # cloud storage is enabled
+        # cloud storage is enabled and the credentials source is static.
         forbidden_to_clear = [
             'cloud_storage_secret_key', 'cloud_storage_access_key',
             'cloud_storage_region', 'cloud_storage_bucket'


### PR DESCRIPTION
Backports #6864 to v22.2.x

this is a manual backport as automatic process failed: https://github.com/redpanda-data/redpanda/actions/runs/3298489137

[force push](https://github.com/redpanda-data/redpanda/compare/4f833351a16878dd6d59a0794ff8c4521381e516..7e2445feb41bcbd7ff9b7666c9a0522e806bc8c0) YAPF run to fix lint issues on redpanda.py