### PR TITLE
tests/KStreams: update commit SHA

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && \
 # many maven dependency downloads without any parallelism.  To avoid re-running it
 # on unrelated changes in other steps, this step is as early on the Dockerfile as possible.
 RUN git -C /opt clone https://github.com/redpanda-data/kafka-streams-examples.git && \
-    cd /opt/kafka-streams-examples && git reset --hard da50fa2723840f6388f99a1dae8d58104fd7650d && \
+    cd /opt/kafka-streams-examples && git reset --hard 913d08c8351c74ee454b79f8e0c1f48ca9b562a5 && \
     mvn -DskipTests=true clean package
 
 # Install our in-tree Java test clientst

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
-from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 
 from rptest.services.compatibility.example_runner import ExampleRunner
@@ -264,7 +263,6 @@ class KafkaStreamsWikipedia(RedpandaTest):
 
         self._timeout = 300
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/2889
     @cluster(num_nodes=5)
     def test_kafka_streams_wikipedia(self):
         example_jar = KafkaStreamExamples.KafkaStreamsWikipedia(


### PR DESCRIPTION
## Cover letter

The new SHA incorporates a small change to the KStreams Wikipedia example. Previously it was possible for 0 messages to be sent to topics. Now a minimum of 1 message is produced. This problem manifested as a ducktape timeout error since the test relies on parsing output.

Fixes: #2889

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Fixes a KafkaStreams integration test where zero messages were produced because of a random number generator. Now a minimum of one message is sent to topics.