### PR TITLE
[v22.2.x] rpc/transport: release caller units when timeout occurs

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -127,7 +127,8 @@ transport::send(netbuf b, rpc::client_opts opts) {
 }
 
 ss::future<result<std::unique_ptr<streaming_context>>>
-transport::make_response_handler(netbuf& b, const rpc::client_opts& opts) {
+transport::make_response_handler(
+  netbuf& b, const rpc::client_opts& opts, sequence_t seq) {
     if (_correlations.find(_correlation_idx + 1) != _correlations.end()) {
         _probe.client_correlation_error();
         vlog(
@@ -150,7 +151,14 @@ transport::make_response_handler(netbuf& b, const rpc::client_opts& opts) {
         throw std::logic_error(
           fmt::format("Tried to reuse correlation id: {}", idx));
     }
-    item_raw_ptr->with_timeout(opts.timeout, [this, idx] {
+    item_raw_ptr->with_timeout(opts.timeout, [this, idx, seq] {
+        /*
+         * remove pending entry from requests queue. If a timeout occurred
+         * before an entry was sent we can not keep the entry alive as it may
+         * contain caller semaphore units, the units must be released when we
+         * notify caller with the result.
+         */
+        _requests_queue.erase(seq);
         auto it = _correlations.find(idx);
         if (likely(it != _correlations.end())) {
             vlog(
@@ -179,7 +187,7 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
     return ss::with_gate(
       _dispatch_gate,
       [this, b = std::move(b), opts = std::move(opts), seq]() mutable {
-          auto f = make_response_handler(b, opts);
+          auto f = make_response_handler(b, opts, seq);
 
           // send
           auto sz = b.buffer().size_bytes();

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -91,7 +91,7 @@ private:
     void dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
-    make_response_handler(netbuf&, const rpc::client_opts&);
+    make_response_handler(netbuf&, const rpc::client_opts&, sequence_t);
 
     ssx::semaphore _memory;
     absl::flat_hash_map<uint32_t, std::unique_ptr<internal::response_handler>>


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6738.
Fixes https://github.com/redpanda-data/redpanda/issues/6926,