### PR TITLE
tests: retrofit to use Verifiable{Producer,Consumer}

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -52,11 +52,21 @@ class InstallOptions:
     """
     def __init__(self,
                  install_previous_version=False,
+                 install_prev_prev_version=False,
                  version=None,
                  num_to_upgrade=0):
         # If true, install the highest version of the prior feature version
         # before HEAD.
         self.install_previous_version = install_previous_version
+
+        # HACK: this is a part of a backport that requires new test infra to
+        # start Redpanda from two versions ago in EndToEndTest. Other test
+        # harnesses can just use the RedpandaInstaller directly to deduce and
+        # install the proper version.
+
+        # If true, install the highest version of the feature version two
+        # versions before HEAD.
+        self.install_prev_prev_version = install_prev_prev_version
 
         # Either RedpandaInstaller.HEAD or a numeric tuple representing the
         # version to install (e.g. (22, 1, 3)).

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -106,6 +106,11 @@ class EndToEndTest(Test):
             if install_opts.install_previous_version:
                 version_to_install = \
                     self.redpanda._installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+            if install_opts.install_prev_prev_version:
+                prev_version = \
+                    self.redpanda._installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+                version_to_install = \
+                    self.redpanda._installer.highest_from_prior_feature_version(prev_version)
             if install_opts.version:
                 version_to_install = install_opts.version
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -118,61 +118,34 @@ PREV_VERSION_LOG_ALLOW_LIST = [
 ]
 
 
-class UpgradeBackToBackTest(PreallocNodesTest):
+class UpgradeBackToBackTest(EndToEndTest):
     """
     Test that runs through two rolling upgrades while running through workloads.
     """
-    MSG_SIZE = 100
-    PRODUCE_COUNT = 100000
-    RANDOM_READ_COUNT = 100
-    RANDOM_READ_PARALLEL = 4
-    CONSUMER_GROUP_READERS = 4
-    topics = (TopicSpec(partition_count=3, replication_factor=3), )
+    def setUp(self):
+        super(UpgradeBackToBackTest, self).setUp()
+        # HACK: this is a part of a backport, but instead of porting over
+        # kgo-verifier that the original test depends on, this uses verifiers
+        # that exist on this branch.
 
-    def __init__(self, test_context):
-        if self.debug_mode:
-            self.MSG_SIZE = 10
-            self.RANDOM_READ_COUNT = 10
-            self.RANDOM_READ_PARALLEL = 1
-            self.CONSUMER_GROUP_READERS = 1
-            self.topics = (TopicSpec(partition_count=1,
-                                     replication_factor=3), )
-        super(UpgradeBackToBackTest, self).__init__(test_context,
-                                                    num_brokers=3,
-                                                    node_prealloc_count=1)
+        # Use a relatively low throughput to give the restarted node a chance
+        # to catch up. If the node is particularly slow compared to the others
+        # (e.g. a locally-built debug binary), catching up can take a while.
+        self.producer_msgs_per_sec = 10
+        install_opts = InstallOptions(install_prev_prev_version=True)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
         self.installer = self.redpanda._installer
         self.intermediate_version = self.installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
         self.initial_version = self.installer.highest_from_prior_feature_version(
             self.intermediate_version)
 
-        self._producer = KgoVerifierProducer(test_context, self.redpanda,
-                                             self.topic, self.MSG_SIZE,
-                                             self.PRODUCE_COUNT,
-                                             self.preallocated_nodes)
-        self._seq_consumer = KgoVerifierSeqConsumer(test_context,
-                                                    self.redpanda,
-                                                    self.topic,
-                                                    self.MSG_SIZE,
-                                                    self.preallocated_nodes,
-                                                    debug_logs=True)
-        self._rand_consumer = KgoVerifierRandomConsumer(
-            test_context, self.redpanda, self.topic, self.MSG_SIZE,
-            self.RANDOM_READ_COUNT, self.RANDOM_READ_PARALLEL,
-            self.preallocated_nodes)
-        self._cg_consumer = KgoVerifierConsumerGroupConsumer(
-            test_context, self.redpanda, self.topic, self.MSG_SIZE,
-            self.CONSUMER_GROUP_READERS, self.preallocated_nodes)
+        # Start running a workload.
+        spec = TopicSpec(name="topic", partition_count=2, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
 
-        self._consumers = [
-            self._seq_consumer, self._rand_consumer, self._cg_consumer
-        ]
-
-    def setUp(self):
-        self.installer.install(self.redpanda.nodes, self.initial_version)
-        super(UpgradeBackToBackTest, self).setUp()
-
-    @cluster(num_nodes=4, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @parametrize(single_upgrade=True)
     @parametrize(single_upgrade=False)
     def test_upgrade_with_all_workloads(self, single_upgrade):
@@ -185,15 +158,11 @@ class UpgradeBackToBackTest(PreallocNodesTest):
             self.redpanda.restart_nodes(self.redpanda.nodes,
                                         start_timeout=90,
                                         stop_timeout=90)
-        self._producer.start(clean=False)
-        self._producer.wait_for_offset_map()
-        wrote_at_least = self._producer.produce_status.acked
-        for consumer in self._consumers:
-            consumer.start(clean=False)
-
-        def stop_producer():
-            self._producer.wait()
-            assert self._producer.produce_status.acked == self.PRODUCE_COUNT
+        self.start_producer(num_nodes=1,
+                            enable_idempotence=True,
+                            throughput=self.producer_msgs_per_sec)
+        self.start_consumer(num_nodes=1)
+        self.await_startup(min_records=self.producer_msgs_per_sec)
 
         produce_during_upgrade = self.initial_version >= (22, 1, 0)
         if produce_during_upgrade:
@@ -206,7 +175,7 @@ class UpgradeBackToBackTest(PreallocNodesTest):
         else:
             # If there's no maintenance mode, write workloads during the
             # restart may be affected, so stop our writes up front.
-            stop_producer()
+            self.producer.stop()
             self.installer.install(self.redpanda.nodes,
                                    self.intermediate_version)
             self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
@@ -236,12 +205,7 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                                             start_timeout=90,
                                             stop_timeout=90)
 
-        for consumer in self._consumers:
-            consumer.wait()
-
-        assert self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least
-        assert self._rand_consumer.consumer_status.validator.total_reads >= self.RANDOM_READ_COUNT * self.RANDOM_READ_PARALLEL
-        assert self._cg_consumer.consumer_status.validator.valid_reads >= wrote_at_least
+        self.run_consumer_validation(enable_idempotence=True)
 
 
 class UpgradeWithWorkloadTest(EndToEndTest):


### PR DESCRIPTION
## Cover letter

I intend on backporting UpgradeBackToBackTest to v22.2.x.

UpgradeBackToBackTest uses kgo-verifier, which has been heavily updated on dev since v22.2. Rather than backporting the infra changes and corresponding updates to usage in tests, this commit swaps out the test's usage for the corresponding Verifiable* variants.

This commit is not meant to be merged to dev!

Pushing as a draft to dev because I see this locally resulting in some failures.

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
