### PR TITLE
Automatic Authentication for Schema Registry and HTTP Proxy - part2

### DIFF
--- a/src/v/cluster/ephemeral_credential_frontend.cc
+++ b/src/v/cluster/ephemeral_credential_frontend.cc
@@ -133,6 +133,17 @@ ss::future<std::error_code> ephemeral_credential_frontend::inform(
     if (err) {
         co_return err;
     }
+
+    if (_self == node_id) {
+        vlog(clusterlog.debug, "Inform self: {}", e_cred_res.credential);
+        co_await put(
+          e_cred_res.credential.principal(),
+          e_cred_res.credential.user(),
+          make_scram_credential(e_cred_res.credential));
+        co_return errc::success;
+    }
+
+    vlog(clusterlog.debug, "Inform {}: {}", node_id, e_cred_res.credential);
     auto req = put_ephemeral_credential_request{
       principal,
       e_cred_res.credential.user(),

--- a/src/v/config/fwd.h
+++ b/src/v/config/fwd.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace config {
+
+struct configuration;
+struct node_config;
+
+configuration& shard_local_cfg();
+node_config& node();
+
+} // namespace config

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -17,7 +17,10 @@ namespace kafka::client {
 ss::future<>
 do_authenticate(shared_broker_t broker, const configuration& config) {
     if (config.sasl_mechanism().empty()) {
-        vlog(kclog.debug, "Connecting to broker without authentication");
+        vlog(
+          kclog.debug,
+          "Connecting to broker {} without authentication",
+          broker->id());
         co_return;
     }
 
@@ -36,7 +39,8 @@ do_authenticate(shared_broker_t broker, const configuration& config) {
 
     vlog(
       kclog.debug,
-      "Connecting to broker with authentication: {}:{}",
+      "Connecting to broker {} with authentication: {}:{}",
+      broker->id(),
       mechanism,
       username);
 

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -53,6 +53,11 @@ static void fill_response(
 
         // acl entries
         for (auto& acl : entry.second) {
+            // ignore ephemeral_users
+            auto ephemeral_user = security::principal_type::ephemeral_user;
+            if (acl.principal().type() == ephemeral_user) {
+                continue;
+            }
             acl_description desc{
               .principal = details::to_kafka_principal(acl.principal()),
               .host = details::to_kafka_host(acl.host()),

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     server.cc
     kafka_client_cache.cc
     sharded_client_cache.cc
+    config_utils.cc
   DEPS
     v::pandaproxy_parsing
     v::pandaproxy_json

--- a/src/v/pandaproxy/config_utils.cc
+++ b/src/v/pandaproxy/config_utils.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/config_utils.h"
+
+#include "cluster/controller.h"
+#include "cluster/ephemeral_credential_frontend.h"
+#include "config/configuration.h"
+#include "kafka/client/client.h"
+#include "kafka/client/configuration.h"
+#include "seastarx.h"
+#include "security/acl.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/exception.hh>
+
+#include <exception>
+
+namespace pandaproxy {
+
+ss::future<std::unique_ptr<kafka::client::configuration>>
+create_client_credentials(
+  cluster::controller& controller,
+  config::configuration const& cluster_cfg,
+  kafka::client::configuration const& client_cfg,
+  security::acl_principal principal) {
+    auto new_cfg = std::make_unique<kafka::client::configuration>(
+      to_yaml(client_cfg, config::redact_secrets::no));
+
+    // If AuthZ is not enabled, don't create credentials.
+    if (!cluster_cfg.kafka_enable_authorization().value_or(
+          cluster_cfg.enable_sasl())) {
+        co_return new_cfg;
+    }
+
+    // If the configuration is overriden, use it.
+    if (
+      client_cfg.scram_password.is_overriden()
+      || client_cfg.scram_username.is_overriden()
+      || client_cfg.sasl_mechanism.is_overriden()) {
+        co_return new_cfg;
+    }
+
+    // Get the internal secret for user
+    auto& frontend = controller.get_ephemeral_credential_frontend().local();
+    auto pw = co_await frontend.get(principal);
+
+    if (pw.err != cluster::errc::success) {
+        co_return ss::coroutine::return_exception(
+          std::runtime_error(fmt::format(
+            "Failed to fetch credential for principal: {}", principal)));
+    }
+
+    new_cfg->sasl_mechanism.set_value(pw.credential.mechanism());
+    new_cfg->scram_username.set_value(pw.credential.user()());
+    new_cfg->scram_password.set_value(pw.credential.password()());
+
+    co_return new_cfg;
+}
+
+ss::future<> set_client_credentials(
+  kafka::client::configuration const& client_cfg,
+  ss::sharded<kafka::client::client>& client) {
+    co_await client.invoke_on_all([&client_cfg](kafka::client::client& client) {
+        client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());
+        client.config().scram_username.set_value(client_cfg.scram_username());
+        client.config().scram_password.set_value(client_cfg.scram_password());
+    });
+}
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/config_utils.h
+++ b/src/v/pandaproxy/config_utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "config/fwd.h"
+#include "kafka/client/fwd.h"
+#include "seastarx.h"
+#include "security/acl.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+#include <vector>
+
+namespace pandaproxy {
+
+ss::future<std::unique_ptr<kafka::client::configuration>>
+create_client_credentials(
+  cluster::controller& controller,
+  config::configuration const& cluster_cfg,
+  kafka::client::configuration const& client_cfg,
+  security::acl_principal principal);
+
+ss::future<> set_client_credentials(
+  kafka::client::configuration const& client_cfg,
+  ss::sharded<kafka::client::client>& client);
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -43,7 +43,10 @@ ss::future<> api::start() {
     _store = std::make_unique<sharded_store>();
     co_await _store->start(_sg);
     co_await _client.start(
-      config::to_yaml(_client_cfg, config::redact_secrets::no));
+      config::to_yaml(_client_cfg, config::redact_secrets::no),
+      [this](std::exception_ptr ex) {
+          return _service.local().mitigate_error(ex);
+      });
     co_await _sequencer.start(
       _node_id, _sg, std::ref(_client), std::ref(*_store));
     co_await _service.start(

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -150,12 +150,11 @@ ss::future<> service::do_start() {
         co_await configure();
         co_await create_internal_topic();
         co_await fetch_internal_topic();
-        vlog(
-          plog.info, "Schema registry successfully initialized internal topic");
+        vlog(plog.info, "Schema registry successfully initialized");
     } catch (...) {
         vlog(
           plog.error,
-          "Schema registry failed to initialize internal topic: {}",
+          "Schema registry failed to initialize: {}",
           std::current_exception());
         throw;
     }

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -57,6 +57,7 @@ public:
 
 private:
     ss::future<> do_start();
+    ss::future<> configure();
     ss::future<> inform(model::node_id);
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -53,9 +53,11 @@ public:
     seq_writer& writer() { return _writer.local(); }
     sharded_store& schema_store() { return _store; }
     request_authenticator& authenticator() { return _auth; }
+    ss::future<> mitigate_error(std::exception_ptr);
 
 private:
     ss::future<> do_start();
+    ss::future<> inform(model::node_id);
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
     configuration _config;
@@ -70,6 +72,7 @@ private:
 
     one_shot _ensure_started;
     request_authenticator _auth;
+    bool _has_ephemeral_credentials{false};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/test/CMakeLists.txt
+++ b/src/v/pandaproxy/test/CMakeLists.txt
@@ -19,3 +19,13 @@ rp_test(
   ARGS "-- -c 1"
   LABELS pandaproxy
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_fixture
+  SOURCES
+    test_config_utils.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::application
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/test/test_config_utils.cc
+++ b/src/v/pandaproxy/test/test_config_utils.cc
@@ -1,0 +1,143 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/base_property.h"
+#include "config/configuration.h"
+#include "config/node_config.h"
+#include "config/tls_config.h"
+#include "json/ostreamwrapper.h"
+#include "json/writer.h"
+#include "kafka/client/client.h"
+#include "kafka/client/configuration.h"
+#include "model/namespace.h"
+#include "pandaproxy/config_utils.h"
+#include "redpanda/tests/fixture.h"
+#include "security/acl.h"
+#include "security/ephemeral_credential_store.h"
+#include "security/sasl_authentication.h"
+#include "security/scram_authenticator.h"
+#include "security/types.h"
+
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <yaml-cpp/emitter.h>
+
+#include <chrono>
+
+namespace pp = pandaproxy;
+
+namespace kafka::client {
+// BOOST_REQURE_EQUAL fails to find this if it's in the global namespace
+bool operator==(configuration const& lhs, configuration const& rhs) {
+    return fmt::format("{}", config::to_yaml(lhs, config::redact_secrets::no))
+           == fmt::format(
+             "{}", config::to_yaml(rhs, config::redact_secrets::no));
+}
+
+std::ostream& operator<<(std::ostream& os, configuration const& c) {
+    YAML::Emitter e{os};
+    auto n = config::to_yaml(c, config::redact_secrets::no);
+    n.SetStyle(YAML::EmitterStyle::value::Block);
+    n["brokers"].SetStyle(YAML::EmitterStyle::value::Block);
+    n["broker_tls"].SetStyle(YAML::EmitterStyle::value::Block);
+    e << n;
+    return os;
+}
+} // namespace kafka::client
+
+namespace {
+
+template<typename T>
+std::unique_ptr<T> clone_config(T const& t) {
+    return T{config::to_yaml(t), config::redact_secrets::no};
+}
+
+} // namespace
+
+FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    auto const& ec_store
+      = app.controller->get_ephemeral_credential_store().local();
+
+    // Default configuration doesn't have a SASL listener
+    config::node_config node_cfg;
+    config::configuration& cluster_cfg{lconf()};
+
+    // Default configuration doesn't override anything
+    kafka::client::configuration client_cfg;
+
+    security::acl_principal principal{
+      security::principal_type::ephemeral_user, "ephemeral_user"};
+
+    const auto create_credentials = [&, this]() {
+        return pp::create_client_credentials(
+          *app.controller, cluster_cfg, client_cfg, principal);
+    };
+
+    // Default configuration, no authz - expect no changes
+    {
+        auto config = create_credentials().get();
+        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
+    }
+
+    const auto sasl_ep = config::broker_authn_endpoint{
+      .name = "sasl",
+      .address = net::unresolved_address{"127.0.0.2", 9092},
+      .authn_method = config::broker_authn_method::sasl};
+
+    // Configure a sasl listener:
+    {
+        std::vector<config::broker_authn_endpoint> kafka_api;
+        kafka_api.push_back(sasl_ep);
+        node_cfg.kafka_api.property::set_value(kafka_api);
+    }
+
+    // Expect no changes as authz isn't enabled:
+    {
+        auto config = create_credentials().get();
+        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
+    }
+
+    // Expect no changes when credentials overriden:
+    {
+        client_cfg.scram_username.set_value(ss::sstring{"user"});
+        client_cfg.scram_password.set_value(ss::sstring{"pass"});
+        client_cfg.sasl_mechanism.set_value(
+          ss::sstring{security::scram_sha512_authenticator::name});
+
+        auto config = create_credentials().get();
+        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
+
+        // reset the credentials
+        client_cfg.scram_username.reset();
+        client_cfg.scram_password.reset();
+        client_cfg.sasl_mechanism.reset();
+    }
+
+    // Enable authz
+    cluster_cfg.kafka_enable_authorization.set_value(std::optional<bool>(true));
+
+    // Expect credentials are created.
+    {
+        auto config = create_credentials().get();
+        BOOST_REQUIRE_EQUAL(
+          config->sasl_mechanism(), security::scram_sha512_authenticator::name);
+        BOOST_REQUIRE(config->scram_username.is_overriden());
+        BOOST_REQUIRE(config->scram_password.is_overriden());
+        BOOST_REQUIRE(ec_store.has(ec_store.find(principal)));
+    }
+}

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -390,6 +390,7 @@ class SecurityConfig:
         self.require_client_auth: bool = True
         self.pp_authn_method: Optional[str] = None
         self.sr_authn_method: Optional[str] = None
+        self.auto_auth: Optional[bool] = None
 
         # The rules to extract principal from mtls
         self.principal_mapping_rules = self.__DEFAULT_PRINCIPAL_MAPPING_RULES
@@ -1702,7 +1703,8 @@ class RedpandaService(Service):
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
                            pp_authn_method=self._security.pp_authn_method,
-                           sr_authn_method=self._security.sr_authn_method)
+                           sr_authn_method=self._security.sr_authn_method,
+                           auto_auth=self._security.auto_auth)
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -104,7 +104,7 @@ schema_registry_client:
 
   retries: 10
   retry_base_backoff_ms: 10
-  {% if sasl_enabled %}
+  {% if sasl_enabled and not auto_auth %}
   sasl_mechanism: {{superuser[2]}}
   scram_username: {{superuser[0]}}
   scram_password: {{superuser[1]}}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -22,7 +22,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.python_librdkafka_serde_client import SerdeClient, SchemaType
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import ResourceSettings, SecurityConfig
+from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig
 
 
 def create_topic_names(count):
@@ -57,6 +57,13 @@ message Test2 {
   Simple id =  1;
 }"""
 
+log_config = LoggingConfig('info',
+                           logger_levels={
+                               'security': 'trace',
+                               'pandaproxy': 'trace',
+                               'kafka/client': 'trace'
+                           })
+
 
 class SchemaRegistryEndpoints(RedpandaTest):
     """
@@ -70,6 +77,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
             enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
             resource_settings=ResourceSettings(num_cpus=1),
+            log_config=log_config,
             **kwargs)
 
         http.client.HTTPConnection.debuglevel = 1


### PR DESCRIPTION
## Cover letter

Wire up Schema Registry and REST Proxy (todo) to allow automatic authorisation via ephemeral secrets, introduced in #6777.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

When SASL and authorisation are enabled on Redpanda, it is no longer required to specify the credentials in `redpanda.yaml`, although it is still possible for backwards comaptibility.

## Release notes

### Features

* Schema Registry and REST Proxy can now use ephemeral credentials to authenticate with Redpanda.