### PR TITLE
storage: upper bound on frequency of snapshots

### DIFF
--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -372,18 +372,13 @@ ss::future<> configuration_manager::maybe_store_highest_known_offset(
     _highest_known_offset = offset;
     _bytes_since_last_offset_update += bytes;
 
-    auto take_result = _storage.resources().configuration_manager_take_bytes(
-      bytes);
-    if (_bytes_since_last_offset_update_units.count()) {
-        _bytes_since_last_offset_update_units.adopt(
-          std::move(take_result.units));
-    } else {
-        _bytes_since_last_offset_update_units = std::move(take_result.units);
-    }
+    auto checkpoint_hint
+      = _storage.resources().configuration_manager_take_bytes(
+        bytes, _bytes_since_last_offset_update_units);
 
     if (
       _bytes_since_last_offset_update < offset_update_treshold
-      && !take_result.checkpoint_hint) {
+      && !checkpoint_hint) {
         co_return;
     }
 

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -43,14 +43,8 @@ void offset_translator::process(const model::record_batch& batch) {
 
     // Update resource manager for the extra dirty bytes, it may hint us
     // to checkpoint early in response.
-    auto take_result = _storage_api.resources().offset_translator_take_bytes(
-      batch.size_bytes());
-    if (_bytes_processed_units.count() == 0) {
-        _bytes_processed_units = std::move(take_result.units);
-    } else {
-        _bytes_processed_units.adopt(std::move(take_result.units));
-    }
-    _checkpoint_hint |= take_result.checkpoint_hint;
+    _checkpoint_hint |= _storage_api.resources().offset_translator_take_bytes(
+      batch.size_bytes(), _bytes_processed_units);
 
     if (
       std::find(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1538,13 +1538,9 @@ int64_t disk_log_impl::compaction_backlog() const {
  * exceeded a threshold.
  */
 void disk_log_impl::wrote_stm_bytes(size_t byte_size) {
-    auto take_result = _manager.resources().stm_take_bytes(byte_size);
-    if (_stm_dirty_bytes_units.count()) {
-        _stm_dirty_bytes_units.adopt(std::move(take_result.units));
-    } else {
-        _stm_dirty_bytes_units = std::move(take_result.units);
-    }
-    if (take_result.checkpoint_hint) {
+    auto checkpoint_hint = _manager.resources().stm_take_bytes(
+      byte_size, _stm_dirty_bytes_units);
+    if (checkpoint_hint) {
         _stm_manager->make_snapshot_in_background();
         _stm_dirty_bytes_units.return_all();
     }

--- a/src/v/storage/storage_resources.cc
+++ b/src/v/storage/storage_resources.cc
@@ -42,6 +42,7 @@ storage_resources::storage_resources(
         _offset_translator_dirty_bytes.set_capacity(v);
         _stm_dirty_bytes.set_capacity(v);
         _configuration_manager_dirty_bytes.set_capacity(v);
+        update_min_checkpoint_bytes();
     });
 
     _max_concurrent_replay.watch([this]() {
@@ -91,9 +92,21 @@ void storage_resources::update_allowance(uint64_t total, uint64_t free) {
     _falloc_step = calc_falloc_step();
 }
 
+void storage_resources::update_min_checkpoint_bytes() {
+    if (_partition_count) {
+        // Limit the checkpoint frequency to 2x what it would be under
+        // uniform traffic to all partitions. This permits us to overshoot
+        // target_replay_bytes by approx 50% under non-uniform writes.
+        _min_checkpoint_bytes = _target_replay_bytes() / (_partition_count * 2);
+    } else {
+        _min_checkpoint_bytes = 0;
+    }
+}
+
 void storage_resources::update_partition_count(size_t partition_count) {
     _partition_count = partition_count;
     _falloc_step_dirty = true;
+    update_min_checkpoint_bytes();
 }
 
 size_t storage_resources::calc_falloc_step() {
@@ -166,37 +179,54 @@ storage_resources::get_falloc_step(std::optional<uint64_t> segment_size_hint) {
     return step;
 }
 
-adjustable_allowance::take_result
-storage_resources::offset_translator_take_bytes(int32_t bytes) {
+bool storage_resources::offset_translator_take_bytes(
+  int32_t bytes, ssx::semaphore_units& units) {
     vlog(
       stlog.trace,
       "offset_translator_take_bytes {} (current {})",
+      units.count(),
       bytes,
       _offset_translator_dirty_bytes.current());
 
-    return _offset_translator_dirty_bytes.take(bytes);
+    return filter_checkpoints(
+      _offset_translator_dirty_bytes.take(bytes), units);
 }
 
-adjustable_allowance::take_result
-storage_resources::configuration_manager_take_bytes(size_t bytes) {
+bool storage_resources::configuration_manager_take_bytes(
+  size_t bytes, ssx::semaphore_units& units) {
     vlog(
       stlog.trace,
-      "configuration_manager_take_bytes {} (current {})",
+      "configuration_manager_take_bytes {} += {} (current {})",
+      units.count(),
       bytes,
       _configuration_manager_dirty_bytes.current());
 
-    return _configuration_manager_dirty_bytes.take(bytes);
+    return filter_checkpoints(
+      _configuration_manager_dirty_bytes.take(bytes), units);
 }
 
-adjustable_allowance::take_result
-storage_resources::stm_take_bytes(size_t bytes) {
+bool storage_resources::stm_take_bytes(
+  size_t bytes, ssx::semaphore_units& units) {
     vlog(
       stlog.trace,
-      "stm_take_bytes {} (current {})",
+      "stm_take_bytes {} += {} (current {})",
+      units.count(),
       bytes,
       _stm_dirty_bytes.current());
 
-    return _stm_dirty_bytes.take(bytes);
+    return filter_checkpoints(_stm_dirty_bytes.take(bytes), units);
+}
+
+bool storage_resources::filter_checkpoints(
+  adjustable_allowance::take_result&& tr, ssx::semaphore_units& units) {
+    // Adopt units from the take_result into the caller's unit store
+    if (units.count()) {
+        units.adopt(std::move(tr.units));
+    } else {
+        units = std::move(tr.units);
+    }
+
+    return tr.checkpoint_hint && (units.count() > _min_checkpoint_bytes);
 }
 
 adjustable_allowance::take_result

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -132,13 +132,13 @@ public:
     size_t get_falloc_step(std::optional<uint64_t>);
     size_t calc_falloc_step();
 
-    adjustable_allowance::take_result
-    offset_translator_take_bytes(int32_t bytes);
+    bool
+    offset_translator_take_bytes(int32_t bytes, ssx::semaphore_units& units);
 
-    adjustable_allowance::take_result
-    configuration_manager_take_bytes(size_t bytes);
+    bool
+    configuration_manager_take_bytes(size_t bytes, ssx::semaphore_units& units);
 
-    adjustable_allowance::take_result stm_take_bytes(size_t bytes);
+    bool stm_take_bytes(size_t bytes, ssx::semaphore_units& units);
 
     adjustable_allowance::take_result compaction_index_take_bytes(size_t bytes);
     bool compaction_index_bytes_available() {
@@ -153,6 +153,25 @@ public:
         return _inflight_close_flush.get_units(1);
     }
 
+    /**
+     * An adjustable_allowance will set checkpoint_hint whenever its units
+     * are exhausted, but this can happen with pathological frequency if
+     * many units are hogged by partitions that have written a lot of
+     * data then stopped.
+     *
+     * To mitigate this, filter out checkpoint hints if the partition
+     * taking units is not occupying more than a threshold number of
+     * units.  This means that instead of doing an avalanche of snapshots
+     * under this unpleasant state, we will instead violate target_replay_bytes
+     */
+    bool filter_checkpoints(
+      adjustable_allowance::take_result&&, ssx::semaphore_units&);
+
+    /**
+     * Call this when the partition count or the target replay bytes changes
+     */
+    void update_min_checkpoint_bytes();
+
 private:
     uint64_t _space_allowance{9};
     uint64_t _space_allowance_free{0};
@@ -163,6 +182,13 @@ private:
     config::binding<uint64_t> _max_concurrent_replay;
     config::binding<uint64_t> _compaction_index_mem_limit;
     size_t _append_chunk_size;
+
+    // A lower bound on how many units a caller must have to be
+    // eligible for flush, to prevent pathological case where on caller
+    // happens to repeatedly request units close to the parent semaphore
+    // being exhausted
+    // See https://github.com/redpanda-data/redpanda/issues/6854
+    uint64_t _min_checkpoint_bytes{0};
 
     size_t _falloc_step{0};
     bool _falloc_step_dirty{false};


### PR DESCRIPTION
## Cover letter

...driven by target_replay_bytes.

This helps if a workload consumes almost all of the target_replay_bytes allowance on one partition, then stops writing that partition and starts writing others.

Previously writes to other partitions could have induced a snapshot as frequently as every write, as every take() from the semaphore would hit the limit to set checkpoint_hint.

With this change, we will only set checkpoint_hint if the caller has taken half of their ideal share of the target_replay_bytes already: thereby limiting their snapshot rate to 2x what it would be under uniform writes to partitions.  The tradeoff is that such workloads may now exceed target_replay_bytes by 50%.

Related: https://github.com/redpanda-data/redpanda/issues/6854

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Fix an issue where state machine snapshots could degrade performance under certain workloads (#6854)