### PR TITLE
rpk/cfg: rename Default to DevDefault and add ProdDefault

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -217,7 +217,7 @@ func (r *ConfigMapResource) CreateConfiguration(
 	ctx context.Context,
 ) (*configuration.GlobalConfiguration, error) {
 	cfg := configuration.For(r.pandaCluster.Spec.Version)
-	cfg.NodeConfiguration = *config.Default()
+	cfg.NodeConfiguration = *config.ProdDefault()
 	mountPoints := resourcetypes.GetTLSMountPoints()
 
 	c := r.pandaCluster.Spec.Configuration

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "13b7ea49c811062afe2a6d275604929e",
+			expectedHash:            "3700f26a4631d5ab31e148352fdea7e0",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "4b241955a317f47a6a06960a333ed661",
+			expectedHash: "24f0b08129b48a3c8f091f13b84e1f1d",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "533227069ff8ee6791b874db60480b40",
+			expectedHash: "e3ab006a8c5db2957c16f982bc6db694",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -135,7 +135,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	}
 
 	hostRPCPort, err := getHostPort(
-		config.Default().Redpanda.RPCServer.Port,
+		config.DevDefault().Redpanda.RPCServer.Port,
 		containerJSON,
 	)
 	if err != nil {
@@ -225,7 +225,7 @@ func CreateNode(
 ) (*NodeState, error) {
 	rPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
+		strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port),
 	)
 	if err != nil {
 		return nil, err
@@ -275,13 +275,13 @@ func CreateNode(
 		"--schema-registry-addr",
 		net.JoinHostPort(ip, strconv.Itoa(config.DefaultSchemaRegPort)),
 		"--rpc-addr",
-		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
+		net.JoinHostPort(ip, strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port)),
 		"--advertise-kafka-addr",
 		AdvertiseAddresses(ip, config.DefaultKafkaPort, kafkaPort),
 		"--advertise-pandaproxy-addr",
 		AdvertiseAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--advertise-rpc-addr",
-		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
+		net.JoinHostPort(ip, strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port)),
 		"--mode dev-container",
 	}
 	containerConfig := container.Config{

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -242,7 +242,7 @@ func startCluster(
 				"--seeds",
 				net.JoinHostPort(
 					seedState.ContainerIP,
-					strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
+					strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port),
 				),
 			}
 			state, err := common.CreateNode(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -228,7 +228,7 @@ func parseSelfIP(self string) (net.IP, error) {
 }
 
 func parseSeedIPs(ips []string) ([]config.SeedServer, error) {
-	defaultRPCPort := config.Default().Redpanda.RPCServer.Port
+	defaultRPCPort := config.DevDefault().Redpanda.RPCServer.Port
 	var seeds []config.SeedServer
 
 	for _, i := range ips {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBootstrap(t *testing.T) {
-	defaultRPCPort := config.Default().Redpanda.RPCServer.Port
+	defaultRPCPort := config.DevDefault().Redpanda.RPCServer.Port
 	tests := []struct {
 		name           string
 		ips            []string
@@ -159,7 +159,7 @@ func TestInitNode(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			c := config.Default()
+			c := config.DevDefault()
 			if test.prevID != "" {
 				c.NodeUUID = test.prevID
 			}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func fillRpkConfig(path, mode string) *config.Config {
-	conf := config.Default()
+	conf := config.DevDefault()
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
 	conf.Rpk = config.RpkConfig{

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -238,7 +238,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if len(proxyAPI) > 0 {
 				if cfg.Pandaproxy == nil {
-					cfg.Pandaproxy = config.Default().Pandaproxy
+					cfg.Pandaproxy = config.DevDefault().Pandaproxy
 				}
 				cfg.Pandaproxy.PandaproxyAPI = proxyAPI
 			}
@@ -259,7 +259,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if len(schemaRegAPI) > 0 {
 				if cfg.SchemaRegistry == nil {
-					cfg.SchemaRegistry = config.Default().SchemaRegistry
+					cfg.SchemaRegistry = config.DevDefault().SchemaRegistry
 				}
 				cfg.SchemaRegistry.SchemaRegistryAPI = schemaRegAPI
 			}
@@ -270,7 +270,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			)
 			rpcServer, err := parseAddress(
 				rpcAddr,
-				config.Default().Redpanda.RPCServer.Port,
+				config.DevDefault().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
 				return err
@@ -314,7 +314,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if advProxyAPI != nil {
 				if cfg.Pandaproxy == nil {
-					cfg.Pandaproxy = config.Default().Pandaproxy
+					cfg.Pandaproxy = config.DevDefault().Pandaproxy
 				}
 				cfg.Pandaproxy.AdvertisedPandaproxyAPI = advProxyAPI
 			}
@@ -325,7 +325,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			)
 			advRPCApi, err := parseAddress(
 				advertisedRPC,
-				config.Default().Redpanda.RPCServer.Port,
+				config.DevDefault().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
 				return err
@@ -350,7 +350,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 
 			if cfg.Redpanda.Directory == "" {
-				cfg.Redpanda.Directory = config.Default().Redpanda.Directory
+				cfg.Redpanda.Directory = config.DevDefault().Redpanda.Directory
 			}
 
 			err = prestart(fs, rpArgs, cfg, prestartCfg, timeout)
@@ -845,7 +845,7 @@ func parseFlags(flags []string) map[string]string {
 
 func parseSeeds(seeds []string) ([]config.SeedServer, error) {
 	seedServers := []config.SeedServer{}
-	defaultPort := config.Default().Redpanda.RPCServer.Port
+	defaultPort := config.DevDefault().Redpanda.RPCServer.Port
 	for _, s := range seeds {
 		addr, err := parseAddress(s, defaultPort)
 		if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -240,7 +240,7 @@ func TestStartCommand(t *testing.T) {
 				"The config should have been created at '%s'",
 				path,
 			)
-			c := config.Default()
+			c := config.DevDefault()
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
@@ -463,7 +463,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			cfg := config.Default()
+			cfg := config.DevDefault()
 			return cfg.Write(fs)
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
@@ -493,7 +493,7 @@ func TestStartCommand(t *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
 			// Check that the generated config is as expected.
-			require.Exactly(st, config.Default().Redpanda.ID, conf.Redpanda.ID)
+			require.Exactly(st, config.DevDefault().Redpanda.ID, conf.Redpanda.ID)
 		},
 	}, {
 		name: "it should write default data_directory if loaded config doesn't have one",
@@ -502,7 +502,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			conf := config.Default()
+			conf := config.DevDefault()
 			conf.Redpanda.Directory = ""
 			return conf.Write(fs)
 		},
@@ -514,7 +514,7 @@ func TestStartCommand(t *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
 			// Check that the generated config is as expected.
-			require.Exactly(st, config.Default().Redpanda.Directory, conf.Redpanda.Directory)
+			require.Exactly(st, config.DevDefault().Redpanda.Directory, conf.Redpanda.Directory)
 		},
 	}, {
 		name: "it should leave redpanda.node_id untouched if --node-id wasn't passed",
@@ -589,7 +589,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			conf := config.Default()
+			conf := config.DevDefault()
 			return conf.Write(fs)
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
@@ -598,7 +598,7 @@ func TestStartCommand(t *testing.T) {
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,
-				config.Default().Rpk.Overprovisioned,
+				config.DevDefault().Rpk.Overprovisioned,
 				conf.Rpk.Overprovisioned,
 			)
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
@@ -55,7 +55,7 @@ func TestStopCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.Default()
+			conf := config.DevDefault()
 			command := baseCommand
 			// trap the signals we want to ignore, to check that the
 			// signal escalation is working.

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -27,7 +27,7 @@ const (
 	DefaultBallastFileSize = "1GiB"
 )
 
-func Default() *Config {
+func DevDefault() *Config {
 	return &Config{
 		fileLocation: DefaultPath,
 		Redpanda: RedpandaNodeConfig{
@@ -55,6 +55,11 @@ func Default() *Config {
 		Pandaproxy:     &Pandaproxy{},
 		SchemaRegistry: &SchemaRegistry{},
 	}
+}
+
+func ProdDefault() *Config {
+	cfg := DevDefault()
+	return setProduction(cfg)
 }
 
 func SetMode(mode string, conf *Config) (*Config, error) {
@@ -90,7 +95,7 @@ func setDevelopment(conf *Config) *Config {
 		AdditionalStartFlags: conf.Rpk.AdditionalStartFlags,
 		EnableUsageStats:     conf.Rpk.EnableUsageStats,
 		CoredumpDir:          conf.Rpk.CoredumpDir,
-		SMP:                  Default().Rpk.SMP,
+		SMP:                  DevDefault().Rpk.SMP,
 		BallastFilePath:      conf.Rpk.BallastFilePath,
 		BallastFileSize:      conf.Rpk.BallastFileSize,
 		Overprovisioned:      true,
@@ -150,7 +155,7 @@ func (c *Config) FileOrDefaults() *Config {
 	if c.File() != nil {
 		return c.File()
 	} else {
-		cfg := Default()
+		cfg := DevDefault()
 		// --config set but the file doesn't exist yet:
 		if c.fileLocation != "" {
 			cfg.fileLocation = c.fileLocation

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -248,7 +248,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 			}
 		}
 	}
-	c := Default()
+	c := DevDefault()
 
 	if err := p.readConfig(fs, c); err != nil {
 		// Sometimes a config file will not exist (e.g. rpk running on MacOS),

--- a/src/go/rpk/pkg/system/metrics_test.go
+++ b/src/go/rpk/pkg/system/metrics_test.go
@@ -30,7 +30,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			return afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -45,7 +45,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			err := afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -67,7 +67,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			err := afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -89,7 +89,7 @@ func TestGatherMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.Default()
+			conf := config.DevDefault()
 			if tt.conf != nil {
 				conf = tt.conf()
 			}

--- a/src/go/rpk/pkg/tuners/coredump/tuner_test.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func validConfig() *config.Config {
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.TuneCoredump = true
 	conf.Rpk.CoredumpDir = "/var/lib/redpanda/coredumps"
 	return conf

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -52,7 +52,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 			expected: func() *factory.TunerParams {
 				params := getValidTunerParams()
 				params.Directories = []string{
-					config.Default().Redpanda.Directory,
+					config.DevDefault().Redpanda.Directory,
 				}
 				return params
 			},
@@ -61,7 +61,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := config.Default()
+			conf := config.DevDefault()
 			res, err := factory.MergeTunerParamsConfig(tt.tunerParams(), conf)
 			require.NoError(t, err)
 			expected := tt.expected()


### PR DESCRIPTION
## Cover letter

This PR includes:

- Renaming `cfg.Default()` to `cfg.DevDefault()`
- Create `cfg.ProdDefault` that is the same default + mode prod.
- Make the operator use `cfg.ProdDefault`

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
