### PR TITLE
tests: fix log allow list on UpgradeFromPriorFeatureVersionCloudStora…

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -362,7 +362,10 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         log_allow_list=RESTART_LOG_ALLOW_LIST +
         # FIXME: 22.2->22.3 manifests are incompatible and not feature-gated currently:
         # https://github.com/redpanda-data/redpanda/issues/6837
-        ["partition_manifest.cc.*Failed to parse topic manifest"])
+        [
+            "partition_manifest.cc.*Failed to parse topic manifest",
+            "Failed to create archivers"
+        ])
     def test_rolling_upgrade(self):
         initial_version = Version(
             self.redpanda.get_version(self.redpanda.nodes[0]))


### PR DESCRIPTION
## Cover letter

…geTest

The scenario this test expects can occur in a way that trips an extra error log line.

This will go away properly in the PR that sorts out cloud storage upgrades: https://github.com/redpanda-data/redpanda/pull/6913

Fixes: https://github.com/redpanda-data/redpanda/pull/6923

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
