### PR TITLE
k8s: Add human redable representation of config in tests

### DIFF
--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -12,6 +12,7 @@ package resources_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -102,9 +103,9 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 	}{
 		{
 			name:                    "Primitive object in additional configuration",
-			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
+			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000", "rpk.overprovisioned": "true"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "3700f26a4631d5ab31e148352fdea7e0",
+			expectedHash:            "5a3cf863cd61e3cfda0c586fad11c13c",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -157,6 +158,15 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			for _, es := range tc.expectedStrings {
 				require.True(t, strings.Contains(data, es), fmt.Sprintf("expecting %s but got %v", es, data))
 			}
+
+			fileName := strings.ReplaceAll("./testdata/"+tc.name+".golden", " ", "_")
+			if os.Getenv("OVERWRITE_GOLDEN_FILES") != "" {
+				err = os.WriteFile(fileName, []byte(data), 0o600)
+				require.NoError(t, err)
+			}
+			golden, err := os.ReadFile(fileName)
+			require.NoError(t, err)
+			require.Equal(t, string(golden), data)
 			hash, err := cfgRes.GetNodeConfigHash(context.TODO())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedHash, hash)

--- a/src/go/k8s/pkg/resources/testdata/Complex_struct_in_additional_configuration.golden
+++ b/src/go/k8s/pkg/resources/testdata/Complex_struct_in_additional_configuration.golden
@@ -1,0 +1,46 @@
+redpanda:
+    data_directory: /var/lib/redpanda/data
+    seed_servers:
+        - host:
+            address: cluster-0.cluster.local
+            port: 33145
+    rpc_server:
+        address: 0.0.0.0
+        port: 33145
+    kafka_api:
+        - address: 0.0.0.0
+          port: 123
+          name: kafka
+    admin:
+        - address: 0.0.0.0
+          port: 345
+          name: admin
+    cloud_storage_cache_directory: /var/lib/shadow-index-cache
+    advertised_rpc_api:
+        address: 0.0.0.0
+        port: 33145
+    auto_create_topics_enabled: false
+    cloud_storage_cache_size: "10737418240"
+    cloud_storage_disable_tls: false
+    cloud_storage_enabled: true
+    cloud_storage_secret_key: XXX
+    cloud_storage_segment_max_upload_interval_sec: 1800
+    log_segment_size: 536870912
+rpk:
+    tune_network: true
+    tune_disk_scheduler: true
+    tune_disk_nomerges: true
+    tune_disk_write_cache: true
+    tune_disk_irq: true
+    tune_cpu: true
+    tune_aio_events: true
+    tune_clocksource: true
+    tune_swappiness: true
+    coredump_dir: /var/lib/redpanda/coredump
+    tune_ballast_file: true
+pandaproxy: {}
+schema_registry:
+    schema_registry_api:
+        - address: 0.0.0.0
+          port: 8081
+          name: external

--- a/src/go/k8s/pkg/resources/testdata/Primitive_object_in_additional_configuration.golden
+++ b/src/go/k8s/pkg/resources/testdata/Primitive_object_in_additional_configuration.golden
@@ -1,0 +1,44 @@
+redpanda:
+    data_directory: /var/lib/redpanda/data
+    seed_servers:
+        - host:
+            address: cluster-0.cluster.local
+            port: 33145
+    rpc_server:
+        address: 0.0.0.0
+        port: 33145
+    kafka_api:
+        - address: 0.0.0.0
+          port: 123
+          name: kafka
+    admin:
+        - address: 0.0.0.0
+          port: 345
+          name: admin
+    cloud_storage_cache_directory: /var/lib/shadow-index-cache
+    advertised_rpc_api:
+        address: 0.0.0.0
+        port: 33145
+    auto_create_topics_enabled: false
+    cloud_storage_cache_size: "10737418240"
+    cloud_storage_disable_tls: false
+    cloud_storage_enabled: true
+    cloud_storage_secret_key: XXX
+    cloud_storage_segment_max_upload_interval_sec: 1800
+    log_segment_size: 536870912
+    transactional_id_expiration_ms: 25920000000
+rpk:
+    tune_network: true
+    tune_disk_scheduler: true
+    tune_disk_nomerges: true
+    tune_disk_write_cache: true
+    tune_disk_irq: true
+    tune_cpu: true
+    tune_aio_events: true
+    tune_clocksource: true
+    tune_swappiness: true
+    coredump_dir: /var/lib/redpanda/coredump
+    tune_ballast_file: true
+    overprovisioned: true
+pandaproxy: {}
+schema_registry: {}

--- a/src/go/k8s/pkg/resources/testdata/shadow_index_cache_directory.golden
+++ b/src/go/k8s/pkg/resources/testdata/shadow_index_cache_directory.golden
@@ -1,0 +1,42 @@
+redpanda:
+    data_directory: /var/lib/redpanda/data
+    seed_servers:
+        - host:
+            address: cluster-0.cluster.local
+            port: 33145
+    rpc_server:
+        address: 0.0.0.0
+        port: 33145
+    kafka_api:
+        - address: 0.0.0.0
+          port: 123
+          name: kafka
+    admin:
+        - address: 0.0.0.0
+          port: 345
+          name: admin
+    cloud_storage_cache_directory: /var/lib/shadow-index-cache
+    advertised_rpc_api:
+        address: 0.0.0.0
+        port: 33145
+    auto_create_topics_enabled: false
+    cloud_storage_cache_size: "10737418240"
+    cloud_storage_disable_tls: false
+    cloud_storage_enabled: true
+    cloud_storage_secret_key: XXX
+    cloud_storage_segment_max_upload_interval_sec: 1800
+    log_segment_size: 536870912
+rpk:
+    tune_network: true
+    tune_disk_scheduler: true
+    tune_disk_nomerges: true
+    tune_disk_write_cache: true
+    tune_disk_irq: true
+    tune_cpu: true
+    tune_aio_events: true
+    tune_clocksource: true
+    tune_swappiness: true
+    coredump_dir: /var/lib/redpanda/coredump
+    tune_ballast_file: true
+pandaproxy: {}
+schema_registry: {}


### PR DESCRIPTION
## Cover letter

This PR adds human readable representation of the Redpanda configuration in operator tests.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

It doesn't affect any user.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none