### PR TITLE
Fix RackAwarePlacementTest.test_node_config_update

### DIFF
--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -231,6 +231,10 @@
                     "type": "long",
                     "description": "cores"
                 },
+                "rack": {
+                    "type": "string",
+                    "description": "rack id"
+                },
                 "membership_status": {
                     "type": "string",
                     "description": "Broker membership status"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -645,6 +645,9 @@ get_brokers(cluster::controller* const controller) {
               ss::httpd::broker_json::broker b;
               b.node_id = broker->id();
               b.num_cores = broker->properties().cores;
+              if (broker->rack()) {
+                  b.rack = *broker->rack();
+              }
               b.membership_status = fmt::format(
                 "{}", broker->get_membership_state());
 
@@ -1904,6 +1907,9 @@ void admin_server::register_broker_routes() {
           ss::httpd::broker_json::broker ret;
           ret.node_id = (*broker)->id();
           ret.num_cores = (*broker)->properties().cores;
+          if ((*broker)->rack()) {
+              ret.rack = *(*broker)->rack();
+          }
           ret.membership_status = fmt::format(
             "{}", (*broker)->get_membership_state());
           ret.maintenance_status = fill_maintenance_status(

--- a/tests/rptest/tests/rack_aware_replica_placement_test.py
+++ b/tests/rptest/tests/rack_aware_replica_placement_test.py
@@ -65,7 +65,7 @@ class RackAwarePlacementTest(RedpandaTest):
                             num_replicas,
                             ids_mapping={}):
         """Validate the replica placement. The method uses provided
-        rack layout and number of replicas for the partitions. 
+        rack layout and number of replicas for the partitions.
         The validation is done by examining existing replica placemnt
         against the rack layout. The validation succedes if every replica
         is placed on a different rack or if there is not enough racks on
@@ -281,6 +281,19 @@ class RackAwarePlacementTest(RedpandaTest):
         for ix, node in enumerate(self.redpanda.nodes):
             self.redpanda.start_node(
                 node, override_cfg_params={"rack": rack_layout[ix]})
+
+        admin = Admin(self.redpanda)
+
+        def rack_ids_updated():
+            for n in self.redpanda.nodes:
+                if any('rack' not in b for b in admin.get_brokers(n)):
+                    return False
+            return True
+
+        wait_until(rack_ids_updated,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="node configurations didn't get updated")
 
         topic = TopicSpec(partition_count=num_partitions,
                           replication_factor=replication_factor)


### PR DESCRIPTION
## Cover letter

Because nodes update their configs asynchrounously, update can finish after the node successfully starts and after we try to create one of the topics (leading to partition allocator using old node configs). To fix this we wait until all nodes see the updated rack ids.

Fixes #6924

## Backport Required

- [x] issue does not exist in previous branches

## UX changes
none

## Release notes
* none
