### PR TITLE
storage/tests: Fix jitter_percents initialization

### DIFF
--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -59,6 +59,7 @@ struct log_config {
       : stype(type)
       , base_dir(std::move(directory))
       , max_segment_size(config::mock_binding<size_t>(std::move(segment_size)))
+      , segment_size_jitter(0) // For deterministic behavior in unit tests.
       , compacted_segment_size(config::mock_binding<size_t>(256_MiB))
       , max_compacted_segment_size(config::mock_binding<size_t>(5_GiB))
       , sanitize_fileops(should)

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -889,7 +889,7 @@ std::filesystem::path compacted_index_path(std::filesystem::path segment_path) {
 
 float random_jitter(jitter_percents jitter_percents) {
     vassert(
-      jitter_percents >= 0 || jitter_percents <= 100,
+      jitter_percents >= 0 && jitter_percents <= 100,
       "jitter percents should be in range [0,100]. Requested {}",
       jitter_percents);
     // multiply by 10 to increase resolution

--- a/src/v/storage/tests/segment_size_jitter_test.cc
+++ b/src/v/storage/tests/segment_size_jitter_test.cc
@@ -13,18 +13,12 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(test_segment_size_jitter_calculation) {
-    storage::log_config cfg(
-      storage::log_config::storage_type::disk,
-      "/tmp",
-      100_MiB,
-      storage::debug_sanitize_files::yes);
-
+    constexpr auto jitter = storage::jitter_percents(5);
     std::array<size_t, 5> sizes = {1_GiB, 2_GiB, 100_MiB, 300_MiB, 10_GiB};
     for (auto original_size : sizes) {
         for (int i = 0; i < 100; ++i) {
-            auto new_sz
-              = original_size
-                * (1 + storage::internal::random_jitter(cfg.segment_size_jitter));
+            auto new_sz = original_size
+                          * (1 + storage::internal::random_jitter(jitter));
             BOOST_REQUIRE_GE(new_sz, 0.95f * original_size);
             BOOST_REQUIRE_LE(new_sz, 1.05f * original_size);
         }

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -238,8 +238,6 @@ public:
           storage::debug_sanitize_files::yes,
           ss::default_priority_class(),
           cache);
-
-        cfg.segment_size_jitter = storage::jitter_percents(0);
         return cfg;
     }
 


### PR DESCRIPTION

Fixes #6930

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none
