### PR TITLE
V22.2.x rpk prod defaults

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -216,7 +216,7 @@ func (r *ConfigMapResource) CreateConfiguration(
 	ctx context.Context,
 ) (*configuration.GlobalConfiguration, error) {
 	cfg := configuration.For(r.pandaCluster.Spec.Version)
-	cfg.NodeConfiguration = *config.Default()
+	cfg.NodeConfiguration = *config.ProdDefault()
 	mountPoints := resourcetypes.GetTLSMountPoints()
 
 	c := r.pandaCluster.Spec.Configuration

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -104,7 +104,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "a3a81f47c734ebcd16ba339c77c7c4c0",
+			expectedHash:            "98864fe2d49162d4bcb1454c2b12bca6",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -114,7 +114,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "cfc65ce54611c67feef7270e8c1d41ba",
+			expectedHash: "f88a65981acb1fe4940880e3b863ebf5",
 		},
 		{
 			name: "shadow index cache directory",
@@ -122,7 +122,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "791074a427c1b5006459bc466586d1a5",
+			expectedHash: "43c0b0d801b8413e6973266bd7cac9bc",
 		},
 	}
 	for _, tc := range testcases {

--- a/src/go/rpk/pkg/api/api_test.go
+++ b/src/go/rpk/pkg/api/api_test.go
@@ -45,7 +45,7 @@ func TestSendMetrics(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.EnableUsageStats = true
 	err = sendMetricsToURL(body, ts.URL, *conf)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestSkipSendMetrics(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.EnableUsageStats = false
 	err := sendMetricsToURL(metricsBody{}, ts.URL, *conf)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestSendEnvironment(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.EnableUsageStats = true
 	err = sendEnvironmentToURL(body, ts.URL, *conf)
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestSkipSendEnvironment(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.EnableUsageStats = false
 	err := sendEnvironmentToURL(environmentBody{}, ts.URL, *conf)
 	require.NoError(t, err)

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -135,7 +135,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	}
 
 	hostRPCPort, err := getHostPort(
-		config.Default().Redpanda.RPCServer.Port,
+		config.DevDefault().Redpanda.RPCServer.Port,
 		containerJSON,
 	)
 	if err != nil {
@@ -225,7 +225,7 @@ func CreateNode(
 ) (*NodeState, error) {
 	rPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
+		strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port),
 	)
 	if err != nil {
 		return nil, err
@@ -275,13 +275,13 @@ func CreateNode(
 		"--schema-registry-addr",
 		net.JoinHostPort(ip, strconv.Itoa(config.DefaultSchemaRegPort)),
 		"--rpc-addr",
-		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
+		net.JoinHostPort(ip, strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port)),
 		"--advertise-kafka-addr",
 		AdvertiseAddresses(ip, config.DefaultKafkaPort, kafkaPort),
 		"--advertise-pandaproxy-addr",
 		AdvertiseAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--advertise-rpc-addr",
-		net.JoinHostPort(ip, strconv.Itoa(config.Default().Redpanda.RPCServer.Port)),
+		net.JoinHostPort(ip, strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port)),
 		"--mode dev-container",
 	}
 	containerConfig := container.Config{

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -242,7 +242,7 @@ func startCluster(
 				"--seeds",
 				net.JoinHostPort(
 					seedState.ContainerIP,
-					strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
+					strconv.Itoa(config.DevDefault().Redpanda.RPCServer.Port),
 				),
 			}
 			state, err := common.CreateNode(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -226,7 +226,7 @@ func parseSelfIP(self string) (net.IP, error) {
 }
 
 func parseSeedIPs(ips []string) ([]config.SeedServer, error) {
-	defaultRPCPort := config.Default().Redpanda.RPCServer.Port
+	defaultRPCPort := config.DevDefault().Redpanda.RPCServer.Port
 	var seeds []config.SeedServer
 
 	for _, i := range ips {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBootstrap(t *testing.T) {
-	defaultRPCPort := config.Default().Redpanda.RPCServer.Port
+	defaultRPCPort := config.DevDefault().Redpanda.RPCServer.Port
 	tests := []struct {
 		name           string
 		ips            []string
@@ -159,7 +159,7 @@ func TestInitNode(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			c := config.Default()
+			c := config.DevDefault()
 			if test.prevID != "" {
 				c.NodeUUID = test.prevID
 			}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func fillRpkConfig(path, mode string) *config.Config {
-	conf := config.Default()
+	conf := config.DevDefault()
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
 	conf.Rpk = config.RpkConfig{

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -243,7 +243,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if len(proxyAPI) > 0 {
 				if cfg.Pandaproxy == nil {
-					cfg.Pandaproxy = config.Default().Pandaproxy
+					cfg.Pandaproxy = config.DevDefault().Pandaproxy
 				}
 				cfg.Pandaproxy.PandaproxyAPI = proxyAPI
 			}
@@ -265,7 +265,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if len(schemaRegAPI) > 0 {
 				if cfg.SchemaRegistry == nil {
-					cfg.SchemaRegistry = config.Default().SchemaRegistry
+					cfg.SchemaRegistry = config.DevDefault().SchemaRegistry
 				}
 				cfg.SchemaRegistry.SchemaRegistryAPI = schemaRegAPI
 			}
@@ -276,7 +276,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			)
 			rpcServer, err := parseAddress(
 				rpcAddr,
-				config.Default().Redpanda.RPCServer.Port,
+				config.DevDefault().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
 				sendEnv(fs, env, cfg, !prestartCfg.checkEnabled, err)
@@ -323,7 +323,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 			if advProxyAPI != nil {
 				if cfg.Pandaproxy == nil {
-					cfg.Pandaproxy = config.Default().Pandaproxy
+					cfg.Pandaproxy = config.DevDefault().Pandaproxy
 				}
 				cfg.Pandaproxy.AdvertisedPandaproxyAPI = advProxyAPI
 			}
@@ -334,7 +334,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			)
 			advRPCApi, err := parseAddress(
 				advertisedRPC,
-				config.Default().Redpanda.RPCServer.Port,
+				config.DevDefault().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
 				sendEnv(fs, env, cfg, !prestartCfg.checkEnabled, err)
@@ -362,7 +362,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			}
 
 			if cfg.Redpanda.Directory == "" {
-				cfg.Redpanda.Directory = config.Default().Redpanda.Directory
+				cfg.Redpanda.Directory = config.DevDefault().Redpanda.Directory
 			}
 
 			checkPayloads, tunerPayloads, err := prestart(
@@ -893,7 +893,7 @@ func parseFlags(flags []string) map[string]string {
 
 func parseSeeds(seeds []string) ([]config.SeedServer, error) {
 	seedServers := []config.SeedServer{}
-	defaultPort := config.Default().Redpanda.RPCServer.Port
+	defaultPort := config.DevDefault().Redpanda.RPCServer.Port
 	for _, s := range seeds {
 		addr, err := parseAddress(s, defaultPort)
 		if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -240,7 +240,7 @@ func TestStartCommand(t *testing.T) {
 				"The config should have been created at '%s'",
 				path,
 			)
-			c := config.Default()
+			c := config.DevDefault()
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
@@ -463,7 +463,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			cfg := config.Default()
+			cfg := config.DevDefault()
 			return cfg.Write(fs)
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
@@ -493,7 +493,7 @@ func TestStartCommand(t *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
 			// Check that the generated config is as expected.
-			require.Exactly(st, config.Default().Redpanda.ID, conf.Redpanda.ID)
+			require.Exactly(st, config.DevDefault().Redpanda.ID, conf.Redpanda.ID)
 		},
 	}, {
 		name: "it should write default data_directory if loaded config doesn't have one",
@@ -502,7 +502,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			conf := config.Default()
+			conf := config.DevDefault()
 			conf.Redpanda.Directory = ""
 			return conf.Write(fs)
 		},
@@ -514,7 +514,7 @@ func TestStartCommand(t *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(st, err)
 			// Check that the generated config is as expected.
-			require.Exactly(st, config.Default().Redpanda.Directory, conf.Redpanda.Directory)
+			require.Exactly(st, config.DevDefault().Redpanda.Directory, conf.Redpanda.Directory)
 		},
 	}, {
 		name: "it should leave redpanda.node_id untouched if --node-id wasn't passed",
@@ -588,7 +588,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 		},
 		before: func(fs afero.Fs) error {
-			conf := config.Default()
+			conf := config.DevDefault()
 			return conf.Write(fs)
 		},
 		postCheck: func(fs afero.Fs, _ *redpanda.RedpandaArgs, st *testing.T) {
@@ -597,7 +597,7 @@ func TestStartCommand(t *testing.T) {
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,
-				config.Default().Rpk.Overprovisioned,
+				config.DevDefault().Rpk.Overprovisioned,
 				conf.Rpk.Overprovisioned,
 			)
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
@@ -55,7 +55,7 @@ func TestStopCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.Default()
+			conf := config.DevDefault()
 			command := baseCommand
 			// trap the signals we want to ignore, to check that the
 			// signal escalation is working.

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -27,7 +27,7 @@ const (
 	DefaultBallastFileSize = "1GiB"
 )
 
-func Default() *Config {
+func DevDefault() *Config {
 	return &Config{
 		fileLocation: DefaultPath,
 		Redpanda: RedpandaNodeConfig{
@@ -55,6 +55,11 @@ func Default() *Config {
 		Pandaproxy:     &Pandaproxy{},
 		SchemaRegistry: &SchemaRegistry{},
 	}
+}
+
+func ProdDefault() *Config {
+	cfg := DevDefault()
+	return setProduction(cfg)
 }
 
 func SetMode(mode string, conf *Config) (*Config, error) {
@@ -90,7 +95,7 @@ func setDevelopment(conf *Config) *Config {
 		AdditionalStartFlags: conf.Rpk.AdditionalStartFlags,
 		EnableUsageStats:     conf.Rpk.EnableUsageStats,
 		CoredumpDir:          conf.Rpk.CoredumpDir,
-		SMP:                  Default().Rpk.SMP,
+		SMP:                  DevDefault().Rpk.SMP,
 		BallastFilePath:      conf.Rpk.BallastFilePath,
 		BallastFileSize:      conf.Rpk.BallastFileSize,
 		Overprovisioned:      true,
@@ -150,7 +155,7 @@ func (c *Config) FileOrDefaults() *Config {
 	if c.File() != nil {
 		return c.File()
 	} else {
-		cfg := Default()
+		cfg := DevDefault()
 		// --config set but the file doesn't exist yet:
 		if c.fileLocation != "" {
 			cfg.fileLocation = c.fileLocation

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func getValidConfig() *Config {
-	conf := Default()
+	conf := DevDefault()
 	conf.Redpanda.SeedServers = []SeedServer{
 		{SocketAddress{"127.0.0.1", 33145}},
 		{SocketAddress{"127.0.0.1", 33146}},
@@ -441,8 +441,8 @@ tune_cpu: true`,
 	}
 }
 
-func TestDefault(t *testing.T) {
-	defaultConfig := Default()
+func TestDevDefault(t *testing.T) {
+	defaultConfig := DevDefault()
 	expected := &Config{
 		fileLocation:   DefaultPath,
 		Pandaproxy:     &Pandaproxy{},
@@ -465,6 +465,45 @@ func TestDefault(t *testing.T) {
 		Rpk: RpkConfig{
 			CoredumpDir:     "/var/lib/redpanda/coredump",
 			Overprovisioned: true,
+		},
+	}
+	require.Exactly(t, expected, defaultConfig)
+}
+
+func TestProdDefault(t *testing.T) {
+	defaultConfig := ProdDefault()
+	expected := &Config{
+		fileLocation:   DefaultPath,
+		Pandaproxy:     &Pandaproxy{},
+		SchemaRegistry: &SchemaRegistry{},
+		Redpanda: RedpandaNodeConfig{
+			Directory: "/var/lib/redpanda/data",
+			RPCServer: SocketAddress{"0.0.0.0", 33145},
+			KafkaAPI: []NamedAuthNSocketAddress{{
+				Address: "0.0.0.0",
+				Port:    9092,
+			}},
+			AdminAPI: []NamedSocketAddress{{
+				Address: "0.0.0.0",
+				Port:    9644,
+			}},
+			SeedServers:   []SeedServer{},
+			DeveloperMode: false,
+		},
+		Rpk: RpkConfig{
+			CoredumpDir:        "/var/lib/redpanda/coredump",
+			Overprovisioned:    false,
+			TuneAioEvents:      true,
+			TuneBallastFile:    true,
+			TuneCPU:            true,
+			TuneClocksource:    true,
+			TuneDiskIrq:        true,
+			TuneDiskScheduler:  true,
+			TuneDiskWriteCache: true,
+			TuneFstrim:         false,
+			TuneNetwork:        true,
+			TuneNomerges:       true,
+			TuneSwappiness:     true,
 		},
 	}
 	require.Exactly(t, expected, defaultConfig)
@@ -689,7 +728,7 @@ schema_registry: {}
 func TestSetMode(t *testing.T) {
 	fillRpkConfig := func(mode string) func() *Config {
 		return func() *Config {
-			conf := Default()
+			conf := DevDefault()
 			val := mode == ModeProd
 			conf.Redpanda.DeveloperMode = !val
 			conf.Rpk = RpkConfig{
@@ -751,7 +790,7 @@ func TestSetMode(t *testing.T) {
 		{
 			name: "it should preserve all the values that shouldn't be reset",
 			startingConf: func() *Config {
-				conf := Default()
+				conf := DevDefault()
 				conf.Rpk.AdminAPI = RpkAdminAPI{
 					Addresses: []string{"some.addr.com:33145"},
 				}
@@ -786,7 +825,7 @@ func TestSetMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
-			defaultConf := Default()
+			defaultConf := DevDefault()
 			if tt.startingConf != nil {
 				defaultConf = tt.startingConf()
 			}

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -249,7 +249,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 			}
 		}
 	}
-	c := Default()
+	c := DevDefault()
 
 	if err := p.readConfig(fs, c); err != nil {
 		// Sometimes a config file will not exist (e.g. rpk running on MacOS),

--- a/src/go/rpk/pkg/system/metrics_test.go
+++ b/src/go/rpk/pkg/system/metrics_test.go
@@ -30,7 +30,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			return afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -45,7 +45,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			err := afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -67,7 +67,7 @@ func TestGatherMetrics(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			err := afero.WriteFile(
 				fs,
-				config.Default().PIDFile(),
+				config.DevDefault().PIDFile(),
 				// Usual /proc/sys/kernel/pid_max value
 				[]byte("4194304"),
 				0o755,
@@ -89,7 +89,7 @@ func TestGatherMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.Default()
+			conf := config.DevDefault()
 			if tt.conf != nil {
 				conf = tt.conf()
 			}

--- a/src/go/rpk/pkg/tuners/coredump/tuner_test.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func validConfig() *config.Config {
-	conf := config.Default()
+	conf := config.DevDefault()
 	conf.Rpk.TuneCoredump = true
 	conf.Rpk.CoredumpDir = "/var/lib/redpanda/coredumps"
 	return conf

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -52,7 +52,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 			expected: func() *factory.TunerParams {
 				params := getValidTunerParams()
 				params.Directories = []string{
-					config.Default().Redpanda.Directory,
+					config.DevDefault().Redpanda.Directory,
 				}
 				return params
 			},
@@ -61,7 +61,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := config.Default()
+			conf := config.DevDefault()
 			res, err := factory.MergeTunerParamsConfig(tt.tunerParams(), conf)
 			require.NoError(t, err)
 			expected := tt.expected()


### PR DESCRIPTION
This is a backport of #6933

The behavior was introduced in 22.2, so we only need to backport to 22.2

## Release notes

### Improvements

* k8s operator no longer defaults to setting `--overprovisioned=true`