### PR TITLE
rpk httpapi: avoid 'any'

### DIFF
--- a/src/go/rpk/pkg/httpapi/httpapi.go
+++ b/src/go/rpk/pkg/httpapi/httpapi.go
@@ -200,8 +200,8 @@ func (cl *Client) With(opts ...Opt) *Client {
 
 // Pathfmt accepts a format string path and path-escapes all args into it with
 // fmt.Sprintf. This only supports %s path formatting.
-func Pathfmt(path string, args ...any) string {
-	encoded := make([]any, len(args))
+func Pathfmt(path string, args ...interface{}) string {
+	encoded := make([]interface{}, len(args))
 	for i, arg := range args {
 		encoded[i] = url.PathEscape(fmt.Sprint(arg))
 	}
@@ -224,7 +224,7 @@ func Values(kvs ...string) url.Values {
 // Get GETs the given path, attaching qps as query parameters if non-nil, and
 // optionally decodes the response body into 'into' if non-nil following the
 // rules of the package documentation.
-func (cl *Client) Get(ctx context.Context, path string, qps url.Values, into any) error {
+func (cl *Client) Get(ctx context.Context, path string, qps url.Values, into interface{}) error {
 	return cl.do(ctx, http.MethodGet, path, qps, nil, into)
 }
 
@@ -232,7 +232,7 @@ func (cl *Client) Get(ctx context.Context, path string, qps url.Values, into any
 // optionally decodes the response body into 'into' if non-nil following the
 // rules of the package documentation. If body is non-nil, it is json encoded
 // as a request body. The required ct parameter sets the Content-Type.
-func (cl *Client) Post(ctx context.Context, path string, qps url.Values, ct string, body, into any) error {
+func (cl *Client) Post(ctx context.Context, path string, qps url.Values, ct string, body, into interface{}) error {
 	cl = cl.With(Headers("Content-Type", ct))
 	return cl.do(ctx, http.MethodPost, path, qps, body, into)
 }
@@ -244,7 +244,7 @@ func (cl *Client) Post(ctx context.Context, path string, qps url.Values, ct stri
 //
 // This is the same as POST with form values, but the Content-Type is
 // automatically set to "application/x-www-form-urlencoded".
-func (cl *Client) PostForm(ctx context.Context, path string, qps, form url.Values, into any) error {
+func (cl *Client) PostForm(ctx context.Context, path string, qps, form url.Values, into interface{}) error {
 	return cl.do(ctx, http.MethodPost, path, qps, form, into)
 }
 
@@ -252,18 +252,18 @@ func (cl *Client) PostForm(ctx context.Context, path string, qps, form url.Value
 // optionally decodes the response body into 'into' if non-nil following the
 // rules of the package documentation. If body is non-nil, it is json encoded
 // as a request body.
-func (cl *Client) Put(ctx context.Context, path string, qps url.Values, body, into any) error {
+func (cl *Client) Put(ctx context.Context, path string, qps url.Values, body, into interface{}) error {
 	return cl.do(ctx, http.MethodPut, path, qps, body, into)
 }
 
 // Delete DELETEs the given path, attaching qps as query parameters if non-nil, and
 // optionally decodes the response body into 'into' if non-nil following the
 // rules of the package documentation.
-func (cl *Client) Delete(ctx context.Context, path string, qps url.Values, into any) error {
+func (cl *Client) Delete(ctx context.Context, path string, qps url.Values, into interface{}) error {
 	return cl.do(ctx, http.MethodDelete, path, qps, nil, into)
 }
 
-func (cl *Client) do(ctx context.Context, method, path string, qps url.Values, body, into any) error {
+func (cl *Client) do(ctx context.Context, method, path string, qps url.Values, body, into interface{}) error {
 	fullURL, err := cl.prepareURL(path, qps)
 	if err != nil {
 		return err
@@ -362,7 +362,7 @@ func (cl *Client) prepareURL(path string, qps url.Values) (string, error) {
 	return u.String(), nil
 }
 
-func prepareBody(body any) (bodyBytes []byte, isValues bool, err error) {
+func prepareBody(body interface{}) (bodyBytes []byte, isValues bool, err error) {
 	if body == nil {
 		return nil, false, nil
 	}

--- a/src/go/rpk/pkg/httpapi/httpapi_test.go
+++ b/src/go/rpk/pkg/httpapi/httpapi_test.go
@@ -24,7 +24,7 @@ func TestAll(t *testing.T) {
 		name string
 
 		cl *Client
-		fn func(*Client) (any, error)
+		fn func(*Client) (interface{}, error)
 
 		respHeader int
 		resp       string
@@ -34,13 +34,13 @@ func TestAll(t *testing.T) {
 		expPath    string
 		expHeaders http.Header
 		expReqBody string
-		expResp    any
+		expResp    interface{}
 		expErr     bool
 	}{
 		{
 			name: "basic_into_string",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				var s string
 				return s, cl.Get(context.Background(), "/foo", nil, &s)
 			},
@@ -58,7 +58,7 @@ func TestAll(t *testing.T) {
 		}, {
 			name: "basic_into_bytes_with_retries",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				var b []byte
 				return b, cl.Get(context.Background(), "/foo2", nil, &b)
 			},
@@ -90,7 +90,7 @@ func TestAll(t *testing.T) {
 				),
 				UserAgent("foo"), // overrides Headers set above
 			),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				return nil, cl.Post(
 					context.Background(),
 					"/bigly",
@@ -118,7 +118,7 @@ func TestAll(t *testing.T) {
 		}, {
 			name: "post_form",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				var s struct {
 					Body string
 				}
@@ -147,7 +147,7 @@ func TestAll(t *testing.T) {
 		}, {
 			name: "put_with_iowriter_resp",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				b := new(bytes.Buffer)
 				return b, cl.Put(context.Background(), "/put", nil, true, b)
 			},
@@ -163,11 +163,11 @@ func TestAll(t *testing.T) {
 			},
 			expPath:    "/put",
 			expReqBody: "true",
-			expResp:    func() any { b := new(bytes.Buffer); b.WriteString("hello"); return b }(),
+			expResp:    func() interface{} { b := new(bytes.Buffer); b.WriteString("hello"); return b }(),
 		}, {
 			name: "delete",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				return nil, cl.Delete(context.Background(), "/del", nil, nil)
 			},
 			respHeader: 200,
@@ -182,7 +182,7 @@ func TestAll(t *testing.T) {
 		}, {
 			name: "get_pathfmt_err",
 			cl:   NewClient(Host(s.URL)),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				return nil, cl.Get(context.Background(), Pathfmt("/%s/%s", 2, "/"), nil, nil)
 			},
 			respHeader: 403,
@@ -198,22 +198,22 @@ func TestAll(t *testing.T) {
 		}, {
 			name:   "missing_host_in_path",
 			cl:     NewClient(),
-			fn:     func(cl *Client) (any, error) { return nil, cl.Get(context.Background(), "/", nil, nil) },
+			fn:     func(cl *Client) (interface{}, error) { return nil, cl.Get(context.Background(), "/", nil, nil) },
 			expErr: true,
 		}, {
 			name:   "missing_url_entirely",
 			cl:     NewClient(),
-			fn:     func(cl *Client) (any, error) { return nil, cl.Get(context.Background(), "", nil, nil) },
+			fn:     func(cl *Client) (interface{}, error) { return nil, cl.Get(context.Background(), "", nil, nil) },
 			expErr: true,
 		}, {
 			name:   "invalid_query",
 			cl:     NewClient(Host((s.URL))),
-			fn:     func(cl *Client) (any, error) { return nil, cl.Get(context.Background(), "/?;", nil, nil) },
+			fn:     func(cl *Client) (interface{}, error) { return nil, cl.Get(context.Background(), "/?;", nil, nil) },
 			expErr: true,
 		}, {
 			name: "canceled_context",
 			cl:   NewClient(Host((s.URL))),
-			fn: func(cl *Client) (any, error) {
+			fn: func(cl *Client) (interface{}, error) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return nil, cl.Get(ctx, "/", nil, nil)


### PR DESCRIPTION
'any' was introduced in 1.19, but vtools is currently pinned to 1.17. Switching to interface avoids test failures.

We missed this because the PR introducing this repeatedly failed on a known flaky redpanda test. Turns out, if redpanda flakes, rpk tests are not run.

This was introduced in #6910 and has been in tip of dev for 14 hours. All other PRs have been failing on redpanda flakes, so this was only caught by _one_ successful redpanda test run in #6909.