### PR TITLE
Redpanda Self Test / Test Orchestration and Management - Part one 

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -138,6 +138,7 @@ v_cc_library(
     node_status_backend.cc
     node_status_rpc_handler.cc
     self_test_backend.cc
+    self_test_frontend.cc
     self_test_rpc_handler.cc
     bootstrap_service.cc
     bootstrap_backend.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -137,6 +137,7 @@ v_cc_library(
     partition_balancer_rpc_handler.cc
     node_status_backend.cc
     node_status_rpc_handler.cc
+    self_test_backend.cc
     bootstrap_service.cc
     bootstrap_backend.cc
     ephemeral_credential_frontend.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -55,6 +55,13 @@ rpcgen(
   INCLUDES ${CMAKE_BINARY_DIR}/src/v
 )
 
+rpcgen(
+  TARGET self_test_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/self_test_rpc.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/self_test_rpc_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+
 v_cc_library(
   NAME cluster
   SRCS
@@ -144,6 +151,7 @@ v_cc_library(
     partition_balancer_rpc
     node_status_rpc
     ephemeral_credential_rpc
+    self_test_rpc
     v::raft
     Roaring::roaring
     absl::flat_hash_map

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -138,6 +138,7 @@ v_cc_library(
     node_status_backend.cc
     node_status_rpc_handler.cc
     self_test_backend.cc
+    self_test_rpc_handler.cc
     bootstrap_service.cc
     bootstrap_backend.cc
     ephemeral_credential_frontend.cc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -53,6 +53,7 @@ class partition_balancer_state;
 class node_status_backend;
 class node_status_table;
 class ephemeral_credential_frontend;
+class self_test_backend;
 
 namespace node {
 class local_monitor;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -54,6 +54,7 @@ class node_status_backend;
 class node_status_table;
 class ephemeral_credential_frontend;
 class self_test_backend;
+class self_test_frontend;
 
 namespace node {
 class local_monitor;

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/self_test_backend.h"
+
+#include "cluster/logger.h"
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/util/log.hh>
+
+namespace cluster {
+
+ss::future<> self_test_backend::start() { return ss::now(); }
+
+ss::future<> self_test_backend::stop() {
+    co_await _gate.close();
+    co_await _disk_test.stop();
+    co_await _network_test.stop();
+    co_await _lock.get_units(); /// Ensure outstanding work is completed
+}
+
+ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
+  std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto) {
+    auto gate_holder = _gate.hold();
+    std::vector<self_test_result> results;
+    if (dto) {
+        /// Disk
+        try {
+            vlog(clusterlog.info, "Starting disk self test...");
+            results.push_back(
+              co_await _disk_test.run(*dto).then([](auto result) {
+                  vlog(clusterlog.info, "Disk self test finished with success");
+                  return result;
+              }));
+        } catch (const std::exception& ex) {
+            vlog(clusterlog.warn, "Disk self test finished with error");
+            results.push_back(self_test_result{.error = ex.what()});
+        }
+    }
+    if (nto) {
+        /// Network
+        try {
+            vlog(clusterlog.info, "Starting network self test...");
+            auto ntr = co_await _network_test.run(*nto).then([](auto results) {
+                vlog(
+                  clusterlog.info, "Network self test finished with success");
+                return results;
+            });
+            std::copy(ntr.begin(), ntr.end(), std::back_inserter(results));
+        } catch (const std::exception& ex) {
+            vlog(clusterlog.warn, "Network self test finished with error");
+            results.push_back(self_test_result{.error = ex.what()});
+        }
+    }
+    co_return results;
+}
+
+get_status_response self_test_backend::start_test(start_test_request req) {
+    auto gate_holder = _gate.hold();
+    auto units = _lock.try_get_units();
+    if (units) {
+        _id = req.id;
+        vlog(
+          clusterlog.info, "Starting redpanda self-tests with id: {}", req.id);
+        (void)do_start_test(req.dto, req.nto)
+          .then([this, id = req.id](auto results) {
+              _prev_run = get_status_response{
+                .id = id,
+                .status = self_test_status::idle,
+                .results = std::move(results)};
+          })
+          .finally([this, units = std::move(units)] {
+              /// TODO: No need for this when disk + network tests are written
+              _disk_test.reset();
+              _network_test.reset();
+          });
+    } else {
+        vlog(
+          clusterlog.info,
+          "Request to start already in-progress test receieved, updating test "
+          "UUID from: {} to: {}",
+          _id,
+          req.id);
+        _id = req.id;
+    }
+    return get_status();
+}
+
+ss::future<get_status_response> self_test_backend::stop_test() {
+    auto gate_holder = _gate.hold();
+    _disk_test.cancel();
+    _network_test.cancel();
+    try {
+        /// When lock is released, the 'then' block above will set the _prev_run
+        /// var with the finalized test results from the cancelled run.
+        static const auto stop_test_timeout = 5s;
+        co_return co_await _lock.with(
+          stop_test_timeout, [this] { return _prev_run; });
+    } catch (const ss::semaphore_timed_out&) {
+        vlog(clusterlog.warn, "Failed to stop self tests within 5s timeout");
+    }
+    co_return get_status_response{
+      .id = _id, .status = self_test_status::running};
+}
+
+get_status_response self_test_backend::get_status() const {
+    if (!_lock.ready()) {
+        return get_status_response{
+          .id = _id, .status = self_test_status::running};
+    }
+    return _prev_run;
+}
+
+} // namespace cluster

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "self_test_benchmarks.h"
+#include "self_test_rpc_types.h"
+#include "utils/mutex.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/smp.hh>
+
+namespace cluster {
+
+/// Class representing the logic and state of how redpanda self tests run
+///
+/// Within this class there is a mutex that ensures only one test can
+/// be executing at once. start_test() immediately returns and tests execute in
+/// the background, its the clients job to periodicially query for finished
+/// tests. The last successful test results and its test identifier are cached
+/// for later retrival.
+class self_test_backend {
+public:
+    static constexpr ss::shard_id shard = 0;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /// Starts a test if one isn't already executing
+    /// Important to note that this method immediately returns, however it
+    /// starts asynchronous jobs that will run in the background
+    ///
+    /// @param req Parameters passed by the leader
+    /// @returns status of having started the tests
+    get_status_response start_test(start_test_request req);
+
+    /// Stops all currently executing tests
+    /// Important to note that the future returned will be resolved when all
+    /// asynchronous work has stopped if this can be done within a 5s window.
+    /// Otherwise a running response status will be returned to caller.
+    ///
+    /// @returns Future<status> after attempt to stop all jobs
+    ss::future<get_status_response> stop_test();
+
+    /// Returns the current status of the system, i.e. are any tests currently
+    /// running or not
+    get_status_response get_status() const;
+
+private:
+    ss::future<std::vector<self_test_result>> do_start_test(
+      std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto);
+
+private:
+    // cached values
+    uuid_t _id;
+    get_status_response _prev_run{.status = self_test_status::idle};
+
+    ss::gate _gate;
+    mutex _lock;
+    diskcheck _disk_test;
+    networkcheck _network_test;
+};
+} // namespace cluster

--- a/src/v/cluster/self_test_benchmarks.h
+++ b/src/v/cluster/self_test_benchmarks.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/self_test_rpc_types.h"
+#include "seastarx.h"
+#include "utils/gate_guard.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sleep.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace cluster {
+
+/// TODO: This entire source file to be replaced by actual self tests
+/// Two self tests are planned for follow up publishing, one to disk the
+/// performance of the disk and another for network
+class self_test_stub {
+public:
+    self_test_stub() = default;
+
+    self_test_stub(const self_test_stub&) = delete;
+    self_test_stub& operator=(const self_test_stub&) = delete;
+
+    self_test_stub(self_test_stub&&) = delete;
+    self_test_stub& operator=(self_test_stub&&) = delete;
+
+    virtual ~self_test_stub() = default;
+
+    virtual ss::future<> stop() {
+        _as.request_abort();
+        return _gate.close();
+    }
+
+    /// Cancel outstanding jobs, can reschedule new ones
+    void cancel() { _cancel = true; };
+    void reset() { _cancel = false; };
+
+protected:
+    virtual ss::future<bool>
+    gated_sleep(ss::lowres_clock::duration stop) final {
+        gate_guard g{_gate};
+        const auto stoptime = ss::lowres_clock::now() + stop;
+        try {
+            while (!_cancel && stoptime > ss::lowres_clock::now()) {
+                co_await ss::sleep_abortable(100ms, _as);
+            }
+        } catch (const ss::sleep_aborted&) {
+            /// Graceful exit
+        }
+        co_return _cancel;
+    }
+
+private:
+    bool _cancel{false};
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+class diskcheck final : public self_test_stub {
+public:
+    ss::future<self_test_result> run(diskcheck_opts opts) {
+        auto start = ss::lowres_clock::now();
+        auto was_cancelled = co_await gated_sleep(opts.duration);
+        auto result = self_test_result{
+          .name = "Stub disk test",
+          .duration = ss::lowres_clock::now() - start};
+        if (was_cancelled) {
+            result.warning = "Test aborted during run";
+        }
+        co_return result;
+    }
+};
+
+class networkcheck final : public self_test_stub {
+public:
+    ss::future<std::vector<self_test_result>> run(netcheck_opts opts) {
+        auto start = ss::lowres_clock::now();
+        auto was_cancelled = co_await gated_sleep(opts.duration);
+        auto result = self_test_result{
+          .name = "Stub network test",
+          .duration = ss::lowres_clock::now() - start};
+        if (was_cancelled) {
+            result.warning = "Test aborted during run";
+        }
+        co_return std::vector<self_test_result>{result};
+    }
+};
+
+} // namespace cluster

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/self_test_frontend.h"
+
+#include "cluster/logger.h"
+#include "cluster/self_test_backend.h"
+#include "ssx/future-util.h"
+#include "vlog.h"
+
+namespace cluster {
+
+namespace {
+
+self_test_frontend::node_test_state enrich(get_status_response r) {
+    return self_test_frontend::node_test_state{.response = std::move(r)};
+}
+
+self_test_frontend::node_test_state
+enrich(result<rpc::client_context<get_status_response>> r) {
+    if (!r.has_error()) {
+        return enrich(r.value().data);
+    }
+    return self_test_frontend::node_test_state{};
+}
+
+} // namespace
+
+self_test_status self_test_frontend::node_test_state::status() const {
+    if (!response) {
+        return self_test_status::unreachable;
+    }
+    return response->status;
+}
+
+self_test_frontend::global_test_state::global_test_state(
+  std::vector<underlying_t::value_type>&& rs)
+  : _participants(rs.begin(), rs.end()) {}
+
+bool self_test_frontend::global_test_state::finished() const {
+    return !_participants.empty() && active_participant_ids().empty();
+}
+
+std::vector<model::node_id>
+self_test_frontend::global_test_state::active_participant_ids() const {
+    std::vector<model::node_id> ids;
+    ids.reserve(_participants.size());
+    for (const auto& [id, participant] : _participants) {
+        if (participant.status() == self_test_status::running) {
+            ids.push_back(id);
+        }
+    }
+    return ids;
+}
+
+/// Implementation of methods in self_test_frontend::local_invoke
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::local_invoke::start_test(start_test_request req) {
+    co_return enrich(_self_be.local().start_test(req));
+}
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::local_invoke::stop_test() {
+    co_return enrich(co_await _self_be.local().stop_test());
+}
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::local_invoke::get_status() {
+    co_return enrich(_self_be.local().get_status());
+}
+
+/// Implementation of methods in self_test_frontend::remote_invoke
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::remote_invoke::start_test(start_test_request req) {
+    auto v = co_await send_self_test_rpc(
+      [req](self_test_rpc_client_protocol c) mutable {
+          return c.start_test(
+            std::move(req), rpc::client_opts(raft::clock_type::now() + 5s));
+      });
+    co_return enrich(v);
+}
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::remote_invoke::stop_test() {
+    auto v = co_await send_self_test_rpc([](self_test_rpc_client_protocol c) {
+        /// Bigger timeout to wait for executing jobs to shutdown
+        return c.stop_test(
+          empty_request{}, rpc::client_opts(raft::clock_type::now() + 30s));
+    });
+    co_return enrich(v);
+}
+
+ss::future<self_test_frontend::node_test_state>
+self_test_frontend::remote_invoke::get_status() {
+    auto v = co_await send_self_test_rpc([](self_test_rpc_client_protocol c) {
+        return c.get_status(
+          empty_request{}, rpc::client_opts(raft::clock_type::now() + 5s));
+    });
+    co_return enrich(v);
+}
+
+/// Implementation of methods in self_test_frontend
+
+self_test_frontend::self_test_frontend(
+  model::node_id self,
+  ss::sharded<cluster::members_table>& members,
+  ss::sharded<cluster::self_test_backend>& self_be,
+  ss::sharded<rpc::connection_cache>& connections)
+  : _self(self)
+  , _members(members)
+  , _self_be(self_be)
+  , _connections(connections) {}
+
+ss::future<> self_test_frontend::start() { return ss::now(); }
+
+ss::future<> self_test_frontend::stop() { co_await _gate.close(); }
+
+ss::future<uuid_t> self_test_frontend::start_test(
+  std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto) {
+    auto gate_holder = _gate.hold();
+    if (!dto && !nto) {
+        throw self_test_exception("No tests specified to run");
+    }
+    const auto stopped_results = co_await stop_test();
+    if (!stopped_results.finished()) {
+        vlog(
+          clusterlog.warn,
+          "Could not stop already running test before calling start,  "
+          "sending start RPCs out anyway.");
+    }
+
+    /// Invoke command to start test on all nodes, using the same test id
+    const auto id = uuid_t::create();
+    start_test_request req{.id = id, .dto = dto, .nto = nto};
+    auto state = co_await invoke_on_all_nodes(
+      [req](auto& handle) { return handle->start_test(req); });
+    co_return id;
+}
+
+ss::future<self_test_frontend::global_test_state>
+self_test_frontend::stop_test() {
+    auto gate_holder = _gate.hold();
+    int8_t retries = 3;
+    auto test_state = co_await status();
+    while (!test_state.finished() && retries-- > 0) {
+        /// invoke_on_all will filter brokers that have shut down cleanly
+        /// from its participants list, retries (if occur) will only occur
+        /// on previously unreachable nodes
+        test_state = co_await invoke_on_all_nodes(
+          [](auto& handle) { return handle->stop_test(); });
+        if (!test_state.finished()) {
+            vlog(
+              clusterlog.warn,
+              "Failed to sucessfully stop all outstanding jobs on all "
+              "remaining_participants: {} , trying again, retries: {}",
+              test_state.active_participant_ids(),
+              retries);
+        }
+        co_await ss::sleep(1s);
+    }
+    co_return test_state;
+}
+
+ss::future<self_test_frontend::global_test_state> self_test_frontend::status() {
+    auto gate_holder = _gate.hold();
+    co_return co_await invoke_on_all_nodes(
+      [](auto& handle) { return handle->get_status(); });
+}
+
+template<typename Func>
+ss::future<self_test_frontend::global_test_state>
+self_test_frontend::invoke_on_all_nodes(Func f) {
+    auto gate_holder = _gate.hold();
+    auto brokers = _members.local().node_ids();
+    auto node_state_vec = co_await ssx::parallel_transform(
+      brokers, [this, f = std::move(f)](const auto& node_id) {
+          std::unique_ptr<invoke_wrapper> handle;
+          if (_self == node_id) {
+              handle = std::make_unique<local_invoke>(node_id, _self_be);
+          } else {
+              handle = std::make_unique<remote_invoke>(
+                node_id, _self, _connections);
+          }
+          return ss::do_with(
+                   std::move(handle),
+                   [f = std::move(f)](auto& handle) { return f(handle); })
+            .then([node_id](node_test_state result) {
+                return std::pair<const model::node_id, node_test_state>(
+                  node_id, std::move(result));
+            });
+      });
+    co_return global_test_state(std::move(node_state_vec));
+}
+
+} // namespace cluster

--- a/src/v/cluster/self_test_frontend.h
+++ b/src/v/cluster/self_test_frontend.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/errc.h"
+#include "cluster/fwd.h"
+#include "cluster/members_table.h"
+#include "cluster/self_test_rpc_service.h"
+#include "cluster/self_test_rpc_types.h"
+#include "config/node_config.h"
+#include "rpc/connection_cache.h"
+#include "rpc/fwd.h"
+
+namespace cluster {
+
+class self_test_exception : public std::runtime_error {
+public:
+    explicit self_test_exception(ss::sstring msg)
+      : std::runtime_error(std::move(msg)) {}
+};
+
+/// Main orchestration tool for the redpanda self_test framework. This tool
+/// sends requests to all peers that will start or stop individual self_test
+/// jobs such as disk, network tests, etc. The status() endpoint can be used
+/// to query the status of all self_tests running cluster-wide.
+class self_test_frontend {
+public:
+    static constexpr auto shard = ss::shard_id(0);
+
+    /// Holds reported result of a status() call from a single broker
+    struct node_test_state {
+        std::optional<get_status_response> response;
+        self_test_status status() const;
+    };
+
+    /// Holds reported self_test results aquired from all brokers in a test
+    class global_test_state {
+    public:
+        using underlying_t
+          = absl::flat_hash_map<model::node_id, node_test_state>;
+
+        explicit global_test_state(std::vector<underlying_t::value_type>&&);
+
+        /// true if there are no active participants and test has started
+        bool finished() const;
+
+        /// returns node_ids of participants that are still running jobs
+        std::vector<model::node_id> active_participant_ids() const;
+
+        /// returns const ref to internal data
+        const underlying_t& results() const { return _participants; }
+
+    private:
+        underlying_t _participants;
+    };
+
+    self_test_frontend(
+      model::node_id self,
+      ss::sharded<cluster::members_table>& members,
+      ss::sharded<cluster::self_test_backend>& this_runner,
+      ss::sharded<rpc::connection_cache>& connections);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    ss::future<uuid_t>
+      start_test(std::optional<diskcheck_opts>, std::optional<netcheck_opts>);
+    ss::future<global_test_state> stop_test();
+    ss::future<global_test_state> status();
+
+private:
+    /// The following abstractions are responsible for invoking an individual
+    /// self test on either a remote node.
+    class invoke_wrapper {
+    public:
+        explicit invoke_wrapper(model::node_id node_id)
+          : _node_id(node_id) {}
+
+        virtual ~invoke_wrapper() = default;
+
+        virtual ss::future<node_test_state> start_test(start_test_request) = 0;
+        virtual ss::future<node_test_state> stop_test() = 0;
+        virtual ss::future<node_test_state> get_status() = 0;
+
+        model::node_id node_id() const { return _node_id; }
+
+    private:
+        model::node_id _node_id;
+    };
+
+    /// Starts/stops/queries status of a single self-test if the node_id is
+    /// not 'this' node. Makes RPC call to remote node to achive this.
+    class remote_invoke : public invoke_wrapper {
+    public:
+        remote_invoke(
+          model::node_id node_id,
+          model::node_id self,
+          ss::sharded<rpc::connection_cache>& connections)
+          : invoke_wrapper(node_id)
+          , _self(self)
+          , _connections(connections) {}
+
+        ss::future<node_test_state> start_test(start_test_request) override;
+        ss::future<node_test_state> stop_test() override;
+        ss::future<node_test_state> get_status() override;
+
+    private:
+        template<typename Func>
+        ss::future<result<rpc::client_context<get_status_response>>>
+        send_self_test_rpc(Func&& f) {
+            return _connections.local()
+              .with_node_client<self_test_rpc_client_protocol>(
+                _self, ss::this_shard_id(), node_id(), 10s, f);
+        }
+
+    private:
+        model::node_id _self;
+        ss::sharded<rpc::connection_cache>& _connections;
+    };
+
+    /// Starts/stops/queries status of a single self-test if the node_id is
+    /// 'this' node. Manually invokes the self_test_backend to achive this
+    class local_invoke : public invoke_wrapper {
+    public:
+        local_invoke(
+          model::node_id node_id,
+          ss::sharded<cluster::self_test_backend>& self_be)
+          : invoke_wrapper(node_id)
+          , _self_be(self_be) {}
+
+        ss::future<node_test_state> start_test(start_test_request) override;
+        ss::future<node_test_state> stop_test() override;
+        ss::future<node_test_state> get_status() override;
+
+    private:
+        ss::sharded<cluster::self_test_backend>& _self_be;
+    };
+
+    /// Send RPC (or locally invoke) a self test endpoint to one or more nodes
+    ///
+    /// @param f Functor that returns a single nodes state and takes a
+    ///   unique_ptr reference of an `invoke_wrapper` subclass instance.
+    /// @returns The current reported status from all nodes
+    template<typename Func>
+    ss::future<global_test_state> invoke_on_all_nodes(Func f);
+
+private:
+    ss::gate _gate;
+
+    model::node_id _self;
+
+    ss::sharded<cluster::members_table>& _members;
+    ss::sharded<cluster::self_test_backend>&
+      _self_be; // only invoked to execute the self test on 'this' node, the
+                // leader node where this frontend will be active as well
+    ss::sharded<rpc::connection_cache>& _connections;
+};
+} // namespace cluster

--- a/src/v/cluster/self_test_rpc.json
+++ b/src/v/cluster/self_test_rpc.json
@@ -1,0 +1,24 @@
+{
+    "namespace": "cluster",
+    "service_name": "self_test_rpc",
+    "includes": [
+        "cluster/self_test_rpc_types.h"
+    ],
+    "methods": [
+        {
+            "name": "start_test",
+            "input_type": "start_test_request",
+            "output_type": "get_status_response"
+        },
+        {
+            "name": "stop_test",
+            "input_type": "empty_request",
+            "output_type": "get_status_response"
+        },
+        {
+            "name": "get_status",
+            "input_type": "empty_request",
+            "output_type": "get_status_response"
+        }
+    ]
+}

--- a/src/v/cluster/self_test_rpc_handler.cc
+++ b/src/v/cluster/self_test_rpc_handler.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/self_test_rpc_handler.h"
+
+namespace cluster {
+
+self_test_rpc_handler::self_test_rpc_handler(
+  ss::scheduling_group sg,
+  ss::smp_service_group ssg,
+  ss::sharded<self_test_backend>& backend)
+  : self_test_rpc_service(sg, ssg)
+  , _self_test_backend(backend) {}
+
+ss::future<get_status_response> self_test_rpc_handler::start_test(
+  start_test_request&& r, rpc::streaming_context&) {
+    return _self_test_backend.invoke_on(
+      self_test_backend::shard,
+      [r](auto& service) { return service.start_test(r); });
+}
+
+ss::future<get_status_response>
+self_test_rpc_handler::stop_test(empty_request&&, rpc::streaming_context&) {
+    return _self_test_backend.invoke_on(
+      self_test_backend::shard,
+      [](auto& service) { return service.stop_test(); });
+}
+
+ss::future<get_status_response>
+self_test_rpc_handler::get_status(empty_request&&, rpc::streaming_context&) {
+    return _self_test_backend.invoke_on(
+      self_test_backend::shard,
+      [](auto& service) { return service.get_status(); });
+}
+
+} // namespace cluster

--- a/src/v/cluster/self_test_rpc_handler.h
+++ b/src/v/cluster/self_test_rpc_handler.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/self_test_backend.h"
+#include "cluster/self_test_rpc_service.h"
+#include "cluster/self_test_rpc_types.h"
+
+namespace cluster {
+
+class self_test_rpc_handler final : public self_test_rpc_service {
+public:
+    self_test_rpc_handler(
+      ss::scheduling_group,
+      ss::smp_service_group,
+      ss::sharded<self_test_backend>&);
+
+    ss::future<get_status_response>
+    start_test(start_test_request&&, rpc::streaming_context&) final;
+
+    ss::future<get_status_response>
+    stop_test(empty_request&&, rpc::streaming_context&) final;
+
+    ss::future<get_status_response>
+    get_status(empty_request&&, rpc::streaming_context&) final;
+
+private:
+    ss::sharded<self_test_backend>& _self_test_backend;
+};
+
+} // namespace cluster

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/errc.h"
+#include "json/document.h"
+#include "model/metadata.h"
+#include "serde/serde.h"
+#include "utils/uuid.h"
+
+namespace cluster {
+
+enum class self_test_status : int8_t { idle = 0, running, unreachable };
+
+inline ss::sstring self_test_status_as_string(self_test_status sts) {
+    switch (sts) {
+    case self_test_status::idle:
+        return "idle";
+    case self_test_status::running:
+        return "running";
+    case self_test_status::unreachable:
+        return "unreachable";
+    default:
+        __builtin_unreachable();
+    }
+}
+
+inline std::ostream& operator<<(std::ostream& o, self_test_status sts) {
+    fmt::print(o, "{}", self_test_status_as_string(sts));
+    return o;
+}
+
+/// TODO: Replace fields with actual fields from real self-tests
+struct diskcheck_opts
+  : serde::
+      envelope<diskcheck_opts, serde::version<0>, serde::compat_version<0>> {
+    ss::lowres_clock::duration duration;
+
+    static diskcheck_opts from_json(const json::Document& doc) {
+        static const auto default_duration = 5;
+        return cluster::diskcheck_opts{
+          .duration = std::chrono::seconds(
+            doc.HasMember("disk_test_execution_time")
+              ? doc["disk_test_execution_time"].GetInt()
+              : default_duration)};
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const diskcheck_opts& opts) {
+        fmt::print(o, "{{duration: {}}}", opts.duration.count());
+        return o;
+    }
+};
+
+/// TODO: Replace fields with actual fields from real self-tests
+struct netcheck_opts
+  : serde::
+      envelope<netcheck_opts, serde::version<0>, serde::compat_version<0>> {
+    ss::lowres_clock::duration duration;
+
+    static netcheck_opts from_json(const json::Document& doc) {
+        static const auto default_duration = 5;
+        return cluster::netcheck_opts{
+          .duration = std::chrono::seconds(
+            doc.HasMember("network_test_execution_time")
+              ? doc["network_test_execution_time"].GetInt()
+              : default_duration)};
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const netcheck_opts& opts) {
+        fmt::print(o, "{{test_duration: {}}}", opts.duration.count());
+        return o;
+    }
+};
+
+struct self_test_result
+  : serde::
+      envelope<self_test_result, serde::version<0>, serde::compat_version<0>> {
+    double p50;
+    double p90;
+    double p99;
+    double p999;
+    double max;
+    uint64_t rps;
+    uint64_t bps;
+    uuid_t test_id;
+    ss::sstring name;
+    ss::sstring info;
+    ss::lowres_clock::duration duration;
+    std::optional<ss::sstring> warning;
+    std::optional<ss::sstring> error;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const self_test_result& r) {
+        fmt::print(
+          o,
+          "{{p50: {} p90: {} p99: {} p999: {} max: {} rps: {} bps: {} test_id: "
+          "{} name: {} info: {} duration: {}ms warning: {} error: {}}}",
+          r.p50,
+          r.p90,
+          r.p99,
+          r.p999,
+          r.max,
+          r.rps,
+          r.bps,
+          r.test_id,
+          r.name,
+          r.info,
+          std::chrono::duration_cast<std::chrono::milliseconds>(r.duration)
+            .count(),
+          r.warning ? *r.warning : "<no_value>",
+          r.error ? *r.error : "<no_value>");
+        return o;
+    }
+};
+
+struct empty_request
+  : serde::
+      envelope<empty_request, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+};
+
+struct start_test_request
+  : serde::envelope<
+      start_test_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    uuid_t id;
+    std::optional<diskcheck_opts> dto;
+    std::optional<netcheck_opts> nto;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const start_test_request& r) {
+        std::stringstream ss;
+        if (r.dto) {
+            fmt::print(ss, "diskcheck_opts: {}", *r.dto);
+        } else {
+            fmt::print(ss, "diskcheck_opts: <no_value>");
+        }
+        if (r.nto) {
+            fmt::print(ss, "netcheck_opts: {}", *r.nto);
+        } else {
+            fmt::print(ss, "netcheck_opts: <no_value>");
+        }
+        fmt::print(o, "{{id: {} {}}}", r.id, ss.str());
+        return o;
+    }
+};
+
+struct get_status_response
+  : serde::envelope<
+      get_status_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    uuid_t id{};
+    self_test_status status{};
+    std::vector<self_test_result> results;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const get_status_response& r) {
+        fmt::print(
+          o,
+          "{{id: {} status:{} test_results: {}}}",
+          r.id,
+          r.status,
+          r.results);
+        return o;
+    }
+};
+
+} // namespace cluster

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -41,6 +41,62 @@
             ]
         },
         {
+            "path": "/v1/debug/self_test/start",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Start self test",
+                    "nickname": "self_test_start",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "schema": "json"
+                        },
+                        "503": {
+                            "description": "Test failed to start",
+                            "schema":{
+                                "type": "json"
+                            }
+                        }
+                    }
+
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/self_test/stop",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "stop self test",
+                    "nickname": "self_test_stop",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/self_test/status",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Query self test",
+                    "nickname": "self_test_status",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+
+            ]
+        },
+        {
             "path": "/v1/debug/peer_status/{id}",
             "operations": [
                 {
@@ -109,6 +165,81 @@
                 "since_last_status": {
                     "type": "long",
                     "description": "Milliseconds since last update from peer"
+                }
+            }
+        },
+        "self_test_result": {
+            "id": "self_test_result",
+            "description": "Result set from a single self_test run",
+            "properties": {
+                "p50": {
+                    "type": "long",
+                    "description": "50th percentile latencies"
+                },
+                "p90": {
+                    "type": "long",
+                    "description": "90th percentile latencies"
+                },
+                "p99": {
+                    "type": "long",
+                    "description": "99th percentile latencies"
+                },
+                "p999": {
+                    "type": "long",
+                    "description": "999th percentile latencies"
+                },
+                "max_latency": {
+                    "type": "long",
+                    "description": "Maximum recorded latency measurement"
+                },
+                "rps": {
+                    "type": "long",
+                    "description": "Number of requests per second"
+                },
+                "bps": {
+                    "type": "long",
+                    "description": "Bytes operated on per second"
+                },
+                "test_id": {
+                    "type": "string",
+                    "description": "Global test uuid identifier"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the test run"
+                },
+                "duration": {
+                    "type": "long",
+                    "description": "Length of time the test took to complete"
+                },
+                "warning": {
+                    "type": "string",
+                    "description": "Warning that arose during test execution"
+                },
+                "error": {
+                    "type": "string",
+                    "description": "Stringified exception if any occurred during test execution"
+                }
+            }
+        },
+        "self_test_node_report": {
+            "id": "self_test_node_report",
+            "description": "Current state of self test on a given broker",
+            "properties": {
+                "node_id": {
+                    "type": "long",
+                    "description": "node_id of the broker reporting"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "One of either idle / running / unreachable"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "type": "self_test_result"
+                    },
+                    "description": "Recordings of test runs from a single node"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -187,6 +187,7 @@ void admin_server::configure_admin_routes() {
     register_hbadger_routes();
     register_transaction_routes();
     register_debug_routes();
+    register_self_test_routes();
     register_cluster_routes();
     register_shadow_indexing_routes();
 }
@@ -2926,6 +2927,130 @@ void admin_server::register_transaction_routes() {
       ss::httpd::transaction_json::delete_partition,
       [this](std::unique_ptr<ss::httpd::request> req) {
           return delete_partition_handler(std::move(req));
+      });
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::self_test_start_handler(std::unique_ptr<ss::httpd::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        vlog(logger.debug, "Need to redirect self_test_start request");
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+    auto doc = parse_json_body(*req);
+    std::optional<cluster::diskcheck_opts> dto;
+    std::optional<cluster::netcheck_opts> nto;
+    if (!doc.HasMember("tests")) {
+        dto = cluster::diskcheck_opts::from_json(doc);
+        nto = cluster::netcheck_opts::from_json(doc);
+    } else {
+        for (const auto& name : doc["tests"].GetArray()) {
+            if (name == "disk") {
+                dto = cluster::diskcheck_opts::from_json(doc);
+            } else if (name == "network") {
+                nto = cluster::netcheck_opts::from_json(doc);
+            }
+        }
+    }
+    try {
+        auto tid = co_await _self_test_frontend.invoke_on(
+          cluster::self_test_frontend::shard,
+          [dto, nto](auto& self_test_frontend) {
+              return self_test_frontend.start_test(dto, nto);
+          });
+        vlog(logger.info, "Request to start self test succeeded: {}", tid);
+        co_return ss::json::json_return_type(tid);
+    } catch (const std::exception& ex) {
+        throw ss::httpd::base_exception(
+          fmt::format("Failed to start self test, reason: {}", ex),
+          ss::httpd::reply::status_type::service_unavailable);
+    }
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::self_test_stop_handler(std::unique_ptr<ss::httpd::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        vlog(logger.info, "Need to redirect self_test_stop request");
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+    auto r = co_await _self_test_frontend.invoke_on(
+      cluster::self_test_frontend::shard,
+      [](auto& self_test_frontend) { return self_test_frontend.stop_test(); });
+    if (!r.finished()) {
+        throw ss::httpd::base_exception(
+          fmt::format(
+            "Failed to stop one or more self_test jobs: {}",
+            r.active_participant_ids()),
+          ss::httpd::reply::status_type::service_unavailable);
+    }
+    vlog(logger.info, "Request to stop self test succeeded");
+    co_return ss::json::json_void();
+}
+
+static ss::httpd::debug_json::self_test_result
+self_test_result_to_json(const cluster::self_test_result& str) {
+    ss::httpd::debug_json::self_test_result r;
+    if (str.error) {
+        r.error = *str.error;
+        return r;
+    }
+    if (str.warning) {
+        r.warning = *str.warning;
+    }
+    r.p50 = str.p50;
+    r.p90 = str.p90;
+    r.p99 = str.p99;
+    r.p999 = str.p999;
+    r.max_latency = str.max;
+    r.rps = str.rps;
+    r.bps = str.bps;
+    r.test_id = ss::sstring(str.test_id);
+    r.name = str.name;
+    r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                   str.duration)
+                   .count();
+    return r;
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::self_test_get_results_handler(
+  std::unique_ptr<ss::httpd::request>) {
+    namespace dbg_ns = ss::httpd::debug_json;
+    std::vector<dbg_ns::self_test_node_report> reports;
+    auto status = co_await _self_test_frontend.invoke_on(
+      cluster::self_test_frontend::shard,
+      [](auto& self_test_frontend) { return self_test_frontend.status(); });
+    reports.reserve(status.results().size());
+    for (const auto& [id, participant] : status.results()) {
+        dbg_ns::self_test_node_report nr;
+        nr.node_id = id;
+        nr.status = cluster::self_test_status_as_string(participant.status());
+        if (participant.response) {
+            for (const auto& r : participant.response->results) {
+                nr.results.push(self_test_result_to_json(r));
+            }
+        }
+        reports.push_back(nr);
+    }
+    co_return ss::json::json_return_type(reports);
+}
+
+void admin_server::register_self_test_routes() {
+    register_route<superuser>(
+      ss::httpd::debug_json::self_test_start,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return self_test_start_handler(std::move(req));
+      });
+
+    register_route<superuser>(
+      ss::httpd::debug_json::self_test_stop,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return self_test_stop_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::debug_json::self_test_status,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return self_test_get_results_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -32,6 +32,7 @@
 #include "cluster/partition_balancer_rpc_service.h"
 #include "cluster/partition_manager.h"
 #include "cluster/security_frontend.h"
+#include "cluster/self_test_frontend.h"
 #include "cluster/shard_table.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
@@ -110,7 +111,8 @@ admin_server::admin_server(
   ss::sharded<cluster::metadata_cache>& metadata_cache,
   ss::sharded<archival::scheduler_service>& archival_service,
   ss::sharded<rpc::connection_cache>& connection_cache,
-  ss::sharded<cluster::node_status_table>& node_status_table)
+  ss::sharded<cluster::node_status_table>& node_status_table,
+  ss::sharded<cluster::self_test_frontend>& self_test_frontend)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -122,7 +124,8 @@ admin_server::admin_server(
   , _connection_cache(connection_cache)
   , _auth(config::shard_local_cfg().admin_api_require_auth.bind(), _controller)
   , _archival_service(archival_service)
-  , _node_status_table(node_status_table) {}
+  , _node_status_table(node_status_table)
+  , _self_test_frontend(self_test_frontend) {}
 
 ss::future<> admin_server::start() {
     configure_metrics_route();

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -230,6 +230,7 @@ private:
     void register_hbadger_routes();
     void register_transaction_routes();
     void register_debug_routes();
+    void register_self_test_routes();
     void register_cluster_routes();
     void register_shadow_indexing_routes();
 
@@ -306,6 +307,14 @@ private:
     /// Shadow indexing routes
     ss::future<ss::json::json_return_type>
       sync_local_state_handler(std::unique_ptr<ss::httpd::request>);
+
+    /// Self test routes
+    ss::future<ss::json::json_return_type>
+      self_test_start_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<ss::json::json_return_type>
+      self_test_stop_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<ss::json::json_return_type>
+      self_test_get_results_handler(std::unique_ptr<ss::httpd::request>);
 
     ss::future<> throw_on_error(
       ss::httpd::request& req,

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -54,7 +54,8 @@ public:
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<archival::scheduler_service>&,
       ss::sharded<rpc::connection_cache>&,
-      ss::sharded<cluster::node_status_table>&);
+      ss::sharded<cluster::node_status_table>&,
+      ss::sharded<cluster::self_test_frontend>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -346,4 +347,5 @@ private:
     bool _ready{false};
     ss::sharded<archival::scheduler_service>& _archival_service;
     ss::sharded<cluster::node_status_table>& _node_status_table;
+    ss::sharded<cluster::self_test_frontend>& _self_test_frontend;
 };

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -18,6 +18,8 @@
 #include "cluster/node/local_monitor.h"
 #include "cluster/node_status_backend.h"
 #include "cluster/node_status_table.h"
+#include "cluster/self_test_backend.h"
+#include "cluster/self_test_frontend.h"
 #include "config/node_config.h"
 #include "coproc/fwd.h"
 #include "features/fwd.h"
@@ -100,6 +102,8 @@ public:
     ss::sharded<cluster::node_status_table> node_status_table;
     ss::sharded<cluster::partition_manager> partition_manager;
     ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
+    ss::sharded<cluster::self_test_backend> self_test_backend;
+    ss::sharded<cluster::self_test_frontend> self_test_frontend;
     ss::sharded<cluster::shard_table> shard_table;
     ss::sharded<cluster::tm_stm_cache> tm_stm_cache;
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -66,7 +66,9 @@ public:
 
     void broken() noexcept { _sem.broken(); }
 
-    bool ready() { return _sem.waiters() == 0 && _sem.available_units() == 1; }
+    bool ready() const noexcept {
+        return _sem.waiters() == 0 && _sem.available_units() == 1;
+    }
 
     size_t waiters() const noexcept { return _sem.waiters(); }
 

--- a/src/v/utils/uuid.cc
+++ b/src/v/utils/uuid.cc
@@ -32,3 +32,5 @@ uuid_t uuid_t::create() {
 std::ostream& operator<<(std::ostream& os, const uuid_t& u) {
     return os << fmt::format("{}", u._uuid);
 }
+
+uuid_t::operator ss::sstring() const { return fmt::format("{}", _uuid); }

--- a/src/v/utils/uuid.h
+++ b/src/v/utils/uuid.h
@@ -8,6 +8,10 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
 #include <absl/hash/hash.h>
 #include <boost/uuid/uuid.hpp>
 
@@ -36,6 +40,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const uuid_t& u);
     friend bool operator==(const uuid_t& u, const uuid_t& v) = default;
+
+    operator ss::sstring() const;
 
     template<typename H>
     friend H AbslHashValue(H h, const uuid_t& u) {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -776,3 +776,12 @@ class Admin:
             raise
         if len(r.text) > 0:
             return r.json()["cluster_uuid"]
+
+    def self_test_start(self, options):
+        return self._request("POST", "debug/self_test/start", json=options)
+
+    def self_test_stop(self):
+        return self._request("POST", "debug/self_test/stop")
+
+    def self_test_status(self):
+        return self._request("GET", "debug/self_test/status").json()

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -1,0 +1,138 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from ducktape.utils.util import wait_until
+
+
+class SelfTestTest(RedpandaTest):
+    """Tests for the redpanda self test feature."""
+    def __init__(self, ctx):
+        super(SelfTestTest, self).__init__(test_context=ctx)
+        self._admin = Admin(self.redpanda)
+
+    def wait_for_self_test_completion(self, timeout):
+        """
+        Completion is defined as all brokers reporting an 'idle'
+        status in the self_test_status() API
+        """
+        def all_idle():
+            node_reports = self._admin.self_test_status()
+            return not any([x['status'] == 'running' for x in node_reports])
+
+        wait_until(all_idle, timeout_sec=timeout, backoff_sec=1)
+
+    @cluster(num_nodes=3)
+    def test_self_test(self):
+        """Assert the self test starts/completes with success."""
+        test_options = {
+            'disk_test_execution_time': 1,
+            'network_test_execution_time': 1
+        }
+
+        # Launch the self test with the options above
+        assert self._admin.self_test_start(test_options).status_code == 200
+
+        # Wait for completion
+        self.wait_for_self_test_completion(5)
+
+        # Verify returned results
+        node_reports = self._admin.self_test_status()
+        for node in node_reports:
+            assert node['status'] == 'idle'
+            assert node.get('results') is not None
+            for report in node['results']:
+                assert 'error' not in report
+                assert 'warning' not in report
+                assert 'duration' in report
+                assert report['duration'] >= 1000, report['duration']
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_self_test_node_crash(self):
+        """Assert the self test starts/completes with success."""
+        test_options = {
+            'disk_test_execution_time': 3,
+            'network_test_execution_time': 3
+        }
+
+        # Launch the self test with the options above
+        assert self._admin.self_test_start(test_options).status_code == 200
+
+        # Allow for some work be done
+        time.sleep(1)
+
+        # Crash a node
+        stopped_nid = self.redpanda.idx(self.redpanda.nodes[0])
+        self.logger.info(f"Killing node {stopped_nid}")
+        self.redpanda.stop_node(self.redpanda.get_node(stopped_nid))
+
+        # Wait for completion
+        self.wait_for_self_test_completion(7)
+
+        # Verify returned results
+        all_status = self._admin.self_test_status()
+        good_node_reports = [
+            x for x in all_status if x['node_id'] != stopped_nid
+        ]
+        for node in good_node_reports:
+            assert node['status'] == 'idle'
+            assert node.get('results') is not None
+            for report in node['results']:
+                assert 'error' not in report
+                assert 'warning' not in report
+                assert 'duration' in report
+                assert report['duration'] >= 1000, report['duration']
+        crashed_nodes_report = [
+            x for x in all_status if x['node_id'] == stopped_nid
+        ][0]
+        assert crashed_nodes_report['status'] == 'unreachable'
+        assert crashed_nodes_report.get('results') is None
+
+    @cluster(num_nodes=3)
+    def test_self_test_cancellable(self):
+        """Assert the self test can cancel an action on command."""
+        test_options = {
+            'disk_test_execution_time': 5,
+            'network_test_execution_time': 5
+        }
+
+        # Launch the self test with the options above
+        start = time.time()
+        assert self._admin.self_test_start(test_options).status_code == 200
+
+        # Wait a second, then send a stop() request
+        time.sleep(1)
+
+        # Stop is synchronous and will return when all jobs have stopped
+        assert self._admin.self_test_stop().status_code == 200
+
+        # Assert that at least a second of total recorded test time has
+        # passed between start & stop calls
+        stop = time.time()
+        total_time_sec = stop - start
+        assert total_time_sec < (test_options['disk_test_execution_time'] +
+                                 test_options['network_test_execution_time'])
+
+        # Ensure system is in an idle state and contains expected report
+        node_reports = self._admin.self_test_status()
+        for node in node_reports:
+            assert node['status'] == 'idle'
+            assert node.get('results') is not None
+            for report in node['results']:
+                assert 'error' not in report
+                assert 'warning' in report
+                assert 'duration' in report
+                # If test was running it was cancelled otherwise it was
+                # cancelled before it even had a chance to start, resulting in
+                # a 0 value for duration
+                assert report['duration'] >= 0


### PR DESCRIPTION
## Cover letter

This is the first of a series of commits that make up the new self test feature, [RFC](https://docs.google.com/document/d/1UBc9CcD-mKkVOtPbO5G_t7UuU2GUIP3I0nnCPTDFpEY/edit#heading=h.fxgc4ycrks86)

This patch set contains the infrastructure and tooling necessary to start, stop and retrieve results from self tests. Clients control the behavior via the admin API. All brokers include a new self test RPC service used to communicate with each other. The leader node is responsible for test orchestration among all peers.

## Release notes
- none