### PR TITLE
cloud_storage: make cluster default read/write properties "sticky"

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -321,8 +321,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
           }
           if (
             part->get_ntp_config().is_archival_enabled()
-            || part->get_ntp_config().is_read_replica_mode_enabled()
-            || config::shard_local_cfg().cloud_storage_enable_remote_write()) {
+            || part->get_ntp_config().is_read_replica_mode_enabled()) {
               auto archiver = ss::make_lw_shared<ntp_archiver>(
                 log->config(),
                 _partition_manager.local(),

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -561,9 +561,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {
-    if (
-      !_raft->log_config().is_archival_enabled()
-      && !config::shard_local_cfg().cloud_storage_enable_remote_write.value()) {
+    if (!_raft->log_config().is_archival_enabled()) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
         return model::offset::max();

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -14,6 +14,7 @@
 #include "cluster/errc.h"
 #include "cluster/persisted_stm.h"
 #include "config/configuration.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -166,12 +167,16 @@ ss::future<> archival_metadata_stm::make_snapshot(
 }
 
 archival_metadata_stm::archival_metadata_stm(
-  raft::consensus* raft, cloud_storage::remote& remote, ss::logger& logger)
+  raft::consensus* raft,
+  cloud_storage::remote& remote,
+  features::feature_table& ft,
+  ss::logger& logger)
   : cluster::persisted_stm("archival_metadata.snapshot", logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
   , _manifest(ss::make_shared<cloud_storage::partition_manifest>(
       raft->ntp(), raft->log_config().get_initial_revision()))
-  , _cloud_storage_api(remote) {}
+  , _cloud_storage_api(remote)
+  , _feature_table(ft) {}
 
 ss::future<std::error_code> archival_metadata_stm::truncate(
   model::offset start_rp_offset,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/types.h"
 #include "cluster/persisted_stm.h"
+#include "features/fwd.h"
 #include "model/metadata.h"
 #include "model/record.h"
 #include "utils/mutex.h"
@@ -40,7 +41,10 @@ class archival_metadata_stm final : public persisted_stm {
 
 public:
     explicit archival_metadata_stm(
-      raft::consensus*, cloud_storage::remote& remote, ss::logger& logger);
+      raft::consensus*,
+      cloud_storage::remote& remote,
+      features::feature_table&,
+      ss::logger& logger);
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.
@@ -141,6 +145,7 @@ private:
     ss::shared_ptr<cloud_storage::partition_manifest> _manifest;
 
     cloud_storage::remote& _cloud_storage_api;
+    features::feature_table& _feature_table;
     ss::abort_source _download_as;
 };
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -125,9 +125,7 @@ ss::future<std::vector<rm_stm::tx_range>> partition::aborted_transactions_cloud(
 
 bool partition::is_remote_fetch_enabled() const {
     const auto& cfg = _raft->log_config();
-    return cfg.is_remote_fetch_enabled()
-           || config::shard_local_cfg()
-                .cloud_storage_enable_remote_read.value();
+    return cfg.is_remote_fetch_enabled();
 }
 
 bool partition::cloud_data_available() const {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -418,10 +418,7 @@ ss::future<> partition::remove_remote_persistent_state() {
     // Backward compatibility: even if remote.delete is true, only do
     // deletion if the partition is in full tiered storage mode (this
     // excludes read replica clusters from deleting data in S3)
-    bool tiered_storage
-      = get_ntp_config().is_tiered_storage()
-        || (config::shard_local_cfg().cloud_storage_enable_remote_write() &&
-            config::shard_local_cfg().cloud_storage_enable_remote_read());
+    bool tiered_storage = get_ntp_config().is_tiered_storage();
 
     if (
       _cloud_storage_partition && tiered_storage

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -85,7 +85,10 @@ partition::partition(
           && _raft->ntp().ns == model::kafka_namespace) {
             _archival_meta_stm
               = ss::make_shared<cluster::archival_metadata_stm>(
-                _raft.get(), cloud_storage_api.local(), clusterlog);
+                _raft.get(),
+                cloud_storage_api.local(),
+                _feature_table.local(),
+                clusterlog);
             stm_manager->add_stm(_archival_meta_stm);
 
             if (cloud_storage_cache.local_is_initialized()) {

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -13,6 +13,7 @@
 #include "cluster/archival_metadata_stm.h"
 #include "cluster/errc.h"
 #include "cluster/persisted_stm.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -71,6 +72,8 @@ struct archival_metadata_stm_base_fixture
     }
 
     archival_metadata_stm_base_fixture() {
+        // Blank feature table to satisfy constructor interface
+        feature_table.start().get();
         // Cloud storage config
         cloud_cfg.start().get();
         cloud_cfg
@@ -92,8 +95,10 @@ struct archival_metadata_stm_base_fixture
     ~archival_metadata_stm_base_fixture() override {
         cloud_api.stop().get();
         cloud_cfg.stop().get();
+        feature_table.stop().get();
     }
 
+    ss::sharded<features::feature_table> feature_table;
     ss::sharded<cloud_storage::configuration> cloud_cfg;
     ss::sharded<cloud_storage::remote> cloud_api;
     ss::logger logger{"archival_metadata_stm_test"};
@@ -104,7 +109,7 @@ struct archival_metadata_stm_fixture : archival_metadata_stm_base_fixture {
         // Archival metadata STM
         start_raft();
         archival_stm = std::make_unique<cluster::archival_metadata_stm>(
-          _raft.get(), cloud_api.local(), logger);
+          _raft.get(), cloud_api.local(), feature_table.local(), logger);
 
         archival_stm->start().get();
     }
@@ -227,7 +232,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
       .get();
 
     cluster::archival_metadata_stm archival_stm(
-      _raft.get(), cloud_api.local(), logger);
+      _raft.get(), cloud_api.local(), feature_table.local(), logger);
 
     archival_stm.start().get();
     wait_for_confirmed_leader();
@@ -424,7 +429,7 @@ FIXTURE_TEST(
     make_old_snapshot(ntp_cfg, m, model::offset{3}).get();
 
     cluster::archival_metadata_stm archival_stm(
-      _raft.get(), cloud_api.local(), logger);
+      _raft.get(), cloud_api.local(), feature_table.local(), logger);
 
     archival_stm.start().get();
     wait_for_confirmed_leader();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -971,13 +971,13 @@ configuration::configuration()
   , cloud_storage_enable_remote_read(
       *this,
       "cloud_storage_enable_remote_read",
-      "Enable remote read for all topics",
+      "Default remote read config value for new topics",
       {.visibility = visibility::tunable},
       false)
   , cloud_storage_enable_remote_write(
       *this,
       "cloud_storage_enable_remote_write",
-      "Enable remote write for all topics",
+      "Default remote write value for new topics",
       {.visibility = visibility::tunable},
       false)
   , cloud_storage_access_key(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -972,13 +972,13 @@ configuration::configuration()
       *this,
       "cloud_storage_enable_remote_read",
       "Default remote read config value for new topics",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , cloud_storage_enable_remote_write(
       *this,
       "cloud_storage_enable_remote_write",
       "Default remote write value for new topics",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , cloud_storage_access_key(
       *this,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -87,19 +87,12 @@ get_bool_value(const config_map_t& config, std::string_view key) {
     return std::nullopt;
 }
 
-static std::optional<model::shadow_indexing_mode>
+static model::shadow_indexing_mode
 get_shadow_indexing_mode(const config_map_t& config) {
     auto arch_enabled = get_bool_value(config, topic_property_remote_write);
     auto si_enabled = get_bool_value(config, topic_property_remote_read);
 
-    // If the topic creation does not explicitly specify a shadow indexing mode
-    // we should use the default shadow indexing mode.
-    if (!arch_enabled && !si_enabled) {
-        return std::nullopt;
-    }
-
-    // If one of the topic properties is missing, patch it with the cluster
-    // config.
+    // If topic properties are missing, patch them with the cluster config.
     if (!arch_enabled) {
         arch_enabled
           = config::shard_local_cfg().cloud_storage_enable_remote_write();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -664,9 +664,8 @@ disk_log_impl::override_retention_config(compaction_config cfg) const {
 }
 
 bool disk_log_impl::is_cloud_retention_active() const {
-    return config::shard_local_cfg().cloud_storage_enabled() && 
-        (config::shard_local_cfg().cloud_storage_enable_remote_write()
-      || config().is_archival_enabled());
+    return config::shard_local_cfg().cloud_storage_enabled()
+           && (config().is_archival_enabled());
 }
 
 compaction_config

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1265,21 +1265,24 @@ class RedpandaService(Service):
         patch_result = self._admin.patch_cluster_config(upsert=values)
         new_version = patch_result['config_version']
 
+        def is_ready():
+            status = self._admin.get_cluster_config_status(
+                node=self.controller())
+            ready = all([n['config_version'] >= new_version for n in status])
+
+            return ready, status
+
         # The version check is >= to permit other config writes to happen in
         # the background, including the write to cluster_id that happens
         # early in the cluster's lifetime
-        wait_until(
-            lambda: all([
-                n['config_version'] >= new_version for n in self._admin.
-                get_cluster_config_status(node=self.controller())
-            ]),
+        config_status = wait_until_result(
+            is_ready,
             timeout_sec=10,
             backoff_sec=0.5,
             err_msg=f"Config status versions did not converge on {new_version}"
         )
 
-        any_restarts = any(n['restart']
-                           for n in self._admin.get_cluster_config_status())
+        any_restarts = any(n['restart'] for n in config_status)
         if any_restarts and expect_restart:
             self.restart_nodes(self.nodes)
         elif any_restarts:

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -190,7 +190,7 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
 
         self.client().alter_topic_config(topic, "redpanda.remote.read",
                                          "false")
-        self.client().alter_topic_config(topic, "redpanda.remote.read",
+        self.client().alter_topic_config(topic, "redpanda.remote.write",
                                          "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -250,7 +250,10 @@ class ShadowIndexingRetentionTest(RedpandaTest):
                                   "redpanda.remote.write": topic_remote_write
                               })
 
-        expect_deletion = cluster_remote_write or topic_remote_write == "true"
+        if topic_remote_write != "-1":
+            expect_deletion = topic_remote_write == "true"
+        else:
+            expect_deletion = cluster_remote_write
 
         produce_total_bytes(self.redpanda,
                             topic=self.topic_name,


### PR DESCRIPTION
## Cover letter

Instead of treating remote.read and remote.write as properties that can be overridden by topics or can be null and thereby get cluster defaults (including updating when those defaults change), we will now always store an explicit value for the properties on the topic, and the cluster defaults will simply control what that explicit value defaults to at time of topic creation (or at time of upgrade, for clusters coming from <= 22.2)

This is based on https://github.com/redpanda-data/redpanda/pull/6876

Fixes https://github.com/redpanda-data/redpanda/issues/6917

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

See release notes

## Release notes

### Improvements

* The properties `cloud_storage_enable_remote_[read|write]` are now applied to topics at creation time, and if they subsequently change, then existing topics' properties do not change.  To modify the tiered storage mode of existing topics, you may set the `redpanda.remote.[read|write]` properties on the topic.
