### PR TITLE
storage: Use whichever retention setting of local and general one is more strict

### DIFF
--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -162,6 +162,8 @@ private:
 
     compaction_config override_retention_config(compaction_config cfg) const;
 
+    bool is_cloud_retention_active() const;
+
 private:
     size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -55,34 +55,14 @@ struct log_config {
       size_t segment_size,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority
-      = ss::default_priority_class()) noexcept
-      : stype(type)
-      , base_dir(std::move(directory))
-      , max_segment_size(config::mock_binding<size_t>(std::move(segment_size)))
-      , segment_size_jitter(0) // For deterministic behavior in unit tests.
-      , compacted_segment_size(config::mock_binding<size_t>(256_MiB))
-      , max_compacted_segment_size(config::mock_binding<size_t>(5_GiB))
-      , sanitize_fileops(should)
-      , compaction_priority(compaction_priority)
-      , retention_bytes(
-          config::mock_binding<std::optional<size_t>>(std::nullopt))
-      , compaction_interval(config::mock_binding<std::chrono::milliseconds>(
-          std::chrono::minutes(10)))
-      , delete_retention(
-          config::mock_binding<std::optional<std::chrono::milliseconds>>(
-            std::chrono::minutes(10080))) {}
-
+      = ss::default_priority_class()) noexcept;
     log_config(
       storage_type type,
       ss::sstring directory,
       size_t segment_size,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority,
-      with_cache with) noexcept
-      : log_config(type, directory, segment_size, should, compaction_priority) {
-        cache = with;
-    }
-
+      with_cache with) noexcept;
     log_config(
       storage_type type,
       ss::sstring directory,
@@ -98,22 +78,7 @@ struct log_config {
       with_cache c,
       batch_cache::reclaim_options recopts,
       std::chrono::milliseconds rdrs_cache_eviction_timeout,
-      ss::scheduling_group compaction_sg) noexcept
-      : stype(type)
-      , base_dir(std::move(directory))
-      , max_segment_size(segment_size)
-      , segment_size_jitter(segment_size_jitter)
-      , compacted_segment_size(compacted_segment_size)
-      , max_compacted_segment_size(max_compacted_segment_size)
-      , sanitize_fileops(should)
-      , compaction_priority(compaction_priority)
-      , retention_bytes(ret_bytes)
-      , compaction_interval(compaction_ival)
-      , delete_retention(del_ret)
-      , cache(c)
-      , reclaim_opts(recopts)
-      , readers_cache_eviction_timeout(rdrs_cache_eviction_timeout)
-      , compaction_sg(compaction_sg) {}
+      ss::scheduling_group compaction_sg) noexcept;
 
     ~log_config() noexcept = default;
     // must be enabled so that we can do ss::sharded<>.start(config);

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -202,7 +202,7 @@ public:
      * NOTE: if removal of an ntp causes the parent topic directory to become
      * empty then it is also removed. Currently topic deletion is the only
      * action that drives partition removal, so this makes sense. This must be
-     * revisted when we start removing partitions for other reasons, like
+     * revisited when we start removing partitions for other reasons, like
      * rebalancing partitions across the cluster, etc...
      */
     ss::future<> remove(model::ntp);


### PR DESCRIPTION
## Cover letter

Using stricter retention settings when both cloud and local retention defining property are set. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6922

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
