### PR TITLE
rpk: use redpanda.admin if rpk.admin_api is nil

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -60,7 +60,13 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			admin, err := admin.NewClient(fs, cfg)
+			// We use NewHostClient because we want to talk to
+			// localhost, and some of out API requests require
+			// choosing the host to talk to. With params of
+			// rpk.admin_api preferring localhost first IF no
+			// rpk.admin_api is actually in the underlying file, we
+			// can always just pick the first host.
+			admin, err := admin.NewHostClient(fs, cfg, "0")
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			cl, err := kafka.NewFranzClient(fs, p, cfg)

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -606,6 +606,17 @@ func defaultFromRedpanda(src []NamedSocketAddress, srcTLS []ServerTLS, dst *[]st
 			add(&localhost, &tlsLocalhost, &mtlsLocalhost, s, a)
 		case ip.IsLoopback():
 			add(&loopback, &tlsLoopback, &mtlsLoopback, s, a)
+		case ip.IsUnspecified():
+			// An unspecified address ("0.0.0.0") tells the server
+			// to listen on all available interfaces. We cannot
+			// dial 0.0.0.0, but we can dial 127.0.0.1 which is an
+			// available interface. Also see:
+			//
+			// 	https://stackoverflow.com/a/20778887
+			//
+			// So, we add a loopback hostport.
+			s = net.JoinHostPort("127.0.0.1", strconv.Itoa(a.Port))
+			add(&loopback, &tlsLoopback, &mtlsLoopback, s, a)
 		case ip.IsPrivate():
 			add(&private, &tlsPrivate, &mtlsPrivate, s, a)
 		default:

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -345,7 +345,7 @@ func TestAddUnsetDefaults(t *testing.T) {
 					},
 					KafkaAPITLS: []ServerTLS{{Name: "tls", Enabled: true}},
 					AdminAPI: []NamedSocketAddress{
-						{Address: "10.0.0.1", Port: 4444, Name: "tls"},
+						{Address: "10.0.0.1", Port: 4444, Name: "tls"}, // same as above, numbers in addr/port slightly changed
 						{Address: "127.0.0.1", Port: 4444, Name: "tls"},
 						{Address: "localhost", Port: 4444, Name: "tls"},
 						{Address: "122.65.33.12", Port: 4444, Name: "tls"},
@@ -397,6 +397,92 @@ func TestAddUnsetDefaults(t *testing.T) {
 							"127.0.2.1:7777",    // loopback
 							"10.0.2.1:7777",     // private
 							"122.65.32.12:7777", // public
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "broker and admin api sorted with TLS and MTLS",
+			inCfg: &Config{
+				Redpanda: RedpandaNodeConfig{
+					KafkaAPI: []NamedAuthNSocketAddress{
+						{Address: "10.1.0.1", Port: 1111, Name: "mtls"}, // similar to above test
+						{Address: "127.1.0.1", Port: 1111, Name: "mtls"},
+						{Address: "localhost", Port: 1111, Name: "mtls"},
+						{Address: "122.61.33.12", Port: 1111, Name: "mtls"},
+						{Address: "10.1.0.1", Port: 5555, Name: "tls"},
+						{Address: "127.1.0.1", Port: 5555, Name: "tls"},
+						{Address: "localhost", Port: 5555, Name: "tls"},
+						{Address: "122.61.33.12", Port: 5555, Name: "tls"},
+					},
+					KafkaAPITLS: []ServerTLS{
+						{Name: "tls", Enabled: true},
+						{Name: "mtls", Enabled: true, RequireClientAuth: true},
+					},
+					AdminAPI: []NamedSocketAddress{
+						{Address: "10.1.0.9", Port: 2222, Name: "mtls"},
+						{Address: "127.1.0.9", Port: 2222, Name: "mtls"},
+						{Address: "localhost", Port: 2222, Name: "mtls"},
+						{Address: "122.61.33.9", Port: 2222, Name: "mtls"},
+						{Address: "10.1.0.9", Port: 4444, Name: "tls"},
+						{Address: "127.1.0.9", Port: 4444, Name: "tls"},
+						{Address: "localhost", Port: 4444, Name: "tls"},
+						{Address: "122.61.33.9", Port: 4444, Name: "tls"},
+					},
+					AdminAPITLS: []ServerTLS{
+						{Name: "mtls", Enabled: true, RequireClientAuth: true},
+						{Name: "tls", Enabled: true},
+					},
+				},
+			},
+			expCfg: &Config{
+				Redpanda: RedpandaNodeConfig{
+					KafkaAPI: []NamedAuthNSocketAddress{
+						{Address: "10.1.0.1", Port: 1111, Name: "mtls"},
+						{Address: "127.1.0.1", Port: 1111, Name: "mtls"},
+						{Address: "localhost", Port: 1111, Name: "mtls"},
+						{Address: "122.61.33.12", Port: 1111, Name: "mtls"},
+						{Address: "10.1.0.1", Port: 5555, Name: "tls"},
+						{Address: "127.1.0.1", Port: 5555, Name: "tls"},
+						{Address: "localhost", Port: 5555, Name: "tls"},
+						{Address: "122.61.33.12", Port: 5555, Name: "tls"},
+					},
+					KafkaAPITLS: []ServerTLS{
+						{Name: "tls", Enabled: true},
+						{Name: "mtls", Enabled: true, RequireClientAuth: true},
+					},
+					AdminAPI: []NamedSocketAddress{
+						{Address: "10.1.0.9", Port: 2222, Name: "mtls"},
+						{Address: "127.1.0.9", Port: 2222, Name: "mtls"},
+						{Address: "localhost", Port: 2222, Name: "mtls"},
+						{Address: "122.61.33.9", Port: 2222, Name: "mtls"},
+						{Address: "10.1.0.9", Port: 4444, Name: "tls"},
+						{Address: "127.1.0.9", Port: 4444, Name: "tls"},
+						{Address: "localhost", Port: 4444, Name: "tls"},
+						{Address: "122.61.33.9", Port: 4444, Name: "tls"},
+					},
+					AdminAPITLS: []ServerTLS{
+						{Name: "mtls", Enabled: true, RequireClientAuth: true},
+						{Name: "tls", Enabled: true},
+					},
+				},
+				Rpk: RpkConfig{
+					KafkaAPI: RpkKafkaAPI{
+						Brokers: []string{
+							"localhost:5555",
+							"127.1.0.1:5555",
+							"10.1.0.1:5555",
+							"122.61.33.12:5555",
+						},
+					},
+					AdminAPI: RpkAdminAPI{
+						Addresses: []string{
+							"localhost:4444",
+							"127.1.0.9:4444",
+							"10.1.0.9:4444",
+							"122.61.33.9:4444",
 						},
 					},
 				},

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -35,10 +35,10 @@ func TestParams_Write(t *testing.T) {
 rpk:
     kafka_api:
         brokers:
-            - 0.0.0.0:9092
+            - 127.0.0.1:9092
     admin_api:
         addresses:
-            - 0.0.0.0:9644
+            - 127.0.0.1:9644
 `,
 		},
 		{
@@ -342,6 +342,7 @@ func TestAddUnsetDefaults(t *testing.T) {
 						{Address: "127.1.2.1", Port: 9999},                 // loopback
 						{Address: "localhost", Port: 9999},                 // localhost
 						{Address: "122.61.32.12", Port: 9999},              // public
+						{Address: "0.0.0.0", Port: 9999},                   // rewritten to 127.0.0.1
 					},
 					KafkaAPITLS: []ServerTLS{{Name: "tls", Enabled: true}},
 					AdminAPI: []NamedSocketAddress{
@@ -368,6 +369,7 @@ func TestAddUnsetDefaults(t *testing.T) {
 						{Address: "127.1.2.1", Port: 9999},
 						{Address: "localhost", Port: 9999},
 						{Address: "122.61.32.12", Port: 9999},
+						{Address: "0.0.0.0", Port: 9999},
 					},
 					KafkaAPITLS: []ServerTLS{{Name: "tls", Enabled: true}},
 					AdminAPI: []NamedSocketAddress{
@@ -387,6 +389,7 @@ func TestAddUnsetDefaults(t *testing.T) {
 						Brokers: []string{
 							"localhost:9999",
 							"127.1.2.1:9999",
+							"127.0.0.1:9999",
 							"10.1.2.1:9999",
 							"122.61.32.12:9999",
 						},

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -290,21 +290,31 @@ func TestAddUnsetDefaults(t *testing.T) {
 			inCfg: &Config{
 				Redpanda: RedpandaNodeConfig{
 					AdminAPI: []NamedSocketAddress{
-						{Address: "10.0.0.1", Port: 4444},     // private
-						{Address: "127.0.0.1", Port: 4444},    // loopback
-						{Address: "localhost", Port: 4444},    // localhost
-						{Address: "122.65.33.12", Port: 4444}, // public
+						{Address: "10.0.0.1", Port: 4444, Name: "tls"},     // private, TLS
+						{Address: "127.0.0.1", Port: 4444, Name: "tls"},    // loopback, TLS
+						{Address: "localhost", Port: 4444, Name: "tls"},    // localhost, TLS
+						{Address: "122.65.33.12", Port: 4444, Name: "tls"}, // public, TLS
+						{Address: "10.0.2.1", Port: 7777},                  // private
+						{Address: "127.0.2.1", Port: 7777},                 // loopback
+						{Address: "localhost", Port: 7777},                 // localhost
+						{Address: "122.65.32.12", Port: 7777},              // public
 					},
+					AdminAPITLS: []ServerTLS{{Name: "tls", Enabled: true}},
 				},
 			},
 			expCfg: &Config{
 				Redpanda: RedpandaNodeConfig{
 					AdminAPI: []NamedSocketAddress{
-						{Address: "10.0.0.1", Port: 4444},
-						{Address: "127.0.0.1", Port: 4444},
-						{Address: "localhost", Port: 4444},
-						{Address: "122.65.33.12", Port: 4444},
+						{Address: "10.0.0.1", Port: 4444, Name: "tls"},
+						{Address: "127.0.0.1", Port: 4444, Name: "tls"},
+						{Address: "localhost", Port: 4444, Name: "tls"},
+						{Address: "122.65.33.12", Port: 4444, Name: "tls"},
+						{Address: "10.0.2.1", Port: 7777},
+						{Address: "127.0.2.1", Port: 7777},
+						{Address: "localhost", Port: 7777},
+						{Address: "122.65.32.12", Port: 7777},
 					},
+					AdminAPITLS: []ServerTLS{{Name: "tls", Enabled: true}},
 				},
 				Rpk: RpkConfig{
 					KafkaAPI: RpkKafkaAPI{
@@ -312,10 +322,14 @@ func TestAddUnsetDefaults(t *testing.T) {
 					},
 					AdminAPI: RpkAdminAPI{
 						Addresses: []string{
-							"localhost:4444",    // private
-							"127.0.0.1:4444",    // loopback
-							"10.0.0.1:4444",     // private
-							"122.65.33.12:4444", // public
+							"localhost:7777",    // localhost
+							"127.0.2.1:7777",    // loopback
+							"10.0.2.1:7777",     // private
+							"122.65.32.12:7777", // public
+							"localhost:4444",    // localhost, TLS
+							"127.0.0.1:4444",    // loopback, TLS
+							"10.0.0.1:4444",     // private, TLS
+							"122.65.33.12:4444", // public, TLS
 						},
 					},
 				},

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -118,6 +118,18 @@ type NamedAuthNSocketAddress struct {
 	AuthN   *string `yaml:"authentication_method,omitempty" json:"authentication_method,omitempty"`
 }
 
+func namedAuthnToNamed(src []NamedAuthNSocketAddress) []NamedSocketAddress {
+	dst := make([]NamedSocketAddress, 0, len(src))
+	for _, a := range src {
+		dst = append(dst, NamedSocketAddress{
+			Address: a.Address,
+			Port:    a.Port,
+			Name:    a.Name,
+		})
+	}
+	return dst
+}
+
 type TLS struct {
 	KeyFile        string `yaml:"key_file,omitempty" json:"key_file"`
 	CertFile       string `yaml:"cert_file,omitempty" json:"cert_file"`


### PR DESCRIPTION
## Cover letter
Previously rpk will use rpk.admin_api.addresses to communicate with admin API, if that field isn't set, rpk will use the default 127.0.0.1:9644

That's a problem if we are running in non-default port or address, now, rpk will use redpanda.admin _if_ rpk.admin_api.addresses is not set

Fixes #2752, Fixes #6860

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Let's say you have this config file:
```yaml
redpanda:
    ...
    admin:
        - address: 1.2.3.4   # non-default address
          port: 9645            # non-default port
    developer_mode:  true
    auto_create_topics_enabled: true
    group_topic_partitions: 3
    storage_min_free_bytes: 10485760
    topic_partitions_per_shard: 1000
rpk:
    tune_disk_irq: true
    ... # no rpk.admin_api set.
```

Running `rpk cluster health` will give you an error like this::
```
* unable to fetch metrics from the admin API: Get "http://127.0.0.1:9644/...
```

The above happened because rpk will use the default host:port instead of using the one set in `redpanda.admin` property, now, rpk will use `redpanda.admin (1.2.3.4:9645)` in this same scenario.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
### Improvements

* rpk now will use the admin address from `redpanda.admin` in the config file if the property `rpk.admin_api.addresses` is empty.
