### PR TITLE
tests: enable debug logging for pandaproxy

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -555,7 +555,8 @@ class RedpandaService(Service):
                     'archival': 'debug',
                     'io': 'debug',
                     'cloud_storage': 'debug',
-                    'seastar_memory': 'debug'
+                    'seastar_memory': 'debug',
+                    'pandaproxy': 'debug'
                 })
 
         self._admin = Admin(self,


### PR DESCRIPTION
## Cover letter

Recently the test tree has had an influx of ducktape tests for the Pandaproxy and Schema Registry. This is in part due to increased customer demand for these services. We are starting to see more CI failures related to the proxy and registry because of the increase in test coverage. Therefore, let's enable debug logging by default.

This will help with debugging #6903 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
