### PR TITLE
features: add early-loaded snapshots of feature table

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -142,7 +142,8 @@ ss::future<> controller::start(cluster_discovery& discovery) {
           return _members_manager.local().validate_configuration_invariants();
       })
       .then([this] {
-          return _feature_backend.start_single(std::ref(_feature_table));
+          return _feature_backend.start_single(
+            std::ref(_feature_table), std::ref(_storage));
       })
       .then([this] {
           return _bootstrap_backend.start_single(

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -14,7 +14,7 @@
 #include "cluster/commands.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
-#include "features/feature_table.h"
+#include "features/fwd.h"
 #include "storage/fwd.h"
 
 namespace cluster {
@@ -34,6 +34,8 @@ public:
       , _storage(storage) {}
 
     ss::future<std::error_code> apply_update(model::record_batch);
+
+    ss::future<> save_snapshot();
 
     bool is_batch_applicable(const model::record_batch& b) {
         return b.header().type == model::record_batch_type::feature_update;

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -15,6 +15,7 @@
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "features/feature_table.h"
+#include "storage/fwd.h"
 
 namespace cluster {
 
@@ -26,8 +27,11 @@ namespace cluster {
  */
 class feature_backend {
 public:
-    feature_backend(ss::sharded<features::feature_table>& table)
-      : _feature_table(table) {}
+    feature_backend(
+      ss::sharded<features::feature_table>& table,
+      ss::sharded<storage::api>& storage)
+      : _feature_table(table)
+      , _storage(storage) {}
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -41,5 +45,6 @@ private:
       feature_update_license_update_cmd>();
 
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<storage::api>& _storage;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -12,6 +12,7 @@
 #include "cluster/simple_batch_builder.h"
 #include "cluster/tests/cluster_test_fixture.h"
 #include "config/configuration.h"
+#include "features/feature_table_snapshot.h"
 #include "net/unresolved_address.h"
 #include "test_utils/fixture.h"
 
@@ -102,4 +103,64 @@ FIXTURE_TEST(
     // single broker
     BOOST_REQUIRE_EQUAL(brokers.size(), 1);
     BOOST_REQUIRE_EQUAL(brokers[0]->id(), id0);
+}
+
+FIXTURE_TEST(test_feature_table_snapshots, cluster_test_fixture) {
+    // Switch on the dummy test features for use in the test.  It is safe
+    // to leave this set for the remainder of process lifetime, as other
+    // tests should not notice or care that there is an extra feature flag.
+    setenv("__REDPANDA_TEST_FEATURES", "true", 1);
+
+    // Start up a node normally
+    const model::node_id id0{0};
+    auto app = create_node_application(
+      id0, configure_node_id::no, empty_seed_starts_cluster::no);
+    BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
+    wait_for_controller_leadership(id0).get();
+    wait_for_all_members(3s).get();
+
+    // Peek at storage, see that it created a snapshot
+    auto snap_opt = app->storage.local().kvs().get(
+      storage::kvstore::key_space::controller,
+      features::feature_table_snapshot::kvstore_key());
+    BOOST_REQUIRE(snap_opt.has_value());
+
+    auto active_version = app->feature_table.local().get_active_version();
+
+    // Restart it
+    remove_node_application(id0);
+    app = create_node_application(
+      id0, configure_node_id::no, empty_seed_starts_cluster::no);
+
+    // Peek at its feature table to check that it is in the expected state,
+    // although this doesn't prove it was loaded from a snapshot.
+    BOOST_REQUIRE(
+      active_version == app->feature_table.local().get_active_version());
+    BOOST_REQUIRE(
+      app->feature_table.local().is_active(features::feature::test_alpha)
+      == false);
+
+    // Now inject a phony snapshot to check that the application really is
+    // loading from the snapshot and not just reconstituting via controller log.
+    features::feature_table_snapshot bogus_snapshot;
+    bogus_snapshot.applied_offset
+      = app->feature_table.local().get_applied_offset();
+    bogus_snapshot.version = app->feature_table.local().get_active_version();
+    bogus_snapshot.states = {features::feature_state_snapshot{
+      .name = "__test_alpha", .state = features::feature_state::state::active}};
+    app->storage.local()
+      .kvs()
+      .put(
+        storage::kvstore::key_space::controller,
+        features::feature_table_snapshot::kvstore_key(),
+        serde::to_iobuf(bogus_snapshot))
+      .get();
+
+    remove_node_application(id0);
+    app = create_node_application(
+      id0, configure_node_id::no, empty_seed_starts_cluster::no);
+
+    BOOST_REQUIRE(
+      app->feature_table.local().is_active(features::feature::test_alpha)
+      == true);
 }

--- a/src/v/features/CMakeLists.txt
+++ b/src/v/features/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   NAME features
   SRCS
     feature_table.cc
+    feature_table_snapshot.cc
     feature_migrator.cc
     migrators/cloud_storage_config.cc
     migrators/group_metadata.cc

--- a/src/v/features/feature_state.h
+++ b/src/v/features/feature_state.h
@@ -16,6 +16,7 @@
 namespace features {
 
 struct feature_spec;
+struct feature_table_snapshot;
 
 /**
  * Feature states
@@ -125,6 +126,8 @@ public:
 
 private:
     state _state{state::unavailable};
+
+    friend struct feature_table_snapshot;
 };
 
 } // namespace features

--- a/src/v/features/feature_state.h
+++ b/src/v/features/feature_state.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/types.h"
+
+namespace features {
+
+struct feature_spec;
+
+/**
+ * Feature states
+ * ==============
+ *
+ * Start as unavailable.  Become available once all nodes
+ * are recent enough.
+ *
+ * Once available, either advance straight to 'preparing'
+ * if available_policy is 'always', else wait for administrator
+ * to activate the feature.
+ *
+ * Once in preparing, either advance straight to 'active'
+ * if prepare_policy is 'always', else wait for notification
+ * that preparation is complete before proceeding.
+ *
+ * Features may be disabled at any time, but from unavailable/available
+ * states they go to disabled_clean, whereas from other states they
+ * go to disabled_dirty.  This tracks whether the feature may have
+ * written persistent structures.
+ *
+    ┌──────────────┐           ┌──────────────────┐
+    │              ├──────────►│                  │
+    │  unavailable │           │  disabled_clean  │
+    │              │◄──────────┤                  │
+    └───────┬──────┘           └───┬──────────────┘
+            │                      │            ▲
+            ▼                      │            │
+    ┌──────────────┐               │            │
+    │              │◄──────────────┘            │
+    │   available  │                            │
+    │              ├────────────────────────────┘
+    └───────┬──────┘
+            │
+            ▼
+    ┌──────────────┐            ┌─────────────────────┐
+    │              ├───────────►│                     │
+    │   preparing  │            │  disabled_preparing │
+    │              │◄───────────┤                     │
+    └───────┬──────┘            └─────────────────────┘
+            │
+            ▼
+    ┌──────────────┐            ┌─────────────────────┐
+    │              ├───────────►│                     │
+    │    active    │            │  disabled_active    │
+    │              │◄───────────┤                     │
+    └──────────────┘            └─────────────────────┘
+ *
+ */
+class feature_state {
+public:
+    enum class state : uint8_t {
+        // Unavailable means not all nodes in the cluster are recent
+        unavailable = 0,
+
+        // Available means the feature is eligible for activation.  If the
+        // feature spec allows it, it may proceed autonomously to preparing
+        // or active.  Otherwise, it may have too wait for an administrator
+        // to permit it to activate.
+        available = 1,
+
+        // Preparing means the feature is in the process of a data migration
+        // or other preparatory step.  It will proceed to active status
+        // autonomously.
+        preparing = 2,
+
+        // Active means the feature is up and running and ready to use.  This
+        // is the normal state of most features through most of their lifetime.
+        active = 3,
+
+        // Administratively disabled, but it was in 'active' or 'preparing'
+        // state at some point in the past.  Indicates that while the feature
+        // is disabled now, there may be data structures written to disk that
+        // depend on this feature to read back.
+        // The distinction between _active and _perparing variants is needed
+        // so that when an administrator re-activates the feature, we know
+        // what state to go back into.
+        disabled_active = 4,
+        disabled_preparing = 5,
+
+        // Administratively disabled, and never progressed past 'available'.
+        // Means that any data structures dependent on this feature were
+        // never written to disk, and no migrations for this feature were done.
+        disabled_clean = 6,
+    };
+
+    const feature_spec& spec;
+
+    feature_state(const feature_spec& spec_)
+      : spec(spec_){};
+
+    // External inputs
+    void notify_version(cluster::cluster_version v);
+
+    // State transition hooks
+    void transition_unavailable() { _state = state::unavailable; }
+
+    void transition_disabled_clean() { _state = state::disabled_clean; }
+    void transition_disabled_preparing() { _state = state::disabled_preparing; }
+    void transition_disabled_active() { _state = state::disabled_active; }
+
+    void transition_available();
+    void transition_preparing();
+    void transition_active();
+
+    state get_state() const { return _state; };
+
+private:
+    state _state{state::unavailable};
+};
+
+} // namespace features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -279,10 +279,15 @@ public:
      */
     void testing_activate_all();
 
+    model::offset get_applied_offset() const { return _applied_offset; }
+
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
+
+    // The controller log offset of last batch applied to this state machine
+    void set_applied_offset(model::offset o) { _applied_offset = o; }
 
     void on_update();
 
@@ -302,6 +307,8 @@ private:
 
     // Currently loaded redpanda license details
     std::optional<security::license> _license;
+
+    model::offset _applied_offset{};
 
     // feature_manager is a friend so that they can initialize
     // the active version on single-node first start.

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -19,10 +19,6 @@
 #include <array>
 #include <string_view>
 
-using cluster::cluster_version;
-using cluster::feature_update_action;
-using cluster::invalid_version;
-
 // cluster classes that we will make friends of the feature_table
 namespace cluster {
 class feature_backend;
@@ -79,7 +75,7 @@ struct feature_spec {
     };
 
     constexpr feature_spec(
-      cluster_version require_version_,
+      cluster::cluster_version require_version_,
       std::string_view name_,
       feature bits_,
       available_policy apol,
@@ -92,7 +88,7 @@ struct feature_spec {
 
     feature bits{0};
     std::string_view name;
-    cluster_version require_version;
+    cluster::cluster_version require_version;
 
     available_policy available_rule;
     prepare_policy prepare_rule;
@@ -100,97 +96,97 @@ struct feature_spec {
 
 constexpr static std::array feature_schema{
   feature_spec{
-    cluster_version{1},
+    cluster::cluster_version{1},
     "central_config",
     feature::central_config,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{2},
+    cluster::cluster_version{2},
     "consumer_offsets",
     feature::consumer_offsets,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::requires_migration},
   feature_spec{
-    cluster_version{3},
+    cluster::cluster_version{3},
     "maintenance_mode",
     feature::maintenance_mode,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{3},
+    cluster::cluster_version{3},
     "mtls_authentication",
     feature::mtls_authentication,
     feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{4},
+    cluster::cluster_version{4},
     "rm_stm_kafka_cache",
     feature::rm_stm_kafka_cache,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{5},
+    cluster::cluster_version{5},
     "serde_raft_0",
     feature::serde_raft_0,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{5},
+    cluster::cluster_version{5},
     "license",
     feature::license,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{5},
+    cluster::cluster_version{5},
     "raft_improved_configuration",
     feature::raft_improved_configuration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{6},
+    cluster::cluster_version{6},
     "transaction_ga",
     feature::transaction_ga,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "raftless_node_status",
     feature::raftless_node_status,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "rpc_v2_by_default",
     feature::rpc_v2_by_default,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "cloud_retention",
     feature::cloud_retention,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::requires_migration},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "node_id_assignment",
     feature::node_id_assignment,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "replication_factor_change",
     feature::replication_factor_change,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{7},
+    cluster::cluster_version{7},
     "ephemeral_secrets",
     feature::ephemeral_secrets,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster_version{2001},
+    cluster::cluster_version{2001},
     "__test_alpha",
     feature::test_alpha,
     feature_spec::available_policy::explicit_only,
@@ -208,7 +204,7 @@ std::string_view to_string_view(feature_state::state);
  */
 class feature_table {
 public:
-    cluster_version get_active_version() const noexcept {
+    cluster::cluster_version get_active_version() const noexcept {
         return _active_version;
     }
 
@@ -257,7 +253,7 @@ public:
 
     ss::future<> stop();
 
-    static cluster_version get_latest_logical_version();
+    static cluster::cluster_version get_latest_logical_version();
 
     feature_table();
 
@@ -283,12 +279,12 @@ public:
 
 private:
     // Only for use by our friends feature backend & manager
-    void set_active_version(cluster_version);
-    void apply_action(const feature_update_action& fua);
+    void set_active_version(cluster::cluster_version);
+    void apply_action(const cluster::feature_update_action& fua);
 
     void on_update();
 
-    cluster_version _active_version{invalid_version};
+    cluster::cluster_version _active_version{cluster::invalid_version};
 
     std::vector<feature_state> _feature_state;
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -27,6 +27,8 @@ class feature_manager;
 
 namespace features {
 
+struct feature_table_snapshot;
+
 enum class feature : std::uint64_t {
     central_config = 0x1,
     consumer_offsets = 0x2,
@@ -311,6 +313,9 @@ private:
 
     // Unit testing hook.
     friend class feature_table_fixture;
+
+    // Permit snapshot generation to read internals
+    friend struct feature_table_snapshot;
 
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/types.h"
+#include "features/feature_state.h"
 #include "security/license.h"
 #include "utils/waiter_queue.h"
 
@@ -194,116 +195,6 @@ constexpr static std::array feature_schema{
     feature::test_alpha,
     feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always}};
-
-/**
- * Feature states
- * ==============
- *
- * Start as unavailable.  Become available once all nodes
- * are recent enough.
- *
- * Once available, either advance straight to 'preparing'
- * if available_policy is 'always', else wait for administrator
- * to activate the feature.
- *
- * Once in preparing, either advance straight to 'active'
- * if prepare_policy is 'always', else wait for notification
- * that preparation is complete before proceeding.
- *
- * Features may be disabled at any time, but from unavailable/available
- * states they go to disabled_clean, whereas from other states they
- * go to disabled_dirty.  This tracks whether the feature may have
- * written persistent structures.
- *
-    ┌──────────────┐           ┌──────────────────┐
-    │              ├──────────►│                  │
-    │  unavailable │           │  disabled_clean  │
-    │              │◄──────────┤                  │
-    └───────┬──────┘           └───┬──────────────┘
-            │                      │            ▲
-            ▼                      │            │
-    ┌──────────────┐               │            │
-    │              │◄──────────────┘            │
-    │   available  │                            │
-    │              ├────────────────────────────┘
-    └───────┬──────┘
-            │
-            ▼
-    ┌──────────────┐            ┌─────────────────────┐
-    │              ├───────────►│                     │
-    │   preparing  │            │  disabled_preparing │
-    │              │◄───────────┤                     │
-    └───────┬──────┘            └─────────────────────┘
-            │
-            ▼
-    ┌──────────────┐            ┌─────────────────────┐
-    │              ├───────────►│                     │
-    │    active    │            │  disabled_active    │
-    │              │◄───────────┤                     │
-    └──────────────┘            └─────────────────────┘
- *
- */
-class feature_state {
-public:
-    enum class state {
-        // Unavailable means not all nodes in the cluster are recent
-        unavailable,
-
-        // Available means the feature is eligible for activation.  If the
-        // feature spec allows it, it may proceed autonomously to preparing
-        // or active.  Otherwise, it may have too wait for an administrator
-        // to permit it to activate.
-        available,
-
-        // Preparing means the feature is in the process of a data migration
-        // or other preparatory step.  It will proceed to active status
-        // autonomously.
-        preparing,
-
-        // Active means the feature is up and running and ready to use.  This
-        // is the normal state of most features through most of their lifetime.
-        active,
-
-        // Administratively disabled, but it was in 'active' or 'preparing'
-        // state at some point in the past.  Indicates that while the feature
-        // is disabled now, there may be data structures written to disk that
-        // depend on this feature to read back.
-        // The distinction between _active and _perparing variants is needed
-        // so that when an administrator re-activates the feature, we know
-        // what state to go back into.
-        disabled_active,
-        disabled_preparing,
-
-        // Administratively disabled, and never progressed past 'available'.
-        // Means that any data structures dependent on this feature were
-        // never written to disk, and no migrations for this feature were done.
-        disabled_clean,
-    };
-
-    const feature_spec& spec;
-
-    feature_state(const feature_spec& spec_)
-      : spec(spec_){};
-
-    // External inputs
-    void notify_version(cluster_version v);
-
-    // State transition hooks
-    void transition_unavailable() { _state = state::unavailable; }
-
-    void transition_disabled_clean() { _state = state::disabled_clean; }
-    void transition_disabled_preparing() { _state = state::disabled_preparing; }
-    void transition_disabled_active() { _state = state::disabled_active; }
-
-    void transition_available();
-    void transition_preparing();
-    void transition_active();
-
-    state get_state() const { return _state; };
-
-private:
-    state _state{state::unavailable};
-};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "feature_table_snapshot.h"
+
+#include "features/feature_table.h"
+#include "features/logger.h"
+#include "vlog.h"
+
+namespace features {
+
+feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
+    feature_table_snapshot fts;
+
+    fts.states.reserve(feature_schema.size());
+
+    fts.version = ft.get_active_version();
+    fts.license = ft.get_license();
+    for (const auto& state : ft._feature_state) {
+        auto& name = state.spec.name;
+        fts.states.push_back(feature_state_snapshot{
+          .name = ss::sstring(name), .state = state._state});
+    }
+
+    return fts;
+}
+
+void feature_table_snapshot::apply(feature_table& ft) const {
+    ft.set_active_version(version);
+    ft._license = license;
+    for (auto& snap_state : ft._feature_state) {
+        auto snap_state_iter = std::find_if(
+          states.begin(),
+          states.end(),
+          [&snap_state](feature_state_snapshot const& s) {
+              return s.name == snap_state.spec.name;
+          });
+        if (snap_state_iter == states.end()) {
+            // The feature table refers to a feature name that the snapshot
+            // doesn't mention: this is normal on upgrade.  The feature will
+            // remain in its default-initialized state.
+            vlog(
+              featureslog.debug,
+              "No state for feature '{}' in snapshot, upgrade in progress?",
+              snap_state.spec.name);
+            continue;
+        } else {
+            snap_state._state = snap_state_iter->state;
+        }
+    }
+
+    ft.on_update();
+}
+
+bytes feature_table_snapshot::kvstore_key() {
+    return iobuf_to_bytes(serde::to_iobuf(ss::sstring("feature_table")));
+}
+
+} // namespace features

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -29,6 +29,7 @@ feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
         fts.states.push_back(feature_state_snapshot{
           .name = ss::sstring(name), .state = state._state});
     }
+    fts.applied_offset = ft.get_applied_offset();
 
     return fts;
 }
@@ -56,6 +57,8 @@ void feature_table_snapshot::apply(feature_table& ft) const {
             snap_state._state = snap_state_iter->state;
         }
     }
+
+    ft.set_applied_offset(applied_offset);
 
     ft.on_update();
 }

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "feature_state.h"
+#include "model/fundamental.h"
 #include "security/license.h"
 #include "serde/serde.h"
 
@@ -41,11 +42,14 @@ struct feature_state_snapshot
  */
 struct feature_table_snapshot
   : serde::envelope<feature_table_snapshot, serde::version<0>> {
+    model::offset applied_offset;
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;
     std::vector<feature_state_snapshot> states;
 
-    auto serde_fields() { return std::tie(version, states, license); }
+    auto serde_fields() {
+        return std::tie(applied_offset, version, states, license);
+    }
 
     /// Create a snapshot from a live feature table
     static feature_table_snapshot from(const feature_table&);

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "feature_state.h"
+#include "security/license.h"
+#include "serde/serde.h"
+
+namespace features {
+
+class feature_table;
+
+/**
+ * Part of feature_table_snapshot that corresponds to the feature_state
+ * stored within feature_table.
+ *
+ * Unlike, feature_state, this class embeds the feature name directly for
+ * serialization, rather than encapsulating a reference to a feature_spec.
+ */
+struct feature_state_snapshot
+  : serde::envelope<feature_state_snapshot, serde::version<0>> {
+    ss::sstring name;
+    feature_state::state state;
+
+    auto serde_fields() { return std::tie(name, state); }
+};
+
+/**
+ * Rather than adding serialization methods to feature_table that would
+ * include some subset of its fields, define a clean separate serialization
+ * containers for when encoding or decoding a snapshot.
+ */
+struct feature_table_snapshot
+  : serde::envelope<feature_table_snapshot, serde::version<0>> {
+    cluster::cluster_version version{cluster::invalid_version};
+    std::optional<security::license> license;
+    std::vector<feature_state_snapshot> states;
+
+    auto serde_fields() { return std::tie(version, states, license); }
+
+    /// Create a snapshot from a live feature table
+    static feature_table_snapshot from(const feature_table&);
+
+    /// Replace the feature table's state with this snapshot
+    void apply(feature_table&) const;
+
+    /// Key for storing the snapshot in the shard 0 kvstore.
+    static bytes kvstore_key();
+};
+
+} // namespace features

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1445,10 +1445,15 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
         // some of initialization that would usually wait for the controller
         // to commit some state to its log.
         vlog(_log.warn, "Running in unit test mode");
-        _feature_table
-          .invoke_on_all(
-            [](features::feature_table& ft) { ft.testing_activate_all(); })
-          .get();
+        if (
+          _feature_table.local().get_active_version()
+          == cluster::invalid_version) {
+            vlog(_log.info, "Switching on all features");
+            _feature_table
+              .invoke_on_all(
+                [](features::feature_table& ft) { ft.testing_activate_all(); })
+              .get();
+        }
     } else {
         // Only populate migrators in non-unit-test mode
         _migrators.push_back(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -126,6 +126,8 @@ private:
     void configure_admin_server();
     void wire_up_redpanda_services(model::node_id);
 
+    void load_feature_table_snapshot();
+
     // Starts the services meant for Redpanda runtime. Must be called after
     // having constructed the subsystems via the corresponding `wire_up` calls.
     void start_runtime_services(cluster::cluster_discovery&);

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -80,6 +80,7 @@ public:
     ss::future<> set_proxy_config(ss::sstring name, std::any val);
     ss::future<> set_proxy_client_config(ss::sstring name, std::any val);
 
+    ss::sharded<features::feature_table> feature_table;
     ss::sharded<cluster::metadata_cache> metadata_cache;
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<cluster::shard_table> shard_table;
@@ -184,7 +185,6 @@ private:
     ss::logger _log;
 
     ss::sharded<rpc::connection_cache> _connection_cache;
-    ss::sharded<features::feature_table> _feature_table;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<kafka::group_manager> _co_group_manager;
     ss::sharded<rpc::rpc_server> _rpc;


### PR DESCRIPTION
## Cover letter

This is part of the master plan to enable us to start removing legacy encoding code in the next major release after 22.3.

Once we have early-loaded snapshots of feature table, we can rely on post-upgrade 22.3 nodes to _always_ use new RPC encoding, and avoid the current behavior of starting connections in rpc v1 mode (ADL) before upgrading.

This also simplifies reasoning about feature flags everywhere they are used: no longer need to worry "what if I am running while the controller is still replaying?".  The only time feature flags will be in flux is during an upgrade, not during startup on subsequent boots.

This is currently implemented as a special case piece of code that stores the snapshot in the kvstore: when we implement generic controller snapshots in future, some of this code might go away (although it will still need a special case load path to load the snapshot before the controller starts up)

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
