### PR TITLE
Fix test to check if configmap ref is nil

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/console_controller_test.go
@@ -203,6 +203,9 @@ var _ = Describe("Console controller", func() {
 					return false
 				}
 				updatedRef := updatedConsole.Status.ConfigMapRef
+				if updatedRef == nil {
+					return false
+				}
 				updatedConfigmapNsn := fmt.Sprintf("%s/%s", updatedRef.Namespace, updatedRef.Name)
 				return updatedConfigmapNsn == configmapNsn
 			}, timeout, interval).Should(BeTrue())


### PR DESCRIPTION
## Cover letter

Add check if ConfigMap ref is nil.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x


<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
