### PR TITLE
Add default protobuf config

### DIFF
--- a/src/go/k8s/pkg/console/configmap.go
+++ b/src/go/k8s/pkg/console/configmap.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/cloudhut/common/rest"
 	"github.com/go-logr/logr"
 	"github.com/redpanda-data/console/backend/pkg/connect"
 	"github.com/redpanda-data/console/backend/pkg/kafka"
+	"github.com/redpanda-data/console/backend/pkg/proto"
 	"github.com/redpanda-data/console/backend/pkg/schema"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	labels "github.com/redpanda-data/redpanda/src/go/k8s/pkg/labels"
@@ -439,6 +441,16 @@ func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
 			}
 		}
 		schemaRegistry = schema.Config{Enabled: y, URLs: []string{cm.clusterobj.SchemaRegistryAPIURL()}, TLS: tls}
+
+		// Default protobuf values to enable decoding in SchemaRegistry
+		// REF https://app.zenhub.com/workspaces/cloud-62684e2c6635e100149514fd/issues/redpanda-data/cloud/2834
+		k.Protobuf = proto.Config{
+			Enabled: y,
+			SchemaRegistry: proto.SchemaRegistryConfig{
+				Enabled:         y,
+				RefreshInterval: time.Second * 10,
+			},
+		}
 	}
 	k.Schema = schemaRegistry
 


### PR DESCRIPTION
## Cover letter

Enable protobuf and schemaRegistry without additional settings to enable decoding protobuf or (avro)  messages in  messages tab of a topic. 
This is a quick PR to unblock customer feedback (see below Slack) that sets default without supporting any other fields under `kafka.protobuf` (e.g. fileSystem, git, mappings)

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
[2834](https://app.zenhub.com/workspaces/cloud-62684e2c6635e100149514fd/issues/redpanda-data/cloud/2834)

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
