### PR TITLE
storage: fix assertion on truncate single batch segment

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -73,6 +73,9 @@ struct index_state
         relative_offset_index.pop_back();
         relative_time_index.pop_back();
         position_index.pop_back();
+        if (empty()) {
+            non_data_timestamps = false;
+        }
     }
     std::tuple<uint32_t, uint32_t, uint64_t> get_entry(size_t i) {
         return {


### PR DESCRIPTION
## Cover letter

The code in maybe_index assumes that if non_data_timestamps is set, then there is exactly one entry in the index.  This was not true if pop_back was called after writing that entry to the index.

Fixes: https://github.com/redpanda-data/redpanda/issues/6956

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
