### PR TITLE
Added PREV_VERSION_LOG_ALLOW_LIST to node_operation_fuzzy_test

### DIFF
--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -23,7 +23,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.services.failure_injector import FailureInjector, FailureSpec
-from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 
@@ -114,7 +114,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
         return topics
 
     @cluster(num_nodes=7,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST + V22_1_CHAOS_ALLOW_LOGS)
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + V22_1_CHAOS_ALLOW_LOGS +
+             PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(enable_failures=[True, False],
             num_to_upgrade=[0, 3],
             compacted_topics=[True, False])

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -114,6 +114,24 @@ IAM_ROLES_API_CALL_ALLOW_LIST = [
     re.compile(r'cloud_roles - .*api request failed')
 ]
 
+# Log errors are used in node_operation_fuzzy_test and partition_movement_test
+PREV_VERSION_LOG_ALLOW_LIST = [
+    # e.g. cluster - controller_backend.cc:400 - Error while reconciling topics - seastar::abort_requested_exception (abort requested)
+    "cluster - .*Error while reconciling topic.*",
+    # Typo fixed in recent versions.
+    # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
+    "raft - .*raft group does not exists on target broker",
+    # e.g. rpc - Service handler thrown an exception - seastar::gate_closed_exception (gate closed)
+    "rpc - .*gate_closed_exception.*",
+    # Tests on mixed versions will start out with an unclean restart before
+    # starting a workload.
+    "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)",
+    # e.g.  raft - [group_id:3, {kafka/topic/2}] consensus.cc:2317 - unable to replicate updated configuration: raft::errc::replicated_entry_truncated
+    "raft - .*unable to replicate updated configuration: .*",
+    # e.g. recovery_stm.cc:432 - recovery append entries error: rpc::errc::client_request_timeout"
+    "raft - .*recovery append entries error.*client_request_timeout"
+]
+
 
 class MetricSamples:
     def __init__(self, samples: list[MetricSample]):

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -27,29 +27,12 @@ from rptest.services.honey_badger import HoneyBadger
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, SISettings
 
 # Errors we should tolerate when moving partitions around
 PARTITION_MOVEMENT_LOG_ERRORS = [
     # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exist on target broker
     "raft - .*raft group does not exist on target broker"
-]
-
-PREV_VERSION_LOG_ALLOW_LIST = [
-    # e.g. cluster - controller_backend.cc:400 - Error while reconciling topics - seastar::abort_requested_exception (abort requested)
-    "cluster - .*Error while reconciling topic.*",
-    # Typo fixed in recent versions.
-    # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
-    "raft - .*raft group does not exists on target broker",
-    # e.g. rpc - Service handler thrown an exception - seastar::gate_closed_exception (gate closed)
-    "rpc - .*gate_closed_exception.*",
-    # Tests on mixed versions will start out with an unclean restart before
-    # starting a workload.
-    "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)",
-    # e.g.  raft - [group_id:3, {kafka/topic/2}] consensus.cc:2317 - unable to replicate updated configuration: raft::errc::replicated_entry_truncated
-    "raft - .*unable to replicate updated configuration: .*",
-    # e.g. recovery_stm.cc:432 - recovery append entries error: rpc::errc::client_request_timeout"
-    "raft - .*recovery append entries error.*client_request_timeout"
 ]
 
 


### PR DESCRIPTION
## Cover letter
This test uses old redpanda's version. And in this version unable to replicate updated has error log lavel.
We need put it in exception for test like we did for partition_movement_test.

Fixes #6925

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none