### PR TITLE
cluster: register node UUIDs after upgrading

### DIFF
--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -126,7 +126,8 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
                       join_node_request(
                         features::feature_table::get_latest_logical_version(),
                         _node_uuid().to_vector(),
-                        self),
+                        self,
+                        join_type::register_uuid),
                       rpc::client_opts(rpc::clock_type::now() + _join_timeout))
                     .then(&rpc::get_ctx_data<join_node_reply>);
               });

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -103,6 +103,12 @@ public:
     // will be set with an ID agreed upon by all seeds.
     ss::future<bool> is_cluster_founder();
 
+    // Repeatedly dispatches registration attempts to the seed servers until
+    // success, until 'should_stop' returns true, or until the abort source
+    // kicks in.
+    ss::future<model::node_id> register_uuid_until(
+      std::function<bool(void)> should_stop = [] { return false; });
+
 private:
     // Sends requests to each seed server to register the local node UUID until
     // one succeeds. Upon success, sets `node_id` to the assigned node ID and

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -174,7 +174,7 @@ public:
 
     // Returns the node ID for the given node UUID. Callers must have a
     // guarantee that the UUID has already been registered before calling.
-    model::node_id get_node_id(const model::node_uuid&);
+    std::optional<model::node_id> get_node_id(const model::node_uuid&);
 
 private:
     using uuid_map_t = absl::flat_hash_map<model::node_uuid, model::node_id>;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -83,6 +83,9 @@ public:
     ss::future<> set_proxy_config(ss::sstring name, std::any val);
     ss::future<> set_proxy_client_config(ss::sstring name, std::any val);
 
+    ss::future<> maybe_register_node_uuid(
+      std::unique_ptr<cluster::cluster_discovery>, ss::abort_source&);
+
     ss::sharded<cluster::metadata_cache> metadata_cache;
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<cluster::shard_table> shard_table;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -599,6 +599,8 @@ class RedpandaService(Service):
         # stash a copy here so that we can quickly look up e.g. addresses later.
         self._node_configs = {}
 
+        self._node_id_by_idx = {}
+
         self._seed_servers = [self.nodes[0]] if len(self.nodes) > 0 else []
 
     def set_seed_servers(self, node_list):
@@ -1819,7 +1821,7 @@ class RedpandaService(Service):
         We first check the admin API to do a kafka-independent check, and then verify
         that kafka clients see the same thing.
         """
-        node_id = self.node_id(node)
+        node_id = self.node_id(node, force_refresh=True)
         self.logger.debug(
             f"registered: checking if broker {node_id} ({node.name}) is registered..."
         )
@@ -2145,7 +2147,18 @@ class RedpandaService(Service):
             shards_per_node[self.idx(node)] = num_shards
         return shards_per_node
 
-    def node_id(self, node):
+    def node_id(self, node, force_refresh=False, timeout_sec=30):
+        """
+        Returns the node ID of a given node. Uses a cached value unless
+        'force_refresh' is set to True.
+
+        NOTE: this is not thread-safe.
+        """
+        idx = self.idx(node)
+        if not force_refresh:
+            if idx in self._node_id_by_idx:
+                return self._node_id_by_idx[idx]
+
         def _try_get_node_id():
             try:
                 node_cfg = self._admin.get_node_config(node)
@@ -2155,9 +2168,11 @@ class RedpandaService(Service):
 
         node_id = wait_until_result(
             _try_get_node_id,
-            timeout_sec=30,
-            err_msg=f"couldn't reach admin endpoing for {node.account.hostname}"
+            timeout_sec=timeout_sec,
+            err_msg=f"couldn't reach admin endpoint for {node.account.hostname}"
         )
+        self.logger.info(f"Got node ID for {node.account.hostname}: {node_id}")
+        self._node_id_by_idx[idx] = node_id
         return node_id
 
     def healthy(self):

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
@@ -24,6 +25,23 @@ def wipe_and_restart(redpanda, node):
     redpanda.start_node(node, auto_assign_node_id=True)
 
 
+def check_node_ids_persist(redpanda):
+    """
+    Checks that all node IDs remain the same after restarting, where after
+    restarting we omit the node IDs from the node config files.
+    """
+    original_node_id_by_idx = {}
+    for node in redpanda.nodes:
+        original_node_id = redpanda.node_id(node, force_refresh=True)
+        original_node_id_by_idx[redpanda.idx(node)] = original_node_id
+
+    redpanda.restart_nodes(redpanda.nodes, auto_assign_node_id=True)
+    for node in redpanda.nodes:
+        original_node_id = original_node_id_by_idx[redpanda.idx(node)]
+        new_node_id = redpanda.node_id(node, force_refresh=True)
+        assert new_node_id == original_node_id, f"{new_node_id} vs {original_node_id}"
+
+
 class NodeIdAssignment(RedpandaTest):
     """
     Test that exercises cluster formation when node IDs are automatically
@@ -38,30 +56,43 @@ class NodeIdAssignment(RedpandaTest):
         self.redpanda.start(auto_assign_node_id=True)
         self._create_initial_topics()
 
-    def check_node_ids_persist(self):
-        """
-        Checks that all node IDs remain the same after restarting.
-        """
-        original_node_id_by_idx = {}
-        for node in self.redpanda.nodes:
-            original_node_id = self.redpanda.node_id(node, force_refresh=True)
-            original_node_id_by_idx[self.redpanda.idx(node)] = original_node_id
-
-        self.redpanda.restart_nodes(self.redpanda.nodes,
-                                    auto_assign_node_id=True)
-        for node in self.redpanda.nodes:
-            original_node_id = original_node_id_by_idx[self.redpanda.idx(node)]
-            new_node_id = self.redpanda.node_id(node, force_refresh=True)
-            assert new_node_id == original_node_id, f"{new_node_id} vs {original_node_id}"
-
     @cluster(num_nodes=3)
     def test_basic_assignment(self):
         brokers = self.admin.get_brokers()
         assert 3 == len(brokers), f"Got {len(brokers)} brokers"
-        self.check_node_ids_persist()
+        check_node_ids_persist(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def test_assign_after_decommission(self):
+        """
+        We should be able to get a new node ID after wiping and decommissioning
+        a node.
+        """
+        replaced_node = self.redpanda.nodes[-1]
+        replaced_node_id = self.redpanda.node_id(replaced_node)
+        self.admin.decommission_broker(replaced_node_id)
+        wipe_and_restart(self.redpanda, replaced_node)
+        new_node_id = self.redpanda.node_id(replaced_node, force_refresh=True)
+        assert replaced_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
+
+    @cluster(num_nodes=3)
+    def test_rejoin_after_decommission(self):
+        """
+        If we only decommission a node without wiping it, it will still use its
+        assigned node ID.
+        """
+        original_node = self.redpanda.nodes[-1]
+        original_node_id = self.redpanda.node_id(original_node)
+        self.admin.decommission_broker(original_node_id)
+        new_node_id = self.redpanda.node_id(original_node, force_refresh=True)
+        assert original_node_id == new_node_id, f"Node came back with different node ID {new_node_id}"
 
     @cluster(num_nodes=3)
     def test_assign_after_clear(self):
+        """
+        Wiping a node that doesn't have a configured node ID should result in a
+        new node ID being assigned to that node.
+        """
         brokers = self.admin.get_brokers()
         assert 3 == len(brokers), f"Got {len(brokers)} brokers"
 
@@ -73,7 +104,19 @@ class NodeIdAssignment(RedpandaTest):
         assert 4 == len(brokers), f"Got {len(brokers)} brokers"
         new_node_id = self.redpanda.node_id(clean_node, force_refresh=True)
         assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
-        self.check_node_ids_persist()
+        check_node_ids_persist(self.redpanda)
+
+    @cluster(num_nodes=3, log_allow_list=["doesn't match stored node ID"])
+    def test_rejoin_with_wrong_node_id(self):
+        """
+        Nodes should fail to start up if attempting to use a different node ID
+        than the one it's previously used, according to its kv-store.
+        """
+        node = self.redpanda.nodes[-1]
+        self.redpanda.stop_node(node)
+        self.redpanda.start_node(node,
+                                 override_cfg_params=dict({"node_id": 10}),
+                                 expect_fail=True)
 
 
 class NodeIdAssignmentUpgrade(RedpandaTest):
@@ -92,7 +135,20 @@ class NodeIdAssignmentUpgrade(RedpandaTest):
         super(NodeIdAssignmentUpgrade, self).setUp()
 
     @cluster(num_nodes=3)
+    def test_omit_node_ids_after_upgrade(self):
+        """
+        In restarting the cluster, even if we omit the node IDs from their
+        configs after upgrading, they should still persist.
+        """
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        check_node_ids_persist(self.redpanda)
+
+    @cluster(num_nodes=3)
     def test_assign_after_upgrade(self):
+        """
+        Upgrade a cluster and then immediately start using the node ID
+        assignment feature.
+        """
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
         self.redpanda.restart_nodes(self.redpanda.nodes,
                                     auto_assign_node_id=True)

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -44,14 +44,14 @@ class NodeIdAssignment(RedpandaTest):
         """
         original_node_id_by_idx = {}
         for node in self.redpanda.nodes:
-            original_node_id = self.redpanda.node_id(node)
+            original_node_id = self.redpanda.node_id(node, force_refresh=True)
             original_node_id_by_idx[self.redpanda.idx(node)] = original_node_id
 
         self.redpanda.restart_nodes(self.redpanda.nodes,
                                     auto_assign_node_id=True)
         for node in self.redpanda.nodes:
             original_node_id = original_node_id_by_idx[self.redpanda.idx(node)]
-            new_node_id = self.redpanda.node_id(node)
+            new_node_id = self.redpanda.node_id(node, force_refresh=True)
             assert new_node_id == original_node_id, f"{new_node_id} vs {original_node_id}"
 
     @cluster(num_nodes=3)
@@ -71,7 +71,7 @@ class NodeIdAssignment(RedpandaTest):
 
         brokers = self.admin.get_brokers()
         assert 4 == len(brokers), f"Got {len(brokers)} brokers"
-        new_node_id = self.redpanda.node_id(clean_node)
+        new_node_id = self.redpanda.node_id(clean_node, force_refresh=True)
         assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
         self.check_node_ids_persist()
 
@@ -108,5 +108,5 @@ class NodeIdAssignmentUpgrade(RedpandaTest):
 
         brokers = self.admin.get_brokers()
         assert 4 == len(brokers), f"Got {len(brokers)} brokers"
-        new_node_id = self.redpanda.node_id(clean_node)
+        new_node_id = self.redpanda.node_id(clean_node, force_refresh=True)
         assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"


### PR DESCRIPTION
## Cover letter

Node UUIDs don't get registered with the cluster until the
node_id_assignment feature is activated. This means that upon upgrading
a cluster, existing nodes' UUIDs won't be registered with the cluster
until the first restart after completing an upgrade.

This PR takes a swing at this by scheduling registration in the background.

It's actually a bit unclear whether there are tangible downsides to not having this. I struggled to come up with a test scenario that would fail without this. Open to suggestions.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
