### PR TITLE
[v22.2.x] storage: fix assertion on truncate single batch segment

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -73,6 +73,9 @@ struct index_state
         relative_offset_index.pop_back();
         relative_time_index.pop_back();
         position_index.pop_back();
+        if (empty()) {
+            non_data_timestamps = false;
+        }
     }
     std::tuple<uint32_t, uint32_t, uint64_t> get_entry(size_t i) {
         return {


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6971.
Fixes https://github.com/redpanda-data/redpanda/issues/6979,