### PR TITLE
pp/rest: Two bug fixes for pandaproxy

### DIFF
--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -251,7 +251,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _base_uri{std::move(base_uri)},
        _res_fmt{res_fmt},
        _req_data{std::move(req_data)},
@@ -307,7 +307,7 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _member_id{std::move(member_id)},
        _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
@@ -343,7 +343,7 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _member_id{std::move(member_id)},
        _res_fmt{res_fmt},
        _req_data{std::move(req_data)},
@@ -385,7 +385,7 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _name{std::move(name)},
        _timeout{timeout},
        _max_bytes{max_bytes},
@@ -437,7 +437,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _member_id{std::move(member_id)},
        _res_fmt{res_fmt},
        _req_data{std::move(req_data)},
@@ -487,7 +487,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{std::move(group_id)},
+      [_group_id{group_id},
        _member_id{std::move(member_id)},
        _req_data{std::move(req_data)},
        _rp{std::move(rp)}](


### PR DESCRIPTION
## Cover letter

Bug fixes for https://github.com/redpanda-data/redpanda/pull/6953

* pp/server: Forward `func` into the capture
  - [Noah was right](https://github.com/redpanda-data/redpanda/pull/6953#discussion_r1006267687)
  - See also [this comment](https://github.com/redpanda-data/redpanda/pull/6781#issuecomment-1293690105)
* pp/rest: Don't move `group_id` into the capture - The shard id was using a moved from value resulting in group operations being dispatched to the wrong thread.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none