### PR TITLE
tx/logging: log tx_errc string instead of underlying int

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -33,6 +33,79 @@
 
 namespace cluster {
 
+std::ostream& operator<<(std::ostream& o, const tx_errc& err) {
+    switch (err) {
+    case tx_errc::none:
+        o << "tx_errc::none";
+        break;
+    case tx_errc::leader_not_found:
+        o << "tx_errc::leader_not_found";
+        break;
+    case tx_errc::shard_not_found:
+        o << "tx_errc::shard_not_found";
+        break;
+    case tx_errc::partition_not_found:
+        o << "tx_errc::partition_not_found";
+        break;
+    case tx_errc::stm_not_found:
+        o << "tx_errc::stm_not_found";
+        break;
+    case tx_errc::partition_not_exists:
+        o << "tx_errc::partition_not_exists";
+        break;
+    case tx_errc::pid_not_found:
+        o << "tx_errc::pid_not_found";
+        break;
+    case tx_errc::timeout:
+        o << "tx_errc::timeout";
+        break;
+    case tx_errc::conflict:
+        o << "tx_errc::conflict";
+        break;
+    case tx_errc::fenced:
+        o << "tx_errc::fenced";
+        break;
+    case tx_errc::stale:
+        o << "tx_errc::stale";
+        break;
+    case tx_errc::not_coordinator:
+        o << "tx_errc::not_coordinator";
+        break;
+    case tx_errc::coordinator_not_available:
+        o << "tx_errc::coordinator_not_available";
+        break;
+    case tx_errc::preparing_rebalance:
+        o << "tx_errc::preparing_rebalance";
+        break;
+    case tx_errc::rebalance_in_progress:
+        o << "tx_errc::rebalance_in_progress";
+        break;
+    case tx_errc::coordinator_load_in_progress:
+        o << "tx_errc::coordinator_load_in_progress";
+        break;
+    case tx_errc::unknown_server_error:
+        o << "tx_errc::unknown_server_error";
+        break;
+    case tx_errc::request_rejected:
+        o << "tx_errc::request_rejected";
+        break;
+    case tx_errc::invalid_producer_epoch:
+        o << "tx_errc::invalid_producer_epoch";
+        break;
+    case tx_errc::invalid_txn_state:
+        o << "tx_errc::invalid_txn_state";
+        break;
+    case tx_errc::invalid_producer_id_mapping:
+        o << "tx_errc::invalid_producer_id_mapping";
+        break;
+    }
+    return o;
+}
+
+std::string tx_errc_category::message(int c) const {
+    return fmt::format("{{{}}}", static_cast<tx_errc>(c));
+}
+
 kafka_stages::kafka_stages(
   ss::future<> enq, ss::future<result<kafka_result>> offset_future)
   : request_enqueued(std::move(enq))

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -126,53 +126,13 @@ enum class tx_errc {
     invalid_txn_state,
     invalid_producer_epoch
 };
+
+std::ostream& operator<<(std::ostream&, const tx_errc&);
+
 struct tx_errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::tx_errc"; }
 
-    std::string message(int c) const final {
-        switch (static_cast<tx_errc>(c)) {
-        case tx_errc::none:
-            return "None";
-        case tx_errc::leader_not_found:
-            return "Leader not found";
-        case tx_errc::shard_not_found:
-            return "Shard not found";
-        case tx_errc::partition_not_found:
-            return "Partition not found";
-        case tx_errc::stm_not_found:
-            return "Stm not found";
-        case tx_errc::partition_not_exists:
-            return "Partition not exists";
-        case tx_errc::pid_not_found:
-            return "Pid not found";
-        case tx_errc::timeout:
-            return "Timeout";
-        case tx_errc::conflict:
-            return "Conflict";
-        case tx_errc::fenced:
-            return "Fenced";
-        case tx_errc::stale:
-            return "Stale";
-        case tx_errc::not_coordinator:
-            return "Not coordinator";
-        case tx_errc::coordinator_not_available:
-            return "Coordinator not available";
-        case tx_errc::preparing_rebalance:
-            return "Preparing rebalance";
-        case tx_errc::rebalance_in_progress:
-            return "Rebalance in progress";
-        case tx_errc::coordinator_load_in_progress:
-            return "Coordinator load in progress";
-        case tx_errc::unknown_server_error:
-            return "Unknown server error";
-        case tx_errc::request_rejected:
-            return "Request rejected";
-        case tx_errc::invalid_producer_epoch:
-            return "Invalid producer epoch";
-        default:
-            return "cluster::tx_errc::unknown";
-        }
-    }
+    std::string message(int) const final;
 };
 inline const std::error_category& tx_error_category() noexcept {
     static tx_errc_category e;

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -20,7 +20,8 @@ import re
 import requests
 
 NON_EXISTENT_TID_LOG_ALLOW_LIST = [
-    re.compile(r".*Unexpected tx_error error: Unknown server error.*")
+    re.compile(
+        r".*Unexpected tx_error error: {tx_errc::unknown_server_error}.*")
 ]
 
 
@@ -344,7 +345,7 @@ class TxAdminTest(RedpandaTest):
                         error_tx_id, partition["ns"], partition["topic"],
                         partition["partition_id"], partition["etag"])
                 except requests.exceptions.HTTPError as e:
-                    assert e.response.text == '{"message": "Unexpected tx_error error: Unknown server error", "code": 500}'
+                    assert e.response.text == '{"message": "Unexpected tx_error error: {tx_errc::unknown_server_error}", "code": 500}'
 
         producer.commit_transaction()
 


### PR DESCRIPTION
## Cover letter

Currently we log the enum int and one needs to manually count through a long list of enum values  to figure out the mapping error type, I did it multiple types when debugging and it is cumbersome.

```
TRACE 2022-10-27 14:20:37,057 [shard 0] tx - tx_gateway_frontend.cc:674
sending name:init_tm_tx, tx_id:{2222}, pid:{producer_identity: id=-1, epoch=0}, ec: cluster::tx_errc:11
```
With the patch, we log the actual enum string.

```
TRACE 2022-10-27 14:48:21,600 [shard 0] tx - tx_gateway_frontend.cc:674
sending name:init_tm_tx, tx_id:{2222}, pid:{producer_identity: id=1, epoch=0}, ec: tx_errc::none
```

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none
