### PR TITLE
Reduce iobuf.h impact on intermediate object sizes

### DIFF
--- a/src/v/bytes/CMakeLists.txt
+++ b/src/v/bytes/CMakeLists.txt
@@ -4,6 +4,7 @@ v_cc_library(
   SRCS
     "bytes.cc"
     "iobuf.cc"
+    oncore.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -14,7 +14,6 @@
 #include "bytes/details/out_of_range.h"
 #include "seastarx.h"
 #include "utils/intrusive_list_helpers.h"
-#include "vassert.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -95,16 +94,7 @@ public:
         }
     }
     void trim(size_t len) { _used_bytes = std::min(len, _used_bytes); }
-    void trim_front(size_t pos) {
-        // required by input_stream<char> converter
-        vassert(
-          pos <= _used_bytes,
-          "trim_front requested {} bytes but io_fragment have only {}",
-          pos,
-          _used_bytes);
-        _used_bytes -= pos;
-        _buf.trim_front(pos);
-    }
+    void trim_front(size_t pos);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     char* get_current() { return _buf.get_write() + _used_bytes; }
     char* get_write() { return _buf.get_write(); }

--- a/src/v/bytes/hash.h
+++ b/src/v/bytes/hash.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+
+#include <boost/container_hash/hash.hpp>
+
+namespace std {
+template<>
+struct hash<::iobuf> {
+    size_t operator()(const ::iobuf& b) const {
+        size_t h = 0;
+        for (auto& f : b) {
+            boost::hash_combine(
+              h, std::hash<std::string_view>{}({f.get(), f.size()}));
+        }
+        return h;
+    }
+};
+} // namespace std

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/details/io_allocation_size.h"
 #include "bytes/iostream.h"
+#include "bytes/scattered_message.h"
 #include "vassert.h"
 
 #include <seastar/core/bitops.hh>

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -10,6 +10,7 @@
 #include "bytes/iobuf.h"
 
 #include "bytes/details/io_allocation_size.h"
+#include "bytes/iostream.h"
 #include "vassert.h"
 
 #include <seastar/core/bitops.hh>

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -283,3 +283,25 @@ std::string iobuf::hexdump(size_t limit) const {
 
     return result.str();
 }
+
+void details::io_fragment::trim_front(size_t pos) {
+    // required by input_stream<char> converter
+    vassert(
+      pos <= _used_bytes,
+      "trim_front requested {} bytes but io_fragment have only {}",
+      pos,
+      _used_bytes);
+    _used_bytes -= pos;
+    _buf.trim_front(pos);
+}
+
+iobuf::placeholder iobuf::reserve(size_t sz) {
+    oncore_debug_verify(_verify_shard);
+    vassert(sz, "zero length reservations are unsupported");
+    reserve_memory(sz);
+    _size += sz;
+    auto it = std::prev(_frags.end());
+    placeholder p(it, it->size(), sz);
+    it->reserve(sz);
+    return p;
+}

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -22,7 +22,6 @@
 #include "utils/intrusive_list_helpers.h"
 #include "vassert.h"
 
-#include <seastar/core/scattered_message.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
 
@@ -391,11 +390,6 @@ inline void iobuf::trim_back(size_t n) {
         pop_back();
     }
 }
-
-/// \brief keeps the iobuf in the deferred destructor of scattered_msg<char>
-/// and wraps each details::io_fragment as a scattered_message<char>::static()
-/// const char*
-ss::scattered_message<char> iobuf_as_scattered(iobuf b);
 
 iobuf iobuf_copy(iobuf::iterator_consumer& in, size_t len);
 namespace std {

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -22,7 +22,6 @@
 #include "utils/intrusive_list_helpers.h"
 #include "vassert.h"
 
-#include <seastar/core/iostream.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
@@ -393,21 +392,10 @@ inline void iobuf::trim_back(size_t n) {
     }
 }
 
-/// \brief wraps an iobuf so it can be used as an input stream data source
-ss::input_stream<char> make_iobuf_input_stream(iobuf io);
-
-/// \brief wraps the iobuf to be used as an output stream sink
-ss::output_stream<char> make_iobuf_ref_output_stream(iobuf& io);
-
-/// \brief exactly like input_stream<char>::read_exactly but returns iobuf
-ss::future<iobuf> read_iobuf_exactly(ss::input_stream<char>& in, size_t n);
-
 /// \brief keeps the iobuf in the deferred destructor of scattered_msg<char>
 /// and wraps each details::io_fragment as a scattered_message<char>::static()
 /// const char*
 ss::scattered_message<char> iobuf_as_scattered(iobuf b);
-
-ss::future<> write_iobuf_to_output_stream(iobuf, ss::output_stream<char>&);
 
 iobuf iobuf_copy(iobuf::iterator_consumer& in, size_t len);
 namespace std {

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -25,8 +25,6 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
 
-#include <boost/container_hash/hash.hpp> // hash_combine
-
 #include <cstddef>
 #include <iosfwd>
 #include <string_view>
@@ -392,17 +390,3 @@ inline void iobuf::trim_back(size_t n) {
 }
 
 iobuf iobuf_copy(iobuf::iterator_consumer& in, size_t len);
-namespace std {
-template<>
-struct hash<::iobuf> {
-    size_t operator()(const ::iobuf& b) const {
-        size_t h = 0;
-        for (auto& f : b) {
-            boost::hash_combine(
-              h, std::hash<std::string_view>{}({f.get(), f.size()}));
-        }
-        return h;
-    }
-};
-
-} // namespace std

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -16,11 +16,10 @@
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/details/io_placeholder.h"
 #include "bytes/details/out_of_range.h"
+#include "bytes/oncore.h"
 #include "likely.h"
 #include "seastarx.h"
 #include "utils/intrusive_list_helpers.h"
-#include "bytes/oncore.h"
-#include "vassert.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -235,16 +234,6 @@ inline void iobuf::create_new_fragment(size_t sz) {
     auto asz = details::io_allocation_size::next_allocation_size(chunk_max);
     auto f = new fragment(ss::temporary_buffer<char>(asz), fragment::empty{});
     append_take_ownership(f);
-}
-inline iobuf::placeholder iobuf::reserve(size_t sz) {
-    oncore_debug_verify(_verify_shard);
-    vassert(sz, "zero length reservations are unsupported");
-    reserve_memory(sz);
-    _size += sz;
-    auto it = std::prev(_frags.end());
-    placeholder p(it, it->size(), sz);
-    it->reserve(sz);
-    return p;
 }
 /// only ensures that a segment of at least reservation is avaible
 /// as an empty details::io_fragment

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -17,12 +17,11 @@
 #include "bytes/details/io_placeholder.h"
 #include "bytes/details/out_of_range.h"
 #include "likely.h"
-#include "oncore.h"
 #include "seastarx.h"
 #include "utils/intrusive_list_helpers.h"
+#include "bytes/oncore.h"
 #include "vassert.h"
 
-#include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
 
 #include <cstddef>

--- a/src/v/bytes/iostream.h
+++ b/src/v/bytes/iostream.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+
+#include <seastar/core/iostream.hh>
+
+/// \brief wraps an iobuf so it can be used as an input stream data source
+ss::input_stream<char> make_iobuf_input_stream(iobuf io);
+
+/// \brief wraps the iobuf to be used as an output stream sink
+ss::output_stream<char> make_iobuf_ref_output_stream(iobuf& io);
+
+/// \brief exactly like input_stream<char>::read_exactly but returns iobuf
+ss::future<iobuf> read_iobuf_exactly(ss::input_stream<char>& in, size_t n);
+
+ss::future<> write_iobuf_to_output_stream(iobuf, ss::output_stream<char>&);

--- a/src/v/bytes/oncore.cc
+++ b/src/v/bytes/oncore.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "bytes/oncore.h"
+
+#include "seastarx.h"
+#include "vassert.h"
+
+#include <seastar/core/smp.hh>
+
+static_assert(std::is_same_v<oncore::shard_id_type, ss::shard_id>);
+
+oncore::oncore()
+  : _owner_shard(ss::this_shard_id()) {}
+
+void oncore::verify_shard_source_location(const char* file, int linenum) const {
+    vassert(
+      _owner_shard == ss::this_shard_id(),
+      "{}:{} - Shard missmatch -  Operation on shard: {}. Owner shard:{}",
+      file,
+      linenum,
+      ss::this_shard_id(),
+      _owner_shard);
+}

--- a/src/v/bytes/oncore.h
+++ b/src/v/bytes/oncore.h
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
-#include "vlog.h"
+#include "utils/source_location.h"
 
 #ifndef NDEBUG
 #define expression_in_debug_mode(x) x
@@ -37,7 +37,5 @@ private:
 #define oncore_debug_verify(member)                                            \
     do {                                                                       \
         expression_in_debug_mode((member).verify_shard_source_location(        \
-          (const char*)&__FILE__[vlog_internal::log_basename_start<            \
-            vlog_internal::basename_index(__FILE__)>::value],                  \
-          __LINE__));                                                          \
+          get_file_basename(), __LINE__));                                     \
     } while (0)

--- a/src/v/bytes/scattered_message.h
+++ b/src/v/bytes/scattered_message.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+
+#include <seastar/core/scattered_message.hh>
+
+/// \brief keeps the iobuf in the deferred destructor of scattered_msg<char>
+/// and wraps each details::io_fragment as a scattered_message<char>::static()
+/// const char*
+ss::scattered_message<char> iobuf_as_scattered(iobuf b);

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -13,6 +13,7 @@
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "bytes/tests/utils.h"
 #include "bytes/utils.h"
 

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -14,6 +14,7 @@
 #include "bytes/iobuf_ostreambuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
+#include "bytes/scattered_message.h"
 #include "bytes/tests/utils.h"
 #include "bytes/utils.h"
 

--- a/src/v/bytes/tests/iobuf_utils_tests.cc
+++ b/src/v/bytes/tests/iobuf_utils_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/hash.h"
 #include "bytes/iostream.h"
 #include "bytes/tests/utils.h"
 

--- a/src/v/bytes/tests/iobuf_utils_tests.cc
+++ b/src/v/bytes/tests/iobuf_utils_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iostream.h"
 #include "bytes/tests/utils.h"
 
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -11,6 +11,7 @@
 #include "cloud_roles/request_response_helpers.h"
 
 #include "bytes/iobuf_istreambuf.h"
+#include "bytes/iostream.h"
 #include "json/istreamwrapper.h"
 
 namespace cloud_roles {

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -10,6 +10,8 @@
 
 #include "cloud_roles/types.h"
 
+#include <seastar/util/variant_utils.hh>
+
 namespace cloud_roles {
 
 std::ostream& operator<<(std::ostream& os, api_request_error_kind kind) {

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/iostream.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/logger.h"
 #include "ssx/future-util.h"

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -11,6 +11,7 @@
 #include "cloud_storage/remote_segment.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/partition_manifest.h"

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "cache_test_fixture.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_service.h"

--- a/src/v/cloud_storage/tests/directory_walker_test.cc
+++ b/src/v/cloud_storage/tests/directory_walker_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/recursive_directory_walker.h"
 #include "seastarx.h"

--- a/src/v/cloud_storage/tests/offset_translation_layer_test.cc
+++ b/src/v/cloud_storage/tests/offset_translation_layer_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/iostream.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/types.h"
 #include "seastarx.h"

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote.h"

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/remote_segment_index.h"
 #include "common_def.h"
 #include "model/record_batch_types.h"

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote.h"

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_segment.h"

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/topic_manifest.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"

--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/tx_range_manifest.h"
 #include "cloud_storage/types.h"

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
 #include "cloud_storage/tx_range_manifest.h"
 
 #include "bytes/iobuf.h"

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -12,6 +12,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
+#include "bytes/iostream.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "json/istreamwrapper.h"

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -12,6 +12,7 @@
 #include "cluster/metrics_reporter.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "cluster/config_frontend.h"
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_frontend.h"

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/persisted_stm.h"
 
+#include "bytes/iostream.h"
 #include "cluster/logger.h"
 #include "raft/consensus.h"
 #include "raft/errc.h"

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/rm_stm.h"
 
+#include "bytes/iostream.h"
 #include "cluster/logger.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "kafka/protocol/request_reader.h"

--- a/src/v/compression/compression.cc
+++ b/src/v/compression/compression.cc
@@ -13,6 +13,7 @@
 #include "compression/internal/lz4_frame_compressor.h"
 #include "compression/internal/snappy_java_compressor.h"
 #include "compression/internal/zstd_compressor.h"
+#include "vassert.h"
 
 namespace compression {
 iobuf compressor::compress(const iobuf& io, type t) {

--- a/src/v/compression/snappy_standard_compressor.cc
+++ b/src/v/compression/snappy_standard_compressor.cc
@@ -12,6 +12,7 @@
 #include "bytes/bytes.h"
 #include "likely.h"
 #include "units.h"
+#include "vassert.h"
 
 #include <fmt/format.h>
 

--- a/src/v/compression/stream_zstd.cc
+++ b/src/v/compression/stream_zstd.cc
@@ -14,6 +14,7 @@
 #include "compression/logger.h"
 #include "likely.h"
 #include "units.h"
+#include "vassert.h"
 #include "vlog.h"
 
 #include <seastar/core/aligned_buffer.hh>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -10,11 +10,11 @@
  */
 
 #pragma once
+#include "bytes/oncore.h"
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
-#include "oncore.h"
 #include "reflection/type_traits.h"
 #include "utils/intrusive_list_helpers.h"
 #include "utils/to_string.h"

--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -12,6 +12,7 @@
 #include "coproc/offset_storage_utils.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "coproc/logger.h"
 #include "reflection/absl/flat_hash_map.h"
 #include "reflection/absl/node_hash_map.h"

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/iobuf.h"
+#include "bytes/scattered_message.h"
 #include "config/base_property.h"
 #include "http/logger.h"
 #include "ssx/sformat.h"

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -9,6 +9,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "http/chunk_encoding.h"
 #include "http/client.h"
 #include "net/dns.h"

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/iostream.h"
+#include "bytes/scattered_message.h"
 #include "kafka/protocol/api_versions.h"
 #include "kafka/protocol/flex_versions.h"
 #include "kafka/protocol/fwd.h"

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/iostream.h"
 #include "kafka/protocol/api_versions.h"
 #include "kafka/protocol/flex_versions.h"
 #include "kafka/protocol/fwd.h"

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -11,6 +11,7 @@
 #include "kafka/server/connection_context.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "config/configuration.h"
 #include "kafka/protocol/sasl_authenticate.h"
 #include "kafka/server/handlers/handler_interface.h"

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
+#include "bytes/scattered_message.h"
 #include "config/configuration.h"
 #include "kafka/protocol/sasl_authenticate.h"
 #include "kafka/server/handlers/handler_interface.h"

--- a/src/v/kafka/server/fetch_session_cache.h
+++ b/src/v/kafka/server/fetch_session_cache.h
@@ -15,6 +15,7 @@
 #include "units.h"
 
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/core/smp.hh>
 
 #include <absl/container/flat_hash_map.h>
 

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -9,6 +9,7 @@
 
 #include "raft/consensus_utils.h"
 
+#include "bytes/iostream.h"
 #include "likely.h"
 #include "model/fundamental.h"
 #include "model/record.h"

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/hash.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "model/adl_serde.h"

--- a/src/v/rpc/netbuf.cc
+++ b/src/v/rpc/netbuf.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/iobuf.h"
+#include "bytes/scattered_message.h"
 #include "compression/stream_zstd.h"
 #include "hashing/xx.h"
 #include "reflection/adl.h"

--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/iostream.h"
 #include "compression/stream_zstd.h"
 #include "hashing/xx.h"
 #include "likely.h"

--- a/src/v/s3/error.cc
+++ b/src/v/s3/error.cc
@@ -12,6 +12,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <map>
+
 namespace s3 {
 
 struct s3_error_category final : std::error_category {

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "cloud_roles/signature.h"
 #include "net/dns.h"
 #include "net/types.h"

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -10,6 +10,7 @@
 #include "storage/compacted_index_chunk_reader.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "hashing/crc32c.h"
 #include "reflection/adl.h"
 #include "storage/compacted_index.h"

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -10,6 +10,7 @@
 #include "storage/kvstore.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "config/configuration.h"
 #include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "bytes/utils.h"
 #include "likely.h"
 #include "model/record.h"

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -10,6 +10,7 @@
 #include "storage/snapshot.h"
 
 #include "bytes/iobuf_parser.h"
+#include "bytes/iostream.h"
 #include "hashing/crc32c.h"
 #include "random/generators.h"
 #include "reflection/adl.h"

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/iostream.h"
 #include "model/tests/random_batch.h"
 #include "storage/directories.h"
 #include "storage/log_manager.h"

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "random/generators.h"
 #include "seastarx.h"
 #include "storage/segment_appender.h"

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -12,6 +12,7 @@
 #include "utils/file_io.h"
 
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>

--- a/src/v/utils/source_location.h
+++ b/src/v/utils/source_location.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include <cstdint>
+
+namespace vlog_internal {
+constexpr int32_t basename_index(
+  const char* const path,
+  const int32_t index = 0,
+  const int32_t slash_index = -1) {
+    // NOLINTNEXTLINE
+    const char c = path[index];
+    if (c == '\0') {
+        return slash_index + 1;
+    }
+    if (c == '/' || c == '\\') {
+        return basename_index(path, index + 1, index);
+    }
+    return basename_index(path, index + 1, slash_index);
+}
+
+template<int32_t V>
+struct log_basename_start {
+    static constexpr const int32_t value = V;
+};
+} // namespace vlog_internal
+
+#define get_file_basename()                                                    \
+    (const char*)&__FILE__[vlog_internal::log_basename_start<                  \
+      vlog_internal::basename_index(__FILE__)>::value]

--- a/src/v/utils/tests/input_stream_fanout_test.cc
+++ b/src/v/utils/tests/input_stream_fanout_test.cc
@@ -10,6 +10,7 @@
  */
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
+#include "bytes/iostream.h"
 #include "random/generators.h"
 #include "utils/fragmented_vector.h"
 #include "utils/stream_utils.h"

--- a/src/v/utils/tests/vint_test.cc
+++ b/src/v/utils/tests/vint_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/bytes.h"
+#include "bytes/iostream.h"
 #include "random/generators.h"
 #include "utils/vint.h"
 

--- a/src/v/v8_engine/data_policy.cc
+++ b/src/v/v8_engine/data_policy.cc
@@ -10,6 +10,8 @@
 
 #include "v8_engine/data_policy.h"
 
+#include "vassert.h"
+
 namespace v8_engine {
 
 std::ostream& operator<<(std::ostream& os, const data_policy& datapolicy) {

--- a/src/v/vlog.h
+++ b/src/v/vlog.h
@@ -8,32 +8,8 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-
 #pragma once
-
-#include <cstdint>
-
-namespace vlog_internal {
-constexpr int32_t basename_index(
-  const char* const path,
-  const int32_t index = 0,
-  const int32_t slash_index = -1) {
-    // NOLINTNEXTLINE
-    const char c = path[index];
-    if (c == '\0') {
-        return slash_index + 1;
-    }
-    if (c == '/' || c == '\\') {
-        return basename_index(path, index + 1, index);
-    }
-    return basename_index(path, index + 1, slash_index);
-}
-
-template<int32_t V>
-struct log_basename_start {
-    static constexpr const int32_t value = V;
-};
-} // namespace vlog_internal
+#include "utils/source_location.h"
 
 // NOLINTNEXTLINE
 #define fmt_with_ctx(method, fmt, args...)                                     \


### PR DESCRIPTION
## Cover letter

The kafka protocol library that we build is nearly 500 MB

```
[nwatkins@fedora clang]$ ls -sh lib/libv_v_kafka_protocol.a 
464M lib/libv_v_kafka_protocol.a
```

A big reason for this is that it contains 66 embedded object files each ranging in size from around 5 MB to 8 MB. An example:

```
7.0M src/v/kafka/protocol/CMakeFiles/v_kafka_protocol.dir/schemata/leave_group_request.cc.o
7.2M src/v/kafka/protocol/CMakeFiles/v_kafka_protocol.dir/schemata/delete_topics_request.cc.o
4.7M src/v/kafka/protocol/CMakeFiles/v_kafka_protocol.dir/schemata/sasl_handshake_request.cc.o
```

And all of these get bundled up into the library archive. Several things contribute the size, and in this PR we focus just on the contribution of `iobuf` and it's dependencies.

I created an object file using the same method as the protocol library compilation and included _only_ `iobuf.h`. The result was 1.3 MB:

```
1.3M src/v/kafka/protocol/CMakeFiles/v_kafka_protocol.dir/schemata/iobuf_test.cc.o
```

After the changes in this PR:

* Eliminating several expensive seastar headers from iobuf.h
* Factoring out logging, assertions, formatting out of the header

I was able to reduce the total size by something like 150x down to 7.3 K:

```
7.3K src/v/kafka/protocol/CMakeFiles/v_kafka_protocol.dir/schemata/iobuf_test.cc.o
```

Note that a lot of the same problematic headers end up getting included through other paths, but the kakfa protocol libraries in particular, are unlikely to need any of this. So this is step one of several to drop down the size of this library and hopefully continue to contribute improvements to build size and speed.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
