### PR TITLE
Improved logging in rm_stm and enabled timequery tests for debug builds

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2974,7 +2974,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
         if (
           _partition->raft()->is_leader()
           && _partition->raft()->term() == _term) {
-            co_await _partition->raft()->step_down();
+            co_await _partition->raft()->step_down("group do abort failed");
         }
         co_return make_abort_tx_reply(cluster::tx_errc::timeout);
     }
@@ -3050,7 +3050,7 @@ group::do_commit(kafka::group_id group_id, model::producer_identity pid) {
         if (
           _partition->raft()->is_leader()
           && _partition->raft()->term() == _term) {
-            co_await _partition->raft()->step_down();
+            co_await _partition->raft()->step_down("group tx commit failed");
         }
         co_return make_commit_tx_reply(cluster::tx_errc::timeout);
     }

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -329,8 +329,9 @@ ss::future<> recovery_stm::handle_install_snapshot_reply(
         return close_snapshot_reader();
     }
     if (reply.value().term > _ptr->_term) {
-        return close_snapshot_reader().then(
-          [this, term = reply.value().term] { return _ptr->step_down(term); });
+        return close_snapshot_reader().then([this, term = reply.value().term] {
+            return _ptr->step_down(term, "snapshot response with greater term");
+        });
     }
     _sent_snapshot_bytes = reply.value().bytes_stored;
 

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -281,7 +281,7 @@ FIXTURE_TEST(test_single_node_recovery_multi_terms, raft_test_fixture) {
     // roll the term
     retry_with_leader(gr, 5, 1s, [](raft_node& leader) {
         return leader.consensus
-          ->step_down(leader.consensus->term() + model::term_id(1))
+          ->step_down(leader.consensus->term() + model::term_id(1), "test")
           .then([] { return true; });
     }).get0();
     // append some entries in next term
@@ -633,7 +633,8 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
     BOOST_REQUIRE(success);
     // step down so last entry in snapshot will be a configuration
     auto leader_raft = get_leader_raft(gr);
-    leader_raft->step_down(leader_raft->term() + model::term_id(1)).get0();
+    leader_raft->step_down(leader_raft->term() + model::term_id(1), "test")
+      .get0();
 
     validate_logs_replication(gr);
     tests::cooperative_spin_wait_with_timeout(2s, [&gr] {

--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -19,7 +19,7 @@ from rptest.services.cluster import cluster
 from rptest.util import segments_count
 
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.utils.mode_checks import cleanup_on_early_exit
+from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode
 
 
 class CompactionEndToEndTest(EndToEndTest):
@@ -75,6 +75,7 @@ class CompactionEndToEndTest(EndToEndTest):
             ],
             transactions=[True, False],
             tx_inject_aborts=[True, False])
+    @skip_debug_mode
     def test_basic_compaction(self, key_set_cardinality,
                               initial_cleanup_policy, transactions,
                               tx_inject_aborts):

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -21,7 +21,7 @@ from rptest.util import (segments_count, wait_for_segments_removal)
 
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
-from ducktape.mark import parametrize
+from ducktape.mark import (parametrize, ok_to_fail)
 
 from rptest.services.kafka import KafkaServiceAdapter
 from kafkatest.services.kafka import KafkaService
@@ -209,12 +209,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         # test parameter to set cluster configs before starting.
         pass
 
-    @cluster(num_nodes=4)
-    @parametrize(cloud_storage=True, batch_cache=False)
-    @parametrize(cloud_storage=False, batch_cache=True)
-    @parametrize(cloud_storage=False, batch_cache=False)
-    @skip_debug_mode
-    def test_timequery(self, cloud_storage: bool, batch_cache: bool):
+    def _do_test_timequery(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise
             # we won't touch the path in skipping_consumer that applies
@@ -243,6 +238,22 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         return self._test_timequery(cluster=self.redpanda,
                                     cloud_storage=cloud_storage,
                                     batch_cache=batch_cache)
+
+    @cluster(num_nodes=4)
+    @parametrize(cloud_storage=True, batch_cache=False)
+    @parametrize(cloud_storage=False, batch_cache=True)
+    @parametrize(cloud_storage=False, batch_cache=False)
+    @skip_debug_mode
+    def test_timequery(self, cloud_storage: bool, batch_cache: bool):
+        return self._do_test_timequery(cloud_storage, batch_cache)
+
+    @ok_to_fail
+    @cluster(num_nodes=4)
+    @parametrize(cloud_storage=True, batch_cache=False)
+    @parametrize(cloud_storage=False, batch_cache=True)
+    @parametrize(cloud_storage=False, batch_cache=False)
+    def test_timequery_debug(self, cloud_storage: bool, batch_cache: bool):
+        return self._do_test_timequery(cloud_storage, batch_cache)
 
 
 class TimeQueryKafkaTest(Test, BaseTimeQuery):


### PR DESCRIPTION
## Cover letter

Improved logging in `cluster::rm_stm`. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
