### PR TITLE
Fix node selection for disruptive tests

### DIFF
--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -203,7 +203,14 @@ class ActionInjectorThread(Thread):
         while not self._stop_requested.is_set():
             if self.disruptive_action.action():
                 self.action_triggered = True
-            time.sleep(self.config.time_between_actions())
+            sleep_interval = self.config.time_between_actions()
+
+            # If we have processed all nodes once, increase the sleep interval
+            # just for this iteration. This avoids the case where the last node
+            # in the previous cycle is restarted again in the next cycle.
+            if self.disruptive_action.node_cycle_complete:
+                sleep_interval *= 3
+            time.sleep(sleep_interval)
             if self.disruptive_action.reverse():
                 self.reverse_action_triggered = True
 

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -42,14 +42,33 @@ class DisruptiveAction:
     The action can be reversible, it also stores the set of affected nodes and the last node
     the action was applied on.
     """
+
+    is_reversible = False
+
     def __init__(self, redpanda: RedpandaService, config: ActionConfig,
                  admin: Admin):
         self.admin = admin
         self.config = config
         self.redpanda = redpanda
+        self.nodes_for_action = set(self.redpanda.nodes)
         self.affected_nodes = set()
-        self.is_reversible = False
+        self.recovered_nodes = set()
         self.last_affected_node = None
+        # Node cycle signals that all nodes in cluster have been processed once.
+        # Since the nodes are selected randomly, it is possible that a node will
+        # be selected last in one cycle and first in the next cycle. This repeated
+        # action will cause a test failure in some cases. We avoid this by increasing
+        # the sleep duration for the iteration when node cycle is complete.
+        self.node_cycle_complete = False
+
+    def recover_node(self, node: ClusterNode):
+        """
+        A node on which the disruptive action had been performed is recovered/restored. This
+        happens for reversible operations such as killing redpanda, where recovery means starting
+        redpanda back up again.
+        """
+        self.recovered_nodes.add(node)
+        self.affected_nodes.remove(node)
 
     def max_affected_nodes_reached(self) -> bool:
         """
@@ -60,19 +79,16 @@ class DisruptiveAction:
 
     def target_node(self) -> Optional[ClusterNode]:
         """
-        Randomly selects the next node to apply the action on. A set of affected
-        nodes is maintained so that we do not apply the action on nodes which were
-        already targeted in previous invocations.
+        Selects the next node to process randomly from available nodes. If the set of available
+        nodes is empty, then we have processed all the nodes in current iteration, and we start
+        on the set of nodes which have already been processed once.
         """
-        available = set(self.redpanda.nodes) - self.affected_nodes
-        if available:
-            selected = random.choice(list(available))
-            names = {n.account.hostname for n in available}
-            self.redpanda.logger.info(
-                f'selected {selected.account.hostname} of {names} for operation'
-            )
-            return selected
-        return None
+        if not self.nodes_for_action:
+            self.nodes_for_action, self.recovered_nodes = self.recovered_nodes, self.nodes_for_action
+            self.node_cycle_complete = False
+        node = random.choice([n for n in self.nodes_for_action])
+        self.nodes_for_action.remove(node)
+        return node
 
     def do_action(self) -> ClusterNode:
         """
@@ -82,7 +98,11 @@ class DisruptiveAction:
 
     def action(self) -> Optional[ClusterNode]:
         if not self.max_affected_nodes_reached():
-            return self.do_action()
+            node = self.do_action()
+            if node and not self.nodes_for_action:
+                # We have processed all nodes in the current cycle.
+                self.node_cycle_complete = True
+            return node
         return None
 
     def do_reverse_action(self) -> ClusterNode:
@@ -101,11 +121,12 @@ class ProcessKill(DisruptiveAction):
     PROCESS_START_WAIT_SEC = 20
     PROCESS_START_WAIT_BACKOFF = 2
 
+    is_reversible = True
+
     def __init__(self, redpanda: RedpandaService, config: ActionConfig,
                  admin: Admin):
         super(ProcessKill, self).__init__(redpanda, config, admin)
         self.failure_injector = FailureInjector(self.redpanda)
-        self.is_reversible = True
 
     def max_affected_nodes_reached(self):
         return len(self.affected_nodes) >= self.config.max_affected_nodes
@@ -130,7 +151,7 @@ class ProcessKill(DisruptiveAction):
 
     def do_reverse_action(self):
         self._start_rp(node=self.last_affected_node)
-        self.affected_nodes.remove(self.last_affected_node)
+        self.recover_node(self.last_affected_node)
         self.redpanda.add_to_started_nodes(self.last_affected_node)
 
         last_affected_node, self.last_affected_node = self.last_affected_node, None
@@ -175,7 +196,7 @@ class ActionInjectorThread(Thread):
         wait_until(all_nodes_started,
                    timeout_sec=self.config.cluster_start_lead_time_sec,
                    backoff_sec=2,
-                   err_msg=f'Cluster not ready to begin actions')
+                   err_msg='Cluster not ready to begin actions')
 
         self.redpanda.logger.info('cluster is ready, starting action loop')
 
@@ -200,12 +221,12 @@ class ActionCtx:
         self.thread = ActionInjectorThread(config, redpanda, disruptive_action)
 
     def __enter__(self):
-        self.redpanda.logger.info(f'entering random failure ctx')
+        self.redpanda.logger.info('entering random failure ctx')
         self.thread.start()
         return self
 
     def __exit__(self, *args, **kwargs):
-        self.redpanda.logger.info(f'leaving random failure ctx')
+        self.redpanda.logger.info('leaving random failure ctx')
         self.thread.stop()
         self.thread.join()
 


### PR DESCRIPTION
## Cover letter

The action injector selects the next node for action using randomness from a set of available nodes. For reversible actions, the node which was affected is added back to available nodes once the action is
reversed.

This leads to a situation where the same node can be selected again and again for disruptions, especially when the node count is low and so randomness is not as effective.

This change switches to a priority queue, initially all nodes begin with priority in the same range so a random node is selected for the first action. once a node is selected, during reversal it is added back with a low priority, so it will not be selected again until all the remaining nodes have been processed.

The priority of nodes is grouped into generations, so that for a 3 node cluster the three nodes initially have the same range of priority, then the next three nodes added back have the same range of priority etc. This ensures that nodes are chosen randomly each time from within nodes of the same generation, and nodes of lower generation are processed first.

Fixes #6889 by making sure that the same node is not restarted repeatedly causing segments not to be removed from it and causing the test to fail.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Improvements

* fixes failing test.

[force push](https://github.com/redpanda-data/redpanda/compare/8399c2ba7e4ca55ed7203a29bf52e00a05a94ed3..218c537cfa60b802aed10fe0e1b9d956e8bf12a9) - remove time limit changes, fix priority calculation

[force push](https://github.com/redpanda-data/redpanda/compare/218c537cfa60b802aed10fe0e1b9d956e8bf12a9..5ec652456c9affc52e68eea688c148ac5de83ec2) - handle full queue by skipping adding node

[force push](https://github.com/redpanda-data/redpanda/compare/5ec652456c9affc52e68eea688c148ac5de83ec2..0d189a2490a226e08cf001409c016d48e2a3a543) - use simpler node selection, adjust sleep interval between cycles