### PR TITLE
Fix checks for replication factor changes

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -247,6 +247,7 @@ ss::future<> controller::start(cluster_discovery& discovery) {
             std::ref(_as),
             std::ref(_cloud_storage_api),
             std::ref(_feature_table),
+            std::ref(_members_table),
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
                   .storage_space_alert_free_threshold_percent.bind();

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -63,6 +63,7 @@ topics_frontend::topics_frontend(
   ss::sharded<ss::abort_source>& as,
   ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::sharded<features::feature_table>& features,
+  ss::sharded<cluster::members_table>& members_table,
   config::binding<unsigned> hard_max_disk_usage_ratio)
   : _self(self)
   , _stm(s)
@@ -75,6 +76,7 @@ topics_frontend::topics_frontend(
   , _as(as)
   , _cloud_storage_api(cloud_storage_api)
   , _features(features)
+  , _members_table(members_table)
   , _hard_max_disk_usage_ratio(hard_max_disk_usage_ratio) {}
 
 static bool

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -50,6 +50,7 @@ public:
       ss::sharded<ss::abort_source>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<features::feature_table>&,
+      ss::sharded<cluster::members_table>&,
       config::binding<unsigned>);
 
     ss::future<std::vector<topic_result>> create_topics(
@@ -215,6 +216,8 @@ private:
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<features::feature_table>& _features;
+
+    ss::sharded<cluster::members_table>& _members_table;
 
     config::binding<unsigned> _hard_max_disk_usage_ratio;
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -498,6 +498,19 @@ std::istream& operator>>(std::istream& i, replication_factor& cs) {
     return i;
 };
 
+replication_factor
+parsing_replication_factor(const std::optional<ss::sstring>& value) {
+    auto raw_value = boost::lexical_cast<int32_t>(*value);
+    if (
+      raw_value <= 0
+      || raw_value
+           > std::numeric_limits<cluster::replication_factor::type>::max()) {
+        throw boost::bad_lexical_cast();
+    }
+
+    return cluster::replication_factor(raw_value);
+}
+
 std::ostream&
 operator<<(std::ostream& o, const incremental_topic_custom_updates& i) {
     fmt::print(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1250,6 +1250,9 @@ using replication_factor
 
 std::istream& operator>>(std::istream& i, replication_factor& cs);
 
+replication_factor
+parsing_replication_factor(const std::optional<ss::sstring>& value);
+
 // This class contains updates for topic properties which are replicates not by
 // topic_frontend
 struct incremental_topic_custom_updates

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -81,6 +81,17 @@ void parse_and_set_tristate(
     }
 }
 
+static void parse_and_set_topic_replication_factor(
+  cluster::property_update<std::optional<cluster::replication_factor>>&
+    property,
+  const std::optional<ss::sstring>& value) {
+    if (!value) {
+        property.value = std::nullopt;
+    }
+
+    property.value = cluster::parsing_replication_factor(value);
+}
+
 static void parse_and_set_shadow_indexing_mode(
   cluster::property_update<std::optional<model::shadow_indexing_mode>>&
     property_update,
@@ -219,7 +230,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
                 continue;
             }
             if (cfg.name == topic_property_replication_factor) {
-                parse_and_set_optional(
+                parse_and_set_topic_replication_factor(
                   update.custom_properties.replication_factor, cfg.value);
                 continue;
             }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -146,8 +146,7 @@ static void parse_and_set_topic_replication_factor(
   config_resource_operation op) {
     // set property value
     if (op == config_resource_operation::set) {
-        property.value = cluster::replication_factor(
-          boost::lexical_cast<cluster::replication_factor::type>(*value));
+        property.value = cluster::parsing_replication_factor(value);
         property.op = cluster::incremental_update_operation::set;
     }
     return;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -102,12 +102,6 @@ CHAOS_LOG_ALLOW_LIST = [
     ),
 ]
 
-# Log errors that are expected in tests that change replication factor
-CHANGE_REPLICATION_FACTOR_ALLOW_LIST = [
-    re.compile(
-        "cluster - .*Unable to allocate topic with given replication factor"),
-]
-
 # Log errors emitted by refresh credentials system when cloud storage is enabled with IAM roles
 # without a corresponding mock service set up to return credentials
 IAM_ROLES_API_CALL_ALLOW_LIST = [

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -14,7 +14,6 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services.admin import Admin
-from rptest.services.redpanda import CHANGE_REPLICATION_FACTOR_ALLOW_LIST
 
 
 class ReplicationFactorChangeTest(RedpandaTest):
@@ -56,20 +55,14 @@ class ReplicationFactorChangeTest(RedpandaTest):
                                      self.replication_factor)
         self.check_rf(self.replication_factor)
 
-    @cluster(num_nodes=4, log_allow_list=CHANGE_REPLICATION_FACTOR_ALLOW_LIST)
+    @cluster(num_nodes=4)
     def check_error_test(self):
         self.replication_factor = -1
-        try:
-            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
-                                         self.replication_factor)
-            assert False, "We can not set replication factor <= 0"
-        except:
-            assert len(self.admin.list_reconfigurations()) == 0
+        res = self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                           self.replication_factor)
+        assert len(self.admin.list_reconfigurations()) == 0
 
         self.replication_factor = 0
-        try:
-            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
-                                         self.replication_factor)
-            assert False, "We can not set replication factor <= 0"
-        except:
-            assert len(self.admin.list_reconfigurations()) == 0
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                     self.replication_factor)
+        assert len(self.admin.list_reconfigurations()) == 0

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -57,17 +57,18 @@ class ReplicationFactorChangeTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     def check_error_test(self):
-        self.replication_factor = -1
-        res = self._rpk.alter_topic_config(self.topic_name, self.rf_property,
-                                           self.replication_factor)
+        self.replication_factor = 3
+        new_rf = -1
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
+        self.check_rf(self.replication_factor)
 
-        self.replication_factor = 0
-        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
-                                     self.replication_factor)
+        new_rf = 0
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
+        self.check_rf(self.replication_factor)
 
-        self.replication_factor = 10000
-        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
-                                     self.replication_factor)
+        new_rf = 10000
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
+        self.check_rf(self.replication_factor)

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -66,3 +66,8 @@ class ReplicationFactorChangeTest(RedpandaTest):
         self._rpk.alter_topic_config(self.topic_name, self.rf_property,
                                      self.replication_factor)
         assert len(self.admin.list_reconfigurations()) == 0
+
+        self.replication_factor = 10000
+        self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                     self.replication_factor)
+        assert len(self.admin.list_reconfigurations()) == 0


### PR DESCRIPTION
## Cover letter
We need to check what user provide for new value in alter-config.
`boost::lexical_cast` do not return error if we pass value < 0 for unsigned type.

Also added check inside increasing rf that num of brokers >= new replication factor

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
