### PR TITLE
cloud_storage: re-upload manifest after housekeeping

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -877,6 +877,10 @@ ss::future<> ntp_archiver::housekeeping() {
             co_await apply_retention();
             co_await garbage_collect();
         }
+
+        if (housekeeping_can_continue()) {
+            co_await upload_manifest();
+        }
     } catch (std::exception& e) {
         vlog(_rtclog.warn, "Error occured during housekeeping", e.what());
     }

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -431,3 +431,14 @@ class S3View:
         except Exception as e:
             self.logger.info(f'error {e} while checking if {o} is a segment')
             return False
+
+    def manifest_for_ntp(self,
+                         topic: str,
+                         partition: int,
+                         ns: str = 'kafka') -> dict:
+        ntp = NTP(ns, topic, partition)
+        assert ntp in self.partition_manifests, f'NTP {ntp} not in manifests in S3: ' \
+                                                f'{pprint.pformat(self.partition_manifests)}'
+        manifest_data = self.partition_manifests[ntp]
+        self.logger.debug(f'manifest: {pprint.pformat(manifest_data)}')
+        return manifest_data

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -442,3 +442,13 @@ class S3View:
         manifest_data = self.partition_manifests[ntp]
         self.logger.debug(f'manifest: {pprint.pformat(manifest_data)}')
         return manifest_data
+
+    def cloud_log_size_for_ntp(self,
+                               topic: str,
+                               partition: int,
+                               ns: str = 'kafka') -> dict:
+        manifest = self.manifest_for_ntp(topic, partition, ns)
+
+        start_offset = manifest['start_offset']
+        return sum(seg_meta['size_bytes']
+                   for seg_meta in manifest['segments'].values())


### PR DESCRIPTION
## Cover letter

This PR changes the upload loop logic to re-upload the partition manifest after performing housekeeping.
Housekeeping can change the manifest in two ways:
1. By advancing the start offset to meet the retention policy
2. By removing segments that are below the new start offset

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
