### PR TITLE
cluster: Add int32_t for tx_status enum

### DIFF
--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -46,7 +46,7 @@ using use_tx_version_with_last_pid_bool
 struct tm_transaction {
     static constexpr uint8_t version = 2;
 
-    enum tx_status {
+    enum tx_status : int32_t {
         ongoing,
         preparing,
         prepared,
@@ -318,7 +318,7 @@ private:
 struct tm_transaction_v1 {
     static constexpr uint8_t version = 1;
 
-    enum tx_status {
+    enum tx_status : int32_t {
         ongoing,
         preparing,
         prepared,
@@ -408,7 +408,7 @@ struct tm_transaction_v1 {
 struct tm_transaction_v0 {
     static constexpr uint8_t version = 0;
 
-    enum tx_status {
+    enum tx_status : int32_t {
         ongoing,
         preparing,
         prepared,


### PR DESCRIPTION
## Cover letter
`tx_status` for transaction struct was not specified. So it may create some problems. Because we serialize it with `adl`. And if basic int type (for `enum`) was changed, redpanda can not deserialize old log records. To avoid this we need to put type which compiler uses for this `enum`.

`std::is_unsigned<decltype(std::__to_underlying<tm_transaction::tx_status>)>::value` shows false
`sizeof(tm_transaction::tx_status)` is 4
so it is `int32_t`

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

