### PR TITLE
misc: fix inconvenient logger name

### DIFF
--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -72,7 +72,7 @@ public:
     void check_environment();
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
 
-    explicit application(ss::sstring = "redpanda::main");
+    explicit application(ss::sstring = "main");
     ~application();
 
     void shutdown();


### PR DESCRIPTION
## Cover letter

Colons conflict with use of colon as a separator
in --logger-log-level

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none