### PR TITLE
tests: fix storage scan when files are deleted

### DIFF
--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -80,6 +80,9 @@ class Partition:
             return
         self.segments[seg].set_size(size)
 
+    def delete_segment(self, segment_name: str):
+        del self.segments[segment_name]
+
     def delete_indices(self, allow_fail=False):
         for _, segment in self.segments.items():
             segment.delete_indices(allow_fail)


### PR DESCRIPTION
## Cover letter

...partway through.

Fixes https://github.com/redpanda-data/redpanda/issues/6999

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
None

## Release notes

* none
