### PR TITLE
Add clang-format to the list of build dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -27,6 +27,7 @@ fi
 deb_deps=(
   ccache
   clang
+  clang-format
   curl
   git
   golang-go
@@ -46,6 +47,7 @@ deb_deps=(
 fedora_deps=(
   ccache
   clang
+  clang-tools-extra 
   curl
   git
   golang

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -47,7 +47,7 @@ deb_deps=(
 fedora_deps=(
   ccache
   clang
-  clang-tools-extra 
+  clang-tools-extra
   curl
   git
   golang


### PR DESCRIPTION
## Cover letter

Debian and Fedora package clang-format separately from the package containing clang binary and each require additional packages to be installed for clang-format to be available on the system. Arch linux installs clang-format as part of the clang package.

## Release notes

* none

### Improvements

* Added clang-format to build dependencies on Debian and Fedora systems. 
