### PR TITLE
Made consumer timeout depended from the build type

### DIFF
--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -148,7 +148,7 @@ class CompactionEndToEndTest(EndToEndTest):
 
         # enable consumer and validate consumed records
         self.start_consumer(num_nodes=1, verify_offsets=False)
-
+        consumer_timeout = 180 if self.debug_mode else 90
         self.run_validation(enable_compaction=True,
                             enable_transactions=transactions,
-                            consumer_timeout_sec=90)
+                            consumer_timeout_sec=consumer_timeout)


### PR DESCRIPTION
## Cover letter

Compaction end to end tests relay on certain data volume being produced
and consumed from redpanda. Debug mode experience a lot of overhead
because of address sanitizer and non seastar memory allocator.

Made consumer timeout longer for debug test to make sure they are not
flaky.

Fixes: #6745

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
