### PR TITLE
cloud_roles: ensures http client is always closed

### DIFF
--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -13,6 +13,7 @@
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iostream.h"
 #include "json/istreamwrapper.h"
+#include "logger.h"
 
 namespace cloud_roles {
 
@@ -39,50 +40,70 @@ get_status(http::client::response_stream_ref& resp) {
     co_return resp->get_headers().result();
 }
 
+using http_call = ss::noncopyable_function<ss::future<api_response>(
+  http::client::request_header&)>;
+
+/// Helper function to catch and log common HTTP errors around user supplied
+/// operation.
+ss::future<api_response> static do_request(
+  http::client::request_header req, http_call func) {
+    try {
+        return func(req);
+    } catch (const std::system_error& ec) {
+        if (!is_retryable(ec)) {
+            vlog(
+              clrl_log.warn,
+              "abort system error {} while making request {}",
+              ec,
+              req);
+            return ss::make_ready_future<api_response>(make_abort_error(ec));
+        } else {
+            vlog(
+              clrl_log.warn,
+              "retryable system error {} while making request {}",
+              ec,
+              req);
+            return ss::make_ready_future<api_response>(
+              make_retryable_error(ec));
+        }
+    } catch (const std::exception& e) {
+        vlog(
+          clrl_log.warn,
+          "abort exception {} while making request {}",
+          e.what(),
+          req);
+        return ss::make_ready_future<api_response>(make_abort_error(e));
+    }
+}
+
+static ss::future<api_response> make_get_request(
+  http::client& client,
+  http::client::request_header req,
+  std::chrono::milliseconds timeout) {
+    auto response_stream = co_await client.request(std::move(req), timeout);
+    auto status = co_await get_status(response_stream);
+    if (is_retryable(status)) {
+        co_return make_retryable_error(
+          fmt::format("http request failed:{}", status));
+    }
+
+    if (status != boost::beast::http::status::ok) {
+        co_return make_abort_error(
+          fmt::format("http request failed:{}", status));
+    }
+    co_return co_await drain_response_stream(std::move(response_stream));
+}
+
 ss::future<api_response> make_request(
   http::client client,
   http::client::request_header req,
   std::chrono::milliseconds timeout) {
-    try {
-        auto response_stream = co_await client.request(std::move(req), timeout);
-        auto status = co_await get_status(response_stream);
-        if (
-          std::find(
-            retryable_http_status.begin(), retryable_http_status.end(), status)
-          != retryable_http_status.end()) {
-            co_return api_request_error{
-              .reason = fmt::format("http request failed:{}", status),
-              .error_kind = api_request_error_kind::failed_retryable};
-        }
-
-        if (status != boost::beast::http::status::ok) {
-            co_return api_request_error{
-              .reason = fmt::format("http request failed:{}", status),
-              .error_kind = api_request_error_kind::failed_abort};
-        }
-
-        auto data = co_await drain_response_stream(std::move(response_stream));
-        co_await client.stop();
-        client.shutdown();
-        co_return data;
-    } catch (const std::system_error& ec) {
-        if (auto code = ec.code(); std::find(
-                                     retryable_system_error_codes.begin(),
-                                     retryable_system_error_codes.end(),
-                                     code.value())
-                                   == retryable_system_error_codes.end()) {
-            co_return api_request_error{
-              .reason = ec.what(),
-              .error_kind = api_request_error_kind::failed_abort};
-        }
-        co_return api_request_error{
-          .reason = ec.what(),
-          .error_kind = api_request_error_kind::failed_retryable};
-    } catch (const std::exception& e) {
-        co_return api_request_error{
-          .reason = e.what(),
-          .error_kind = api_request_error_kind::failed_abort};
-    }
+    return http::with_client(
+      std::move(client), [req = std::move(req), timeout](auto& client) mutable {
+          return do_request(req, [&client, timeout](auto& req) mutable {
+              return make_get_request(client, req, timeout);
+          });
+      });
 }
 
 json::Document parse_json_response(iobuf resp) {
@@ -94,57 +115,49 @@ json::Document parse_json_response(iobuf resp) {
     return doc;
 }
 
+static ss::future<api_response> make_post_request(
+  http::client& client,
+  http::client::request_header& req,
+  iobuf&& content,
+  std::chrono::milliseconds timeout) {
+    req.set(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(content.size_bytes()));
+
+    auto stream = make_iobuf_input_stream(std::move(content));
+    auto response = co_await client.request(std::move(req), stream, timeout);
+    auto status = co_await get_status(response);
+    if (is_retryable(status)) {
+        co_return make_retryable_error(
+          fmt::format("http request failed:{}", status));
+    }
+
+    if (status != boost::beast::http::status::ok) {
+        co_return make_abort_error(
+          fmt::format("http request failed:{}", status));
+    }
+    auto data = co_await drain_response_stream(std::move(response));
+    co_await stream.close();
+    co_return data;
+}
+
 ss::future<api_response> post_request(
   http::client client,
   http::client::request_header req,
   iobuf content,
   std::chrono::milliseconds timeout) {
-    try {
-        req.set(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(content.size_bytes()));
-
-        auto stream = make_iobuf_input_stream(std::move(content));
-        auto resp = co_await client.request(std::move(req), stream, timeout);
-        auto status = co_await get_status(resp);
-        if (
-          std::find(
-            retryable_http_status.begin(), retryable_http_status.end(), status)
-          != retryable_http_status.end()) {
-            co_return api_request_error{
-              .reason = fmt::format("http request failed:{}", status),
-              .error_kind = api_request_error_kind::failed_retryable};
-        }
-
-        if (status != boost::beast::http::status::ok) {
-            co_return api_request_error{
-              .reason = fmt::format("http request failed:{}", status),
-              .error_kind = api_request_error_kind::failed_abort};
-        }
-
-        auto data = co_await drain_response_stream(std::move(resp));
-        co_await stream.close();
-        co_await client.stop();
-        client.shutdown();
-        co_return data;
-    } catch (const std::system_error& ec) {
-        if (auto code = ec.code(); std::find(
-                                     retryable_system_error_codes.begin(),
-                                     retryable_system_error_codes.end(),
-                                     code.value())
-                                   == retryable_system_error_codes.end()) {
-            co_return api_request_error{
-              .reason = ec.what(),
-              .error_kind = api_request_error_kind::failed_abort};
-        }
-        co_return api_request_error{
-          .reason = ec.what(),
-          .error_kind = api_request_error_kind::failed_retryable};
-    } catch (const std::exception& e) {
-        co_return api_request_error{
-          .reason = e.what(),
-          .error_kind = api_request_error_kind::failed_abort};
-    }
+    return http::with_client(
+      std::move(client),
+      [req = std::move(req), content = std::move(content), timeout](
+        auto& client) mutable -> ss::future<api_response> {
+          return do_request(
+            req,
+            [&client, content = std::move(content), timeout](
+              auto& req) mutable {
+                return make_post_request(
+                  client, req, std::move(content), timeout);
+            });
+      });
 }
 
 ss::future<api_response> post_request(

--- a/src/v/cloud_roles/request_response_helpers.h
+++ b/src/v/cloud_roles/request_response_helpers.h
@@ -14,8 +14,6 @@
 #include "http/client.h"
 #include "json/document.h"
 
-#include <boost/property_tree/ptree.hpp>
-
 namespace cloud_roles {
 
 inline constexpr std::chrono::milliseconds default_request_timeout{5000};

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -70,4 +70,43 @@ operator<<(std::ostream& os, const api_response_parse_error& err) {
     return os;
 }
 
+bool is_retryable(const std::system_error& ec) {
+    auto code = ec.code();
+    return std::find(
+             retryable_system_error_codes.begin(),
+             retryable_system_error_codes.end(),
+             code.value())
+           != retryable_system_error_codes.end();
+}
+
+bool is_retryable(boost::beast::http::status status) {
+    return std::find(
+             retryable_http_status.begin(), retryable_http_status.end(), status)
+           != retryable_http_status.end();
+}
+
+api_request_error make_abort_error(const std::exception& ex) {
+    return api_request_error{
+      .reason = ex.what(),
+      .error_kind = api_request_error_kind::failed_abort,
+    };
+}
+
+api_request_error make_abort_error(ss::sstring reason) {
+    return api_request_error{
+      .reason = reason, .error_kind = api_request_error_kind::failed_abort};
+}
+
+api_request_error make_retryable_error(const std::exception& ex) {
+    return api_request_error{
+      .reason = ex.what(),
+      .error_kind = api_request_error_kind::failed_retryable,
+    };
+}
+
+api_request_error make_retryable_error(ss::sstring reason) {
+    return api_request_error{
+      .reason = reason, .error_kind = api_request_error_kind::failed_retryable};
+}
+
 } // namespace cloud_roles

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -26,6 +26,8 @@ namespace cloud_roles {
 static constexpr auto retryable_system_error_codes = std::to_array(
   {ECONNREFUSED, ENETUNREACH, ETIMEDOUT, ECONNRESET, EPIPE});
 
+bool is_retryable(const std::system_error& ec);
+
 static constexpr auto retryable_http_status = std::to_array({
   boost::beast::http::status::request_timeout,
   boost::beast::http::status::gateway_timeout,
@@ -35,6 +37,8 @@ static constexpr auto retryable_http_status = std::to_array({
   boost::beast::http::status::network_connect_timeout_error,
 });
 
+bool is_retryable(boost::beast::http::status status);
+
 enum class api_request_error_kind { failed_abort, failed_retryable };
 
 std::ostream& operator<<(std::ostream& os, api_request_error_kind kind);
@@ -43,6 +47,12 @@ struct api_request_error {
     ss::sstring reason;
     api_request_error_kind error_kind;
 };
+
+api_request_error make_abort_error(const std::exception& ex);
+api_request_error make_abort_error(ss::sstring reason);
+
+api_request_error make_retryable_error(const std::exception& ex);
+api_request_error make_retryable_error(ss::sstring reason);
 
 std::ostream&
 operator<<(std::ostream& os, const api_request_error& request_error);

--- a/src/v/test_utils/http_imposter.cc
+++ b/src/v/test_utils/http_imposter.cc
@@ -138,7 +138,7 @@ void http_imposter_fixture::fail_request_if(
   http_imposter_fixture::request_predicate predicate,
   http_test_utils::response response) {
     _fail_requests_when.push_back(std::move(predicate));
-    _fail_responses[_fail_requests_when.size() - 1] = response;
+    _fail_responses[_fail_requests_when.size() - 1] = std::move(response);
 }
 
 void http_imposter_fixture::reset_http_call_state() {


### PR DESCRIPTION
## Cover letter

The http client in cloud_roles::make_request was not closed when exception is thrown. RAII cannot be used for ensuring the client is closed, as the client stop method returns a future which cannot be returned from/blocked on in destructor.

This change introduces a helper modeled after ss::with_file to accept and own an http client and close it after a user-supplied operation is finished.

It also adds a helper to wrap making an http request with catching and logging common http call errors.

Fixes: #6899 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
