### PR TITLE
Adjust raft voter priority before the kafka API is ready

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -441,6 +441,14 @@ ss::future<> controller::start(cluster_discovery& discovery) {
       });
 }
 
+ss::future<> controller::set_ready() {
+    if (_is_ready) {
+        return ss::now();
+    }
+    _is_ready = true;
+    return _raft_manager.invoke_on_all(&raft::group_manager::set_ready);
+}
+
 ss::future<> controller::shutdown_input() {
     if (_raft0) {
         _raft0->shutdown_input();

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -141,6 +141,11 @@ public:
     ss::future<> shutdown_input();
     ss::future<> stop();
 
+    /**
+     * Called when the node is ready to become a leader
+     */
+    ss::future<> set_ready();
+
 private:
     friend controller_probe;
 
@@ -201,6 +206,7 @@ private:
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     controller_probe _probe;
     ss::sharded<bootstrap_backend> _bootstrap_backend; // single instance
+    bool _is_ready = false;
 };
 
 } // namespace cluster

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -88,9 +88,6 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
     ss::sstring username{"admin"};
     ss::sstring userpass{"foopar"};
 
-    info("Waiting for leadership");
-    wait_for_controller_leadership().get();
-
     info("Enable SASL and restart");
     enable_sasl_and_restart(username);
     auto disable_sasl = ss::defer([this] {
@@ -99,7 +96,8 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
         info("Disable SASL and restart");
         disable_sasl_and_restart();
     });
-
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
     ss::sstring user_body = fmt::format(
       R"({{"username": "{}", "password": "{}","algorithm": "SCRAM-SHA-256"}})",
       username,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -96,7 +96,8 @@ consensus::consensus(
   storage::api& storage,
   std::optional<std::reference_wrapper<recovery_throttle>> recovery_throttle,
   recovery_memory_quota& recovery_mem_quota,
-  features::feature_table& ft)
+  features::feature_table& ft,
+  std::optional<voter_priority> voter_priority_override)
   : _self(nid, initial_cfg.revision_id())
   , _group(group)
   , _jit(std::move(jit))
@@ -132,6 +133,7 @@ consensus::consensus(
       storage::simple_snapshot_manager::default_snapshot_filename,
       _scheduling.default_iopc)
   , _configuration_manager(std::move(initial_cfg), _group, _storage, _ctxlog)
+  , _node_priority_override(voter_priority_override)
   , _append_requests_buffer(*this, 256) {
     setup_metrics();
     update_follower_stats(_configuration_manager.get_latest());

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -97,7 +97,8 @@ public:
       storage::api&,
       std::optional<std::reference_wrapper<recovery_throttle>>,
       recovery_memory_quota&,
-      features::feature_table&);
+      features::feature_table&,
+      std::optional<voter_priority> = std::nullopt);
 
     /// Initial call. Allow for internal state recovery
     ss::future<> start();
@@ -368,6 +369,14 @@ public:
         _node_priority_override = raft::zero_voter_priority;
     }
 
+    /**
+     * Resets node priority only if it was not blocked
+     */
+    void reset_node_priority() {
+        if (_node_priority_override == raft::min_voter_priority) {
+            unblock_new_leadership();
+        }
+    }
     /*
      * Allow the current node to become a leader for this group.
      */

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -93,7 +93,8 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
       _storage,
       _recovery_throttle,
       _recovery_mem_quota,
-      _feature_table);
+      _feature_table,
+      std::nullopt);
 
     return ss::with_gate(_gate, [this, raft] {
         return _heartbeats.register_group(raft).then([this, raft] {

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -64,6 +64,13 @@ ss::future<> group_manager::stop() {
           [](ss::lw_shared_ptr<consensus> raft) { return raft->stop(); });
     });
 }
+void group_manager::set_ready() {
+    _is_ready = true;
+    std::for_each(
+      _groups.begin(), _groups.end(), [](ss::lw_shared_ptr<consensus>& c) {
+          c->reset_node_priority();
+      });
+}
 
 ss::future<> group_manager::stop_heartbeats() { return _heartbeats.stop(); }
 
@@ -94,7 +101,7 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
       _recovery_throttle,
       _recovery_mem_quota,
       _feature_table,
-      std::nullopt);
+      _is_ready ? std::nullopt : std::make_optional(min_voter_priority));
 
     return ss::with_gate(_gate, [this, raft] {
         return _heartbeats.register_group(raft).then([this, raft] {

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -55,6 +55,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    void set_ready();
     ss::future<> stop_heartbeats();
 
     ss::future<ss::lw_shared_ptr<raft::consensus>> create_group(
@@ -108,6 +109,7 @@ private:
     recovery_throttle& _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
     features::feature_table& _feature_table;
+    bool _is_ready;
 };
 
 } // namespace raft

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -170,7 +170,8 @@ struct raft_node {
           storage.local(),
           recovery_throttle.local(),
           recovery_mem_quota,
-          feature_table.local());
+          feature_table.local(),
+          std::nullopt);
 
         // create connections to initial nodes
         consensus->config().for_each_broker(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1485,7 +1485,7 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     }
 
     start_kafka(node_id, app_signal);
-
+    controller->set_ready().get();
     _admin.invoke_on_all([](admin_server& admin) { admin.set_ready(); }).get();
 
     vlog(_log.info, "Successfully started Redpanda!");

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1466,6 +1466,10 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
             *controller, group_router));
     }
 
+    if (cd.is_cluster_founder().get()) {
+        controller->set_ready().get();
+    }
+
     start_runtime_services(cd);
 
     if (_proxy_config) {

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -129,11 +129,14 @@ class FailureInjector:
         node.account.ssh(cmd)
 
     def _heal(self, node):
-        self.redpanda.logger.info(f"healing node {node.account.hostname}")
-        cmd = "iptables -D OUTPUT -p tcp --destination-port 33145 -j DROP"
-        node.account.ssh(cmd)
-        cmd = "iptables -D INPUT -p tcp --destination-port 33145 -j DROP"
-        node.account.ssh(cmd)
+        try:
+            self.redpanda.logger.info(f"healing node {node.account.hostname}")
+            cmd = "iptables -D OUTPUT -p tcp --destination-port 33145 -j DROP"
+            node.account.ssh(cmd)
+            cmd = "iptables -D INPUT -p tcp --destination-port 33145 -j DROP"
+            node.account.ssh(cmd)
+        except:
+            pass
 
     def _delete_netem(self, node):
         tc_netem.tc_netem_delete(node)
@@ -141,12 +144,12 @@ class FailureInjector:
     def _heal_all(self):
         self.redpanda.logger.info(f"healling all network failures")
         for n in self.redpanda.nodes:
-            n.account.ssh("iptables -P INPUT ACCEPT")
-            n.account.ssh("iptables -P FORWARD ACCEPT")
-            n.account.ssh("iptables -P OUTPUT ACCEPT")
-            n.account.ssh("iptables -F")
-            n.account.ssh("iptables -X")
             try:
+                n.account.ssh("iptables -P INPUT ACCEPT")
+                n.account.ssh("iptables -P FORWARD ACCEPT")
+                n.account.ssh("iptables -P OUTPUT ACCEPT")
+                n.account.ssh("iptables -F")
+                n.account.ssh("iptables -X")
                 self._delete_netem(n)
             except:
                 # skip error as deleting netem may fail if there are no rules applied

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -80,7 +80,7 @@ class ShutdownTest(EndToEndTest):
         pending_attempts = 5
         while pending_attempts != 0:
             # Pick the current leader and restart it, repeat
-            wait_until(lambda: checked_get_leader,
+            wait_until(lambda: checked_get_leader(),
                        timeout_sec=30,
                        backoff_sec=2,
                        err_msg=f"Leader not found for ntp: {self.topic}/0")

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -16,9 +16,20 @@ from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
 from rptest.services.admin import Admin
 from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.util import wait_until_result
 
 
 class ShutdownTest(EndToEndTest):
+    def __init__(self, test_context):
+        super().__init__(test_context)
+        self.stopped = False
+        self.background_failures = None
+
+    def teardown(self):
+        self.stopped = True
+        if self.background_failures:
+            self.background_failures.join()  # Wait for ip tables rules reset.
+
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_timely_shutdown_with_failures(self):
         '''
@@ -41,11 +52,12 @@ class ShutdownTest(EndToEndTest):
                 leader = admin.get_partition_leader(namespace="kafka",
                                                     topic=self.topic.name,
                                                     partition=0)
-                return next(
-                    filter(lambda n: self.redpanda.idx(n) == leader,
-                           self.redpanda.nodes))
+                return (True,
+                        next(
+                            filter(lambda n: self.redpanda.idx(n) == leader,
+                                   self.redpanda.nodes)))
             except:
-                return None
+                return False
 
         self.redpanda.start()
         # Background load generation
@@ -56,14 +68,12 @@ class ShutdownTest(EndToEndTest):
                    backoff_sec=2,
                    err_msg=f"Leader not found for ntp: {self.topic}/0")
 
-        stopped = False
-
         def pause_non_leader_node():
             """Picks a non leader node for the ntp and isolates it repeatedly"""
             with FailureInjector(self.redpanda) as finjector:
                 timeout_s = 5
                 failure = FailureSpec.FAILURE_ISOLATE
-                while not stopped:
+                while not self.stopped:
                     node = random.choice(self.redpanda.nodes)
                     assert node
                     if node == checked_get_leader():
@@ -73,18 +83,18 @@ class ShutdownTest(EndToEndTest):
                         FailureSpec(node=node, type=failure, length=timeout_s))
 
         # Inject failures in the background.
-        background_failures = threading.Thread(target=pause_non_leader_node,
-                                               args=(),
-                                               daemon=True)
-        background_failures.start()
+        self.background_failures = threading.Thread(
+            target=pause_non_leader_node, args=(), daemon=True)
+        self.background_failures.start()
         pending_attempts = 5
         while pending_attempts != 0:
             # Pick the current leader and restart it, repeat
-            wait_until(lambda: checked_get_leader(),
-                       timeout_sec=30,
-                       backoff_sec=2,
-                       err_msg=f"Leader not found for ntp: {self.topic}/0")
-            leader = checked_get_leader()
+            leader = wait_until_result(
+                lambda: checked_get_leader(),
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg=f"Leader not found for ntp: {self.topic}/0")
+
             assert leader
             self.redpanda.logger.info(
                 f"Restarting leader node {leader.account.hostname}")
@@ -92,7 +102,5 @@ class ShutdownTest(EndToEndTest):
             pending_attempts -= 1
 
         # Stop the finjector
-        stopped = True
-        background_failures.join()  # Wait for ip tables rules reset.
-        assert not background_failures.is_alive()
+        self.stopped = True
         self.producer.stop()


### PR DESCRIPTION
## Cover letter

Changing voter priority of current node to minimum before the node is ready to serve Kafka traffic. This is preventing the node from becoming a controller before it can handle clients requests.

Fixes: #6892, Fixes: #7025, Fixes: #7016


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->


## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
### Improvements
- faster recovery from rolling restart
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
