### PR TITLE
rpk: add `fetch_reads_debounce_timeout:10` to mode dev-container

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1042,6 +1042,7 @@ func setContainerModeCfgFields(cfg *config.Config) {
 	cfg.Redpanda.Other["group_topic_partitions"] = 3
 	cfg.Redpanda.Other["storage_min_free_bytes"] = 10485760
 	cfg.Redpanda.Other["topic_partitions_per_shard"] = 1000
+	cfg.Redpanda.Other["fetch_reads_debounce_timeout"] = 10
 }
 
 func getOrFindInstallDir(fs afero.Fs, installDir string) (string, error) {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -244,10 +244,11 @@ func TestStartCommand(t *testing.T) {
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":   true,
+				"group_topic_partitions":       3,
+				"storage_min_free_bytes":       10485760,
+				"topic_partitions_per_shard":   1000,
+				"fetch_reads_debounce_timeout": 10,
 			}
 
 			conf, err := new(config.Params).Load(fs)
@@ -1404,10 +1405,11 @@ func TestStartCommand(t *testing.T) {
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":   true,
+				"group_topic_partitions":       3,
+				"storage_min_free_bytes":       10485760,
+				"topic_partitions_per_shard":   1000,
+				"fetch_reads_debounce_timeout": 10,
 			}
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},
@@ -1453,10 +1455,11 @@ func TestStartCommand(t *testing.T) {
 
 			// Config:
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":   true,
+				"group_topic_partitions":       3,
+				"storage_min_free_bytes":       10485760,
+				"topic_partitions_per_shard":   1000,
+				"fetch_reads_debounce_timeout": 10,
 			}
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
@@ -1495,8 +1498,9 @@ func TestStartCommand(t *testing.T) {
 				"auto_create_topics_enabled": false,
 				"group_topic_partitions":     1,
 				// rest of --mode dev-container cfg fields
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"storage_min_free_bytes":       10485760,
+				"topic_partitions_per_shard":   1000,
+				"fetch_reads_debounce_timeout": 10,
 			}
 			require.Exactly(st, expectedClusterFields, conf.Redpanda.Other)
 		},

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -99,7 +99,8 @@ class RpkRedpandaStartTest(RedpandaTest):
             "auto_create_topics_enabled": "true",
             "group_topic_partitions": "3",
             "storage_min_free_bytes": "10485760",
-            "topic_partitions_per_shard": "1000"
+            "topic_partitions_per_shard": "1000",
+            "fetch_reads_debounce_timeout": "10"
         }
 
         for p in expected_cluster_properties:


### PR DESCRIPTION
## Cover letter

Useful for trading latency and "hot" polling. Ref: https://github.com/redpanda-data/redpanda/issues/5661#issuecomment-1211452812 

Fixes #5661

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* `rpk redpanda start --mode dev-container` now sets cluster property `add fetch_reads_debounce_timeout` to 10ms.

^ that also applies to developer mode which is the default right now.

## Release notes
### Improvements

* `rpk redpanda start --mode dev-container` now sets cluster property `add fetch_reads_debounce_timeout` to 10ms.
