### PR TITLE
Set host header when getting AWS creds in order to work with `kube2iam`

### DIFF
--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -63,6 +63,8 @@ ss::future<api_response> aws_refresh_impl::fetch_credentials() {
     }
 
     http::client::request_header creds_req;
+    creds_req.insert(
+      boost::beast::http::field::host, {api_host().data(), api_host().size()});
     creds_req.method(boost::beast::http::verb::get);
     creds_req.target(
       fmt::format("/latest/meta-data/iam/security-credentials/{}", *_role));
@@ -107,6 +109,8 @@ api_response_parse_result aws_refresh_impl::parse_response(iobuf resp) {
 
 ss::future<api_response> aws_refresh_impl::fetch_role_name() {
     http::client::request_header role_req;
+    role_req.insert(
+      boost::beast::http::field::host, {api_host().data(), api_host().size()});
     role_req.method(boost::beast::http::verb::get);
     role_req.target("/latest/meta-data/iam/security-credentials/");
     co_return co_await make_request(


### PR DESCRIPTION
## Cover letter

Feature: support fetching credentials when on [`kube2iam`](https://github.com/jtblin/kube2iam)



## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Send `Host` header to EC2 metadata server (`169.254.169.254`) in order to work with [`kube2iam`](https://github.com/jtblin/kube2iam)

### Improvements

* Support retrieving credentials from [`kube2iam`](https://github.com/jtblin/kube2iam).

-->

### Improvements

* Support retrieving credentials from [`kube2iam`](https://github.com/jtblin/kube2iam).