### PR TITLE
rpk/k8s: bump franz-go to unreleased commit

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20220726211426-9ad7e9d59990
 	github.com/spf13/afero v1.9.2
 	github.com/stretchr/testify v1.7.1
-	github.com/twmb/franz-go v1.9.0
+	github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce
 	github.com/twmb/franz-go/pkg/kadm v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -885,8 +885,9 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twmb/franz-go v1.5.0/go.mod h1:ZKQ5AtqBbdc783bLCay7nDc21lJnIIA8mFJYhLMF19E=
-github.com/twmb/franz-go v1.9.0 h1:q2X6DekP91zm3Jh1F7OxChgiBss3bteJv3sOc+VngRk=
 github.com/twmb/franz-go v1.9.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
+github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce h1:aMSo6EtBEMvTg5ATviVUEq0LOwcCTDQhJ1GJcN3gi0o=
+github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go/pkg/kadm v1.3.0 h1:BIHmIjVdbh+qRs4GcR0hR2IiQJZkOkVtZdZRK3AQoNI=
 github.com/twmb/franz-go/pkg/kadm v1.3.0/go.mod h1:4NEqvW6UF35no5dRwOieSFtmFKf5GR4dLB3zhOkAurA=
 github.com/twmb/franz-go/pkg/kmsg v1.0.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	github.com/tklauser/go-sysconf v0.3.10
-	github.com/twmb/franz-go v1.9.0
+	github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce
 	github.com/twmb/franz-go/pkg/kadm v1.3.0
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0
 	github.com/twmb/tlscfg v1.2.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -405,8 +405,9 @@ github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYa
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/tklauser/numcpus v0.5.0 h1:ooe7gN0fg6myJ0EKoTAf5hebTZrH52px3New/D9iJ+A=
 github.com/tklauser/numcpus v0.5.0/go.mod h1:OGzpTxpcIMNGYQdit2BYL1pvk/dSOaJWjKoflh+RQjo=
-github.com/twmb/franz-go v1.9.0 h1:q2X6DekP91zm3Jh1F7OxChgiBss3bteJv3sOc+VngRk=
 github.com/twmb/franz-go v1.9.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
+github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce h1:aMSo6EtBEMvTg5ATviVUEq0LOwcCTDQhJ1GJcN3gi0o=
+github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go/pkg/kadm v1.3.0 h1:BIHmIjVdbh+qRs4GcR0hR2IiQJZkOkVtZdZRK3AQoNI=
 github.com/twmb/franz-go/pkg/kadm v1.3.0/go.mod h1:4NEqvW6UF35no5dRwOieSFtmFKf5GR4dLB3zhOkAurA=
 github.com/twmb/franz-go/pkg/kmsg v1.2.0 h1:jYWh2qFw5lDbNv5Gvu/sMKagzICxuA5L6m1W2Oe7XUo=


### PR DESCRIPTION
## Cover letter

This is the first commit after v1.9.1; this unreleased commit will go in the next feature release (target date 2w to 2mo, depending). This commit contains a small helper to guess TLS errors, making rpk output a bit nicer.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
