### PR TITLE
storage/storage resources: fix trace logs

### DIFF
--- a/src/v/storage/storage_resources.cc
+++ b/src/v/storage/storage_resources.cc
@@ -183,10 +183,10 @@ bool storage_resources::offset_translator_take_bytes(
   int32_t bytes, ssx::semaphore_units& units) {
     vlog(
       stlog.trace,
-      "offset_translator_take_bytes {} (current {})",
+      "offset_translator_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
-      _offset_translator_dirty_bytes.current());
+      _offset_translator_dirty_bytes.available_units());
 
     return filter_checkpoints(
       _offset_translator_dirty_bytes.take(bytes), units);
@@ -199,7 +199,7 @@ bool storage_resources::configuration_manager_take_bytes(
       "configuration_manager_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
-      _configuration_manager_dirty_bytes.current());
+      _configuration_manager_dirty_bytes.available_units());
 
     return filter_checkpoints(
       _configuration_manager_dirty_bytes.take(bytes), units);
@@ -212,7 +212,7 @@ bool storage_resources::stm_take_bytes(
       "stm_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
-      _stm_dirty_bytes.current());
+      _stm_dirty_bytes.available_units());
 
     return filter_checkpoints(_stm_dirty_bytes.take(bytes), units);
 }

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -89,6 +89,7 @@ public:
     }
 
     size_t current() const noexcept { return _sem.current(); }
+    ssize_t available_units() const noexcept { return _sem.available_units(); }
 
 private:
     ssx::semaphore _sem;


### PR DESCRIPTION

## Cover letter

- One of these had a missing {}
- The "+=" notation should have been -= when taking units
- available_units() instead of current() to give visibility of negative semaphore values.

Once merged will pull this commit into https://github.com/redpanda-data/redpanda/pull/6983

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
