### PR TITLE
tests: fix rare KeyError in storage get_sizes

### DIFF
--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -81,7 +81,10 @@ class Partition:
         self.segments[seg].set_size(size)
 
     def delete_segment(self, segment_name: str):
-        del self.segments[segment_name]
+        try:
+            del self.segments[segment_name]
+        except KeyError:
+            pass
 
     def delete_indices(self, allow_fail=False):
         for _, segment in self.segments.items():


### PR DESCRIPTION
## Cover letter

If we ended up listing the same segment twice,
the set of segment names that we stat() to get sizes can include duplicates, leading to removing
the same segment twice when handling deleted segments.

Followup to
```
commit 56f076cfc3b4e558cef92b3cb1b32fb2dd9abb75
Author: John Spray <jcs@redpanda.com>
Date:   Fri Oct 28 18:16:09 2022 +0100

    tests: fix storage scan when files are deleted
    
    ...partway through.
    
    Fixes UpgradeFromPriorFeatureVersionCloudStorageTest
```

Fixes https://github.com/redpanda-data/redpanda/issues/6991

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none