### PR TITLE
features: add some comments

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -79,6 +79,17 @@ std::string_view to_string_view(feature_state::state s) {
 
 // The version that this redpanda node will report: increment this
 // on protocol changes to raft0 structures, like adding new services.
+//
+// For your convenience, a rough guide to the history of how logical
+// versions mapped to redpanda release versions:
+//  22.1.1 -> 3  (22.1.5 was version 4)
+//  22.2.1 -> 5  (22.2.6 later proceeds to version 6)
+//  22.3.1 -> 7
+//
+// Although some previous stable branches have included feature version
+// bumps, this is _not_ the intended usage, as stable branches are
+// meant to be safely downgradable within the branch, and new features
+// imply that new data formats may be written.
 static constexpr cluster_version latest_version = cluster_version{7};
 
 feature_table::feature_table() {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1776,6 +1776,11 @@ void application::load_feature_table_snapshot() {
           snap.version);
         // From this point, it is undefined to whether this process will be able
         // to decode anything it sees on the network or on disk.
+        //
+        // This case will have stricter enforcement in future, to protect the
+        // user from acccidentally getting a cluster into a broken state by
+        // downgrading too far:
+        // https://github.com/redpanda-data/redpanda/issues/7018
 #ifndef NDEBUG
         vassert(my_version >= snap.version, "Incompatible downgrade detected");
 #endif


### PR DESCRIPTION
## Cover letter

This is a non-code change to fill out some useful context for folks dealing with logical cluster versions

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none