### PR TITLE
tests: fix retention settings in scale tests

### DIFF
--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -165,7 +165,7 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
         rpk = RpkTool(self.redpanda)
         rpk.alter_topic_config(self.topic, 'redpanda.remote.write', 'true')
         rpk.alter_topic_config(self.topic, 'redpanda.remote.read', 'true')
-        rpk.alter_topic_config(self.topic, 'retention.bytes',
+        rpk.alter_topic_config(self.topic, 'retention.local.target.bytes',
                                str(segment_size))
 
         self._producer.start(clean=False)


### PR DESCRIPTION
### Cover letter
'retention.bytes' now controls the cloud retention policy for topics with shadow indexing enabled. This commit updates the shadow indexing scale tests to set local retention instead in order to achieve the old semantics.

I tried to add a test that reproduces the crashy behaviour, but I've not been able to get it to crash in my env.
I'll keep trying, but let's fix the current issue first.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #7008 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [X] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
