### PR TITLE
Schema Registry && REST Proxy: Add an access log.

### DIFF
--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -30,6 +30,8 @@ namespace pandaproxy::rest {
 
 using server = proxy::server;
 
+ss::logger rest_proxy_access("rest_proxy_access");
+
 const security::acl_principal principal{
   security::principal_type::ephemeral_user, "__pandaproxy"};
 
@@ -123,7 +125,8 @@ proxy::proxy(
       "header",
       "/definitions",
       _ctx,
-      json::serialization_format::application_json)
+      json::serialization_format::application_json,
+      rest_proxy_access)
   , _ensure_started{[this]() { return do_start(); }}
   , _controller(controller) {
     _inflight_config_binding.watch([this]() {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -42,6 +42,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/http/exception.hh>
+#include <seastar/util/log.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -49,6 +50,7 @@
 namespace pandaproxy::schema_registry {
 
 static constexpr auto audit_svc_name = "Redpanda Schema Registry Service";
+ss::logger schema_registry_access{"schema_registry_access"};
 
 using server = ctx_server<service>;
 const security::acl_principal principal{
@@ -622,7 +624,8 @@ service::service(
       "schema_registry_header",
       "/schema_registry_definitions",
       _ctx,
-      json::serialization_format::schema_registry_v1_json)
+      json::serialization_format::schema_registry_v1_json,
+      schema_registry_access)
   , _store(store)
   , _writer(sequencer)
   , _controller(controller)

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -22,6 +22,7 @@
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/net/tls.hh>
+#include <seastar/util/log.hh>
 
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
@@ -29,6 +30,7 @@
 #include <charconv>
 #include <exception>
 #include <memory>
+#include <type_traits>
 
 namespace pandaproxy {
 
@@ -77,12 +79,14 @@ struct handler_adaptor : ss::httpd::handler_base {
       server::function_handler&& handler,
       ss::httpd::path_description& path_desc,
       const ss::sstring& metrics_group_name,
-      json::serialization_format exceptional_mime_type)
+      json::serialization_format exceptional_mime_type,
+      ss::logger& log)
       : _pending_requests(pending_requests)
       , _ctx(ctx)
       , _handler(std::move(handler))
       , _probe(path_desc, metrics_group_name)
-      , _exceptional_mime_type(exceptional_mime_type) {}
+      , _exceptional_mime_type(exceptional_mime_type)
+      , _log(log) {}
 
     ss::future<std::unique_ptr<ss::http::reply>> handle(
       const ss::sstring&,
@@ -112,6 +116,16 @@ struct handler_adaptor : ss::httpd::handler_base {
             co_return std::move(rp.rep);
         }
         auto sem_units = co_await ss::get_units(_ctx.mem_sem, req_size);
+
+        // Username is empty 'cos auth wrapper happens later :'()
+        auto access_log = ssx::sformat(
+          R"("{} {} {} {} HTTP/{}")",
+          rq.req->get_client_address().addr(),
+          rq.user.name,
+          rq.req->_method,
+          rq.req->_url,
+          rq.req->_version);
+
         if (_ctx.as.abort_requested()) {
             set_reply_unavailable(*rp.rep);
             rp.mime_type = _exceptional_mime_type;
@@ -133,6 +147,13 @@ struct handler_adaptor : ss::httpd::handler_base {
             rp = server::reply_t{exception_reply(ex), _exceptional_mime_type};
         }
         set_and_measure_response(rp);
+        vlog(
+          _log.info,
+          "{} {} {}",
+          access_log,
+          static_cast<std::underlying_type_t<ss::http::reply::status_type>>(
+            rp.rep->_status),
+          rp.rep->_content.size());
         co_return std::move(rp.rep);
     }
 
@@ -141,6 +162,7 @@ struct handler_adaptor : ss::httpd::handler_base {
     server::function_handler _handler;
     probe _probe;
     json::serialization_format _exceptional_mime_type;
+    ss::logger& _log;
 };
 
 server::server(
@@ -150,7 +172,8 @@ server::server(
   const ss::sstring& header,
   const ss::sstring& definitions,
   context_t& ctx,
-  json::serialization_format exceptional_mime_type)
+  json::serialization_format exceptional_mime_type,
+  ss::logger& log)
   : _server(server_name)
   , _public_metrics_group_name(public_metrics_group_name)
   , _pending_reqs()
@@ -158,7 +181,8 @@ server::server(
   , _has_routes(false)
   , _ctx(ctx)
   , _exceptional_mime_type(exceptional_mime_type)
-  , _probe{} {
+  , _probe{}
+  , _log(log) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -177,7 +201,8 @@ void server::route(server::route_t r) {
       std::move(r.handler),
       r.path_desc,
       _public_metrics_group_name,
-      _exceptional_mime_type);
+      _exceptional_mime_type,
+      _log);
     r.path_desc.set(_server._routes, handler);
 }
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -121,7 +121,8 @@ public:
       const ss::sstring& header,
       const ss::sstring& definitions,
       context_t& ctx,
-      json::serialization_format exceptional_mime_type);
+      json::serialization_format exceptional_mime_type,
+      ss::logger& log);
 
     void route(route_t route);
     void routes(routes_t&& routes);
@@ -141,6 +142,7 @@ private:
     context_t& _ctx;
     json::serialization_format _exceptional_mime_type;
     std::unique_ptr<server_probe> _probe;
+    ss::logger& _log;
 };
 
 template<typename service_t>


### PR DESCRIPTION
## Cover letter

I was asked several times just last week alone if there was an access log. Opinions on whether this is useful, as well as code review, please.

Format is:
`DEBUG <DATE_TIME> [<SHARD>] <rest_proxy|schema_registry> - server.cc:<LINE_NO> - "<METHOD> <URL> <HTTP VERSION>" <STATUS CODE> <RESPONSE_SIZE>`
E.g.:
`DEBUG 2022-11-01 18:00:05,305 [shard 0] rest_proxy - server.cc:128 - "GET /topics HTTP/1.1" 200 2`

Fixes #6915

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

### Improvements

* schema_registry: Add an access log with logger `schema_registry` (at debug level)
* rest_proxy: Add an access log with logger `rest_proxy` (at debug level)
