### PR TITLE
cluster_discovery: clarify and test setting seeds-driven bootstrap configs

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1841,14 +1841,16 @@ class RedpandaService(Service):
                               override_cfg_params=None,
                               start_timeout=None,
                               stop_timeout=None,
-                              use_maintenance_mode=True):
+                              use_maintenance_mode=True,
+                              omit_seeds_on_idx_one=True):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         restarter = RollingRestarter(self)
         restarter.restart_nodes(nodes,
                                 override_cfg_params=override_cfg_params,
                                 start_timeout=start_timeout,
                                 stop_timeout=stop_timeout,
-                                use_maintenance_mode=use_maintenance_mode)
+                                use_maintenance_mode=use_maintenance_mode,
+                                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
 
     def registered(self, node):
         """

--- a/tests/rptest/services/rolling_restarter.py
+++ b/tests/rptest/services/rolling_restarter.py
@@ -31,6 +31,10 @@ class RollingRestarter:
         the given configs.
         """
         admin = self.redpanda._admin
+        if start_timeout is None:
+            start_timeout = self.redpanda.node_ready_timeout_s
+        if stop_timeout is None:
+            stop_timeout = self.redpanda.node_ready_timeout_s
 
         def has_drained_leaders(node):
             try:

--- a/tests/rptest/services/rolling_restarter.py
+++ b/tests/rptest/services/rolling_restarter.py
@@ -24,7 +24,8 @@ class RollingRestarter:
                       override_cfg_params=None,
                       start_timeout=None,
                       stop_timeout=None,
-                      use_maintenance_mode=True):
+                      use_maintenance_mode=True,
+                      omit_seeds_on_idx_one=True):
         """
         Performs a rolling restart on the given nodes, optionally overriding
         the given configs.
@@ -83,9 +84,11 @@ class RollingRestarter:
 
             self.redpanda.stop_node(node, timeout=stop_timeout)
 
-            self.redpanda.start_node(node,
-                                     override_cfg_params,
-                                     timeout=start_timeout)
+            self.redpanda.start_node(
+                node,
+                override_cfg_params,
+                timeout=start_timeout,
+                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
 
             controller_leader = wait_until_cluster_healthy(start_timeout)
 


### PR DESCRIPTION
## Cover letter

Currently we can exit out of cluster discovery if we discover that the
local node isn't a cluster founder. The list of reasons to exit early is
currently:
- we are not in the seed server list
- we have a cluster UUID in our key-value store
- another seed server already advertises a cluster UUID

These alone are sufficient in prevent accidental bootstrap in the event
of a node wipe. However, these alone are insufficient for performing a
rolling restart into using the seeds-driven configs (e.g. if an
automated deployment started using the new configs automatically after
performing an upgrade).

Consider a rolling restart where before the restart, all nodes were
configured with root-driven bootstrap (empty_seed_starts_cluster=true).
At a certain point, there would be a mismatch between the restarted node
and the other nodes, and Redpanda will throw an error.

To avoid this, this commit adds a check during cluster discovery to
assume that we are a non-founder if a non-empty controller directory
exists. With this, there is less confusion around mismatches in remote
configurations, since the only time remote state is relevant is when
there is no local state.

This PR also includes a couple tests to exercise the mentioned upgrade scenarios.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
