### PR TITLE
tests: handle uninitialized segment size

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -246,7 +246,8 @@ def wait_for_local_storage_truncate(redpanda,
         storage = redpanda.storage(sizes=True)
         sizes = []
         for node_partition in storage.partitions("kafka", topic):
-            total_size = sum(s.size for s in node_partition.segments.values())
+            total_size = sum(s.size if s.size else 0
+                             for s in node_partition.segments.values())
             redpanda.logger.debug(
                 f"  {topic}/{partition_idx} node {node_partition.node.name} local size {total_size} ({len(node_partition.segments)} segments)"
             )


### PR DESCRIPTION
## Cover letter

This commit addresses errors like:

```
    TypeError("unsupported operand type(s) for +: 'int' and 'NoneType'")
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 135, in run
    data = self.run_test()
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 227, in run_test
    return self.test_context.function(self.test)
  File "/root/tests/rptest/services/cluster.py", line 35, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/upgrade_test.py", line 430, in test_rolling_upgrade
    wait_for_local_storage_truncate(self.redpanda,
  File "/root/tests/rptest/util.py", line 257, in wait_for_local_storage_truncate
    wait_until(is_truncated, timeout_sec=timeout_sec, backoff_sec=1)
  File "/root/tests/rptest/util.py", line 72, in wait_until
    raise e
  File "/root/tests/rptest/util.py", line 65, in wait_until
    if condition():
  File "/root/tests/rptest/util.py", line 249, in is_truncated
    total_size = sum(s.size for s in node_partition.segments.values())
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
