### PR TITLE
[transaction] Clear old pids from rm_stm state in overflow

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -35,6 +35,7 @@ partition::partition(
   ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::sharded<cloud_storage::cache>& cloud_storage_cache,
   ss::sharded<features::feature_table>& feature_table,
+  config::binding<uint64_t> max_concurrent_producer_ids,
   std::optional<s3::bucket_name> read_replica_bucket)
   : _raft(r)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
@@ -74,7 +75,11 @@ partition::partition(
 
         if (has_rm_stm) {
             _rm_stm = ss::make_shared<cluster::rm_stm>(
-              clusterlog, _raft.get(), _tx_gateway_frontend, _feature_table);
+              clusterlog,
+              _raft.get(),
+              _tx_gateway_frontend,
+              _feature_table,
+              max_concurrent_producer_ids);
             stm_manager->add_stm(_rm_stm);
         }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -19,6 +19,7 @@
 #include "cluster/tm_stm.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/property.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -47,6 +48,7 @@ public:
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
       ss::sharded<features::feature_table>&,
+      config::binding<uint64_t>,
       std::optional<s3::bucket_name> read_replica_bucket = std::nullopt);
 
     raft::group_id group() const { return _raft->group(); }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -52,14 +52,16 @@ partition_manager::partition_manager(
   ss::sharded<cloud_storage::partition_recovery_manager>& recovery_mgr,
   ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::sharded<cloud_storage::cache>& cloud_storage_cache,
-  ss::sharded<features::feature_table>& feature_table)
+  ss::sharded<features::feature_table>& feature_table,
+  config::binding<uint64_t> max_concurrent_producer_ids)
   : _storage(storage.local())
   , _raft_manager(raft)
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _partition_recovery_mgr(recovery_mgr)
   , _cloud_storage_api(cloud_storage_api)
   , _cloud_storage_cache(cloud_storage_cache)
-  , _feature_table(feature_table) {}
+  , _feature_table(feature_table)
+  , _max_concurrent_producer_ids(max_concurrent_producer_ids) {}
 
 partition_manager::ntp_table_container
 partition_manager::get_topic_partition_table(
@@ -155,6 +157,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _cloud_storage_api,
       _cloud_storage_cache,
       _feature_table,
+      _max_concurrent_producer_ids,
       read_replica_bucket);
 
     _ntp_table.emplace(log.config().ntp(), p);

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -40,7 +40,8 @@ public:
       ss::sharded<cloud_storage::partition_recovery_manager>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      config::binding<uint64_t>);
 
     using manage_cb_t
       = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
@@ -201,6 +202,8 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::gate _gate;
     bool _block_new_leadership{false};
+
+    config::binding<uint64_t> _max_concurrent_producer_ids;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
 };

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -484,6 +484,7 @@ private:
     };
 
     ss::future<> clear_old_tx_pids();
+    ss::future<> clear_old_idempotent_pids();
 
     // When a request is retried while the first appempt is still
     // being replicated the retried request is parked until the

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -167,7 +167,8 @@ public:
       ss::logger&,
       raft::consensus*,
       ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      config::binding<uint64_t> max_concurrent_producer_ids);
 
     ss::future<checked<model::term_id, tx_errc>> begin_tx(
       model::producer_identity, model::tx_seq, std::chrono::milliseconds);
@@ -624,6 +625,8 @@ private:
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     ss::sharded<features::feature_table>& _feature_table;
     prefix_logger _ctx_log;
+
+    config::binding<uint64_t> _max_concurrent_producer_ids;
 };
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -484,6 +484,14 @@ private:
         }
     };
 
+    enum class clear_type : int8_t {
+        tx_pids,
+        idempotent_pids,
+    };
+
+    void spawn_background_clean_for_pids(clear_type type);
+
+    ss::future<> clear_old_pids(clear_type type);
     ss::future<> clear_old_tx_pids();
     ss::future<> clear_old_idempotent_pids();
 
@@ -627,6 +635,7 @@ private:
     prefix_logger _ctx_log;
 
     config::binding<uint64_t> _max_concurrent_producer_ids;
+    mutex _clean_old_pids_mtx;
 };
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -419,6 +419,15 @@ private:
         absl::flat_hash_map<model::producer_identity, model::tx_seq> tx_seqs;
         absl::flat_hash_map<model::producer_identity, expiration_info>
           expiration;
+
+        void forget(const model::producer_identity& pid) {
+            fence_pid_epoch.erase(pid.get_id());
+            ongoing_map.erase(pid);
+            prepared.erase(pid);
+            seq_table.erase(pid);
+            tx_seqs.erase(pid);
+            expiration.erase(pid);
+        }
     };
 
     struct mem_state {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -467,6 +467,8 @@ private:
         }
     };
 
+    ss::future<> clear_old_tx_pids();
+
     // When a request is retried while the first appempt is still
     // being replicated the retried request is parked until the
     // original request is replicated.

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -31,6 +31,20 @@
 
 static ss::logger logger{"append-test"};
 
+static config::binding<uint64_t> get_config_bound() {
+    static config::config_store store;
+    static config::bounded_property<uint64_t> max_saved_pids_count(
+      store,
+      "max_saved_pids_count",
+      "Max pids count inside rm_stm states",
+      {.needs_restart = config::needs_restart::no,
+       .visibility = config::visibility::user},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1});
+
+    return max_saved_pids_count.bind();
+}
+
 FIXTURE_TEST(
   test_rm_stm_doesnt_interfere_with_out_of_session_messages,
   mux_state_machine_fixture) {
@@ -40,7 +54,11 @@ FIXTURE_TEST(
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -96,7 +114,11 @@ FIXTURE_TEST(
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -153,7 +175,11 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -222,7 +248,11 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -286,7 +316,11 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -343,7 +377,11 @@ FIXTURE_TEST(
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -383,7 +421,11 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -41,6 +41,20 @@ struct rich_reader {
     model::record_batch_reader reader;
 };
 
+static config::binding<uint64_t> get_config_bound() {
+    static config::config_store store;
+    static config::bounded_property<uint64_t> max_saved_pids_count(
+      store,
+      "max_saved_pids_count",
+      "Max pids count inside rm_stm states",
+      {.needs_restart = config::needs_restart::no,
+       .visibility = config::visibility::user},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1});
+
+    return max_saved_pids_count.bind();
+}
+
 static rich_reader make_rreader(
   model::producer_identity pid,
   int first_seq,
@@ -69,7 +83,11 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -153,7 +171,11 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -238,7 +260,11 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -328,7 +354,11 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -370,7 +400,11 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -432,7 +466,11 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -499,7 +537,11 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     ss::sharded<features::feature_table> feature_table;
     feature_table.start().get0();
     cluster::rm_stm stm(
-      logger, _raft.get(), tx_gateway_frontend, feature_table);
+      logger,
+      _raft.get(),
+      tx_gateway_frontend,
+      feature_table,
+      get_config_bound());
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -1,4 +1,5 @@
 #include "cluster/rm_stm.h"
+#include "config/config_store.h"
 #include "raft/tests/mux_state_machine_fixture.h"
 #include "raft/tests/raft_group_fixture.h"
 #include "storage/tests/utils/disk_log_builder.h"
@@ -16,9 +17,22 @@ using cluster::random_tx_generator;
     start_raft(o);                                                             \
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;             \
     ss::sharded<features::feature_table> feature_table;                        \
+    config::config_store store;                                                \
+    config::bounded_property<uint64_t> max_saved_pids_count(                   \
+      store,                                                                   \
+      "max_saved_pids_count",                                                  \
+      "Max pids count inside rm_stm states",                                   \
+      {.needs_restart = config::needs_restart::no,                             \
+       .visibility = config::visibility::user},                                \
+      std::numeric_limits<uint64_t>::max(),                                    \
+      {.min = 1});                                                             \
     feature_table.start().get0();                                              \
     auto stm = ss::make_shared<cluster::rm_stm>(                               \
-      test_logger, _raft.get(), tx_gateway_frontend, feature_table);           \
+      test_logger,                                                             \
+      _raft.get(),                                                             \
+      tx_gateway_frontend,                                                     \
+      feature_table,                                                           \
+      max_saved_pids_count.bind());                                            \
     stm->testing_only_disable_auto_abort();                                    \
     stm->start().get0();                                                       \
     auto stop = ss::defer([&] {                                                \

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -471,6 +471,14 @@ configuration::configuration()
       "write with the given producer id.",
       {.visibility = visibility::user},
       10080min)
+  , max_concurrent_producer_ids(
+      *this,
+      "max_concurrent_producer_ids",
+      "Max cache size for pids which rm_stm stores inside internal state. In "
+      "overflow rm_stm will delete old pids and clear their status",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1})
   , enable_idempotence(
       *this,
       "enable_idempotence",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -114,6 +114,7 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> kafka_connection_rate_limit_overrides;
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
+    bounded_property<uint64_t> max_concurrent_producer_ids;
     property<bool> enable_idempotence;
     property<bool> enable_transactions;
     property<uint32_t> abort_index_segment_size;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -891,7 +891,10 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(partition_recovery_manager),
       std::ref(cloud_storage_api),
       std::ref(shadow_index_cache),
-      std::ref(feature_table))
+      std::ref(feature_table),
+      ss::sharded_parameter([] {
+          return config::shard_local_cfg().max_concurrent_producer_ids.bind();
+      }))
       .get();
     vlog(_log.info, "Partition manager started");
 


### PR DESCRIPTION
## Cover letter
### Problem
User can use transaction/idempotency in different way. Some of them can be cause of problem. For example: user can create producer per request. Idempotency in kafka protocol works per session, the session is scoped by a producer so if user create a producer per request we will store all info for each producer in Idempotency case. It does not provide any benefits for user, but will create big maps in internal state for `rm_stm`. Also the same things for transaction.

We need to prevent this type overflow. So idea is add new settings (`max_concurrent_producer_ids`). And when `rm_stm` will reach this limits we will spawn clear process for log and mame state.

### Fix
For Idempotency we use `_log_state.seq_table`, where we store session info. The simplest way to track order of last `apply_data` for pid. We will store seq_entry inside intrusive list to store replication order.

For transaction is a little bit harder. We can not delete any info for ongoing transaction. But we can understand do user finish transaction or not, For this we just need to check `_log_state.tx_seqs`. Because on abort or commit we clear this map. So for all commited/aborted txs we just can delete all info from internal maps

Fixes #5321 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* Adding new redpanda setting (`max_concurrent_producer_ids`) to control how much sessions for transaction/idempotency will be saved


