### PR TITLE
c/controller_backend: update leaders table on ntp deletion

### DIFF
--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -118,13 +118,15 @@ private:
     ss::future<std::error_code> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);
-    ss::future<std::error_code> maybe_refresh_cluster_health(
-      force_refresh, model::timeout_clock::time_point);
+    ss::future<std::pair<refreshed_metadata, std::error_code>>
+      maybe_refresh_cluster_health(
+        force_refresh, model::timeout_clock::time_point);
     ss::future<std::error_code> refresh_cluster_health_cache(force_refresh);
     ss::future<std::error_code>
       dispatch_refresh_cluster_health_request(model::node_id);
 
-    cluster_health_report build_cluster_report(const cluster_report_filter&);
+    cluster_health_report
+    build_cluster_report(const cluster_report_filter&, refreshed_metadata);
 
     std::optional<node_health_report>
     build_node_report(model::node_id, const node_report_filter&);

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -154,8 +154,12 @@ struct node_health_report
     }
 };
 
+using refreshed_metadata = ss::bool_class<struct refreshed_metadata_tag>;
 struct cluster_health_report
-  : serde::envelope<cluster_health_report, serde::version<0>> {
+  : serde::envelope<
+      cluster_health_report,
+      serde::version<1>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     std::optional<model::node_id> raft0_leader;
@@ -166,6 +170,11 @@ struct cluster_health_report
     // node reports are node specific information collected directly on a
     // node
     std::vector<node_health_report> node_reports;
+
+    // Hint indicating whether health metadata was refreshed before
+    // generating this report.
+    refreshed_metadata was_metadata_refreshed = refreshed_metadata::no;
+
     friend std::ostream&
     operator<<(std::ostream&, const cluster_health_report&);
 

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -371,6 +371,10 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
 
 ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
   cluster_health_report report) {
+    if (report.was_metadata_refreshed == refreshed_metadata::no) {
+        co_return;
+    }
+
     for (const auto& node_report : report.node_reports) {
         co_await _leaders.invoke_on_all(
           [&node_report](partition_leaders_table& leaders) {

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -11,7 +11,7 @@ import re
 from typing import Optional, Callable
 from rptest.util import wait_until_result
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.utils.util import TimeoutError
+from ducktape.utils.util import wait_until, TimeoutError
 
 from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
@@ -90,42 +90,60 @@ class ClusterMetricsTest(RedpandaTest):
             hosts=started_hosts,
             check=lambda node_id: node_id != self.redpanda.idx(prev))
 
-    def _get_value_from_samples(self, samples: MetricSamples):
-        """
-        Extract the metric value from the samples.
-        Only one sample is expected as cluster level metrics have no labels.
-        """
-        assert len(samples.samples) == 1
-        return samples.samples[0].value
+    def _get_metrics_value_from_node(self, node: ClusterNode, pattern: str):
+        samples = self._get_metrics_from_node(node, [pattern])
+        assert pattern in samples
+        value = samples[pattern].samples[0].value
+        self.logger.info(f"Found metric value {value} for {pattern}")
+        return value
 
-    def _assert_cluster_metrics(
+    def _wait_until_metric_has_value(self, node: ClusterNode, pattern: str,
+                                     value):
+        wait_until(
+            lambda: value == self._get_metrics_value_from_node(node, pattern),
+            timeout_sec=10,
+            backoff_sec=2,
+            err_msg=f"Metric {pattern} never reached expected value {value}")
+
+    def _wait_until_metric_holds_value(self, node: ClusterNode, pattern: str,
+                                       value):
+        self._wait_until_metric_has_value(node, pattern, value)
+
+        try:
+            wait_until(lambda: value != self._get_metrics_value_from_node(
+                node, pattern),
+                       timeout_sec=5,
+                       backoff_sec=1)
+        except TimeoutError as e:
+            # Timing out is the desirable outcome here as it means
+            # that the value remained constant.
+            return
+
+        assert False, f"Metric {pattern} did not stabilise on {value}"
+
+    def _get_metrics_from_node(
             self, node: ClusterNode,
-            expect_metrics: bool) -> Optional[dict[str, MetricSamples]]:
-        """
-        Assert that cluster metrics are reported (or not) from the specified node.
-        """
+            patterns: list[str]) -> Optional[dict[str, MetricSamples]]:
         def get_metrics_from_node_sync(patterns: list[str]):
             samples = self.redpanda.metrics_samples(
                 patterns, [node], MetricsEndpoint.PUBLIC_METRICS)
             success = samples is not None
             return success, samples
 
-        def get_metrics_from_node(patterns: list[str]):
-            metrics = None
+        try:
+            return wait_until_result(
+                lambda: get_metrics_from_node_sync(patterns),
+                timeout_sec=2,
+                backoff_sec=.1)
+        except TimeoutError as e:
+            return None
 
-            try:
-                metrics = wait_until_result(
-                    lambda: get_metrics_from_node_sync(patterns),
-                    timeout_sec=2,
-                    backoff_sec=.1)
-            except TimeoutError as e:
-                if expect_metrics:
-                    raise e
-
-            return metrics
-
-        metrics_samples = get_metrics_from_node(
-            ClusterMetricsTest.cluster_level_metrics)
+    def _assert_cluster_metrics(self, node: ClusterNode, expect_metrics: bool):
+        """
+        Assert that cluster metrics are reported (or not) from the specified node.
+        """
+        metrics_samples = self._get_metrics_from_node(
+            node, ClusterMetricsTest.cluster_level_metrics)
 
         if expect_metrics:
             assert metrics_samples, f"Missing expected metrics from node {node.name}"
@@ -226,3 +244,32 @@ class ClusterMetricsTest(RedpandaTest):
         # 'disable_public_metrics' == true
         controller = self._wait_until_controller_leader_is_stable()
         self._assert_cluster_metrics(controller, expect_metrics=False)
+
+    @cluster(num_nodes=3)
+    def partition_count_decreases_on_deletion_test(self):
+        controller = self._wait_until_controller_leader_is_stable()
+        self._assert_reported_by_controller(controller)
+
+        try:
+            self._wait_until_metric_has_value(controller,
+                                              "cluster_partitions",
+                                              value=1)
+
+            RpkTool(self.redpanda).create_topic("topic-a", partitions=20)
+            RpkTool(self.redpanda).create_topic("topic-b", partitions=10)
+            self._wait_until_metric_holds_value(controller,
+                                                "cluster_partitions",
+                                                value=31)
+
+            RpkTool(self.redpanda).delete_topic("topic-a")
+            self._wait_until_metric_holds_value(controller,
+                                                "cluster_partitions",
+                                                value=11)
+
+            RpkTool(self.redpanda).create_topic("topic-a", partitions=30)
+            self._wait_until_metric_holds_value(controller,
+                                                "cluster_partitions",
+                                                value=41)
+        except Exception as e:
+            topics_info = RpkTool(self.redpanda).list_topics()
+            raise e


### PR DESCRIPTION
## Cover letter

The partition leaders table contains partition leaders for all partitions
across the cluster. For this reason we need to delete from it regardless
of whether a replica of the partition being deleted is present on the node.

Currently, the table is only updated if a replica of the partition being
deleted is present. Thus, if the replication factor of a
partitions is not equal to the size of the cluster, the nodes that are
not replicating the partition will not delete it from their local
tables.

One reason why this is problematic is because the cluster level
metrics published from 'controller_probe' use the partition leaders
table.

I've also had to update the metadata dissemination service to force a
cluster health refresh. Otherwise, the stale metadata gets applied to
the leaders table and results in previously deleted leaders reappearing.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
<!-- Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ... -->

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none
