### PR TITLE
transactions: fix check for ongoing tx

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -352,6 +352,7 @@ private:
         is_known |= _mem_state.estimated.contains(pid);
         is_known |= _mem_state.tx_start.contains(pid);
         is_known |= _log_state.ongoing_map.contains(pid);
+        is_known |= _log_state.tx_seqs.contains(pid);
         return is_known;
     }
 


### PR DESCRIPTION
## Cover letter

Abort is idempotent, basically when Redpanda can't find an ongoing tx it thinks that it was already aborted and returns success without doing anything. The problem is that when we check for an ongoing tx we check if a partition already got any data but ignores if a transaction started but hasn't received any data. Fixing it.

Fixes #6284

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none