### PR TITLE
s3: ensures that stream is closed when uploading segment

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -716,11 +716,15 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
             uploads_remaining -= 1;
         }
 
+        auto upload_segments_count = std::count_if(
+          ctx.uploads.begin(), ctx.uploads.end(), [](const auto& upload) {
+              return upload.result.has_value();
+          });
         vlog(
           _rtclog.debug,
           "scheduled {} uploads for upload kind: {}, uploads remaining: "
           "{}",
-          ctx.uploads.size(),
+          upload_segments_count,
           ctx.upload_kind,
           uploads_remaining);
 
@@ -745,7 +749,10 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
         }
     }
     if (flist.empty()) {
-        vlog(_rtclog.debug, "no uploads started, returning");
+        vlog(
+          _rtclog.debug,
+          "no uploads started for segment upload kind: {}, returning",
+          segment_kind);
         co_return total;
     }
     auto results = co_await ss::when_all_succeed(begin(flist), end(flist));

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -713,7 +713,14 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
                 break;
             }
 
-            uploads_remaining -= 1;
+            // Decrement remaining upload count if the last call actually
+            // scheduled an upload.
+            if (!ctx.uploads.empty()) {
+                const auto& last_scheduled = ctx.uploads.back();
+                if (last_scheduled.result.has_value()) {
+                    uploads_remaining -= 1;
+                }
+            }
         }
 
         auto upload_segments_count = std::count_if(

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -267,26 +267,40 @@ concat_segment_data_source_impl::concat_segment_data_source_impl(
   , _current_pos{_segments.begin()}
   , _start_pos{start_pos}
   , _end_pos{end_pos}
-  , _priority_class{priority_class} {}
+  , _priority_class{priority_class}
+  , _name{"uninitialized"} {}
 
 ss::future<ss::temporary_buffer<char>> concat_segment_data_source_impl::get() {
     ss::gate::holder guard{_gate};
     if (!_current_stream) {
-        _current_stream = co_await next_stream();
+        co_await next_stream();
     }
 
     ss::temporary_buffer<char> buf = co_await _current_stream->read();
     while (buf.empty() && _current_pos != _segments.end()) {
-        _current_stream = co_await next_stream();
+        co_await next_stream();
         buf = co_await _current_stream->read();
     }
 
     co_return buf;
 }
 
-ss::future<ss::input_stream<char>>
-concat_segment_data_source_impl::next_stream() {
+ss::future<> concat_segment_data_source_impl::next_stream() {
+    if (_current_stream) {
+        vlog(
+          stlog.trace,
+          "closing stream for current segment {} before switching to next "
+          "segment",
+          _name);
+        co_await _current_stream->close();
+    }
+
     if (_current_handle) {
+        vlog(
+          stlog.trace,
+          "closing handle for current segment {} before switching to next "
+          "segment",
+          _name);
         co_await _current_handle->close();
     }
 
@@ -307,19 +321,29 @@ concat_segment_data_source_impl::next_stream() {
         end = _end_pos;
     }
 
+    _name = segment->filename();
     _current_handle = co_await segment->reader().data_stream(
       start, end, _priority_class);
-    auto stream = _current_handle->take_stream();
+    _current_stream = _current_handle->take_stream();
 
     _current_pos++;
-    co_return stream;
+
+    vlog(stlog.trace, "opened segment {}", _name);
+    co_return;
 }
 
 ss::future<> concat_segment_data_source_impl::close() {
     co_await _gate.close();
-    if (_current_handle) {
-        co_return co_await _current_handle->close();
+    if (_current_stream) {
+        vlog(stlog.trace, "closing stream for segment {}", _name);
+        co_await _current_stream->close();
     }
+
+    if (_current_handle) {
+        vlog(stlog.trace, "closing handle for segment {}", _name);
+        co_await _current_handle->close();
+    }
+    co_return;
 }
 
 concat_segment_reader_view::concat_segment_reader_view(

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -270,6 +270,7 @@ concat_segment_data_source_impl::concat_segment_data_source_impl(
   , _priority_class{priority_class} {}
 
 ss::future<ss::temporary_buffer<char>> concat_segment_data_source_impl::get() {
+    ss::gate::holder guard{_gate};
     if (!_current_stream) {
         _current_stream = co_await next_stream();
     }
@@ -315,6 +316,7 @@ concat_segment_data_source_impl::next_stream() {
 }
 
 ss::future<> concat_segment_data_source_impl::close() {
+    co_await _gate.close();
     if (_current_handle) {
         co_return co_await _current_handle->close();
     }

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -220,6 +220,8 @@ private:
     // The file position upto which the last segment will be read.
     size_t _end_pos;
     ss::io_priority_class _priority_class;
+
+    ss::gate _gate;
 };
 
 /**

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -204,7 +204,7 @@ private:
     /**
      * Switches over to the next segment, if the current segment is depleted.
      */
-    ss::future<ss::input_stream<char>> next_stream();
+    ss::future<> next_stream();
 
 private:
     using segment_seq = std::vector<ss::lw_shared_ptr<segment>>;
@@ -222,6 +222,7 @@ private:
     ss::io_priority_class _priority_class;
 
     ss::gate _gate;
+    ss::sstring _name;
 };
 
 /**


### PR DESCRIPTION
## Cover letter

In s3 client put_object, an input stream is moved into the function and expected to be unconditionally closed by the function. There is a chance that the function body throws an exception and the stream is never closed.

With the changes to support uploading compacted segments, the stream is actually a wrapper for a file data source, not closing this can trigger an assertion and crash the application.

This change ensures that the relevant parts of the code are called with seastar futurize_invoke to make sure that the stream is closed.

Additionally when the concat segment data source (which constitutes the input stream) is closed, it does not check for pending in-flight requests. It closes its current reader handle, which may be uninitialized during the close in which case it will be a no-op.

However any in-flight request may resume after the close operation has run and initialize the reader handle, which will now never be closed. 

To avoid this a gate is added to the data source which will be entered on a read request and waited for on a close request to make sure all pending requests are finished before closing the handle.

Fixes #7060 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* None
