### PR TITLE
Fixed potentially incorrect coroutine lambdas capturing `this`

### DIFF
--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -106,6 +106,7 @@ private:
 
     static std::filesystem::path bootstrap_path();
     static std::filesystem::path cache_path();
+    ss::future<> wait_for_bootstrap();
 
     config_status my_latest_status;
     status_map status;

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -17,6 +17,10 @@
 #include "features/fwd.h"
 #include "storage/fwd.h"
 
+#include <seastar/core/future.hh>
+
+#include <system_error>
+
 namespace cluster {
 
 /**
@@ -42,6 +46,7 @@ public:
     }
 
 private:
+    ss::future<> apply_feature_update_command(feature_update_cmd);
     static constexpr auto accepted_commands = make_commands_list<
       feature_update_cmd,
       feature_update_license_update_cmd>();

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -51,6 +51,7 @@ private:
     ss::future<bool> ensure_topic_replication(model::topic_namespace_view);
     ss::future<bool> ensure_partition_replication(model::ntp);
     void tick();
+    ss::future<> do_tick();
 
     model::node_id _self;
     size_t _target_replication_factor;

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -267,7 +267,7 @@ ss::future<produce_response> client::produce_records(
       std::move(partitions),
       [this, topic](kafka::produce_request::partition p) mutable
       -> ss::future<produce_response::partition> {
-          co_return co_await produce_record_batch(
+          return produce_record_batch(
             model::topic_partition(topic, p.partition_index),
             std::move(*p.records->adapter.batch));
       });

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -196,6 +196,7 @@ private:
 
     void attach_partition(ss::lw_shared_ptr<cluster::partition>);
     void detach_partition(const model::ntp&);
+    ss::future<> do_detach_partition(model::ntp);
 
     struct attached_partition {
         bool loading;

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -213,17 +213,17 @@ ss::future<response_ptr> create_topics_handler::handle(
     // Record the number of partition mutations in each requested topic,
     // calulcating throttle delay if necessary
     auto quota_exceeded_it = co_await ssx::partition(
-      begin,
-      valid_range_end,
-      [&ctx, &response](const creatable_topic& t) -> ss::future<bool> {
+      begin, valid_range_end, [&ctx, &response](const creatable_topic& t) {
           /// Capture before next scheduling point below
           auto& response_ref = response;
-          const auto delay
-            = co_await ctx.quota_mgr().record_partition_mutations(
-              ctx.header().client_id, t.num_partitions);
-          response_ref.data.throttle_time_ms = std::max(
-            response_ref.data.throttle_time_ms, delay);
-          co_return delay == 0ms;
+          return ctx.quota_mgr()
+            .record_partition_mutations(
+              ctx.header().client_id, t.num_partitions)
+            .then([&response_ref](std::chrono::milliseconds delay) {
+                response_ref.data.throttle_time_ms = std::max(
+                  response_ref.data.throttle_time_ms, delay);
+                return delay == 0ms;
+            });
       });
 
     std::transform(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1050,20 +1050,21 @@ consensus::cancel_configuration_change(model::revision_id revision) {
                  cfg.cancel_configuration_change(revision);
                  return cfg;
              })
-      .then([this](std::error_code ec) -> ss::future<std::error_code> {
+      .then([this](std::error_code ec) {
           if (!ec) {
               // current leader is not a voter, step down
               if (!config().is_voter(_self)) {
-                  ssx::semaphore_units u;
-                  try {
-                      u = co_await _op_lock.get_units();
-                  } catch (const ss::broken_semaphore&) {
-                      co_return errc::shutting_down;
-                  }
-                  do_step_down("current leader is not voter");
+                  return _op_lock
+                    .with([this, ec] {
+                        do_step_down("current leader is not voter");
+                        return ec;
+                    })
+                    .handle_exception_type([](const ss::broken_semaphore&) {
+                        return make_error_code(errc::shutting_down);
+                    });
               }
           }
-          co_return ec;
+          return ss::make_ready_future<std::error_code>(ec);
       });
 }
 
@@ -3041,32 +3042,34 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                 .timeout_now(
                   target_rni.id(), std::move(req), rpc::client_opts(timeout))
 
-                .then(
-                  [this](result<timeout_now_reply> reply)
-                    -> ss::future<std::error_code> {
-                      if (!reply) {
-                          co_return reply.error();
-                      } else {
-                          // Step down before setting _transferring_leadership
-                          // to false, to ensure we do not accept any more
-                          // writes in the gap between new leader acking timeout
-                          // now and new leader sending a vote for its new term.
-                          // (If we accepted more writes, our log could get
-                          //  ahead of new leader, and it could lose election)
-                          try {
-                              auto units = co_await _op_lock.get_units();
+                .then([this](result<timeout_now_reply> reply) {
+                    if (!reply) {
+                        return ss::make_ready_future<std::error_code>(
+                          reply.error());
+                    } else {
+                        // Step down before setting _transferring_leadership
+                        // to false, to ensure we do not accept any more
+                        // writes in the gap between new leader acking timeout
+                        // now and new leader sending a vote for its new term.
+                        // (If we accepted more writes, our log could get
+                        //  ahead of new leader, and it could lose election)
+
+                        return _op_lock
+                          .with([this] {
                               do_step_down("leadership_transfer");
                               if (_leader_id) {
                                   _leader_id = std::nullopt;
                                   trigger_leadership_notification();
                               }
 
-                              co_return make_error_code(errc::success);
-                          } catch (const ss::broken_semaphore&) {
-                              co_return errc::shutting_down;
-                          }
-                      }
-                  });
+                              return make_error_code(errc::success);
+                          })
+                          .handle_exception_type(
+                            [](const ss::broken_semaphore&) {
+                                return make_error_code(errc::shutting_down);
+                            });
+                    }
+                });
           });
     });
 

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -333,12 +333,12 @@ ss::future<> offset_translator::maybe_checkpoint() {
 
     constexpr size_t checkpoint_threshold = 64_MiB;
 
-    co_await _checkpoint_lock.with([this]() -> ss::future<> {
+    co_await _checkpoint_lock.with([this]() {
         if (
           _bytes_processed
             < _bytes_processed_at_checkpoint + checkpoint_threshold
           && !_checkpoint_hint) {
-            co_return;
+            return ss::now();
         }
 
         vlog(
@@ -349,7 +349,7 @@ ss::future<> offset_translator::maybe_checkpoint() {
           _highest_known_offset,
           _checkpoint_hint);
 
-        co_await do_checkpoint();
+        return do_checkpoint();
     });
 }
 

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -73,9 +73,10 @@ replicate_batcher::cache_and_wait_for_result(
          *
          */
         ssx::background
-          = ssx::spawn_with_gate_then(_bg, [this]() -> ss::future<> {
-                auto units = co_await _lock.get_units();
-                co_await flush(std::move(units), false);
+          = ssx::spawn_with_gate_then(_bg, [this]() {
+                return _lock.get_units().then([this](auto units) {
+                    return flush(std::move(units), false);
+                });
             }).handle_exception([item](const std::exception_ptr& e) {
                 item->set_exception(e);
             });

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -295,12 +295,13 @@ ss::future<result<replicate_result>> replicate_entries_stm::apply(units_t u) {
 
     // wait for the requests to be dispatched in background and then release
     // units
-    (void)ss::with_gate(_req_bg, [this]() -> ss::future<> {
+    (void)ss::with_gate(_req_bg, [this]() {
         // Wait until all RPCs will be dispatched
-        co_await _dispatch_sem.wait(_requests_count);
-        // release memory reservations, and destroy data
-        _req.reset();
-        _units.release();
+        return _dispatch_sem.wait(_requests_count).then([this] {
+            // release memory reservations, and destroy data
+            _req.reset();
+            _units.release();
+        });
     });
 
     co_return build_replicate_result();

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -91,6 +91,9 @@ public:
     index_state release_index_state() && { return std::move(_state); }
 
 private:
+    ss::future<bool> materialize_index_from_file(ss::file);
+    ss::future<> flush_to_file(ss::file);
+
     ss::sstring _name;
     size_t _step;
     size_t _acc{0};


### PR DESCRIPTION
## Cover letter
Fixes problematic lambda coroutines in the following sub-systems. Problems are potentially clobbered captured this.
```
storage
raft
kafka
cluster
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
