### PR TITLE
Made  debugging `netstat` output more detailed

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1151,7 +1151,7 @@ class RedpandaService(Service):
 
         for line in node.account.ssh_capture("ps aux"):
             self.logger.debug(line.strip())
-        for line in node.account.ssh_capture("netstat -ant"):
+        for line in node.account.ssh_capture("netstat -panelot"):
             self.logger.debug(line.strip())
 
     def start_service(self, node, start):


### PR DESCRIPTION
## Cover letter

Made debugging `netstat` output run before starting redpanda more detailed. Including a process that is listening on a particular port will make it easier to debug issues.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none