### PR TITLE
tests: add RedpandaService.wait_until for failing faster on crashes

### DIFF
--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -1,3 +1,6 @@
+from ducktape.utils.util import wait_until
+
+
 class KafkaServiceAdapter:
     '''
         Simple adapter to match KafkaService interface with 
@@ -19,6 +22,11 @@ class KafkaServiceAdapter:
 
     def start(self, add_principals=""):
         return self._kafka_service.start(add_principals)
+
+    def wait_until(self, *args, **kwargs):
+        # RedpandaService does some helpful liveness checks to fail faster on crashes,
+        # we don't need this when emulating the interface for Kafka.
+        return wait_until(*args, **kwargs)
 
     def __getattribute__(self, name):
         try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -761,12 +761,12 @@ class RedpandaService(Service):
                 return int(line.split()[2])
         assert False, "couldn't parse df output"
 
-    def _for_nodes(self, nodes, cb: callable, *, parallel: bool):
+    def _for_nodes(self, nodes, cb: callable, *, parallel: bool) -> list:
         if not parallel:
             # Trivial case: just loop and call
             for n in nodes:
                 cb(n)
-            return
+            return list(map(cb, nodes))
 
         n_workers = len(nodes)
         if n_workers > 0:
@@ -774,7 +774,9 @@ class RedpandaService(Service):
                     max_workers=n_workers) as executor:
                 # The list() wrapper is to cause futures to be evaluated here+now
                 # (including throwing any exceptions) and not just spawned in background.
-                list(executor.map(cb, nodes))
+                return list(executor.map(cb, nodes))
+        else:
+            return []
 
     def _startup_poll_interval(self, first_start):
         """

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -341,10 +341,10 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
 
         # The wait condition will also apply some changes
         # such as topic creation and deletion
-        wait_until(create_or_delete_until_producer_fin,
-                   timeout_sec=timeout,
-                   backoff_sec=0.5,
-                   err_msg='Producer did not finish')
+        self.redpanda.wait_until(create_or_delete_until_producer_fin,
+                                 timeout_sec=timeout,
+                                 backoff_sec=0.5,
+                                 err_msg='Producer did not finish')
 
         producer.wait()
         rand_consumer.wait()


### PR DESCRIPTION
## Cover letter

Some of our tests might wait for 5-10 minutes trying to progress a client, when redpanda has stopped in the background.

In these long waits, it makes sense to regularly check redpanda is still alive: this way if we have a test that promptly causes a crash, we can quickly reproduce it with a test: this is mainly useful when iterating on a test on your workstation, but will also make some NodeCrash failures in CI a bit easier to handle, as the log will be shorter and it'll be more obvious where  the node died.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
