### PR TITLE
 Watch console ConfigMap deletes

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -19,12 +19,15 @@ import (
 	adminutils "github.com/redpanda-data/redpanda/src/go/k8s/pkg/admin"
 	consolepkg "github.com/redpanda-data/redpanda/src/go/k8s/pkg/console"
 	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -257,8 +260,10 @@ func (r *ConsoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&redpandav1alpha1.Console{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(utils.DeletePredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&netv1.Ingress{}).
 		Complete(r)
 }
 

--- a/src/go/k8s/controllers/redpanda/console_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/console_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,23 +54,26 @@ var _ = Describe("Console controller", func() {
 
 		timeout  = time.Second * 30
 		interval = time.Millisecond * 100
+
+		deploymentImage      = "vectorized/console:latest"
+		enableSchemaRegistry = true
+		enableConnect        = false
 	)
 
-	Context("When creating Console", func() {
+	BeforeEach(func() {
 		ctx := context.Background()
-		It("Should expose Console web app", func() {
-			By("Creating a Cluster")
-			key, _, redpandaCluster := getInitialTestCluster(ClusterName)
+		key, _, redpandaCluster := getInitialTestCluster(ClusterName)
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: key.Name}, &redpandav1alpha1.Cluster{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				Expect(err).To(Equal(nil))
+			}
 			Expect(k8sClient.Create(ctx, redpandaCluster)).Should(Succeed())
 			Eventually(clusterConfiguredConditionStatusGetter(key), timeout, interval).Should(BeTrue())
-
-			var (
-				deploymentImage      = "vectorized/console:latest"
-				enableSchemaRegistry = true
-				enableConnect        = false
-			)
-
-			By("Creating a Console")
+		}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ConsoleNamespace, Name: ConsoleName}, &redpandav1alpha1.Console{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				Expect(err).To(Equal(nil))
+			}
 			console := &redpandav1alpha1.Console{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "redpanda.vectorized.io/v1alpha1",
@@ -87,6 +91,20 @@ var _ = Describe("Console controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, console)).Should(Succeed())
+			consoleLookupKey := types.NamespacedName{Name: ConsoleName, Namespace: ConsoleNamespace}
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, consoleLookupKey, &redpandav1alpha1.Console{}) == nil
+			}, timeout, interval).Should(BeTrue())
+		}
+	})
+
+	Context("When creating Console", func() {
+		ctx := context.Background()
+		It("Should expose Console web app", func() {
+			By("Getting Console")
+			consoleLookupKey := types.NamespacedName{Name: ConsoleName, Namespace: ConsoleNamespace}
+			console := &redpandav1alpha1.Console{}
+			Expect(k8sClient.Get(ctx, consoleLookupKey, console)).Should(Succeed())
 
 			By("Having a Secret for SASL user")
 			secretLookupKey := types.NamespacedName{Name: fmt.Sprintf("%s-%s", ConsoleName, resources.ConsoleSuffix), Namespace: ConsoleNamespace}
@@ -156,7 +174,6 @@ var _ = Describe("Console controller", func() {
 			// TODO: Not yet discussed if gonna use Ingress, check when finalized
 
 			By("Having the Console URLs in status")
-			consoleLookupKey := types.NamespacedName{Name: ConsoleName, Namespace: ConsoleNamespace}
 			createdConsole := &redpandav1alpha1.Console{}
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, consoleLookupKey, createdConsole); err != nil {

--- a/src/go/k8s/pkg/utils/predicates.go
+++ b/src/go/k8s/pkg/utils/predicates.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// DeletePredicate implements a predicate function that watches only delete events
+type DeletePredicate struct {
+	predicate.Funcs
+}
+
+func (DeletePredicate) Delete(e event.DeleteEvent) bool {
+	return true
+}


### PR DESCRIPTION
## Cover letter
Reopening #6943 as I accidentally deleted the branch

ConfigMap is immutable but it can still be manually deleted. This PR watches delete events only for ConfigMap so it will not have lot of unnecessary errors about "object has been modified". Also adds watch for owned Ingress resources.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

If user manually deleted Console's referenced ConfigMap, operator should recreate it.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Improvements

- Recreate Console's referenced ConfigMap if manually deleted.

