### PR TITLE
Init Cluster UUID in upgraded clusters

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -137,8 +137,9 @@ bootstrap_backend::apply_update(model::record_batch b) {
               cluster_uuid_key,
               serde::to_iobuf(cmd.value.uuid));
             _cluster_uuid_applied = cmd.value.uuid;
+            vlog(
+              clusterlog.debug, "Cluster UUID initialized {}", cmd.value.uuid);
 
-            vlog(clusterlog.info, "Cluster created {}", cmd.value.uuid);
             co_return errc::success;
         }));
 }

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -49,6 +49,7 @@ public:
 private:
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
+    std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 
 } // namespace cluster

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -71,11 +71,10 @@ ss::future<node_id> cluster_discovery::determine_node_id() {
 cluster_discovery::brokers cluster_discovery::founding_brokers() const {
     vassert(
       _is_cluster_founder.has_value(), "must call discover_founding_brokers()");
-    if (!*_is_cluster_founder) {
-        vassert(
-          _founding_brokers.empty(),
-          "Should return empty if this node is not founding a new cluster");
-    }
+    vassert(
+      _founding_brokers.empty() == !*_is_cluster_founder,
+      "Should return broker(s) if and only if this node is founding a new "
+      "cluster");
     return _founding_brokers;
 }
 

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -85,12 +85,10 @@ public:
     //
     // If this node is a cluster founder, returns all seed servers, after
     // making sure that all founders are configured with identical seed servers
-    // list.
+    // list. In case of root-driven bootstrap, that reflects to a list of just
+    // the root broker.
     //
     // If this node is not a cluster founder, returns an empty list.
-    //
-    // In case of root-driven bootstrap, that reflects to a list of just the
-    // root broker.
     brokers founding_brokers() const;
 
     // A cluster founder is a node that is configured as a seed server, and

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -505,17 +505,42 @@ ss::future<> controller::stop() {
     });
 }
 
-ss::future<> controller::create_cluster() {
+ss::future<> controller::create_cluster(const create_cluster_mode mode) {
     vassert(
       ss::this_shard_id() == controller_stm_shard,
       "Cluster can only be created from controller_stm_shard");
+
     bootstrap_cluster_cmd_data cmd_data;
     cmd_data.uuid = model::cluster_uuid(uuid_t::create());
-    cmd_data.bootstrap_user_cred
-      = security_frontend::get_bootstrap_user_creds_from_env();
-    vlog(clusterlog.info, "Creating cluster {}", cmd_data.uuid);
+    if (mode == create_cluster_mode::bootstrap) {
+        cmd_data.bootstrap_user_cred
+          = security_frontend::get_bootstrap_user_creds_from_env();
+    }
 
     for (simple_time_jitter<model::timeout_clock> retry_jitter(1s);;) {
+        // A new cluster is created by the leader of raft0 consisting of seed
+        // servers, once elected, or by the root.
+        // * In seed driven bootstrap mode, non-leaders will wait for
+        // cluster_uuid to appear, or for leadership change, while the leader
+        // will proceed with cluster creation once elected.
+        // * In root driven bootstrap mode, root is the only cluster member and
+        // joiners never make it into create_cluster(), so checking for
+        // cluster_uuid() never returns true and the wait for leadership is
+        // really just a wait for the consensus object to finish writing its
+        // last_voted_for from its self-vote.
+        while (!_storage.local().get_cluster_uuid() && !_raft0->is_leader()) {
+            co_await ss::sleep_abortable(100ms, _as.local());
+        }
+        if (_storage.local().get_cluster_uuid()) {
+            // Cluster has been created by other seed node and replicated here
+            vlog(
+              clusterlog.info,
+              "Cluster UUID is {}",
+              *_storage.local().get_cluster_uuid());
+            co_return;
+        }
+
+        vlog(clusterlog.info, "Creating cluster {}", cmd_data.uuid);
         model::record_batch b = serde_serialize_cmd(
           bootstrap_cluster_cmd{0, cmd_data});
         // cluster::replicate_and_wait() cannot be used here because it checks
@@ -548,59 +573,40 @@ ss::future<> controller::create_cluster() {
  * to it, and before we have started communicating with peers.
  */
 ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
-    auto is_cluster_founder = co_await discovery.is_cluster_founder();
-    if (!is_cluster_founder) {
-        co_return;
-    }
 
-    if (config::node().empty_seed_starts_cluster()) {
-        // This is the legacy empty-seed-starts-cluster mode
-        vassert(
-          config::node().seed_servers().empty(), "We are not on the root node");
-
-        if (
-          _raft0->last_visible_index() > model::offset{}
-          || _raft0->config().brokers().size() > 1) {
-            // The controller log has already been written to
-            co_return;
+    if (co_await discovery.is_cluster_founder()) {
+        if (config::node().empty_seed_starts_cluster()) {
+            vassert(
+              config::node().seed_servers().empty(),
+              "Cluster founder is not the root node");
+            vassert(
+              _raft0->config().brokers().size() == 1,
+              "Root is a cluster founder but joiners are in the cluster alrdy");
         }
 
-        // Internal RPC does not start until after controller startup
-        // is complete (we are called during controller startup), so
-        // it is guaranteed that if we were single node/empty controller
-        // log at start of this function, we will still be in that state
-        // here.  The wait for leadership is really just a wait for the
-        // consensus object to finish writing its last_voted_for from
-        // its self-vote.
-        while (!_raft0->is_leader()) {
-            co_await ss::sleep(100ms);
-        }
-
-        co_return co_await create_cluster();
-    }
-
-    // The new cluster creation is done by the leader of raft0 consisting of
-    // seed servers, once elected
-    while (!_storage.local().get_cluster_uuid() && !_raft0->is_leader()) {
-        co_await ss::sleep(100ms);
+        co_return co_await create_cluster(create_cluster_mode::bootstrap);
     }
 
     if (_storage.local().get_cluster_uuid()) {
         vlog(
           clusterlog.info,
-          "Cluster is {}",
+          "Member of cluster UUID {}",
           *_storage.local().get_cluster_uuid());
         co_return;
     }
 
-    if (
-      _raft0->last_visible_index() > model::offset{}
-      || _raft0->config().brokers().size() > 1) {
-        // The controller log has already been written to
-        // TODO: create_cluster() but use the metrics' cluster_id
-    }
-
-    co_return co_await create_cluster();
+    // No cluster UUID in non-founder is a possibility that a pre-22.3
+    // cluster needs a UUID
+    ssx::background
+      = _feature_table.local()
+          .await_feature(
+            features::feature::seeds_driven_bootstrap_capable, _as.local())
+          .then([this] {
+              return create_cluster(create_cluster_mode::cluster_uuid_only);
+          })
+          .handle_exception([](const std::exception_ptr e) {
+              vlog(clusterlog.warn, "Error creating cluster UUID. {}", e);
+          });
 }
 
 /**

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -578,7 +578,6 @@ ss::future<> controller::create_cluster(const create_cluster_mode mode) {
  * to it, and before we have started communicating with peers.
  */
 ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
-
     if (co_await discovery.is_cluster_founder()) {
         if (config::node().empty_seed_starts_cluster()) {
             vassert(

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -119,6 +119,8 @@ public:
 
     ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
 
+    ss::sharded<storage::api>& get_storage() { return _storage; }
+
     bool is_raft0_leader() const {
         vassert(
           ss::this_shard_id() == ss::shard_id(0),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -151,11 +151,15 @@ public:
 private:
     friend controller_probe;
 
+    enum class create_cluster_mode { bootstrap, cluster_uuid_only };
     /**
      * Create a \c bootstrap_cluster_cmd, replicate-and-wait it to the current
      * quorum, retry infinitely if replicate-and-wait fails.
+     *
+     * \param mode Controls whether to perform a full bootstrap for a brand new
+     * cluster, or only partial cluster creation for upgrade from 22.2.
      */
-    ss::future<> create_cluster();
+    ss::future<> create_cluster(create_cluster_mode mode);
 
     ss::future<> cluster_creation_hook(cluster_discovery& discovery);
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -288,7 +288,7 @@ members_manager::apply_update(model::record_batch b) {
                                      : fmt::to_string(*requested_node_id);
           vlog(
             clusterlog.info,
-            "Applying registration of UUID {} with {}",
+            "Applying registration of node UUID {} with {}",
             node_uuid,
             node_id_str);
           if (requested_node_id) {
@@ -297,7 +297,7 @@ members_manager::apply_update(model::record_batch b) {
               }
               vlog(
                 clusterlog.warn,
-                "Couldn't register UUID {}, node ID {} already taken",
+                "Couldn't register node UUID {}, node ID {} already taken",
                 node_uuid,
                 requested_node_id);
               return ss::make_ready_future<std::error_code>(
@@ -597,7 +597,7 @@ ss::future<result<join_node_reply>> members_manager::replicate_new_node_uuid(
                                       : "no node ID";
     vlog(
       clusterlog.debug,
-      "Replicating registration of UUID {} with {}",
+      "Replicating registration of node UUID {} with {}",
       node_uuid,
       node_id_str);
     // Otherwise, replicate a request to register the UUID.
@@ -609,7 +609,7 @@ ss::future<result<join_node_reply>> members_manager::replicate_new_node_uuid(
       model::timeout_clock::now() + 30s);
     vlog(
       clusterlog.debug,
-      "Registration replication completed for UUID '{}': {}",
+      "Registration replication completed for node UUID '{}': {}",
       node_uuid,
       errc);
     if (errc != errc::success) {
@@ -619,7 +619,7 @@ ss::future<result<join_node_reply>> members_manager::replicate_new_node_uuid(
     if (node_id && assigned_node_id != *node_id) {
         vlog(
           clusterlog.warn,
-          "Node registration for UUID {} as {} completed but already already "
+          "Node registration for node UUID {} as {} completed but already "
           "assigned as {}",
           node_uuid,
           *node_id,
@@ -661,7 +661,8 @@ members_manager::handle_join_request(join_node_request const req) {
       && req.node_uuid.size() != model::node_uuid::type::length) {
         vlog(
           clusterlog.warn,
-          "Invalid join request, expected UUID or empty; got {}-byte value",
+          "Invalid join request, expected node UUID or empty; got {}-byte "
+          "value",
           req.node_uuid.size());
         co_return errc::invalid_request;
     }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -51,6 +51,8 @@ std::string_view to_string_view(feature f) {
         return "replication_factor_change";
     case feature::ephemeral_secrets:
         return "ephemeral_secrets";
+    case feature::seeds_driven_bootstrap_capable:
+        return "seeds_driven_bootstrap_capable";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -45,6 +45,7 @@ enum class feature : std::uint64_t {
     node_id_assignment = 0x1000,
     replication_factor_change = 0x2000,
     ephemeral_secrets = 0x4000,
+    seeds_driven_bootstrap_capable = 0x8000,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,
@@ -185,6 +186,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{7},
     "ephemeral_secrets",
     feature::ephemeral_secrets,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{7},
+    "seeds_driven_bootstrap_capable",
+    feature::seeds_driven_bootstrap_capable,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -51,6 +51,21 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/cluster/uuid",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get the UUID of the cluster this node belongs to. Not to be confused with the configurable cluster identifier used in metrics",
+                    "type": "get_cluster_uuid",
+                    "nickname": "get_cluster_uuid",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {
@@ -124,6 +139,14 @@
                     "items": {
                         "type": "int"
                     }
+                }
+            }
+        },
+        "uuid": {
+            "id": "uuid",
+            "properties": {
+                "cluster_uuid": {
+                    "type": "string"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3041,6 +3041,20 @@ void admin_server::register_cluster_routes() {
           co_return ss::json::json_return_type(
             co_await map_partition_results(std::move(res.value())));
       });
+
+    register_route_sync<publik>(
+      ss::httpd::cluster_json::get_cluster_uuid,
+      [this](ss::httpd::const_req) -> ss::json::json_return_type {
+          vlog(logger.debug, "Requested cluster UUID");
+          const std::optional<model::cluster_uuid>& cluster_uuid
+            = _controller->get_storage().local().get_cluster_uuid();
+          if (cluster_uuid) {
+              ss::httpd::cluster_json::uuid ret;
+              ret.cluster_uuid = fmt::format("{}", cluster_uuid);
+              return ss::json::json_return_type(std::move(ret));
+          }
+          return ss::json::json_return_type(ss::json::json_void());
+      });
 }
 
 void admin_server::register_shadow_indexing_routes() {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -121,7 +121,8 @@ private:
     void register_route(ss::httpd::path_description const& path, F handler) {
         path.set(
           _server._routes,
-          [this, handler](std::unique_ptr<ss::httpd::request> req) {
+          [this, handler](std::unique_ptr<ss::httpd::request> req)
+            -> ss::future<ss::json::json_return_type> {
               auto auth_state = apply_auth<required_auth>(*req);
 
               // Note: a request is only logged if it does not throw
@@ -142,6 +143,35 @@ private:
                     .handle_exception(exception_intercepter<
                                       decltype(handler(std::move(req)).get0())>(
                       url, auth_state));
+              }
+          });
+    }
+
+    /**
+     * Variant of register_route for synchronous handlers.
+     * \tparam F An ss::httpd::json_request_function, or variant
+     *    with an extra request_auth_state argument if peek_auth is true.
+     */
+    template<auth_level required_auth, bool peek_auth = false, typename F>
+    void
+    register_route_sync(ss::httpd::path_description const& path, F handler) {
+        path.set(
+          _server._routes,
+          [this,
+           handler](ss::httpd::const_req req) -> ss::json::json_return_type {
+              const auto auth_state = apply_auth<required_auth>(req);
+              log_request(req, auth_state);
+
+              const auto url = req.get_url();
+              try {
+                  if constexpr (peek_auth) {
+                      return handler(req, auth_state);
+                  } else {
+                      return handler(req);
+                  }
+              } catch (...) {
+                  log_exception(url, auth_state, std::current_exception());
+                  throw;
               }
           });
     }


### PR DESCRIPTION
## Cover letter

When an existing cluster is upgraded to 22.3, we want it to have the `bootstrap_cluster_cmd` in the controller log, as well as a cluster UUID assigned. This way going forward we will be able to rely on cluster UUID as a mandatory property of any existing cluster.

This PR also adds an admin API endpoint `v1/cluster/uuid` so that it is possible to query the cluster UUID a node belongs to.

Fixes #333

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Admin API `v1/cluster/uuid` returns `{"cluster_uuid": "<UUID>"}` or empty if the node is not a part of a cluster yet.

## Release notes

* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
