### PR TITLE
Schema Registry and REST Proxy: health checks

### DIFF
--- a/src/v/pandaproxy/api/api-doc/rest.json
+++ b/src/v/pandaproxy/api/api-doc/rest.json
@@ -547,4 +547,18 @@
           }
         }
       }
+    },
+    "/status/ready": {
+      "get": {
+        "summary": "Health check",
+        "operationId": "http_rest_status_ready",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        }
+      }
     }

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -848,4 +848,18 @@
           }
         }
       }
+    },
+    "/status/ready": {
+      "get": {
+        "summary": "Health check",
+        "operationId": "schema_registry_status_ready",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        }
+      }
     }

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -493,4 +493,15 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
       });
 }
 
+ss::future<proxy::server::reply_t>
+status_ready(proxy::server::request_t rq, proxy::server::reply_t rp) {
+    auto make_metadata_req = []() {
+        return kafka::metadata_request{.list_all_topics = false};
+    };
+
+    auto res = co_await rq.dispatch(make_metadata_req);
+    rp.rep->set_status(ss::httpd::reply::status_type::ok);
+    co_return rp;
+}
+
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/handlers.h
+++ b/src/v/pandaproxy/rest/handlers.h
@@ -49,4 +49,7 @@ get_consumer_offsets(proxy::server::request_t rq, proxy::server::reply_t rp);
 ss::future<proxy::server::reply_t>
 post_consumer_offsets(proxy::server::request_t rq, proxy::server::reply_t rp);
 
+ss::future<proxy::server::reply_t>
+status_ready(proxy::server::request_t rq, proxy::server::reply_t rp);
+
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -96,6 +96,10 @@ server::routes_t get_proxy_routes(ss::gate& gate, one_shot& es) {
       ss::httpd::rest_json::post_consumer_offsets,
       wrap(gate, es, post_consumer_offsets)});
 
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::rest_json::http_rest_status_ready,
+      wrap(gate, es, status_ready)});
+
     return routes;
 }
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -516,4 +516,11 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     co_return rp;
 }
 
+ss::future<server::reply_t>
+status_ready(server::request_t rq, server::reply_t rp) {
+    co_await rq.service().writer().read_sync();
+    rp.rep->set_status(ss::httpd::reply::status_type::ok);
+    co_return rp;
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -74,4 +74,7 @@ ss::future<ctx_server<service>::reply_t> delete_subject_version(
 ss::future<ctx_server<service>::reply_t> compatibility_subject_version(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> status_ready(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -161,6 +161,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       ss::httpd::schema_registry_json::compatibility_subject_version,
       wrap(gate, es, compatibility_subject_version)});
 
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::schema_registry_status_ready,
+      wrap(gate, es, status_ready)});
+
     return routes;
 }
 


### PR DESCRIPTION
## Cover letter

Add health checks available at:
* `:8081/status/ready`
* `:8082/status/ready`

Return `200` on success and `503` on failure. These check that there is a connection between the service and Redpanda.

These are designed to replace the corresponding:

* `:8081/subjects`
* `:8082/brokers`

That are recommended today. They can be improved upon at a later date.

## Backport Required

Lets backport; it's simple and a vast improvement on:
* `:8081/subjects`
* `:8082/topics`

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

Health checks are available at `/status/ready` and will return `200` or `503` status code depending on whether REST Proxy or Schema Registry is able to connect to Redpanda.

A good use case is to inform a loadbalancer for routes that don't require to be routed to a specific instance of the service (consumer endpoints on REST Proxy).

It is not a good idea to use these as a Kubernetes probe, or other signal that the service is down, as that usually results in the orchestrator killing Redpanda, which is undesirable. 

## Release notes

### Features

* REST Proxy: A health check is now available at `:8082/status/ready`
* Schema Registry: A health check is now available at `:8081/status/ready`
