### PR TITLE
tx/compaction: Adjust aborted tx ranges for compacted segments.

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -507,6 +507,10 @@ class RedpandaService(Service):
         "backtraces": {
             "path": BACKTRACE_CAPTURE,
             "collect_default": True
+        },
+        "data": {
+            "path": DATA_DIR,
+            "collect_default": False
         }
     }
 
@@ -679,6 +683,9 @@ class RedpandaService(Service):
 
     def require_client_auth(self):
         return self._security.require_client_auth
+
+    def mark_data_dir_for_collection(self):
+        self.logs["data"]["collect_default"] = True
 
     @property
     def dedicated_nodes(self):

--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -145,8 +145,9 @@ class CompactionEndToEndTest(EndToEndTest):
             rpk.cluster_config_set("log_compaction_interval_ms", str(3000))
 
             # wait for compaction to merge some adjacent segments
+            wait_timeout_sec = 300 if self.debug_mode else 180
             wait_until(lambda: segment_number_matches(lambda s: s < 5),
-                       timeout_sec=180,
+                       timeout_sec=wait_timeout_sec,
                        backoff_sec=2)
 
             # enable consumer and validate consumed records

--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -19,7 +19,7 @@ from rptest.services.cluster import cluster
 from rptest.util import segments_count
 
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode
+from rptest.utils.mode_checks import cleanup_on_early_exit
 
 
 class CompactionEndToEndTest(EndToEndTest):
@@ -75,7 +75,6 @@ class CompactionEndToEndTest(EndToEndTest):
             ],
             transactions=[True, False],
             tx_inject_aborts=[True, False])
-    @skip_debug_mode
     def test_basic_compaction(self, key_set_cardinality,
                               initial_cleanup_policy, transactions,
                               tx_inject_aborts):

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -226,6 +226,9 @@ class EndToEndTest(Test):
                    err_msg="Timed out after %ds while awaiting record consumption of %d records" %\
                    (timeout_sec, min_records))
 
+    def _collect_segment_data(self):
+        self.redpanda.mark_data_dir_for_collection()
+
     def _collect_all_logs(self):
         for s in self.test_context.services:
             self.mark_for_collect(s)


### PR DESCRIPTION
## Cover letter

Returns to the client abort transaction ranges spanning the [first transactional batch offset, end]in the consumed result rather than the entire offset range. More details in the individual commits.

Fixes #6997, Fixes #7024

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none


## Release notes

* none

### Features

* none

### Improvements

* none
