### PR TITLE
cloud_storage: limit on hydrated segments per shard

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -94,6 +94,14 @@ size_t materialized_segments::max_segments() const {
       _max_partitions_per_shard() * default_segment_factor));
 }
 
+size_t materialized_segments::current_readers() const {
+    return _reader_units.outstanding();
+}
+
+size_t materialized_segments::current_segments() const {
+    return _segment_units.outstanding();
+}
+
 void materialized_segments::evict_reader(
   std::unique_ptr<remote_segment_batch_reader> reader) {
     _eviction_list.push_back(std::move(reader));

--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -282,7 +282,8 @@ void materialized_segments::maybe_trim_segment(
         // enqueue it for eviction.
         vlog(
           cst_log.debug,
-          "Materialized segment with base offset {} is stale",
+          "Materialized segment {} offset {} is stale",
+          st.ntp(),
           st.offset_key);
         // this will delete and unlink the object from
         // _materialized collection
@@ -293,7 +294,10 @@ void materialized_segments::maybe_trim_segment(
             // is only instantiated by remote_partition and will
             // be disposed before the remote_partition it points to.
             vassert(
-              false, "materialized_segment_state outlived remote_partition");
+              false,
+              "materialized_segment_state outlived remote_partition (offset "
+              "{})",
+              st.offset_key);
         }
     } else {
         // We would like to trim this segment, but cannot right now

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -120,7 +120,13 @@ private:
 
     /// Synchronous scan of segments for eviction, reads+modifies _materialized
     /// and writes victims to _eviction_list
-    void trim_segments();
+    void trim_segments(std::optional<size_t>);
+
+    // List of segments to offload, accumulated during trim_segments
+    using offload_list_t
+      = std::vector<std::pair<materialized_segment_state*, kafka::offset>>;
+
+    void maybe_trim_segment(materialized_segment_state&, offload_list_t&);
 
     // Permit probe to query object counts
     friend class remote_probe;

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -27,6 +27,7 @@ namespace cloud_storage {
 
 class remote_segment;
 class remote_segment_batch_reader;
+class remote_probe;
 
 /**
  * This class tracks:
@@ -77,6 +78,12 @@ private:
     size_t max_readers() const;
     size_t max_segments() const;
 
+    /// How many remote_segment_batch_reader instances exist
+    size_t current_readers() const;
+
+    /// How many materialized_segment_state instances exist
+    size_t current_segments() const;
+
     /// List of segments and readers waiting to have their stop() method
     /// called before destruction
     eviction_list_t _eviction_list;
@@ -114,6 +121,9 @@ private:
     /// Synchronous scan of segments for eviction, reads+modifies _materialized
     /// and writes victims to _eviction_list
     void trim_segments();
+
+    // Permit probe to query object counts
+    friend class remote_probe;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -63,6 +63,8 @@ public:
 
     ssx::semaphore_units get_reader_units();
 
+    ssx::semaphore_units get_segment_units();
+
 private:
     /// Timer use to periodically evict stale readers
     ss::timer<ss::lowres_clock> _stm_timer;
@@ -70,8 +72,10 @@ private:
 
     config::binding<uint32_t> _max_partitions_per_shard;
     config::binding<std::optional<uint32_t>> _max_readers_per_shard;
+    config::binding<std::optional<uint32_t>> _max_segments_per_shard;
 
     size_t max_readers() const;
+    size_t max_segments() const;
 
     /// List of segments and readers waiting to have their stop() method
     /// called before destruction
@@ -95,6 +99,10 @@ private:
     /// Concurrency limit on how many remote_segment_batch_reader may be
     /// instantiated at once on one shard.
     adjustable_semaphore _reader_units;
+
+    /// Concurrency limit on how many segments may be materialized at
+    /// once: this will trigger faster trimming under pressure.
+    adjustable_semaphore _segment_units;
 
     /// Consume from _eviction_list
     ss::future<> run_eviction_loop();

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -20,12 +20,15 @@
 
 namespace cloud_storage {
 
+class materialized_segments;
+
 /// Cloud storage endpoint level probe
 class remote_probe {
 public:
     explicit remote_probe(
       remote_metrics_disabled disabled,
-      remote_metrics_disabled public_disabled);
+      remote_metrics_disabled public_disabled,
+      materialized_segments&);
 
     /// Register topic manifest upload
     void topic_manifest_upload() { _cnt_topic_manifest_uploads++; }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -189,11 +189,12 @@ remote::remote(
   const s3::configuration& conf,
   model::cloud_credentials_source cloud_credentials_source)
   : _pool(limit(), conf)
+  , _auth_refresh_bg_op{_gate, _as, conf, cloud_credentials_source}
+  , _materialized(std::make_unique<materialized_segments>())
   , _probe(
       remote_metrics_disabled(static_cast<bool>(conf.disable_metrics)),
-      remote_metrics_disabled(static_cast<bool>(conf.disable_public_metrics)))
-  , _auth_refresh_bg_op{_gate, _as, conf, cloud_credentials_source}
-  , _materialized(std::make_unique<materialized_segments>()) {
+      remote_metrics_disabled(static_cast<bool>(conf.disable_public_metrics)),
+      *_materialized) {
     // If the credentials source is from config file, bypass the background op
     // to refresh credentials periodically, and load pool with static
     // credentials right now.

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -259,9 +259,11 @@ private:
     s3::client_pool _pool;
     ss::gate _gate;
     ss::abort_source _as;
-    remote_probe _probe;
     auth_refresh_bg_op _auth_refresh_bg_op;
     std::unique_ptr<materialized_segments> _materialized;
+
+    // Lifetime: probe has reference to _materialized, must be destroyed after
+    remote_probe _probe;
 };
 
 } // namespace cloud_storage

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1188,6 +1188,13 @@ configuration::configuration()
       "partition if the shard is at its maximum partition capacity.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , cloud_storage_max_materialized_segments_per_shard(
+      *this,
+      "cloud_storage_max_materialized_segments_per_shard",
+      "Maximum concurrent readers of remote data per CPU core.  If unset, "
+      "value of `topic_partitions_per_shard` multiplied by 2 is used.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -251,6 +251,8 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
+    property<std::optional<uint32_t>>
+      cloud_storage_max_materialized_segments_per_shard;
 
     one_or_many_property<ss::sstring> superusers;
 

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -84,6 +84,17 @@ public:
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 
+    /**
+     * Since we know our expected total capacity, we may calculate how many
+     * units are currently leant out.
+     *
+     * If capacity was recently adjusted we might have more units outstanding
+     * than the total capacity (i.e. when available_units() is negative)
+     */
+    size_t outstanding() const noexcept {
+        return _capacity - available_units();
+    }
+
 private:
     ssx::semaphore _sem;
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -459,6 +459,8 @@ class RedpandaService(Service):
 
     RAISE_ON_ERRORS_KEY = "raise_on_error"
 
+    TRIM_LOGS_KEY = "trim_logs"
+
     LOG_LEVEL_KEY = "redpanda_log_level"
     DEFAULT_LOG_LEVEL = "info"
 
@@ -585,6 +587,8 @@ class RedpandaService(Service):
 
         self._dedicated_nodes = self._context.globals.get(
             self.DEDICATED_NODE_KEY, False)
+
+        self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
 
         if resource_settings is None:
             resource_settings = ResourceSettings()
@@ -1703,6 +1707,9 @@ class RedpandaService(Service):
             self._installer.reset_current_install([node])
 
     def trim_logs(self):
+        if not self._trim_logs:
+            return
+
         # Excessive logging may cause disks to fill up quickly.
         # Call this method to removes TRACE and DEBUG log lines from redpanda logs
         # Ensure this is only done on tests that have passed


### PR DESCRIPTION
## Cover letter

This is a followup to https://github.com/redpanda-data/redpanda/pull/7042, split out to make test/review easier.

In this PR:
- the `materialized_segments` class from #7042 is extended with a semaphore to track all the materialized_segment_state objects that exist, and pro-actively trim segments if we hit a configurable limit on how many should be materialized at once.
- Metrics are also added for the number of readers and the number of hydrated segments that exist.
- A flush on remote_partition::stop to ensure all a partition's dependent objects are destroyed before the partition is destroyed
- some small test improvements

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

### Improvements

* Improved stability under read workloads touching many tiered storage segments in quick succession
* A new cluster configuration property cloud_storage_max_segments_per_shard is added, which controls the maximum number of segments that per CPU core that may be promoted into a readable state from cloud storage. This may be tuned downward to reduce memory consumption at the possible cost of read throughput. The default setting is two per partition (i.e. the value of topic_partitions_per_shard multiplied by 2 is used).
* Two new metrics are added to the /public_metrics endpoint: `redpanda_cloud_storage_active_segments` and `redpanda_cloud_storage_readers`.
