### PR TITLE
tests: remove copy of wait_until

### DIFF
--- a/tests/rptest/tests/limits_test.py
+++ b/tests/rptest/tests/limits_test.py
@@ -14,12 +14,11 @@ from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services import redpanda
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 import string
-
-from rptest.util import wait_until
 
 
 def _timed_out(e: RpkException):

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -13,7 +13,7 @@ import time
 from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
-from rptest.util import wait_until, wait_until_result
+from rptest.util import wait_until_result
 from rptest.clients.default import DefaultClient
 from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
 from rptest.services.failure_injector import FailureInjector, FailureSpec
@@ -25,6 +25,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool, RpkException
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
 
 # We inject failures which might cause consumer groups
 # to re-negotiate, so it is necessary to have a longer

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -19,8 +19,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
-
-from rptest.util import wait_until
+from ducktape.utils.util import wait_until
 
 
 class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):

--- a/tests/rptest/tests/prealloc_nodes.py
+++ b/tests/rptest/tests/prealloc_nodes.py
@@ -10,7 +10,7 @@
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.tests.test import TestContext
-from rptest.util import wait_until
+from ducktape.utils.util import wait_until
 
 
 class PreallocNodesTest(RedpandaTest):

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -16,7 +16,7 @@ from typing import Optional
 import requests
 
 from ducktape.mark import parametrize
-from rptest.util import wait_until
+from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk import RpkTool, RpkException

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -5,8 +5,9 @@ from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings, RedpandaService, LoggingConfig
 from rptest.tests.end_to_end import EndToEndTest
-from rptest.util import wait_until_segments, wait_for_removal_of_n_segments, wait_until
+from rptest.util import wait_until_segments, wait_for_removal_of_n_segments
 from rptest.utils.si_utils import S3Snapshot
+from ducktape.utils.util import wait_until
 
 
 class ShadowIndexingCompactedTopicTest(EndToEndTest):

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 from ducktape.errors import TimeoutError
+from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -50,31 +51,6 @@ class Scale:
     @property
     def release(self):
         return self._scale == Scale.RELEASE
-
-
-def wait_until(condition,
-               timeout_sec,
-               backoff_sec=.1,
-               err_msg="",
-               retry_on_exc=False):
-    start = time.time()
-    stop = start + timeout_sec
-    last_exception = None
-    while time.time() < stop:
-        try:
-            if condition():
-                return
-            else:
-                last_exception = None
-        except BaseException as e:
-            last_exception = e
-            if not retry_on_exc:
-                raise e
-        time.sleep(backoff_sec)
-
-    # it is safe to call Exception from None - will be just treated as a normal exception
-    raise TimeoutError(
-        err_msg() if callable(err_msg) else err_msg) from last_exception
 
 
 def wait_until_result(condition, *args, **kwargs):


### PR DESCRIPTION
## Cover letter

This was added in b4a5fb27, and eventually we repointed ducktape to a version that includes the wait_until fix: the copy is no longer needed.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none