### PR TITLE
Update ducktape kgo-verifier services

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard cf552ccba1c6a68f53b51bbdbbcdb50c4e2c8cfe && \
+    cd /opt/kgo-verifier && git reset --hard 98f1f57dab8bb8abe615f733a0ea307026ce13a5 && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -39,7 +39,10 @@ class KgoRepeaterService(Service):
                  key_count: Optional[int] = None,
                  group_name: str = "repeat01",
                  max_buffered_records: Optional[int] = None,
-                 mb_per_worker: Optional[int] = None):
+                 mb_per_worker: Optional[int] = None,
+                 use_transactions: bool = False,
+                 transaction_abort_rate: Optional[float] = None,
+                 msgs_per_transaction: Optional[int] = None):
         # num_nodes=0 because we're asking it to not allocate any for us
         super().__init__(context, num_nodes=0 if nodes else 1)
 
@@ -65,6 +68,10 @@ class KgoRepeaterService(Service):
             mb_per_worker = 4
 
         self.mb_per_worker = mb_per_worker
+
+        self.use_transactions = use_transactions
+        self.transaction_abort_rate = transaction_abort_rate
+        self.msgs_per_transaction = msgs_per_transaction
 
         self._stopped = False
 
@@ -92,6 +99,15 @@ class KgoRepeaterService(Service):
 
         if self.max_buffered_records is not None:
             cmd += f" -max-buffered-records={self.max_buffered_records}"
+
+        if self.use_transactions:
+            cmd += f" -use-transactions"
+
+            if self.transaction_abort_rate is not None:
+                cmd += f" -transaction-abort-rate={self.transaction_abort_rate}"
+
+            if self.msgs_per_transaction is not None:
+                cmd += f" -msgs-per-transaction={self.msgs_per_transaction}"
 
         cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 &"
 


### PR DESCRIPTION
## Cover letter
This PR updates the kgo-verifier services in ducktape to use the newer version that support transactions.


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
* none

### Features

* none

### Improvements

* none

