### PR TITLE
tests: wait for reversal of injected failures

### DIFF
--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -354,6 +354,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
                 decommission(idx)
 
         enable_failures = False
+        finjector_thread.join()
         admin_fuzz.wait(20, 180)
         admin_fuzz.stop()
         self.run_validation(min_records=self.min_produced_records,


### PR DESCRIPTION
## Cover letter
This commit updates the nodes operations fuzzy test to wait for all failures injected to be reverted before finishing. Skipping the 'join' call results with the clean-up racing with the end of the test and risks leaving failures behind.

I think this race is the root cause for a couple of the bad CI runs we've seen. [Here](https://buildkite.com/redpanda/vtools/builds/4054#01843b72-5026-483d-a0b7-5c3736f0554d) the test was stopped due to some bad log lines being presented and that raced with the healing of the failures. Since the failure thread is created as a daemon it gets stopped when the test ends and can leave failures behind.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #7086

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [X] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes
* none

## Release notes
* none