### PR TITLE
rpk: avoid overwriting pandaproxy if no flags are passed to rpk start

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -312,7 +312,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if advProxyAPI != nil {
+			if len(advProxyAPI) > 0 {
 				if cfg.Pandaproxy == nil {
 					cfg.Pandaproxy = config.DevDefault().Pandaproxy
 				}


### PR DESCRIPTION

## Cover letter
If you start redpanda using rpk with no pandaproxy flags and have the field `pandaproxy.advertised_pandaproxy_api` in your config file, then rpk will delete this field after starting redpanda.

This was caused because we were doing a nil check in a slice instead of a length verification.

Fixes #7090

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

* none

## Release notes
* bugfix: rpk no longer deletes `pandaproxy.advertised_pandaproxy_api` if no pandaproxy flags are passed when starting redpanda using `rpk redpanda start`
