### PR TITLE
cloud_storage: fix is_data_available for truncated case

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -497,7 +497,13 @@ const model::ntp& remote_partition::get_ntp() const {
 }
 
 bool remote_partition::is_data_available() const {
-    return _manifest.size() > 0;
+    // Only advertize data if we have segments _and_ our start offset
+    // corresponds to some data (not if our start_offset points off
+    // the end of the manifest, as a result of a truncation where we
+    // have not yet cleaned out the segments.
+    return _manifest.size() > 0
+           && _manifest.find(_manifest.get_start_offset().value())
+                != _manifest.end();
 }
 
 // returns term last kafka offset


### PR DESCRIPTION
## Cover letter

If we have segment but none of them are ahead of
the start_offset, we should not advertise to the
Kafka read path that we have data available.

This avoids hitting an assertion later in
`first_uploaded_offset` which checks that a segment exists at the start offset in the manifest.

Fixes https://github.com/redpanda-data/redpanda/issues/7092

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none