### PR TITLE
tests/docker: Mark arroyo test suite as ok_to_fail

### DIFF
--- a/tests/rptest/tests/compatibility/arroyo_test.py
+++ b/tests/rptest/tests/compatibility/arroyo_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 
@@ -33,6 +34,7 @@ class ArroyoTest(PreallocNodesTest):
             },
             **kwargs)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/6826
     @cluster(num_nodes=4)
     def test_arroyo_test_suite(self):
         test_node = self.preallocated_nodes[0]


### PR DESCRIPTION
- From v1.0.0 to v1.1.0

- Fixes to a recent flaky test within the suite are here: https://github.com/getsentry/arroyo/commit/a45b7b1230b86f735152aaeab56ce197c42bddb7 its suspected that this may be the cause of a recently failing test, since the fix is very close to the assertion that is triggering in our suite