### PR TITLE
tests: fix cloud diagnostic bundle on node crash

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -45,9 +45,9 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                 # (https://github.com/redpanda-data/redpanda/issues/5004)
                 # self.redpanda.decode_backtraces()
 
-                self.redpanda.raise_on_crash()
-
                 self.redpanda.cloud_storage_diagnostics()
+
+                self.redpanda.raise_on_crash()
 
                 raise
             else:


### PR DESCRIPTION
## Cover letter

Need to gather the diagnostics before we potentially raise for a crash.

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
