### PR TITLE
add rpk cloud byoc shim

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/byoc.go
@@ -110,7 +110,7 @@ Redpanda cluster.
 
 The BYOC command runs Terraform to create and start the agent. You first need
 a redpanda-id (or cluster ID); this is used to get the details of how your
-agent should be provisioned. You can create a BYOC cluster in our cloud UX
+agent should be provisioned. You can create a BYOC cluster in our cloud UI
 and then come back to this command to complete the process.
 `,
 		DisableFlagParsing: true,
@@ -157,7 +157,8 @@ and then come back to this command to complete the process.
 			path, token, _, err := loginAndEnsurePluginVersion(cmd.Context(), fs, cfg, redpandaID)
 			out.MaybeDie(err, "unable to ensure byoc plugin version: %v", err)
 
-			execFn(path, append(args, "--cloud-api-token", token))
+			err = execFn(path, append(args, "--cloud-api-token", token))
+			out.MaybeDie(err, "unable to execute plugin: %v", err)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/byoc.go
@@ -1,0 +1,176 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package byoc
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// We manage the byoc plugin, and we install it under "rpk cloud byoc".
+	// Whenever we run a byoc subcommand, we want to load our token and
+	// pass it to the subcommand as an extra flag.
+	plugin.RegisterManaged("byoc", []string{"cloud", "byoc"}, func(cmd *cobra.Command, fs afero.Fs) *cobra.Command {
+		var params cloudcfg.Params
+		run := cmd.Run
+
+		// Plugin commands disable flag parsing because we want to pass
+		// raw flags directly to the plugin. We are hijacking the exec
+		// and want to parse a few flags ourselves.
+		cmd.Run = func(cmd *cobra.Command, args []string) {
+			var redpandaID string
+			err := parseExecFlags(args, &params.ClientID, &params.ClientSecret, &redpandaID, true)
+			out.MaybeDieErr(err)
+
+			// We require our plugin to always be the exact version
+			// pinned in the control plane.
+			cfg, err := params.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			_, token, _, err := loginAndEnsurePluginVersion(cmd.Context(), fs, cfg, redpandaID)
+			out.MaybeDie(err, "unable to ensure byoc plugin version: %v", err)
+
+			// Finally, exec.
+			run(cmd, append(args, "--cloud-api-token", token))
+		}
+		return cmd
+	})
+}
+
+func findFlag(args []string, flag string) string {
+	for i, arg := range args {
+		// "--foo bar"
+		if arg == flag && len(args) > i {
+			return args[i+1]
+		}
+		// "--foo=bar"
+		if strings.HasPrefix(arg, flag+"=") {
+			return strings.TrimPrefix(arg, flag+"=")
+		}
+	}
+	return ""
+}
+
+// For our byoc command, and for plugin shadow commands, we disable flag
+// parsing so that we can pass raw flags to the plugin itself. However, we want
+// to hijack a few of these flags within byoc.
+//
+// --client-id and --client-secret can override our auth flow, and
+// --redpanda-id is potentially required.
+func parseExecFlags(args []string, clientID, clientSecret, redpandaID *string, requireRedpandaID bool) error {
+	flagClientID := findFlag(args, "--"+cloudcfg.FlagClientID)
+	flagClientSecret := findFlag(args, "--"+cloudcfg.FlagClientSecret)
+	if flagClientID != "" || flagClientSecret != "" {
+		if flagClientID == "" || flagClientSecret == "" {
+			return errors.New("--client-id and --client-secret are required together if either are used")
+		}
+		*clientID = flagClientID
+		*clientSecret = flagClientSecret
+	}
+
+	// We require --redpanda-id when execing the plugin.
+	flagRedpandaID := findFlag(args, "--redpanda-id")
+	if flagRedpandaID == "" && requireRedpandaID {
+		return errors.New("missing required --redpanda-id flag")
+	}
+	*redpandaID = flagRedpandaID
+
+	// We disallow manually specifying --cloud-api-token,
+	// which we load ourselves.
+	if token := findFlag(args, "--cloud-api-token"); token != "" {
+		return errors.New("--cloud-api-token cannot be manually specified")
+	}
+	return nil
+}
+
+// NewCommand returns a new byoc plugin command.
+func NewCommand(fs afero.Fs, execFn func(string, []string) error) *cobra.Command {
+	var params cloudcfg.Params
+	cmd := &cobra.Command{
+		Use:   "byoc",
+		Short: "Manage a Redpanda cloud BYOC agent",
+		Long: `Manage a Redpanda cloud BYOC agent
+
+For BYOC, Redpanda installs an agent service in your owned cluster. The agent
+then proceeds to provision further infrastructure and eventually, a full
+Redpanda cluster.
+
+The BYOC command runs Terraform to create and start the agent. You first need
+a redpanda-id (or cluster ID); this is used to get the details of how your
+agent should be provisioned. You can create a BYOC cluster in our cloud UX
+and then come back to this command to complete the process.
+`,
+		DisableFlagParsing: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			var redpandaID string
+			err := parseExecFlags(args, &params.ClientID, &params.ClientSecret, &redpandaID, false)
+			out.MaybeDieErr(err)
+
+			cfg, err := params.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// We bind rpk to the plugin implementation a little
+			// bit: we only want to download and exec the plugin if
+			// it *looks* like the user is trying a direct plugin
+			// command. Since we are disable flag parsing, this is
+			// a little bit tricky: we have to find the first arg,
+			// not --flag=val nor --flag val.
+			//
+			// This has edge cases that we are not handling, such
+			// as a person using short flags, bool flags, etc.
+			//
+			// Better would be if we could skip unknown flags,
+			// similar to redpanda start.
+			//
+			// TODO: remove DisableUknownFlags in rpk, #7100.
+			var isKnown bool
+			for i := 0; i < len(args); i++ {
+				arg := args[i]
+				switch {
+				case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "="):
+					i++
+				case arg == "aws":
+					isKnown = true
+				case arg == "gcp":
+					isKnown = true
+				}
+			}
+
+			if !isKnown || redpandaID == "" {
+				cmd.Help()
+				return
+			}
+
+			path, token, _, err := loginAndEnsurePluginVersion(cmd.Context(), fs, cfg, redpandaID)
+			out.MaybeDie(err, "unable to ensure byoc plugin version: %v", err)
+
+			execFn(path, append(args, "--cloud-api-token", token))
+		},
+	}
+
+	// We add these flags, but they will not be parsed because of
+	// DisableFlagParsing. We manually parse them.
+	cmd.Flags().StringVar(&params.ClientID, cloudcfg.FlagClientID, "", "The client ID of the organization in Redpanda Cloud")
+	cmd.Flags().StringVar(&params.ClientSecret, cloudcfg.FlagClientSecret, "", "The client secret of the organization in Redpanda Cloud")
+	cmd.MarkFlagsRequiredTogether(cloudcfg.FlagClientID, cloudcfg.FlagClientSecret)
+
+	cmd.AddCommand(
+		newInstallCommand(fs),
+		newUninstallCommand(fs),
+	)
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
@@ -118,6 +118,9 @@ func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *cloudcfg
 	// require the FilenameSHA to have at least 20 characters.
 	byoc, pluginExists := plugin.ListPlugins(fs, []string{pluginDir}).Find("byoc")
 	if pluginExists {
+		if !byoc.Managed {
+			return "", "", false, fmt.Errorf("found external plugin at %s, the old plugin must be removed first", byoc.Path)
+		}
 		if c := cfg.SkipVersionCheck; c == "1" || c == "true" {
 			return byoc.Path, token, false, nil
 		}

--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
@@ -118,6 +118,9 @@ func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *cloudcfg
 	// require the FilenameSHA to have at least 20 characters.
 	byoc, pluginExists := plugin.ListPlugins(fs, []string{pluginDir}).Find("byoc")
 	if pluginExists {
+		if c := cfg.SkipVersionCheck; c == "1" || c == "true" {
+			return byoc.Path, token, false, nil
+		}
 		currentSha, err := plugin.Sha256Path(fs, byoc.Path)
 		if err != nil {
 			return "", "", false, fmt.Errorf("unable to determine the sha256sum of %q: %v", byoc.Path, err)

--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
@@ -1,0 +1,145 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package byoc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cloud/auth"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloudapi"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newInstallCommand(fs afero.Fs) *cobra.Command {
+	var params cloudcfg.Params
+	var redpandaID string
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the BYOC plugin",
+		Long: `Install the BYOC plugin
+
+This command downloads the BYOC managed plugin if necessary. The plugin is
+installed by default if you try to run a non-install command, but this command
+exists if you want to download the plugin ahead of time.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			cfg, err := params.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			_, _, installed, err := loginAndEnsurePluginVersion(cmd.Context(), fs, cfg, redpandaID)
+			out.MaybeDie(err, "unable to install byoc plugin: %v", err)
+			if !installed {
+				fmt.Print(`
+Your BYOC plugin is currently up to date, avoiding reinstalling!
+`)
+				return
+			}
+			fmt.Print(`
+BYOC plugin installed successfully!
+
+This plugin supports autocompletion through 'rpk cloud byoc'. If you enable rpk
+autocompletion, start a new terminal and tab complete through it!
+`)
+		},
+	}
+	cmd.Flags().StringVar(&redpandaID, "redpanda-id", "", "")
+	cmd.MarkFlagRequired("redpanda-id")
+
+	cmd.Flags().StringVar(&params.ClientID, cloudcfg.FlagClientID, "", "The client ID of the organization in Redpanda Cloud")
+	cmd.Flags().StringVar(&params.ClientSecret, cloudcfg.FlagClientSecret, "", "The client secret of the organization in Redpanda Cloud")
+	cmd.MarkFlagsRequiredTogether(cloudcfg.FlagClientID, cloudcfg.FlagClientSecret)
+	return cmd
+}
+
+func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *cloudcfg.Config, redpandaID string) (binPath string, token string, installed bool, rerr error) {
+	// First load our configuration and token.
+	pluginDir, err := plugin.DefaultBinPath()
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to determine managed plugin path: %w", err)
+	}
+	token, err = auth.LoadFlow(ctx, fs, cfg)
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to load the cloud token: %w", err)
+	}
+
+	// Check our current version of the plugin.
+	cl := cloudapi.NewClient(cfg.CloudURL, token)
+	cluster, err := cl.Cluster(ctx, redpandaID)
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to request cluster details for %q: %w", redpandaID, err)
+	}
+	pack, err := cl.InstallPack(ctx, cluster.Spec.InstallPackVersion)
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to request install pack details for %q: %v", cluster.Spec.InstallPackVersion, err)
+	}
+	name := fmt.Sprintf("byoc-%s-%s", runtime.GOOS, runtime.GOARCH)
+	artifact, found := pack.Artifacts.Find(name)
+	if !found {
+		return "", "", false, fmt.Errorf("unable to find byoc plugin %s", name)
+	}
+
+	// Check if the plugin is downloaded and matches the remote version. We
+	// require the FilenameSHA to have at least 20 characters.
+	byoc, pluginExists := plugin.ListPlugins(fs, []string{pluginDir}).Find("byoc")
+	if pluginExists {
+		if len(byoc.FilenameSHA) >= plugin.FilenameSHALength && strings.HasPrefix(artifact.ChecksumSHA256, byoc.FilenameSHA) {
+			return byoc.Path, token, false, nil // remote version matches, all is good, return token
+		}
+		// If we successfully install the plugin, we need to remove any
+		// old plugins: the filename will be different, so it is not
+		// just simply replaced.
+		defer func() {
+			if rerr == nil {
+				messages, anyFailed := removePluginAll(byoc)
+				for _, message := range messages {
+					fmt.Println(message)
+				}
+				if anyFailed {
+					rerr = fmt.Errorf("unable to remove all old plugins, please run `rpk cloud byoc uninstall` and retry")
+				}
+			}
+		}()
+	}
+
+	// Remote version is different: download current plugin version and
+	// replace.
+	bin, err := plugin.Download(ctx, artifact.Location, artifact.ChecksumSHA256)
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to replace out of date plugin: %w", err)
+	}
+
+	// Ensure the dir exists, but if we have to create it, we do not want
+	// sudo.
+	if exists, _ := afero.DirExists(fs, pluginDir); !exists {
+		if rpkos.IsRunningSudo() {
+			return "", "", false, fmt.Errorf("detected rpk is running with sudo; please execute this command without sudo to avoid saving the plugin as a root owned binary in %s", pluginDir)
+		}
+		err = os.MkdirAll(pluginDir, 0o755)
+		if err != nil {
+			return "", "", false, fmt.Errorf("unable to create the plugin bin directory: %v", err)
+		}
+	}
+
+	path, err := plugin.WriteBinary(fs, "byoc", pluginDir, bin, artifact.ChecksumSHA256, false, true)
+	if err != nil {
+		return "", "", false, fmt.Errorf("unable to write byoc plugin to disk: %w", err)
+	}
+
+	return path, token, true, nil
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/uninstall.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/uninstall.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package byoc
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newUninstallCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the BYOC plugin",
+		Long: `Uninstall the BYOC plugin
+
+This command deletes your locally downloaded BYOC managed plugin if it exists.
+Often, you only need to download the plugin to create your cluster once, and
+then you never need the plugin again. You can uninstall to save a small bit of
+disk space.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			pluginDir, err := plugin.DefaultBinPath()
+			out.MaybeDie(err, "unable to determine managed plugin path: %w", err)
+			byoc, pluginExists := plugin.ListPlugins(fs, []string{pluginDir}).Find("byoc")
+			if !pluginExists {
+				out.Exit("The BYOC managed plugin is not installed!")
+			}
+			messages, anyFailed := removePluginAll(byoc)
+			for _, message := range messages {
+				fmt.Println(message)
+			}
+			if anyFailed {
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+func removePluginAll(p *plugin.Plugin) (messages []string, anyFailed bool) {
+	if err := os.Remove(p.Path); err != nil {
+		messages = append(messages, fmt.Sprintf("Unable to remove %q: %v", p.Path, err))
+		anyFailed = true
+	} else {
+		messages = append(messages, fmt.Sprintf("Removed %q", p.Path))
+	}
+
+	for _, shadowed := range p.ShadowedPaths {
+		if err := os.Remove(shadowed); err != nil {
+			messages = append(messages, fmt.Sprintf("Unable to remove shadowed at %q: %v", p.Path, err))
+			anyFailed = true
+		} else {
+			messages = append(messages, fmt.Sprintf("Remove shadowed at %q", p.Path))
+		}
+	}
+	return
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/cloud.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/cloud.go
@@ -10,17 +10,19 @@
 package cloud
 
 import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cloud/byoc"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(fs afero.Fs) *cobra.Command {
+func NewCommand(fs afero.Fs, execFn func(string, []string) error) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Interact with Redpanda cloud",
 	}
 
 	cmd.AddCommand(
+		byoc.NewCommand(fs, execFn),
 		newLoginCommand(fs),
 		newLogoutCommand(fs),
 	)

--- a/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/config.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/config.go
@@ -36,10 +36,10 @@ type Config struct {
 	ClientSecret string `yaml:"client_secret,omitempty"`
 	AuthToken    string `yaml:"auth_token,omitempty"`
 
-	AuthURL      string `yaml:"-"`
-	AuthAudience string `yaml:"-"`
-
-	CloudURL string `yaml:"-"`
+	AuthURL          string `yaml:"-"`
+	AuthAudience     string `yaml:"-"`
+	CloudURL         string `yaml:"-"`
+	SkipVersionCheck string `yaml:"-"`
 }
 
 func (c *Config) fileCfg() fileCfg {

--- a/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/config.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/config.go
@@ -63,17 +63,6 @@ func (c *Config) ClearCredentials() {
 	c.AuthToken = ""
 }
 
-// Pretty returns a string with the configuration formatted in a human-readable
-// form.
-func (c *Config) Pretty() string {
-	format := `
-Client ID:            %s 
-Client Secret:        %s
-Authorization Token:  %s
-`
-	return fmt.Sprintf(format, c.ClientID, c.ClientSecret, c.AuthToken)
-}
-
 // defaultCfgPath returns the default path where the cloud configuration will
 // live, normally: '$HOME/.config/rpk/__cloud.yaml'.
 func defaultCfgPath() (string, error) {

--- a/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/params.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/cloudcfg/params.go
@@ -25,10 +25,10 @@ const (
 	envClientID     = "RPK_CLOUD_CLIENT_ID"
 	envClientSecret = "RPK_CLOUD_CLIENT_SECRET"
 
-	envAuthURL      = "RPK_CLOUD_AUTH_URL"
-	envAuthAudience = "RPK_CLOUD_AUTH_AUDIENCE"
-
-	envCloudURL = "RPK_CLOUD_URL"
+	envAuthURL          = "RPK_CLOUD_AUTH_URL"
+	envAuthAudience     = "RPK_CLOUD_AUTH_AUDIENCE"
+	envCloudURL         = "RPK_CLOUD_URL"
+	envSkipVersionCheck = "RPK_CLOUD_SKIP_VERSION_CHECK"
 )
 
 // Params contains values that can be set by flags.
@@ -76,6 +76,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 		{envAuthURL, "", &cfg.AuthURL},
 		{envAuthAudience, "", &cfg.AuthAudience},
 		{envCloudURL, "", &cfg.CloudURL},
+		{envSkipVersionCheck, "", &cfg.SkipVersionCheck},
 	} {
 		if v, ok := os.LookupEnv(override.env); ok && len(v) > 0 {
 			*override.dst = v

--- a/src/go/rpk/pkg/cli/cmd/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/login.go
@@ -22,6 +22,7 @@ import (
 
 func newLoginCommand(fs afero.Fs) *cobra.Command {
 	var params cloudcfg.Params
+	var save bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the Redpanda cloud",
@@ -61,10 +62,15 @@ and then re-specify the client credentials next time you log in.
 `, err)
 			}
 			out.MaybeDie(err, "unable to login into Redpanda Cloud: %v", err)
+			if save {
+				err = cfg.SaveAll(fs)
+				out.MaybeDie(err, "unable to save client ID and client secret: %v", err)
+			}
 			fmt.Println("Successfully logged in.")
 		},
 	}
 
+	cmd.Flags().BoolVar(&save, "save", false, "Save environment or flag specified client ID and client secret to the configuration file")
 	cmd.Flags().StringVar(&params.ClientID, cloudcfg.FlagClientID, "", "The client ID of the organization in Redpanda Cloud")
 	cmd.Flags().StringVar(&params.ClientSecret, cloudcfg.FlagClientSecret, "", "The client secret of the organization in Redpanda Cloud")
 	cmd.MarkFlagsRequiredTogether(cloudcfg.FlagClientID, cloudcfg.FlagClientSecret)

--- a/src/go/rpk/pkg/cli/cmd/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/login.go
@@ -24,9 +24,9 @@ func newLoginCommand(fs afero.Fs) *cobra.Command {
 	var params cloudcfg.Params
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to the Redpanda cloud",
+		Short: "Log in to the Redpanda cloud",
 		Args:  cobra.ExactArgs(0),
-		Long: `Login to the Redpanda cloud
+		Long: `Log in to the Redpanda cloud
 
 This command checks for an existing token and, if present, ensures it is still
 valid. If no token is found or the token is no longer valid, this command will

--- a/src/go/rpk/pkg/cli/cmd/cloud/logout.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/logout.go
@@ -26,8 +26,14 @@ func newLogoutCommand(fs afero.Fs) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Log out from the Redpanda cloud",
-		Args:  cobra.ExactArgs(0),
+		Short: "Log out from Redpanda cloud",
+		Long: `Log out from Redpanda cloud
+
+This command deletes your cloud auth token. If you want to log out entirely and
+switch to a different organization, you can use the --clear-credentials flag to
+additionally clear your client ID and client secret.
+`,
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if rpkos.IsRunningSudo() {
 				out.Die("detected rpk is running with sudo; please execute this command without sudo to avoid saving the cloud configuration as a root owned file")

--- a/src/go/rpk/pkg/cli/cmd/plugin/install.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/install.go
@@ -63,7 +63,7 @@ If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
 			if len(version) > 0 {
 				// We do not use sha's for this temporary
 				// direct download path.
-				body, err = tryDirectDownload(name, version)
+				body, err = tryDirectDownload(cmd.Context(), name, version)
 				if err != nil {
 					log.Debugf("unable to download: %v", err)
 				}
@@ -112,7 +112,7 @@ Remote sha256: %s
 			}
 
 			fmt.Println("Downloaded! Writing plugin to disk...")
-			dst, err := plugin.WriteBinary(fs, name, dir, body, remoteSha, autoComplete, false)
+			dst, err := plugin.WriteBinary(fs, name, dir, body, autoComplete, false)
 			out.MaybeDieErr(err)
 
 			// If we add shas to filenames, then writing our binary
@@ -180,8 +180,8 @@ func checkAndCreateDefaultPath(fs afero.Fs) error {
 	return nil
 }
 
-func tryDirectDownload(name, version string) ([]byte, error) {
+func tryDirectDownload(ctx context.Context, name, version string) ([]byte, error) {
 	u := fmt.Sprintf("https://dl.redpanda.com/public/rpk-plugins/raw/names/%[1]s-%[2]s-%[3]s/versions/%[4]s/%[1]s.tgz", name, runtime.GOOS, runtime.GOARCH, version)
 	fmt.Printf("Searching for plugin %q in %s...\n", name, u)
-	return plugin.Download(context.Background(), u, "")
+	return plugin.Download(ctx, u, true, "")
 }

--- a/src/go/rpk/pkg/cli/cmd/plugin/install.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/install.go
@@ -76,7 +76,7 @@ If --dir is not present, rpk will create $HOME/.local/bin if it does not exist.
 				var userAlreadyHas bool
 				installed := plugin.ListPlugins(fs, plugin.UserPaths())
 				for _, p := range installed {
-					if name == p.Name() {
+					if name == p.FullName() {
 						sha, err := plugin.Sha256Path(fs, p.Path)
 						out.MaybeDieErr(err)
 

--- a/src/go/rpk/pkg/cli/cmd/plugin/install.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/install.go
@@ -107,7 +107,7 @@ Remote sha256: %s
 			}
 
 			fmt.Println("Downloaded! Writing plugin to disk...")
-			dst, err := plugin.WriteBinary(fs, name, dir, body, autoComplete, false)
+			dst, err := plugin.WriteBinary(fs, name, dir, body, "", autoComplete, false)
 			out.MaybeDieErr(err)
 
 			fmt.Printf("Success! Plugin %q has been saved to %q and is now ready to use!\n", name, dst)

--- a/src/go/rpk/pkg/cli/cmd/plugin/list.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/list.go
@@ -51,7 +51,7 @@ whether you have "shadowed" plugins (the same plugin specified multiple times).
 					if len(p.ShadowedPaths) > 0 {
 						shadowed = p.ShadowedPaths[0]
 					}
-					tw.Print(p.Name(), p.Path, shadowed)
+					tw.Print(p.FullName(), p.Path, shadowed)
 
 					if len(p.ShadowedPaths) < 1 {
 						continue

--- a/src/go/rpk/pkg/cli/cmd/plugin/uninstall.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/uninstall.go
@@ -29,7 +29,8 @@ func newUninstallCommand(fs afero.Fs) *cobra.Command {
 
 This command lists locally installed plugins and removes the first plugin that
 matches the requested removal. If --include-shadowed is specified, this command
-also removes all shadowed plugins of the same name.
+also removes all shadowed plugins of the same name. To remove a command under a
+nested namespace ("rpk foo bar"), you can use "foo_bar".
 `,
 
 		Args: cobra.ExactArgs(1),

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -90,39 +90,22 @@ func Execute() {
 
 	addPlatformDependentCmds(fs, root)
 
-	// To support autocompletion even for plugins, we list all plugins now
-	// and add tiny commands to our root command. Cobra works by creating
-	// autocompletion scripts that contain the commands discoverable from
-	// the root command, so by adding cobra.Command's for all plugins, we
-	// allow autocompletion.
+	// Plugin autocompletion: Cobra creates autocompletion for shells via
+	// all commands discoverable from the root command. Plugins that are
+	// prefixed .rpk.ac- indicate they support the --help-autocomplete
+	// flag. We exec with the flag and then create a bunch of fake cobra
+	// commands within rpk. The plugin now looks like it is a part of rpk.
 	//
-	// We do not want any plugin to shadow or replace functionality of any
-	// rpk command. We do not want `rpk-acl-foo` to exec a plugin, when
-	// `rpk acl` exists and the single argument foo may be important. We
-	// block rpk command shadowing by not keeping any plugin that shares an
-	// argument search path with a rpk command.
+	// We block plugins from overwriting actual rpk commands (rpk acl),
+	// unless the plugin is specifically rpk managed.
 	//
-	// Further, unlike kubectl, we do not allow one plugin to be at the end
-	// of another plugin (rpk foo bar cannot exist if rpk foo does). This
-	// is ensured by the return from listPlugins, but we can also ensure
-	// that here by only adding a plugin with exec if a command does not
-	// exist yet.
-	for _, plugin := range plugin.ListPlugins(fs, plugin.UserPaths()) {
-		if _, _, err := root.Find(plugin.Arguments); err != nil {
-			addPluginWithExec(root, plugin.Arguments, plugin.Path)
-		}
-	}
-
-	// Lastly, if rpk is being exec'd with arguments that do not match a
-	// command nor a discovered plugin, we do one more search for an
-	// external plugin. Given the above code, this is likely to find
-	// nothing, but this does not hurt.
-	if _, _, err := root.Find(os.Args[1:]); err != nil {
-		if foundPath, err := tryExecPlugin(new(osPluginHandler), os.Args[1:]); len(foundPath) > 0 {
-			if err != nil {
-				log.Fatalf("exec %s: %v\n", foundPath, err)
-			}
-			os.Exit(0)
+	// Managed plugins are slightly weirder and are documented below.
+	for _, p := range plugin.ListPlugins(fs, plugin.UserPaths()) {
+		p, managedHook := plugin.LookupManaged(p)
+		if managedHook != nil {
+			addPluginWithExec(root, p.Name, p.Arguments, p.Path, managedHook, fs)
+		} else {
+			addPluginWithExec(root, p.Name, p.Arguments, p.Path, nil, nil)
 		}
 	}
 
@@ -147,108 +130,87 @@ func Execute() {
 	}
 }
 
-type pluginHandler interface {
-	lookPath(file string) (path string, ok bool)
-	exec(path string, args []string) error
-}
+// See the two use cases for this.
+const pluginShortSuffix = " external plugin"
 
-// tryExecPlugin looks for a plugin, based on the following rules:
+// This recursive function handles everything related to installing a plugin
+// into rpk.
 //
-//   - all "pieces" (non-flags) are joined with an underscore
-//   - we prefer the longest command match
-//   - we search upward by piece until we run out of pieces
-//   - the command must be executable
+// 1) We create a command space so that the plugin looks to be at the correct
+// location: .rpk-foo_bar will be installed at "rpk foo bar".
 //
-// So,
+// 2) If the plugin indicates autocomplete (.rpk.ac-) or is managed
+// (.rpk.managed-), we install autocompletion.
 //
-//	rpk foo-bar baz boz fizz-buzz --flag
+// 3) If the plugin is managed, we use our managed hook as the run function
+// rather than our standard exec-plugin run function.
 //
-// is translated into searching and execing (with osPluginHandler), in order:
-//
-//	rpk-foo-bar_baz_boz_fizz-buzz (with args "--flag")
-//	rpk-foo-bar_baz_boz           (with args "fizz-buzz --flag")
-//	rpk-foo-bar_baz               (with args "boz fizz-buzz --flag")
-//	rpk-foo-bar                   (with args "baz boz fizz-buzz --flag")
-//
-// If a plugin is run, this returns the run error and true, otherwise this
-// returns false.
-func tryExecPlugin(h pluginHandler, args []string) (string, error) {
-	var pieces []string
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") { // found a flag, quit
-			break
-		}
-		pieces = append(pieces, arg)
-	}
-
-	if len(pieces) == 0 {
-		return "", nil // no plugin specified (command is just "rpk")
-	}
-
-	foundPath := ""
-	for len(pieces) > 0 {
-		joined := strings.Join(pieces, "_")
-		if path, ok := h.lookPath(plugin.NamePrefixAutoComplete + joined); ok {
-			foundPath = path
-			break
-		}
-		if path, ok := h.lookPath(plugin.NamePrefix + joined); ok {
-			foundPath = path
-			break
-		}
-		pieces = pieces[:len(pieces)-1] // did not find with this piece, strip and search higher
-	}
-	if len(foundPath) == 0 {
-		return "", nil
-	}
-
-	return foundPath, h.exec(foundPath, args[len(pieces):])
-}
-
-// This recursive function recursively adds commands to parent commands,
-// stopping when there is only one piece left.
-//
-// Pieces corresponds to the pieces of a plugin, and on the last piece, the
-// cobra.Command will execute execPath.
+// These steps are documented more below.
 func addPluginWithExec(
-	parentCmd *cobra.Command, pieces []string, execPath string,
+	parentCmd *cobra.Command,
+	name string,
+	pieces []string,
+	execPath string,
+	managedHook plugin.ManagedHook,
+	fs afero.Fs,
 ) {
-	// pieces[0] must exist because this function is only called from the
-	// result of listPlugins (which ensures there are pieces), or
-	// recursively below when there is more than one piece.
-	p0 := pieces[0]
+	// Step 1: we install the plugin into our existing command space.
+	//
+	// For simple plugins with one piece, this is easy. For more complex,
+	// or for managed plugins, this is a bit more confusing.
+	//
+	// How: we first "find" the path to the plugin and then install
+	// anything new recursively.
+	//
+	// Simple: .rpk-foo, we do not recurse. We find "foo" does not exist,
+	// and then we add the command under "rpk".
+	//
+	// Complex: .rpk-foo_bar, we see "foo" does not exist and install it
+	// under "rpk", then we recurse and see "bar" does not exist and
+	// install it under "rpk".
+	//
+	// Managed: managed plugins are an agreement of the plugin name to how
+	// that name is managed within rpk. For example, the byoc plugin (named
+	// .rpk.managed-byoc) gets prefixed with rpk with "cloud", so that the
+	// plugin is installed at "rpk cloud byoc". This command also already
+	// exists, so the main thing we add here is exec and autocompletion of
+	// byoc subcommands.
 
-	childCmd, _, err := parentCmd.Find(pieces)
+	p0 := pieces[0]
+	childCmd, _, err := parentCmd.Find([]string{p0})
 
 	// If the command does not exist, then err will be non-nil. If the
 	// command does not exist and the parent does not have subcommands,
-	// then childCmd is equal to parentCmd. We also check nil to be sure.
+	// then childCmd is equal to parentCmd.
 	if err != nil || childCmd == nil || parentCmd == childCmd {
 		childCmd = &cobra.Command{
 			Use:                p0,
-			Short:              fmt.Sprintf("%s external plugin", p0),
+			Short:              p0 + pluginShortSuffix,
 			DisableFlagParsing: true,
+			Run: func(_ *cobra.Command, args []string) {
+				osExec(execPath, args)
+			},
 		}
 		parentCmd.AddCommand(childCmd)
 	}
 
 	if len(pieces) > 1 { // recursive: we are not done yet adding our nested command
 		args := pieces[1:]
-		addPluginWithExec(childCmd, args, execPath)
+		addPluginWithExec(childCmd, name, args, execPath, managedHook, fs)
 		return
 	}
 
-	childCmd.Run = func(_ *cobra.Command, args []string) { // base: we are at the last piece and can add our exec
-		new(osPluginHandler).exec(execPath, args)
-	}
-
-	// If the exec command has the rpk.ac- prefix, then the plugin
-	// signifies that it supports --help-autocomplete, and we can exec it
-	// quickly to get useful fields for the command.
-	if !strings.HasPrefix(filepath.Base(execPath), plugin.NamePrefixAutoComplete) {
+	// If the command does not indicate autocomplete and is not managed, we
+	// are done. Note that managed commands likely do not have any fake
+	// commands installed yet: managed commands receive additional logic in
+	// the autocompletion step.
+	base := filepath.Base(execPath)
+	if !strings.HasPrefix(base, plugin.NamePrefixAutoComplete) && !strings.HasPrefix(base, plugin.NamePrefixManaged) {
 		return
 	}
 
+	// Step 2: we exec the plugin with --help-autocomplete and we install
+	// autocompletion.
 	out, err := (&exec.Cmd{
 		Path: execPath,
 		Args: []string{execPath, plugin.FlagAutoComplete},
@@ -268,7 +230,7 @@ func addPluginWithExec(
 		return
 	}
 
-	addPluginHelp(childCmd, p0, helps, execPath)
+	addPluginHelp(childCmd, name, helps, execPath, managedHook, fs)
 }
 
 type pluginHelp struct {
@@ -287,24 +249,27 @@ var (
 // If a plugin supports --help-autocomplete, we exec it and add its commands to
 // rpk itself. This allows autocompletion to work across plugins.
 //
-// In this function, we validate the plugin's return, ensuring the paths it
-// returns for commands follows the convention we expect.
-//
 // We expect similar paths to the binary path of a plugin itself:
 //
-//	cloud_foo-bar corresponds to "rpk cloud foo bar"
-//	cloud_foo_bar corresponds to "rpk cloud foo-bar"
+//	cloud_foo_bar corresponds to "rpk cloud foo bar"
+//	cloud_foo-bar corresponds to "rpk cloud foo-bar"
 //	cloud         corresponds to "rpk cloud"
-//
-// For sanity, all returned paths must begin with the plugin name itself and a
-// dash. The only path that can be without a dash is a help for the plugin name
-// itself (e.g., "cloud").
 func addPluginHelp(
-	cmd *cobra.Command, pluginName string, helps []pluginHelp, execPath string,
+	cmd *cobra.Command,
+	pluginName string,
+	helps []pluginHelp,
+	execPath string,
+	managedHook plugin.ManagedHook,
+	fs afero.Fs,
 ) {
 	childPrefix := pluginName + "_"
 	uniques := make(map[string]pluginHelp, len(helps))
 	for _, h := range helps {
+		// Plugin help is supposed to be prefixed with the plugin name,
+		// but to support people renaming a plugin locally on disk, we
+		// strip the plugin's name and prefix with the on-disk name.
+		piece0 := strings.Split(h.Path, "_")[0]
+		h.Path = pluginName + strings.TrimPrefix(h.Path, piece0)
 		if _, exists := uniques[h.Path]; exists {
 			log.Debugf("invalid plugin help returned duplicate path %s", h.Path)
 			return
@@ -345,8 +310,13 @@ func addPluginHelp(
 		return
 	}
 
-	addPluginHelpToCmd(cmd, pluginName, us.help)
-	addPluginSubcommands(cmd, us, nil, execPath)
+	// For managed plugins, the plugin could be installed over an existing
+	// command. We want to keep the rpk version. Plugin installed commands
+	// all have the same prefix.
+	if strings.HasSuffix(cmd.Short, pluginShortSuffix) {
+		addPluginHelpToCmd(cmd, pluginName, us.help)
+	}
+	addPluginSubcommands(cmd, us, nil, execPath, managedHook, fs)
 }
 
 type useHelp struct {
@@ -375,28 +345,33 @@ func trackHelp(on *useHelp, pieces []string, help pluginHelp) {
 
 // As the final part of adding autocompletion for plugins, this function takes
 // our pre-built useHelp which is shaped like our desired cobra.Command's and
-// actually creates that shape.
-//
-// We always have to track the leading pieces for each subcommand, so that when
-// we exec the plugin, we re-create the args that we passed to and consumed by
-// rpk.
+// actually creates the fake command space.
 func addPluginSubcommands(
 	parentCmd *cobra.Command,
 	parentHelp *useHelp,
 	leadingPieces []string,
 	execPath string,
+	managedHook plugin.ManagedHook,
+	fs afero.Fs,
 ) {
 	for childUse, childHelp := range parentHelp.inner {
 		childCmd := &cobra.Command{
 			Short:              fmt.Sprintf("%s external plugin", childUse),
 			DisableFlagParsing: true,
 			Run: func(cmd *cobra.Command, args []string) {
-				new(osPluginHandler).exec(execPath, append(append(leadingPieces, cmd.Use), args...))
+				osExec(execPath, append(append(leadingPieces, cmd.Use), args...))
 			},
 		}
 		addPluginHelpToCmd(childCmd, childUse, childHelp.help)
+
+		// Step 3, from way above: if this is a managed command, we now
+		// (finally) need to hook this fake command's run through the
+		// managed hook.
+		if managedHook != nil {
+			childCmd = managedHook(childCmd, fs)
+		}
 		if childHelp.inner != nil {
-			addPluginSubcommands(childCmd, childHelp, append(leadingPieces, childCmd.Use), execPath)
+			addPluginSubcommands(childCmd, childHelp, append(leadingPieces, childCmd.Use), execPath, managedHook, fs)
 		}
 
 		parentCmd.AddCommand(childCmd)
@@ -420,14 +395,7 @@ func addPluginHelpToCmd(cmd *cobra.Command, use string, h pluginHelp) {
 	}
 }
 
-type osPluginHandler struct{}
-
-func (*osPluginHandler) lookPath(file string) (string, bool) {
-	path, err := exec.LookPath(file)
-	return path, err == nil
-}
-
-func (*osPluginHandler) exec(path string, args []string) error {
+func osExec(path string, args []string) error {
 	args = append([]string{path}, args...)
 	env := os.Environ()
 	if runtime.GOOS == "windows" {

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -76,7 +76,7 @@ func Execute() {
 
 	root.AddCommand(
 		acl.NewCommand(fs),
-		cloud.NewCommand(fs),
+		cloud.NewCommand(fs, osExec),
 		cluster.NewCommand(fs),
 		container.NewCommand(),
 		debug.NewCommand(fs),

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -205,7 +205,7 @@ func addPluginWithExec(
 	// commands installed yet: managed commands receive additional logic in
 	// the autocompletion step.
 	base := filepath.Base(execPath)
-	if !strings.HasPrefix(base, plugin.NamePrefixAutoComplete) && !strings.HasPrefix(base, plugin.NamePrefixManaged) {
+	if !plugin.IsAutoComplete(base) && !plugin.IsManaged(base) {
 		return
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/root_test.go
+++ b/src/go/rpk/pkg/cli/cmd/root_test.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -18,124 +15,6 @@ func TestLogOutput(t *testing.T) {
 	// Execute should have configured logrus's global logger instance to log to
 	// STDOUT.
 	require.Exactly(t, os.Stdout, logrus.StandardLogger().Out)
-}
-
-func TestTryExecPlugin(t *testing.T) {
-	fs := func() testPluginHandler {
-		return testPluginHandler{
-			".rpk-foo-bar_baz":     nil,
-			".rpk-foo-bar":         nil,
-			".rpk-fizz_buzz_bizzy": nil,
-		}
-	}
-	hit := func(file, args string) testPluginHandler {
-		h := fs()
-		h[".rpk-"+file] = map[string]int{args: 1}
-		return h
-	}
-
-	for _, test := range []struct {
-		name      string
-		args      []string
-		exp       testPluginHandler
-		unhandled bool
-	}{
-		{
-			name: "prefer longest command match",
-			args: []string{"foo-bar", "baz"},
-			exp:  hit("foo-bar_baz", ""),
-		},
-
-		{
-			name: "match shorter command if not all pieces specified",
-			args: []string{"foo-bar", "--baz"},
-			exp:  hit("foo-bar", "--baz"),
-		},
-
-		{
-			name: "match shorter command, flag with argument",
-			args: []string{"foo-bar", "--baz", "buzz"},
-			exp:  hit("foo-bar", "--baz\x00buzz"),
-		},
-
-		{
-			name: "match shorter command, no flags",
-			args: []string{"foo-bar"},
-			exp:  hit("foo-bar", ""),
-		},
-
-		{
-			name: "pieces joined with dash",
-			args: []string{"fizz", "buzz", "bizzy"},
-			exp:  hit("fizz_buzz_bizzy", ""),
-		},
-
-		{
-			name:      "no plugin found",
-			args:      []string{"unknown", "unknown", "unknown"},
-			exp:       fs(),
-			unhandled: true,
-		},
-
-		{
-			name:      "exec error returns error",
-			args:      []string{testPluginFileExecError},
-			exp:       fs(),
-			unhandled: true,
-		},
-
-		{
-			name:      "no args is unhandled",
-			args:      []string{},
-			exp:       fs(),
-			unhandled: true,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			fs := fs()
-			foundPath, err := tryExecPlugin(fs, test.args)
-			if err != nil {
-				if len(test.args) > 0 && test.args[1] != "ERROR" {
-					t.Errorf("unexpected tryExecPlugin error for arg0 %s: %v", test.args[0], err)
-				}
-				return
-			}
-			if !test.unhandled && len(foundPath) == 0 {
-				t.Error("foundPath is unexpectedly empty")
-			}
-			require.Equal(t, fs, test.exp, "%s fs not as expected", test.name)
-		})
-	}
-}
-
-const (
-	testPluginPathPrefix    = "/test/plugin/path/"
-	testPluginFileExecError = "ERROR"
-)
-
-type testPluginHandler map[string]map[string]int // path => args used => # times calledk
-
-func (t testPluginHandler) lookPath(file string) (string, bool) {
-	_, ok := t[file]
-	return testPluginPathPrefix + file, ok
-}
-
-func (t testPluginHandler) exec(path string, args []string) error {
-	if !strings.HasPrefix(path, testPluginPathPrefix) {
-		return fmt.Errorf("missing expected plugin path prefix %s", testPluginPathPrefix)
-	}
-	file := strings.TrimPrefix(path, testPluginPathPrefix)
-	if file == testPluginFileExecError {
-		return errors.New("error")
-	}
-	argHits := t[file]
-	if argHits == nil {
-		argHits = make(map[string]int)
-		t[file] = argHits
-	}
-	joined := strings.Join(args, "\x00")
-	argHits[joined]++
-	return nil
 }
 
 func TestAddPluginWithExec(t *testing.T) {
@@ -155,15 +34,15 @@ func TestAddPluginWithExec(t *testing.T) {
 		return child
 	}
 
-	addPluginWithExec(root, []string{"foo", "bar"}, "") // we cannot test exec path, so we leave empty
+	addPluginWithExec(root, "foo", []string{"foo", "bar"}, "", nil, nil) // we cannot test exec path, so we leave empty
 	assert.Equal(t, []string{"foo"}, subcommands(root), "expected one subcommand of root to be [foo]")
 	assert.Equal(t, []string{"bar"}, subcommands(find(root, []string{"foo"})), "expected one subcommand of root foo to be [bar]")
 
-	addPluginWithExec(root, []string{"foo", "baz"}, "")
+	addPluginWithExec(root, "foo", []string{"foo", "baz"}, "", nil, nil)
 	assert.Equal(t, []string{"foo"}, subcommands(root), "expected one subcommand of root to still be [foo]")
 	assert.Equal(t, []string{"bar", "baz"}, subcommands(find(root, []string{"foo"})), "expected two subcommands of root foo to be [bar, baz]")
 
-	addPluginWithExec(root, []string{"fizz"}, "")
+	addPluginWithExec(root, "fizz", []string{"fizz"}, "", nil, nil)
 	assert.Equal(t, []string{"fizz", "foo"}, subcommands(root), "expected one subcommand of root to be [fizz, foo]")
 	assert.Equal(t, []string{"bar", "baz"}, subcommands(find(root, []string{"foo"})), "expected two subcommands of root foo to still be [bar, baz]")
 	assert.Equal(t, []string(nil), subcommands(find(root, []string{"fizz"})), "expected no subcommands under fizz")

--- a/src/go/rpk/pkg/cloudapi/api_cluster.go
+++ b/src/go/rpk/pkg/cloudapi/api_cluster.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloudapi
+
+import (
+	"context"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+)
+
+const clusterPath = "/api/v1/clusters"
+
+// ClusterSpec contains the current spec for a cluster.
+type ClusterSpec struct {
+	InstallPackVersion string `json:"installPackVersion"`
+}
+
+// Cluster contains information about a Redpanda cluster.
+type Cluster struct {
+	NameID
+
+	Spec ClusterSpec `json:"spec"`
+}
+
+// Cluster returns information about a Redpanda cluster.
+func (cl *Client) Cluster(ctx context.Context, clusterID string) (c Cluster, err error) {
+	path := httpapi.Pathfmt(clusterPath+"/%s", clusterID)
+	return c, cl.cl.Get(ctx, path, nil, &c)
+}

--- a/src/go/rpk/pkg/cloudapi/api_installpack.go
+++ b/src/go/rpk/pkg/cloudapi/api_installpack.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloudapi
+
+import (
+	"context"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+)
+
+const installpackPath = "/api/v1/clusters-resources/install-pack-versions"
+
+// InstallPackArtifact contains an artifact name and version.
+type InstallPackArtifact struct {
+	Name           string `json:"name"`
+	Version        string `json:"version"`
+	Location       string `json:"location"`
+	ChecksumSHA256 string `json:"checksumSha256"`
+}
+
+type InstallPackArtifacts []InstallPackArtifact
+
+// Find returns the arftifact if it exists.
+func (as InstallPackArtifacts) Find(name string) (InstallPackArtifact, bool) {
+	for _, a := range as {
+		if a.Name == name {
+			return a, true
+		}
+	}
+	return InstallPackArtifact{}, false
+}
+
+// InstallPack contains pinned versions for an install pack.
+type InstallPack struct {
+	ID        string               `json:"id"`
+	Artifacts InstallPackArtifacts `json:"artifacts"`
+}
+
+// Cluster returns information about a Redpanda cluster.
+func (cl *Client) InstallPack(ctx context.Context, version string) (p InstallPack, err error) {
+	path := httpapi.Pathfmt(installpackPath+"/%s", version)
+	return p, cl.cl.Get(ctx, path, nil, &p)
+}

--- a/src/go/rpk/pkg/cloudapi/cloudapi.go
+++ b/src/go/rpk/pkg/cloudapi/cloudapi.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package cloudapi provides a client to talk to the Redpanda Cloud API.
+package cloudapi
+
+import (
+	"sort"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+)
+
+// Client talks to the cloud API.
+type Client struct {
+	cl *httpapi.Client
+}
+
+// NewClient initializes and returns a client for talking to the cloud API.
+// If the host is empty, this defaults to the prod API host.
+func NewClient(host, authToken string) *Client {
+	if host == "" {
+		host = "https://cloud-api.prd.cloud.redpanda.com"
+	}
+	return &Client{
+		cl: httpapi.NewClient(
+			httpapi.Host(host),
+			httpapi.BearerAuth(authToken),
+		),
+	}
+}
+
+// NameID is a common type used in may endpoints / many structs.
+type NameID struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Less returns whether this name is less than the other name.
+func (n NameID) Less(other NameID) bool {
+	return n.Name < other.Name || n.Name == other.Name && n.ID < other.ID
+}
+
+// NameIDs is an alias for a slice of names; this exists to provide
+// an easy sorting method.
+type NameIDs []NameID
+
+// Sort allows for sorting before returning from API requests.
+func (nids NameIDs) Sort() { sort.Slice(nids, func(i, j int) bool { return nids[i].Less(nids[j]) }) }

--- a/src/go/rpk/pkg/plugin/managed.go
+++ b/src/go/rpk/pkg/plugin/managed.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package plugin
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+var (
+	managedMu sync.Mutex
+	managed   = make(map[string]regManaged)
+)
+
+// ManagedHook is a hook to be called with the given fake-plugin-installed exec
+// command and return a potentially wrapped command.
+type ManagedHook func(*cobra.Command, afero.Fs) *cobra.Command
+
+type regManaged struct {
+	replaceArgs []string
+	hook        ManagedHook
+}
+
+// RegisterManaged registers a plugin name to replacement args and a hook
+// command.
+//
+// Replacement arguments replace the first argument of the plugin: Replacement
+// args ["cloud", "byoc"] can replace "byoc" to install the byoc plugin at "rpk
+// cloud byoc". Only the first argument is ever replaced, and if there are no
+// replacement args, the plugin name is kept as is.
+//
+// The hook allows intercepting fake-plugin-exec-commands before the exec is
+// actually ran. This can be used to login or attach extra flags.
+func RegisterManaged(name string, replaceArgs []string, hook ManagedHook) {
+	managedMu.Lock()
+	defer managedMu.Unlock()
+	if _, exists := managed[name]; exists {
+		panic(fmt.Sprintf("doubly managed plugin %s", name))
+	}
+	managed[name] = regManaged{
+		replaceArgs: replaceArgs,
+		hook:        hook,
+	}
+}
+
+// LookupManaged looks up if a plugin is managed. If so, this potentially
+// replaces arguments and returns the managed hook to use on the command.
+// If not, this returns the plugin unmodified and no hook.
+func LookupManaged(plugin Plugin) (Plugin, ManagedHook) {
+	managedMu.Lock()
+	defer managedMu.Unlock()
+	reg, ok := managed[plugin.Name]
+	if !ok {
+		return plugin, nil
+	}
+	if len(reg.replaceArgs) > 0 {
+		plugin.Arguments = append(reg.replaceArgs, plugin.Arguments[1:]...)
+	}
+	return plugin, reg.hook
+}

--- a/src/go/rpk/pkg/plugin/manifest.go
+++ b/src/go/rpk/pkg/plugin/manifest.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 	"runtime"
 	"sort"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -177,12 +176,6 @@ func (p *ManifestPlugin) Download(baseURL, os, host string) ([]byte, error) {
 		return nil, err // error already annotated
 	}
 
-	if decompress && !strings.HasSuffix(path, ".gz") {
-		// Download expects ".gz" to auto-decompress. Our plugin should
-		// have this, but just in case...
-		path += ".gz"
-	}
-
 	u := baseURL + path
-	return Download(context.Background(), u, sha)
+	return Download(context.Background(), u, decompress, sha)
 }

--- a/src/go/rpk/pkg/plugin/manifest.go
+++ b/src/go/rpk/pkg/plugin/manifest.go
@@ -1,11 +1,16 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package plugin
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -172,52 +177,12 @@ func (p *ManifestPlugin) Download(baseURL, os, host string) ([]byte, error) {
 		return nil, err // error already annotated
 	}
 
+	if decompress && !strings.HasSuffix(path, ".gz") {
+		// Download expects ".gz" to auto-decompress. Our plugin should
+		// have this, but just in case...
+		path += ".gz"
+	}
+
 	u := baseURL + path
-	req, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodGet,
-		u,
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create request %s: %v", u, err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("unable to issue request to %s: %v", u, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("unsuccessful plugin response from %s, status: %s", u, http.StatusText(resp.StatusCode))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read response from %s: %v", u, err)
-	}
-
-	if decompress {
-		gzr, err := gzip.NewReader(bytes.NewBuffer(body))
-		if err != nil {
-			return nil, fmt.Errorf("unable to create gzip reader: %w", err)
-		}
-		if body, err = io.ReadAll(gzr); err != nil {
-			return nil, fmt.Errorf("unable to gzip decompress plugin: %w", err)
-		}
-		if err = gzr.Close(); err != nil {
-			return nil, fmt.Errorf("unable to close gzip reader: %w", err)
-		}
-	}
-
-	shasum := sha256.Sum256(body)
-	gotsha := strings.ToLower(hex.EncodeToString(shasum[:]))
-	expsha := strings.ToLower(sha)
-
-	if gotsha != expsha {
-		return nil, fmt.Errorf("checksum of plugin %s does not match what the manifest specifies (downloaded sha256sum: %s, manifest specified sha256sum: %s)", u, gotsha, expsha)
-	}
-
-	return body, nil
+	return Download(context.Background(), u, sha)
 }

--- a/src/go/rpk/pkg/plugin/manifest_test.go
+++ b/src/go/rpk/pkg/plugin/manifest_test.go
@@ -1,3 +1,12 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package plugin
 
 import (

--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -94,6 +94,16 @@ func IsManaged(name string) bool {
 	return calcName(name).managed
 }
 
+// IsSamePluginPath returns true if an old plugin path is the "same" as a new
+// plugin path. Two paths are the same if they live in the same directory and
+// have the same non-prefix name. The prefix is ignored.
+func IsSamePluginPath(oldPath, newPath string) bool {
+	ldir, rdir := filepath.Dir(oldPath), filepath.Dir(newPath)
+	lbase, rbase := filepath.Base(oldPath), filepath.Base(newPath)
+	l, r := calcName(lbase), calcName(rbase)
+	return ldir == rdir && l.rest == r.rest
+}
+
 // Plugin groups information about a plugin's location on disk with the
 // arguments to call the plugin.
 //

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -20,19 +20,18 @@ func TestListPlugins(t *testing.T) {
 	t.Parallel()
 
 	fs := testfs.FromMap(map[string]testfs.Fmode{
-		"/usr/local/sbin/.rpk-non_executable":         {Mode: 0o666, Contents: ""},
-		"/usr/local/sbin/.rpk-barely_executable":      {Mode: 0o100, Contents: ""},
-		"/bin/.rpk-barely_executable":                 {Mode: 0o100, Contents: "shadowed!"},
-		"/bin/.rpk.ac-barely_executable":              {Mode: 0o100, Contents: "also shadowed!"},
-		"/bin/.rpk.ac-auto_completed":                 {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.0123456789abcdef7890.managed-man2": {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.managed-man2_nested":               {Mode: 0o777, Contents: ""},
-		"/bin/has/dir/":                               {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.ac-":                               {Mode: 0o777, Contents: "empty name ignored"},
-		"/bin/.rpk-":                                  {Mode: 0o777, Contents: "empty name ignored"},
-		"/bin/.rpkunrelated":                          {Mode: 0o777, Contents: ""},
-		"/bin/rpk-nodot":                              {Mode: 0o777, Contents: ""},
-		"/unsearched/.rpk-valid_unused":               {Mode: 0o777, Contents: ""},
+		"/usr/local/sbin/.rpk-non_executable":    {Mode: 0o666, Contents: ""},
+		"/usr/local/sbin/.rpk-barely_executable": {Mode: 0o100, Contents: ""},
+		"/bin/.rpk-barely_executable":            {Mode: 0o100, Contents: "shadowed!"},
+		"/bin/.rpk.ac-barely_executable":         {Mode: 0o100, Contents: "also shadowed!"},
+		"/bin/.rpk.ac-auto_completed":            {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.managed-man2_nested":          {Mode: 0o777, Contents: ""},
+		"/bin/has/dir/":                          {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.ac-":                          {Mode: 0o777, Contents: "empty name ignored"},
+		"/bin/.rpk-":                             {Mode: 0o777, Contents: "empty name ignored"},
+		"/bin/.rpkunrelated":                     {Mode: 0o777, Contents: ""},
+		"/bin/rpk-nodot":                         {Mode: 0o777, Contents: ""},
+		"/unsearched/.rpk-valid_unused":          {Mode: 0o777, Contents: ""},
 	})
 
 	got := ListPlugins(fs, []string{
@@ -56,13 +55,6 @@ func TestListPlugins(t *testing.T) {
 				"/bin/.rpk-barely_executable",
 				"/bin/.rpk.ac-barely_executable",
 			},
-		},
-		{
-			Name:        "man2",
-			Path:        "/bin/.rpk.0123456789abcdef7890.managed-man2",
-			Arguments:   []string{"man2"},
-			Managed:     true,
-			FilenameSHA: "0123456789abcdef7890",
 		},
 		{
 			Name:      "man2",
@@ -117,24 +109,24 @@ func TestWriteBinary(t *testing.T) {
 	})
 
 	{
-		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), "", true, false)
+		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), true, false)
 		require.NoError(t, err, "creating an autocomplete binary failed")
 		require.Equal(t, "/bin/.rpk.ac-autocomplete", dst, "binary path not as expected")
 	}
 	{
-		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), "", false, false)
+		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), false, false)
 		require.NoError(t, err, "creating a non-autocomplete binary failed")
 		require.Equal(t, "/usr/bin/.rpk-non-auto", dst, "binary path not as expected")
 	}
 	{
-		dst, err := WriteBinary(fs, "managed", "/usr/bin", []byte("m"), "0123456789abcdef7890123", false, true)
+		dst, err := WriteBinary(fs, "managed", "/usr/bin", []byte("m"), false, true)
 		require.NoError(t, err, "creating a managed binary failed")
-		require.Equal(t, "/usr/bin/.rpk.0123456789abcdef7890.managed-managed", dst, "binary path not as expected")
+		require.Equal(t, "/usr/bin/.rpk.managed-managed", dst, "binary path not as expected")
 	}
 
 	testfs.Expect(t, fs, map[string]testfs.Fmode{
-		"/bin/.rpk.ac-autocomplete":                          {Mode: 0o755, Contents: "ac"},
-		"/usr/bin/.rpk-non-auto":                             {Mode: 0o755, Contents: "nonac"},
-		"/usr/bin/.rpk.0123456789abcdef7890.managed-managed": {Mode: 0o755, Contents: "m"},
+		"/bin/.rpk.ac-autocomplete":     {Mode: 0o755, Contents: "ac"},
+		"/usr/bin/.rpk-non-auto":        {Mode: 0o755, Contents: "nonac"},
+		"/usr/bin/.rpk.managed-managed": {Mode: 0o755, Contents: "m"},
 	})
 }

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -20,19 +20,19 @@ func TestListPlugins(t *testing.T) {
 	t.Parallel()
 
 	fs := testfs.FromMap(map[string]testfs.Fmode{
-		"/usr/local/sbin/.rpk-non_executable":    {Mode: 0o666, Contents: ""},
-		"/usr/local/sbin/.rpk-barely_executable": {Mode: 0o100, Contents: ""},
-		"/bin/.rpk-barely_executable":            {Mode: 0o100, Contents: "shadowed!"},
-		"/bin/.rpk.ac-barely_executable":         {Mode: 0o100, Contents: "also shadowed!"},
-		"/bin/.rpk.ac-auto_completed":            {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.managed-man2":                 {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.managed-man2_nested":          {Mode: 0o777, Contents: ""},
-		"/bin/has/dir/":                          {Mode: 0o777, Contents: ""},
-		"/bin/.rpk.ac-":                          {Mode: 0o777, Contents: "empty name ignored"},
-		"/bin/.rpk-":                             {Mode: 0o777, Contents: "empty name ignored"},
-		"/bin/.rpkunrelated":                     {Mode: 0o777, Contents: ""},
-		"/bin/rpk-nodot":                         {Mode: 0o777, Contents: ""},
-		"/unsearched/.rpk-valid_unused":          {Mode: 0o777, Contents: ""},
+		"/usr/local/sbin/.rpk-non_executable":         {Mode: 0o666, Contents: ""},
+		"/usr/local/sbin/.rpk-barely_executable":      {Mode: 0o100, Contents: ""},
+		"/bin/.rpk-barely_executable":                 {Mode: 0o100, Contents: "shadowed!"},
+		"/bin/.rpk.ac-barely_executable":              {Mode: 0o100, Contents: "also shadowed!"},
+		"/bin/.rpk.ac-auto_completed":                 {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.0123456789abcdef7890.managed-man2": {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.managed-man2_nested":               {Mode: 0o777, Contents: ""},
+		"/bin/has/dir/":                               {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.ac-":                               {Mode: 0o777, Contents: "empty name ignored"},
+		"/bin/.rpk-":                                  {Mode: 0o777, Contents: "empty name ignored"},
+		"/bin/.rpkunrelated":                          {Mode: 0o777, Contents: ""},
+		"/bin/rpk-nodot":                              {Mode: 0o777, Contents: ""},
+		"/unsearched/.rpk-valid_unused":               {Mode: 0o777, Contents: ""},
 	})
 
 	got := ListPlugins(fs, []string{
@@ -58,10 +58,11 @@ func TestListPlugins(t *testing.T) {
 			},
 		},
 		{
-			Name:      "man2",
-			Path:      "/bin/.rpk.managed-man2",
-			Arguments: []string{"man2"},
-			Managed:   true,
+			Name:        "man2",
+			Path:        "/bin/.rpk.0123456789abcdef7890.managed-man2",
+			Arguments:   []string{"man2"},
+			Managed:     true,
+			FilenameSHA: "0123456789abcdef7890",
 		},
 		{
 			Name:      "man2",
@@ -116,24 +117,24 @@ func TestWriteBinary(t *testing.T) {
 	})
 
 	{
-		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), true, false)
+		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), "", true, false)
 		require.NoError(t, err, "creating an autocomplete binary failed")
 		require.Equal(t, "/bin/.rpk.ac-autocomplete", dst, "binary path not as expected")
 	}
 	{
-		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), false, false)
+		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), "", false, false)
 		require.NoError(t, err, "creating a non-autocomplete binary failed")
 		require.Equal(t, "/usr/bin/.rpk-non-auto", dst, "binary path not as expected")
 	}
 	{
-		dst, err := WriteBinary(fs, "managed", "/usr/bin", []byte("m"), false, true)
+		dst, err := WriteBinary(fs, "managed", "/usr/bin", []byte("m"), "0123456789abcdef7890123", false, true)
 		require.NoError(t, err, "creating a managed binary failed")
-		require.Equal(t, "/usr/bin/.rpk.managed-managed", dst, "binary path not as expected")
+		require.Equal(t, "/usr/bin/.rpk.0123456789abcdef7890.managed-managed", dst, "binary path not as expected")
 	}
 
 	testfs.Expect(t, fs, map[string]testfs.Fmode{
-		"/bin/.rpk.ac-autocomplete":     {Mode: 0o755, Contents: "ac"},
-		"/usr/bin/.rpk-non-auto":        {Mode: 0o755, Contents: "nonac"},
-		"/usr/bin/.rpk.managed-managed": {Mode: 0o755, Contents: "m"},
+		"/bin/.rpk.ac-autocomplete":                          {Mode: 0o755, Contents: "ac"},
+		"/usr/bin/.rpk-non-auto":                             {Mode: 0o755, Contents: "nonac"},
+		"/usr/bin/.rpk.0123456789abcdef7890.managed-managed": {Mode: 0o755, Contents: "m"},
 	})
 }

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -1,3 +1,12 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package plugin
 
 import (
@@ -16,6 +25,7 @@ func TestListPlugins(t *testing.T) {
 		"/bin/.rpk-barely_executable":            {Mode: 0o100, Contents: "shadowed!"},
 		"/bin/.rpk.ac-barely_executable":         {Mode: 0o100, Contents: "also shadowed!"},
 		"/bin/.rpk.ac-auto_completed":            {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.managed-man2":                 {Mode: 0o777, Contents: ""},
 		"/bin/has/dir/":                          {Mode: 0o777, Contents: ""},
 		"/bin/.rpk.ac-":                          {Mode: 0o777, Contents: "empty name ignored"},
 		"/bin/.rpk-":                             {Mode: 0o777, Contents: "empty name ignored"},
@@ -43,6 +53,11 @@ func TestListPlugins(t *testing.T) {
 		{
 			Path:      "/bin/.rpk.ac-auto_completed",
 			Arguments: []string{"auto", "completed"},
+		},
+		{
+			Path:      "/bin/.rpk.managed-man2",
+			Arguments: []string{"man2"},
+			Managed:   true,
 		},
 	}
 
@@ -91,18 +106,24 @@ func TestWriteBinary(t *testing.T) {
 	})
 
 	{
-		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), true)
+		dst, err := WriteBinary(fs, "autocomplete", "/bin/", []byte("ac"), true, false)
 		require.NoError(t, err, "creating an autocomplete binary failed")
 		require.Equal(t, "/bin/.rpk.ac-autocomplete", dst, "binary path not as expected")
 	}
 	{
-		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), false)
+		dst, err := WriteBinary(fs, "non-auto", "/usr/bin", []byte("nonac"), false, false)
 		require.NoError(t, err, "creating a non-autocomplete binary failed")
 		require.Equal(t, "/usr/bin/.rpk-non-auto", dst, "binary path not as expected")
 	}
+	{
+		dst, err := WriteBinary(fs, "managed", "/usr/bin", []byte("m"), false, true)
+		require.NoError(t, err, "creating a managed binary failed")
+		require.Equal(t, "/usr/bin/.rpk.managed-managed", dst, "binary path not as expected")
+	}
 
 	testfs.Expect(t, fs, map[string]testfs.Fmode{
-		"/bin/.rpk.ac-autocomplete": {Mode: 0o755, Contents: "ac"},
-		"/usr/bin/.rpk-non-auto":    {Mode: 0o755, Contents: "nonac"},
+		"/bin/.rpk.ac-autocomplete":     {Mode: 0o755, Contents: "ac"},
+		"/usr/bin/.rpk-non-auto":        {Mode: 0o755, Contents: "nonac"},
+		"/usr/bin/.rpk.managed-managed": {Mode: 0o755, Contents: "m"},
 	})
 }

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -26,6 +26,7 @@ func TestListPlugins(t *testing.T) {
 		"/bin/.rpk.ac-barely_executable":         {Mode: 0o100, Contents: "also shadowed!"},
 		"/bin/.rpk.ac-auto_completed":            {Mode: 0o777, Contents: ""},
 		"/bin/.rpk.managed-man2":                 {Mode: 0o777, Contents: ""},
+		"/bin/.rpk.managed-man2_nested":          {Mode: 0o777, Contents: ""},
 		"/bin/has/dir/":                          {Mode: 0o777, Contents: ""},
 		"/bin/.rpk.ac-":                          {Mode: 0o777, Contents: "empty name ignored"},
 		"/bin/.rpk-":                             {Mode: 0o777, Contents: "empty name ignored"},
@@ -43,6 +44,12 @@ func TestListPlugins(t *testing.T) {
 
 	exp := Plugins{
 		{
+			Name:      "auto",
+			Path:      "/bin/.rpk.ac-auto_completed",
+			Arguments: []string{"auto", "completed"},
+		},
+		{
+			Name:      "barely",
 			Path:      "/usr/local/sbin/.rpk-barely_executable",
 			Arguments: []string{"barely", "executable"},
 			ShadowedPaths: []string{
@@ -51,12 +58,15 @@ func TestListPlugins(t *testing.T) {
 			},
 		},
 		{
-			Path:      "/bin/.rpk.ac-auto_completed",
-			Arguments: []string{"auto", "completed"},
-		},
-		{
+			Name:      "man2",
 			Path:      "/bin/.rpk.managed-man2",
 			Arguments: []string{"man2"},
+			Managed:   true,
+		},
+		{
+			Name:      "man2",
+			Path:      "/bin/.rpk.managed-man2_nested",
+			Arguments: []string{"man2", "nested"},
 			Managed:   true,
 		},
 	}


### PR DESCRIPTION
## Cover letter

This adds an `rpk cloud byoc` shim that "manages" the byoc plugin directly. This is a new mode of plugins: rpk knows some things about what is needed for the plugin, and rpk manages those things before execing the plugin. rpk also execs the plugin with a few extra flags that the user did not specify.

With this, we avoid bundling the byoc code directly into rpk, but we make it very easy to download. If the user attempts to paste a command when the plugin is not yet downloaded, we download the plugin behind the scenes and exec it. We also always ensure the plugin is the version required as currently pinned in the cloud API.

This also modifies a bunch of plugin code to support this new change, and hopefully makes the plugin shadow command space in root.go easier to understand.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

This adds a new command, `rpk cloud byoc`.

## Release notes

### Features

* `rpk cloud` has a new `byoc` command, which manages the byoc plugin directly and makes it easier to use