### PR TITLE
load bare config with no defaults

### DIFF
--- a/src/go/k8s/cmd/configurator/main_test.go
+++ b/src/go/k8s/cmd/configurator/main_test.go
@@ -10,22 +10,14 @@
 package main
 
 import (
-	"fmt"
-	"log"
 	"testing"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPopulateRack(t *testing.T) {
-	fs := afero.NewOsFs()
-	p := config.Params{ConfigPath: ""}
-	cfg, err := p.Load(fs)
-	if err != nil {
-		log.Fatalf("%s", fmt.Errorf("unable to read the redpanda configuration file: %w", err))
-	}
+	cfg := &config.Config{}
 	tests := []struct {
 		Zone         string
 		ZoneID       string

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/redpanda-data/console/backend v0.0.0-20220728140642-884100150168
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20220726211426-9ad7e9d59990
-	github.com/spf13/afero v1.9.2
 	github.com/stretchr/testify v1.7.1
 	github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce
 	github.com/twmb/franz-go/pkg/kadm v1.3.0
@@ -101,6 +100,7 @@ require (
 	github.com/sethgrid/pester v1.2.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
## Cover letter

When using config.Load, developer defaults were leaking into the configuration. Since the rpk tooling isn't needed for this file, just replace it with basic yaml unmarshalling.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* fix a bug that configures all clusters as development clusters

<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
