### PR TITLE
Set license to be at the last part of reconciliation

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -115,10 +115,6 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.setLicense(ctx, &redpandaCluster, log); err != nil {
-		return ctrl.Result{}, fmt.Errorf("setting license: %w", err)
-	}
-
 	redpandaPorts := networking.NewRedpandaPorts(&redpandaCluster)
 	nodeports := collectNodePorts(redpandaPorts)
 	headlessPorts := collectHeadlessPorts(redpandaPorts)
@@ -264,7 +260,18 @@ func (r *ClusterReconciler) Reconcile(
 		log.Info(requeueErr.Error())
 		return ctrl.Result{RequeueAfter: requeueErr.RequeueAfter}, nil
 	}
-	return ctrl.Result{}, err
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// setting license should be at the last part as it requires AdminAPI to be running
+	if cc := redpandaCluster.Status.GetCondition(redpandav1alpha1.ClusterConfiguredConditionType); cc == nil || cc.Status != corev1.ConditionTrue {
+		return ctrl.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+	if err := r.setLicense(ctx, &redpandaCluster, log); err != nil {
+		return ctrl.Result{}, fmt.Errorf("setting license: %w", err)
+	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Cover letter
Setting license must be set at the end of reconciliation because it requires AdminAPI to be running.
`SetLicense` don't return specific errors and we don't currently enforce license in the Redpanda cluster.
This PR ignores set license errors and just requeues them after one minute.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Improvements

* Fixes license setting in Redpanda cluster

