### PR TITLE
Set Kafka SASL password as envar

### DIFF
--- a/src/go/k8s/pkg/console/configmap.go
+++ b/src/go/k8s/pkg/console/configmap.go
@@ -89,9 +89,8 @@ func (cm *ConfigMap) Ensure(ctx context.Context) error {
 		return err
 	}
 	username := string(secret.Data[corev1.BasicAuthUsernameKey])
-	password := string(secret.Data[corev1.BasicAuthPasswordKey])
 
-	config, err := cm.generateConsoleConfig(ctx, username, password)
+	config, err := cm.generateConsoleConfig(ctx, username)
 	if err != nil {
 		return err
 	}
@@ -135,13 +134,13 @@ func (cm *ConfigMap) Key() types.NamespacedName {
 // This should match the fields at https://github.com/redpanda-data/console/blob/master/docs/config/console.yaml
 // We are copying the fields instead of importing them because (1) they don't have json tags (2) some fields aren't ideal for K8s (e.g. TLS certs shouldn't be file paths but Secret reference)
 func (cm *ConfigMap) generateConsoleConfig(
-	ctx context.Context, username, password string,
+	ctx context.Context, username string,
 ) (configString string, err error) {
 	consoleConfig := &ConsoleConfig{
 		MetricsNamespace: cm.consoleobj.Spec.MetricsPrefix,
 		ServeFrontend:    cm.consoleobj.Spec.ServeFrontend,
 		Server:           cm.genServer(),
-		Kafka:            cm.genKafka(username, password),
+		Kafka:            cm.genKafka(username),
 		Enterprise:       cm.genEnterprise(),
 		Redpanda:         cm.genRedpanda(),
 	}
@@ -430,7 +429,7 @@ func (s *SecretTLSCa) useCaCert() bool {
 	return !s.UsePublicCerts && s.NodeSecretRef != nil
 }
 
-func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
+func (cm *ConfigMap) genKafka(username string) kafka.Config {
 	k := kafka.Config{
 		Brokers:  getBrokers(cm.clusterobj),
 		ClientID: fmt.Sprintf("redpanda-console-%s-%s", cm.consoleobj.GetNamespace(), cm.consoleobj.GetName()),
@@ -486,7 +485,6 @@ func (cm *ConfigMap) genKafka(username, password string) kafka.Config {
 		sasl = kafka.SASLConfig{
 			Enabled:   yes,
 			Username:  username,
-			Password:  password,
 			Mechanism: admin.ScramSha256,
 		}
 	}

--- a/src/go/k8s/pkg/console/deployment.go
+++ b/src/go/k8s/pkg/console/deployment.go
@@ -331,7 +331,8 @@ const (
 	enterpriseGoogleSAMountName = "enterprise-google-sa"
 	enterpriseGoogleSAMountPath = "/etc/console/enterprise/google"
 
-	prometheusBasicAuthPassowrdEnvVar = "CLOUD_PROMETHEUSENDPOINT_BASICAUTH_PASSWORD"
+	prometheusBasicAuthPasswordEnvVar = "CLOUD_PROMETHEUSENDPOINT_BASICAUTH_PASSWORD"
+	kafkaSASLBasicAuthPasswordEnvVar  = "KAFKA_SASL_PASSWORD" //nolint:gosec // not a secret
 )
 
 func (d *Deployment) getVolumes(ss map[string]string) []corev1.Volume {
@@ -502,17 +503,28 @@ func (d *Deployment) getContainers(ss map[string]string) []corev1.Container {
 	}
 }
 
-func (d *Deployment) genEnvVars() []corev1.EnvVar {
-	if d.consoleobj.Spec.Cloud == nil ||
-		d.consoleobj.Spec.Cloud.PrometheusEndpoint == nil ||
-		!d.consoleobj.Spec.Cloud.PrometheusEndpoint.Enabled {
-		return []corev1.EnvVar{}
+func (d *Deployment) genEnvVars() (envars []corev1.EnvVar) {
+	if d.clusterobj.IsSASLOnInternalEnabled() {
+		envars = append(envars, corev1.EnvVar{
+			Name: kafkaSASLBasicAuthPasswordEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: corev1.BasicAuthPasswordKey,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: KafkaSASecretKey(d.consoleobj).Name,
+					},
+				},
+			},
+		})
 	}
-	// the webhook enforces that the secret is in the same namespace as console
-	passwordRef := d.consoleobj.Spec.Cloud.PrometheusEndpoint.BasicAuth.PasswordRef
-	return []corev1.EnvVar{
-		{
-			Name: prometheusBasicAuthPassowrdEnvVar,
+
+	if d.consoleobj.Spec.Cloud != nil &&
+		d.consoleobj.Spec.Cloud.PrometheusEndpoint != nil &&
+		d.consoleobj.Spec.Cloud.PrometheusEndpoint.Enabled {
+		// the webhook enforces that the secret is in the same namespace as console
+		passwordRef := d.consoleobj.Spec.Cloud.PrometheusEndpoint.BasicAuth.PasswordRef
+		envars = append(envars, corev1.EnvVar{
+			Name: prometheusBasicAuthPasswordEnvVar,
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					Key: passwordRef.Key,
@@ -521,6 +533,8 @@ func (d *Deployment) genEnvVars() []corev1.EnvVar {
 					},
 				},
 			},
-		},
+		})
 	}
+
+	return envars
 }


### PR DESCRIPTION
## Cover letter

Instead of setting the Kafka SASL password in ConfigMap, set it as envar mounted from a Secret in the Deployment.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Improvements

* Set Kafka SASL password as environment variable
