### PR TITLE
archival: make archiver no-op for unit tests

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -146,7 +146,7 @@ public:
     ///
     /// \param lso_override last stable offset override
     /// \return future that returns number of uploaded/failed segments
-    ss::future<batch_result> upload_next_candidates(
+    virtual ss::future<batch_result> upload_next_candidates(
       std::optional<model::offset> last_stable_offset_override = std::nullopt);
 
     ss::future<cloud_storage::download_result> sync_manifest();
@@ -169,6 +169,8 @@ public:
     /// segments that are below the current start offset and segments
     /// that have been replaced with their compacted equivalent.
     ss::future<> garbage_collect();
+
+    virtual ~ntp_archiver() = default;
 
 private:
     /// Information about started upload

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -33,6 +33,8 @@
 namespace archival {
 namespace internal {
 
+class scheduler_service_accessor;
+
 using namespace std::chrono_literals;
 
 /// Shard-local archiver service.
@@ -46,6 +48,8 @@ using namespace std::chrono_literals;
 /// - Re-upload manifest(s)
 /// - Reset timer
 class scheduler_service_impl {
+    friend class scheduler_service_accessor;
+
 public:
     /// \brief create scheduler service
     ///


### PR DESCRIPTION


## Cover letter

When an archiver is created inside a unit test, it co-exists with another archiver which has been created by the redpanda app fixture. These two archivers run in parallel and may cause multiple issues with assertions. The http test server sees more requests than expected and the manifest gets advanced further than expected.

This change allows replacing the archiver in fixture with a no-op archiver. This allows the assertions in the unit test to solely depend on the archiver started by the test.

The no-op archiver should be put into the fixture before any data is generated by test to make sure there is no interference.

An existing test which used request masking is also converted to use no-op archiver. The request masking API is not removed from the imposter as it may be useful in other places.

Fixes #7116 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
