### PR TITLE
tests: register failure injectors

### DIFF
--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -49,12 +49,14 @@ class FailureSpec:
 class FailureInjector:
     def __init__(self, redpanda):
         self.redpanda = redpanda
+        self.uuid = self.redpanda.register_failure_injector(self)
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, value, traceback):
         self._heal_all()
+        self.redpanda.deregister_failure_injector(self.uuid)
 
     def inject_failure(self, spec):
         self.redpanda.logger.info(f"injecting failure: {spec}")


### PR DESCRIPTION
## Cover letter

This commit extends testing infra to keep track of created failure injectors and
warn when a tests finishes, but leaves behind an alive failure injector (this
accountability is desirable as stray failure injectors will impact subsequent tests).

Note that we don't actually make an attempt to stop the failure injectors. We simply
log when a violation happens. This should give us enough info to figure out where
the issues is and fix it at the call site.

## Backport Required
- [X] not a bug fix
...

## Release notes
* none