### PR TITLE
Fixed metadata dissemination race condition

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -130,15 +130,13 @@ ss::future<> health_monitor_backend::stop() {
 }
 
 cluster_health_report health_monitor_backend::build_cluster_report(
-  const cluster_report_filter& filter,
-  refreshed_metadata was_metadata_refreshed) {
+  const cluster_report_filter& filter) {
     std::vector<node_health_report> reports;
     std::vector<node_state> statuses;
     // refreshing node status is not expensive on leader, we can refresh it
     // every time
     if (_raft0->is_elected_leader()) {
         refresh_nodes_status();
-        was_metadata_refreshed = refreshed_metadata::yes;
     }
 
     auto nodes = filter.nodes.empty() ? _members.local().all_broker_ids()
@@ -160,8 +158,7 @@ cluster_health_report health_monitor_backend::build_cluster_report(
     return cluster_health_report{
       .raft0_leader = _raft0->get_leader_id(),
       .node_states = std::move(statuses),
-      .node_reports = std::move(reports),
-      .was_metadata_refreshed = was_metadata_refreshed};
+      .node_reports = std::move(reports)};
 }
 
 void health_monitor_backend::refresh_nodes_status() {
@@ -423,20 +420,18 @@ health_monitor_backend::get_cluster_health(
       "requesting cluster state report with filter: {}, force refresh: {}",
       filter,
       refresh);
-    auto [refreshed, ec] = co_await maybe_refresh_cluster_health(
-      refresh, deadline);
+    auto ec = co_await maybe_refresh_cluster_health(refresh, deadline);
     if (ec) {
         co_return ec;
     }
 
-    co_return build_cluster_report(filter, refreshed);
+    co_return build_cluster_report(filter);
 }
 
 ss::future<storage::disk_space_alert>
 health_monitor_backend::get_cluster_disk_health(
   force_refresh refresh, model::timeout_clock::time_point deadline) {
-    auto [refreshed, ec] = co_await maybe_refresh_cluster_health(
-      refresh, deadline);
+    auto ec = co_await maybe_refresh_cluster_health(refresh, deadline);
     if (ec) {
         vlog(clusterlog.warn, "Failed to refresh cluster health.");
         // No obvious choice what to return here; really, health data should be
@@ -450,7 +445,7 @@ health_monitor_backend::get_cluster_disk_health(
     co_return _reports_disk_health;
 }
 
-ss::future<std::pair<refreshed_metadata, std::error_code>>
+ss::future<std::error_code>
 health_monitor_backend::maybe_refresh_cluster_health(
   force_refresh refresh, model::timeout_clock::time_point deadline) {
     auto const need_refresh = refresh
@@ -473,21 +468,20 @@ health_monitor_backend::maybe_refresh_cluster_health(
                   rate,
                   "error refreshing cluster health state - {}",
                   err.message());
-                co_return std::make_pair(refreshed_metadata::no, err);
+                co_return err;
             }
         } catch (const ss::broken_semaphore&) {
             // Refresh was waiting on _refresh_mutex during shutdown
-            co_return std::make_pair(
-              refreshed_metadata::no, errc::shutting_down);
+            co_return errc::shutting_down;
         } catch (const ss::timed_out_error&) {
             vlog(
               clusterlog.info,
               "timed out when refreshing cluster health state, falling back to "
               "previous cluster health snapshot");
-            co_return std::make_pair(refreshed_metadata::no, errc::timeout);
+            co_return errc::timeout;
         }
     }
-    co_return std::make_pair(refreshed_metadata{need_refresh}, errc::success);
+    co_return errc::success;
 }
 
 ss::future<result<node_health_report>>
@@ -748,7 +742,7 @@ std::chrono::milliseconds health_monitor_backend::max_metadata_age() {
 ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
 health_monitor_backend::get_node_drain_status(
   model::node_id node_id, model::timeout_clock::time_point deadline) {
-    auto [refreshed, ec] = co_await maybe_refresh_cluster_health(
+    auto ec = co_await maybe_refresh_cluster_health(
       force_refresh::no, deadline);
     if (ec) {
         co_return ec;
@@ -765,7 +759,7 @@ health_monitor_backend::get_node_drain_status(
 ss::future<cluster_health_overview>
 health_monitor_backend::get_cluster_health_overview(
   model::timeout_clock::time_point deadline) {
-    auto [refreshed, ec] = co_await maybe_refresh_cluster_health(
+    auto ec = co_await maybe_refresh_cluster_health(
       force_refresh::no, deadline);
 
     cluster_health_overview ret;

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -118,15 +118,13 @@ private:
     ss::future<std::error_code> collect_cluster_health();
     ss::future<result<node_health_report>>
       collect_remote_node_health(model::node_id);
-    ss::future<std::pair<refreshed_metadata, std::error_code>>
-      maybe_refresh_cluster_health(
-        force_refresh, model::timeout_clock::time_point);
+    ss::future<std::error_code> maybe_refresh_cluster_health(
+      force_refresh, model::timeout_clock::time_point);
     ss::future<std::error_code> refresh_cluster_health_cache(force_refresh);
     ss::future<std::error_code>
       dispatch_refresh_cluster_health_request(model::node_id);
 
-    cluster_health_report
-    build_cluster_report(const cluster_report_filter&, refreshed_metadata);
+    cluster_health_report build_cluster_report(const cluster_report_filter&);
 
     std::optional<node_health_report>
     build_node_report(model::node_id, const node_report_filter&);

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -154,12 +154,8 @@ struct node_health_report
     }
 };
 
-using refreshed_metadata = ss::bool_class<struct refreshed_metadata_tag>;
 struct cluster_health_report
-  : serde::envelope<
-      cluster_health_report,
-      serde::version<1>,
-      serde::compat_version<0>> {
+  : serde::envelope<cluster_health_report, serde::version<0>> {
     static constexpr int8_t current_version = 0;
 
     std::optional<model::node_id> raft0_leader;
@@ -170,11 +166,6 @@ struct cluster_health_report
     // node reports are node specific information collected directly on a
     // node
     std::vector<node_health_report> node_reports;
-
-    // Hint indicating whether health metadata was refreshed before
-    // generating this report.
-    refreshed_metadata was_metadata_refreshed = refreshed_metadata::no;
-
     friend std::ostream&
     operator<<(std::ostream&, const cluster_health_report&);
 

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -371,10 +371,6 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
 
 ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
   cluster_health_report report) {
-    if (report.was_metadata_refreshed == refreshed_metadata::no) {
-        co_return;
-    }
-
     for (const auto& node_report : report.node_reports) {
         co_await _leaders.invoke_on_all(
           [&node_report](partition_leaders_table& leaders) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -367,6 +367,10 @@ public:
 
     std::vector<model::ntp> all_updates_in_progress() const;
 
+    model::revision_id last_applied_revision() const {
+        return _last_applied_revision_id;
+    }
+
 private:
     friend topic_table_probe;
 
@@ -396,6 +400,7 @@ private:
     hierarchy_t _topics_hierarchy;
 
     updates_t _updates_in_progress;
+    model::revision_id _last_applied_revision_id;
 
     std::vector<delta> _pending_deltas;
     std::vector<std::unique_ptr<waiter>> _waiters;


### PR DESCRIPTION
## Cover letter

As the metadata updates and leadership updates are asynchronous we must
tolerate reordering i.e. leadership update for already deleted
partitions or for not yet created one. Leadership table should not
apply updates for deleted partitions while keep applying updates for the
one that are not yet known.

Applied updates filtering based on the last applied revision. If the
topic doesn't exists in topics table but its revision is already known
to the table then the update will be discarded as the topic was already
deleted.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
