### PR TITLE
tests: make failure injector _heal more robust

### DIFF
--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -129,14 +129,20 @@ class FailureInjector:
         node.account.ssh(cmd)
 
     def _heal(self, node):
+        self.redpanda.logger.info(f"healing node {node.account.hostname}")
         try:
-            self.redpanda.logger.info(f"healing node {node.account.hostname}")
             cmd = "iptables -D OUTPUT -p tcp --destination-port 33145 -j DROP"
             node.account.ssh(cmd)
+        except Exception as e:
+            self.redpanda.logger.error(
+                f"Failed to clean up OUTPUT rule on {node.name}: {e}")
+
+        try:
             cmd = "iptables -D INPUT -p tcp --destination-port 33145 -j DROP"
             node.account.ssh(cmd)
-        except:
-            pass
+        except Exception as e:
+            self.redpanda.logger.error(
+                f"Failed to clean up INPUT rule on {node.name}: {e}")
 
     def _delete_netem(self, node):
         tc_netem.tc_netem_delete(node)


### PR DESCRIPTION
## Cover letter

- If something goes wrong cleaning the OUTPUT rule, don't let that stop us trying to clear the INPUT rule.
- Log exceptions so that we can see what is going wrong.

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none
