### PR TITLE
Disable `EndToEndShadowIndexingTestCompactedTopic` in debug mode

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -29,6 +29,7 @@ from rptest.util import (
     wait_for_removal_of_n_segments,
 )
 from rptest.utils.si_utils import S3Snapshot
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class EndToEndShadowIndexingBase(EndToEndTest):
@@ -127,7 +128,7 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         cleanup_policy="compact,delete",
         segment_bytes=EndToEndShadowIndexingBase.segment_size // 2), )
 
-    @ok_to_fail
+    @skip_debug_mode
     @cluster(num_nodes=5)
     def test_write(self):
         # Set compaction interval high at first, so we can get enough segments in log


### PR DESCRIPTION


## Cover letter

Disable debug build run for `EndToEndShadowIndexingTestCompactedTopic.test_write` test. The test is flacky on CI in debug and shows a lot of reactor stalls.

Also, remove the `ok_to_fail` decorator.

Fixes #7091

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none

### Features

* none

### Improvements

* none
