### PR TITLE
Small Improvements to RedpandaLicense feature

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_features.go
+++ b/src/go/rpk/pkg/api/admin/api_features.go
@@ -48,6 +48,7 @@ type LicenseProperties struct {
 	Organization string `json:"org"`
 	Type         string `json:"type"`
 	Expires      int64  `json:"expires"`
+	Checksum     string `json:"sha256"`
 }
 
 // GetFeatures returns information about the available features.

--- a/src/go/rpk/pkg/cli/cmd/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/license/info.go
@@ -53,8 +53,9 @@ func newInfoCommand(fs afero.Fs) *cobra.Command {
 						Organization string
 						Type         string
 						Expires      string
-						Expired      bool `json:"license_expired,omitempty"`
-					}{info.Properties.Organization, info.Properties.Type, tm, expired}, "", "  ")
+						Checksum     string `json:"ChecksumSHA256,omitempty"`
+						Expired      bool   `json:"license_expired,omitempty"`
+					}{info.Properties.Organization, info.Properties.Type, tm, info.Properties.Checksum, expired}, "", "  ")
 					out.MaybeDie(err, "unable to print license information as json: %v", err)
 					fmt.Printf("%s\n", props)
 				} else {

--- a/src/go/rpk/pkg/cli/cmd/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/license/info.go
@@ -50,10 +50,10 @@ func newInfoCommand(fs afero.Fs) *cobra.Command {
 				if format == "json" {
 					tm := time.Unix(info.Properties.Expires, 0).Format("Jan 2 2006")
 					props, err := json.MarshalIndent(struct {
-						Organization string
-						Type         string
-						Expires      string
-						Checksum     string `json:"ChecksumSHA256,omitempty"`
+						Organization string `json:"organization"`
+						Type         string `json:"type"`
+						Expires      string `json:"expires"`
+						Checksum     string `json:"checksum_sha256,omitempty"`
 						Expired      bool   `json:"license_expired,omitempty"`
 					}{info.Properties.Organization, info.Properties.Type, tm, info.Properties.Checksum, expired}, "", "  ")
 					out.MaybeDie(err, "unable to print license information as json: %v", err)

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -144,6 +144,10 @@
                 "expires": {
                     "type": "long",
                     "description": "Expiration date of the license in Unix epoch seconds"
+                },
+                "sha256": {
+                    "type": "string",
+                    "description": "Checksum (sha256) of the raw license data"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1808,6 +1808,7 @@ void admin_server::register_features_routes() {
               lc.org = license->organization;
               lc.type = security::license_type_to_string(license->type);
               lc.expires = license->expiry.count();
+              lc.sha256 = license->checksum;
               res.license = lc;
           }
           co_return std::move(res);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1836,6 +1836,13 @@ void admin_server::register_features_routes() {
                   throw ss::httpd::bad_request_exception(
                     fmt::format("License is expired: {}", license));
               }
+              const auto& ft = _controller->get_feature_table().local();
+              const auto& loaded_license = ft.get_license();
+              if (loaded_license && (*loaded_license == license)) {
+                  /// Loaded license is idential to license in request, do
+                  /// nothing and return 200(OK)
+                  co_return ss::json::json_void();
+              }
               auto& fm = _controller->get_feature_manager();
               auto err = co_await fm.invoke_on(
                 cluster::feature_manager::backend_shard,

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -11,6 +11,7 @@
 
 #include "security/license.h"
 
+#include "hashing/secure.h"
 #include "json/document.h"
 #include "json/validator.h"
 #include "utils/base64.h"
@@ -191,6 +192,16 @@ static void parse_data_section(license& lc, const json::Document& doc) {
     lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
 }
 
+static ss::sstring calculate_sha256_checksum(const ss::sstring& raw_license) {
+    bytes checksum;
+    hash_sha256 h;
+    h.update(raw_license);
+    const auto digest = h.reset();
+    checksum.resize(digest.size());
+    std::copy_n(digest.begin(), digest.size(), checksum.begin());
+    return to_hex(checksum);
+}
+
 license make_license(const ss::sstring& raw_license) {
     try {
         license lc;
@@ -205,6 +216,7 @@ license make_license(const ss::sstring& raw_license) {
             throw license_malformed_exception("Malformed data section");
         }
         parse_data_section(lc, doc);
+        lc.checksum = calculate_sha256_checksum(raw_license);
         return lc;
     } catch (const base64_decoder_exception&) {
         throw license_malformed_exception("Failed to decode data section");

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -62,15 +62,16 @@ inline std::ostream& operator<<(std::ostream& os, license_type lt) {
     return os;
 }
 
-struct license : serde::envelope<license, serde::version<0>> {
+struct license : serde::envelope<license, serde::version<1>> {
     /// Expected encoded contents
     uint8_t format_version;
     license_type type;
     ss::sstring organization;
     std::chrono::seconds expiry;
+    ss::sstring checksum;
 
     auto serde_fields() {
-        return std::tie(format_version, type, organization, expiry);
+        return std::tie(format_version, type, organization, expiry, checksum);
     }
 
     /// true if todays date is greater then \ref expiry

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -77,5 +77,8 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content) {
     BOOST_CHECK_EQUAL(license.type, license_type::enterprise);
     BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
     BOOST_CHECK_EQUAL(license.expiry.count(), 4813252273);
+    BOOST_CHECK_EQUAL(
+      license.checksum,
+      "2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf");
 }
 } // namespace security

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -188,10 +188,16 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
                 "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
             return
         expected_license_contents = {
-            'expires': 4813252273,
-            'format_version': 0,
-            'org': 'redpanda-testing',
-            'type': 'enterprise'
+            'expires':
+            4813252273,
+            'format_version':
+            0,
+            'org':
+            'redpanda-testing',
+            'type':
+            'enterprise',
+            'sha256':
+            '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf'
         }
 
         assert self.admin.put_license(license).status_code == 200

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -219,9 +219,14 @@ class RpkClusterTest(RedpandaTest):
             err_msg="unable to retrieve license information")
 
         expected_license = {
-            'Expires': "Jul 11 2122",
-            'Organization': 'redpanda-testing',
-            'Type': 'enterprise'
+            'Expires':
+            "Jul 11 2122",
+            'Organization':
+            'redpanda-testing',
+            'Type':
+            'enterprise',
+            'ChecksumSHA256':
+            '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf'
         }
         result = json.loads(rp_license)
         assert expected_license == result, result

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -219,13 +219,13 @@ class RpkClusterTest(RedpandaTest):
             err_msg="unable to retrieve license information")
 
         expected_license = {
-            'Expires':
+            'expires':
             "Jul 11 2122",
-            'Organization':
+            'organization':
             'redpanda-testing',
-            'Type':
+            'type':
             'enterprise',
-            'ChecksumSHA256':
+            'checksum_sha256':
             '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf'
         }
         result = json.loads(rp_license)


### PR DESCRIPTION
## Cover letter

Included in this patchset are two quality-of-life improvements to the internal redpanda license infrastructure.
1. Make PUT_license totally idempotent
    - PUT calls of the same identical license will do nothing. Previously another controller log message was written.
2. Have GET_license return the checksum of the current loaded license

Fixes: #7119

## example via rpk
```
➜  redpanda git:(license-improvements) ✗ rpk cluster license info  --format=json
{
  "Organization": "redpanda-testing",
  "Type": "enterprise",
  "Expires": "Jul 11 2122",
  "ChecksumSHA256": "2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf"
}
```

## release notes
- Includes changes to make /v1/features/license (PUT) call totally idempotent
- Includes changes to make /v/1features/license (GET) to include the checksum of the loaded license in response