### PR TITLE
cloud_storage: segment lifecycle metrics

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -52,8 +52,7 @@ ntp_archiver::ntp_archiver(
   const configuration& conf,
   cloud_storage::remote& remote,
   ss::lw_shared_ptr<cluster::partition> part)
-  : _probe(conf.ntp_metrics_disabled, ntp.ntp())
-  , _ntp(ntp.ntp())
+  : _ntp(ntp.ntp())
   , _rev(ntp.get_initial_revision())
   , _partition_manager(partition_manager)
   , _remote(remote)
@@ -76,7 +75,8 @@ ntp_archiver::ntp_archiver(
   , _housekeeping_interval(
       config::shard_local_cfg().cloud_storage_housekeeping_interval_ms.bind())
   , _housekeeping_jitter(_housekeeping_interval(), 5ms)
-  , _next_housekeeping(_housekeeping_jitter()) {
+  , _next_housekeeping(_housekeeping_jitter())
+  , _ntp_metrics_disabled(conf.ntp_metrics_disabled) {
     vassert(
       _partition && _partition->is_elected_leader(),
       "must be the leader to launch ntp_archiver {}",
@@ -151,6 +151,10 @@ void ntp_archiver::run_upload_loop() {
       _ntp);
     _upload_loop_state = loop_state::started;
 
+    if (!_probe) {
+        _probe.emplace(_ntp_metrics_disabled, _ntp);
+    }
+
     // NOTE: not using ssx::spawn_with_gate_then here because we want to log
     // inside the gate (so that _rtclog is guaranteed to be alive).
     ssx::spawn_with_gate(_gate, [this] {
@@ -172,6 +176,8 @@ void ntp_archiver::run_upload_loop() {
           .finally([this] {
               vlog(_rtclog.debug, "upload loop stopped");
               _upload_loop_state = loop_state::stopped;
+
+              _probe.reset();
           });
     });
 }
@@ -318,7 +324,7 @@ ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
 void ntp_archiver::update_probe() {
     const auto& man = manifest();
 
-    _probe.segments_in_manifest(man.size());
+    _probe->segments_in_manifest(man.size());
 
     const auto first_addressable = man.first_addressable_segment();
     const auto truncated_seg_count = first_addressable == man.end()
@@ -326,7 +332,7 @@ void ntp_archiver::update_probe() {
                                        : std::distance(
                                          man.begin(), first_addressable);
 
-    _probe.segments_to_delete(
+    _probe->segments_to_delete(
       truncated_seg_count + man.replaced_segments_count());
 }
 
@@ -721,7 +727,7 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
 
         // this metric is only relevant for non compacted uploads.
         if (ctx.upload_kind == segment_upload_kind::non_compacted) {
-            _probe.upload_lag(ctx.last_offset - ctx.start_offset);
+            _probe->upload_lag(ctx.last_offset - ctx.start_offset);
         }
 
         while (uploads_remaining > 0 && upload_loop_can_continue()) {
@@ -793,8 +799,8 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
         const auto& upload = scheduled[ixupload[i]];
 
         if (segment_kind == segment_upload_kind::non_compacted) {
-            _probe.uploaded(*upload.delta);
-            _probe.uploaded_bytes(upload.meta->size_bytes);
+            _probe->uploaded(*upload.delta);
+            _probe->uploaded_bytes(upload.meta->size_bytes);
 
             model::offset expected_base_offset;
             if (manifest().get_last_offset() < model::offset{0}) {
@@ -804,7 +810,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
                                        + model::offset{1};
             }
             if (upload.meta->base_offset > expected_base_offset) {
-                _probe.gap_detected(
+                _probe->gap_detected(
                   upload.meta->base_offset - expected_base_offset);
             }
         }
@@ -1156,7 +1162,7 @@ ss::future<> ntp_archiver::garbage_collect() {
           "retry on the next housekeeping run.");
     }
 
-    _probe.segments_deleted(successful_deletes);
+    _probe->segments_deleted(successful_deletes);
     vlog(
       _rtclog.debug, "Deleted {} segments from the cloud", successful_deletes);
 }

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -279,6 +279,8 @@ private:
     ss::future<cloud_storage::upload_result>
     delete_segment(const remote_segment_path& path);
 
+    void update_probe();
+
     bool upload_loop_can_continue() const;
     bool sync_manifest_loop_can_continue() const;
     bool housekeeping_can_continue() const;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -290,7 +290,6 @@ private:
     remote_segment_path
     segment_path_for_candidate(const upload_candidate& candidate);
 
-    ntp_level_probe _probe;
     model::ntp _ntp;
     model::initial_revision_id _rev;
     cluster::partition_manager& _partition_manager;
@@ -319,6 +318,9 @@ private:
     config::binding<std::chrono::milliseconds> _housekeeping_interval;
     simple_time_jitter<ss::lowres_clock> _housekeeping_jitter;
     ss::lowres_clock::time_point _next_housekeeping;
+
+    per_ntp_metrics_disabled _ntp_metrics_disabled;
+    std::optional<ntp_level_probe> _probe{std::nullopt};
 
     loop_state _upload_loop_state{loop_state::initial};
     loop_state _sync_manifest_loop_state{loop_state::initial};

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -105,6 +105,20 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
            "This may grow due to retention or non compacted segments being "
            "replaced with their compacted equivalent."),
          labels)
+         .aggregate(aggregate_labels),
+       sm::make_gauge(
+         "segments",
+         [this] { return _segments_in_manifest; },
+         sm::description(
+           "Total number of accounted segments in the cloud for the topic"),
+         labels)
+         .aggregate(aggregate_labels),
+       sm::make_gauge(
+         "segments_pending_deletion",
+         [this] { return _segments_to_delete; },
+         sm::description("Total number of segments pending deletion from the "
+                         "cloud for the topic"),
+         labels)
          .aggregate(aggregate_labels)});
 }
 

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -52,6 +52,10 @@ public:
         _segments_deleted += deleted_count;
     };
 
+    void segments_in_manifest(int64_t count) { _segments_in_manifest = count; };
+
+    void segments_to_delete(int64_t count) { _segments_to_delete = count; };
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;
@@ -63,6 +67,10 @@ private:
     int64_t _pending = 0;
     /// Number of segments deleted by garbage collection
     int64_t _segments_deleted = 0;
+    /// Number of accounted segments in the cloud
+    int64_t _segments_in_manifest = 0;
+    /// Number of segments awaiting deletion
+    int64_t _segments_to_delete = 0;
 
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics{

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -311,6 +311,15 @@ local_segment_path partition_manifest::generate_local_segment_path(
       fmt::format("{}_{}/{}", ntp.path(), val.ntp_revision, name()));
 }
 
+partition_manifest::const_iterator
+partition_manifest::first_addressable_segment() const {
+    if (_start_offset == model::offset{}) {
+        return end();
+    }
+
+    return _segments.find(_start_offset);
+}
+
 partition_manifest::const_iterator partition_manifest::begin() const {
     return _segments.begin();
 }
@@ -388,6 +397,10 @@ std::vector<segment_meta> partition_manifest::replaced_segments() const {
         res.push_back(lw_segment_meta::convert(s));
     }
     return res;
+}
+
+size_t partition_manifest::replaced_segments_count() const {
+    return _replaced.size();
 }
 
 void partition_manifest::move_aligned_offset_range(

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -192,6 +192,11 @@ public:
 
     remote_segment_path generate_segment_path(const segment_meta&) const;
 
+    /// Return an iterator to the first addressable segment (i.e. base offset
+    /// is greater than or equal to the start offset). If no such segment
+    /// exists, return the end iterator.
+    const_iterator first_addressable_segment() const;
+
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;
     const_iterator end() const;
@@ -271,6 +276,9 @@ public:
 
     /// Return collection of segments that were replaced by newer segments.
     std::vector<segment_meta> replaced_segments() const;
+
+    /// Return the number of replaced segments currently awaiting deletion.
+    size_t replaced_segments_count() const;
 
     /// Removes all replaced segments from the manifest.
     /// Method 'replaced_segments' will return empty value


### PR DESCRIPTION
## Cover letter

This PR introduces two new cloud storage related topic level metrics. If you've got ideas for other things
that may be useful, feel free to comment.
* redpanda_cloud_storage_segments:
    * Description: Total number of accounted segments in the cloud for
    the topic
    * Labels: redpanda_namespace, redpanda_topic
    * Type: gauge
* redpanda_cloud_storage_segments_pending_deletion:
    * Description: Total number of segments awaiting deletion from the
      cloud for the topic
    * Labels: redpanda_namespace, redpanda_topic
    * Type: gauge

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes
### Improvements
Two new metrics are introduced to help track the lifetime of segments uploaded to the cloud:
* redpanda_cloud_storage_segments:
    * Description: Total number of accounted segments in the cloud for
    the topic
    * Labels: redpanda_namespace, redpanda_topic
    * Type: gauge
* redpanda_cloud_storage_segments_pending_deletion:
    * Description: Total number of segments awaiting deletion from the
      cloud for the topic
    * Labels: redpanda_namespace, redpanda_topic
    * Type: gauge
