### PR TITLE
archival: Do not upload tx-manifests for compacted segments

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1091,7 +1091,7 @@ ss::future<> ntp_archiver::garbage_collect() {
 
     auto to_remove = _partition->archival_meta_stm()->get_segments_to_cleanup();
 
-    std::atomic<size_t> successful_deletes{0};
+    size_t successful_deletes{0};
     co_await ss::max_concurrent_for_each(
       to_remove,
       _concurrency,
@@ -1134,7 +1134,7 @@ ss::future<> ntp_archiver::garbage_collect() {
           "retry on the next housekeeping run.");
     }
 
-    _probe->segments_deleted(successful_deletes);
+    _probe->segments_deleted(static_cast<int64_t>(successful_deletes));
     vlog(
       _rtclog.debug, "Deleted {} segments from the cloud", successful_deletes);
 }

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -292,6 +292,9 @@ private:
     remote_segment_path
     segment_path_for_candidate(const upload_candidate& candidate);
 
+    /// Method to use with lazy_abort_source
+    bool archiver_lost_leadership(cloud_storage::lazy_abort_source& las);
+
     model::ntp _ntp;
     model::initial_revision_id _rev;
     cluster::partition_manager& _partition_manager;


### PR DESCRIPTION
## Cover letter

This PR disables uploads for tx-manifests if the segment is compacted, because compacted segments doesn't have any record batches produced by aborted transactions. It also accommodates few minor refactorings.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
* 
## Release notes


* none


### Features

* none

### Improvements

* none
