### PR TITLE
tests/pp: account for partition movement

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -330,6 +330,30 @@ client::list_offsets(model::topic_partition tp) {
     });
 }
 
+namespace {
+ss::future<fetch_response> maybe_throw_exception(
+  shared_broker_t b, model::topic_partition tp, fetch_response res) {
+    if (res.data.error_code != error_code::none) {
+        return ss::make_exception_future<fetch_response>(
+          broker_error(b->id(), res.data.error_code));
+    }
+
+    const auto& topics = res.data.topics;
+    if (topics.size() != 1 || topics[0].partitions.size() != 1) {
+        return ss::make_exception_future<fetch_response>(
+          partition_error(tp, error_code::unknown_server_error));
+    }
+
+    const auto& part = topics[0].partitions[0];
+    if (part.error_code != error_code::none) {
+        return ss::make_exception_future<fetch_response>(
+          partition_error(tp, part.error_code));
+    }
+
+    return ss::make_ready_future<fetch_response>(std::move(res));
+}
+} // namespace
+
 ss::future<fetch_response> client::fetch_partition(
   model::topic_partition tp,
   model::offset offset,
@@ -350,7 +374,11 @@ ss::future<fetch_response> client::fetch_partition(
                            return _brokers.find(leader);
                        })
                        .then([&tp, &build_request](shared_broker_t&& b) {
-                           return b->dispatch(build_request(tp));
+                           return b->dispatch(build_request(tp))
+                             .then([b, &tp](fetch_response res) {
+                                 return maybe_throw_exception(
+                                   b, tp, std::move(res));
+                             });
                        });
                  })
             .handle_exception([&tp](std::exception_ptr ex) {


### PR DESCRIPTION
## Cover letter

It seems that partition movement may occur between the calls to produce and fetch. This can manifest as an unknown_topic_or_partition error. The original version of this fetch_topic test always sent requests to the same node. Now we account for partition movement by first waiting for a stable leader and then sending the request to the leader.

Fixes #7007

Changes from force-push `c7780c1` and ` 8b81c98`:
- Drop first and last commit, we only need the commit that returns exceptions
- Cosmetic changes

Changes from force-push `f837644` and `2ae10e8`:
- Style changes

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
