### PR TITLE
archival: adds fixture with cloud storage disabled

### DIFF
--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -33,8 +33,6 @@
 namespace archival {
 namespace internal {
 
-class scheduler_service_accessor;
-
 using namespace std::chrono_literals;
 
 /// Shard-local archiver service.
@@ -48,8 +46,6 @@ using namespace std::chrono_literals;
 /// - Re-upload manifest(s)
 /// - Reset timer
 class scheduler_service_impl {
-    friend class scheduler_service_accessor;
-
 public:
     /// \brief create scheduler service
     ///

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -121,6 +121,8 @@ public:
     ~enable_cloud_storage_fixture();
 };
 
+struct disable_cloud_storage {};
+
 /// Archiver fixture that contains S3 mock and full redpanda stack.
 class archiver_fixture
   : public http_imposter_fixture
@@ -131,6 +133,9 @@ public:
     archiver_fixture()
       : redpanda_thread_fixture(
         redpanda_thread_fixture::init_cloud_storage_tag{}) {}
+
+    archiver_fixture(disable_cloud_storage)
+      : redpanda_thread_fixture() {}
 
     std::unique_ptr<storage::disk_log_builder> get_started_log_builder(
       model::ntp ntp, model::revision_id rev = model::revision_id(0));
@@ -181,6 +186,12 @@ private:
       bool fit_segments);
 
     std::unordered_map<model::ntp, std::vector<segment_layout>> layouts;
+};
+
+class archiver_fixture_with_cloud_storage_disabled : public archiver_fixture {
+public:
+    archiver_fixture_with_cloud_storage_disabled()
+      : archiver_fixture(disable_cloud_storage{}) {}
 };
 
 std::tuple<archival::configuration, cloud_storage::configuration>


### PR DESCRIPTION
## Cover letter

A new fixture is added with cloud storage disabled, used where the test starts an ntp archiver which should be the only archiver service running.

This set of changes also removes previously added friend class and no-op archiver which did not work as expected.

Fixes #7116 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
