### PR TITLE
tx/compaction: fix LSO computation during bootstrap

### DIFF
--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -313,10 +313,8 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
-    auto res = archiver->upload_next_candidates().get();
-
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     auto part = app.partition_manager.local().get(manifest_ntp);
@@ -338,8 +336,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     auto seg = mark_segments_as_compacted({0});
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
-    res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
     verify_segment_request("0-1-v1.log", manifest);
@@ -358,8 +355,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     reset_http_call_state();
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
-    res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
@@ -388,8 +384,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     auto part = app.partition_manager.local().get(manifest_ntp);
@@ -411,8 +406,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     auto seg = mark_segments_as_compacted({0, 1});
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
-    res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
     BOOST_REQUIRE_EQUAL(
@@ -451,8 +445,7 @@ FIXTURE_TEST(
     mark_segments_as_compacted({0, 1});
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
     std::stringstream st;
@@ -489,8 +482,7 @@ FIXTURE_TEST(test_upload_compacted_segments_fill_gap, reupload_fixture) {
     mark_segments_as_compacted({0});
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
@@ -529,8 +521,7 @@ FIXTURE_TEST(test_upload_compacted_segments_ends_in_gap, reupload_fixture) {
     mark_segments_as_compacted({0});
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
@@ -568,8 +559,7 @@ FIXTURE_TEST(test_upload_compacted_segments_begins_in_gap, reupload_fixture) {
     mark_segments_as_compacted({0, 1});
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
@@ -595,8 +585,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
@@ -632,8 +621,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     auto seg = mark_segments_as_compacted({0});
 
     expected = archival::ntp_archiver::batch_result{{1, 0, 0}, {1, 0, 0}};
-    res = archiver->upload_next_candidates(model::offset::max()).get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected, model::offset::max());
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     manifest = part->archival_meta_stm()->manifest();
@@ -662,8 +650,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
@@ -710,8 +697,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
 
     // The non-compacted uploads proceed as normal, the compacted upload fails.
     expected = archival::ntp_archiver::batch_result{{1, 0, 0}, {0, 1, 0}};
-    res = archiver->upload_next_candidates(model::offset::max()).get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected, model::offset::max());
 
     log_requests();
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
@@ -738,10 +724,9 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
     listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
-    auto res = archiver->upload_next_candidates().get();
 
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     auto part = app.partition_manager.local().get(manifest_ntp);
@@ -763,8 +748,7 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
     auto seg = mark_segments_as_compacted({0});
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {0, 0, 0}};
-    res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 0);
 
     BOOST_REQUIRE_EQUAL(
@@ -785,10 +769,9 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
     listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
-    auto res = archiver->upload_next_candidates().get();
 
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     auto part = app.partition_manager.local().get(manifest_ntp);
@@ -815,8 +798,7 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
     config::shard_local_cfg()
       .get("cloud_storage_enable_compacted_topic_reupload")
       .set_value(false);
-    res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 0);
 
     BOOST_REQUIRE_EQUAL(
@@ -846,8 +828,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
 
     // 4 out of 5 segments uploaded due to archiver limit of 4
     archival::ntp_archiver::batch_result expected{{4, 0, 0}, {0, 0, 0}};
-    auto res = archiver->upload_next_candidates().get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
 
     BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
@@ -887,8 +868,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     // Mark four segments as compacted, so they are valid for upload
     auto seg = mark_segments_as_compacted({0, 1, 2, 3});
     expected = archival::ntp_archiver::batch_result{{4, 0, 0}, {0, 0, 0}};
-    res = archiver->upload_next_candidates(model::offset::max()).get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected, model::offset::max());
     BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     manifest = part->archival_meta_stm()->manifest();
@@ -906,8 +886,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     reset_http_call_state();
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
 
-    res = archiver->upload_next_candidates(model::offset::max()).get();
-    BOOST_REQUIRE(res == expected);
+    upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
     verify_concat_segment_request(

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -149,6 +149,7 @@ public:
     void delete_topic(model::ns ns, model::topic topic);
     void wait_for_topic_deletion(const model::ntp& ntp);
     void add_topic_with_random_data(const model::ntp& ntp, int num_batches);
+    void wait_for_lso(const model::ntp&);
     /// Provides access point for segment_matcher CRTP template
     storage::api& get_local_storage_api();
     /// Get archival scheduler service
@@ -217,6 +218,14 @@ struct log_spec {
 storage::disk_log_builder make_log_builder(std::string_view data_path);
 
 void populate_log(storage::disk_log_builder& b, const log_spec& spec);
+
+ss::future<archival::ntp_archiver::batch_result> upload_next_with_retries(
+  archival::ntp_archiver&, std::optional<model::offset> lso = std::nullopt);
+
+void upload_and_verify(
+  archival::ntp_archiver&,
+  archival::ntp_archiver::batch_result,
+  std::optional<model::offset> lso = std::nullopt);
 
 /// Creates num_batches with a single record each, used to fit segments close to
 /// each other without gaps.

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -158,6 +158,8 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
 
     wait_for_partition_leadership(ntp);
 
+    wait_for_lso(ntp);
+
     auto& service = get_scheduler_service();
 
     service.reconcile_archivers().get();

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1635,8 +1635,31 @@ ss::future<result<kafka_result>> rm_stm::replicate_msg(
 }
 
 model::offset rm_stm::last_stable_offset() {
-    auto first_tx_start = model::offset::max();
+    // There are two main scenarios we deal with here.
+    // 1. stm is still bootstrapping
+    // 2. stm is past bootstrapping.
+    //
+    // We distinguish between (1) and (2) based on the offset
+    // we save during first apply (_bootstrap_committed_offset).
 
+    // We always want to return only the `applied` state as it
+    // contains aborted transactions metadata that is consumed by
+    // the client to distinguish aborted data batches.
+    //
+    // We optimize for the case where there are no inflight transactional
+    // batches to return the high water mark.
+    if (unlikely(!_bootstrap_committed_offset)) {
+        return model::offset::min();
+    }
+
+    auto last_applied = last_applied_offset();
+    auto next_to_apply = model::next_offset(last_applied);
+    if (last_applied < _bootstrap_committed_offset.value()) {
+        return next_to_apply;
+    }
+
+    // Check for any in-flight transactions.
+    auto first_tx_start = model::offset::max();
     if (_is_tx_enabled) {
         if (!_log_state.ongoing_set.empty()) {
             first_tx_start = *_log_state.ongoing_set.begin();
@@ -1656,9 +1679,12 @@ model::offset rm_stm::last_stable_offset() {
 
     auto last_visible_index = _c->last_visible_index();
     if (first_tx_start <= last_visible_index) {
-        return first_tx_start;
+        // There are in flight transactions < high water mark that may
+        // not be applied yet. We still need to consider only applied
+        // transactions.
+        return std::min(first_tx_start, next_to_apply);
     }
-
+    // no inflight transactions.
     return model::next_offset(last_visible_index);
 }
 
@@ -2070,6 +2096,9 @@ void rm_stm::apply_fence(model::record_batch&& b) {
 }
 
 ss::future<> rm_stm::apply(model::record_batch b) {
+    if (unlikely(!_bootstrap_committed_offset)) {
+        _bootstrap_committed_offset = _c->committed_offset();
+    }
     auto last_offset = b.last_offset();
 
     const auto& hdr = b.header();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -554,6 +554,10 @@ private:
           features::feature::transaction_ga);
     }
 
+    // Defines the commit offset range for the stm bootstrap.
+    // Set on first apply upcall and used to identify if the
+    // stm is still replaying the log.
+    std::optional<model::offset> _bootstrap_committed_offset;
     ss::basic_rwlock<> _state_lock;
     bool _is_abort_idx_reduction_requested{false};
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -98,7 +98,9 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -119,8 +121,11 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
                  .get0();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
+
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
@@ -133,8 +138,9 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
-
-    BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
+        return tx_offset < stm.last_stable_offset();
+    }).get0();
 }
 
 // tests:
@@ -176,7 +182,9 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -197,7 +205,9 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
                  .get0();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
@@ -213,8 +223,9 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
       std::any_of(aborted_txs.begin(), aborted_txs.end(), [pid2](auto x) {
           return x.pid == pid2;
       }));
-
-    BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
+        return tx_offset < stm.last_stable_offset();
+    }).get0();
 }
 
 // tests:
@@ -256,7 +267,9 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -277,7 +290,9 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
                  .get0();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
-    BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
+        return first_offset < stm.last_stable_offset();
+    }).get0();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
@@ -300,7 +315,9 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
           return x.pid == pid2;
       }));
 
-    BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
+    tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
+        return tx_offset < stm.last_stable_offset();
+    }).get0();
 }
 
 // transactional writes of an unknown tx are rejected

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -73,7 +73,10 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -132,7 +135,6 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
     BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
-    feature_table.stop().get0();
 }
 
 // tests:
@@ -149,7 +151,10 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -210,7 +215,6 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
       }));
 
     BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
-    feature_table.stop().get0();
 }
 
 // tests:
@@ -227,7 +231,10 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -294,7 +301,6 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
       }));
 
     BOOST_REQUIRE_LT(tx_offset, stm.last_stable_offset());
-    feature_table.stop().get0();
 }
 
 // transactional writes of an unknown tx are rejected
@@ -309,7 +315,10 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -334,7 +343,6 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
                    raft::replicate_options(raft::consistency_level::quorum_ack))
                  .get0();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
-    feature_table.stop().get0();
 }
 
 // begin fences off old transactions
@@ -349,7 +357,10 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -394,7 +405,6 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
                    raft::replicate_options(raft::consistency_level::quorum_ack))
                  .get0();
     BOOST_REQUIRE(!(bool)offset_r);
-    feature_table.stop().get0();
 }
 
 // transactional writes of an aborted tx are rejected
@@ -409,7 +419,10 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -456,7 +469,6 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
                    raft::replicate_options(raft::consistency_level::quorum_ack))
                  .get0();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
-    feature_table.stop().get0();
 }
 
 // Tests aborted transaction semantics with single and multi segment
@@ -474,8 +486,11 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
+    auto stop = ss::defer([&stm, &feature_table] {
+        stm.stop().get0();
+        feature_table.stop().get0();
+    });
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
@@ -689,5 +704,4 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
             BOOST_REQUIRE_EQUAL(txes[0].pid, pid2);
         }
     }
-    feature_table.stop().get0();
 }

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -106,6 +106,8 @@ protected:
     void set_next(model::offset offset);
     virtual ss::future<> handle_eviction();
 
+    model::offset last_applied_offset() { return model::prev_offset(_next); }
+
     consensus* _raft;
     ss::gate _gate;
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Redpanda Data, Inc.
+
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.md
@@ -92,7 +93,9 @@ class TopicRecreateTest(RedpandaTest):
 
         def topic_is_healthy():
             partitions = rpk.describe_topic(spec.name)
-            offsets_present = [p.high_watermark > 0 for p in partitions]
+            hw_offsets = [p.high_watermark for p in partitions]
+            offsets_present = [hw > 0 for hw in hw_offsets]
+            self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(
                 offsets_present)
 


### PR DESCRIPTION
When the state machine is still bootstrapping, not all changes may be applied by the time housekeeping code looks to compact the segment.

This may result in an LSO for which an incomplete log state is tracked because not all changes were applied. Particulary aborted transactions are not fully populated by then and the subsequent self compaction sees missing aborted ranges and ends up retaining those batches.

We noticed this behavior in a chaos job that configured a very low compacted segment size (1MB) and repeatedly appended data to it injecting transfer/resize operations as that happens. This resulted in the following sequence of actions.

- partition bootstrapping
- house keeping queried for LSO, returned offset X
- applied offset Y << X (aborted transactions not up to date)
- compaction misses some aborted ranges and commits them in the log
- client sees aborted transactions.

To avoid this, we never exceed last applied offset when computing LSO. This delays compaction until all the changes are applied and the state machine catches up.

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes https://github.com/redpanda-data/redpanda-jepsen/issues/20

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none

### Features

* none

### Improvements

* none
