### PR TITLE
Support schema registry with basic auth for console

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -992,6 +992,13 @@ func (r *Cluster) IsSchemaRegistryMutualTLSEnabled() bool {
 		r.Spec.Configuration.SchemaRegistry.TLS.RequireClientAuth
 }
 
+// IsSchemaRegistryAuthHTTPBasic returns true if schema registry authentication method
+// is enabled with HTTP Basic
+func (r *Cluster) IsSchemaRegistryAuthHTTPBasic() bool {
+	return r.Spec.Configuration.SchemaRegistry != nil &&
+		r.Spec.Configuration.SchemaRegistry.AuthenticationMethod == httpBasicAuthorizationMechanism
+}
+
 // IsUsingMaintenanceModeHooks tells if the cluster is configured to use maintenance mode hooks on the pods.
 // Maintenance mode feature needs to be enabled for this to be relevant.
 func (r *Cluster) IsUsingMaintenanceModeHooks() bool {

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -47,6 +47,7 @@ const (
 	noneAuthorizationMechanism         = "none"
 	saslAuthorizationMechanism         = "sasl"
 	mTLSIdentityAuthorizationMechanism = "mtls_identity"
+	httpBasicAuthorizationMechanism    = "http_basic"
 
 	defaultSchemaRegistryPort = 8081
 )

--- a/src/go/k8s/pkg/console/configmap.go
+++ b/src/go/k8s/pkg/console/configmap.go
@@ -453,6 +453,9 @@ func (cm *ConfigMap) genKafka(username string) kafka.Config {
 			}
 		}
 		schemaRegistry = schema.Config{Enabled: y, URLs: []string{cm.clusterobj.SchemaRegistryAPIURL()}, TLS: tls}
+		if cm.clusterobj.IsSchemaRegistryAuthHTTPBasic() {
+			schemaRegistry.Username = username
+		}
 
 		// Default protobuf values to enable decoding in SchemaRegistry
 		// REF https://app.zenhub.com/workspaces/cloud-62684e2c6635e100149514fd/issues/redpanda-data/cloud/2834

--- a/src/go/k8s/pkg/console/deployment_internal_test.go
+++ b/src/go/k8s/pkg/console/deployment_internal_test.go
@@ -1,0 +1,116 @@
+package console
+
+import (
+	"testing"
+
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenEnvVars(t *testing.T) { //nolint:funlen // test table is long
+	kakfaEnableAuth := true
+	table := []struct {
+		consoleSpec    redpandav1alpha1.ConsoleSpec
+		clusterSpec    redpandav1alpha1.ClusterSpec
+		expectedEnvars []string
+	}{
+		{
+			consoleSpec: redpandav1alpha1.ConsoleSpec{
+				Cloud: &redpandav1alpha1.CloudConfig{
+					PrometheusEndpoint: &redpandav1alpha1.PrometheusEndpointConfig{
+						Enabled: true,
+						BasicAuth: redpandav1alpha1.BasicAuthConfig{
+							PasswordRef: redpandav1alpha1.SecretKeyRef{
+								Name: "any",
+								Key:  "any",
+							},
+						},
+					},
+				},
+			},
+			clusterSpec: redpandav1alpha1.ClusterSpec{
+				KafkaEnableAuthorization: &kakfaEnableAuth,
+				Configuration: redpandav1alpha1.RedpandaConfig{
+					SchemaRegistry: &redpandav1alpha1.SchemaRegistryAPI{
+						AuthenticationMethod: "http_basic",
+					},
+				},
+			},
+			expectedEnvars: []string{
+				kafkaSASLBasicAuthPasswordEnvVar,
+				schemaRegistryBasicAuthPasswordEnvVar,
+				prometheusBasicAuthPasswordEnvVar,
+			},
+		},
+		{
+			consoleSpec: redpandav1alpha1.ConsoleSpec{},
+			clusterSpec: redpandav1alpha1.ClusterSpec{
+				KafkaEnableAuthorization: &kakfaEnableAuth,
+			},
+			expectedEnvars: []string{
+				kafkaSASLBasicAuthPasswordEnvVar,
+			},
+		},
+		{
+			consoleSpec: redpandav1alpha1.ConsoleSpec{},
+			clusterSpec: redpandav1alpha1.ClusterSpec{
+				Configuration: redpandav1alpha1.RedpandaConfig{
+					SchemaRegistry: &redpandav1alpha1.SchemaRegistryAPI{
+						AuthenticationMethod: "http_basic",
+					},
+				},
+			},
+			expectedEnvars: []string{
+				schemaRegistryBasicAuthPasswordEnvVar,
+			},
+		},
+		{
+			consoleSpec: redpandav1alpha1.ConsoleSpec{
+				Cloud: &redpandav1alpha1.CloudConfig{
+					PrometheusEndpoint: &redpandav1alpha1.PrometheusEndpointConfig{
+						Enabled: true,
+						BasicAuth: redpandav1alpha1.BasicAuthConfig{
+							PasswordRef: redpandav1alpha1.SecretKeyRef{
+								Name: "any",
+								Key:  "any",
+							},
+						},
+					},
+				},
+			},
+			clusterSpec: redpandav1alpha1.ClusterSpec{},
+			expectedEnvars: []string{
+				prometheusBasicAuthPasswordEnvVar,
+			},
+		},
+	}
+
+	nsn := metav1.ObjectMeta{
+		Name:      "any",
+		Namespace: "default",
+	}
+	for _, tt := range table {
+		console := &redpandav1alpha1.Console{
+			ObjectMeta: nsn,
+			Spec:       tt.consoleSpec,
+		}
+		cluster := &redpandav1alpha1.Cluster{
+			ObjectMeta: nsn,
+			Spec:       tt.clusterSpec,
+		}
+		deployment := NewDeployment(nil, nil, console, cluster, nil, nil)
+		genEnvVars := deployment.genEnvVars()
+
+		for _, e := range tt.expectedEnvars {
+			var found bool
+			for _, envar := range genEnvVars {
+				if envar.Name == e {
+					found = true
+				}
+			}
+			require.True(t, found, "expected envar %s, but not found", e)
+		}
+		require.Equal(t, len(tt.expectedEnvars), len(genEnvVars), "expected envars generated is %d, found %d", len(tt.expectedEnvars), len(genEnvVars))
+	}
+}


### PR DESCRIPTION
## Cover letter

Set Kafka.SchemaRegistry.Username/Password in console configuration
This PR uses the Console SA as basic auth creds for schema registry if basic auth is enabled

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None. User will still just set SchemaRegistry as enabled=true/false and the operator sets the proper basic auth credentials in Console configmap. It will use the Console SA created by the operator.

## Release notes

### Features

* Support basic auth for console schema registry