### PR TITLE
tests: marked flaky librdkafka tests ok to fail

### DIFF
--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -11,7 +11,7 @@ import subprocess
 import os
 
 from rptest.services.cluster import cluster
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ok_to_fail
 
 from rptest.services.librdkafka_test_case import LibrdkafkaTestcase
 from rptest.tests.redpanda_test import RedpandaTest
@@ -73,9 +73,10 @@ class LibrdkafkaTest(RedpandaTest):
                                                  "default_topic_partitions": 4
                                              })
 
+    @ok_to_fail  #
     @cluster(num_nodes=4)
     @matrix(test_num=tests_to_run())
-    @skip_debug_mode
+    @skip_debug_mode  # https://github.com/redpanda-data/redpanda/issues/7148
     def test_librdkafka(self, test_num):
         tc = LibrdkafkaTestcase(self.test_context, self.redpanda, test_num)
         tc.start()


### PR DESCRIPTION

## Cover letter

Marked flaky librdkafka tests ok to fail. The failures should be investigated in #7148 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
