### PR TITLE
Tests timely shutdown fixes

### DIFF
--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -86,21 +86,24 @@ class ShutdownTest(EndToEndTest):
         self.background_failures = threading.Thread(
             target=pause_non_leader_node, args=(), daemon=True)
         self.background_failures.start()
-        pending_attempts = 5
-        while pending_attempts != 0:
-            # Pick the current leader and restart it, repeat
-            leader = wait_until_result(
-                lambda: checked_get_leader(),
-                timeout_sec=30,
-                backoff_sec=2,
-                err_msg=f"Leader not found for ntp: {self.topic}/0")
+        try:
+            pending_attempts = 5
+            while pending_attempts != 0:
+                # Pick the current leader and restart it, repeat
+                leader = wait_until_result(
+                    lambda: checked_get_leader(),
+                    timeout_sec=30,
+                    backoff_sec=2,
+                    err_msg=f"Leader not found for ntp: {self.topic}/0")
 
-            assert leader
-            self.redpanda.logger.info(
-                f"Restarting leader node {leader.account.hostname}")
-            self.redpanda.restart_nodes(leader)
-            pending_attempts -= 1
+                assert leader
+                self.redpanda.logger.info(
+                    f"Restarting leader node {leader.account.hostname}")
+                self.redpanda.restart_nodes(leader)
+                pending_attempts -= 1
+        finally:
+            # Stop the finjector
+            self.stopped = True
+            self.background_failures.join()
 
-        # Stop the finjector
-        self.stopped = True
         self.producer.stop()


### PR DESCRIPTION
## Cover letter

This test was bombarding nodes with a high rate of redundant iptables operations, did not stop the failure injector during the test (delayed until teardown), and the failure injector's _heal_all method was unreliable.

It is not totally proved that this is behind the Fixes issues, but seems very likely.

Fixes: https://github.com/redpanda-data/redpanda/issues/7086
Fixes: https://github.com/redpanda-data/redpanda/issues/6967

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none