### PR TITLE
cloud_storage: disable failing unit test on ARM

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,9 +1,16 @@
+# The intention here is to temporarely disable the test_upload_segments_leadership_transfer
+# unit test in the ARM CI runs. Once issue #7116 is fixed, the test should be reinstated.
+set(TEST_TO_IGNORE "")
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^arm|aarch64")
+    set(TEST_TO_IGNORE "--run_test=!test_upload_segments_leadership_transfer")
+endif()
+
 rp_test(
   UNIT_TEST
   BINARY_NAME test_archival_service
   SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc ntp_archiver_reupload_test.cc retention_strategy_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils v::cloud_roles
-  ARGS "-- -c 1"
+  ARGS "${TEST_TO_IGNORE} -- -c 1"
   LABELS archival
 )


### PR DESCRIPTION
## Cover letter

This PR *temporarily* disables the test_upload_segments_leadership_transfer unit test on ARM. The rationale for doing this is that it is currently blocking ARM CI runs from progressing past the unit test stage, which may potentially hide other failures. The test should be re-enabled once fixed.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes
* none