### PR TITLE
Partition count metric enhancement

### DIFF
--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -86,14 +86,7 @@ void controller_probe::setup_metrics() {
         sm::make_gauge(
           "partitions",
           [this] {
-              const auto& leaders_table
-                = _controller.get_partition_leaders().local();
-
-              auto partitions_count = 0;
-              leaders_table.for_each_leader(
-                [&partitions_count](auto&&...) { ++partitions_count; });
-
-              return partitions_count;
+              return _controller.get_topics_state().local().partition_count();
           },
           sm::description(
             "Number of partitions in the cluster (replicas not included)"))

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -63,6 +63,7 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     for (auto& pas : md.get_assignments()) {
         auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
         for (auto& r : pas.replicas) {
+            _partition_count++;
             md.replica_revisions[pas.id][r.node_id] = model::revision_id(
               offset);
         }
@@ -122,6 +123,7 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
         }
 
         for (auto& p_as : tp->second.get_assignments()) {
+            _partition_count--;
             auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p_as.id);
             _updates_in_progress.erase(ntp);
             _pending_deltas.emplace_back(
@@ -152,6 +154,7 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
       = cmd.value.cfg.new_total_partition_count;
     // add assignments of newly created partitions
     for (auto& p_as : cmd.value.assignments) {
+        _partition_count++;
         p_as.id += model::partition_id(prev_partition_count);
         tp->second.get_assignments().emplace(p_as);
         // propagate deltas

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -371,6 +371,8 @@ public:
         return _last_applied_revision_id;
     }
 
+    size_t partition_count() const { return _partition_count; }
+
 private:
     friend topic_table_probe;
 
@@ -398,6 +400,7 @@ private:
 
     underlying_t _topics;
     hierarchy_t _topics_hierarchy;
+    size_t _partition_count{0};
 
     updates_t _updates_in_progress;
     model::revision_id _last_applied_revision_id;

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -253,23 +253,23 @@ class ClusterMetricsTest(RedpandaTest):
         try:
             self._wait_until_metric_has_value(controller,
                                               "cluster_partitions",
-                                              value=1)
+                                              value=0)
 
             RpkTool(self.redpanda).create_topic("topic-a", partitions=20)
             RpkTool(self.redpanda).create_topic("topic-b", partitions=10)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
-                                                value=31)
+                                                value=30)
 
             RpkTool(self.redpanda).delete_topic("topic-a")
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
-                                                value=11)
+                                                value=10)
 
             RpkTool(self.redpanda).create_topic("topic-a", partitions=30)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
-                                                value=41)
+                                                value=40)
         except Exception as e:
             topics_info = RpkTool(self.redpanda).list_topics()
             raise e


### PR DESCRIPTION
## Cover letter

Made querying for partition count not dependent on iterating over all partition list.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
