### PR TITLE
cloud_storage: fix partition recovery with data-less segments

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -22,7 +22,7 @@
 
 namespace cloud_storage {
 
-ss::future<offset_translator::stream_stats> offset_translator::copy_stream(
+ss::future<stream_stats> offset_translator::copy_stream(
   ss::input_stream<char> src,
   ss::output_stream<char> dst,
   retry_chain_node& fib) const {

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -21,6 +21,12 @@
 
 namespace cloud_storage {
 
+struct stream_stats {
+    model::offset min_offset = model::offset::max();
+    model::offset max_offset = model::offset::min();
+    uint64_t size_bytes{};
+};
+
 /// This instance of this class is supposed to be used to
 /// translate from redpanda offsets to kafka offsets in the
 /// shadow-indexing and recovery contexts.
@@ -32,12 +38,6 @@ public:
       storage::opt_abort_source_t as = std::nullopt)
       : _initial_delta(initial_delta)
       , _as(as) {}
-
-    struct stream_stats {
-        model::offset min_offset;
-        model::offset max_offset;
-        uint64_t size_bytes{};
-    };
 
     /// Copy source stream into the destination stream
     ///

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -163,7 +163,7 @@ private:
     /// The downloaded file will have a custom suffix
     /// which has to be changed. The downloaded file path
     /// is returned by the futue.
-    ss::future<std::optional<offset_range>>
+    ss::future<std::optional<cloud_storage::stream_stats>>
     download_segment_file(const segment_meta& segm, const download_part& part);
 
     /// Helper for download_segment_file
@@ -174,8 +174,7 @@ private:
       remote_segment_path,
       std::filesystem::path,
       offset_translator,
-      model::offset*,
-      model::offset*);
+      stream_stats&);
 
     using offset_map_t = absl::btree_map<model::offset, segment_meta>;
 

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -121,6 +121,24 @@ class EndToEndTopicRecovery(RedpandaTest):
         rpk.describe_topic(topic)
         rpk.describe_topic_configs(topic)
 
+    def _s3_has_all_data(self, num_messages):
+        objects = list(self.redpanda.get_objects_from_si())
+        for o in objects:
+            if o.Key.endswith("/manifest.json") and self.topic in o.Key:
+                data = self.redpanda.s3_client.get_object_data(
+                    self._bucket, o.Key)
+                manifest = json.loads(data)
+                last_upl_offset = manifest['last_offset']
+                self.logger.info(
+                    f"Found manifest at {o.Key}, last_offset is {last_upl_offset}"
+                )
+                # We have one partition so this invariant holds
+                # it has to be changed when the number of partitions
+                # will get larger. This will also require different
+                # S3 check.
+                return last_upl_offset >= num_messages
+        return False
+
     @cluster(num_nodes=4)
     @matrix(message_size=[5000],
             num_messages=[100000],
@@ -142,23 +160,8 @@ class EndToEndTopicRecovery(RedpandaTest):
         self._producer.wait()
         assert self._producer.produce_status.acked >= num_messages
 
-        def s3_has_all_data():
-            objects = list(self.redpanda.get_objects_from_si())
-            total_size = 0
-            for o in objects:
-                if o.Key.endswith("/manifest.json") and self.topic in o.Key:
-                    data = self.redpanda.s3_client.get_object_data(
-                        self._bucket, o.Key)
-                    manifest = json.loads(data)
-                    last_upl_offset = manifest['last_offset']
-                    self.logger.info(
-                        f"Found manifest at {o.Key}, last_offset is {last_upl_offset}"
-                    )
-                    return last_upl_offset >= num_messages
-            return False
-
         time.sleep(10)
-        wait_until(s3_has_all_data,
+        wait_until(lambda: self._s3_has_all_data(num_messages),
                    timeout_sec=600,
                    backoff_sec=5,
                    err_msg=f"Not all data is uploaded to S3 bucket")
@@ -234,27 +237,8 @@ class EndToEndTopicRecovery(RedpandaTest):
 
         assert producer.num_aborted > 0
 
-        # Wait until everything is uploaded
-        def s3_has_all_data():
-            objects = list(self.redpanda.get_objects_from_si())
-            for o in objects:
-                if o.Key.endswith("/manifest.json") and self.topic in o.Key:
-                    data = self.redpanda.s3_client.get_object_data(
-                        self._bucket, o.Key)
-                    manifest = json.loads(data)
-                    last_upl_offset = manifest['last_offset']
-                    self.logger.info(
-                        f"Found manifest at {o.Key}, last_offset is {last_upl_offset}"
-                    )
-                    # We have one partition so this invariant holds
-                    # it has to be changed when the number of partitions
-                    # will get larger. This will also require dfferent
-                    # S3 check.
-                    return last_upl_offset >= producer.cur_offset
-            return False
-
         time.sleep(10)
-        wait_until(s3_has_all_data,
+        wait_until(lambda: self._s3_has_all_data(producer.cur_offset),
                    timeout_sec=300,
                    backoff_sec=5,
                    err_msg=f"Not all data is uploaded to S3 bucket")

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -140,6 +140,47 @@ class EndToEndTopicRecovery(RedpandaTest):
         return False
 
     @cluster(num_nodes=4)
+    @matrix(num_messages=[2])
+    def test_restore_with_config_batches(self, num_messages):
+        """related to issue 6413: force the creation of remote segments containing only configuration batches,
+        check that older data can be nonetheless recovered even if the total download size
+         would exceed the property retention.bytes.
+         in other words, only segments containing at least some data counts towards retention.bytes limit"""
+        """1. generate some messages
+        2. restart the cluster to generate some config-only remote segments
+        3. restore topic with a small retention.bytes to force redpanda 
+           to get over the limit and skip over configuration batches"""
+        self.logger.info("start")
+        self.init_producer(5000, num_messages)
+        self._producer.start(clean=False)
+        self._producer.wait()
+        assert self._producer.produce_status.acked >= num_messages
+        self.logger.info("waiting S3")
+        wait_until(lambda: self._s3_has_all_data(num_messages),
+                   timeout_sec=100,
+                   backoff_sec=5,
+                   err_msg="Not all data is uploaded to S3 bucket")
+
+        for i in range(3):
+            self.logger.info(f"iteration {i}")
+            self._stop_redpanda_nodes()
+            self._start_redpanda_nodes()
+
+        self.logger.info("final iteration")
+        self._stop_redpanda_nodes()
+        self._wipe_data()
+
+        # Run recovery
+        self._start_redpanda_nodes()
+        for topic_spec in self.topics:
+            self._restore_topic(topic_spec, {'retention.bytes': 512})
+
+        self.init_consumer(5000)
+        self._consumer.start(clean=False)
+        # we just care for the consumer to receive some data
+        self._consumer.wait(timeout_sec=100)
+
+    @cluster(num_nodes=4)
     @matrix(message_size=[5000],
             num_messages=[100000],
             recovery_overrides=[{}, {


### PR DESCRIPTION
## Cover letter

download remote segments skipping over configuration-only segments

when retention.bytes is set, download_log_with_capped_size is used to not exceed this size limit. counts toward this limit only those segments that contain some topic data. previously the segments to download were precomputed from offset_meta keeping a total_size sum. now sum is done while downloading segments, to account for segments that contain no data and that will be discarded

Fixes #6413

last commit contains the main change

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x
