### PR TITLE
kafka/client && pandaproxy: avoid-capturing-lambda-coroutines 

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -54,9 +54,10 @@ ss::future<shared_broker_t> make_broker(
           vlog(kclog.warn, "std::system_error: {}", ex.what());
           return ss::make_exception_future<shared_broker_t>(ex);
       })
-      .then([&config](shared_broker_t broker) -> ss::future<shared_broker_t> {
-          co_await do_authenticate(broker, config);
-          co_return broker;
+      .then([&config](shared_broker_t broker) {
+          return do_authenticate(broker, config).then([broker]() {
+              return broker;
+          });
       });
 }
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -309,26 +309,26 @@ client::list_offsets(model::topic_partition tp) {
 
 ss::future<list_offsets_response>
 client::do_list_offsets(model::topic_partition tp) {
-        auto node_id = co_await _topic_cache.leader(tp);
-        auto broker = co_await _brokers.find(node_id);
-        auto res = co_await broker->dispatch(kafka::list_offsets_request{
-          .data = {.topics{
-            {{.name{tp.topic},
-              .partitions{
-                {{.partition_index{tp.partition}, .max_num_offsets = 1}}}}}}}});
+    auto node_id = co_await _topic_cache.leader(tp);
+    auto broker = co_await _brokers.find(node_id);
+    auto res = co_await broker->dispatch(kafka::list_offsets_request{
+      .data = {.topics{
+        {{.name{tp.topic},
+          .partitions{
+            {{.partition_index{tp.partition}, .max_num_offsets = 1}}}}}}}});
 
-        const auto& topics = res.data.topics;
-        auto ec = error_code::none;
-        if (topics.size() != 1 || topics[0].partitions.size() != 1) {
-            co_return ss::coroutine::exception(std::make_exception_ptr(
-              broker_error(node_id, error_code::unknown_server_error)));
-        }
-        ec = topics[0].partitions[0].error_code;
-        if (ec != error_code::none) {
-            co_return ss::coroutine::exception(
-              std::make_exception_ptr(partition_error(tp, ec)));
-        }
-        co_return res;
+    const auto& topics = res.data.topics;
+    auto ec = error_code::none;
+    if (topics.size() != 1 || topics[0].partitions.size() != 1) {
+        co_return ss::coroutine::exception(std::make_exception_ptr(
+          broker_error(node_id, error_code::unknown_server_error)));
+    }
+    ec = topics[0].partitions[0].error_code;
+    if (ec != error_code::none) {
+        co_return ss::coroutine::exception(
+          std::make_exception_ptr(partition_error(tp, ec)));
+    }
+    co_return res;
 }
 
 ss::future<fetch_response> client::fetch_partition(

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -174,6 +174,9 @@ public:
     configuration& config() { return _config; }
 
 private:
+    ss::future<list_offsets_response>
+    do_list_offsets(model::topic_partition tp);
+
     /// \brief Connect and update metdata.
     ss::future<> do_connect(net::unresolved_address addr);
 

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -195,18 +195,23 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
 
     vlog(plog.debug, "get_topics_name: topic: {}", topic);
 
-    auto res = co_await rq.dispatch(
-      [user{rq.user}, data{rq.req->content.data()}, topic, req_fmt](
-        kafka::client::client& client) mutable {
+    co_return co_await rq.dispatch(
+      [data{rq.req->content.data()},
+       topic,
+       req_fmt,
+       res_fmt,
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           auto records = ppj::rjson_parse(
             data, ppj::produce_request_handler(req_fmt));
-          return client.produce_records(topic, std::move(records));
+          return client.produce_records(topic, std::move(records))
+            .then([rp{std::move(rp)},
+                   res_fmt](kafka::produce_response res) mutable {
+                auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
+                rp.rep->write_body("json", json_rslt);
+                rp.mime_type = res_fmt;
+                return std::move(rp);
+            });
       });
-
-    auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
-    rp.rep->write_body("json", json_rslt);
-    rp.mime_type = res_fmt;
-    co_return rp;
 }
 
 static ss::sstring make_consumer_uri_base(
@@ -251,18 +256,11 @@ create_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _base_uri{std::move(base_uri)},
-       _res_fmt{res_fmt},
-       _req_data{std::move(req_data)},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto base_uri{std::move(_base_uri)};
-          auto res_fmt{_res_fmt};
-          auto req_data{std::move(_req_data)};
-          auto rp{std::move(_rp)};
-
+      [group_id,
+       base_uri{std::move(base_uri)},
+       res_fmt,
+       req_data{std::move(req_data)},
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "create_consumer: group_id: {}, name: {}, min_bytes: {}, timeout: "
@@ -274,22 +272,32 @@ create_consumer(server::request_t rq, server::reply_t rp) {
             req_data.auto_offset_reset,
             req_data.auto_commit_enable);
 
-          try {
-              co_await client.get_consumer(group_id, req_data.name);
-              auto ec = make_error_condition(
-                reply_error_code::consumer_already_exists);
-              rp.rep = errored_body(ec, ec.message());
-              co_return std::move(rp);
-          } catch (const kafka::client::consumer_error& e) {
-              // Ignore - consumer doesn't exist
-          }
-          auto name = co_await client.create_consumer(group_id, req_data.name);
-          json::create_consumer_response res{
-            .instance_id = name, .base_uri = base_uri + name};
-          auto json_rslt = ppj::rjson_serialize(res);
-          rp.rep->write_body("json", json_rslt);
-          rp.mime_type = res_fmt;
-          co_return std::move(rp);
+          return client.get_consumer(group_id, req_data.name)
+            .then([group_id](const kafka::client::shared_consumer_t&) mutable {
+                auto ec = make_error_condition(
+                  reply_error_code::consumer_already_exists);
+                server::reply_t rp;
+                rp.rep = errored_body(ec, ec.message());
+                return ss::make_ready_future<server::reply_t>(std::move(rp));
+            })
+            .handle_exception_type(
+              [group_id,
+               base_uri{std::move(base_uri)},
+               res_fmt,
+               req_data{std::move(req_data)},
+               rp{std::move(rp)},
+               &client](const kafka::client::consumer_error&) mutable {
+                  return client.create_consumer(group_id, req_data.name)
+                    .then([rp{std::move(rp)}, base_uri, res_fmt](
+                            kafka::member_id name) mutable {
+                        json::create_consumer_response res{
+                          .instance_id = name, .base_uri = base_uri + name};
+                        auto json_rslt = ppj::rjson_serialize(res);
+                        rp.rep->write_body("json", json_rslt);
+                        rp.mime_type = res_fmt;
+                        return std::move(rp);
+                    });
+              });
       });
 }
 
@@ -307,22 +315,19 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _member_id{std::move(member_id)},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto member_id{std::move(_member_id)};
-          auto rp{std::move(_rp)};
+      [group_id, member_id{std::move(member_id)}, rp{std::move(rp)}](
+        kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "remove_consumer: group_id: {}, member_id: {}",
             group_id,
             member_id);
 
-          co_await client.remove_consumer(group_id, member_id);
-          rp.rep->set_status(ss::httpd::reply::status_type::no_content);
-          co_return std::move(rp);
+          return client.remove_consumer(group_id, member_id)
+            .then([rp{std::move(rp)}]() mutable {
+                rp.rep->set_status(ss::httpd::reply::status_type::no_content);
+                return std::move(rp);
+            });
       });
 }
 
@@ -343,17 +348,11 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _member_id{std::move(member_id)},
-       _res_fmt{res_fmt},
-       _req_data{std::move(req_data)},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto member_id{std::move(_member_id)};
-          auto res_fmt{_res_fmt};
-          auto req_data{std::move(_req_data)};
-          auto rp{std::move(_rp)};
+      [group_id,
+       member_id{std::move(member_id)},
+       req_data{std::move(req_data)},
+       res_fmt,
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "subscribe_consumer: group_id: {}, member_id: {}, topics: {}",
@@ -361,11 +360,13 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
             member_id,
             req_data.topics);
 
-          co_await client.subscribe_consumer(
-            group_id, member_id, std::move(req_data.topics));
-          rp.mime_type = res_fmt;
-          rp.rep->set_status(ss::httpd::reply::status_type::no_content);
-          co_return std::move(rp);
+          return client
+            .subscribe_consumer(group_id, member_id, std::move(req_data.topics))
+            .then([res_fmt, rp{std::move(rp)}]() mutable {
+                rp.mime_type = res_fmt;
+                rp.rep->set_status(ss::httpd::reply::status_type::no_content);
+                return std::move(rp);
+            });
       });
 }
 
@@ -385,19 +386,12 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _name{std::move(name)},
-       _timeout{timeout},
-       _max_bytes{max_bytes},
-       _res_fmt{res_fmt},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto name{std::move(_name)};
-          auto timeout{_timeout};
-          auto max_bytes{_max_bytes};
-          auto res_fmt{_res_fmt};
-          auto rp{std::move(_rp)};
+      [group_id,
+       name{std::move(name)},
+       timeout,
+       max_bytes,
+       res_fmt,
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "consumer_fetch: group_id: {}, name: {}, timeout: {}, max_bytes: "
@@ -407,18 +401,19 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
             timeout,
             max_bytes);
 
-          auto res = co_await client.consumer_fetch(
-            group_id, name, timeout, max_bytes);
-          ::json::StringBuffer str_buf;
-          ::json::Writer<::json::StringBuffer> w(str_buf);
+          return client.consumer_fetch(group_id, name, timeout, max_bytes)
+            .then([res_fmt, rp{std::move(rp)}](auto res) mutable {
+                ::json::StringBuffer str_buf;
+                ::json::Writer<::json::StringBuffer> w(str_buf);
 
-          ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
+                ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
 
-          // TODO Ben: Prevent this linearization
-          ss::sstring json_rslt = str_buf.GetString();
-          rp.rep->write_body("json", json_rslt);
-          rp.mime_type = res_fmt;
-          co_return std::move(rp);
+                // TODO Ben: Prevent this linearization
+                ss::sstring json_rslt = str_buf.GetString();
+                rp.rep->write_body("json", json_rslt);
+                rp.mime_type = res_fmt;
+                return std::move(rp);
+            });
       });
 }
 
@@ -437,17 +432,11 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _member_id{std::move(member_id)},
-       _res_fmt{res_fmt},
-       _req_data{std::move(req_data)},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto member_id{std::move(_member_id)};
-          auto res_fmt{_res_fmt};
-          auto req_data{std::move(_req_data)};
-          auto rp{std::move(_rp)};
+      [group_id,
+       member_id{std::move(member_id)},
+       req_data{std::move(req_data)},
+       res_fmt,
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "get_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -455,15 +444,17 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
             member_id,
             req_data);
 
-          auto res = co_await client.consumer_offset_fetch(
-            group_id, member_id, std::move(req_data));
-          ::json::StringBuffer str_buf;
-          ::json::Writer<::json::StringBuffer> w(str_buf);
-          ppj::rjson_serialize(w, res);
-          ss::sstring json_rslt = str_buf.GetString();
-          rp.rep->write_body("json", json_rslt);
-          rp.mime_type = res_fmt;
-          co_return std::move(rp);
+          return client
+            .consumer_offset_fetch(group_id, member_id, std::move(req_data))
+            .then([rp{std::move(rp)}, res_fmt](auto res) mutable {
+                ::json::StringBuffer str_buf;
+                ::json::Writer<::json::StringBuffer> w(str_buf);
+                ppj::rjson_serialize(w, res);
+                ss::sstring json_rslt = str_buf.GetString();
+                rp.rep->write_body("json", json_rslt);
+                rp.mime_type = res_fmt;
+                return std::move(rp);
+            });
       });
 }
 
@@ -487,15 +478,10 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
     co_return co_await rq.dispatch(
       group_id,
-      [_group_id{group_id},
-       _member_id{std::move(member_id)},
-       _req_data{std::move(req_data)},
-       _rp{std::move(rp)}](
-        kafka::client::client& client) mutable -> ss::future<server::reply_t> {
-          auto group_id{std::move(_group_id)};
-          auto member_id{std::move(_member_id)};
-          auto req_data{std::move(_req_data)};
-          auto rp{std::move(_rp)};
+      [group_id,
+       member_id{std::move(member_id)},
+       req_data{std::move(req_data)},
+       rp{std::move(rp)}](kafka::client::client& client) mutable {
           vlog(
             plog.debug,
             "post_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -503,10 +489,12 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
             member_id,
             req_data);
 
-          auto res = co_await client.consumer_offset_commit(
-            group_id, member_id, std::move(req_data));
-          rp.rep->set_status(ss::httpd::reply::status_type::no_content);
-          co_return std::move(rp);
+          return client
+            .consumer_offset_commit(group_id, member_id, std::move(req_data))
+            .then([rp{std::move(rp)}](auto) mutable {
+                rp.rep->set_status(ss::httpd::reply::status_type::no_content);
+                return std::move(rp);
+            });
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -66,6 +66,25 @@ private:
 
     void advance_offset_inner(model::offset offset);
 
+    ss::future<std::optional<schema_id>> do_write_subject_version(
+      canonical_schema ref, model::offset write_at, seq_writer& seq);
+
+    ss::future<std::optional<bool>> do_write_config(
+      std::optional<subject> sub,
+      compatibility_level compat,
+      model::offset write_at,
+      seq_writer& seq);
+
+    ss::future<std::optional<bool>> do_delete_subject_version(
+      subject sub,
+      schema_version version,
+      model::offset write_at,
+      seq_writer& seq);
+
+    ss::future<std::optional<std::vector<schema_version>>>
+    do_delete_subject_impermanent(
+      subject sub, model::offset write_at, seq_writer& seq);
+
     ss::future<std::vector<schema_version>> delete_subject_permanent_inner(
       subject sub, std::optional<schema_version> version);
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -132,8 +132,14 @@ private:
 
 template<typename service_t>
 class ctx_server : public server {
+    using base = server;
+
 public:
-    using server::server;
+    using reply_t = base::reply_t;
+    using function_handler
+      = ss::noncopyable_function<ss::future<reply_t>(request_t, reply_t)>;
+
+    using base::server;
 
     struct context_t : server::context_t {
         service_t& service;
@@ -245,6 +251,10 @@ public:
                   auth_result.get_username(), auth_result.get_password()};
             }
         }
+
+        using reply_t = typename base::reply_t;
+        using function_handler
+          = ss::noncopyable_function<ss::future<reply_t>(request_t, reply_t)>;
 
         credential_t user;
         config::rest_authn_method authn_method;


### PR DESCRIPTION
## Cover letter

* Avoid  capturing lamdda coroutines, as lifetimes are tricky. #7114
* Fix a lifetime issue with the requests:  #7139

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none