### PR TITLE
tests: more logging in shadow_indexing_tx_test

### DIFF
--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -117,8 +117,14 @@ class ShadowIndexingTxTest(RedpandaTest):
                 break
             consumed.extend([(m.key(), m.offset()) for m in msgs])
 
+        self.logger.info(
+            f"consumed {len(consumed)} records, expected {len(producer.keys)} keys"
+        )
+
         first_mismatch = ''
-        for p_key, (c_key, c_offset) in zip_longest(producer.keys, consumed):
+        for p_key, (c_key, c_offset) in zip_longest(producer.keys,
+                                                    consumed,
+                                                    fillvalue=(None, -1)):
             if p_key != c_key:
                 first_mismatch = f"produced: {p_key}, consumed: {c_key} (offset: {c_offset})"
                 break


### PR DESCRIPTION
## Cover letter

Make sure that the test triggers assertion if the output is wrong. The problem which caused #7147 is not clear because the consumer returned fewer keys then expected. In this case `zip_longest` adds 'None' values in place of missing entries. The PR fixes this by adding a `fillvalue` parameter. It also extends the logging.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none



### Features

*none

### Improvements

* none
