### PR TITLE
prefix_truncate_recovery_test: retry leadership transfers

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -662,7 +662,7 @@ class Admin:
         Looks up current ntp leader and transfer leadership to target node,
         this operations is NOP when current leader is the same as target.
         If user pass None for target this function will choose next replica for new leader.
-        If leadership transfer was performed this function return True
+        Returns true if leadership was transferred to the target node.
         """
         def _get_details():
             p = self.get_partitions(topic=topic,
@@ -685,7 +685,7 @@ class Admin:
 
         if target_id is not None:
             if leader_id == target_id:
-                return False
+                return True
             path = f"raft/{details['raft_group_id']}/transfer_leadership?target={target_id}"
         else:
             path = f"raft/{details['raft_group_id']}/transfer_leadership"

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -181,11 +181,17 @@ class PrefixTruncateRecoveryUpgradeTest(PrefixTruncateRecoveryTestBase):
         def _run_recovery(src_node, dst_node):
             # Force leadership to 'src_node' so we can deterministically check
             # mixed-version traffic.
-            self.redpanda._admin.transfer_leadership_to(
+            # Note it's possible to see surprising error codes on older
+            # versions following a node restart (e.g. 500 insteaad of 503/504);
+            # just retry until leadership is moved.
+            wait_until(lambda: self.redpanda._admin.transfer_leadership_to(
                 namespace="kafka",
                 topic=self.topic,
                 partition=0,
-                target_id=self.redpanda.idx(src_node))
+                target_id=self.redpanda.idx(src_node)),
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       retry_on_exc=True)
             # Speed the test up a bit by using acks=1.
             self.run_recovery(acks=1, dst_node=dst_node)
 


### PR DESCRIPTION
## Cover letter

Immediately following a node restart, attempts to transfer leadership to the restarted node may be misconstrued as a node that needs recovery, resulting in a raft::errc::timeout, which yields code 500 in versions that don't have https://github.com/redpanda-data/redpanda/pull/6388 (i.e. 22.3 and below).

Since 500 is a generic error, rather than adding 500 to the accepted retriable codes, this commit opts to retry the leadership transfer until leadership is actually transferred, ignoring all errors.

This entailed tweaking the return semantics of transfer_leadership_to(), which no other test appears to be using.

Fixes #5589


Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
