### PR TITLE
Reinstated timequery test for debug builds

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -243,16 +243,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
     @parametrize(cloud_storage=True, batch_cache=False)
     @parametrize(cloud_storage=False, batch_cache=True)
     @parametrize(cloud_storage=False, batch_cache=False)
-    @skip_debug_mode
     def test_timequery(self, cloud_storage: bool, batch_cache: bool):
-        return self._do_test_timequery(cloud_storage, batch_cache)
-
-    @ok_to_fail
-    @cluster(num_nodes=4)
-    @parametrize(cloud_storage=True, batch_cache=False)
-    @parametrize(cloud_storage=False, batch_cache=True)
-    @parametrize(cloud_storage=False, batch_cache=False)
-    def test_timequery_debug(self, cloud_storage: bool, batch_cache: bool):
         return self._do_test_timequery(cloud_storage, batch_cache)
 
 


### PR DESCRIPTION
## Cover letter

Reinstated `timequery` test for debug builds 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6685

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
