### PR TITLE
convert coroutine lambdas to normal lambdas

### DIFF
--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -99,8 +99,8 @@ struct conn_quota_fixture {
                 auto range = boost::irange(0u, take_units);
                 return ss::do_for_each(range, [this, shard, addr, &cq](auto) {
                     return cq.get(addr).then([this, shard](auto u) {
-                    BOOST_TEST_REQUIRE(u.live());
-                    shard_units[shard].push_back(std::move(u));
+                        BOOST_TEST_REQUIRE(u.live());
+                        shard_units[shard].push_back(std::move(u));
                     });
                 });
             })
@@ -221,9 +221,9 @@ void conn_quota_fixture::test_borrows(
                 auto range = boost::irange(0u, take_each);
                 return ss::do_for_each(range, [this, i, &cq](auto) {
                     return cq.get(addr1).then([this, i](auto u) {
-                    BOOST_TEST_REQUIRE(u.live());
-                    shard_units[i].push_back(std::move(u));
-                });
+                        BOOST_TEST_REQUIRE(u.live());
+                        shard_units[i].push_back(std::move(u));
+                    });
                 });
             })
           .get();
@@ -247,8 +247,8 @@ void conn_quota_fixture::test_borrows(
         2,
         [this, i = 2](conn_quota& cq) {
             return cq.get(addr1).then([this, i](auto u) {
-            BOOST_TEST_REQUIRE(u.live());
-            shard_units[i].push_back(std::move(u));
+                BOOST_TEST_REQUIRE(u.live());
+                shard_units[i].push_back(std::move(u));
             });
         })
       .get();
@@ -313,8 +313,8 @@ FIXTURE_TEST(test_change_limits, conn_quota_fixture) {
                 auto range = boost::irange(0, 3);
                 return ss::do_for_each(range, [this, i, &cq](auto) {
                     return cq.get(addr1).then([this, i](auto u) {
-                    BOOST_TEST_REQUIRE(u.live());
-                    shard_units[i].push_back(std::move(u));
+                        BOOST_TEST_REQUIRE(u.live());
+                        shard_units[i].push_back(std::move(u));
                     });
                 });
             })

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -10,6 +10,8 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/later.hh>
 
+#include <boost/range/irange.hpp>
+
 static ss::logger logger("test");
 
 using namespace net;
@@ -93,12 +95,14 @@ struct conn_quota_fixture {
         scq
           .invoke_on(
             shard,
-            [shard, this, take_units, addr](conn_quota& cq) -> ss::future<> {
-                for (unsigned int j = 0; j < take_units; ++j) {
-                    auto u = co_await cq.get(addr);
+            [shard, this, take_units, addr](conn_quota& cq) {
+                auto range = boost::irange(0u, take_units);
+                return ss::do_for_each(range, [this, shard, addr, &cq](auto) {
+                    return cq.get(addr).then([this, shard](auto u) {
                     BOOST_TEST_REQUIRE(u.live());
                     shard_units[shard].push_back(std::move(u));
-                }
+                    });
+                });
             })
           .get();
     }
@@ -213,12 +217,14 @@ void conn_quota_fixture::test_borrows(
         scq
           .invoke_on(
             i,
-            [i, take_each, this](conn_quota& cq) -> ss::future<> {
-                for (unsigned int j = 0; j < take_each; ++j) {
-                    auto u = co_await cq.get(addr1);
+            [i, take_each, this](conn_quota& cq) {
+                auto range = boost::irange(0u, take_each);
+                return ss::do_for_each(range, [this, i, &cq](auto) {
+                    return cq.get(addr1).then([this, i](auto u) {
                     BOOST_TEST_REQUIRE(u.live());
                     shard_units[i].push_back(std::move(u));
-                }
+                });
+                });
             })
           .get();
     }
@@ -239,10 +245,11 @@ void conn_quota_fixture::test_borrows(
     scq
       .invoke_on(
         2,
-        [this, i = 2](conn_quota& cq) -> ss::future<> {
-            auto u = co_await cq.get(addr1);
+        [this, i = 2](conn_quota& cq) {
+            return cq.get(addr1).then([this, i](auto u) {
             BOOST_TEST_REQUIRE(u.live());
             shard_units[i].push_back(std::move(u));
+            });
         })
       .get();
 
@@ -303,11 +310,13 @@ FIXTURE_TEST(test_change_limits, conn_quota_fixture) {
           .invoke_on(
             i,
             [i, this](conn_quota& cq) -> ss::future<> {
-                for (unsigned int j = 0; j < 3; ++j) {
-                    auto u = co_await cq.get(addr1);
+                auto range = boost::irange(0, 3);
+                return ss::do_for_each(range, [this, i, &cq](auto) {
+                    return cq.get(addr1).then([this, i](auto u) {
                     BOOST_TEST_REQUIRE(u.live());
                     shard_units[i].push_back(std::move(u));
-                }
+                    });
+                });
             })
           .get();
     }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1499,27 +1499,29 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
 void application::start_runtime_services(cluster::cluster_discovery& cd) {
     ssx::background = feature_table.invoke_on_all(
       [this](features::feature_table& ft) {
-              return ft.await_feature(features::feature::rpc_v2_by_default).then([this] {
-              if (ss::this_shard_id() == 0) {
-                  vlog(_log.info, "Activating RPC protocol v2");
-              }
-              _connection_cache.local().set_default_transport_version(
-                rpc::transport_version::v2);
-              }).handle_exception([this](const std::exception_ptr& e) {
-          try {
-              std::rethrow_exception(e);
-          } catch (ss::abort_requested_exception&) {
-              // Shutting down
-          } catch (...) {
-              // Should never happen, abort is the only exception that
-              // await_feature can throw, other than perhaps bad_alloc.
-              vlog(
-                _log.error,
-                "Unexpected error awaiting RPCv2 feature: {} {}",
-                std::current_exception(),
-                ss::current_backtrace());
-          }
-          });
+          return ft.await_feature(features::feature::rpc_v2_by_default)
+            .then([this] {
+                if (ss::this_shard_id() == 0) {
+                    vlog(_log.info, "Activating RPC protocol v2");
+                }
+                _connection_cache.local().set_default_transport_version(
+                  rpc::transport_version::v2);
+            })
+            .handle_exception([this](const std::exception_ptr& e) {
+                try {
+                    std::rethrow_exception(e);
+                } catch (ss::abort_requested_exception&) {
+                    // Shutting down
+                } catch (...) {
+                    // Should never happen, abort is the only exception that
+                    // await_feature can throw, other than perhaps bad_alloc.
+                    vlog(
+                      _log.error,
+                      "Unexpected error awaiting RPCv2 feature: {} {}",
+                      std::current_exception(),
+                      ss::current_backtrace());
+                }
+            });
       });
 
     // single instance

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1498,17 +1498,18 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
 
 void application::start_runtime_services(cluster::cluster_discovery& cd) {
     ssx::background = feature_table.invoke_on_all(
-      [this](features::feature_table& ft) -> ss::future<> {
-          try {
-              co_await ft.await_feature(features::feature::rpc_v2_by_default);
+      [this](features::feature_table& ft) {
+              return ft.await_feature(features::feature::rpc_v2_by_default).then([this] {
               if (ss::this_shard_id() == 0) {
                   vlog(_log.info, "Activating RPC protocol v2");
               }
               _connection_cache.local().set_default_transport_version(
                 rpc::transport_version::v2);
+              }).handle_exception([this](const std::exception_ptr& e) {
+          try {
+              std::rethrow_exception(e);
           } catch (ss::abort_requested_exception&) {
               // Shutting down
-              co_return;
           } catch (...) {
               // Should never happen, abort is the only exception that
               // await_feature can throw, other than perhaps bad_alloc.
@@ -1517,8 +1518,8 @@ void application::start_runtime_services(cluster::cluster_discovery& cd) {
                 "Unexpected error awaiting RPCv2 feature: {} {}",
                 std::current_exception(),
                 ss::current_backtrace());
-              co_return;
           }
+          });
       });
 
     // single instance

--- a/src/v/rp_util/main.cc
+++ b/src/v/rp_util/main.cc
@@ -24,8 +24,7 @@ int corpus_write(char** argv, std::filesystem::path dir) {
     seastar::app_template app;
     try {
         return app.run(1, argv, [dir = std::move(dir)]() -> ss::future<int> {
-            co_await compat::write_corpus(dir);
-            co_return 0;
+            return compat::write_corpus(dir).then([] { return 0; });
         });
     } catch (...) {
         std::cerr << std::current_exception() << "\n";


### PR DESCRIPTION
## Cover letter

Converts a batch of coroutine lambda into normal lambdas to address liftetime issues of captures.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
