### PR TITLE
Initialize _abort_interval_ms in group::group ctor

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -102,6 +102,8 @@ group::group(
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
   , _enable_group_metrics(group_metrics)
+  , _abort_interval_ms(config::shard_local_cfg()
+                         .abort_timed_out_transactions_interval_ms.value())
   , _tx_frontend(tx_frontend)
   , _feature_table(feature_table) {
     _state = md.members.empty() ? group_state::empty : group_state::stable;


### PR DESCRIPTION
The `_abort_interval_ms` value was initialized in one constructor but not the other, causing it to have an arbitrary value. In particular, if it has the value 0, we have an infinite timer loop since the timer is rearmed for "now" as soon as it runs.

Fixes #7171.

## Cover letter

Described in commit.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None.

## Release notes

* none
