### PR TITLE
cloud_storage: fix a hang in shutdown by closing S3 connection pool earlier

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -616,7 +616,11 @@ ss::future<> remote_segment::run_hydrate_bg() {
             }
         }
     } catch (const ss::broken_condition_variable&) {
-        vlog(_ctxlog.debug, "Hydraton loop is stopped");
+        vlog(_ctxlog.debug, "Hydration loop shut down");
+    } catch (const ss::abort_requested_exception&) {
+        vlog(_ctxlog.debug, "Hydration loop shut down");
+    } catch (const ss::gate_closed_exception&) {
+        vlog(_ctxlog.debug, "Hydration loop shut down");
     } catch (...) {
         vlog(
           _ctxlog.error,


### PR DESCRIPTION
## Cover letter

    This prevents a hang shutting down, if partitions are
    busy trying to load content from S3, perhaps in a cache
    thrash where they do not complete promptly.  These readers
    will prevent remote_partition::stop from proceding because
    they hold its gate.
    
    By shutting down the S3 connection pool early, we ensure that
    these readers will get abort_request exceptions when they
    try to acquire an S3 client, and thereby not spin.

Issue https://github.com/redpanda-data/redpanda/issues/6411 exposed this hang, but it also describes a more serious issue, so this PR is not marked as fixing it.

Related: https://github.com/redpanda-data/redpanda/issues/6411

## Backport Required


- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

### Improvements

* Redpanda shutdown is more prompt when client reads to S3 are in progress at the same time as Redpanda shuts down.
