### PR TITLE
tests: remove data-dir-fetching logic temporarily

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -507,10 +507,6 @@ class RedpandaService(Service):
         "backtraces": {
             "path": BACKTRACE_CAPTURE,
             "collect_default": True
-        },
-        "data": {
-            "path": DATA_DIR,
-            "collect_default": False
         }
     }
 
@@ -683,9 +679,6 @@ class RedpandaService(Service):
 
     def require_client_auth(self):
         return self._security.require_client_auth
-
-    def mark_data_dir_for_collection(self):
-        self.logs["data"]["collect_default"] = True
 
     @property
     def dedicated_nodes(self):

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -227,7 +227,10 @@ class EndToEndTest(Test):
                    (timeout_sec, min_records))
 
     def _collect_segment_data(self):
-        self.redpanda.mark_data_dir_for_collection()
+        # TODO: data collection is disabled because it was
+        # affecting other tests.
+        # See issue https://github.com/redpanda-data/redpanda/issues/7179
+        pass
 
     def _collect_all_logs(self):
         for s in self.test_context.services:


### PR DESCRIPTION

## Cover letter

This commit attempted to add collection of the redpanda data directory that was off by default, but it was actually happening in all tests.

Related: https://github.com/redpanda-data/redpanda/issues/7179

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none