### PR TITLE
tests: fix failing to stop redpanda if admin api unresponsive

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1618,8 +1618,13 @@ class RedpandaService(Service):
         if not os.path.isdir(service_dir):
             mkdir_p(service_dir)
 
-        rpk = RpkTool(self)
-        rpk.cluster_config_export(cluster_config_filename, True)
+        try:
+            rpk = RpkTool(self)
+            rpk.cluster_config_export(cluster_config_filename, True)
+        except Exception as e:
+            # Configuration is optional: if redpanda has e.g. crashed, you
+            # will not be able to get it from the admin API
+            self.logger.info(f"{self.who_am_i()}: error getting config: {e}")
 
         self.logger.info("%s: stopping service" % self.who_am_i())
 


### PR DESCRIPTION
## Cover letter

The recently added code for gathering configuration should not be allowed to prevent the overall stop() from proceeding if it encounters an error.

The processes will be eventually SIGKILL'd in clean_node(), but this prevents us seeing them shut down gracefully (it is really useful to know if redpanda successfully shuts down cleanly after it got into a bad state, we can find shutdown hang bugs this way)

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none