### PR TITLE
cloud_storage: limit the size of the segment deletion backlog

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -310,6 +310,7 @@ private:
     ss::lowres_clock::duration _upload_loop_initial_backoff;
     ss::lowres_clock::duration _upload_loop_max_backoff;
     config::binding<std::chrono::milliseconds> _sync_manifest_timeout;
+    config::binding<size_t> _max_segments_pending_deletion;
     simple_time_jitter<ss::lowres_clock> _backoff_jitter{100ms};
     size_t _concurrency{4};
     ss::lowres_clock::time_point _last_upload_time;

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -279,6 +279,104 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
     }
 }
 
+FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
+    /*
+     * This test verifies that the limit imposed by
+     * cloud_storage_max_segments_pending_deletion_per_partition on the garbage
+     * collection deletion backlog is respected. See
+     * ntp_archiver_service::garbage_collect for more details.
+     *
+     * It works as follows:
+     * 1. Create 4 segments; the first 3 have an old time stamp
+     * 2. Upload all segments
+     * 3. Set cloud_storage_max_segments_pending_deletion_per_partition to 2
+     * 4. Set up the HTTP imposter to fail the DELETE request
+     * for one of the "old" segments.
+     * 4. Trigger retention and garbage collection. DELETE requests
+     * will be sent out for the 3 "old" segments, but one of them will
+     * fail.
+     * 5. Check that the start offset was updated (i.e. manifest was
+     * updated) despite the failure to delete. This should have happened
+     * as the backlog size was breached (3 > 2).
+     */
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    cloud_storage::remote remote(
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
+
+    auto old_stamp = model::timestamp{
+      model::timestamp::now().value()
+      - std::chrono::milliseconds{10min}.count()};
+    std::vector<segment_desc> segments = {
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(0),
+       .term = model::term_id(1),
+       .timestamp = old_stamp},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(1000),
+       .term = model::term_id(2),
+       .timestamp = old_stamp},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(2000),
+       .term = model::term_id(3),
+       .timestamp = old_stamp},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(3000),
+       .term = model::term_id(4)}};
+
+    init_storage_api_local(segments);
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->high_watermark() >= model::offset(3000);
+    }).get();
+
+    config::shard_local_cfg().delete_retention_ms.set_value(
+      std::chrono::milliseconds{1min});
+    config::shard_local_cfg()
+      .cloud_storage_max_segments_pending_deletion_per_partition(2);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+
+    auto res = archiver.upload_next_candidates().get();
+    BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
+    BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
+
+    // Fail the second deletion request received.
+    fail_request_if(
+      [delete_request_idx = 0](const ss::httpd::request& req) mutable {
+          if (req._method == "DELETE") {
+              return 2 == ++delete_request_idx;
+          }
+
+          return false;
+      },
+      {.body
+       = {archival_tests::forbidden_payload.data(), archival_tests::forbidden_payload.size()},
+       .status = ss::httpd::reply::status_type::bad_request});
+
+    archiver.apply_retention().get();
+    archiver.garbage_collect().get();
+
+    for (auto [url, req] : get_targets()) {
+        vlog(test_log.info, "{} {}", req._method, req._url);
+    }
+
+    const auto& manifest_after_retention
+      = part->archival_meta_stm()->manifest();
+    vlog(
+      test_log.info,
+      "Start offset after garbage collection is {}",
+      manifest_after_retention.get_start_offset());
+    BOOST_REQUIRE(
+      manifest_after_retention.get_start_offset() == model::offset(3000));
+}
+
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     model::offset lso{9999};

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -61,7 +61,16 @@ static constexpr std::string_view error_payload
     <RequestId>requestid</RequestId>
 </Error>)xml";
 
-}
+static constexpr std::string_view forbidden_payload
+  = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>AccessDenied</Code>
+    <Message>Access Denied</Message>
+    <Resource>resource</Resource>
+    <RequestId>requestid</RequestId>
+</Error>)xml";
+
+} // namespace archival_tests
 
 /// This utility can be used to match content of the log
 /// with manifest and request content. It's also can be

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -278,6 +278,11 @@ partition_manifest::generate_segment_path(const segment_meta& meta) const {
       _ntp, meta.ntp_revision, name, meta.archiver_term);
 }
 
+remote_segment_path
+partition_manifest::generate_segment_path(const lw_segment_meta& meta) const {
+    return generate_segment_path(lw_segment_meta::convert(meta));
+}
+
 segment_name partition_manifest::generate_remote_segment_name(
   const partition_manifest::value& val) {
     switch (val.sname_format) {
@@ -379,6 +384,11 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
         return true;
     }
     return false;
+}
+
+std::vector<partition_manifest::lw_segment_meta>
+partition_manifest::lw_replaced_segments() const {
+    return _replaced;
 }
 
 std::vector<segment_meta> partition_manifest::replaced_segments() const {

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -191,6 +191,7 @@ public:
     timequery(model::timestamp t) const;
 
     remote_segment_path generate_segment_path(const segment_meta&) const;
+    remote_segment_path generate_segment_path(const lw_segment_meta&) const;
 
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;
@@ -268,6 +269,10 @@ public:
     /// Returns an iterator to the segment containing offset o, such that o >=
     /// segment.base_offset and o <= segment.committed_offset.
     const_iterator segment_containing(model::offset o) const;
+
+    // Return collection of segments that were replaced in lightweight format.
+    std::vector<partition_manifest::lw_segment_meta>
+    lw_replaced_segments() const;
 
     /// Return collection of segments that were replaced by newer segments.
     std::vector<segment_meta> replaced_segments() const;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -675,17 +675,16 @@ void archival_metadata_stm::apply_update_start_offset(const start_offset& so) {
     }
 }
 
-std::vector<cloud_storage::segment_meta>
+std::vector<cloud_storage::partition_manifest::lw_segment_meta>
 archival_metadata_stm::get_segments_to_cleanup() const {
     // Include replaced segments to the backlog
-    std::vector<cloud_storage::segment_meta> backlog
-      = _manifest->replaced_segments();
+    using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
+    std::vector<lw_segment_meta> backlog = _manifest->lw_replaced_segments();
+
     auto so = _manifest->get_start_offset().value_or(model::offset(0));
     for (const auto& m : *_manifest) {
         if (m.second.committed_offset < so) {
-            auto name = cloud_storage::generate_local_segment_name(
-              m.second.base_offset, m.second.segment_term);
-            backlog.push_back(m.second);
+            backlog.push_back(lw_segment_meta::convert(m.second));
         } else {
             break;
         }

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cloud_storage/fwd.h"
+#include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "cluster/persisted_stm.h"
 #include "features/fwd.h"
@@ -89,7 +90,8 @@ public:
 
     // Return list of all segments that has to be
     // removed from S3.
-    std::vector<cloud_storage::segment_meta> get_segments_to_cleanup() const;
+    std::vector<cloud_storage::partition_manifest::lw_segment_meta>
+    get_segments_to_cleanup() const;
 
 private:
     ss::future<std::error_code> do_add_segments(

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -266,6 +266,8 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
 
 FIXTURE_TEST(
   test_archival_stm_segment_truncate, archival_metadata_stm_fixture) {
+    using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
+
     wait_for_confirmed_leader();
     auto& ntp_cfg = _raft->log_config();
     std::vector<cloud_storage::segment_meta> m;
@@ -311,7 +313,7 @@ FIXTURE_TEST(
     auto name = cloud_storage::generate_local_segment_name(
       backlog[0].base_offset, backlog[0].segment_term);
     BOOST_REQUIRE(pm.get(name) != nullptr);
-    BOOST_REQUIRE(backlog[0] == *pm.get(name));
+    BOOST_REQUIRE(backlog[0] == lw_segment_meta::convert(*pm.get(name)));
 
     // Truncate the STM, next segment should be added to the backlog
     archival_stm->truncate(model::offset(200), ss::lowres_clock::now() + 10s)
@@ -324,7 +326,7 @@ FIXTURE_TEST(
         auto name = cloud_storage::generate_local_segment_name(
           it.base_offset, it.segment_term);
         BOOST_REQUIRE(pm.get(name) != nullptr);
-        BOOST_REQUIRE(it == *pm.get(name));
+        BOOST_REQUIRE(it == lw_segment_meta::convert(*pm.get(name)));
     }
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1118,6 +1118,15 @@ configuration::configuration()
       "Interval for cloud storage housekeeping tasks",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_storage_max_segments_pending_deletion_per_partition(
+      *this,
+      "cloud_storage_max_segments_pending_deletion_per_partition",
+      "The per-partition limit for the number of segments pending deletion "
+      "from the cloud. Segments can be deleted due to retention or compaction. "
+      "If this limit is breached and deletion fails, then segments will be "
+      "orphaned in the cloud and will have to be removed manually",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5000)
   , cloud_storage_enable_compacted_topic_reupload(
       *this,
       "cloud_storage_enable_compacted_topic_reupload",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -232,6 +232,7 @@ struct configuration final : public config_store {
       cloud_storage_readreplica_manifest_sync_timeout_ms;
     property<std::chrono::milliseconds> cloud_storage_metadata_sync_timeout_ms;
     property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
+    property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
 
     // Archival upload controller


### PR DESCRIPTION
## Cover letter

Previously, if any deletion from S3 failed while performing garbage collection the manifest
was not updated. This means that the backlog of segments pending removal
(segments below the current start offset and replaced segments) grows unbounded.
This is problematic. For example: if redpanda has access to an S3 bucket with put/get permissions
but no delete permissions, when the backlog grows large enough we'll bad_alloc when attempting
to allocate a vector to hold it.

This PR introduces a new tunable cluster config `cloud_storage_max_segments_pending_deletion`.
If the number of segments to remove exceeds the limit, the manifest gets updated even if deletions
from S3 failed. All segments for which deletion failed will become orphaned (i.e. not in the manifest.
but still present in S3) and will have to be deleted manually, but this is preferable to impacting the stability
of the system and crashing unexpectedly.

The default for `cloud_storage_max_segments_pending_deletion` is `5000`, so the maximum size
of the vector in which we accumulate segments pending removal is between 200KiB and 300KiB.
If the segment size is 256MiB (default for cloudv2), then we can support deleting roughly 4GiB of data
within a housekeeping interval (5min by default). 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #6844 
## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [X] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes
### Improvements
* Introduced a configurable limit for the number of segments pending deletion from the could.
This limit is controlled by the `cloud_storage_max_segments_pending_deletion` cluster config.
