### PR TITLE
cloud_storage: cache thrashing/pressure mitigations

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -133,6 +133,10 @@ private:
     access_time_tracker _access_time_tracker;
     ss::timer<ss::lowres_clock> _tracker_timer;
 
+    /// Remember when we last finished clean_up_cache, in order to
+    /// avoid wastefully running it again soon after.
+    ss::lowres_clock::time_point _last_clean_up;
+
     friend class cache_test_fixture;
 };
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -183,6 +183,9 @@ private:
 
     using tx_range_vec = fragmented_vector<model::tx_range>;
     std::optional<tx_range_vec> _tx_range;
+
+    // For backing off on apparent thrash/saturation of the local cache
+    simple_time_jitter<ss::lowres_clock> _cache_backoff_jitter;
 };
 
 class remote_segment_batch_consumer;


### PR DESCRIPTION
## Cover letter

This PR adds mitigation for situations where the cache is full, and the space management code is indiscriminately trimming objects that materialized segments are trying to use, causing endless loops of promotion + eviction that hang consumers:
- When the promotion code notices that something they just added to the cache has gone away, they use a jittered backoff to improve the chances that some subset of partitions will remain hydrated long enough to serve some reads.
- The cache trimming is limited to happen with a 5 second gap between runs, to prevent a continuous trimming loop.
- The trimming code now only trims .tx and .index files when removing the log segment .log file, to avoid situations where many segments are in a state with only a subset of their required objects in cache.

Fixes #6411 

## Backport Required

Calling this "not a bug fix" because it's a meaningful functional change rather than a point bug fix: 22.2 tiered storage systems must work within the limitations they have (cache must be comfortably larger than working set)

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
