### PR TITLE
archival: Fix read replicas sync loop

### DIFF
--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -26,6 +26,7 @@
 #include "test_utils/http_imposter.h"
 
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -452,4 +453,35 @@ FIXTURE_TEST(
     BOOST_REQUIRE(archival_stm.manifest() == m);
 
     archival_stm.stop().get();
+}
+
+FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {
+    wait_for_confirmed_leader();
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(999),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+    m.push_back(segment_meta{
+      .base_offset = model::offset(1000),
+      .committed_offset = model::offset(1999),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(999),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(1)});
+    // Replicate add_segment_cmd command that adds segment with offset 0
+    auto batcher = archival_stm->batch_start(ss::lowres_clock::now() + 10s);
+    batcher.add_segments(m);
+    batcher.cleanup_metadata();
+    batcher.replicate().get();
+    BOOST_REQUIRE(archival_stm->manifest().size() == 2);
+    BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(0));
+    BOOST_REQUIRE(archival_stm->manifest().replaced_segments().size() == 0);
+    BOOST_REQUIRE(
+      archival_stm->manifest().begin()->second.archiver_term
+      == model::term_id(2));
 }


### PR DESCRIPTION
## Cover letter

Before this fix read replica wasn't able to see reuploads of compacted segments. The truncations were also ignored. The fix changes the way we sync local STM with remote manifest. New segments are added first, then we add new compacted segments. After that we truncate the manifest and issue a cleanup command.

The cleanup is done only if compacted segments are added or truncation happened.

Also, this PR adds batching to `archival_metadata_stm`. The batrcher simply adds multiple commands to the single `archival_metadata_stm` command. In case of read replica we can batch all updates with truncation followed by the cleanup command.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none


### Features

* none

### Improvements

* none

