### PR TITLE
Node UUID map initialized from cluster discovery

### DIFF
--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -33,12 +33,15 @@ namespace cluster {
  * This class applies the cluster initialization message to
  * - storage, persisting the cluster UUID to the kvstore,
  * - credential_store, to initialize the bootstrap user
+ * - members_manager, to initialize node UUID map
  * - TODO: apply the initial licence
  */
 class bootstrap_backend final {
 public:
     bootstrap_backend(
-      ss::sharded<security::credential_store>&, ss::sharded<storage::api>&);
+      ss::sharded<security::credential_store>&,
+      ss::sharded<storage::api>&,
+      ss::sharded<members_manager>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -49,8 +52,10 @@ public:
 
 private:
     ss::future<std::error_code> apply(bootstrap_cluster_cmd);
+
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
+    ss::sharded<members_manager>& _members_manager;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/bootstrap_service.cc
+++ b/src/v/cluster/bootstrap_service.cc
@@ -34,6 +34,7 @@ bootstrap_service::cluster_bootstrap_info(
       [](const config::seed_server& seed_server) { return seed_server.addr; });
     r.empty_seed_starts_cluster = config::node().empty_seed_starts_cluster();
     r.cluster_uuid = _storage.local().get_cluster_uuid();
+    r.node_uuid = _storage.local().node_uuid();
 
     vlog(clusterlog.debug, "Replying cluster_bootstrap_info: {}", r);
     co_return r;

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -40,6 +40,7 @@ struct cluster_bootstrap_info_reply
     std::vector<net::unresolved_address> seed_servers;
     bool empty_seed_starts_cluster;
     std::optional<model::cluster_uuid> cluster_uuid;
+    model::node_uuid node_uuid;
 
     auto serde_fields() {
         return std::tie(
@@ -47,7 +48,8 @@ struct cluster_bootstrap_info_reply
           version,
           seed_servers,
           empty_seed_starts_cluster,
-          cluster_uuid);
+          cluster_uuid,
+          node_uuid);
     }
 
     friend std::ostream&
@@ -55,12 +57,13 @@ struct cluster_bootstrap_info_reply
         fmt::print(
           o,
           "{{broker: {}, version: {}, seed_servers: {}, "
-          "empty_seed_starts_cluster: {}, cluster_uuid: {}}}",
+          "empty_seed_starts_cluster: {}, cluster_uuid: {}, node_uuid: {}}}",
           v.broker,
           v.version,
           v.seed_servers,
           v.empty_seed_starts_cluster,
-          v.cluster_uuid);
+          v.cluster_uuid,
+          v.node_uuid);
         return o;
     }
 };

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -64,6 +64,8 @@ struct cluster_bootstrap_info_reply;
 class cluster_discovery {
 public:
     using brokers = std::vector<model::broker>;
+    using node_ids_by_uuid
+      = absl::flat_hash_map<model::node_uuid, model::node_id>;
 
     cluster_discovery(
       const model::node_uuid& node_uuid, storage::api&, ss::abort_source&);
@@ -101,10 +103,18 @@ public:
     // will be set with an ID agreed upon by all seeds.
     ss::future<bool> is_cluster_founder();
 
+    // Returns node_uuid to node_id map built during cluster discovery.
+    // Non-const to allow moving the contents away, since it is supposed to be
+    // a single use call.
+    //
+    // \pre is_cluster_founder() future has been completed
+    // \pre get_node_ids_by_uuid() has never been called
+    node_ids_by_uuid& get_node_ids_by_uuid();
+
 private:
-    // Sends requests to each seed server to register the local node UUID until
-    // one succeeds. Upon success, sets `node_id` to the assigned node ID and
-    // returns true.
+    // Sends requests to each seed server to register the local node UUID
+    // until one succeeds. Upon success, sets `node_id` to the assigned node
+    // ID and returns true.
     ss::future<bool> dispatch_node_uuid_registration_to_seeds(model::node_id&);
 
     // Requests `cluster_bootstrap_info` from the given address, returning
@@ -116,8 +126,9 @@ private:
     // Initializes founder state (whether a cluster already exists, whether
     // this node is a founder, etc). Requests cluster_bootstrap_info from all
     // seeds to determine whether the local node is a cluster founder, and if
-    // so, populates `_founding_brokers`. Validates that all seeds are
-    // consistent with one another and agree on the set of founding brokers.
+    // so, populates `_founding_brokers` and `_node_ids_by_uuid`. Validates that
+    // all seeds are consistent with one another and agree on the set of
+    // founding brokers.
     //
     // Sets `_is_cluster_founder` upon completion.
     ss::future<> discover_founding_brokers();
@@ -130,6 +141,7 @@ private:
     storage::api& _storage;
     ss::abort_source& _as;
     brokers _founding_brokers;
+    node_ids_by_uuid _node_ids_by_uuid;
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -505,17 +505,11 @@ ss::future<> controller::stop() {
     });
 }
 
-ss::future<> controller::create_cluster(const create_cluster_mode mode) {
+ss::future<>
+controller::create_cluster(const bootstrap_cluster_cmd_data cmd_data) {
     vassert(
       ss::this_shard_id() == controller_stm_shard,
       "Cluster can only be created from controller_stm_shard");
-
-    bootstrap_cluster_cmd_data cmd_data;
-    cmd_data.uuid = model::cluster_uuid(uuid_t::create());
-    if (mode == create_cluster_mode::bootstrap) {
-        cmd_data.bootstrap_user_cred
-          = security_frontend::get_bootstrap_user_creds_from_env();
-    }
 
     for (simple_time_jitter<model::timeout_clock> retry_jitter(1s);;) {
         // A new cluster is created by the leader of raft0 consisting of seed
@@ -588,7 +582,13 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
               "Root is a cluster founder but joiners are in the cluster alrdy");
         }
 
-        co_return co_await create_cluster(create_cluster_mode::bootstrap);
+        // Full cluster bootstrap
+        bootstrap_cluster_cmd_data cmd_data;
+        cmd_data.uuid = model::cluster_uuid(uuid_t::create());
+        cmd_data.bootstrap_user_cred
+          = security_frontend::get_bootstrap_user_creds_from_env();
+        cmd_data.node_ids_by_uuid = std::move(discovery.get_node_ids_by_uuid());
+        co_return co_await create_cluster(std::move(cmd_data));
     }
 
     if (_storage.local().get_cluster_uuid()) {
@@ -599,14 +599,18 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         co_return;
     }
 
-    // No cluster UUID in non-founder is a possibility that a pre-22.3
-    // cluster needs a UUID
+    // A missing cluster UUID on a non-founder may indicate this node was
+    // upgraded from a version before 22.3. Replicate just a cluster UUID so we
+    // can advertise that a cluster has already been bootstrapped to nodes
+    // trying to discover existing clusters.
     ssx::background
       = _feature_table.local()
           .await_feature(
             features::feature::seeds_driven_bootstrap_capable, _as.local())
           .then([this] {
-              return create_cluster(create_cluster_mode::cluster_uuid_only);
+              bootstrap_cluster_cmd_data cmd_data;
+              cmd_data.uuid = model::cluster_uuid(uuid_t::create());
+              return create_cluster(std::move(cmd_data));
           })
           .handle_exception([](const std::exception_ptr e) {
               vlog(clusterlog.warn, "Error creating cluster UUID. {}", e);

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -158,7 +158,9 @@ ss::future<> controller::start(cluster_discovery& discovery) {
       })
       .then([this] {
           return _bootstrap_backend.start_single(
-            std::ref(_credentials), std::ref(_storage));
+            std::ref(_credentials),
+            std::ref(_storage),
+            std::ref(_members_manager));
       })
       .then([this] {
           return _config_frontend.start(

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -151,15 +151,11 @@ public:
 private:
     friend controller_probe;
 
-    enum class create_cluster_mode { bootstrap, cluster_uuid_only };
     /**
      * Create a \c bootstrap_cluster_cmd, replicate-and-wait it to the current
      * quorum, retry infinitely if replicate-and-wait fails.
-     *
-     * \param mode Controls whether to perform a full bootstrap for a brand new
-     * cluster, or only partial cluster creation for upgrade from 22.2.
      */
-    ss::future<> create_cluster(create_cluster_mode mode);
+    ss::future<> create_cluster(bootstrap_cluster_cmd_data cmd_data);
 
     ss::future<> cluster_creation_hook(cluster_discovery& discovery);
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -39,6 +39,8 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
 
+#include <fmt/ranges.h>
+
 #include <chrono>
 #include <system_error>
 namespace cluster {
@@ -352,6 +354,14 @@ model::node_id members_manager::get_node_id(const model::node_uuid& node_uuid) {
       it != _id_by_uuid.end(),
       "Node registration must be completed before calling");
     return it->second;
+}
+
+void members_manager::apply_initial_node_uuid_map(uuid_map_t id_by_uuid) {
+    vassert(_id_by_uuid.empty(), "will not overwrite existing data");
+    if (!id_by_uuid.empty()) {
+        vlog(clusterlog.debug, "Initial node UUID map: {}", id_by_uuid);
+    }
+    _id_by_uuid = std::move(id_by_uuid);
 }
 
 template<typename Cmd>

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -109,6 +109,8 @@ public:
         friend std::ostream& operator<<(std::ostream&, const node_update&);
     };
 
+    using uuid_map_t = absl::flat_hash_map<model::node_uuid, model::node_id>;
+
     members_manager(
       consensus_ptr,
       ss::sharded<controller_stm>&,
@@ -176,8 +178,11 @@ public:
     // guarantee that the UUID has already been registered before calling.
     model::node_id get_node_id(const model::node_uuid&);
 
+    // Initialize `_id_by_uuid`. Should be called once only when bootstrapping a
+    // cluster.
+    void apply_initial_node_uuid_map(uuid_map_t);
+
 private:
-    using uuid_map_t = absl::flat_hash_map<model::node_uuid, model::node_id>;
     using seed_iterator = std::vector<config::seed_server>::const_iterator;
     // Cluster join
     void join_raft0();

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2036,10 +2036,13 @@ struct bootstrap_cluster_cmd_data
       const bootstrap_cluster_cmd_data&, const bootstrap_cluster_cmd_data&)
       = default;
 
-    auto serde_fields() { return std::tie(uuid, bootstrap_user_cred); }
+    auto serde_fields() {
+        return std::tie(uuid, bootstrap_user_cred, node_ids_by_uuid);
+    }
 
     model::cluster_uuid uuid;
     std::optional<user_and_credential> bootstrap_user_cred;
+    absl::flat_hash_map<model::node_uuid, model::node_id> node_ids_by_uuid;
 };
 
 enum class reconciliation_status : int8_t {


### PR DESCRIPTION
## Cover letter

The node UUID to ID map in `members_manager` was not initialized until it was populated by cluster joiners. That has allowed for slow seed nodes (ones that miss their oportunity to be founding nodes because of being slow) to also possibly miss the assignment of `node_id` based on their `seed_servers` index. That could happen if another node joins the cluster before a slow seed node and grabs the `node_id` that should have belonged to it.

To prevent that, the node UUID to ID map needs to be initialized at the time of cluster bootstrap phase. This PR introduces
* advertisement of node UUID at cluster discovery phase via `cluster_bootstap_info`
* building of node UUID map upon analysis of `cluster_bootstap_info` replies from the seeds
* storage of node UUID map in `bootstrap_cluster_cmd`
* initialization of node UUID map in `members_manager`

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #333

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none
* 
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
<!--
Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
