### PR TITLE
tests: retry getting partition assignments

### DIFF
--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -12,6 +12,7 @@ import random
 
 import requests
 from rptest.services.admin import Admin
+from rptest.util import wait_until_result
 from ducktape.utils.util import wait_until
 
 
@@ -61,7 +62,18 @@ class PartitionMovementMixin():
 
     @staticmethod
     def _get_assignments(admin, topic, partition):
-        res = admin.get_partitions(topic, partition)
+        def try_get_partitions():
+            try:
+                res = admin.get_partitions(topic, partition)
+                return (True, res)
+            except requests.exceptions.HTTPError:
+                # Retry HTTP errors, eg. 404 if the receiving node's controller
+                # is catching up and doesn't yet know about the partition.
+                return (False, None)
+
+        res = wait_until_result(try_get_partitions,
+                                timeout_sec=30,
+                                backoff_sec=1)
 
         def normalize(a):
             return dict(node_id=a["node_id"], core=a["core"])


### PR DESCRIPTION
## Cover letter

A common pattern in partition movement tests is:

1. describe topics with a Kafka client
2. pick a partition at random
3. get replica assignments for that partition from a random node
4. dispatch movements based on the current assignment

Depending on when in the lifespan of the test, it's possible that step 3 fails because the selected partition, while created on a majority, has not had its existence propagated to every node, e.g.:

```
DEBUG 2022-11-04 17:12:58,381 [shard 1] admin_api_server - admin_server.cc:353 - [_anonymous] GET http://docker-rp-15:9644/v1/partitions/kafka/__consumer_offsets/4
...
TRACE 2022-11-04 17:12:58,411 [shard 1] cluster - controller_backend.cc:771 - [{kafka/__consumer_offsets/4}] executing operation: {type: addition, revision: 37, assignment: { id: 4, group_id: 25, replicas: {{node_id: 2, shard: 0}, {node_id: 4, shard: 0}, {node_id: 5, shard: 0}} }, previous assignment: {nullopt}}
```

...where the call to get partition metadata failed because the controller hadn't played the creation of __consumer_offsets/4 yet.

This commit adds a retry to step 3. I considered other approaches like adding explicit waits for topic metadata to quiesce in test bodies, but given this affects a several tests that all follow the same pattern, I opted for an approach that improved them all transparently.

Fixes #7103

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
