### PR TITLE
[v22.2.x] prefix_truncate_recovery_test: retry leadership transfers

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -637,7 +637,7 @@ class Admin:
         Looks up current ntp leader and transfer leadership to target node,
         this operations is NOP when current leader is the same as target.
         If user pass None for target this function will choose next replica for new leader.
-        If leadership transfer was performed this function return True
+        Returns true if leadership was transferred to the target node.
         """
         def _get_details():
             p = self.get_partitions(topic=topic,
@@ -660,7 +660,7 @@ class Admin:
 
         if target_id is not None:
             if leader_id == target_id:
-                return False
+                return True
             path = f"raft/{details['raft_group_id']}/transfer_leadership?target={target_id}"
         else:
             path = f"raft/{details['raft_group_id']}/transfer_leadership"

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -180,11 +180,17 @@ class PrefixTruncateRecoveryUpgradeTest(PrefixTruncateRecoveryTestBase):
         def _run_recovery(src_node, dst_node):
             # Force leadership to 'src_node' so we can deterministically check
             # mixed-version traffic.
-            self.redpanda._admin.transfer_leadership_to(
+            # Note it's possible to see surprising error codes on older
+            # versions following a node restart (e.g. 500 insteaad of 503/504);
+            # just retry until leadership is moved.
+            wait_until(lambda: self.redpanda._admin.transfer_leadership_to(
                 namespace="kafka",
                 topic=self.topic,
                 partition=0,
-                target_id=self.redpanda.idx(src_node))
+                target_id=self.redpanda.idx(src_node)),
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       retry_on_exc=True)
             # Speed the test up a bit by using acks=1.
             self.run_recovery(acks=1, dst_node=dst_node)
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/7163.
Fixes https://github.com/redpanda-data/redpanda/issues/7206,