### PR TITLE
kafka/client/consumer: Shutdown and fetch improvements

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -499,6 +499,22 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
               return c->fetch(
                 std::chrono::duration_cast<std::chrono::milliseconds>(timeout),
                 max_bytes);
+          })
+          .then([this](kafka::fetch_response res) {
+              bool has_error = std::any_of(
+                res.data.topics.begin(),
+                res.data.topics.end(),
+                [](auto const& topics) {
+                    return std::any_of(
+                      topics.partitions.begin(),
+                      topics.partitions.end(),
+                      [](const auto& p) {
+                          return p.error_code != error_code::none;
+                      });
+                });
+              return (has_error ? _wait_or_start_update_metadata() : ss::now())
+                .then(
+                  [res{std::move(res)}]() mutable { return std::move(res); });
           });
     });
 }

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -110,15 +110,15 @@ void consumer::start() {
     _heartbeat_timer.set_callback([me{shared_from_this()}]() {
         vlog(kclog.trace, "Consumer: {}: timer cb", *me);
         (void)me->heartbeat()
-          .handle_exception_type([me](const consumer_error& e) {
+          .handle_exception_type([me](const exception_base& e) {
               vlog(
-                kclog.error,
-                "Consumer: {}: heartbeat failed: {}",
-                *me,
-                e.error);
+                kclog.info, "Consumer: {}: heartbeat failed: {}", *me, e.error);
           })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
               vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
+          })
+          .handle_exception([me](const std::exception_ptr& e) {
+              vlog(kclog.error, "Consumer: {}: heartbeat failed: {}", *me, e);
           });
     });
     _heartbeat_timer.rearm_periodic(_config.consumer_heartbeat_interval());

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -100,9 +100,10 @@ log_config = LoggingConfig('info',
 
 
 class Consumer:
-    def __init__(self, res):
+    def __init__(self, res, logger):
         self.instance_id = res["instance_id"]
         self.base_uri = res["base_uri"]
+        self.logger = logger
 
     def subscribe(self,
                   topics,
@@ -123,6 +124,26 @@ class Consumer:
                            headers=headers,
                            **kwargs)
         return res
+
+    def fetch_n(self, count, timeout_sec=10):
+        fetch_result = []
+
+        def do_fetch():
+            cf_res = self.fetch()
+            assert cf_res.status_code == requests.codes.ok
+            records = cf_res.json()
+            self.logger.debug(f"Fetched {len(records)} records: {records}")
+            fetch_result.extend(records)
+            if len(fetch_result) != count:
+                self.logger.info(f"Fetch Mitigation {len(fetch_result)}")
+            return len(fetch_result) == count
+
+        wait_until(lambda: do_fetch(),
+                   timeout_sec=timeout_sec,
+                   backoff_sec=0,
+                   err_msg="Timeout waiting for records to appear")
+
+        return fetch_result
 
     def get_offsets(self,
                     data=None,
@@ -676,7 +697,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         cc_res = self._create_consumer(group_id)
         assert cc_res.status_code == requests.codes.ok
 
-        c0 = Consumer(cc_res.json())
+        c0 = Consumer(cc_res.json(), self.logger)
 
         self.logger.info("Subscribe a consumer with no accept header")
         sc_res = c0.subscribe(
@@ -745,7 +766,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         cc_res = self._create_consumer(group_id)
         assert cc_res.status_code == requests.codes.ok
 
-        c0 = Consumer(cc_res.json())
+        c0 = Consumer(cc_res.json(), self.logger)
 
         self.logger.info("Remove a consumer with invalid accept header")
         sc_res = c0.remove(
@@ -813,7 +834,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         self.logger.info("Create a consumer")
         cc_res = self._create_consumer(group_id)
         assert cc_res.status_code == requests.codes.ok
-        c0 = Consumer(cc_res.json())
+        c0 = Consumer(cc_res.json(), self.logger)
 
         # Subscribe a consumer
         self.logger.info(f"Subscribe consumer to topics: {topics}")
@@ -834,12 +855,8 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
 
         # Fetch from a consumer
         self.logger.info(f"Consumer fetch")
-        cf_res = c0.fetch()
-        assert cf_res.status_code == requests.codes.ok
-        fetch_result = cf_res.json()
         # 3 topics * 3 msg
-        assert len(fetch_result) == 3 * 3
-        print(fetch_result)
+        c0.fetch_n(3 * 3)
 
         self.logger.info(f"Get consumer offsets")
         co_res_raw = c0.get_offsets(data=json.dumps(co_req))
@@ -902,7 +919,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         self.logger.info("Create a consumer")
         cc_res = self._create_consumer(group_id)
         assert cc_res.status_code == requests.codes.ok
-        c0 = Consumer(cc_res.json())
+        c0 = Consumer(cc_res.json(), self.logger)
 
         # Subscribe a consumer
         self.logger.info(f"Subscribe consumer to topics: {topics}")
@@ -911,13 +928,8 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
 
         # Fetch from a consumer
         self.logger.info(f"Consumer fetch")
-        cf_res = c0.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
-        assert cf_res.status_code == requests.codes.ok
-        fetch_result = cf_res.json()
         # 3 topics * 3 msg
-        assert len(fetch_result) == 3 * 3
-        for r in fetch_result:
-            assert r["value"]["object"]
+        c0.fetch_n(3 * 3)
 
         # Remove consumer
         self.logger.info("Remove consumer")
@@ -1190,7 +1202,7 @@ class PandaProxyBasicAuthTest(PandaProxyEndpoints):
         cc_res = self._create_consumer(group_id,
                                        auth=(super_username, super_password))
         assert cc_res.status_code == requests.codes.ok
-        c0 = Consumer(cc_res.json())
+        c0 = Consumer(cc_res.json(), self.logger)
 
         # Subscribe a consumer
         self.logger.info(f"Subscribe consumer to topics: {self.topic}")


### PR DESCRIPTION
## Cover letter

* Improve failed heartbeat logging
  * Catch more error types
  * Improve log level
  * Avoid ignored exceptional future

* Handle double-leave 

  It's possible for leave to be called multiple times, for example if the Proxy is shut down during an existing leave request.

* Handle fetch error
  Update metadata if there is a partition error so that the next fetch will work. 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.2.x
- [x] v22.1.x
- [x] v21.11.x

## UX changes

* none

## Release notes

### Improvements

* pandaproxy: consumer fetch: More gracefully handle partition movement
* pandaproxy: Shut down consumers more gracefully during shutdown.