### PR TITLE
net: suppress WARN logs on TLS disconnects

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -12,7 +12,44 @@
 #include "net/exceptions.h"
 #include "rpc/service.h"
 
+#include <gnutls/gnutls.h>
+
 namespace net {
+
+/**
+ * Identify error cases that should be quickly retried, e.g.
+ * TCP disconnects, timeouts. Network errors may also show up
+ * indirectly as errors from the TLS layer.
+ */
+bool is_reconnect_error(const std::system_error& e) {
+    auto v = e.code().value();
+
+    // The name() of seastar's gnutls_error_category class
+    constexpr std::string_view gnutls_category_name{"GnuTLS"};
+
+    if (e.code().category().name() == gnutls_category_name) {
+        switch (v) {
+        case GNUTLS_E_PUSH_ERROR:
+        case GNUTLS_E_PULL_ERROR:
+        case GNUTLS_E_PREMATURE_TERMINATION:
+            return true;
+        default:
+            return false;
+        }
+    } else {
+        switch (v) {
+        case ECONNREFUSED:
+        case ENETUNREACH:
+        case ETIMEDOUT:
+        case ECONNRESET:
+        case EPIPE:
+            return true;
+        default:
+            return false;
+        }
+    }
+    __builtin_unreachable();
+}
 
 /**
  * If the exception is a "boring" disconnection case, then populate this with

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -42,6 +42,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case ENETUNREACH:
         case ETIMEDOUT:
         case ECONNRESET:
+        case ECONNABORTED:
         case EPIPE:
             return true;
         default:
@@ -62,10 +63,7 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
     try {
         rethrow_exception(e);
     } catch (std::system_error& e) {
-        if (
-          e.code() == std::errc::broken_pipe
-          || e.code() == std::errc::connection_reset
-          || e.code() == std::errc::connection_aborted) {
+        if (is_reconnect_error(e)) {
             return e.code().message();
         }
     } catch (const net::batched_output_stream_closed& e) {

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -28,6 +28,7 @@
  */
 namespace net {
 
+bool is_reconnect_error(const std::system_error& e);
 std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr);
 
 class connection : public boost::intrusive::list_base_hook<> {


### PR DESCRIPTION
## Cover letter

We recently did the same thing in cloud_storage for our S3 connections: any dropped connection using TLS can give one of these GnuTLS error codes rather than a normal connection reset/abort/pipe error.

Fixes #6803 
Fixes https://github.com/redpanda-data/redpanda/issues/7195

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

None

## Release notes

* none