### PR TITLE
cluster: Fix parsing replication factor ub

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -571,9 +571,8 @@ std::istream& operator>>(std::istream& i, replication_factor& cs) {
     return i;
 };
 
-replication_factor
-parsing_replication_factor(const std::optional<ss::sstring>& value) {
-    auto raw_value = boost::lexical_cast<int32_t>(*value);
+replication_factor parsing_replication_factor(const ss::sstring& value) {
+    auto raw_value = boost::lexical_cast<int32_t>(value);
     if (
       raw_value <= 0
       || raw_value

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1221,8 +1221,7 @@ using replication_factor
 
 std::istream& operator>>(std::istream& i, replication_factor& cs);
 
-replication_factor
-parsing_replication_factor(const std::optional<ss::sstring>& value);
+replication_factor parsing_replication_factor(const ss::sstring& value);
 
 // This class contains updates for topic properties which are replicates not by
 // topic_frontend

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -87,9 +87,9 @@ static void parse_and_set_topic_replication_factor(
   const std::optional<ss::sstring>& value) {
     if (!value) {
         property.value = std::nullopt;
+    } else {
+        property.value = cluster::parsing_replication_factor(*value);
     }
-
-    property.value = cluster::parsing_replication_factor(value);
 }
 
 static void parse_and_set_shadow_indexing_mode(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -146,7 +146,10 @@ static void parse_and_set_topic_replication_factor(
   config_resource_operation op) {
     // set property value
     if (op == config_resource_operation::set) {
-        property.value = cluster::parsing_replication_factor(value);
+        property.value = std::nullopt;
+        if (value) {
+            property.value = cluster::parsing_replication_factor(*value);
+        }
         property.op = cluster::incremental_update_operation::set;
     }
     return;


### PR DESCRIPTION
## Cover letter

Parsing rf in alter-config contains ub because we can pass std::nullopt inside function which does not check it.
Now we do this check before run `parsing_replication_factor`

Fixes #7031 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* None

## Release notes

* None