### PR TITLE
pp/cache: remove debounce logic

### DIFF
--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -86,18 +86,6 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
                 vlog(plog.debug, "Cache size reached, evicting {}", item.key);
                 inner_list.pop_back();
                 _evicted_items.push_back(std::move(item));
-
-                // If the timer is not armed, then trigger it for a few
-                // seconds from now. If the timer is armed and it won't run
-                // until far into the future, then trigger it a few seconds
-                // from now. If the timer is armed and it will run soon,
-                // then do nothing.
-                auto window = ss::lowres_clock::now() + 1s;
-                if (
-                  !_gc_timer.armed()
-                  || (_gc_timer.armed() && _gc_timer.get_timeout() > window)) {
-                    _gc_timer.rearm(window);
-                }
             }
         }
 


### PR DESCRIPTION
## Cover letter

Previously, debounce logic was written into the cache in an effort to free resources sooner-rather-than later. However, there was a race to which shard "pings" the gc timer first during cache eviction.

This PR removes the debounce logic completely. The consequence of this is that clients may not be freed until some seconds later since gc runs on a 10s interval.

Fixes #7219
Reopens #6607 (but that's not a release blocker)

## Backport Required

- [ ] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

* none
