### PR TITLE
pp: basic auth upgrade tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -629,8 +629,8 @@ class PandaproxyConfig(TlsConfig):
 
     def __init__(self):
         super(PandaproxyConfig, self).__init__()
-        self.cache_keep_alive_ms: int = 300000
-        self.cache_max_size: int = 10
+        self.cache_keep_alive_ms: Optional[int] = 300000
+        self.cache_max_size: Optional[int] = 10
 
 
 class SchemaRegistryConfig(TlsConfig):

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -63,8 +63,12 @@ pandaproxy:
     authentication_method: {{ pandaproxy_config.authn_method }}
     {% endif %}
 
+  {% if pandaproxy_config.cache_keep_alive_ms is not none %}
   client_keep_alive: {{ pandaproxy_config.cache_keep_alive_ms }}
+  {% endif %}
+  {% if pandaproxy_config.cache_max_size is not none %}
   client_cache_max_size: {{ pandaproxy_config.cache_max_size }}
+  {% endif %}
 
   advertised_pandaproxy_api:
     address: "{{node.account.hostname}}"


### PR DESCRIPTION
## Cover letter

Users can use basic authentication with the Pandaproxy added support for basic authentication but we are missing upgrade tests. This PR tests upgrading clusters with Basic Auth Enabled.

Closes #6766

Changes from force-push `fd9590b`:
- Test upgrades in pairs starting from `22.2.x`
- Enable sasl throughout the whole test

Changes from force-push `55bfed3`:
- In redpanda.yaml template, explicitly check for `none` type

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [x] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

* none

## Release notes

* none
