### PR TITLE
tests/services_self_test: enable debug logs for kgo-verifier

### DIFF
--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -87,7 +87,8 @@ class KgoVerifierSelfTest(PreallocNodesTest):
                                        topic,
                                        16384,
                                        1000,
-                                       custom_node=self.preallocated_nodes)
+                                       custom_node=self.preallocated_nodes,
+                                       debug_logs=True)
         producer.start()
         producer.wait_for_acks(1000, timeout_sec=30, backoff_sec=1)
         producer.wait_for_offset_map()
@@ -99,14 +100,16 @@ class KgoVerifierSelfTest(PreallocNodesTest):
             16384,
             100,
             2,
-            nodes=self.preallocated_nodes)
+            nodes=self.preallocated_nodes,
+            debug_logs=True)
         rand_consumer.start(clean=False)
 
         seq_consumer = KgoVerifierSeqConsumer(self.test_context,
                                               self.redpanda,
                                               topic,
                                               16384,
-                                              nodes=self.preallocated_nodes)
+                                              nodes=self.preallocated_nodes,
+                                              debug_logs=True)
         seq_consumer.start(clean=False)
 
         group_consumer = KgoVerifierConsumerGroupConsumer(
@@ -115,7 +118,8 @@ class KgoVerifierSelfTest(PreallocNodesTest):
             topic,
             16384,
             2,
-            nodes=self.preallocated_nodes)
+            nodes=self.preallocated_nodes,
+            debug_logs=True)
         group_consumer.start(clean=False)
 
         producer.wait(timeout_sec=60)


### PR DESCRIPTION
Since this test exists to detect issues in the tool, on a failure we will certainly be interested in the debug logs, and these are reasonably small because the test is just smoke test.

Related https://github.com/redpanda-data/redpanda/issues/7231

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
