### PR TITLE
[v22.2.x] Ducktape: Timeout many_clients_test producers at 5s

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -120,7 +120,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     export PATH="/root/.cargo/bin:${PATH}" && \
     git clone https://github.com/redpanda-data/client-swarm.git && \
     cd client-swarm && \
-    git reset --hard 28790f8 && \
+    git reset --hard a03a8ae && \
     cargo build --release && \
     cp target/release/client-swarm /usr/local/bin && \
     cd .. && rm -rf client-swarm && rm -rf /root/.cargo

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -53,6 +53,7 @@ class ManyClientsTest(RedpandaTest):
 
         PARTITION_COUNT = 100
         PRODUCER_COUNT = 4000
+        PRODUCER_TIMEOUT_MS = 5000
         TOPIC_NAME = "manyclients"
         RECORDS_PER_PRODUCER = 1000
 
@@ -78,7 +79,8 @@ class ManyClientsTest(RedpandaTest):
                                  save_msgs=False)
 
         producer = ProducerSwarm(self.test_context, self.redpanda, TOPIC_NAME,
-                                 PRODUCER_COUNT, RECORDS_PER_PRODUCER)
+                                 PRODUCER_COUNT, RECORDS_PER_PRODUCER,
+                                 PRODUCER_TIMEOUT_MS)
         producer.start()
         consumer_a.start()
         consumer_b.start()

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -21,7 +21,8 @@ class ProducerSwarm(BackgroundThreadService):
                  producers: int,
                  records_per_producer: int,
                  log_level="INFO",
-                 properties={}):
+                 properties={},
+                 timeout_ms: int = 1000):
         super(ProducerSwarm, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
@@ -30,9 +31,10 @@ class ProducerSwarm(BackgroundThreadService):
         self._stopping = threading.Event()
         self._log_level = log_level
         self._properties = properties
+        self._timeout_ms = timeout_ms
 
     def _worker(self, idx, node):
-        cmd = f"RUST_LOG={self._log_level} client-swarm --brokers {self._redpanda.brokers()} producers --topic {self._topic} --count {self._producers} --messages {self._records_per_producer}"
+        cmd = f"RUST_LOG={self._log_level} client-swarm --brokers {self._redpanda.brokers()} producers --topic {self._topic} --count {self._producers} --messages {self._records_per_producer} --timeout-ms {self._timeout_ms}"
         for k, v in self._properties.items():
             cmd += f" --properties {k}={v}"
         try:


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/7128.
Fixes https://github.com/redpanda-data/redpanda/issues/7240,