### PR TITLE
config: force an odd value for default_topic_replications

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -50,6 +50,12 @@ enum class visibility {
     deprecated,
 };
 
+// Whether to force an even or an odd value for a given property.
+enum class odd_even_constraint {
+    even,
+    odd,
+};
+
 std::string_view to_string_view(visibility v);
 
 class base_property {

--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "config/base_property.h"
 #include "config/property.h"
 
 namespace config {
@@ -68,6 +69,7 @@ struct numeric_bounds {
     std::optional<T> min = std::nullopt;
     std::optional<T> max = std::nullopt;
     std::optional<T> align = std::nullopt;
+    std::optional<odd_even_constraint> oddeven = std::nullopt;
 
     T clamp(T& original) {
         T result = original;
@@ -96,6 +98,14 @@ struct numeric_bounds {
         } else if (align.has_value() && value % align.value() != T{0}) {
             return fmt::format(
               "not aligned, must be aligned to nearest {}", align.value());
+        } else if (
+          oddeven.has_value() && oddeven.value() == odd_even_constraint::odd
+          && value % 2 == T{0}) {
+            return fmt::format("value must be odd");
+        } else if (
+          oddeven.has_value() && oddeven.value() == odd_even_constraint::even
+          && value % 2 == T{1}) {
+            return fmt::format("value must be even");
         }
         return std::nullopt;
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -10,6 +10,7 @@
 #include "config/configuration.h"
 
 #include "config/base_property.h"
+#include "config/bounded_property.h"
 #include "config/node_config.h"
 #include "config/validators.h"
 #include "model/metadata.h"
@@ -517,7 +518,8 @@ configuration::configuration()
       "default_topic_replications",
       "Default replication factor for new topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1)
+      1,
+      {.min = 1, .oddeven = odd_even_constraint::odd})
   , transaction_coordinator_replication(
       *this, "transaction_coordinator_replication")
   , id_allocator_replication(*this, "id_allocator_replication")

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -123,7 +123,7 @@ struct configuration final : public config_store {
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
-    property<int16_t> default_topic_replication;
+    bounded_property<int16_t> default_topic_replication;
     deprecated_property transaction_coordinator_replication;
     deprecated_property id_allocator_replication;
     property<model::cleanup_policy_bitflags>


### PR DESCRIPTION
## Cover letter

Currently Redpanda allows user to set an even value for `default_topic_replications`, but this doesn't make any sense in the quorum system.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

This fix will prevent users from configuring any *even* value to the cluster configuration property, `default_topic_replications`

Example output with rpk
```
$ rpk cluster config set default_topic_replications 2
No changes were made: Validation errors:
 * default_topic_replications: value must be odd
```
