### PR TITLE
cloud_storage: disable ntp archiver unit test on arm

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,9 +1,15 @@
-rp_test(
-  UNIT_TEST
-  BINARY_NAME test_archival_service
-  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc ntp_archiver_reupload_test.cc retention_strategy_test.cc
-  DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils v::cloud_roles
-  ARGS "-- -c 1"
-  LABELS archival
-)
+# These tests are flaky on ARM architectures. They have been
+# disabled temporarely to unblock the v22.3.1 release process.
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^arm|aarch64")
+    message(WARNING "Skipping test_archival_service_rpunit on ARM.")
+else()
+    rp_test(
+      UNIT_TEST
+      BINARY_NAME test_archival_service
+      SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc segment_reupload_test.cc ntp_archiver_reupload_test.cc retention_strategy_test.cc
+      DEFINITIONS BOOST_TEST_DYN_LINK
+      LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils v::cloud_roles
+      ARGS "-- -c 1"
+      LABELS archival
+    )
+endif()


### PR DESCRIPTION
## Cover letter

This PR temporarily disables the test_archival_service_rpunit test suite on ARM.
These tests have become flaky on ARM and this is done in order to unblock the release process for v22.3.1.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [X] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes
* none
