### PR TITLE
tests: update kgo-verifier

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 98f1f57dab8bb8abe615f733a0ea307026ce13a5 && \
+    cd /opt/kgo-verifier && git reset --hard 33afb9a && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients


### PR DESCRIPTION
## Cover letter

The latest version pulls in latest franz-go, and
does more prompt client teardown in seq_consumer, avoiding spurious fetch requests to servers are consumers are done but not yet destroyed.

Related: https://github.com/redpanda-data/redpanda/issues/7231

## Backport Required

- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

None

## Release notes

* none