### PR TITLE
Remove trailing return types from lambdas

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -504,7 +504,7 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
 
     auto reset_func =
       [this,
-       candidate]() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+       candidate] {
         return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
           std::make_unique<storage::concat_segment_reader_view>(
             candidate.sources,

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -502,9 +502,7 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
       [this](auto& s) { return archiver_lost_leadership(s); },
     };
 
-    auto reset_func =
-      [this,
-       candidate] {
+    auto reset_func = [this, candidate] {
         return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
           std::make_unique<storage::concat_segment_reader_view>(
             candidate.sources,

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -340,7 +340,7 @@ scheduler_service_impl::remove_archivers(std::vector<model::ntp> to_remove) {
     gate_guard g(_gate);
     return ss::parallel_for_each(
              to_remove,
-             [this](const model::ntp& ntp) -> ss::future<> {
+             [this](const model::ntp& ntp) {
                  vlog(_rtclog.info, "removing archiver for {}", ntp.path());
                  auto archiver = _archivers.at(ntp);
                  return archiver->stop().finally([this, ntp] {

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -149,7 +149,7 @@ ss::future<api_response> post_request(
     return http::with_client(
       std::move(client),
       [req = std::move(req), content = std::move(content), timeout](
-        auto& client) mutable -> ss::future<api_response> {
+        auto& client) mutable {
           return do_request(
             req,
             [&client, content = std::move(content), timeout](

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -372,7 +372,7 @@ partition_downloader::download_log_with_capped_size(
                  (data_found
                   && (total_size + offset_segment_it->second.size_bytes >= max_size));
       },
-      [&]() -> ss::future<> {
+      [&] {
           auto [_, s] = *offset_segment_it;
           ++offset_segment_it;
 
@@ -475,7 +475,7 @@ partition_downloader::download_log_with_capped_time(
     co_await ss::max_concurrent_for_each(
       staged_downloads,
       max_concurrency,
-      [this, &dlpart, &dloffsets](const segment_meta& s) -> ss::future<> {
+      [this, &dlpart, &dloffsets](const segment_meta& s) {
           retry_chain_node fib(&_rtcnode);
           retry_chain_logger dllog(cst_log, fib);
           vlog(
@@ -618,7 +618,7 @@ partition_downloader::download_segment_file(
                    _localpath{localpath},
                    _otl{otl}](
                     uint64_t len,
-                    ss::input_stream<char> in) -> ss::future<uint64_t> {
+                    ss::input_stream<char> in) {
         return download_segment_file_stream(
           len,
           std::move(in),

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -616,9 +616,7 @@ partition_downloader::download_segment_file(
                    _part{part},
                    _remote_path{remote_path},
                    _localpath{localpath},
-                   _otl{otl}](
-                    uint64_t len,
-                    ss::input_stream<char> in) {
+                   _otl{otl}](uint64_t len, ss::input_stream<char> in) {
         return download_segment_file_stream(
           len,
           std::move(in),

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -203,7 +203,7 @@ FIXTURE_TEST(invalidate_outside_cache_dir_throws, cache_test_fixture) {
     ss::recursive_touch_directory(CACHE_DIR.native()).get();
     auto target_dir = ss::open_directory(CACHE_DIR.native()).get();
     target_dir
-      .list_directory([this](const ss::directory_entry& entry) -> ss::future<> {
+      .list_directory([this](const ss::directory_entry& entry) {
           auto entry_path = std::filesystem::path(CACHE_DIR)
                             / std::filesystem::path(entry.name);
           return ss::recursive_remove_directory(entry_path.native());
@@ -231,7 +231,7 @@ FIXTURE_TEST(invalidate_prefix_outside_cache_dir_throws, cache_test_fixture) {
     ss::recursive_touch_directory(CACHE_DIR.native()).get();
     auto target_dir = ss::open_directory(CACHE_DIR.native()).get();
     target_dir
-      .list_directory([this](const ss::directory_entry& entry) -> ss::future<> {
+      .list_directory([this](const ss::directory_entry& entry) {
           auto entry_path = std::filesystem::path(CACHE_DIR)
                             / std::filesystem::path(entry.name);
           return ss::recursive_remove_directory(entry_path.native());
@@ -259,7 +259,7 @@ FIXTURE_TEST(put_outside_cache_dir_throws, cache_test_fixture) {
     ss::recursive_touch_directory(CACHE_DIR.native()).get();
     auto target_dir = ss::open_directory(CACHE_DIR.native()).get();
     target_dir
-      .list_directory([this](const ss::directory_entry& entry) -> ss::future<> {
+      .list_directory([this](const ss::directory_entry& entry) {
           auto entry_path = std::filesystem::path(CACHE_DIR)
                             / std::filesystem::path(entry.name);
           return ss::recursive_remove_directory(entry_path.native());

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -124,12 +124,12 @@ FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -157,12 +157,12 @@ FIXTURE_TEST(
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto lost_leadership = lazy_abort_source{
@@ -188,12 +188,12 @@ FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -218,12 +218,12 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto upl_res = remote
@@ -279,12 +279,12 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
       manifest_ntp, manifest_revision, name, model::term_id{123});
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
 
     retry_chain_node fib(100ms, 20ms);
@@ -327,12 +327,12 @@ FIXTURE_TEST(test_segment_delete, s3_imposter_fixture) { // NOLINT
     retry_chain_node fib(100ms, 20ms);
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    auto reset_stream =
-      [] {
+    auto reset_stream = [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out))));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(
+          std::make_unique<storage::segment_reader_handle>(
+            make_iobuf_input_stream(std::move(out))));
     };
     auto upl_res = remote
                      .upload_segment(

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -125,11 +125,11 @@ FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -158,11 +158,11 @@ FIXTURE_TEST(
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto lost_leadership = lazy_abort_source{
@@ -189,11 +189,11 @@ FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto res = remote
@@ -219,11 +219,11 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
     retry_chain_node fib(100ms, 20ms);
     auto upl_res = remote
@@ -280,11 +280,11 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
 
     retry_chain_node fib(100ms, 20ms);
@@ -328,11 +328,11 @@ FIXTURE_TEST(test_segment_delete, s3_imposter_fixture) { // NOLINT
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
-      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+      [] {
         iobuf out;
         out.append(manifest_payload.data(), manifest_payload.size());
-        co_return std::make_unique<storage::segment_reader_handle>(
-          make_iobuf_input_stream(std::move(out)));
+        return ss::make_ready_future<std::unique_ptr<storage::stream_provider>>(std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out))));
     };
     auto upl_res = remote
                      .upload_segment(

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -53,8 +53,7 @@ feature_manager::feature_manager(
         model::node_id from,
         model::node_id to,
         feature_barrier_tag tag,
-        bool entered)
-        {
+        bool entered) {
           auto timeout = 5s;
           return _connection_cache.local()
             .with_node_client<cluster::controller_client_protocol>(

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -54,7 +54,7 @@ feature_manager::feature_manager(
         model::node_id to,
         feature_barrier_tag tag,
         bool entered)
-        -> ss::future<result<rpc::client_context<feature_barrier_response>>> {
+        {
           auto timeout = 5s;
           return _connection_cache.local()
             .with_node_client<cluster::controller_client_protocol>(

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -98,7 +98,7 @@ ss::future<> members_manager::start() {
         if (b.id() == _self.id()) {
             continue;
         }
-        ssx::spawn_with_gate(_gate, [this, &b]() -> ss::future<> {
+        ssx::spawn_with_gate(_gate, [this, &b] {
             return initialize_broker_connection(b);
         });
     }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -98,9 +98,8 @@ ss::future<> members_manager::start() {
         if (b.id() == _self.id()) {
             continue;
         }
-        ssx::spawn_with_gate(_gate, [this, &b] {
-            return initialize_broker_connection(b);
-        });
+        ssx::spawn_with_gate(
+          _gate, [this, &b] { return initialize_broker_connection(b); });
     }
     _last_connection_update_offset = _raft0->get_latest_configuration_offset();
     co_return;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2115,7 +2115,7 @@ tx_gateway_frontend::get_all_transactions() {
       *shard,
       _ssg,
       [](tx_gateway_frontend& self)
-        -> ss::future<tx_gateway_frontend::return_all_txs_res> {
+        {
           auto partition = self._partition_manager.local().get(
             model::tx_manager_ntp);
           if (!partition) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2112,10 +2112,7 @@ tx_gateway_frontend::get_all_transactions() {
     }
 
     co_return co_await container().invoke_on(
-      *shard,
-      _ssg,
-      [](tx_gateway_frontend& self)
-        {
+      *shard, _ssg, [](tx_gateway_frontend& self) {
           auto partition = self._partition_manager.local().get(
             model::tx_manager_ntp);
           if (!partition) {

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -185,7 +185,7 @@ reconciliation_backend::fetch_and_reconcile(events_cache_t deltas) {
     co_await ss::parallel_for_each(
       deltas.begin(),
       deltas.end(),
-      [this](events_cache_t::value_type& p) -> ss::future<> {
+      [this](events_cache_t::value_type& p) {
           return process_updates(p.first, std::move(p.second));
       });
 }

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -183,9 +183,7 @@ reconciliation_backend::fetch_and_reconcile(events_cache_t deltas) {
         co_return;
     }
     co_await ss::parallel_for_each(
-      deltas.begin(),
-      deltas.end(),
-      [this](events_cache_t::value_type& p) {
+      deltas.begin(), deltas.end(), [this](events_cache_t::value_type& p) {
           return process_updates(p.first, std::move(p.second));
       });
 }

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -339,7 +339,7 @@ write_materialized(output_write_inputs replies, output_write_args args) {
     grouping_t grs = group_replies(std::move(replies));
     bool err{false};
     co_await ss::parallel_for_each(
-      grs, [args, &err](grouping_t::value_type& vt) -> ss::future<> {
+      grs, [args, &err](grouping_t::value_type& vt) {
           return process_reply_group(vt.first, std::move(vt.second), args)
             .handle_exception([args, &err](const std::exception_ptr& e) {
                 try {

--- a/src/v/coproc/tests/failure_recovery_tests.cc
+++ b/src/v/coproc/tests/failure_recovery_tests.cc
@@ -40,8 +40,7 @@ FIXTURE_TEST(test_wasm_engine_restart, coproc_test_fixture) {
           model::partition_id(i));
     }
 
-    auto push_inputs =
-      [this](const std::vector<model::ntp>& ntps) {
+    auto push_inputs = [this](const std::vector<model::ntp>& ntps) {
         std::vector<ss::future<>> fs;
         for (const auto& ntp : ntps) {
             fs.emplace_back(produce(ntp, make_random_batch(500)));

--- a/src/v/coproc/tests/failure_recovery_tests.cc
+++ b/src/v/coproc/tests/failure_recovery_tests.cc
@@ -41,7 +41,7 @@ FIXTURE_TEST(test_wasm_engine_restart, coproc_test_fixture) {
     }
 
     auto push_inputs =
-      [this](const std::vector<model::ntp>& ntps) -> ss::future<> {
+      [this](const std::vector<model::ntp>& ntps) {
         std::vector<ss::future<>> fs;
         for (const auto& ntp : ntps) {
             fs.emplace_back(produce(ntp, make_random_batch(500)));

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -34,13 +34,12 @@ ss::future<> fiber_mock_fixture::init_test(test_parameters params) {
           params.tn.ns, params.tn.tp, model::partition_id(i));
         auto shard = app.shard_table.local().shard_for(ntp);
         vassert(shard, "topic not up yet");
-        co_await _state.invoke_on(
-          *shard, [this, ntp, params](state& s) {
-              return make_source(ntp, s, params).then([ntp, &s](auto src) {
-                  auto [_, success] = s.routes.emplace(ntp, src);
-                  vassert(success, "no double insert attempt should occur");
-              });
-          });
+        co_await _state.invoke_on(*shard, [this, ntp, params](state& s) {
+            return make_source(ntp, s, params).then([ntp, &s](auto src) {
+                auto [_, success] = s.routes.emplace(ntp, src);
+                vassert(success, "no double insert attempt should occur");
+            });
+        });
     }
 }
 

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -35,7 +35,7 @@ ss::future<> fiber_mock_fixture::init_test(test_parameters params) {
         auto shard = app.shard_table.local().shard_for(ntp);
         vassert(shard, "topic not up yet");
         co_await _state.invoke_on(
-          *shard, [this, ntp, params](state& s) -> ss::future<> {
+          *shard, [this, ntp, params](state& s) {
               return make_source(ntp, s, params).then([ntp, &s](auto src) {
                   auto [_, success] = s.routes.emplace(ntp, src);
                   vassert(success, "no double insert attempt should occur");

--- a/src/v/features/migrators/group_metadata.cc
+++ b/src/v/features/migrators/group_metadata.cc
@@ -720,7 +720,7 @@ ss::future<> group_metadata_migration::migrate_metadata() {
                 [&pm = _controller.get_partition_manager(),
                  &st = _controller.get_shard_table(),
                  &as = _controller.get_abort_source(),
-                 ntps = std::move(ntps)]() mutable -> ss::future<> {
+                 ntps = std::move(ntps)]() mutable {
                     return dispatch_ntps_migration(std::move(ntps), pm, st, as);
                 });
           });

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -266,8 +266,7 @@ ss::future<produce_response> client::produce_records(
     // Produce batch to tp
     auto responses = co_await ssx::parallel_transform(
       std::move(partitions),
-      [this, topic](kafka::produce_request::partition p) mutable
-      {
+      [this, topic](kafka::produce_request::partition p) mutable {
           return produce_record_batch(
             model::topic_partition(topic, p.partition_index),
             std::move(*p.records->adapter.batch));

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -267,7 +267,7 @@ ss::future<produce_response> client::produce_records(
     auto responses = co_await ssx::parallel_transform(
       std::move(partitions),
       [this, topic](kafka::produce_request::partition p) mutable
-      -> ss::future<produce_response::partition> {
+      {
           return produce_record_batch(
             model::topic_partition(topic, p.partition_index),
             std::move(*p.records->adapter.batch));

--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -431,7 +431,7 @@ void conn_quota::cancel_reclaim_to(
             auto units = allowance->reclaim_lock.try_get_units().value();
             allowance->reclaim = false;
             return container()
-              .invoke_on_others([addr](conn_quota& cq) -> ss::future<> {
+              .invoke_on_others([addr](conn_quota& cq) {
                   cq.cancel_reclaim_from(addr);
                   return ss::now();
               })

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -420,9 +420,7 @@ ss::future<> offset_translator::move_persistent_state(
       });
 
     co_await api.invoke_on(
-      target_shard,
-      [gr = group,
-       state = std::move(state)](storage::api& api) {
+      target_shard, [gr = group, state = std::move(state)](storage::api& api) {
           std::vector<ss::future<>> write_futures;
           write_futures.reserve(2);
           if (state->offset_map) {

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -422,7 +422,7 @@ ss::future<> offset_translator::move_persistent_state(
     co_await api.invoke_on(
       target_shard,
       [gr = group,
-       state = std::move(state)](storage::api& api) -> ss::future<> {
+       state = std::move(state)](storage::api& api) {
           std::vector<ss::future<>> write_futures;
           write_futures.reserve(2);
           if (state->offset_map) {

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -631,7 +631,7 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
     // validate translation on target shard
     ss::smp::submit_to(
       target_shard,
-      [&api = _api, ntp = test_ntp]() -> ss::future<> {
+      [&api = _api, ntp = test_ntp] {
           auto remote_ot = raft::offset_translator{
             {model::record_batch_type::raft_configuration,
              model::record_batch_type::checkpoint},

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2252,8 +2252,7 @@ admin_server::mark_transaction_expired_handler(
     co_return co_await _partition_manager.invoke_on(
       *shard,
       [_ntp = std::move(ntp), pid, _req = std::move(req), this](
-        cluster::partition_manager& pm) mutable
-      {
+        cluster::partition_manager& pm) mutable {
           auto ntp = std::move(_ntp);
           auto req = std::move(_req);
           auto partition = pm.get(ntp);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2253,7 +2253,7 @@ admin_server::mark_transaction_expired_handler(
       *shard,
       [_ntp = std::move(ntp), pid, _req = std::move(req), this](
         cluster::partition_manager& pm) mutable
-      -> ss::future<ss::json::json_return_type> {
+      {
           auto ntp = std::move(_ntp);
           auto req = std::move(_req);
           auto partition = pm.get(ntp);

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -121,8 +121,7 @@ private:
     void register_route(ss::httpd::path_description const& path, F handler) {
         path.set(
           _server._routes,
-          [this, handler](std::unique_ptr<ss::httpd::request> req)
-            {
+          [this, handler](std::unique_ptr<ss::httpd::request> req) {
               auto auth_state = apply_auth<required_auth>(*req);
 
               // Note: a request is only logged if it does not throw

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -122,7 +122,7 @@ private:
         path.set(
           _server._routes,
           [this, handler](std::unique_ptr<ss::httpd::request> req)
-            -> ss::future<ss::json::json_return_type> {
+            {
               auto auth_state = apply_auth<required_auth>(*req);
 
               // Note: a request is only logged if it does not throw

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1329,7 +1329,7 @@ void application::start_bootstrap_services() {
           .get();
 
     storage
-      .invoke_on_all([disk_stats](storage::api& sa) -> ss::future<> {
+      .invoke_on_all([disk_stats](storage::api& sa) {
           sa.resources().update_allowance(
             disk_stats.total_bytes, disk_stats.free_bytes);
           return ss::now();

--- a/src/v/rp_util/main.cc
+++ b/src/v/rp_util/main.cc
@@ -35,7 +35,7 @@ int corpus_write(char** argv, std::filesystem::path dir) {
 int corpus_check(char** argv, std::filesystem::path path) {
     seastar::app_template app;
     try {
-        return app.run(1, argv, [path = std::move(path)]() -> ss::future<int> {
+        return app.run(1, argv, [path = std::move(path)]() {
             return compat::check_type(path).then([] { return 0; });
         });
     } catch (...) {

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -128,7 +128,7 @@ public:
                               {{method.output_type}},
                               Codec>::exec(in, ctx, {{method.id}},
       [this](
-          {{method.input_type}}&& t, rpc::streaming_context& ctx) -> ss::future<{{method.output_type}}> {
+          {{method.input_type}}&& t, rpc::streaming_context& ctx) {
           return {{method.name}}(std::move(t), ctx);
       });
     }

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -558,9 +558,9 @@ ss::future<client::head_object_result> client::head_object(
     return _client.request(std::move(header.value()), timeout)
       .then(
         [key](const http::client::response_stream_ref& ref)
-          -> ss::future<head_object_result> {
+          {
             return ref->prefetch_headers().then(
-              [ref, key]() -> ss::future<head_object_result> {
+              [ref, key] {
                   auto status = ref->get_headers().result();
                   if (status == boost::beast::http::status::not_found) {
                       vlog(

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -296,7 +296,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
     }
     return fut
       .then([this, timeout] { return _iterator.reader->read_some(timeout); })
-      .then([this, timeout](result<records_t> recs) -> ss::future<storage_t> {
+      .then([this, timeout](result<records_t> recs) {
           if (!recs) {
               set_end_of_stream();
               vlog(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -244,7 +244,7 @@ static ss::future<> do_write_clean_compacted_index(
     return natural_index_of_entries_to_keep(reader)
       .then(
         [reader, cfg, tmpname, &resources](
-          roaring::Roaring bitmap) -> ss::future<> {
+          roaring::Roaring bitmap) {
             auto truncating_writer = make_file_backed_compacted_index(
               tmpname.string(), cfg.iopc, cfg.sanitize, true, resources);
 
@@ -252,7 +252,7 @@ static ss::future<> do_write_clean_compacted_index(
               reader, std::move(bitmap), std::move(truncating_writer));
         })
       .then(
-        [old_name = tmpname, new_name = reader.filename()]() -> ss::future<> {
+        [old_name = tmpname, new_name = reader.filename()]() {
             // from glibc: If oldname is not a directory, then any
             // existing file named newname is removed during the
             // renaming operation


### PR DESCRIPTION
## Cover letter

Removes trailing return types from all lambdas. This was cobwebs left over from coroutine-lambda use, and generally just adds additional work to maintain if return types change and can also affect indentation.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
