### PR TITLE
kafka/server: Don't provide a topic property override for cleanup_policy_flags

### DIFF
--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -244,18 +244,7 @@ ss::future<response_ptr> create_topics_handler::handle(
     valid_range_end = quota_exceeded_it;
 
     auto to_create = to_cluster_type(begin, valid_range_end);
-    /**
-     * We always override cleanup policy. i.e. topic cleanup policy will
-     * stay the same even if it was changed in defaults (broker
-     * configuration) and there was no override passed by client while
-     * creating a topic. The the same policy is applied in Kafka.
-     */
-    for (auto& tp : to_create) {
-        if (!tp.cfg.properties.cleanup_policy_bitflags.has_value()) {
-            tp.cfg.properties.cleanup_policy_bitflags
-              = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
-        }
-    }
+
     // Create the topics with controller on core 0
     co_return co_await ctx.topics_frontend()
       .create_topics(std::move(to_create), to_timeout(request.data.timeout_ms))


### PR DESCRIPTION
## Cover letter

Remove code that manually overrides the `cleanup_policy_flag` topic property. The manual override is always performed modifying the topic property configuration tag from `DEFAULT_CONFIG` to `DYNAMIC_TOPIC_CONFIG`. Furthermore the override is setting the value to the current default anyway (`delete`), and this action will have no perceived effect. 

However performing this set results in filling an optional with a value, which modifies the `SOURCE` field of the topic property returned via a `describe_configs` request. This results in an inconsistency with Apache Kafka which can be observed by running `rpk topic describe` on a freshly made topic on both systems. 

Without change
```
CONFIGS
=======
KEY                           VALUE                          SOURCE
cleanup.policy                delete                         DYNAMIC_TOPIC_CONFIG
...
``` 
With change
```
CONFIGS
=======
KEY                           VALUE                          SOURCE
cleanup.policy                delete                         DEFAULT_CONFIG
...

## Release notes
- none