### PR TITLE
tests: use realistic segment sizes in ManyClientsTest

### DIFF
--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -36,6 +36,11 @@ class ManyClientsTest(RedpandaTest):
         # as this is just a "did we stay up?" test
         kwargs['log_level'] = "info"
         kwargs['resource_settings'] = resource_settings
+        kwargs['extra_rp_conf'] = {
+            # Enable segment size jitter as this is a stress test and does not
+            # rely on exact segment counts.
+            'log_segment_size_jitter_percent': 5,
+        }
         super().__init__(*args, **kwargs)
 
     @cluster(num_nodes=6)

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -50,9 +50,6 @@ class ManyClientsTest(RedpandaTest):
         than usual.
         """
 
-        # This test requires dedicated system resources to run reliably.
-        assert self.redpanda.dedicated_nodes
-
         # Scale tests are not run on debug builds
         assert not self.debug_mode
 
@@ -62,13 +59,15 @@ class ManyClientsTest(RedpandaTest):
         TOPIC_NAME = "manyclients"
         RECORDS_PER_PRODUCER = 1000
 
+        # Realistic conditions: 128MB is the segment size in the cloud
+        segment_size = 128 * 1024 * 1024
+        retention_size = 2 * segment_size
+
         self.client().create_topic(
-            TopicSpec(
-                name=TOPIC_NAME,
-                partition_count=PARTITION_COUNT,
-                retention_bytes=10 * 1024 * 1024,
-                segment_bytes=1024 * 1024 * 5,
-            ))
+            TopicSpec(name=TOPIC_NAME,
+                      partition_count=PARTITION_COUNT,
+                      retention_bytes=retention_size,
+                      segment_bytes=segment_size))
 
         # Two consumers, just so that we are at least touching consumer
         # group functionality, if not stressing the overall number of consumers.


### PR DESCRIPTION
## Cover letter

It was pointed out in #6904 that this test does a lot of segment rolls.  Although those may not be the cause of the failure in that ticket, it is unnecessary for this test to use such tiny segments now that we already run it on dedicated nodes.  For a stress test, more realistic configuration is better, so update it to use the same segment size that we use in the cloud.

Related: #6904 

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

None

## Release notes

* none