### PR TITLE
Refactored the way how node information is stored in members table

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -293,7 +293,7 @@ void archiver_fixture::initialize_shard(
         all_ntp[d.ntp] += 1;
     }
     wait_for_controller_leadership().get();
-    auto broker = app.controller->get_members_table().local().get_broker(
+    auto nm = app.controller->get_members_table().local().get_node_metadata(
       model::node_id(1));
     for (const auto& ntp : all_ntp) {
         vlog(
@@ -317,7 +317,7 @@ void archiver_fixture::initialize_shard(
             storage::ntp_config(
               ntp.first, data_dir.string(), std::move(defaults)),
             raft::group_id(1),
-            {*broker.value()})
+            {nm->broker})
           .get();
         BOOST_CHECK_EQUAL(
           api.log_mgr().get(ntp.first)->segment_count(), ntp.second);

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -51,11 +51,6 @@ struct configuration;
 namespace cluster {
 
 class metadata_cache;
-/// This method calculates the machine nodes that were updated/added
-/// and removed
-patch<broker_ptr> calculate_changed_brokers(
-  const std::vector<broker_ptr>& new_list,
-  const std::vector<broker_ptr>& old_list);
 
 /// Creates the same topic_result for all requests
 template<typename T>

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -626,7 +626,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
 int16_t controller::internal_topic_replication() const {
     auto replication_factor
       = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
-    if (replication_factor > (int16_t)_members_table.local().broker_count()) {
+    if (replication_factor > (int16_t)_members_table.local().node_count()) {
         // Fall back to r=1 if we do not have sufficient nodes
         return 1;
     } else {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -626,9 +626,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
 int16_t controller::internal_topic_replication() const {
     auto replication_factor
       = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
-    if (
-      replication_factor
-      > (int16_t)_members_table.local().brokers().size()) {
+    if (replication_factor > (int16_t)_members_table.local().brokers().size()) {
         // Fall back to r=1 if we do not have sufficient nodes
         return 1;
     } else {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -626,7 +626,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
 int16_t controller::internal_topic_replication() const {
     auto replication_factor
       = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
-    if (replication_factor > (int16_t)_members_table.local().brokers().size()) {
+    if (replication_factor > (int16_t)_members_table.local().broker_count()) {
         // Fall back to r=1 if we do not have sufficient nodes
         return 1;
     } else {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -628,7 +628,7 @@ int16_t controller::internal_topic_replication() const {
       = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
     if (
       replication_factor
-      > (int16_t)_members_table.local().all_brokers().size()) {
+      > (int16_t)_members_table.local().brokers().size()) {
         // Fall back to r=1 if we do not have sufficient nodes
         return 1;
     } else {

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -80,12 +80,12 @@ std::vector<model::broker> create_brokers_set(
       std::cend(replicas),
       std::back_inserter(brokers),
       [&members](const model::broker_shard& bs) {
-          auto br = members.get_broker(bs.node_id);
-          if (!br) {
+          auto nm = members.get_node_metadata_ref(bs.node_id);
+          if (!nm) {
               throw std::logic_error(
                 fmt::format("Replica node {} is not available", bs.node_id));
           }
-          return *br->get();
+          return nm->get().broker;
       });
     return brokers;
 }
@@ -103,8 +103,8 @@ std::vector<raft::broker_revision> create_brokers_set(
       std::cend(replicas),
       std::back_inserter(brokers),
       [&members, &replica_revisions](const model::broker_shard& bs) {
-          auto br = members.get_broker(bs.node_id);
-          if (!br) {
+          auto nm = members.get_node_metadata_ref(bs.node_id);
+          if (!nm) {
               throw std::logic_error(
                 fmt::format("Replica node {} is not available", bs.node_id));
           }
@@ -116,7 +116,7 @@ std::vector<raft::broker_revision> create_brokers_set(
             bs.node_id,
             replica_revisions.size());
           return raft::broker_revision{
-            .broker = *br->get(), .rev = rev_it->second};
+            .broker = nm->get().broker, .rev = rev_it->second};
       });
     return brokers;
 }

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -71,7 +71,7 @@ void controller_probe::setup_metrics() {
           [this] {
               const auto& members_table
                 = _controller.get_members_table().local();
-              return members_table.all_brokers_count();
+              return members_table.broker_count();
           },
           sm::description("Number of configured brokers in the cluster"))
           .aggregate({sm::shard_label}),

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -71,7 +71,7 @@ void controller_probe::setup_metrics() {
           [this] {
               const auto& members_table
                 = _controller.get_members_table().local();
-              return members_table.broker_count();
+              return members_table.node_count();
           },
           sm::description("Number of configured brokers in the cluster"))
           .aggregate({sm::shard_label}),

--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -59,7 +59,7 @@ ss::future<> feature_barrier_state_base::barrier(feature_barrier_tag tag) {
     std::set<model::node_id> sent_to;
     while (true) {
         bool all_sent = true;
-        for (const auto& member_id : _members.broker_ids()) {
+        for (const auto& member_id : _members.node_ids()) {
             if (member_id == _self) {
                 // Don't try and send to self
                 continue;
@@ -167,7 +167,7 @@ feature_barrier_response feature_barrier_state_base::update_barrier(
     } else {
         i->second.node_enter(peer, entered);
         bool all_in = true;
-        for (const auto& member_id : _members.broker_ids()) {
+        for (const auto& member_id : _members.node_ids()) {
             if (!i->second.is_node_entered(member_id)) {
                 vlog(
                   clusterlog.debug,

--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -44,7 +44,7 @@ ss::future<> feature_barrier_state_base::barrier(feature_barrier_tag tag) {
         co_await _members.await_membership(_self, _as);
     }
 
-    if (_members.all_broker_ids().size() < 2) {
+    if (_members.broker_ids().size() < 2) {
         // We are alone, immediate complete.
         vlog(clusterlog.debug, "barrier exit {} (single node)", tag);
         co_return;
@@ -59,7 +59,7 @@ ss::future<> feature_barrier_state_base::barrier(feature_barrier_tag tag) {
     std::set<model::node_id> sent_to;
     while (true) {
         bool all_sent = true;
-        for (const auto& member_id : _members.all_broker_ids()) {
+        for (const auto& member_id : _members.broker_ids()) {
             if (member_id == _self) {
                 // Don't try and send to self
                 continue;
@@ -167,7 +167,7 @@ feature_barrier_response feature_barrier_state_base::update_barrier(
     } else {
         i->second.node_enter(peer, entered);
         bool all_in = true;
-        for (const auto& member_id : _members.all_broker_ids()) {
+        for (const auto& member_id : _members.broker_ids()) {
             if (!i->second.is_node_entered(member_id)) {
                 vlog(
                   clusterlog.debug,

--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -44,7 +44,7 @@ ss::future<> feature_barrier_state_base::barrier(feature_barrier_tag tag) {
         co_await _members.await_membership(_self, _as);
     }
 
-    if (_members.broker_ids().size() < 2) {
+    if (_members.broker_count() < 2) {
         // We are alone, immediate complete.
         vlog(clusterlog.debug, "barrier exit {} (single node)", tag);
         co_return;

--- a/src/v/cluster/feature_barrier.cc
+++ b/src/v/cluster/feature_barrier.cc
@@ -44,7 +44,7 @@ ss::future<> feature_barrier_state_base::barrier(feature_barrier_tag tag) {
         co_await _members.await_membership(_self, _as);
     }
 
-    if (_members.broker_count() < 2) {
+    if (_members.node_count() < 2) {
         // We are alone, immediate complete.
         vlog(clusterlog.debug, "barrier exit {} (single node)", tag);
         co_return;

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -329,7 +329,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // Ensure that our _node_versions contains versions for all
     // nodes in members_table & that they are all sufficiently recent
     const auto& member_table = _members.local();
-    for (const auto& node_id : member_table.all_broker_ids()) {
+    for (const auto& node_id : member_table.broker_ids()) {
         auto v_iter = _node_versions.find(node_id);
         if (v_iter == _node_versions.end()) {
             vlog(

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -329,7 +329,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // Ensure that our _node_versions contains versions for all
     // nodes in members_table & that they are all sufficiently recent
     const auto& member_table = _members.local();
-    for (const auto& node_id : member_table.broker_ids()) {
+    for (const auto& node_id : member_table.node_ids()) {
         auto v_iter = _node_versions.find(node_id);
         if (v_iter == _node_versions.end()) {
             vlog(

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -190,7 +190,7 @@ ss::future<> health_manager::do_tick() {
 
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
-    if (_members.local().all_brokers().size() >= 3) {
+    if (_members.local().brokers().size() >= 3) {
         /*
          * we try to be conservative here. if something goes wrong we'll
          * back off and wait before trying to fix replication for any

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -190,7 +190,7 @@ ss::future<> health_manager::do_tick() {
 
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
-    if (_members.local().brokers().size() >= 3) {
+    if (_members.local().broker_count() >= 3) {
         /*
          * we try to be conservative here. if something goes wrong we'll
          * back off and wait before trying to fix replication for any

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -190,7 +190,7 @@ ss::future<> health_manager::do_tick() {
 
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
-    if (_members.local().broker_count() >= 3) {
+    if (_members.local().node_count() >= 3) {
         /*
          * we try to be conservative here. if something goes wrong we'll
          * back off and wait before trying to fix replication for any

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -166,20 +166,20 @@ void health_monitor_backend::refresh_nodes_status() {
     absl::erase_if(
       _status, [this](auto& e) { return !_members.local().contains(e.first); });
 
-    for (auto& b : _members.local().brokers()) {
+    for (auto& [id, nm] : _members.local().nodes()) {
         node_state status;
-        status.id = b->id();
-        status.membership_state = b->get_membership_state();
+        status.id = id;
+        status.membership_state = nm.state.get_membership_state();
 
         // current node is always alive
-        if (b->id() == _raft0->self().id()) {
+        if (id == _raft0->self().id()) {
             status.is_alive = alive::yes;
         }
-        auto res = _raft0->get_follower_metrics(b->id());
+        auto res = _raft0->get_follower_metrics(id);
         if (res) {
             status.is_alive = alive(res.value().is_live);
         }
-        _status.insert_or_assign(b->id(), status);
+        _status.insert_or_assign(id, status);
     }
 }
 
@@ -763,17 +763,17 @@ health_monitor_backend::get_cluster_health_overview(
       force_refresh::no, deadline);
 
     cluster_health_overview ret;
-    const auto brokers = _members.local().brokers();
+    const auto& brokers = _members.local().nodes();
     ret.all_nodes.reserve(brokers.size());
 
-    for (auto& broker : brokers) {
-        ret.all_nodes.push_back(broker->id());
-        if (broker->id() == _raft0->self().id()) {
+    for (auto& [id, _] : brokers) {
+        ret.all_nodes.push_back(id);
+        if (id == _raft0->self().id()) {
             continue;
         }
-        auto it = _status.find(broker->id());
+        auto it = _status.find(id);
         if (it == _status.end() || !it->second.is_alive) {
-            ret.nodes_down.push_back(broker->id());
+            ret.nodes_down.push_back(id);
         }
     }
     absl::node_hash_set<model::ntp> leaderless;

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -139,7 +139,7 @@ cluster_health_report health_monitor_backend::build_cluster_report(
         refresh_nodes_status();
     }
 
-    auto nodes = filter.nodes.empty() ? _members.local().all_broker_ids()
+    auto nodes = filter.nodes.empty() ? _members.local().broker_ids()
                                       : filter.nodes;
     reports.reserve(nodes.size());
     statuses.reserve(nodes.size());
@@ -166,7 +166,7 @@ void health_monitor_backend::refresh_nodes_status() {
     absl::erase_if(
       _status, [this](auto& e) { return !_members.local().contains(e.first); });
 
-    for (auto& b : _members.local().all_brokers()) {
+    for (auto& b : _members.local().brokers()) {
         node_state status;
         status.id = b->id();
         status.membership_state = b->get_membership_state();
@@ -566,7 +566,7 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
      */
     vlog(clusterlog.debug, "collecting cluster health statistics");
     // collect all reports
-    auto ids = _members.local().all_broker_ids();
+    auto ids = _members.local().broker_ids();
     auto reports = co_await ssx::async_transform(
       ids.begin(), ids.end(), [this](model::node_id id) {
           if (id == _raft0->self().id()) {
@@ -763,7 +763,7 @@ health_monitor_backend::get_cluster_health_overview(
       force_refresh::no, deadline);
 
     cluster_health_overview ret;
-    const auto brokers = _members.local().all_brokers();
+    const auto brokers = _members.local().brokers();
     ret.all_nodes.reserve(brokers.size());
 
     for (auto& broker : brokers) {

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -139,7 +139,7 @@ cluster_health_report health_monitor_backend::build_cluster_report(
         refresh_nodes_status();
     }
 
-    auto nodes = filter.nodes.empty() ? _members.local().broker_ids()
+    auto nodes = filter.nodes.empty() ? _members.local().node_ids()
                                       : filter.nodes;
     reports.reserve(nodes.size());
     statuses.reserve(nodes.size());
@@ -566,7 +566,7 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
      */
     vlog(clusterlog.debug, "collecting cluster health statistics");
     // collect all reports
-    auto ids = _members.local().broker_ids();
+    auto ids = _members.local().node_ids();
     auto reports = co_await ssx::async_transform(
       ids.begin(), ids.end(), [this](model::node_id id) {
           if (id == _raft0->self().id()) {

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -697,7 +697,7 @@ ss::future<> members_backend::reconcile() {
       meta.update
       && meta.update->type
            == members_manager::node_update_type::decommissioned) {
-        auto node = _members.local().get_broker(meta.update->id);
+        auto node = _members.local().get_node_metadata_ref(meta.update->id);
         if (!node) {
             vlog(
               clusterlog.debug,
@@ -705,7 +705,7 @@ ss::future<> members_backend::reconcile() {
               meta.update->id);
             co_return;
         }
-        const auto is_draining = node.value()->get_membership_state()
+        const auto is_draining = node->get().state.get_membership_state()
                                  == model::membership_state::draining;
         const auto all_reallocations_finished = std::all_of(
           meta.partition_reallocations.begin(),
@@ -995,7 +995,7 @@ void members_backend::handle_recommissioned(
 }
 
 void members_backend::stop_node_decommissioning(model::node_id id) {
-    if (_members.local().get_broker(id) == std::nullopt) {
+    if (!_members.local().contains(id)) {
         return;
     }
     // remove all pending decommissioned updates for this node

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -208,9 +208,7 @@ ss::future<> members_manager::handle_raft0_cfg_update(
 
 ss::future<std::error_code>
 members_manager::apply_update(model::record_batch b) {
-    vlog(clusterlog.info, "Applying update to members_manager");
     if (b.header().type == model::record_batch_type::raft_configuration) {
-        vlog(clusterlog.info, "Raft config update");
         co_return co_await apply_raft_configuration_batch(std::move(b));
     }
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -152,7 +152,7 @@ calculate_brokers_diff(members_table& m, const raft::group_configuration& cfg) {
     cfg.for_each_broker([&new_list](const model::broker& br) {
         new_list.push_back(ss::make_lw_shared<model::broker>(br));
     });
-    std::vector<broker_ptr> old_list = m.all_brokers();
+    std::vector<broker_ptr> old_list = m.brokers();
 
     return calculate_changed_brokers(std::move(new_list), std::move(old_list));
 }
@@ -1018,7 +1018,7 @@ members_manager::handle_configuration_update_request(
     }
     vlog(
       clusterlog.trace, "Handling node {} configuration update", req.node.id());
-    auto all_brokers = _members_table.local().all_brokers();
+    auto all_brokers = _members_table.local().brokers();
     if (auto err = check_result_configuration(all_brokers, req.node); err) {
         vlog(
           clusterlog.warn,

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -146,22 +146,24 @@ ss::future<> members_manager::maybe_update_current_node_configuration() {
       });
 }
 
-cluster::patch<broker_ptr>
-calculate_brokers_diff(members_table& m, const raft::group_configuration& cfg) {
-    cluster::patch<broker_ptr> ret;
+members_manager::changed_nodes members_manager::calculate_changed_nodes(
+  const raft::group_configuration& cfg) const {
+    changed_nodes ret;
     for (auto& cfg_broker : cfg.brokers()) {
         // current members table doesn't contain configuration broker, it was
         // added
-        auto node = m.get_node_metadata_ref(cfg_broker.id());
-        if (!node || node.value().get().broker != cfg_broker) {
-            ret.additions.push_back(
-              ss::make_lw_shared<model::broker>(cfg_broker));
+        auto node = _members_table.local().get_node_metadata_ref(
+          cfg_broker.id());
+
+        if (!node) {
+            ret.added.push_back(cfg_broker);
+        } else if (node->get().broker != cfg_broker) {
+            ret.updated.push_back(cfg_broker);
         }
     }
-    for (auto [id, nm] : m.nodes()) {
+    for (auto [id, broker] : _members_table.local().nodes()) {
         if (!cfg.contains_broker(id)) {
-            ret.deletions.push_back(
-              ss::make_lw_shared<model::broker>(nm.broker));
+            ret.removed.push_back(id);
         }
     }
 
@@ -175,14 +177,13 @@ ss::future<> members_manager::handle_raft0_cfg_update(
       "updating cluster configuration with {}",
       cfg.brokers());
 
-    // distribute to all cluster::members_table
     co_await _allocator.invoke_on(
       partition_allocator::shard, [cfg](partition_allocator& allocator) {
           allocator.update_allocation_nodes(cfg.brokers());
       });
 
-    auto diff = calculate_brokers_diff(_members_table.local(), cfg);
-    auto added_brokers = diff.additions;
+    auto diff = calculate_changed_nodes(cfg);
+    auto added_nodes = diff.added;
     co_await _members_table.invoke_on_all(
       [cfg = std::move(cfg), update_offset](members_table& m) mutable {
           m.update_brokers(update_offset, cfg.brokers());
@@ -191,15 +192,14 @@ ss::future<> members_manager::handle_raft0_cfg_update(
     if (update_offset <= _last_connection_update_offset) {
         co_return;
     }
-
     // update internode connections
-    co_await update_connections(std::move(diff));
 
+    co_await update_connections(std::move(diff));
     _last_connection_update_offset = update_offset;
 
-    for (const broker_ptr& broker : added_brokers) {
+    for (const auto& broker : added_nodes) {
         co_await _update_queue.push_eventually(node_update{
-          .id = broker->id(),
+          .id = broker.id(),
           .type = node_update_type::added,
           .offset = update_offset,
         });
@@ -391,29 +391,38 @@ ss::future<> members_manager::stop() {
     return _gate.close();
 }
 
-ss::future<> members_manager::update_connections(patch<broker_ptr> diff) {
-    return ss::do_with(std::move(diff), [this](patch<broker_ptr>& diff) {
-        return ss::do_for_each(
-                 diff.deletions,
-                 [this](broker_ptr removed) {
-                     return remove_broker_client(
-                       _self.id(), _connection_cache, removed->id());
-                 })
-          .then([this, &diff] {
-              return ss::do_for_each(diff.additions, [this](broker_ptr b) {
-                  if (b->id() == _self.id()) {
-                      // Do not create client to local broker
-                      return ss::make_ready_future<>();
-                  }
-                  return update_broker_client(
-                    _self.id(),
-                    _connection_cache,
-                    b->id(),
-                    b->rpc_address(),
-                    _rpc_tls_config);
-              });
-          });
-    });
+ss::future<>
+members_manager::update_connections(members_manager::changed_nodes changed) {
+    auto const self_id = _self.id();
+    for (auto& id : changed.removed) {
+        if (id == self_id) {
+            continue;
+        }
+        co_await remove_broker_client(self_id, _connection_cache, id);
+    }
+    for (auto& broker : changed.added) {
+        if (broker.id() == self_id) {
+            continue;
+        }
+        co_await update_broker_client(
+          self_id,
+          _connection_cache,
+          broker.id(),
+          broker.rpc_address(),
+          _rpc_tls_config);
+    }
+
+    for (auto& broker : changed.updated) {
+        if (broker.id() == self_id) {
+            continue;
+        }
+        co_await update_broker_client(
+          self_id,
+          _connection_cache,
+          broker.id(),
+          broker.rpc_address(),
+          _rpc_tls_config);
+    }
 }
 
 static inline ss::future<>
@@ -1028,10 +1037,10 @@ members_manager::handle_configuration_update_request(
           all_brokers);
         return ss::make_ready_future<ret_t>(errc::invalid_configuration_update);
     }
-    auto node_ptr = ss::make_lw_shared(std::move(req.node));
-    patch<broker_ptr> broker_update_patch{
-      .additions = {node_ptr}, .deletions = {}};
-    auto f = update_connections(std::move(broker_update_patch));
+    changed_nodes changed;
+    changed.updated.push_back(req.node);
+
+    auto f = update_connections(std::move(changed));
     // Current node is not the leader have to send an RPC to leader
     // controller
     std::optional<model::node_id> leader_id = _raft0->get_leader_id();
@@ -1045,8 +1054,8 @@ members_manager::handle_configuration_update_request(
     // curent node is a leader
     if (leader_id == _self.id()) {
         // Just update raft0 configuration
-        return _raft0->update_group_member(*node_ptr).then(
-          [node_ptr](std::error_code ec) {
+        return _raft0->update_group_member(req.node).then(
+          [](std::error_code ec) {
               if (ec) {
                   vlog(
                     clusterlog.warn,
@@ -1072,7 +1081,7 @@ members_manager::handle_configuration_update_request(
              _rpc_tls_config,
              _join_timeout,
              [tout = ss::lowres_clock::now() + _join_timeout,
-              node = *node_ptr,
+              node = req.node,
               target = *leader_id](controller_client_protocol c) mutable {
                  return c
                    .update_node_configuration(

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -184,6 +184,12 @@ public:
 
 private:
     using seed_iterator = std::vector<config::seed_server>::const_iterator;
+    struct changed_nodes {
+        std::vector<model::broker> added;
+        std::vector<model::broker> updated;
+        std::vector<model::node_id> removed;
+    };
+
     // Cluster join
     void join_raft0();
     bool is_already_member() const;
@@ -217,7 +223,9 @@ private:
     // Raft 0 config updates
     ss::future<>
       handle_raft0_cfg_update(raft::group_configuration, model::offset);
-    ss::future<> update_connections(patch<broker_ptr>);
+    changed_nodes
+    calculate_changed_nodes(const raft::group_configuration&) const;
+    ss::future<> update_connections(changed_nodes);
 
     ss::future<> maybe_update_current_node_configuration();
     ss::future<> dispatch_configuration_update(model::broker);

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -30,7 +30,7 @@ std::vector<node_metadata> members_table::node_list() const {
     }
     return nodes;
 }
-size_t members_table::broker_count() const { return _nodes.size(); }
+size_t members_table::node_count() const { return _nodes.size(); }
 
 std::vector<model::node_id> members_table::broker_ids() const {
     std::vector<model::node_id> ids;

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -20,7 +20,7 @@
 
 namespace cluster {
 
-std::vector<broker_ptr> members_table::all_brokers() const {
+std::vector<broker_ptr> members_table::brokers() const {
     std::vector<broker_ptr> brokers;
     brokers.reserve(_brokers.size());
     for (auto& [id, broker] : _brokers) {
@@ -33,14 +33,14 @@ std::vector<broker_ptr> members_table::all_brokers() const {
     return brokers;
 }
 
-size_t members_table::all_brokers_count() const {
+size_t members_table::broker_count() const {
     return std::count_if(_brokers.begin(), _brokers.end(), [](auto entry) {
         return entry.second->get_membership_state()
                != model::membership_state::removed;
     });
 }
 
-std::vector<model::node_id> members_table::all_broker_ids() const {
+std::vector<model::node_id> members_table::broker_ids() const {
     std::vector<model::node_id> ids;
     ids.reserve(_brokers.size());
     for (auto& [id, broker] : _brokers) {
@@ -265,7 +265,7 @@ void members_table::unregister_members_updated_notification(
 
 void members_table::notify_members_updated() {
     for (const auto& [id, cb] : _members_updated_notifications) {
-        cb(all_broker_ids());
+        cb(broker_ids());
     }
 }
 

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -20,43 +20,43 @@
 
 namespace cluster {
 
-std::vector<broker_ptr> members_table::brokers() const {
-    std::vector<broker_ptr> brokers;
-    brokers.reserve(_brokers.size());
-    for (auto& [id, broker] : _brokers) {
-        if (
-          broker->get_membership_state() != model::membership_state::removed) {
-            brokers.push_back(broker);
-        }
+const members_table::cache_t& members_table::nodes() const { return _nodes; }
+
+std::vector<node_metadata> members_table::node_list() const {
+    std::vector<node_metadata> nodes;
+    nodes.reserve(_nodes.size());
+    for (const auto& [_, meta] : _nodes) {
+        nodes.push_back(meta);
     }
-
-    return brokers;
+    return nodes;
 }
-
-size_t members_table::broker_count() const {
-    return std::count_if(_brokers.begin(), _brokers.end(), [](auto entry) {
-        return entry.second->get_membership_state()
-               != model::membership_state::removed;
-    });
-}
+size_t members_table::broker_count() const { return _nodes.size(); }
 
 std::vector<model::node_id> members_table::broker_ids() const {
     std::vector<model::node_id> ids;
-    ids.reserve(_brokers.size());
-    for (auto& [id, broker] : _brokers) {
-        if (
-          broker->get_membership_state() != model::membership_state::removed) {
-            ids.push_back(id);
-        }
+    ids.reserve(_nodes.size());
+    for (const auto& [id, _] : _nodes) {
+        ids.push_back(id);
     }
     return ids;
 }
 
-std::optional<broker_ptr> members_table::get_broker(model::node_id id) const {
-    if (auto it = _brokers.find(id); it != _brokers.end()) {
-        return it->second;
+std::optional<std::reference_wrapper<const node_metadata>>
+members_table::get_node_metadata_ref(model::node_id id) const {
+    auto it = _nodes.find(id);
+    if (it == _nodes.end()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    return std::make_optional(std::cref(it->second));
+}
+
+std::optional<node_metadata>
+members_table::get_node_metadata(model::node_id id) const {
+    auto it = _nodes.find(id);
+    if (it == _nodes.end()) {
+        return std::nullopt;
+    }
+    return it->second;
 }
 
 void members_table::update_brokers(
@@ -64,37 +64,33 @@ void members_table::update_brokers(
     _version = model::revision_id(version());
 
     for (auto& br : new_brokers) {
-        /**
-         * broker properties may be updated event if it is draining partitions,
-         * we have to preserve its membership and maintenance states.
-         */
-        auto it = _brokers.find(br.id());
-        if (it != _brokers.end()) {
-            // save state from the previous version of the broker
-            const auto membership_state = it->second->get_membership_state();
-            const auto maintenance_state = it->second->get_maintenance_state();
-            it->second = ss::make_lw_shared<model::broker>(br);
+        auto it = _nodes.find(br.id());
+        if (it != _nodes.end()) {
+            // update configuration
+            it->second.broker = br;
 
-            // preserve state from previous version
-            if (membership_state != model::membership_state::removed) {
-                it->second->set_membership_state(membership_state);
-            }
-            it->second->set_maintenance_state(maintenance_state);
         } else {
-            _brokers.emplace(br.id(), ss::make_lw_shared<model::broker>(br));
+            _nodes.emplace(
+              br.id(),
+              node_metadata{
+                .broker = br,
+                .state = broker_state{},
+              });
         }
 
         _waiters.notify(br.id());
     }
-
-    for (auto& [id, br] : _brokers) {
-        auto it = std::find_if(
+    for (auto it = _nodes.begin(); it != _nodes.end();) {
+        auto new_it = std::find_if(
           new_brokers.begin(),
           new_brokers.end(),
-          [id = id](const model::broker& br) { return br.id() == id; });
-        if (it == new_brokers.end()) {
-            br->set_membership_state(model::membership_state::removed);
+          [id = it->first](const model::broker& br) { return br.id() == id; });
+        if (new_it == new_brokers.end()) {
+            _removed_nodes.emplace(it->first, it->second);
+            _nodes.erase(it++);
+            continue;
         }
+        ++it;
     }
 
     notify_members_updated();
@@ -103,9 +99,11 @@ std::error_code
 members_table::apply(model::offset version, decommission_node_cmd cmd) {
     _version = model::revision_id(version());
 
-    if (auto it = _brokers.find(cmd.key); it != _brokers.end()) {
-        auto& [id, broker] = *it;
-        if (broker->get_membership_state() != model::membership_state::active) {
+    if (auto it = _nodes.find(cmd.key); it != _nodes.end()) {
+        auto& [id, metadata] = *it;
+        if (
+          metadata.state.get_membership_state()
+          != model::membership_state::active) {
             return errc::invalid_node_operation;
         }
         vlog(
@@ -113,7 +111,7 @@ members_table::apply(model::offset version, decommission_node_cmd cmd) {
           "changing node {} membership state to: {}",
           id,
           model::membership_state::draining);
-        broker->set_membership_state(model::membership_state::draining);
+        metadata.state.set_membership_state(model::membership_state::draining);
         return errc::success;
     }
     return errc::node_does_not_exists;
@@ -123,10 +121,11 @@ std::error_code
 members_table::apply(model::offset version, recommission_node_cmd cmd) {
     _version = model::revision_id(version());
 
-    if (auto it = _brokers.find(cmd.key); it != _brokers.end()) {
-        auto& [id, broker] = *it;
+    if (auto it = _nodes.find(cmd.key); it != _nodes.end()) {
+        auto& [id, metadata] = *it;
         if (
-          broker->get_membership_state() != model::membership_state::draining) {
+          metadata.state.get_membership_state()
+          != model::membership_state::draining) {
             return errc::invalid_node_operation;
         }
         vlog(
@@ -134,7 +133,7 @@ members_table::apply(model::offset version, recommission_node_cmd cmd) {
           "changing node {} membership state to: {}",
           id,
           model::membership_state::active);
-        broker->set_membership_state(model::membership_state::active);
+        metadata.state.set_membership_state(model::membership_state::active);
         return errc::success;
     }
     return errc::node_does_not_exists;
@@ -144,17 +143,17 @@ std::error_code
 members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     _version = model::revision_id(version());
 
-    const auto target = _brokers.find(cmd.key);
-    if (target == _brokers.end()) {
+    const auto target = _nodes.find(cmd.key);
+    if (target == _nodes.end()) {
         return errc::node_does_not_exists;
     }
-    auto& [id, broker] = *target;
+    auto& [id, metadata] = *target;
 
     // no rules to enforce when disabling maintenance mode
     const auto enable = cmd.value;
     if (!enable) {
         if (
-          broker->get_maintenance_state()
+          metadata.state.get_maintenance_state()
           == model::maintenance_state::inactive) {
             vlog(
               clusterlog.trace, "node {} already not in maintenance state", id);
@@ -162,13 +161,14 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
         }
 
         vlog(clusterlog.info, "marking node {} not in maintenance state", id);
-        broker->set_maintenance_state(model::maintenance_state::inactive);
+        metadata.state.set_maintenance_state(
+          model::maintenance_state::inactive);
         notify_maintenance_state_change(id, model::maintenance_state::inactive);
 
         return errc::success;
     }
 
-    if (_brokers.size() < 2) {
+    if (_nodes.size() < 2) {
         // Maintenance mode is refused on size 1 clusters in the admin API, but
         // we might be upgrading from a version that didn't have the validation.
         vlog(
@@ -179,7 +179,9 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
         return errc::success;
     }
 
-    if (broker->get_maintenance_state() == model::maintenance_state::active) {
+    if (
+      metadata.state.get_maintenance_state()
+      == model::maintenance_state::active) {
         vlog(clusterlog.trace, "node {} already in maintenance state", id);
         return errc::success;
     }
@@ -188,12 +190,12 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
      * enforce one-node-at-a-time in maintenance mode rule
      */
     const auto other = std::find_if(
-      _brokers.cbegin(), _brokers.cend(), [](const auto& b) {
-          return b.second->get_maintenance_state()
+      _nodes.cbegin(), _nodes.cend(), [](const auto& b) {
+          return b.second.state.get_maintenance_state()
                  == model::maintenance_state::active;
       });
 
-    if (other != _brokers.cend()) {
+    if (other != _nodes.cend()) {
         vlog(
           clusterlog.info,
           "cannot place node {} into maintenance mode. node {} already in "
@@ -205,7 +207,7 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
 
     vlog(clusterlog.info, "marking node {} in maintenance state", id);
 
-    broker->set_maintenance_state(model::maintenance_state::active);
+    metadata.state.set_maintenance_state(model::maintenance_state::active);
 
     notify_maintenance_state_change(id, model::maintenance_state::active);
 
@@ -213,9 +215,7 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
 }
 
 bool members_table::contains(model::node_id id) const {
-    return _brokers.contains(id)
-           && _brokers.find(id)->second->get_membership_state()
-                != model::membership_state::removed;
+    return _nodes.contains(id);
 }
 
 notification_id_type

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -32,7 +32,7 @@ std::vector<node_metadata> members_table::node_list() const {
 }
 size_t members_table::node_count() const { return _nodes.size(); }
 
-std::vector<model::node_id> members_table::broker_ids() const {
+std::vector<model::node_id> members_table::node_ids() const {
     std::vector<model::node_id> ids;
     ids.reserve(_nodes.size());
     for (const auto& [id, _] : _nodes) {
@@ -265,7 +265,7 @@ void members_table::unregister_members_updated_notification(
 
 void members_table::notify_members_updated() {
     for (const auto& [id, cb] : _members_updated_notifications) {
-        cb(broker_ids());
+        cb(node_ids());
     }
 }
 

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -27,8 +27,6 @@ class members_table {
 public:
     using cache_t = absl::node_hash_map<model::node_id, node_metadata>;
 
-    using broker_ptr = ss::lw_shared_ptr<model::broker>;
-
     const cache_t& nodes() const;
     std::vector<node_metadata> node_list() const;
     size_t node_count() const;

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -31,7 +31,7 @@ public:
 
     const cache_t& nodes() const;
     std::vector<node_metadata> node_list() const;
-    size_t broker_count() const;
+    size_t node_count() const;
 
     std::vector<model::node_id> broker_ids() const;
 

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -27,11 +27,11 @@ class members_table {
 public:
     using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
-    std::vector<broker_ptr> all_brokers() const;
+    std::vector<broker_ptr> brokers() const;
 
-    size_t all_brokers_count() const;
+    size_t broker_count() const;
 
-    std::vector<model::node_id> all_broker_ids() const;
+    std::vector<model::node_id> broker_ids() const;
 
     /// Returns single broker if exists in cache
     std::optional<broker_ptr> get_broker(model::node_id) const;

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -33,7 +33,7 @@ public:
     std::vector<node_metadata> node_list() const;
     size_t node_count() const;
 
-    std::vector<model::node_id> broker_ids() const;
+    std::vector<model::node_id> node_ids() const;
 
     /// Returns single broker if exists in cache
     std::optional<std::reference_wrapper<const node_metadata>>

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -156,8 +156,8 @@ ss::future<std::vector<node_metadata>> metadata_cache::alive_nodes() const {
     co_return !brokers.empty() ? brokers : _members_table.local().node_list();
 }
 
-std::vector<model::node_id> metadata_cache::broker_ids() const {
-    return _members_table.local().broker_ids();
+std::vector<model::node_id> metadata_cache::node_ids() const {
+    return _members_table.local().node_ids();
 }
 
 bool metadata_cache::should_reject_writes() const {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -111,11 +111,11 @@ std::optional<broker_ptr> metadata_cache::get_broker(model::node_id nid) const {
     return _members_table.local().get_broker(nid);
 }
 
-std::vector<broker_ptr> metadata_cache::all_brokers() const {
-    return _members_table.local().all_brokers();
+std::vector<broker_ptr> metadata_cache::brokers() const {
+    return _members_table.local().brokers();
 }
 
-ss::future<std::vector<broker_ptr>> metadata_cache::all_alive_brokers() const {
+ss::future<std::vector<broker_ptr>> metadata_cache::alive_brokers() const {
     std::vector<broker_ptr> brokers;
     auto res = co_await _health_monitor.local().get_nodes_status(
       config::shard_local_cfg().metadata_status_wait_timeout_ms()
@@ -123,7 +123,7 @@ ss::future<std::vector<broker_ptr>> metadata_cache::all_alive_brokers() const {
     if (!res) {
         // if we were not able to refresh the cache, return all brokers
         // (controller may be unreachable)
-        co_return _members_table.local().all_brokers();
+        co_return _members_table.local().brokers();
     }
 
     std::set<model::node_id> brokers_with_health;
@@ -142,17 +142,17 @@ ss::future<std::vector<broker_ptr>> metadata_cache::all_alive_brokers() const {
     // presume it is newly added and assume it is alive.  This avoids
     // newly added nodes being inconsistently excluded from metadata
     // responses until all nodes' health caches update.
-    for (const auto& broker : _members_table.local().all_brokers()) {
+    for (const auto& broker : _members_table.local().brokers()) {
         if (!brokers_with_health.contains(broker->id())) {
             brokers.push_back(broker);
         }
     }
 
-    co_return !brokers.empty() ? brokers : _members_table.local().all_brokers();
+    co_return !brokers.empty() ? brokers : _members_table.local().brokers();
 }
 
-std::vector<model::node_id> metadata_cache::all_broker_ids() const {
-    return _members_table.local().all_broker_ids();
+std::vector<model::node_id> metadata_cache::broker_ids() const {
+    return _members_table.local().broker_ids();
 }
 
 bool metadata_cache::should_reject_writes() const {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -116,8 +116,8 @@ const members_table::cache_t& metadata_cache::nodes() const {
     return _members_table.local().nodes();
 }
 
-size_t metadata_cache::broker_count() const {
-    return _members_table.local().broker_count();
+size_t metadata_cache::node_count() const {
+    return _members_table.local().node_count();
 }
 
 ss::future<std::vector<node_metadata>> metadata_cache::alive_nodes() const {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -115,6 +115,10 @@ std::vector<broker_ptr> metadata_cache::brokers() const {
     return _members_table.local().brokers();
 }
 
+size_t metadata_cache::broker_count() const {
+    return _members_table.local().broker_count();
+}
+
 ss::future<std::vector<broker_ptr>> metadata_cache::alive_brokers() const {
     std::vector<broker_ptr> brokers;
     auto res = co_await _health_monitor.local().get_nodes_status(

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -107,34 +107,35 @@ const topic_table::underlying_t& metadata_cache::all_topics_metadata() const {
     return _topics_state.local().all_topics_metadata();
 }
 
-std::optional<broker_ptr> metadata_cache::get_broker(model::node_id nid) const {
-    return _members_table.local().get_broker(nid);
+std::optional<node_metadata>
+metadata_cache::get_node_metadata(model::node_id nid) const {
+    return _members_table.local().get_node_metadata(nid);
 }
 
-std::vector<broker_ptr> metadata_cache::brokers() const {
-    return _members_table.local().brokers();
+const members_table::cache_t& metadata_cache::nodes() const {
+    return _members_table.local().nodes();
 }
 
 size_t metadata_cache::broker_count() const {
     return _members_table.local().broker_count();
 }
 
-ss::future<std::vector<broker_ptr>> metadata_cache::alive_brokers() const {
-    std::vector<broker_ptr> brokers;
+ss::future<std::vector<node_metadata>> metadata_cache::alive_nodes() const {
+    std::vector<node_metadata> brokers;
     auto res = co_await _health_monitor.local().get_nodes_status(
       config::shard_local_cfg().metadata_status_wait_timeout_ms()
       + model::timeout_clock::now());
     if (!res) {
         // if we were not able to refresh the cache, return all brokers
         // (controller may be unreachable)
-        co_return _members_table.local().brokers();
+        co_return _members_table.local().node_list();
     }
 
     std::set<model::node_id> brokers_with_health;
     for (auto& st : res.value()) {
         brokers_with_health.insert(st.id);
         if (st.is_alive) {
-            auto broker = _members_table.local().get_broker(st.id);
+            auto broker = _members_table.local().get_node_metadata(st.id);
             if (broker) {
                 brokers.push_back(std::move(*broker));
             }
@@ -146,13 +147,13 @@ ss::future<std::vector<broker_ptr>> metadata_cache::alive_brokers() const {
     // presume it is newly added and assume it is alive.  This avoids
     // newly added nodes being inconsistently excluded from metadata
     // responses until all nodes' health caches update.
-    for (const auto& broker : _members_table.local().brokers()) {
-        if (!brokers_with_health.contains(broker->id())) {
+    for (const auto& [id, broker] : _members_table.local().nodes()) {
+        if (!brokers_with_health.contains(id)) {
             brokers.push_back(broker);
         }
     }
 
-    co_return !brokers.empty() ? brokers : _members_table.local().brokers();
+    co_return !brokers.empty() ? brokers : _members_table.local().node_list();
 }
 
 std::vector<model::node_id> metadata_cache::broker_ids() const {

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -109,7 +109,7 @@ public:
     const members_table::cache_t& nodes() const;
 
     /// Returns curent broker count
-    size_t broker_count() const;
+    size_t node_count() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
     ss::future<std::vector<node_metadata>> alive_nodes() const;

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -105,13 +105,13 @@ public:
     const topic_table::underlying_t& all_topics_metadata() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
-    std::vector<broker_ptr> all_brokers() const;
+    std::vector<broker_ptr> brokers() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
-    ss::future<std::vector<broker_ptr>> all_alive_brokers() const;
+    ss::future<std::vector<broker_ptr>> alive_brokers() const;
 
     /// Returns all broker ids
-    std::vector<model::node_id> all_broker_ids() const;
+    std::vector<model::node_id> broker_ids() const;
 
     /// Returns single broker if exists in cache,returns copy as the content of
     /// broker can change

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -115,7 +115,7 @@ public:
     ss::future<std::vector<node_metadata>> alive_nodes() const;
 
     /// Returns all broker ids
-    std::vector<model::node_id> broker_ids() const;
+    std::vector<model::node_id> node_ids() const;
 
     /// Returns single broker if exists in cache,returns copy as the content of
     /// broker can change

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "cluster/members_table.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
@@ -105,20 +106,20 @@ public:
     const topic_table::underlying_t& all_topics_metadata() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
-    std::vector<broker_ptr> brokers() const;
+    const members_table::cache_t& nodes() const;
 
     /// Returns curent broker count
     size_t broker_count() const;
 
     /// Returns all brokers, returns copy as the content of broker can change
-    ss::future<std::vector<broker_ptr>> alive_brokers() const;
+    ss::future<std::vector<node_metadata>> alive_nodes() const;
 
     /// Returns all broker ids
     std::vector<model::node_id> broker_ids() const;
 
     /// Returns single broker if exists in cache,returns copy as the content of
     /// broker can change
-    std::optional<broker_ptr> get_broker(model::node_id) const;
+    std::optional<node_metadata> get_node_metadata(model::node_id) const;
 
     bool should_reject_writes() const;
 

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -107,6 +107,9 @@ public:
     /// Returns all brokers, returns copy as the content of broker can change
     std::vector<broker_ptr> brokers() const;
 
+    /// Returns curent broker count
+    size_t broker_count() const;
+
     /// Returns all brokers, returns copy as the content of broker can change
     ss::future<std::vector<broker_ptr>> alive_brokers() const;
 

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -281,7 +281,7 @@ metadata_dissemination_service::dispatch_get_metadata_update(
 }
 
 void metadata_dissemination_service::collect_pending_updates() {
-    auto brokers = _members_table.local().broker_ids();
+    auto brokers = _members_table.local().node_ids();
     for (auto& ntp_leader : _requests) {
         auto assignment = _topics.local().get_partition_assignment(
           ntp_leader.ntp);
@@ -321,7 +321,7 @@ void metadata_dissemination_service::collect_pending_updates() {
 void metadata_dissemination_service::cleanup_finished_updates() {
     std::vector<model::node_id> _to_remove;
     _to_remove.reserve(_pending_updates.size());
-    auto brokers = _members_table.local().broker_ids();
+    auto brokers = _members_table.local().node_ids();
     for (auto& [node_id, meta] : _pending_updates) {
         auto it = std::find(brokers.begin(), brokers.end(), node_id);
         if (meta.finished || it == brokers.end()) {

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -114,7 +114,7 @@ ss::future<> metadata_dissemination_service::start() {
     }
     _dispatch_timer.arm(_dissemination_interval);
     // poll either seed servers or configuration
-    auto all_brokers = _members_table.local().all_brokers();
+    auto all_brokers = _members_table.local().brokers();
     // use hash set to deduplicate ids
     absl::flat_hash_set<net::unresolved_address> all_broker_addresses;
     all_broker_addresses.reserve(all_brokers.size() + _seed_servers.size());
@@ -281,7 +281,7 @@ metadata_dissemination_service::dispatch_get_metadata_update(
 }
 
 void metadata_dissemination_service::collect_pending_updates() {
-    auto brokers = _members_table.local().all_broker_ids();
+    auto brokers = _members_table.local().broker_ids();
     for (auto& ntp_leader : _requests) {
         auto assignment = _topics.local().get_partition_assignment(
           ntp_leader.ntp);
@@ -321,7 +321,7 @@ void metadata_dissemination_service::collect_pending_updates() {
 void metadata_dissemination_service::cleanup_finished_updates() {
     std::vector<model::node_id> _to_remove;
     _to_remove.reserve(_pending_updates.size());
-    auto brokers = _members_table.local().all_broker_ids();
+    auto brokers = _members_table.local().broker_ids();
     for (auto& [node_id, meta] : _pending_updates) {
         auto it = std::find(brokers.begin(), brokers.end(), node_id);
         if (meta.finished || it == brokers.end()) {

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -114,13 +114,13 @@ ss::future<> metadata_dissemination_service::start() {
     }
     _dispatch_timer.arm(_dissemination_interval);
     // poll either seed servers or configuration
-    auto all_brokers = _members_table.local().brokers();
+    const auto& all_brokers = _members_table.local().nodes();
     // use hash set to deduplicate ids
     absl::flat_hash_set<net::unresolved_address> all_broker_addresses;
     all_broker_addresses.reserve(all_brokers.size() + _seed_servers.size());
     // collect ids
-    for (auto& b : all_brokers) {
-        all_broker_addresses.emplace(b->rpc_address());
+    for (auto& [_, b] : all_brokers) {
+        all_broker_addresses.emplace(b.broker.rpc_address());
     }
     for (auto& id : _seed_servers) {
         all_broker_addresses.emplace(id);

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -191,12 +191,12 @@ metrics_reporter::build_metrics_snapshot() {
         auto& metrics = it->second;
         metrics.is_alive = (bool)ns.is_alive;
 
-        auto broker = _members_table.local().get_broker(ns.id);
-        if (!broker) {
+        auto nm = _members_table.local().get_node_metadata_ref(ns.id);
+        if (!nm) {
             continue;
         }
 
-        metrics.cpu_count = broker.value()->properties().cores;
+        metrics.cpu_count = nm->get().broker.properties().cores;
     }
 
     for (auto& report : report.value().node_reports) {

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -140,13 +140,13 @@ ss::future<result<node_status>> node_status_backend::send_node_status_request(
   model::node_id target, node_status_request r) {
     auto gate_holder = _gate.hold();
 
-    auto broker = _members_table.local().get_broker(target);
-    if (!broker) {
+    auto nm = _members_table.local().get_node_metadata_ref(target);
+    if (!nm) {
         co_return make_error_code(errc::node_does_not_exists);
     }
 
     auto connection_source_shard = co_await maybe_create_client(
-      target, broker.value()->rpc_address());
+      target, nm->get().broker.rpc_address());
 
     auto send_by = rpc::clock_type::now() + _period();
     auto reply = co_await _node_connection_cache.local()

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -66,24 +66,27 @@ void partition_balancer_planner::init_per_node_state(
   const std::vector<raft::follower_metrics>& follower_metrics,
   reallocation_request_state& rrs,
   plan_data& result) const {
-    for (const auto& broker : _state.members().brokers()) {
+    for (const auto& [id, broker] : _state.members().nodes()) {
         if (
-          broker->get_membership_state() == model::membership_state::removed) {
+          broker.state.get_membership_state()
+          == model::membership_state::removed) {
             continue;
         }
 
-        rrs.all_nodes.push_back(broker->id());
+        rrs.all_nodes.push_back(id);
 
         if (
-          broker->get_maintenance_state() == model::maintenance_state::active) {
-            vlog(clusterlog.debug, "node {}: in maintenance", broker->id());
+          broker.state.get_maintenance_state()
+          == model::maintenance_state::active) {
+            vlog(clusterlog.debug, "node {}: in maintenance", id);
             rrs.num_nodes_in_maintenance += 1;
         }
 
         if (
-          broker->get_membership_state() == model::membership_state::draining) {
-            vlog(clusterlog.debug, "node {}: decommissioning", broker->id());
-            rrs.decommissioning_nodes.insert(broker->id());
+          broker.state.get_membership_state()
+          == model::membership_state::draining) {
+            vlog(clusterlog.debug, "node {}: decommissioning", id);
+            rrs.decommissioning_nodes.insert(id);
         }
     }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -66,7 +66,7 @@ void partition_balancer_planner::init_per_node_state(
   const std::vector<raft::follower_metrics>& follower_metrics,
   reallocation_request_state& rrs,
   plan_data& result) const {
-    for (const auto& broker : _state.members().all_brokers()) {
+    for (const auto& broker : _state.members().brokers()) {
         if (
           broker->get_membership_state() == model::membership_state::removed) {
             continue;

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -493,8 +493,8 @@ absl::flat_hash_set<model::node_id> leader_balancer::muted_nodes() const {
                 .count());
         }
 
-        if (auto broker_ptr = _members.get_broker(follower.id); broker_ptr) {
-            auto maintenance_state = (*broker_ptr)->get_maintenance_state();
+        if (auto nm = _members.get_node_metadata_ref(follower.id); nm) {
+            auto maintenance_state = (*nm).get().state.get_maintenance_state();
 
             if (maintenance_state == model::maintenance_state::active) {
                 nodes.insert(follower.id);

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -199,7 +199,7 @@ std::error_code partition_allocator::check_cluster_limits(
     // The effective values are the node count times the smallest node's
     // resources: this avoids wrongly assuming the system will handle partition
     // counts that only fit when scheduled onto certain nodes.
-    auto broker_count = _members.local().broker_count();
+    auto broker_count = _members.local().node_count();
     uint64_t effective_cpu_count = broker_count * min_core_count;
     uint64_t effective_cluster_memory = broker_count * min_memory_bytes;
     uint64_t effective_cluster_disk = broker_count * min_disk_bytes;

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -147,7 +147,7 @@ partition_allocator::allocate_partition(
  */
 std::error_code partition_allocator::check_cluster_limits(
   allocation_request const& request) const {
-    if (_members.local().all_brokers().empty()) {
+    if (_members.local().brokers().empty()) {
         // Empty members table, we're probably running in a unit test
         return errc::success;
     }
@@ -170,7 +170,7 @@ std::error_code partition_allocator::check_cluster_limits(
     uint32_t min_core_count = 0;
     uint64_t min_memory_bytes = 0;
     uint64_t min_disk_bytes = 0;
-    auto all_brokers = _members.local().all_brokers();
+    auto all_brokers = _members.local().brokers();
     for (const auto& b : all_brokers) {
         if (min_core_count == 0) {
             min_core_count = b->properties().cores;

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -135,8 +135,8 @@ FIXTURE_TEST(test_autocreate_on_non_leader, cluster_test_fixture) {
 
     // Wait for cluster to reach stable state
     tests::cooperative_spin_wait_with_timeout(10s, [this] {
-        return get_local_cache(model::node_id(0)).all_brokers().size() == 2
-               && get_local_cache(model::node_id(1)).all_brokers().size() == 2;
+        return get_local_cache(model::node_id(0)).brokers().size() == 2
+               && get_local_cache(model::node_id(1)).brokers().size() == 2;
     }).get();
 
     std::vector<cluster::topic_result> results;

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -135,8 +135,8 @@ FIXTURE_TEST(test_autocreate_on_non_leader, cluster_test_fixture) {
 
     // Wait for cluster to reach stable state
     tests::cooperative_spin_wait_with_timeout(10s, [this] {
-        return get_local_cache(model::node_id(0)).brokers().size() == 2
-               && get_local_cache(model::node_id(1)).brokers().size() == 2;
+        return get_local_cache(model::node_id(0)).broker_count() == 2
+               && get_local_cache(model::node_id(1)).broker_count() == 2;
     }).get();
 
     std::vector<cluster::topic_result> results;

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -135,8 +135,8 @@ FIXTURE_TEST(test_autocreate_on_non_leader, cluster_test_fixture) {
 
     // Wait for cluster to reach stable state
     tests::cooperative_spin_wait_with_timeout(10s, [this] {
-        return get_local_cache(model::node_id(0)).broker_count() == 2
-               && get_local_cache(model::node_id(1)).broker_count() == 2;
+        return get_local_cache(model::node_id(0)).node_count() == 2
+               && get_local_cache(model::node_id(1)).node_count() == 2;
     }).get();
 
     std::vector<cluster::topic_result> results;

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -165,9 +165,7 @@ public:
         return tests::cooperative_spin_wait_with_timeout(timeout, [this] {
             return std::all_of(
               _instances.begin(), _instances.end(), [this](auto& p) {
-                  return p.second->app.metadata_cache.local()
-                           .brokers()
-                           .size()
+                  return p.second->app.metadata_cache.local().brokers().size()
                          == _instances.size();
               });
         });

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -165,7 +165,7 @@ public:
         return tests::cooperative_spin_wait_with_timeout(timeout, [this] {
             return std::all_of(
               _instances.begin(), _instances.end(), [this](auto& p) {
-                  return p.second->app.metadata_cache.local().broker_count()
+                  return p.second->app.metadata_cache.local().node_count()
                          == _instances.size();
               });
         });

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -166,7 +166,7 @@ public:
             return std::all_of(
               _instances.begin(), _instances.end(), [this](auto& p) {
                   return p.second->app.metadata_cache.local()
-                           .all_brokers()
+                           .brokers()
                            .size()
                          == _instances.size();
               });

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -165,7 +165,7 @@ public:
         return tests::cooperative_spin_wait_with_timeout(timeout, [this] {
             return std::all_of(
               _instances.begin(), _instances.end(), [this](auto& p) {
-                  return p.second->app.metadata_cache.local().brokers().size()
+                  return p.second->app.metadata_cache.local().broker_count()
                          == _instances.size();
               });
         });

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -13,6 +13,7 @@
 #include "cluster/tests/cluster_test_fixture.h"
 #include "config/configuration.h"
 #include "features/feature_table_snapshot.h"
+#include "model/metadata.h"
 #include "net/unresolved_address.h"
 #include "test_utils/fixture.h"
 
@@ -25,11 +26,11 @@ FIXTURE_TEST(test_join_single_node, cluster_test_fixture) {
 
     wait_for_all_members(3s).get();
 
-    auto brokers = get_local_cache(model::node_id{0}).brokers();
+    auto brokers = get_local_cache(model::node_id{0}).nodes();
 
     // single broker
     BOOST_REQUIRE_EQUAL(brokers.size(), 1);
-    BOOST_REQUIRE_EQUAL(brokers[0]->id(), model::node_id(0));
+    BOOST_REQUIRE(brokers.contains(model::node_id(0)));
 }
 
 FIXTURE_TEST(test_two_node_cluster, cluster_test_fixture) {
@@ -98,11 +99,12 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
     wait_for_controller_leadership(id0).get();
     wait_for_all_members(3s).get();
-    auto brokers = get_local_cache(id0).brokers();
+
+    auto brokers = get_local_cache(model::node_id{0}).nodes();
 
     // single broker
     BOOST_REQUIRE_EQUAL(brokers.size(), 1);
-    BOOST_REQUIRE_EQUAL(brokers[0]->id(), id0);
+    BOOST_REQUIRE(brokers.contains(id0));
 }
 
 FIXTURE_TEST(test_feature_table_snapshots, cluster_test_fixture) {

--- a/src/v/cluster/tests/cluster_tests.cc
+++ b/src/v/cluster/tests/cluster_tests.cc
@@ -25,7 +25,7 @@ FIXTURE_TEST(test_join_single_node, cluster_test_fixture) {
 
     wait_for_all_members(3s).get();
 
-    auto brokers = get_local_cache(model::node_id{0}).all_brokers();
+    auto brokers = get_local_cache(model::node_id{0}).brokers();
 
     // single broker
     BOOST_REQUIRE_EQUAL(brokers.size(), 1);
@@ -98,7 +98,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(0, *config::node().node_id());
     wait_for_controller_leadership(id0).get();
     wait_for_all_members(3s).get();
-    auto brokers = get_local_cache(id0).all_brokers();
+    auto brokers = get_local_cache(id0).brokers();
 
     // single broker
     BOOST_REQUIRE_EQUAL(brokers.size(), 1);

--- a/src/v/cluster/tests/cluster_utils_tests.cc
+++ b/src/v/cluster/tests/cluster_utils_tests.cc
@@ -16,50 +16,6 @@
 #include <seastar/net/socket_defs.hh>
 #include <seastar/testing/thread_test_case.hh>
 
-cluster::broker_ptr test_broker(int32_t id) {
-    return ss::make_lw_shared<model::broker>(
-      model::node_id{id},
-      net::unresolved_address("127.0.0.1", 9092),
-      net::unresolved_address("127.0.0.1", 1234),
-      std::nullopt,
-      model::broker_properties{.cores = 32});
-}
-
-SEASTAR_THREAD_TEST_CASE(test_group_cfg_difference) {
-    auto broker_1 = test_broker(1); // intact
-    auto broker_2 = test_broker(2); // additions
-    auto broker_3 = test_broker(3); // deletions
-    auto broker_4 = test_broker(4); // new
-    auto broker_5 = test_broker(5); // additions
-
-    cluster::broker_ptr broker_2_additions = ss::make_lw_shared<model::broker>(
-      model::node_id{2},
-      net::unresolved_address("127.0.0.1", 9092),
-      net::unresolved_address("172.168.1.1", 1234),
-      std::nullopt,
-      model::broker_properties{.cores = 32});
-
-    cluster::broker_ptr broker_5_additions = ss::make_lw_shared<model::broker>(
-      model::node_id{5},
-      net::unresolved_address("127.0.0.1", 9092),
-      net::unresolved_address("127.0.0.1", 6060),
-      std::nullopt,
-      model::broker_properties{.cores = 32});
-
-    auto diff = cluster::calculate_changed_brokers(
-      {broker_1, broker_2_additions, broker_4, broker_5_additions},
-      {broker_1, broker_2, broker_3, broker_5});
-
-    BOOST_REQUIRE_EQUAL(diff.deletions.size(), 1);
-    BOOST_REQUIRE_EQUAL(diff.deletions[0]->id(), model::node_id(3));
-    BOOST_REQUIRE_EQUAL(diff.additions.size(), 3);
-    BOOST_REQUIRE_EQUAL(diff.additions[0]->id(), model::node_id(2));
-    BOOST_REQUIRE_EQUAL(diff.additions[1]->id(), model::node_id(4));
-    BOOST_REQUIRE_EQUAL(diff.additions[2]->id(), model::node_id(5));
-    BOOST_REQUIRE_EQUAL(diff.additions[0]->rpc_address().host(), "172.168.1.1");
-    BOOST_REQUIRE_EQUAL(diff.additions[2]->rpc_address().port(), 6060);
-}
-
 SEASTAR_THREAD_TEST_CASE(test_has_local_replicas) {
     model::node_id id{2};
 

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -35,9 +35,9 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       5s,
       [this, node_0, node_1, node_2] {
-          return get_local_cache(node_0).broker_count() == 3
-                 && get_local_cache(node_1).broker_count() == 3
-                 && get_local_cache(node_2).broker_count() == 3;
+          return get_local_cache(node_0).node_count() == 3
+                 && get_local_cache(node_1).node_count() == 3
+                 && get_local_cache(node_2).node_count() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -35,9 +35,9 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       5s,
       [this, node_0, node_1, node_2] {
-          return get_local_cache(node_0).all_brokers().size() == 3
-                 && get_local_cache(node_1).all_brokers().size() == 3
-                 && get_local_cache(node_2).all_brokers().size() == 3;
+          return get_local_cache(node_0).brokers().size() == 3
+                 && get_local_cache(node_1).brokers().size() == 3
+                 && get_local_cache(node_2).brokers().size() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -44,9 +44,9 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
 
     // wait for cluster to be stable
     tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return get_local_cache(model::node_id{0}).all_brokers().size() == 3
-               && get_local_cache(model::node_id{1}).all_brokers().size() == 3
-               && get_local_cache(model::node_id{2}).all_brokers().size() == 3;
+        return get_local_cache(model::node_id{0}).brokers().size() == 3
+               && get_local_cache(model::node_id{1}).brokers().size() == 3
+               && get_local_cache(model::node_id{2}).brokers().size() == 3;
     }).get0();
 
     std::vector<ss::future<std::vector<cluster::topic_result>>> futures;

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -44,9 +44,9 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
 
     // wait for cluster to be stable
     tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return get_local_cache(model::node_id{0}).brokers().size() == 3
-               && get_local_cache(model::node_id{1}).brokers().size() == 3
-               && get_local_cache(model::node_id{2}).brokers().size() == 3;
+        return get_local_cache(model::node_id{0}).broker_count() == 3
+               && get_local_cache(model::node_id{1}).broker_count() == 3
+               && get_local_cache(model::node_id{2}).broker_count() == 3;
     }).get0();
 
     std::vector<ss::future<std::vector<cluster::topic_result>>> futures;

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -44,9 +44,9 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
 
     // wait for cluster to be stable
     tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return get_local_cache(model::node_id{0}).broker_count() == 3
-               && get_local_cache(model::node_id{1}).broker_count() == 3
-               && get_local_cache(model::node_id{2}).broker_count() == 3;
+        return get_local_cache(model::node_id{0}).node_count() == 3
+               && get_local_cache(model::node_id{1}).node_count() == 3
+               && get_local_cache(model::node_id{2}).node_count() == 3;
     }).get0();
 
     std::vector<ss::future<std::vector<cluster::topic_result>>> futures;

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -74,15 +74,15 @@ FIXTURE_TEST(
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.all_brokers().size() == 3
-                 && cache_2.all_brokers().size() == 3;
+          return cache_1.brokers().size() == 3
+                 && cache_2.brokers().size() == 3;
       })
       .get0();
 
     // Make sure we have 3 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.all_brokers().size(), 3);
-    BOOST_REQUIRE_EQUAL(cache_1.all_brokers().size(), 3);
-    BOOST_REQUIRE_EQUAL(cache_2.all_brokers().size(), 3);
+    BOOST_REQUIRE_EQUAL(cache_0.brokers().size(), 3);
+    BOOST_REQUIRE_EQUAL(cache_1.brokers().size(), 3);
+    BOOST_REQUIRE_EQUAL(cache_2.brokers().size(), 3);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -113,11 +113,11 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
 
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
-      [&cache_1] { return cache_1.all_brokers().size() == 2; })
+      [&cache_1] { return cache_1.brokers().size() == 2; })
       .get0();
     // Make sure we have 2 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.all_brokers().size(), 2);
-    BOOST_REQUIRE_EQUAL(cache_1.all_brokers().size(), 2);
+    BOOST_REQUIRE_EQUAL(cache_0.brokers().size(), 2);
+    BOOST_REQUIRE_EQUAL(cache_1.brokers().size(), 2);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -136,8 +136,8 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.all_brokers().size() == 3
-                 && cache_2.all_brokers().size() == 3;
+          return cache_1.brokers().size() == 3
+                 && cache_2.brokers().size() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -74,14 +74,14 @@ FIXTURE_TEST(
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.brokers().size() == 3 && cache_2.brokers().size() == 3;
+          return cache_1.broker_count() == 3 && cache_2.broker_count() == 3;
       })
       .get0();
 
     // Make sure we have 3 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.brokers().size(), 3);
-    BOOST_REQUIRE_EQUAL(cache_1.brokers().size(), 3);
-    BOOST_REQUIRE_EQUAL(cache_2.brokers().size(), 3);
+    BOOST_REQUIRE_EQUAL(cache_0.broker_count(), 3);
+    BOOST_REQUIRE_EQUAL(cache_1.broker_count(), 3);
+    BOOST_REQUIRE_EQUAL(cache_2.broker_count(), 3);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -112,11 +112,11 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
 
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
-      [&cache_1] { return cache_1.brokers().size() == 2; })
+      [&cache_1] { return cache_1.broker_count() == 2; })
       .get0();
     // Make sure we have 2 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.brokers().size(), 2);
-    BOOST_REQUIRE_EQUAL(cache_1.brokers().size(), 2);
+    BOOST_REQUIRE_EQUAL(cache_0.broker_count(), 2);
+    BOOST_REQUIRE_EQUAL(cache_1.broker_count(), 2);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -135,7 +135,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.brokers().size() == 3 && cache_2.brokers().size() == 3;
+          return cache_1.broker_count() == 3 && cache_2.broker_count() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -74,14 +74,14 @@ FIXTURE_TEST(
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.broker_count() == 3 && cache_2.broker_count() == 3;
+          return cache_1.node_count() == 3 && cache_2.node_count() == 3;
       })
       .get0();
 
     // Make sure we have 3 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.broker_count(), 3);
-    BOOST_REQUIRE_EQUAL(cache_1.broker_count(), 3);
-    BOOST_REQUIRE_EQUAL(cache_2.broker_count(), 3);
+    BOOST_REQUIRE_EQUAL(cache_0.node_count(), 3);
+    BOOST_REQUIRE_EQUAL(cache_1.node_count(), 3);
+    BOOST_REQUIRE_EQUAL(cache_2.node_count(), 3);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -112,11 +112,11 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
 
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
-      [&cache_1] { return cache_1.broker_count() == 2; })
+      [&cache_1] { return cache_1.node_count() == 2; })
       .get0();
     // Make sure we have 2 working nodes
-    BOOST_REQUIRE_EQUAL(cache_0.broker_count(), 2);
-    BOOST_REQUIRE_EQUAL(cache_1.broker_count(), 2);
+    BOOST_REQUIRE_EQUAL(cache_0.node_count(), 2);
+    BOOST_REQUIRE_EQUAL(cache_1.node_count(), 2);
 
     // Create topic with replication factor 1
     std::vector<cluster::topic_configuration> topics;
@@ -135,7 +135,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.broker_count() == 3 && cache_2.broker_count() == 3;
+          return cache_1.node_count() == 3 && cache_2.node_count() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -74,8 +74,7 @@ FIXTURE_TEST(
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.brokers().size() == 3
-                 && cache_2.brokers().size() == 3;
+          return cache_1.brokers().size() == 3 && cache_2.brokers().size() == 3;
       })
       .get0();
 
@@ -136,8 +135,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     tests::cooperative_spin_wait_with_timeout(
       std::chrono::seconds(10),
       [&cache_1, &cache_2] {
-          return cache_1.brokers().size() == 3
-                 && cache_2.brokers().size() == 3;
+          return cache_1.brokers().size() == 3 && cache_2.brokers().size() == 3;
       })
       .get0();
 

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -16,6 +16,7 @@
 #include "cluster/partition_balancer_state.h"
 #include "cluster/tests/utils.h"
 #include "cluster/topic_updates_dispatcher.h"
+#include "cluster/types.h"
 #include "model/metadata.h"
 #include "random/generators.h"
 #include "test_utils/fixture.h"
@@ -178,8 +179,8 @@ struct partition_balancer_planner_fixture {
         auto& members_table = workers.members.local();
 
         std::vector<model::broker> new_brokers;
-        for (auto broker_ptr : members_table.brokers()) {
-            new_brokers.push_back(*broker_ptr);
+        for (auto [id, nm] : members_table.nodes()) {
+            new_brokers.push_back(nm.broker);
         }
 
         for (size_t i = 0; i < nodes_amount; ++i) {
@@ -319,20 +320,20 @@ struct partition_balancer_planner_fixture {
     void set_maintenance_mode(model::node_id id) {
         workers.members.local().apply(
           model::offset{}, cluster::maintenance_mode_cmd(id, true));
-        auto broker = workers.members.local().get_broker(id);
+        auto broker = workers.members.local().get_node_metadata_ref(id);
         BOOST_REQUIRE(broker);
         BOOST_REQUIRE(
-          broker.value()->get_maintenance_state()
+          broker.value().get().state.get_maintenance_state()
           == model::maintenance_state::active);
     }
 
     void set_decommissioning(model::node_id id) {
         workers.members.local().apply(
           model::offset{}, cluster::decommission_node_cmd(id, 0));
-        auto broker = workers.members.local().get_broker(id);
+        auto broker = workers.members.local().get_node_metadata_ref(id);
         BOOST_REQUIRE(broker);
         BOOST_REQUIRE(
-          broker.value()->get_membership_state()
+          broker.value().get().state.get_membership_state()
           == model::membership_state::draining);
     }
 

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -178,7 +178,7 @@ struct partition_balancer_planner_fixture {
         auto& members_table = workers.members.local();
 
         std::vector<model::broker> new_brokers;
-        for (auto broker_ptr : members_table.all_brokers()) {
+        for (auto broker_ptr : members_table.brokers()) {
             new_brokers.push_back(*broker_ptr);
         }
 

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -122,7 +122,7 @@ public:
               controllers.cbegin(),
               controllers.cend(),
               [this](cluster::controller* c) {
-                  return c->get_members_table().local().broker_ids().size()
+                  return c->get_members_table().local().node_ids().size()
                          == nodes.size();
               });
         }).get0();

--- a/src/v/cluster/tests/partition_moving_test.cc
+++ b/src/v/cluster/tests/partition_moving_test.cc
@@ -122,7 +122,7 @@ public:
               controllers.cbegin(),
               controllers.cend(),
               [this](cluster::controller* c) {
-                  return c->get_members_table().local().all_broker_ids().size()
+                  return c->get_members_table().local().broker_ids().size()
                          == nodes.size();
               });
         }).get0();

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -223,7 +223,7 @@ public:
                 return ss::make_ready_future<bool>(false);
             }
             auto ids
-              = (*leader)->controller->get_members_table().local().broker_ids();
+              = (*leader)->controller->get_members_table().local().node_ids();
             test_logger.info("current brokers: {}", ids);
             return ss::make_ready_future<bool>(
               std::find(ids.begin(), ids.end(), id) == ids.end());

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -52,7 +52,7 @@ public:
               apps.cbegin(), apps.cend(), [node_count](auto c) {
                   return c.second->controller->get_members_table()
                            .local()
-                           .all_broker_ids()
+                           .broker_ids()
                            .size()
                          == node_count;
               });
@@ -226,7 +226,7 @@ public:
             auto ids = (*leader)
                          ->controller->get_members_table()
                          .local()
-                         .all_broker_ids();
+                         .broker_ids();
             test_logger.info("current brokers: {}", ids);
             return ss::make_ready_future<bool>(
               std::find(ids.begin(), ids.end(), id) == ids.end());

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -52,8 +52,7 @@ public:
               apps.cbegin(), apps.cend(), [node_count](auto c) {
                   return c.second->controller->get_members_table()
                            .local()
-                           .broker_ids()
-                           .size()
+                           .broker_count()
                          == node_count;
               });
         }).get0();

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -52,7 +52,7 @@ public:
               apps.cbegin(), apps.cend(), [node_count](auto c) {
                   return c.second->controller->get_members_table()
                            .local()
-                           .broker_count()
+                           .node_count()
                          == node_count;
               });
         }).get0();

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -223,10 +223,8 @@ public:
             if (!leader) {
                 return ss::make_ready_future<bool>(false);
             }
-            auto ids = (*leader)
-                         ->controller->get_members_table()
-                         .local()
-                         .broker_ids();
+            auto ids
+              = (*leader)->controller->get_members_table().local().broker_ids();
             test_logger.info("current brokers: {}", ids);
             return ss::make_ready_future<bool>(
               std::find(ids.begin(), ids.end(), id) == ids.end());

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1147,12 +1147,12 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
 
     if (
       static_cast<size_t>(new_replication_factor)
-      > _members_table.local().all_brokers_count()) {
+      > _members_table.local().broker_count()) {
         vlog(
           clusterlog.warn,
           "New replication factor({}) is greater than number of brokers({})",
           new_replication_factor,
-          _members_table.local().all_brokers_count());
+          _members_table.local().broker_count());
         co_return errc::topic_invalid_replication_factor;
     }
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1147,12 +1147,12 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
 
     if (
       static_cast<size_t>(new_replication_factor)
-      > _members_table.local().broker_count()) {
+      > _members_table.local().node_count()) {
         vlog(
           clusterlog.warn,
           "New replication factor({}) is greater than number of brokers({})",
           new_replication_factor,
-          _members_table.local().broker_count());
+          _members_table.local().node_count());
         co_return errc::topic_invalid_replication_factor;
     }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -952,6 +952,20 @@ std::ostream& operator<<(std::ostream& o, const remote_topic_properties& rtps) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const broker_state& state) {
+    fmt::print(
+      o,
+      "{{membership_state: {}, maintenance_state: {}}}",
+      state._membership_state,
+      state._maintenance_state);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const node_metadata& nm) {
+    fmt::print(o, "{{broker: {}, state: {} }}", nm.broker, nm.state);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2829,6 +2829,56 @@ struct cancel_partition_movements_reply
     std::vector<move_cancellation_result> partition_results;
 };
 
+/**
+ * Broker state transitions are coordinated centrally as opposite to
+ * configuration which change is requested by the described node itself. Broker
+ * state represents centrally managed node properties. The difference between
+ * broker state and configuration is that the configuration change is made on
+ * the node while state changes are managed by the cluster controller.
+ */
+class broker_state
+  : public serde::
+      envelope<broker_state, serde::version<0>, serde::compat_version<0>> {
+public:
+    model::membership_state get_membership_state() const {
+        return _membership_state;
+    }
+    void set_membership_state(model::membership_state st) {
+        _membership_state = st;
+    }
+
+    model::maintenance_state get_maintenance_state() const {
+        return _maintenance_state;
+    }
+    void set_maintenance_state(model::maintenance_state st) {
+        _maintenance_state = st;
+    }
+    friend bool operator==(const broker_state&, const broker_state&) = default;
+
+    friend std::ostream& operator<<(std::ostream&, const broker_state&);
+
+    auto serde_fields() {
+        return std::tie(_membership_state, _maintenance_state);
+    }
+
+private:
+    model::membership_state _membership_state = model::membership_state::active;
+    model::maintenance_state _maintenance_state
+      = model::maintenance_state::inactive;
+};
+
+/**
+ * Node metadata describes a cluster node with its state and configuration
+ */
+struct node_metadata {
+    model::broker broker;
+    broker_state state;
+
+    friend bool operator==(const node_metadata&, const node_metadata&)
+      = default;
+    friend std::ostream& operator<<(std::ostream&, const node_metadata&);
+};
+
 /*
  * Partition Allocation Domains is the way to make certain partition replicas
  * distributed evenly across the nodes of the cluster. When partition allocation

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -42,7 +42,6 @@
 
 namespace cluster {
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
-using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
 // A cluster version is a logical protocol version describing the content
 // of the raft0 on disk structures, and available features.  These are
@@ -1683,17 +1682,6 @@ struct update_topic_properties_reply
       = default;
 
     auto serde_fields() { return std::tie(results); }
-};
-
-template<typename T>
-struct patch {
-    std::vector<T> additions;
-    std::vector<T> deletions;
-    std::vector<T> updates;
-
-    bool empty() const {
-        return additions.empty() && deletions.empty() && updates.empty();
-    }
 };
 
 // generic type used for various registration handles such as in ntp_callbacks.h

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
@@ -29,7 +29,7 @@ coproc_cluster_fixture::enable_coprocessors(std::vector<deploy> copros) {
       std::back_inserter(ids),
       [](const deploy& d) { return coproc::script_id(d.id); });
     co_await coproc_api_fixture::enable_coprocessors(std::move(copros));
-    auto node_ids = get_node_ids();
+    auto node_ids = get_broker_ids();
     co_await ss::parallel_for_each(
       node_ids, [this, ids](const model::node_id& node_id) {
           application* app = get_node_application(node_id);
@@ -61,7 +61,7 @@ application* coproc_cluster_fixture::create_node_application(
     return app;
 }
 
-std::vector<model::node_id> coproc_cluster_fixture::get_node_ids() {
+std::vector<model::node_id> coproc_cluster_fixture::get_broker_ids() {
     std::vector<model::node_id> ids;
     std::transform(
       _instances.cbegin(),

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
@@ -29,7 +29,7 @@ coproc_cluster_fixture::enable_coprocessors(std::vector<deploy> copros) {
       std::back_inserter(ids),
       [](const deploy& d) { return coproc::script_id(d.id); });
     co_await coproc_api_fixture::enable_coprocessors(std::move(copros));
-    auto node_ids = get_broker_ids();
+    auto node_ids = get_node_ids();
     co_await ss::parallel_for_each(
       node_ids, [this, ids](const model::node_id& node_id) {
           application* app = get_node_application(node_id);
@@ -61,7 +61,7 @@ application* coproc_cluster_fixture::create_node_application(
     return app;
 }
 
-std::vector<model::node_id> coproc_cluster_fixture::get_broker_ids() {
+std::vector<model::node_id> coproc_cluster_fixture::get_node_ids() {
     std::vector<model::node_id> ids;
     std::transform(
       _instances.cbegin(),

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
@@ -50,7 +50,7 @@ public:
       int coproc_supervisor_port = 43189);
 
 private:
-    std::vector<model::node_id> get_broker_ids();
+    std::vector<model::node_id> get_node_ids();
 
 private:
     absl::flat_hash_map<model::node_id, wasm_ptr> _instances;

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
@@ -50,7 +50,7 @@ public:
       int coproc_supervisor_port = 43189);
 
 private:
-    std::vector<model::node_id> get_node_ids();
+    std::vector<model::node_id> get_broker_ids();
 
 private:
     absl::flat_hash_map<model::node_id, wasm_ptr> _instances;

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -131,7 +131,7 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           return try_create_consumer_group_topic(
                    ctx.coordinator_mapper(),
                    ctx.topics_frontend(),
-                   (int16_t)ctx.metadata_cache().brokers().size())
+                   (int16_t)ctx.metadata_cache().broker_count())
             .then([&ctx, request = std::move(request)](bool created) {
                 /*
                  * if the topic is successfully created then the metadata cache

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -27,13 +27,15 @@ namespace kafka {
 
 static ss::future<response_ptr>
 handle_leader(request_context& ctx, model::node_id leader) {
-    auto broker = ctx.metadata_cache().get_broker(leader);
+    auto broker = ctx.metadata_cache().get_node_metadata(leader);
     if (broker) {
         auto& b = *broker;
-        for (const auto& listener : b->kafka_advertised_listeners()) {
+        for (const auto& listener : b.broker.kafka_advertised_listeners()) {
             if (listener.name == ctx.listener()) {
                 return ctx.respond(find_coordinator_response(
-                  b->id(), listener.address.host(), listener.address.port()));
+                  b.broker.id(),
+                  listener.address.host(),
+                  listener.address.port()));
             }
         }
     }

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -133,7 +133,7 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           return try_create_consumer_group_topic(
                    ctx.coordinator_mapper(),
                    ctx.topics_frontend(),
-                   (int16_t)ctx.metadata_cache().broker_count())
+                   (int16_t)ctx.metadata_cache().node_count())
             .then([&ctx, request = std::move(request)](bool created) {
                 /*
                  * if the topic is successfully created then the metadata cache

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -131,7 +131,7 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           return try_create_consumer_group_topic(
                    ctx.coordinator_mapper(),
                    ctx.topics_frontend(),
-                   (int16_t)ctx.metadata_cache().all_brokers().size())
+                   (int16_t)ctx.metadata_cache().brokers().size())
             .then([&ctx, request = std::move(request)](bool created) {
                 /*
                  * if the topic is successfully created then the metadata cache

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -459,7 +459,7 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // just for the size estimate.
     constexpr size_t extra_bytes_per_broker = 200;
     size_estimate
-      += md_cache.broker_count()
+      += md_cache.node_count()
          * (sizeof(metadata_response_broker) + extra_bytes_per_broker);
 
     for (auto& [tp_ns, topic_metadata] : md_cache.all_topics_metadata()) {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -372,7 +372,7 @@ template<>
 ss::future<response_ptr> metadata_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     metadata_response reply;
-    auto alive_brokers = co_await ctx.metadata_cache().all_alive_brokers();
+    auto alive_brokers = co_await ctx.metadata_cache().alive_brokers();
     for (const auto& broker : alive_brokers) {
         std::optional<model::broker_endpoint> peer_listener;
         for (const auto& listener : broker->kafka_advertised_listeners()) {
@@ -459,7 +459,7 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // just for the size estimate.
     constexpr size_t extra_bytes_per_broker = 200;
     size_estimate
-      += md_cache.all_brokers().size()
+      += md_cache.brokers().size()
          * (sizeof(metadata_response_broker) + extra_bytes_per_broker);
 
     for (auto& [tp_ns, topic_metadata] : md_cache.all_topics_metadata()) {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -459,7 +459,7 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // just for the size estimate.
     constexpr size_t extra_bytes_per_broker = 200;
     size_estimate
-      += md_cache.brokers().size()
+      += md_cache.broker_count()
          * (sizeof(metadata_response_broker) + extra_bytes_per_broker);
 
     for (auto& [tp_ns, topic_metadata] : md_cache.all_topics_metadata()) {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -307,7 +307,7 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
  *         be used in kafka metadata responses.
  */
 static const std::optional<model::broker_endpoint>
-guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
+guess_peer_listener(request_context& ctx, const cluster::node_metadata& nm) {
     // Peer has no listener with name matching the name of the
     // listener serving this Kafka request.  This can happen during
     // configuration changes
@@ -318,7 +318,7 @@ guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
       klog.warn,
       "Broker {} has no listener named '{}', falling "
       "back to guessing peer listener",
-      broker->id(),
+      nm.broker.id(),
       ctx.listener());
 
     // Look up port for the listener in use for this request
@@ -333,7 +333,7 @@ guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
             // is not yet consistent with what's in members_table,
             // because a node configuration update didn't propagate
             // via raft0 yet
-            if (broker->id() == *config::node().node_id()) {
+            if (nm.broker.id() == *config::node().node_id()) {
                 return l;
             }
         }
@@ -350,7 +350,7 @@ guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
     }
 
     // Fallback 1: Try to match by port
-    for (const auto& listener : broker->kafka_advertised_listeners()) {
+    for (const auto& listener : nm.broker.kafka_advertised_listeners()) {
         // filter broker listeners by active connection
         if (listener.address.port() == my_port) {
             return listener;
@@ -359,8 +359,8 @@ guess_peer_listener(request_context& ctx, cluster::broker_ptr broker) {
 
     // Fallback 2: no name or port match, return first listener from
     // peer.
-    if (!broker->kafka_advertised_listeners().empty()) {
-        return broker->kafka_advertised_listeners()[0];
+    if (!nm.broker.kafka_advertised_listeners().empty()) {
+        return nm.broker.kafka_advertised_listeners()[0];
     } else {
         // A broker with no kafka listeners, there is no way to
         // include it in our response
@@ -372,10 +372,10 @@ template<>
 ss::future<response_ptr> metadata_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     metadata_response reply;
-    auto alive_brokers = co_await ctx.metadata_cache().alive_brokers();
-    for (const auto& broker : alive_brokers) {
+    auto alive_brokers = co_await ctx.metadata_cache().alive_nodes();
+    for (const auto& nm : alive_brokers) {
         std::optional<model::broker_endpoint> peer_listener;
-        for (const auto& listener : broker->kafka_advertised_listeners()) {
+        for (const auto& listener : nm.broker.kafka_advertised_listeners()) {
             // filter broker listeners by active connection
             if (listener.name == ctx.listener()) {
                 peer_listener = listener;
@@ -384,15 +384,15 @@ ss::future<response_ptr> metadata_handler::handle(
         }
 
         if (!peer_listener) {
-            peer_listener = guess_peer_listener(ctx, broker);
+            peer_listener = guess_peer_listener(ctx, nm);
         }
 
         if (peer_listener) {
             reply.data.brokers.push_back(metadata_response::broker{
-              .node_id = broker->id(),
+              .node_id = nm.broker.id(),
               .host = peer_listener->address.host(),
               .port = peer_listener->address.port(),
-              .rack = broker->rack()});
+              .rack = nm.broker.rack()});
         }
     }
 

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -126,7 +126,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
           _controller->get_topics_frontend().local(),
           (int16_t)_controller->get_members_table()
             .local()
-            .all_brokers()
+            .brokers()
             .size());
         if (!has_created) {
             vlog(

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -124,7 +124,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
         auto has_created = co_await try_create_consumer_group_topic(
           _group_router.local().coordinator_mapper().local(),
           _controller->get_topics_frontend().local(),
-          (int16_t)_controller->get_members_table().local().broker_count());
+          (int16_t)_controller->get_members_table().local().node_count());
         if (!has_created) {
             vlog(
               cluster::txlog.warn,

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -124,10 +124,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
         auto has_created = co_await try_create_consumer_group_topic(
           _group_router.local().coordinator_mapper().local(),
           _controller->get_topics_frontend().local(),
-          (int16_t)_controller->get_members_table()
-            .local()
-            .brokers()
-            .size());
+          (int16_t)_controller->get_members_table().local().brokers().size());
         if (!has_created) {
             vlog(
               cluster::txlog.warn,

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -124,7 +124,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
         auto has_created = co_await try_create_consumer_group_topic(
           _group_router.local().coordinator_mapper().local(),
           _controller->get_topics_frontend().local(),
-          (int16_t)_controller->get_members_table().local().brokers().size());
+          (int16_t)_controller->get_members_table().local().broker_count());
         if (!has_created) {
             vlog(
               cluster::txlog.warn,

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -74,6 +74,9 @@ struct broker_properties
                && etc_props == other.etc_props;
     }
 
+    friend std::ostream&
+    operator<<(std::ostream&, const model::broker_properties&);
+
     auto serde_fields() {
         return std::tie(
           cores,

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -199,16 +199,6 @@ public:
     const net::unresolved_address& rpc_address() const { return _rpc_address; }
     const std::optional<rack_id>& rack() const { return _rack; }
 
-    membership_state get_membership_state() const { return _membership_state; }
-    void set_membership_state(membership_state st) { _membership_state = st; }
-
-    maintenance_state get_maintenance_state() const {
-        return _maintenance_state;
-    }
-    void set_maintenance_state(maintenance_state st) {
-        _maintenance_state = st;
-    }
-
     void replace_unassigned_node_id(const node_id id) {
         vassert(
           _id == unassigned_node_id,
@@ -230,9 +220,6 @@ private:
     net::unresolved_address _rpc_address;
     std::optional<rack_id> _rack;
     broker_properties _properties;
-    // in memory state, not serialized
-    membership_state _membership_state = membership_state::active;
-    maintenance_state _maintenance_state{maintenance_state::inactive};
 
     friend std::ostream& operator<<(std::ostream&, const broker&);
 };

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -150,6 +150,7 @@ enum class membership_state : int8_t { active, draining, removed };
 enum class maintenance_state { active, inactive };
 
 std::ostream& operator<<(std::ostream&, membership_state);
+std::ostream& operator<<(std::ostream&, maintenance_state);
 
 class broker
   : public serde::

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -188,6 +188,7 @@ public:
 
     broker(broker&&) noexcept = default;
     broker& operator=(broker&&) noexcept = default;
+    broker& operator=(const broker&) noexcept = default;
     broker(const broker&) = default;
     const node_id& id() const { return _id; }
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -371,6 +371,17 @@ std::ostream& operator<<(std::ostream& o, membership_state st) {
     return o << "unknown membership state {" << static_cast<int>(st) << "}";
 }
 
+std::ostream& operator<<(std::ostream& o, maintenance_state st) {
+    switch (st) {
+    case maintenance_state::active:
+        return o << "active";
+    case maintenance_state::inactive:
+        return o << "inactive";
+    }
+
+    __builtin_unreachable();
+}
+
 std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs) {
     switch (cs) {
     case cloud_credentials_source::config_file:

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -202,13 +202,12 @@ std::ostream& operator<<(std::ostream& o, const model::broker& b) {
     fmt::print(
       o,
       "{{id: {}, kafka_advertised_listeners: {}, rpc_address: {}, rack: {}, "
-      "properties: {}, membership_state: {}}}",
+      "properties: {}}}",
       b.id(),
       b.kafka_advertised_listeners(),
       b.rpc_address(),
       b.rack(),
-      b.properties(),
-      b.get_membership_state());
+      b.properties());
     return o;
 }
 

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -228,7 +228,7 @@ ss::future<> proxy::inform(model::node_id id) {
 
     // Inform all nodes
     return seastar::parallel_for_each(
-      _controller->get_members_table().local().broker_ids(),
+      _controller->get_members_table().local().node_ids(),
       [this](model::node_id id) { return do_inform(id); });
 }
 

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -228,7 +228,7 @@ ss::future<> proxy::inform(model::node_id id) {
 
     // Inform all nodes
     return seastar::parallel_for_each(
-      _controller->get_members_table().local().all_broker_ids(),
+      _controller->get_members_table().local().broker_ids(),
       [this](model::node_id id) { return do_inform(id); });
 }
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -234,7 +234,7 @@ ss::future<> service::inform(model::node_id id) {
 
     // Inform all nodes
     return seastar::parallel_for_each(
-      _controller->get_members_table().local().all_broker_ids(),
+      _controller->get_members_table().local().broker_ids(),
       [this](model::node_id id) { return do_inform(id); });
 }
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -234,7 +234,7 @@ ss::future<> service::inform(model::node_id id) {
 
     // Inform all nodes
     return seastar::parallel_for_each(
-      _controller->get_members_table().local().broker_ids(),
+      _controller->get_members_table().local().node_ids(),
       [this](model::node_id id) { return do_inform(id); });
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2534,7 +2534,7 @@ void admin_server::register_partition_routes() {
               }
               // special case, controller is raft group 0
               p.raft_group_id = 0;
-              for (const auto& i : _metadata_cache.local().broker_ids()) {
+              for (const auto& i : _metadata_cache.local().node_ids()) {
                   if (!leader_opt.has_value() || leader_opt.value() != i) {
                       ss::httpd::partition_json::assignment a;
                       a.node_id = i;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1949,7 +1949,7 @@ admin_server::start_broker_maintenance_handler(
           "progress?)");
     }
 
-    if (_controller->get_members_table().local().broker_count() < 2) {
+    if (_controller->get_members_table().local().node_count() < 2) {
         throw ss::httpd::bad_request_exception(
           "Maintenance mode may not be used on a single node "
           "cluster");

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -450,7 +450,8 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
           ss::httpd::reply::status_type::service_unavailable);
     }
 
-    auto leader_opt = _metadata_cache.local().get_broker(leader_id_opt.value());
+    auto leader_opt = _metadata_cache.local().get_node_metadata(
+      leader_id_opt.value());
     if (!leader_opt.has_value()) {
         throw ss::httpd::base_exception(
           fmt::format(
@@ -518,7 +519,8 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
             auto listener_idx = size_t(
               std::distance(kafka_endpoints.begin(), match_i));
 
-            auto leader_advertised_addrs = leader->kafka_advertised_listeners();
+            auto leader_advertised_addrs
+              = leader.broker.kafka_advertised_listeners();
             if (leader_advertised_addrs.size() < listener_idx + 1) {
                 vlog(
                   logger.debug,
@@ -526,7 +528,7 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
                   "index for {}, "
                   "falling back to internal RPC address",
                   req_hostname);
-                target_host = leader->rpc_address().host();
+                target_host = leader.broker.rpc_address().host();
             } else {
                 target_host
                   = leader_advertised_addrs[listener_idx].address.host();
@@ -643,22 +645,22 @@ get_brokers(cluster::controller* const controller) {
 
           // Collect broker information from the members table.
           auto& members_table = controller->get_members_table().local();
-          for (auto& broker : members_table.brokers()) {
+          for (auto& [id, nm] : members_table.nodes()) {
               ss::httpd::broker_json::broker b;
-              b.node_id = broker->id();
-              b.num_cores = broker->properties().cores;
-              if (broker->rack()) {
-                  b.rack = *broker->rack();
+              b.node_id = id;
+              b.num_cores = nm.broker.properties().cores;
+              if (nm.broker.rack()) {
+                  b.rack = *nm.broker.rack();
               }
               b.membership_status = fmt::format(
-                "{}", broker->get_membership_state());
+                "{}", nm.state.get_membership_state());
 
               // These fields are defaults that will be overwritten with
               // data from the health report.
               b.is_alive = true;
               b.maintenance_status = fill_maintenance_status(std::nullopt);
 
-              broker_map[broker->id()] = b;
+              broker_map[id] = b;
           }
 
           // Enrich the broker information with data from the health report.
@@ -1883,8 +1885,8 @@ void admin_server::register_features_routes() {
 ss::future<ss::json::json_return_type>
 admin_server::get_broker_handler(std::unique_ptr<ss::httpd::request> req) {
     model::node_id id = parse_broker_id(*req);
-    auto broker = _metadata_cache.local().get_broker(id);
-    if (!broker) {
+    auto node_meta = _metadata_cache.local().get_node_metadata(id);
+    if (!node_meta) {
         throw ss::httpd::not_found_exception(
           fmt::format("broker with id: {} not found", id));
     }
@@ -1901,13 +1903,13 @@ admin_server::get_broker_handler(std::unique_ptr<ss::httpd::request> req) {
     }
 
     ss::httpd::broker_json::broker ret;
-    ret.node_id = (*broker)->id();
-    ret.num_cores = (*broker)->properties().cores;
-    if ((*broker)->rack()) {
-        ret.rack = *(*broker)->rack();
+    ret.node_id = node_meta->broker.id();
+    ret.num_cores = node_meta->broker.properties().cores;
+    if (node_meta->broker.rack()) {
+        ret.rack = node_meta->broker.rack().value();
     }
     ret.membership_status = fmt::format(
-      "{}", (*broker)->get_membership_state());
+      "{}", node_meta->state.get_membership_state());
     ret.maintenance_status = fill_maintenance_status(
       maybe_drain_status.value());
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -643,7 +643,7 @@ get_brokers(cluster::controller* const controller) {
 
           // Collect broker information from the members table.
           auto& members_table = controller->get_members_table().local();
-          for (auto& broker : members_table.all_brokers()) {
+          for (auto& broker : members_table.brokers()) {
               ss::httpd::broker_json::broker b;
               b.node_id = broker->id();
               b.num_cores = broker->properties().cores;
@@ -1947,7 +1947,7 @@ admin_server::start_broker_maintenance_handler(
           "progress?)");
     }
 
-    if (_controller->get_members_table().local().all_brokers().size() < 2) {
+    if (_controller->get_members_table().local().brokers().size() < 2) {
         throw ss::httpd::bad_request_exception(
           "Maintenance mode may not be used on a single node "
           "cluster");
@@ -2532,7 +2532,7 @@ void admin_server::register_partition_routes() {
               }
               // special case, controller is raft group 0
               p.raft_group_id = 0;
-              for (const auto& i : _metadata_cache.local().all_broker_ids()) {
+              for (const auto& i : _metadata_cache.local().broker_ids()) {
                   if (!leader_opt.has_value() || leader_opt.value() != i) {
                       ss::httpd::partition_json::assignment a;
                       a.node_id = i;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1947,7 +1947,7 @@ admin_server::start_broker_maintenance_handler(
           "progress?)");
     }
 
-    if (_controller->get_members_table().local().brokers().size() < 2) {
+    if (_controller->get_members_table().local().broker_count() < 2) {
         throw ss::httpd::bad_request_exception(
           "Maintenance mode may not be used on a single node "
           "cluster");

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -390,7 +390,7 @@ public:
 
               // Await initial config status messages from all nodes
               auto& members = app.controller->get_members_table().local();
-              return config_mgr.get_status().size() == members.brokers().size();
+              return config_mgr.get_status().size() == members.broker_count();
           });
     }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -390,8 +390,7 @@ public:
 
               // Await initial config status messages from all nodes
               auto& members = app.controller->get_members_table().local();
-              return config_mgr.get_status().size()
-                     == members.brokers().size();
+              return config_mgr.get_status().size() == members.brokers().size();
           });
     }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -391,7 +391,7 @@ public:
               // Await initial config status messages from all nodes
               auto& members = app.controller->get_members_table().local();
               return config_mgr.get_status().size()
-                     == members.all_brokers().size();
+                     == members.brokers().size();
           });
     }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -390,7 +390,7 @@ public:
 
               // Await initial config status messages from all nodes
               auto& members = app.controller->get_members_table().local();
-              return config_mgr.get_status().size() == members.broker_count();
+              return config_mgr.get_status().size() == members.node_count();
           });
     }
 


### PR DESCRIPTION
## Cover letter

Introduced types providing an abstraction for redpanda cluster node.
Redpanda cluster node have two types of properties. One of them
`cluster::node_configuration` is managed by the node local configuration
and the other one `cluster::member_state` is managed centrally by
controller based on commands uptading it.

The `node_configuration` and `member_state` abstractions allow us to
separate the two concepts and slowy move away from Kafka broker
nomenclature.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

Describe in plain language how this PR affects an end-user. What topic flags, configuration flags, command line flags, deprecation policies etc are added/changed.

<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
