### PR TITLE
s3: ensure lifetimes are extended when recovering from error

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -606,7 +606,7 @@ ss::future<> client::put_object(
     auto header = _requestor.make_unsigned_put_object_request(
       name, id, payload_size, tags);
     if (!header) {
-        return body.close().then([&header] {
+        return body.close().then([header] {
             return ss::make_exception_future<>(
               std::system_error(header.error()));
         });


### PR DESCRIPTION
## Cover letter

When returning early from s3 put object, make sure that the http error and body life long enough to be able to close them.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

* none

## Release notes

* none
