### PR TITLE
tests: add node cleanup when starting rp with rpk

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1159,12 +1159,16 @@ class RedpandaService(Service):
         if not expect_fail:
             self._started.append(node)
 
-    def start_node_with_rpk(self, node, additional_args=""):
+    def start_node_with_rpk(self, node, additional_args="", clean_node=True):
         """
         Start a single instance of redpanda using rpk. similar to start_node, 
         this function will not return until redpanda appears to have started 
         successfully.
         """
+        if clean_node:
+            self.clean_node(node, preserve_current_install=True)
+        else:
+            self.logger.debug("%s: skip cleaning node" % self.who_am_i(node))
         node.account.mkdirs(RedpandaService.DATA_DIR)
         node.account.mkdirs(os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
 

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -77,6 +77,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             [f"{n.account.hostname}" for n in self.redpanda.nodes])
 
         def config_bootstrap_with_rpk(node):
+            self.redpanda.clean_node(node)
             node.account.mkdirs(
                 os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
             seeds_arg = f"--ips={seeds_str}"
@@ -95,9 +96,10 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # Run a start with no arguments, as is done when Redpanda is run by a
         # systemd service.
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 self.redpanda.start_node_with_rpk,
-                                 parallel=True)
+        self.redpanda._for_nodes(
+            self.redpanda.nodes,
+            lambda n: self.redpanda.start_node_with_rpk(n, clean_node=False),
+            parallel=True)
         node_ids = set()
         for node in self.redpanda.nodes:
             node_ids.add(self.redpanda.node_id(node))
@@ -160,11 +162,15 @@ class RpkRedpandaStartTest(RedpandaTest):
         node = self.redpanda.nodes[0]
         node.account.mkdirs(os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
 
+        # First we clean the node and then we write via
+        # rpk redpanda mode set prod.
         self.redpanda.clean_node(node)
         rpk = RpkRemoteTool(self.redpanda, node)
         rpk.mode_set("production")
 
-        self.redpanda.start_node_with_rpk(node)
+        # Avoid cleaning, that will delete the config files and we
+        # already cleaned the node above.
+        self.redpanda.start_node_with_rpk(node, clean_node=False)
 
         # First we check that we don't modify redpanda.developer_mode
         # on the first start.


### PR DESCRIPTION
## Cover letter

The normal use case for starting with rpk is to _not_ use the standard setup from RedpandaTest class so we need to cleanup the node before starting.

Fixes #7021

## Backport Required
* none


## UX changes
* none

## Release notes
* none
