### PR TITLE
Check if public_metrics are enabled

### DIFF
--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -11,6 +11,7 @@
 
 #include "resource_mgmt/available_memory.h"
 
+#include "config/configuration.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "seastarx.h"
 
@@ -60,8 +61,8 @@ void available_memory::update_low_water_mark() {
 }
 
 void available_memory::register_metrics() {
-    if (_metrics) {
-        // already initialized
+    if (_metrics || config::shard_local_cfg().disable_public_metrics()) {
+        // already initialized or disabled
         return;
     }
 

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -3,6 +3,6 @@ rp_test(
   BINARY_NAME resource_mgmt
   SOURCES
     available_memory_test.cc
-  LIBRARIES v::seastar_testing_main v::resource_mgmt
+  LIBRARIES v::seastar_testing_main v::resource_mgmt v::config
   LABELS resource_mgmt
 )


### PR DESCRIPTION
Check if disable_public_metrics is set and in this case do not register the available_memory related metrics on the public metrics endpoint.

## Cover letter

Without this change, the metrics show up on the public endpoint even when that endpoint is disabled.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release notes

* none


### Improvements

Metrics do not show up in public_metrics when endpoint is disabled.