### PR TITLE
raft: amend error code when leadership transfer can't proceed due to recovery

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3026,7 +3026,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                     _log.offsets().dirty_offset);
 
                   return seastar::make_ready_future<std::error_code>(
-                    make_error_code(errc::timeout));
+                    make_error_code(errc::exponential_backoff));
               }
 
               timeout_now_request req{


### PR DESCRIPTION
## Cover letter

When do_transfer_leadersip(), if a follower is still not caught up after prepare_transfer_leadership() is done, a `timeout` was returned. However it's not really a timeout, it's a flap (we thought recovery was done but it's not). This commit changes it to `exponential_backoff` so that admin API would return a 503 (plz retry) for that rather than
a 504 (we couldn't do it in time).

Fixes #6902

This not a fix for the root cause of the issue, only a change of interpretation of the error.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX changes

* none
<!-- don't ship user breaking changes. Ping PMs for help with user visible changes  -->

## Release notes

* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
