### PR TITLE
[v22.1.x] kafka/client/consumer: Shutdown and fetch improvements

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -526,7 +526,25 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
               auto timeout = std::max(
                 model::timeout_clock::duration{0},
                 end - model::timeout_clock::now());
-              return c->fetch(timeout, max_bytes);
+              return c->fetch(
+                std::chrono::duration_cast<std::chrono::milliseconds>(timeout),
+                max_bytes);
+          })
+          .then([this](kafka::fetch_response res) {
+              bool has_error = std::any_of(
+                res.data.topics.begin(),
+                res.data.topics.end(),
+                [](auto const& topics) {
+                    return std::any_of(
+                      topics.partitions.begin(),
+                      topics.partitions.end(),
+                      [](const auto& p) {
+                          return p.error_code != error_code::none;
+                      });
+                });
+              return (has_error ? _wait_or_start_update_metadata() : ss::now())
+                .then(
+                  [res{std::move(res)}]() mutable { return std::move(res); });
           });
     });
 }

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -110,15 +110,15 @@ void consumer::start() {
     _heartbeat_timer.set_callback([me{shared_from_this()}]() {
         vlog(kclog.trace, "Consumer: {}: timer cb", *me);
         (void)me->heartbeat()
-          .handle_exception_type([me](const consumer_error& e) {
+          .handle_exception_type([me](const exception_base& e) {
               vlog(
-                kclog.error,
-                "Consumer: {}: heartbeat failed: {}",
-                *me,
-                e.error);
+                kclog.info, "Consumer: {}: heartbeat failed: {}", *me, e.error);
           })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
               vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
+          })
+          .handle_exception([me](const std::exception_ptr& e) {
+              vlog(kclog.error, "Consumer: {}: heartbeat failed: {}", *me, e);
           });
     });
     _heartbeat_timer.rearm_periodic(_config.consumer_heartbeat_interval());


### PR DESCRIPTION
Backport #7210 

## Cover letter

* Improve failed heartbeat logging
  * Catch more error types
  * Improve log level
  * Avoid ignored exceptional future

* Handle double-leave 

  It's possible for leave to be called multiple times, for example if the Proxy is shut down during an existing leave request.

* Handle fetch error
  Update metadata if there is a partition error so that the next fetch will work. 

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] is a backport
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## UX changes

* none

## Release notes

### Improvements

* pandaproxy: consumer fetch: More gracefully handle partition movement
* pandaproxy: Shut down consumers more gracefully during shutdown.