### PR TITLE
operator/config: update kube-rbac-proxy to v0.13.1

### DIFF
--- a/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=7"
         ports:
         - containerPort: 8443
           name: https

--- a/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Cover letter

The version of `kube-rbac-proxy` used by the operator is more than 2.5 years old and several bug fixes and security patches have been released for it since.

This PR updates the image to the most recently released version.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release notes

* none

