### PR TITLE
controller: fix Redpanda 22.3 failing to start when license was loaded with 22.2 Redpanda

### DIFF
--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -62,7 +62,8 @@ inline std::ostream& operator<<(std::ostream& os, license_type lt) {
     return os;
 }
 
-struct license : serde::envelope<license, serde::version<1>> {
+struct license
+  : serde::envelope<license, serde::version<1>, serde::compat_version<0>> {
     /// Expected encoded contents
     uint8_t format_version;
     license_type type;


### PR DESCRIPTION
## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## release notes
- Fix for bug that would prevent the start of redpanda if a license was loaded in a previous version