### PR TITLE
serde: require explicit compat_version

### DIFF
--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -19,7 +19,7 @@
 namespace cluster {
 
 struct cluster_bootstrap_info_request
-  : serde::envelope<cluster_bootstrap_info_request, serde::version<0>> {
+  : serde::envelope<cluster_bootstrap_info_request, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend std::ostream&
@@ -32,7 +32,7 @@ struct cluster_bootstrap_info_request
 };
 
 struct cluster_bootstrap_info_reply
-  : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>> {
+  : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     model::broker broker;

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -19,7 +19,10 @@
 namespace cluster {
 
 struct cluster_bootstrap_info_request
-  : serde::envelope<cluster_bootstrap_info_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      cluster_bootstrap_info_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend std::ostream&
@@ -32,7 +35,10 @@ struct cluster_bootstrap_info_request
 };
 
 struct cluster_bootstrap_info_reply
-  : serde::envelope<cluster_bootstrap_info_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      cluster_bootstrap_info_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     model::broker broker;

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -45,7 +45,7 @@ public:
      * the optional fields may not be set if draining has been requested, but
      * not yet started. in this case the values are not yet known.
      */
-    struct drain_status : serde::envelope<drain_status, serde::version<0>> {
+    struct drain_status : serde::envelope<drain_status, serde::version<0>, serde::compat_version<0>> {
         bool finished{false};
         bool errors{false};
         std::optional<size_t> partitions;

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -45,7 +45,9 @@ public:
      * the optional fields may not be set if draining has been requested, but
      * not yet started. in this case the values are not yet known.
      */
-    struct drain_status : serde::envelope<drain_status, serde::version<0>, serde::compat_version<0>> {
+    struct drain_status
+      : serde::
+          envelope<drain_status, serde::version<0>, serde::compat_version<0>> {
         bool finished{false};
         bool errors{false};
         std::optional<size_t> partitions;

--- a/src/v/cluster/ephemeral_credential_serde.h
+++ b/src/v/cluster/ephemeral_credential_serde.h
@@ -22,7 +22,7 @@
 namespace cluster {
 
 struct put_ephemeral_credential_request
-  : serde::envelope<put_ephemeral_credential_request, serde::version<0>> {
+  : serde::envelope<put_ephemeral_credential_request, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     put_ephemeral_credential_request() = default;
@@ -42,7 +42,7 @@ struct put_ephemeral_credential_request
 };
 
 struct put_ephemeral_credential_reply
-  : serde::envelope<put_ephemeral_credential_reply, serde::version<0>> {
+  : serde::envelope<put_ephemeral_credential_reply, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     put_ephemeral_credential_reply() = default;

--- a/src/v/cluster/ephemeral_credential_serde.h
+++ b/src/v/cluster/ephemeral_credential_serde.h
@@ -22,7 +22,10 @@
 namespace cluster {
 
 struct put_ephemeral_credential_request
-  : serde::envelope<put_ephemeral_credential_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      put_ephemeral_credential_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     put_ephemeral_credential_request() = default;
@@ -42,7 +45,10 @@ struct put_ephemeral_credential_request
 };
 
 struct put_ephemeral_credential_reply
-  : serde::envelope<put_ephemeral_credential_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      put_ephemeral_credential_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     put_ephemeral_credential_reply() = default;

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -39,7 +39,7 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
  * node state is determined from controller, and it doesn't require contacting
  * with the node directly
  */
-struct node_state : serde::envelope<node_state, serde::version<0>> {
+struct node_state : serde::envelope<node_state, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     model::node_id id;
@@ -52,7 +52,7 @@ struct node_state : serde::envelope<node_state, serde::version<0>> {
     auto serde_fields() { return std::tie(id, membership_state, is_alive); }
 };
 
-struct partition_status : serde::envelope<partition_status, serde::version<0>> {
+struct partition_status : serde::envelope<partition_status, serde::version<0>, serde::compat_version<0>> {
     /**
      * We increase a version here 'backward' since incorrect assertion would
      * cause older redpanda versions to crash.
@@ -86,7 +86,7 @@ struct partition_status : serde::envelope<partition_status, serde::version<0>> {
       = default;
 };
 
-struct topic_status : serde::envelope<topic_status, serde::version<0>> {
+struct topic_status : serde::envelope<topic_status, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     model::topic_namespace tp_ns;
@@ -102,7 +102,7 @@ struct topic_status : serde::envelope<topic_status, serde::version<0>> {
  * instance of time
  */
 struct node_health_report
-  : serde::envelope<node_health_report, serde::version<0>> {
+  : serde::envelope<node_health_report, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 2;
 
     model::node_id id;
@@ -155,7 +155,7 @@ struct node_health_report
 };
 
 struct cluster_health_report
-  : serde::envelope<cluster_health_report, serde::version<0>> {
+  : serde::envelope<cluster_health_report, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     std::optional<model::node_id> raft0_leader;
@@ -198,7 +198,7 @@ using include_partitions_info = ss::bool_class<struct include_partitions_tag>;
  * Filters are used to limit amout of data returned in health reports
  */
 struct partitions_filter
-  : serde::envelope<partitions_filter, serde::version<0>> {
+  : serde::envelope<partitions_filter, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     using partitions_set_t = absl::node_hash_set<model::partition_id>;
@@ -217,7 +217,7 @@ struct partitions_filter
 };
 
 struct node_report_filter
-  : serde::envelope<node_report_filter, serde::version<0>> {
+  : serde::envelope<node_report_filter, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     include_partitions_info include_partitions = include_partitions_info::yes;
@@ -233,7 +233,7 @@ struct node_report_filter
 };
 
 struct cluster_report_filter
-  : serde::envelope<cluster_report_filter, serde::version<0>> {
+  : serde::envelope<cluster_report_filter, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
     // filtering that will be applied to node reports
     node_report_filter node_report_filter;
@@ -257,7 +257,7 @@ using force_refresh = ss::bool_class<struct hm_force_refresh_tag>;
  */
 
 struct get_node_health_request
-  : serde::envelope<get_node_health_request, serde::version<0>> {
+  : serde::envelope<get_node_health_request, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
     static constexpr int8_t revision_id_version = -1;
@@ -281,7 +281,7 @@ struct get_node_health_request
 };
 
 struct get_node_health_reply
-  : serde::envelope<get_node_health_reply, serde::version<0>> {
+  : serde::envelope<get_node_health_reply, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;
@@ -298,7 +298,7 @@ struct get_node_health_reply
 };
 
 struct get_cluster_health_request
-  : serde::envelope<get_cluster_health_request, serde::version<0>> {
+  : serde::envelope<get_cluster_health_request, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
     static constexpr int8_t revision_id_version = -1;
@@ -339,7 +339,7 @@ struct get_cluster_health_request
 };
 
 struct get_cluster_health_reply
-  : serde::envelope<get_cluster_health_reply, serde::version<0>> {
+  : serde::envelope<get_cluster_health_reply, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -39,7 +39,8 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
  * node state is determined from controller, and it doesn't require contacting
  * with the node directly
  */
-struct node_state : serde::envelope<node_state, serde::version<0>, serde::compat_version<0>> {
+struct node_state
+  : serde::envelope<node_state, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     model::node_id id;
@@ -52,7 +53,9 @@ struct node_state : serde::envelope<node_state, serde::version<0>, serde::compat
     auto serde_fields() { return std::tie(id, membership_state, is_alive); }
 };
 
-struct partition_status : serde::envelope<partition_status, serde::version<0>, serde::compat_version<0>> {
+struct partition_status
+  : serde::
+      envelope<partition_status, serde::version<0>, serde::compat_version<0>> {
     /**
      * We increase a version here 'backward' since incorrect assertion would
      * cause older redpanda versions to crash.
@@ -86,7 +89,8 @@ struct partition_status : serde::envelope<partition_status, serde::version<0>, s
       = default;
 };
 
-struct topic_status : serde::envelope<topic_status, serde::version<0>, serde::compat_version<0>> {
+struct topic_status
+  : serde::envelope<topic_status, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     model::topic_namespace tp_ns;
@@ -102,7 +106,10 @@ struct topic_status : serde::envelope<topic_status, serde::version<0>, serde::co
  * instance of time
  */
 struct node_health_report
-  : serde::envelope<node_health_report, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      node_health_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 2;
 
     model::node_id id;
@@ -155,7 +162,10 @@ struct node_health_report
 };
 
 struct cluster_health_report
-  : serde::envelope<cluster_health_report, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      cluster_health_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     std::optional<model::node_id> raft0_leader;
@@ -198,7 +208,8 @@ using include_partitions_info = ss::bool_class<struct include_partitions_tag>;
  * Filters are used to limit amout of data returned in health reports
  */
 struct partitions_filter
-  : serde::envelope<partitions_filter, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<partitions_filter, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     using partitions_set_t = absl::node_hash_set<model::partition_id>;
@@ -217,7 +228,10 @@ struct partitions_filter
 };
 
 struct node_report_filter
-  : serde::envelope<node_report_filter, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      node_report_filter,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     include_partitions_info include_partitions = include_partitions_info::yes;
@@ -233,7 +247,10 @@ struct node_report_filter
 };
 
 struct cluster_report_filter
-  : serde::envelope<cluster_report_filter, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      cluster_report_filter,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
     // filtering that will be applied to node reports
     node_report_filter node_report_filter;
@@ -257,7 +274,10 @@ using force_refresh = ss::bool_class<struct hm_force_refresh_tag>;
  */
 
 struct get_node_health_request
-  : serde::envelope<get_node_health_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_node_health_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
     static constexpr int8_t revision_id_version = -1;
@@ -281,7 +301,10 @@ struct get_node_health_request
 };
 
 struct get_node_health_reply
-  : serde::envelope<get_node_health_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_node_health_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;
@@ -298,7 +321,10 @@ struct get_node_health_reply
 };
 
 struct get_cluster_health_request
-  : serde::envelope<get_cluster_health_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_cluster_health_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
     static constexpr int8_t revision_id_version = -1;
@@ -339,7 +365,10 @@ struct get_cluster_health_request
 };
 
 struct get_cluster_health_reply
-  : serde::envelope<get_cluster_health_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_cluster_health_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -23,7 +23,7 @@
 
 namespace cluster {
 
-struct ntp_leader : serde::envelope<ntp_leader, serde::version<0>> {
+struct ntp_leader : serde::envelope<ntp_leader, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
@@ -54,7 +54,7 @@ struct ntp_leader : serde::envelope<ntp_leader, serde::version<0>> {
 };
 
 struct ntp_leader_revision
-  : serde::envelope<ntp_leader_revision, serde::version<0>> {
+  : serde::envelope<ntp_leader_revision, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
@@ -92,7 +92,7 @@ struct ntp_leader_revision
 };
 
 struct update_leadership_request
-  : serde::envelope<update_leadership_request, serde::version<0>> {
+  : serde::envelope<update_leadership_request, serde::version<0>, serde::compat_version<0>> {
     std::vector<ntp_leader> leaders;
 
     update_leadership_request() noexcept = default;
@@ -114,7 +114,7 @@ struct update_leadership_request
 };
 
 struct update_leadership_request_v2
-  : serde::envelope<update_leadership_request_v2, serde::version<0>> {
+  : serde::envelope<update_leadership_request_v2, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t version = 0;
     std::vector<ntp_leader_revision> leaders;
 
@@ -138,7 +138,7 @@ struct update_leadership_request_v2
 };
 
 struct update_leadership_reply
-  : serde::envelope<update_leadership_reply, serde::version<0>> {
+  : serde::envelope<update_leadership_reply, serde::version<0>, serde::compat_version<0>> {
     update_leadership_reply() noexcept = default;
 
     friend std::ostream&
@@ -151,7 +151,7 @@ struct update_leadership_reply
 };
 
 struct get_leadership_request
-  : serde::envelope<get_leadership_request, serde::version<0>> {
+  : serde::envelope<get_leadership_request, serde::version<0>, serde::compat_version<0>> {
     get_leadership_request() noexcept = default;
 
     friend std::ostream&
@@ -164,7 +164,7 @@ struct get_leadership_request
 };
 
 struct get_leadership_reply
-  : serde::envelope<get_leadership_reply, serde::version<0>> {
+  : serde::envelope<get_leadership_reply, serde::version<0>, serde::compat_version<0>> {
     std::vector<ntp_leader> leaders;
 
     get_leadership_reply() noexcept = default;

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -23,7 +23,8 @@
 
 namespace cluster {
 
-struct ntp_leader : serde::envelope<ntp_leader, serde::version<0>, serde::compat_version<0>> {
+struct ntp_leader
+  : serde::envelope<ntp_leader, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
@@ -54,7 +55,10 @@ struct ntp_leader : serde::envelope<ntp_leader, serde::version<0>, serde::compat
 };
 
 struct ntp_leader_revision
-  : serde::envelope<ntp_leader_revision, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      ntp_leader_revision,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id term;
     std::optional<model::node_id> leader_id;
@@ -92,7 +96,10 @@ struct ntp_leader_revision
 };
 
 struct update_leadership_request
-  : serde::envelope<update_leadership_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      update_leadership_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<ntp_leader> leaders;
 
     update_leadership_request() noexcept = default;
@@ -114,7 +121,10 @@ struct update_leadership_request
 };
 
 struct update_leadership_request_v2
-  : serde::envelope<update_leadership_request_v2, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      update_leadership_request_v2,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t version = 0;
     std::vector<ntp_leader_revision> leaders;
 
@@ -138,7 +148,10 @@ struct update_leadership_request_v2
 };
 
 struct update_leadership_reply
-  : serde::envelope<update_leadership_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      update_leadership_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     update_leadership_reply() noexcept = default;
 
     friend std::ostream&
@@ -151,7 +164,10 @@ struct update_leadership_reply
 };
 
 struct get_leadership_request
-  : serde::envelope<get_leadership_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_leadership_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     get_leadership_request() noexcept = default;
 
     friend std::ostream&
@@ -164,7 +180,10 @@ struct get_leadership_request
 };
 
 struct get_leadership_reply
-  : serde::envelope<get_leadership_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      get_leadership_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<ntp_leader> leaders;
 
     get_leadership_reply() noexcept = default;

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -35,7 +35,7 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
-struct local_state : serde::envelope<local_state, serde::version<0>> {
+struct local_state : serde::envelope<local_state, serde::version<0>, serde::compat_version<0>> {
     application_version redpanda_version;
     cluster_version logical_version{invalid_version};
     std::chrono::milliseconds uptime;

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -35,7 +35,8 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
-struct local_state : serde::envelope<local_state, serde::version<0>, serde::compat_version<0>> {
+struct local_state
+  : serde::envelope<local_state, serde::version<0>, serde::compat_version<0>> {
     application_version redpanda_version;
     cluster_version logical_version{invalid_version};
     std::chrono::milliseconds uptime;

--- a/src/v/cluster/node_status_rpc_types.h
+++ b/src/v/cluster/node_status_rpc_types.h
@@ -17,7 +17,10 @@
 namespace cluster {
 
 struct node_status_metadata
-  : serde::envelope<node_status_metadata, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      node_status_metadata,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     model::node_id node_id;
@@ -30,7 +33,10 @@ struct node_status_metadata
 };
 
 struct node_status_request
-  : serde::envelope<node_status_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      node_status_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     node_status_metadata sender_metadata;
@@ -43,7 +49,8 @@ struct node_status_request
 };
 
 struct node_status_reply
-  : serde::envelope<node_status_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<node_status_reply, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     node_status_metadata replier_metadata;

--- a/src/v/cluster/node_status_rpc_types.h
+++ b/src/v/cluster/node_status_rpc_types.h
@@ -17,7 +17,7 @@
 namespace cluster {
 
 struct node_status_metadata
-  : serde::envelope<node_status_metadata, serde::version<0>> {
+  : serde::envelope<node_status_metadata, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     model::node_id node_id;
@@ -30,7 +30,7 @@ struct node_status_metadata
 };
 
 struct node_status_request
-  : serde::envelope<node_status_request, serde::version<0>> {
+  : serde::envelope<node_status_request, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     node_status_metadata sender_metadata;
@@ -43,7 +43,7 @@ struct node_status_request
 };
 
 struct node_status_reply
-  : serde::envelope<node_status_reply, serde::version<0>> {
+  : serde::envelope<node_status_reply, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     node_status_metadata replier_metadata;

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -45,9 +45,9 @@ struct node_disk_space {
 };
 
 struct partition_balancer_violations
-  : serde::envelope<partition_balancer_violations, serde::version<0>> {
+  : serde::envelope<partition_balancer_violations, serde::version<0>, serde::compat_version<0>> {
     struct unavailable_node
-      : serde::envelope<unavailable_node, serde::version<0>> {
+      : serde::envelope<unavailable_node, serde::version<0>, serde::compat_version<0>> {
         model::node_id id;
         model::timestamp unavailable_since;
 
@@ -70,7 +70,7 @@ struct partition_balancer_violations
         }
     };
 
-    struct full_node : serde::envelope<full_node, serde::version<0>> {
+    struct full_node : serde::envelope<full_node, serde::version<0>, serde::compat_version<0>> {
         model::node_id id;
         uint32_t disk_used_percent;
 
@@ -159,7 +159,7 @@ operator<<(std::ostream& os, partition_balancer_status status) {
 }
 
 struct partition_balancer_overview_request
-  : serde::envelope<partition_balancer_overview_request, serde::version<0>> {
+  : serde::envelope<partition_balancer_overview_request, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend std::ostream&
@@ -172,7 +172,7 @@ struct partition_balancer_overview_request
 };
 
 struct partition_balancer_overview_reply
-  : serde::envelope<partition_balancer_overview_reply, serde::version<0>> {
+  : serde::envelope<partition_balancer_overview_reply, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     errc error;

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -45,9 +45,15 @@ struct node_disk_space {
 };
 
 struct partition_balancer_violations
-  : serde::envelope<partition_balancer_violations, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      partition_balancer_violations,
+      serde::version<0>,
+      serde::compat_version<0>> {
     struct unavailable_node
-      : serde::envelope<unavailable_node, serde::version<0>, serde::compat_version<0>> {
+      : serde::envelope<
+          unavailable_node,
+          serde::version<0>,
+          serde::compat_version<0>> {
         model::node_id id;
         model::timestamp unavailable_since;
 
@@ -70,7 +76,9 @@ struct partition_balancer_violations
         }
     };
 
-    struct full_node : serde::envelope<full_node, serde::version<0>, serde::compat_version<0>> {
+    struct full_node
+      : serde::
+          envelope<full_node, serde::version<0>, serde::compat_version<0>> {
         model::node_id id;
         uint32_t disk_used_percent;
 
@@ -159,7 +167,10 @@ operator<<(std::ostream& os, partition_balancer_status status) {
 }
 
 struct partition_balancer_overview_request
-  : serde::envelope<partition_balancer_overview_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      partition_balancer_overview_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend std::ostream&
@@ -172,7 +183,10 @@ struct partition_balancer_overview_request
 };
 
 struct partition_balancer_overview_reply
-  : serde::envelope<partition_balancer_overview_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      partition_balancer_overview_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     errc error;

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -38,13 +38,19 @@ namespace {
 // Fake command type used to test serde-only types.
 static constexpr int8_t fake_serde_only_cmd_type = 0;
 struct fake_serde_only_key
-  : serde::envelope<fake_serde_only_key, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      fake_serde_only_key,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     ss::sstring str;
 };
 struct fake_serde_only_val
-  : serde::envelope<fake_serde_only_val, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      fake_serde_only_val,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     ss::sstring str;

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -38,13 +38,13 @@ namespace {
 // Fake command type used to test serde-only types.
 static constexpr int8_t fake_serde_only_cmd_type = 0;
 struct fake_serde_only_key
-  : serde::envelope<fake_serde_only_key, serde::version<0>> {
+  : serde::envelope<fake_serde_only_key, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     ss::sstring str;
 };
 struct fake_serde_only_val
-  : serde::envelope<fake_serde_only_val, serde::version<0>> {
+  : serde::envelope<fake_serde_only_val, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     ss::sstring str;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -52,7 +52,10 @@ using cluster_version = named_type<int64_t, struct cluster_version_tag>;
 constexpr cluster_version invalid_version = cluster_version{-1};
 
 struct allocate_id_request
-  : serde::envelope<allocate_id_request, serde::version<0>> {
+  : serde::envelope<
+      allocate_id_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::timeout_clock::duration timeout;
 
     allocate_id_request() noexcept = default;
@@ -74,7 +77,8 @@ struct allocate_id_request
 };
 
 struct allocate_id_reply
-  : serde::envelope<allocate_id_reply, serde::version<0>> {
+  : serde::
+      envelope<allocate_id_reply, serde::version<0>, serde::compat_version<0>> {
     int64_t id;
     errc ec;
 
@@ -171,7 +175,8 @@ enum class partition_removal_mode : uint8_t {
 };
 
 struct try_abort_request
-  : serde::envelope<try_abort_request, serde::version<0>> {
+  : serde::
+      envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
     model::partition_id tm;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -198,7 +203,9 @@ struct try_abort_request
     auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
 };
 
-struct try_abort_reply : serde::envelope<try_abort_reply, serde::version<0>> {
+struct try_abort_reply
+  : serde::
+      envelope<try_abort_reply, serde::version<0>, serde::compat_version<0>> {
     using committed_type = ss::bool_class<struct committed_type_tag>;
     using aborted_type = ss::bool_class<struct aborted_type_tag>;
 
@@ -233,7 +240,10 @@ struct try_abort_reply : serde::envelope<try_abort_reply, serde::version<0>> {
 };
 
 struct init_tm_tx_request
-  : serde::envelope<init_tm_tx_request, serde::version<0>> {
+  : serde::envelope<
+      init_tm_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     kafka::transactional_id tx_id;
     std::chrono::milliseconds transaction_timeout_ms;
     model::timeout_clock::duration timeout;
@@ -259,7 +269,9 @@ struct init_tm_tx_request
     }
 };
 
-struct init_tm_tx_reply : serde::envelope<init_tm_tx_reply, serde::version<0>> {
+struct init_tm_tx_reply
+  : serde::
+      envelope<init_tm_tx_reply, serde::version<0>, serde::compat_version<0>> {
     // partition_not_exists, not_leader, topic_not_exists
     model::producer_identity pid;
     tx_errc ec;
@@ -320,7 +332,9 @@ struct end_tx_request {
 struct end_tx_reply {
     tx_errc error_code{};
 };
-struct begin_tx_request : serde::envelope<begin_tx_request, serde::version<0>> {
+struct begin_tx_request
+  : serde::
+      envelope<begin_tx_request, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -386,7 +400,10 @@ struct begin_tx_reply
 };
 
 struct prepare_tx_request
-  : serde::envelope<prepare_tx_request, serde::version<0>> {
+  : serde::envelope<
+      prepare_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id etag;
     model::partition_id tm;
@@ -421,7 +438,9 @@ struct prepare_tx_request
     }
 };
 
-struct prepare_tx_reply : serde::envelope<prepare_tx_reply, serde::version<0>> {
+struct prepare_tx_reply
+  : serde::
+      envelope<prepare_tx_reply, serde::version<0>, serde::compat_version<0>> {
     tx_errc ec;
 
     prepare_tx_reply() noexcept = default;
@@ -438,7 +457,8 @@ struct prepare_tx_reply : serde::envelope<prepare_tx_reply, serde::version<0>> {
 };
 
 struct commit_tx_request
-  : serde::envelope<commit_tx_request, serde::version<0>> {
+  : serde::
+      envelope<commit_tx_request, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -465,7 +485,9 @@ struct commit_tx_request
     operator<<(std::ostream& o, const commit_tx_request& r);
 };
 
-struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
+struct commit_tx_reply
+  : serde::
+      envelope<commit_tx_reply, serde::version<0>, serde::compat_version<0>> {
     tx_errc ec;
 
     commit_tx_reply() noexcept = default;
@@ -481,7 +503,9 @@ struct commit_tx_reply : serde::envelope<commit_tx_reply, serde::version<0>> {
     friend std::ostream& operator<<(std::ostream& o, const commit_tx_reply& r);
 };
 
-struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {
+struct abort_tx_request
+  : serde::
+      envelope<abort_tx_request, serde::version<0>, serde::compat_version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -507,7 +531,9 @@ struct abort_tx_request : serde::envelope<abort_tx_request, serde::version<0>> {
     friend std::ostream& operator<<(std::ostream& o, const abort_tx_request& r);
 };
 
-struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
+struct abort_tx_reply
+  : serde::
+      envelope<abort_tx_reply, serde::version<0>, serde::compat_version<0>> {
     tx_errc ec;
 
     abort_tx_reply() noexcept = default;
@@ -524,7 +550,10 @@ struct abort_tx_reply : serde::envelope<abort_tx_reply, serde::version<0>> {
 };
 
 struct begin_group_tx_request
-  : serde::envelope<begin_group_tx_request, serde::version<0>> {
+  : serde::envelope<
+      begin_group_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
@@ -570,7 +599,10 @@ struct begin_group_tx_request
 };
 
 struct begin_group_tx_reply
-  : serde::envelope<begin_group_tx_reply, serde::version<0>> {
+  : serde::envelope<
+      begin_group_tx_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::term_id etag;
     tx_errc ec;
 
@@ -594,7 +626,10 @@ struct begin_group_tx_reply
 };
 
 struct prepare_group_tx_request
-  : serde::envelope<prepare_group_tx_request, serde::version<0>> {
+  : serde::envelope<
+      prepare_group_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::term_id etag;
@@ -644,7 +679,10 @@ struct prepare_group_tx_request
 };
 
 struct prepare_group_tx_reply
-  : serde::envelope<prepare_group_tx_reply, serde::version<0>> {
+  : serde::envelope<
+      prepare_group_tx_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     tx_errc ec;
 
     prepare_group_tx_reply() noexcept = default;
@@ -663,7 +701,10 @@ struct prepare_group_tx_reply
 };
 
 struct commit_group_tx_request
-  : serde::envelope<commit_group_tx_request, serde::version<0>> {
+  : serde::envelope<
+      commit_group_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -709,7 +750,10 @@ struct commit_group_tx_request
 };
 
 struct commit_group_tx_reply
-  : serde::envelope<commit_group_tx_reply, serde::version<0>> {
+  : serde::envelope<
+      commit_group_tx_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     tx_errc ec;
 
     commit_group_tx_reply() noexcept = default;
@@ -728,7 +772,10 @@ struct commit_group_tx_reply
 };
 
 struct abort_group_tx_request
-  : serde::envelope<abort_group_tx_request, serde::version<0>> {
+  : serde::envelope<
+      abort_group_tx_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
@@ -774,7 +821,10 @@ struct abort_group_tx_request
 };
 
 struct abort_group_tx_reply
-  : serde::envelope<abort_group_tx_reply, serde::version<0>> {
+  : serde::envelope<
+      abort_group_tx_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     tx_errc ec;
 
     abort_group_tx_reply() noexcept = default;
@@ -797,7 +847,8 @@ struct abort_group_tx_reply
 /// - Always specifies node_id
 /// (remove this RPC two versions after join_node_request was
 ///  added to replace it)
-struct join_request : serde::envelope<join_request, serde::version<0>> {
+struct join_request
+  : serde::envelope<join_request, serde::version<0>, serde::compat_version<0>> {
     join_request() noexcept = default;
 
     explicit join_request(model::broker b)
@@ -815,7 +866,8 @@ struct join_request : serde::envelope<join_request, serde::version<0>> {
     auto serde_fields() { return std::tie(node); }
 };
 
-struct join_reply : serde::envelope<join_reply, serde::version<0>> {
+struct join_reply
+  : serde::envelope<join_reply, serde::version<0>, serde::compat_version<0>> {
     bool success;
 
     join_reply() noexcept = default;
@@ -839,7 +891,8 @@ struct join_reply : serde::envelope<join_reply, serde::version<0>> {
 ///   node_id (https://github.com/redpanda-data/redpanda/issues/2793)
 ///   in future.
 struct join_node_request
-  : serde::envelope<join_node_request, serde::version<0>> {
+  : serde::
+      envelope<join_node_request, serde::version<0>, serde::compat_version<0>> {
     join_node_request() noexcept = default;
 
     explicit join_node_request(
@@ -878,7 +931,9 @@ struct join_node_request
     auto serde_fields() { return std::tie(logical_version, node_uuid, node); }
 };
 
-struct join_node_reply : serde::envelope<join_node_reply, serde::version<0>> {
+struct join_node_reply
+  : serde::
+      envelope<join_node_reply, serde::version<0>, serde::compat_version<0>> {
     bool success{false};
     model::node_id id{model::unassigned_node_id};
 
@@ -900,7 +955,10 @@ struct join_node_reply : serde::envelope<join_node_reply, serde::version<0>> {
 };
 
 struct configuration_update_request
-  : serde::envelope<configuration_update_request, serde::version<0>> {
+  : serde::envelope<
+      configuration_update_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     configuration_update_request() noexcept = default;
     explicit configuration_update_request(model::broker b, model::node_id tid)
       : node(std::move(b))
@@ -920,7 +978,10 @@ struct configuration_update_request
 };
 
 struct configuration_update_reply
-  : serde::envelope<configuration_update_reply, serde::version<0>> {
+  : serde::envelope<
+      configuration_update_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     configuration_update_reply() noexcept = default;
     explicit configuration_update_reply(bool success)
       : success(success) {}
@@ -940,7 +1001,10 @@ struct configuration_update_reply
 /// Partition assignment describes an assignment of all replicas for single NTP.
 /// The replicas are hold in vector of broker_shard.
 struct partition_assignment
-  : serde::envelope<partition_assignment, serde::version<0>> {
+  : serde::envelope<
+      partition_assignment,
+      serde::version<0>,
+      serde::compat_version<0>> {
     partition_assignment() noexcept = default;
     partition_assignment(
       raft::group_id group,
@@ -969,7 +1033,10 @@ struct partition_assignment
 };
 
 struct remote_topic_properties
-  : serde::envelope<remote_topic_properties, serde::version<0>> {
+  : serde::envelope<
+      remote_topic_properties,
+      serde::version<0>,
+      serde::compat_version<0>> {
     remote_topic_properties() = default;
     remote_topic_properties(
       model::initial_revision_id remote_revision,
@@ -1107,7 +1174,10 @@ incremental_update_operation_as_string(incremental_update_operation op) {
 
 template<typename T>
 struct property_update
-  : serde::envelope<property_update<T>, serde::version<0>> {
+  : serde::envelope<
+      property_update<T>,
+      serde::version<0>,
+      serde::compat_version<0>> {
     property_update() = default;
     property_update(T v, incremental_update_operation op)
       : value(std::move(v))
@@ -1134,7 +1204,10 @@ struct property_update
 
 template<typename T>
 struct property_update<tristate<T>>
-  : serde::envelope<property_update<tristate<T>>, serde::version<0>> {
+  : serde::envelope<
+      property_update<tristate<T>>,
+      serde::version<0>,
+      serde::compat_version<0>> {
     property_update()
       : value(std::nullopt){};
 
@@ -1253,7 +1326,10 @@ struct incremental_topic_custom_updates
  * Struct representing single topic properties update
  */
 struct topic_properties_update
-  : serde::envelope<topic_properties_update, serde::version<0>> {
+  : serde::envelope<
+      topic_properties_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
     // We need version to indetify request with custom_properties
     static constexpr int32_t version = -1;
     topic_properties_update() noexcept = default;
@@ -1394,7 +1470,10 @@ struct custom_assignable_topic_configuration {
 };
 
 struct create_partitions_configuration
-  : serde::envelope<create_partitions_configuration, serde::version<0>> {
+  : serde::envelope<
+      create_partitions_configuration,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using custom_assignment = std::vector<model::node_id>;
 
     create_partitions_configuration() = default;
@@ -1422,7 +1501,10 @@ struct create_partitions_configuration
 };
 
 struct topic_configuration_assignment
-  : serde::envelope<topic_configuration_assignment, serde::version<0>> {
+  : serde::envelope<
+      topic_configuration_assignment,
+      serde::version<0>,
+      serde::compat_version<0>> {
     topic_configuration_assignment() = default;
 
     topic_configuration_assignment(
@@ -1444,8 +1526,10 @@ struct topic_configuration_assignment
 };
 
 struct create_partitions_configuration_assignment
-  : serde::
-      envelope<create_partitions_configuration_assignment, serde::version<0>> {
+  : serde::envelope<
+      create_partitions_configuration_assignment,
+      serde::version<0>,
+      serde::compat_version<0>> {
     create_partitions_configuration_assignment() = default;
     create_partitions_configuration_assignment(
       create_partitions_configuration cfg,
@@ -1467,7 +1551,8 @@ struct create_partitions_configuration_assignment
       = default;
 };
 
-struct topic_result : serde::envelope<topic_result, serde::version<0>> {
+struct topic_result
+  : serde::envelope<topic_result, serde::version<0>, serde::compat_version<0>> {
     topic_result() noexcept = default;
     explicit topic_result(model::topic_namespace t, errc ec = errc::success)
       : tp_ns(std::move(t))
@@ -1483,7 +1568,10 @@ struct topic_result : serde::envelope<topic_result, serde::version<0>> {
 };
 
 struct create_topics_request
-  : serde::envelope<create_topics_request, serde::version<0>> {
+  : serde::envelope<
+      create_topics_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<topic_configuration> topics;
     model::timeout_clock::duration timeout;
 
@@ -1498,7 +1586,10 @@ struct create_topics_request
 };
 
 struct create_topics_reply
-  : serde::envelope<create_topics_reply, serde::version<0>> {
+  : serde::envelope<
+      create_topics_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<topic_result> results;
     std::vector<model::topic_metadata> metadata;
     std::vector<topic_configuration> configs;
@@ -1522,7 +1613,10 @@ struct create_topics_reply
 };
 
 struct finish_partition_update_request
-  : serde::envelope<finish_partition_update_request, serde::version<0>> {
+  : serde::envelope<
+      finish_partition_update_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::ntp ntp;
     std::vector<model::broker_shard> new_replica_set;
 
@@ -1538,7 +1632,10 @@ struct finish_partition_update_request
 };
 
 struct finish_partition_update_reply
-  : serde::envelope<finish_partition_update_reply, serde::version<0>> {
+  : serde::envelope<
+      finish_partition_update_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     cluster::errc result;
 
     friend bool operator==(
@@ -1553,7 +1650,10 @@ struct finish_partition_update_reply
 };
 
 struct update_topic_properties_request
-  : serde::envelope<update_topic_properties_request, serde::version<0>> {
+  : serde::envelope<
+      update_topic_properties_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<topic_properties_update> updates;
 
     friend std::ostream&
@@ -1568,7 +1668,10 @@ struct update_topic_properties_request
 };
 
 struct update_topic_properties_reply
-  : serde::envelope<update_topic_properties_reply, serde::version<0>> {
+  : serde::envelope<
+      update_topic_properties_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<topic_result> results;
 
     friend std::ostream&
@@ -1678,7 +1781,10 @@ struct topic_table_delta {
 };
 
 struct create_acls_cmd_data
-  : serde::envelope<create_acls_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      create_acls_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<security::acl_binding> bindings;
 
@@ -1696,7 +1802,10 @@ struct create_acls_cmd_data
 };
 
 struct create_acls_request
-  : serde::envelope<create_acls_request, serde::version<0>> {
+  : serde::envelope<
+      create_acls_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     create_acls_cmd_data data;
     model::timeout_clock::duration timeout;
 
@@ -1720,7 +1829,8 @@ struct create_acls_request
 };
 
 struct create_acls_reply
-  : serde::envelope<create_acls_reply, serde::version<0>> {
+  : serde::
+      envelope<create_acls_reply, serde::version<0>, serde::compat_version<0>> {
     std::vector<errc> results;
 
     friend bool operator==(const create_acls_reply&, const create_acls_reply&)
@@ -1736,7 +1846,10 @@ struct create_acls_reply
 };
 
 struct delete_acls_cmd_data
-  : serde::envelope<delete_acls_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      delete_acls_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<security::acl_binding_filter> filters;
 
@@ -1755,7 +1868,10 @@ struct delete_acls_cmd_data
 
 // result for a single filter
 struct delete_acls_result
-  : serde::envelope<delete_acls_result, serde::version<0>> {
+  : serde::envelope<
+      delete_acls_result,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
     std::vector<security::acl_binding> bindings;
 
@@ -1772,7 +1888,10 @@ struct delete_acls_result
 };
 
 struct delete_acls_request
-  : serde::envelope<delete_acls_request, serde::version<0>> {
+  : serde::envelope<
+      delete_acls_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     delete_acls_cmd_data data;
     model::timeout_clock::duration timeout;
 
@@ -1796,7 +1915,8 @@ struct delete_acls_request
 };
 
 struct delete_acls_reply
-  : serde::envelope<delete_acls_reply, serde::version<0>> {
+  : serde::
+      envelope<delete_acls_reply, serde::version<0>, serde::compat_version<0>> {
     std::vector<delete_acls_result> results;
 
     friend bool operator==(const delete_acls_reply&, const delete_acls_reply&)
@@ -1812,7 +1932,8 @@ struct delete_acls_reply
 };
 
 struct backend_operation
-  : serde::envelope<backend_operation, serde::version<0>> {
+  : serde::
+      envelope<backend_operation, serde::version<0>, serde::compat_version<0>> {
     ss::shard_id source_shard;
     partition_assignment p_as;
     topic_table_delta::op_type type;
@@ -1825,7 +1946,10 @@ struct backend_operation
 };
 
 struct create_data_policy_cmd_data
-  : serde::envelope<create_data_policy_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      create_data_policy_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1; // In future dp will be vector
 
     auto serde_fields() { return std::tie(dp); }
@@ -1838,7 +1962,10 @@ struct create_data_policy_cmd_data
 };
 
 struct non_replicable_topic
-  : serde::envelope<non_replicable_topic, serde::version<0>> {
+  : serde::envelope<
+      non_replicable_topic,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     model::topic_namespace source;
     model::topic_namespace name;
@@ -1855,7 +1982,9 @@ struct non_replicable_topic
 using config_version = named_type<int64_t, struct config_version_type>;
 constexpr config_version config_version_unset = config_version{-1};
 
-struct config_status : serde::envelope<config_status, serde::version<0>> {
+struct config_status
+  : serde::
+      envelope<config_status, serde::version<0>, serde::compat_version<0>> {
     model::node_id node;
     config_version version{config_version_unset};
     bool restart{false};
@@ -1871,7 +2000,10 @@ struct config_status : serde::envelope<config_status, serde::version<0>> {
 };
 
 struct cluster_property_kv
-  : serde::envelope<cluster_property_kv, serde::version<0>> {
+  : serde::envelope<
+      cluster_property_kv,
+      serde::version<0>,
+      serde::compat_version<0>> {
     cluster_property_kv() = default;
     cluster_property_kv(ss::sstring k, ss::sstring v)
       : key(std::move(k))
@@ -1889,7 +2021,10 @@ struct cluster_property_kv
 };
 
 struct cluster_config_delta_cmd_data
-  : serde::envelope<cluster_config_delta_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      cluster_config_delta_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
     std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
@@ -1906,7 +2041,10 @@ struct cluster_config_delta_cmd_data
 };
 
 struct cluster_config_status_cmd_data
-  : serde::envelope<cluster_config_status_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      cluster_config_status_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     friend bool operator==(
@@ -1920,7 +2058,10 @@ struct cluster_config_status_cmd_data
 };
 
 struct feature_update_action
-  : serde::envelope<feature_update_action, serde::version<0>> {
+  : serde::envelope<
+      feature_update_action,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     enum class action_t : std::uint16_t {
         // Notify when a feature is done with preparing phase
@@ -1948,7 +2089,10 @@ struct feature_update_action
 };
 
 struct feature_update_cmd_data
-  : serde::envelope<feature_update_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      feature_update_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     // To avoid ambiguity on 'versions' here: `current_version`
     // is the encoding version of the struct, subsequent version
     // fields are the payload.
@@ -1970,8 +2114,10 @@ struct feature_update_cmd_data
 using force_abort_update = ss::bool_class<struct force_abort_update_tag>;
 
 struct cancel_moving_partition_replicas_cmd_data
-  : serde::
-      envelope<cancel_moving_partition_replicas_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      cancel_moving_partition_replicas_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     cancel_moving_partition_replicas_cmd_data() = default;
     explicit cancel_moving_partition_replicas_cmd_data(force_abort_update force)
       : force(force) {}
@@ -1981,7 +2127,10 @@ struct cancel_moving_partition_replicas_cmd_data
 };
 
 struct move_topic_replicas_data
-  : serde::envelope<move_topic_replicas_data, serde::version<0>> {
+  : serde::envelope<
+      move_topic_replicas_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     move_topic_replicas_data() noexcept = default;
     explicit move_topic_replicas_data(
       model::partition_id partition, std::vector<model::broker_shard> replicas)
@@ -1998,7 +2147,10 @@ struct move_topic_replicas_data
 };
 
 struct feature_update_license_update_cmd_data
-  : serde::envelope<feature_update_license_update_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      feature_update_license_update_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     // Struct encoding version
@@ -2013,7 +2165,10 @@ struct feature_update_license_update_cmd_data
 };
 
 struct user_and_credential
-  : serde::envelope<user_and_credential, serde::version<0>> {
+  : serde::envelope<
+      user_and_credential,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     static constexpr int8_t current_version = 0;
 
@@ -2033,7 +2188,10 @@ struct user_and_credential
 };
 
 struct bootstrap_cluster_cmd_data
-  : serde::envelope<bootstrap_cluster_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      bootstrap_cluster_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend bool operator==(
@@ -2057,7 +2215,10 @@ enum class reconciliation_status : int8_t {
 std::ostream& operator<<(std::ostream&, const reconciliation_status&);
 
 class ntp_reconciliation_state
-  : public serde::envelope<ntp_reconciliation_state, serde::version<0>> {
+  : public serde::envelope<
+      ntp_reconciliation_state,
+      serde::version<0>,
+      serde::compat_version<0>> {
 public:
     ntp_reconciliation_state() noexcept = default;
 
@@ -2102,7 +2263,10 @@ private:
 };
 
 struct reconciliation_state_request
-  : serde::envelope<reconciliation_state_request, serde::version<0>> {
+  : serde::envelope<
+      reconciliation_state_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<model::ntp> ntps;
 
     friend bool operator==(
@@ -2119,7 +2283,10 @@ struct reconciliation_state_request
 };
 
 struct reconciliation_state_reply
-  : serde::envelope<reconciliation_state_reply, serde::version<0>> {
+  : serde::envelope<
+      reconciliation_state_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<ntp_reconciliation_state> results;
 
     friend bool operator==(
@@ -2136,7 +2303,10 @@ struct reconciliation_state_reply
 };
 
 struct decommission_node_request
-  : serde::envelope<decommission_node_request, serde::version<0>> {
+  : serde::envelope<
+      decommission_node_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::node_id id;
 
     friend bool operator==(
@@ -2153,7 +2323,10 @@ struct decommission_node_request
 };
 
 struct decommission_node_reply
-  : serde::envelope<decommission_node_reply, serde::version<0>> {
+  : serde::envelope<
+      decommission_node_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
 
     friend bool
@@ -2170,7 +2343,10 @@ struct decommission_node_reply
 };
 
 struct recommission_node_request
-  : serde::envelope<recommission_node_request, serde::version<0>> {
+  : serde::envelope<
+      recommission_node_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::node_id id;
 
     friend bool operator==(
@@ -2187,7 +2363,10 @@ struct recommission_node_request
 };
 
 struct recommission_node_reply
-  : serde::envelope<recommission_node_reply, serde::version<0>> {
+  : serde::envelope<
+      recommission_node_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
 
     friend bool
@@ -2204,7 +2383,10 @@ struct recommission_node_reply
 };
 
 struct finish_reallocation_request
-  : serde::envelope<finish_reallocation_request, serde::version<0>> {
+  : serde::envelope<
+      finish_reallocation_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::node_id id;
 
     friend bool operator==(
@@ -2221,7 +2403,10 @@ struct finish_reallocation_request
 };
 
 struct finish_reallocation_reply
-  : serde::envelope<finish_reallocation_reply, serde::version<0>> {
+  : serde::envelope<
+      finish_reallocation_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
 
     friend bool operator==(
@@ -2238,7 +2423,10 @@ struct finish_reallocation_reply
 };
 
 struct set_maintenance_mode_request
-  : serde::envelope<set_maintenance_mode_request, serde::version<0>> {
+  : serde::envelope<
+      set_maintenance_mode_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     model::node_id id;
     bool enabled;
@@ -2257,7 +2445,10 @@ struct set_maintenance_mode_request
 };
 
 struct set_maintenance_mode_reply
-  : serde::envelope<set_maintenance_mode_reply, serde::version<0>> {
+  : serde::envelope<
+      set_maintenance_mode_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     errc error;
 
@@ -2275,7 +2466,10 @@ struct set_maintenance_mode_reply
 };
 
 struct config_status_request
-  : serde::envelope<config_status_request, serde::version<0>> {
+  : serde::envelope<
+      config_status_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     config_status status;
 
     friend std::ostream&
@@ -2289,7 +2483,10 @@ struct config_status_request
 };
 
 struct config_status_reply
-  : serde::envelope<config_status_reply, serde::version<0>> {
+  : serde::envelope<
+      config_status_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
 
     friend std::ostream& operator<<(std::ostream&, const config_status_reply&);
@@ -2302,7 +2499,10 @@ struct config_status_reply
 };
 
 struct feature_action_request
-  : serde::envelope<feature_action_request, serde::version<0>> {
+  : serde::envelope<
+      feature_action_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     feature_update_action action;
 
     friend bool
@@ -2316,7 +2516,10 @@ struct feature_action_request
 };
 
 struct feature_action_response
-  : serde::envelope<feature_action_response, serde::version<0>> {
+  : serde::envelope<
+      feature_action_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
 
     friend bool
@@ -2333,7 +2536,10 @@ using feature_barrier_tag
   = named_type<ss::sstring, struct feature_barrier_tag_type>;
 
 struct feature_barrier_request
-  : serde::envelope<feature_barrier_request, serde::version<0>> {
+  : serde::envelope<
+      feature_barrier_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     feature_barrier_tag tag; // Each cooperative barrier must use a unique tag
     model::node_id peer;
@@ -2350,7 +2556,10 @@ struct feature_barrier_request
 };
 
 struct feature_barrier_response
-  : serde::envelope<feature_barrier_response, serde::version<0>> {
+  : serde::envelope<
+      feature_barrier_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     bool entered;  // Has the respondent entered?
     bool complete; // Has the respondent exited?
@@ -2366,7 +2575,10 @@ struct feature_barrier_response
 };
 
 struct create_non_replicable_topics_request
-  : serde::envelope<create_non_replicable_topics_request, serde::version<0>> {
+  : serde::envelope<
+      create_non_replicable_topics_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<non_replicable_topic> topics;
     model::timeout_clock::duration timeout;
@@ -2383,7 +2595,10 @@ struct create_non_replicable_topics_request
 };
 
 struct create_non_replicable_topics_reply
-  : serde::envelope<create_non_replicable_topics_reply, serde::version<0>> {
+  : serde::envelope<
+      create_non_replicable_topics_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
     std::vector<topic_result> results;
 
@@ -2399,7 +2614,10 @@ struct create_non_replicable_topics_reply
 };
 
 struct config_update_request final
-  : serde::envelope<config_update_request, serde::version<0>> {
+  : serde::envelope<
+      config_update_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
 
@@ -2414,7 +2632,10 @@ struct config_update_request final
 };
 
 struct config_update_reply
-  : serde::envelope<config_update_reply, serde::version<0>> {
+  : serde::envelope<
+      config_update_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     errc error;
     cluster::config_version latest_version{config_version_unset};
 
@@ -2427,7 +2648,9 @@ struct config_update_reply
     auto serde_fields() { return std::tie(error, latest_version); }
 };
 
-struct hello_request final : serde::envelope<hello_request, serde::version<0>> {
+struct hello_request final
+  : serde::
+      envelope<hello_request, serde::version<0>, serde::compat_version<0>> {
     model::node_id peer;
 
     // milliseconds since epoch
@@ -2441,7 +2664,8 @@ struct hello_request final : serde::envelope<hello_request, serde::version<0>> {
     friend std::ostream& operator<<(std::ostream&, const hello_request&);
 };
 
-struct hello_reply : serde::envelope<hello_reply, serde::version<0>> {
+struct hello_reply
+  : serde::envelope<hello_reply, serde::version<0>, serde::compat_version<0>> {
     errc error;
 
     friend bool operator==(const hello_reply&, const hello_reply&) = default;
@@ -2521,7 +2745,10 @@ private:
 };
 
 struct move_cancellation_result
-  : serde::envelope<move_cancellation_result, serde::version<0>> {
+  : serde::envelope<
+      move_cancellation_result,
+      serde::version<0>,
+      serde::compat_version<0>> {
     move_cancellation_result() = default;
 
     move_cancellation_result(model::ntp ntp, cluster::errc ec)
@@ -2545,7 +2772,10 @@ enum class partition_move_direction { to_node, from_node, all };
 std::ostream& operator<<(std::ostream&, const partition_move_direction&);
 
 struct cancel_all_partition_movements_request
-  : serde::envelope<cancel_all_partition_movements_request, serde::version<0>> {
+  : serde::envelope<
+      cancel_all_partition_movements_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     cancel_all_partition_movements_request() = default;
 
     auto serde_fields() { return std::tie(); }
@@ -2562,8 +2792,10 @@ struct cancel_all_partition_movements_request
     }
 };
 struct cancel_node_partition_movements_request
-  : serde::
-      envelope<cancel_node_partition_movements_request, serde::version<0>> {
+  : serde::envelope<
+      cancel_node_partition_movements_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::node_id node_id;
     partition_move_direction direction;
 
@@ -2579,7 +2811,10 @@ struct cancel_node_partition_movements_request
 };
 
 struct cancel_partition_movements_reply
-  : serde::envelope<cancel_partition_movements_reply, serde::version<0>> {
+  : serde::envelope<
+      cancel_partition_movements_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     friend bool operator==(
       const cancel_partition_movements_reply&,
       const cancel_partition_movements_reply&)

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -28,7 +28,7 @@ class feature_table;
  * serialization, rather than encapsulating a reference to a feature_spec.
  */
 struct feature_state_snapshot
-  : serde::envelope<feature_state_snapshot, serde::version<0>> {
+  : serde::envelope<feature_state_snapshot, serde::version<0>, serde::compat_version<0>> {
     ss::sstring name;
     feature_state::state state;
 
@@ -41,7 +41,7 @@ struct feature_state_snapshot
  * containers for when encoding or decoding a snapshot.
  */
 struct feature_table_snapshot
-  : serde::envelope<feature_table_snapshot, serde::version<0>> {
+  : serde::envelope<feature_table_snapshot, serde::version<0>, serde::compat_version<0>> {
     model::offset applied_offset;
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -28,7 +28,10 @@ class feature_table;
  * serialization, rather than encapsulating a reference to a feature_spec.
  */
 struct feature_state_snapshot
-  : serde::envelope<feature_state_snapshot, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      feature_state_snapshot,
+      serde::version<0>,
+      serde::compat_version<0>> {
     ss::sstring name;
     feature_state::state state;
 
@@ -41,7 +44,10 @@ struct feature_state_snapshot
  * containers for when encoding or decoding a snapshot.
  */
 struct feature_table_snapshot
-  : serde::envelope<feature_table_snapshot, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      feature_table_snapshot,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::offset applied_offset;
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -57,7 +57,7 @@ using initial_revision_id
 /// Rack id type
 using rack_id = named_type<ss::sstring, struct rack_id_model_type>;
 struct broker_properties
-  : serde::envelope<broker_properties, serde::version<0>> {
+  : serde::envelope<broker_properties, serde::version<0>, serde::compat_version<0>> {
     uint32_t cores;
     uint32_t available_memory_gb;
     uint32_t available_disk_gb;
@@ -84,7 +84,7 @@ struct broker_properties
 };
 
 struct broker_endpoint final
-  : serde::envelope<broker_endpoint, serde::version<0>> {
+  : serde::envelope<broker_endpoint, serde::version<0>, serde::compat_version<0>> {
     ss::sstring name;
     net::unresolved_address address;
 
@@ -149,7 +149,7 @@ enum class maintenance_state { active, inactive };
 
 std::ostream& operator<<(std::ostream&, membership_state);
 
-class broker : public serde::envelope<broker, serde::version<0>> {
+class broker : public serde::envelope<broker, serde::version<0>, serde::compat_version<0>> {
 public:
     broker() noexcept = default;
 
@@ -260,7 +260,7 @@ struct broker_shard {
 };
 
 struct partition_metadata
-  : serde::envelope<partition_metadata, serde::version<0>> {
+  : serde::envelope<partition_metadata, serde::version<0>, serde::compat_version<0>> {
     partition_metadata() noexcept = default;
     explicit partition_metadata(partition_id p) noexcept
       : id(p) {}
@@ -384,7 +384,7 @@ struct topic_namespace_eq {
     }
 };
 
-struct topic_metadata : serde::envelope<topic_metadata, serde::version<0>> {
+struct topic_metadata : serde::envelope<topic_metadata, serde::version<0>, serde::compat_version<0>> {
     topic_metadata() noexcept = default;
     explicit topic_metadata(topic_namespace v) noexcept
       : tp_ns(std::move(v)) {}

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -57,7 +57,8 @@ using initial_revision_id
 /// Rack id type
 using rack_id = named_type<ss::sstring, struct rack_id_model_type>;
 struct broker_properties
-  : serde::envelope<broker_properties, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<broker_properties, serde::version<0>, serde::compat_version<0>> {
     uint32_t cores;
     uint32_t available_memory_gb;
     uint32_t available_disk_gb;
@@ -84,7 +85,8 @@ struct broker_properties
 };
 
 struct broker_endpoint final
-  : serde::envelope<broker_endpoint, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<broker_endpoint, serde::version<0>, serde::compat_version<0>> {
     ss::sstring name;
     net::unresolved_address address;
 
@@ -149,7 +151,9 @@ enum class maintenance_state { active, inactive };
 
 std::ostream& operator<<(std::ostream&, membership_state);
 
-class broker : public serde::envelope<broker, serde::version<0>, serde::compat_version<0>> {
+class broker
+  : public serde::
+      envelope<broker, serde::version<0>, serde::compat_version<0>> {
 public:
     broker() noexcept = default;
 
@@ -260,7 +264,10 @@ struct broker_shard {
 };
 
 struct partition_metadata
-  : serde::envelope<partition_metadata, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      partition_metadata,
+      serde::version<0>,
+      serde::compat_version<0>> {
     partition_metadata() noexcept = default;
     explicit partition_metadata(partition_id p) noexcept
       : id(p) {}
@@ -384,7 +391,9 @@ struct topic_namespace_eq {
     }
 };
 
-struct topic_metadata : serde::envelope<topic_metadata, serde::version<0>, serde::compat_version<0>> {
+struct topic_metadata
+  : serde::
+      envelope<topic_metadata, serde::version<0>, serde::compat_version<0>> {
     topic_metadata() noexcept = default;
     explicit topic_metadata(topic_namespace v) noexcept
       : tp_ns(std::move(v)) {}

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -444,7 +444,7 @@ using producer_id = named_type<int64_t, struct producer_identity_id>;
 using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
 
 struct producer_identity
-  : serde::envelope<producer_identity, serde::version<0>> {
+  : serde::envelope<producer_identity, serde::version<0>, serde::compat_version<0>> {
     int64_t id{-1};
     int16_t epoch{0};
 

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -444,7 +444,8 @@ using producer_id = named_type<int64_t, struct producer_identity_id>;
 using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
 
 struct producer_identity
-  : serde::envelope<producer_identity, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<producer_identity, serde::version<0>, serde::compat_version<0>> {
     int64_t id{-1};
     int16_t epoch{0};
 

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -25,7 +25,7 @@ namespace net {
 /// Class representing unresolved network address in form of <host name, port>
 /// tuple
 class unresolved_address
-  : public serde::envelope<unresolved_address, serde::version<0>> {
+  : public serde::envelope<unresolved_address, serde::version<0>, serde::compat_version<0>> {
 public:
     using inet_family = std::optional<ss::net::inet_address::family>;
 

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -25,7 +25,10 @@ namespace net {
 /// Class representing unresolved network address in form of <host name, port>
 /// tuple
 class unresolved_address
-  : public serde::envelope<unresolved_address, serde::version<0>, serde::compat_version<0>> {
+  : public serde::envelope<
+      unresolved_address,
+      serde::version<0>,
+      serde::compat_version<0>> {
 public:
     using inet_family = std::optional<ss::net::inet_address::family>;
 

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -25,7 +25,7 @@ struct broker_revision {
 };
 
 static constexpr model::revision_id no_revision{};
-class vnode : public serde::envelope<vnode, serde::version<0>> {
+class vnode : public serde::envelope<vnode, serde::version<0>, serde::compat_version<0>> {
 public:
     constexpr vnode() = default;
 
@@ -99,7 +99,7 @@ struct group_nodes {
 };
 
 struct configuration_update
-  : serde::envelope<configuration_update, serde::version<0>> {
+  : serde::envelope<configuration_update, serde::version<0>, serde::compat_version<0>> {
     std::vector<vnode> replicas_to_add;
     std::vector<vnode> replicas_to_remove;
 

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -25,7 +25,8 @@ struct broker_revision {
 };
 
 static constexpr model::revision_id no_revision{};
-class vnode : public serde::envelope<vnode, serde::version<0>, serde::compat_version<0>> {
+class vnode
+  : public serde::envelope<vnode, serde::version<0>, serde::compat_version<0>> {
 public:
     constexpr vnode() = default;
 
@@ -99,7 +100,10 @@ struct group_nodes {
 };
 
 struct configuration_update
-  : serde::envelope<configuration_update, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      configuration_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
     std::vector<vnode> replicas_to_add;
     std::vector<vnode> replicas_to_remove;
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -46,7 +46,8 @@ static constexpr clock_type::time_point no_timeout
 using group_id = named_type<int64_t, struct raft_group_id_type>;
 
 struct protocol_metadata
-  : serde::envelope<protocol_metadata, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<protocol_metadata, serde::version<0>, serde::compat_version<0>> {
     group_id group;
     model::offset commit_index;
     model::term_id term;
@@ -193,7 +194,10 @@ struct follower_metrics {
 };
 
 struct append_entries_request
-  : serde::envelope<append_entries_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      append_entries_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     using flush_after_append = ss::bool_class<struct flush_after_append_tag>;
 
     /*
@@ -291,7 +295,10 @@ private:
  * efficient encoding of a vectory of append_entries_reply.
  */
 struct append_entries_reply
-  : serde::envelope<append_entries_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      append_entries_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     enum class status : uint8_t {
         success,
         failure,
@@ -352,7 +359,8 @@ struct heartbeat_metadata {
 /// individual raft responses one at a time - for example to start replaying the
 /// log at some offset
 struct heartbeat_request
-  : serde::envelope<heartbeat_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<heartbeat_request, serde::version<0>, serde::compat_version<0>> {
     std::vector<heartbeat_metadata> heartbeats;
 
     heartbeat_request() noexcept = default;
@@ -369,7 +377,9 @@ struct heartbeat_request
     void serde_read(iobuf_parser&, const serde::header&);
 };
 
-struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>, serde::compat_version<0>> {
+struct heartbeat_reply
+  : serde::
+      envelope<heartbeat_reply, serde::version<0>, serde::compat_version<0>> {
     std::vector<append_entries_reply> meta;
 
     heartbeat_reply() noexcept = default;
@@ -385,7 +395,8 @@ struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>, ser
     void serde_read(iobuf_parser&, const serde::header&);
 };
 
-struct vote_request : serde::envelope<vote_request, serde::version<0>, serde::compat_version<0>> {
+struct vote_request
+  : serde::envelope<vote_request, serde::version<0>, serde::compat_version<0>> {
     vnode node_id;
     // node id to validate on receiver
     vnode target_node_id;
@@ -418,7 +429,8 @@ struct vote_request : serde::envelope<vote_request, serde::version<0>, serde::co
     }
 };
 
-struct vote_reply : serde::envelope<vote_reply, serde::version<0>, serde::compat_version<0>> {
+struct vote_reply
+  : serde::envelope<vote_reply, serde::version<0>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's term, for the caller to upate itself
@@ -508,7 +520,10 @@ struct snapshot_metadata {
 };
 
 struct install_snapshot_request
-  : serde::envelope<install_snapshot_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      install_snapshot_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // leader’s term
@@ -578,7 +593,10 @@ private:
 };
 
 struct install_snapshot_reply
-  : serde::envelope<install_snapshot_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      install_snapshot_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // current term, for leader to update itself
@@ -622,7 +640,10 @@ struct write_snapshot_cfg {
 };
 
 struct timeout_now_request
-  : serde::envelope<timeout_now_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      timeout_now_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
 
@@ -656,7 +677,8 @@ struct timeout_now_request
 };
 
 struct timeout_now_reply
-  : serde::envelope<timeout_now_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::
+      envelope<timeout_now_reply, serde::version<0>, serde::compat_version<0>> {
     enum class status : uint8_t { success, failure };
     // node id to validate on receiver
     vnode target_node_id;
@@ -683,7 +705,10 @@ struct timeout_now_reply
 
 // if not target is specified then the most up-to-date node will be selected
 struct transfer_leadership_request
-  : serde::envelope<transfer_leadership_request, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      transfer_leadership_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
     group_id group;
     std::optional<model::node_id> target;
     raft::group_id target_group() const { return group; }
@@ -702,7 +727,10 @@ struct transfer_leadership_request
 };
 
 struct transfer_leadership_reply
-  : serde::envelope<transfer_leadership_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<
+      transfer_leadership_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
     bool success{false};
     raft::errc result;
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -46,7 +46,7 @@ static constexpr clock_type::time_point no_timeout
 using group_id = named_type<int64_t, struct raft_group_id_type>;
 
 struct protocol_metadata
-  : serde::envelope<protocol_metadata, serde::version<0>> {
+  : serde::envelope<protocol_metadata, serde::version<0>, serde::compat_version<0>> {
     group_id group;
     model::offset commit_index;
     model::term_id term;
@@ -193,7 +193,7 @@ struct follower_metrics {
 };
 
 struct append_entries_request
-  : serde::envelope<append_entries_request, serde::version<0>> {
+  : serde::envelope<append_entries_request, serde::version<0>, serde::compat_version<0>> {
     using flush_after_append = ss::bool_class<struct flush_after_append_tag>;
 
     /*
@@ -291,7 +291,7 @@ private:
  * efficient encoding of a vectory of append_entries_reply.
  */
 struct append_entries_reply
-  : serde::envelope<append_entries_reply, serde::version<0>> {
+  : serde::envelope<append_entries_reply, serde::version<0>, serde::compat_version<0>> {
     enum class status : uint8_t {
         success,
         failure,
@@ -352,7 +352,7 @@ struct heartbeat_metadata {
 /// individual raft responses one at a time - for example to start replaying the
 /// log at some offset
 struct heartbeat_request
-  : serde::envelope<heartbeat_request, serde::version<0>> {
+  : serde::envelope<heartbeat_request, serde::version<0>, serde::compat_version<0>> {
     std::vector<heartbeat_metadata> heartbeats;
 
     heartbeat_request() noexcept = default;
@@ -369,7 +369,7 @@ struct heartbeat_request
     void serde_read(iobuf_parser&, const serde::header&);
 };
 
-struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>> {
+struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>, serde::compat_version<0>> {
     std::vector<append_entries_reply> meta;
 
     heartbeat_reply() noexcept = default;
@@ -385,7 +385,7 @@ struct heartbeat_reply : serde::envelope<heartbeat_reply, serde::version<0>> {
     void serde_read(iobuf_parser&, const serde::header&);
 };
 
-struct vote_request : serde::envelope<vote_request, serde::version<0>> {
+struct vote_request : serde::envelope<vote_request, serde::version<0>, serde::compat_version<0>> {
     vnode node_id;
     // node id to validate on receiver
     vnode target_node_id;
@@ -418,7 +418,7 @@ struct vote_request : serde::envelope<vote_request, serde::version<0>> {
     }
 };
 
-struct vote_reply : serde::envelope<vote_reply, serde::version<0>> {
+struct vote_reply : serde::envelope<vote_reply, serde::version<0>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's term, for the caller to upate itself
@@ -508,7 +508,7 @@ struct snapshot_metadata {
 };
 
 struct install_snapshot_request
-  : serde::envelope<install_snapshot_request, serde::version<0>> {
+  : serde::envelope<install_snapshot_request, serde::version<0>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // leader’s term
@@ -578,7 +578,7 @@ private:
 };
 
 struct install_snapshot_reply
-  : serde::envelope<install_snapshot_reply, serde::version<0>> {
+  : serde::envelope<install_snapshot_reply, serde::version<0>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     // current term, for leader to update itself
@@ -622,7 +622,7 @@ struct write_snapshot_cfg {
 };
 
 struct timeout_now_request
-  : serde::envelope<timeout_now_request, serde::version<0>> {
+  : serde::envelope<timeout_now_request, serde::version<0>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
 
@@ -656,7 +656,7 @@ struct timeout_now_request
 };
 
 struct timeout_now_reply
-  : serde::envelope<timeout_now_reply, serde::version<0>> {
+  : serde::envelope<timeout_now_reply, serde::version<0>, serde::compat_version<0>> {
     enum class status : uint8_t { success, failure };
     // node id to validate on receiver
     vnode target_node_id;
@@ -683,7 +683,7 @@ struct timeout_now_reply
 
 // if not target is specified then the most up-to-date node will be selected
 struct transfer_leadership_request
-  : serde::envelope<transfer_leadership_request, serde::version<0>> {
+  : serde::envelope<transfer_leadership_request, serde::version<0>, serde::compat_version<0>> {
     group_id group;
     std::optional<model::node_id> target;
     raft::group_id target_group() const { return group; }
@@ -702,7 +702,7 @@ struct transfer_leadership_request
 };
 
 struct transfer_leadership_reply
-  : serde::envelope<transfer_leadership_reply, serde::version<0>> {
+  : serde::envelope<transfer_leadership_reply, serde::version<0>, serde::compat_version<0>> {
     bool success{false};
     raft::errc result;
 

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -109,7 +109,7 @@ static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_only>);
 static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_only>);
 
 struct echo_req_adl_serde
-  : serde::envelope<echo_req_adl_serde, serde::version<1>> {
+  : serde::envelope<echo_req_adl_serde, serde::version<1>, serde::compat_version<1>> {
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -127,7 +127,7 @@ struct echo_req_adl_serde
 };
 
 struct echo_resp_adl_serde
-  : serde::envelope<echo_resp_adl_serde, serde::version<1>> {
+  : serde::envelope<echo_resp_adl_serde, serde::version<1>, serde::compat_version<1>> {
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -150,7 +150,7 @@ static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_serde>);
 static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_serde>);
 
 struct echo_req_serde_only
-  : serde::envelope<echo_req_serde_only, serde::version<1>> {
+  : serde::envelope<echo_req_serde_only, serde::version<1>, serde::compat_version<1>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 
@@ -169,7 +169,7 @@ struct echo_req_serde_only
 };
 
 struct echo_resp_serde_only
-  : serde::envelope<echo_resp_serde_only, serde::version<1>> {
+  : serde::envelope<echo_resp_serde_only, serde::version<1>, serde::compat_version<1>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -109,7 +109,10 @@ static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_only>);
 static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_only>);
 
 struct echo_req_adl_serde
-  : serde::envelope<echo_req_adl_serde, serde::version<1>, serde::compat_version<1>> {
+  : serde::envelope<
+      echo_req_adl_serde,
+      serde::version<1>,
+      serde::compat_version<1>> {
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -127,7 +130,10 @@ struct echo_req_adl_serde
 };
 
 struct echo_resp_adl_serde
-  : serde::envelope<echo_resp_adl_serde, serde::version<1>, serde::compat_version<1>> {
+  : serde::envelope<
+      echo_resp_adl_serde,
+      serde::version<1>,
+      serde::compat_version<1>> {
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -150,7 +156,10 @@ static_assert(!rpc::is_rpc_adl_exempt<echo_req_adl_serde>);
 static_assert(!rpc::is_rpc_adl_exempt<echo_resp_adl_serde>);
 
 struct echo_req_serde_only
-  : serde::envelope<echo_req_serde_only, serde::version<1>, serde::compat_version<1>> {
+  : serde::envelope<
+      echo_req_serde_only,
+      serde::version<1>,
+      serde::compat_version<1>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 
@@ -169,7 +178,10 @@ struct echo_req_serde_only
 };
 
 struct echo_resp_serde_only
-  : serde::envelope<echo_resp_serde_only, serde::version<1>, serde::compat_version<1>> {
+  : serde::envelope<
+      echo_resp_serde_only,
+      serde::version<1>,
+      serde::compat_version<1>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -135,7 +135,9 @@ std::ostream& operator<<(std::ostream&, principal_type);
 /*
  * Kafka principal is (principal-type, principal)
  */
-class acl_principal : public serde::envelope<acl_principal, serde::version<0>, serde::compat_version<0>> {
+class acl_principal
+  : public serde::
+      envelope<acl_principal, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_principal() = default;
     acl_principal(principal_type type, ss::sstring name)
@@ -170,7 +172,8 @@ inline const acl_principal acl_wildcard_user(principal_type::user, "*");
  * pattern type changes how matching occurs (e.g. literal, name prefix).
  */
 class resource_pattern
-  : public serde::envelope<resource_pattern, serde::version<0>, serde::compat_version<0>> {
+  : public serde::
+      envelope<resource_pattern, serde::version<0>, serde::compat_version<0>> {
 public:
     static constexpr const char* wildcard = "*";
     resource_pattern() = default;
@@ -204,7 +207,9 @@ private:
 /*
  * A host (or wildcard) in an ACL rule.
  */
-class acl_host : public serde::envelope<acl_host, serde::version<0>, serde::compat_version<0>> {
+class acl_host
+  : public serde::
+      envelope<acl_host, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_host() = default;
     explicit acl_host(const ss::sstring& host)
@@ -243,7 +248,9 @@ inline const acl_host acl_wildcard_host = acl_host::wildcard_host();
  * permitted to execute an operation on. When associated with a resource, it
  * describes if the principal can execute the operation on that resource.
  */
-class acl_entry : public serde::envelope<acl_entry, serde::version<0>, serde::compat_version<0>> {
+class acl_entry
+  : public serde::
+      envelope<acl_entry, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_entry() = default;
     acl_entry(
@@ -286,7 +293,9 @@ private:
  * An ACL binding is an association of resource(s) and an ACL entry. An ACL
  * binding describes if a principal may access resources.
  */
-class acl_binding : public serde::envelope<acl_binding, serde::version<0>, serde::compat_version<0>> {
+class acl_binding
+  : public serde::
+      envelope<acl_binding, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_binding() = default;
     acl_binding(resource_pattern pattern, acl_entry entry)
@@ -316,7 +325,10 @@ private:
  * A filter for matching resources.
  */
 class resource_pattern_filter
-  : public serde::envelope<resource_pattern_filter, serde::version<0>, serde::compat_version<0>> {
+  : public serde::envelope<
+      resource_pattern_filter,
+      serde::version<0>,
+      serde::compat_version<0>> {
 public:
     enum class serialized_pattern_type {
         literal = 0,
@@ -400,7 +412,8 @@ operator<<(std::ostream&, resource_pattern_filter::serialized_pattern_type);
  * A filter for matching ACL entries.
  */
 class acl_entry_filter
-  : public serde::envelope<acl_entry_filter, serde::version<0>, serde::compat_version<0>> {
+  : public serde::
+      envelope<acl_entry_filter, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_entry_filter() = default;
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
@@ -457,7 +470,10 @@ private:
  * A filter for matching ACL bindings.
  */
 class acl_binding_filter
-  : public serde::envelope<acl_binding_filter, serde::version<0>, serde::compat_version<0>> {
+  : public serde::envelope<
+      acl_binding_filter,
+      serde::version<0>,
+      serde::compat_version<0>> {
 public:
     acl_binding_filter() = default;
     acl_binding_filter(resource_pattern_filter pattern, acl_entry_filter acl)

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -135,7 +135,7 @@ std::ostream& operator<<(std::ostream&, principal_type);
 /*
  * Kafka principal is (principal-type, principal)
  */
-class acl_principal : public serde::envelope<acl_principal, serde::version<0>> {
+class acl_principal : public serde::envelope<acl_principal, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_principal() = default;
     acl_principal(principal_type type, ss::sstring name)
@@ -170,7 +170,7 @@ inline const acl_principal acl_wildcard_user(principal_type::user, "*");
  * pattern type changes how matching occurs (e.g. literal, name prefix).
  */
 class resource_pattern
-  : public serde::envelope<resource_pattern, serde::version<0>> {
+  : public serde::envelope<resource_pattern, serde::version<0>, serde::compat_version<0>> {
 public:
     static constexpr const char* wildcard = "*";
     resource_pattern() = default;
@@ -204,7 +204,7 @@ private:
 /*
  * A host (or wildcard) in an ACL rule.
  */
-class acl_host : public serde::envelope<acl_host, serde::version<0>> {
+class acl_host : public serde::envelope<acl_host, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_host() = default;
     explicit acl_host(const ss::sstring& host)
@@ -243,7 +243,7 @@ inline const acl_host acl_wildcard_host = acl_host::wildcard_host();
  * permitted to execute an operation on. When associated with a resource, it
  * describes if the principal can execute the operation on that resource.
  */
-class acl_entry : public serde::envelope<acl_entry, serde::version<0>> {
+class acl_entry : public serde::envelope<acl_entry, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_entry() = default;
     acl_entry(
@@ -286,7 +286,7 @@ private:
  * An ACL binding is an association of resource(s) and an ACL entry. An ACL
  * binding describes if a principal may access resources.
  */
-class acl_binding : public serde::envelope<acl_binding, serde::version<0>> {
+class acl_binding : public serde::envelope<acl_binding, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_binding() = default;
     acl_binding(resource_pattern pattern, acl_entry entry)
@@ -316,7 +316,7 @@ private:
  * A filter for matching resources.
  */
 class resource_pattern_filter
-  : public serde::envelope<resource_pattern_filter, serde::version<0>> {
+  : public serde::envelope<resource_pattern_filter, serde::version<0>, serde::compat_version<0>> {
 public:
     enum class serialized_pattern_type {
         literal = 0,
@@ -400,7 +400,7 @@ operator<<(std::ostream&, resource_pattern_filter::serialized_pattern_type);
  * A filter for matching ACL entries.
  */
 class acl_entry_filter
-  : public serde::envelope<acl_entry_filter, serde::version<0>> {
+  : public serde::envelope<acl_entry_filter, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_entry_filter() = default;
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
@@ -457,7 +457,7 @@ private:
  * A filter for matching ACL bindings.
  */
 class acl_binding_filter
-  : public serde::envelope<acl_binding_filter, serde::version<0>> {
+  : public serde::envelope<acl_binding_filter, serde::version<0>, serde::compat_version<0>> {
 public:
     acl_binding_filter() = default;
     acl_binding_filter(resource_pattern_filter pattern, acl_entry_filter acl)

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -19,7 +19,8 @@
 namespace security {
 
 class scram_credential
-  : public serde::envelope<scram_credential, serde::version<0>, serde::compat_version<0>> {
+  : public serde::
+      envelope<scram_credential, serde::version<0>, serde::compat_version<0>> {
 public:
     scram_credential() noexcept = default;
 

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -19,7 +19,7 @@
 namespace security {
 
 class scram_credential
-  : public serde::envelope<scram_credential, serde::version<0>> {
+  : public serde::envelope<scram_credential, serde::version<0>, serde::compat_version<0>> {
 public:
     scram_credential() noexcept = default;
 

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -35,10 +35,7 @@ struct compat_version {
  *                         (change for every incompatible update)
  * \tparam CompatVersion   the minimum required version able to parse the type
  */
-template<
-  typename T,
-  typename Version,
-  typename CompatVersion = compat_version<Version::v>>
+template<typename T, typename Version, typename CompatVersion>
 struct envelope {
     bool operator==(envelope const&) const = default;
     auto operator<=>(envelope const&) const = default;
@@ -55,10 +52,7 @@ struct envelope {
  * This can be changed - for example by a separate template parameter
  * template <..., typename HashAlgo = crc32c>
  */
-template<
-  typename T,
-  typename Version,
-  typename CompatVersion = compat_version<Version::v>>
+template<typename T, typename Version, typename CompatVersion>
 struct checksum_envelope {
     bool operator==(checksum_envelope const&) const = default;
     using value_t = T;

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -234,7 +234,8 @@ SEASTAR_THREAD_TEST_CASE(uuid_test) {
     BOOST_REQUIRE_EQUAL(u, r);
 }
 
-struct uuid_struct : serde::envelope<uuid_struct, serde::version<0>, serde::compat_version<0>> {
+struct uuid_struct
+  : serde::envelope<uuid_struct, serde::version<0>, serde::compat_version<0>> {
     uuid_t single;
     std::optional<uuid_t> opt1;
     std::optional<uuid_t> opt2;
@@ -308,11 +309,15 @@ SEASTAR_THREAD_TEST_CASE(complex_uuid_types_test) {
 // vector length may take different size (vint)
 // vector data may have different size (_ints.size() * sizeof(int))
 struct inner_differing_sizes
-  : serde::envelope<inner_differing_sizes, serde::version<1>, serde::compat_version<1>> {
+  : serde::envelope<
+      inner_differing_sizes,
+      serde::version<1>,
+      serde::compat_version<1>> {
     std::vector<int32_t> _ints;
 };
 
-struct complex_msg : serde::envelope<complex_msg, serde::version<3>, serde::compat_version<3>> {
+struct complex_msg
+  : serde::envelope<complex_msg, serde::version<3>, serde::compat_version<3>> {
     std::vector<inner_differing_sizes> _vec;
     int32_t _x;
 };

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -234,7 +234,7 @@ SEASTAR_THREAD_TEST_CASE(uuid_test) {
     BOOST_REQUIRE_EQUAL(u, r);
 }
 
-struct uuid_struct : serde::envelope<uuid_struct, serde::version<0>> {
+struct uuid_struct : serde::envelope<uuid_struct, serde::version<0>, serde::compat_version<0>> {
     uuid_t single;
     std::optional<uuid_t> opt1;
     std::optional<uuid_t> opt2;
@@ -308,11 +308,11 @@ SEASTAR_THREAD_TEST_CASE(complex_uuid_types_test) {
 // vector length may take different size (vint)
 // vector data may have different size (_ints.size() * sizeof(int))
 struct inner_differing_sizes
-  : serde::envelope<inner_differing_sizes, serde::version<1>> {
+  : serde::envelope<inner_differing_sizes, serde::version<1>, serde::compat_version<1>> {
     std::vector<int32_t> _ints;
 };
 
-struct complex_msg : serde::envelope<complex_msg, serde::version<3>> {
+struct complex_msg : serde::envelope<complex_msg, serde::version<3>, serde::compat_version<3>> {
     std::vector<inner_differing_sizes> _vec;
     int32_t _x;
 };

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -38,7 +38,7 @@ inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
     return std::max(a, b);
 }
 
-struct disk : serde::envelope<disk, serde::version<0>> {
+struct disk : serde::envelope<disk, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     ss::sstring path;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -38,7 +38,8 @@ inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
     return std::max(a, b);
 }
 
-struct disk : serde::envelope<disk, serde::version<0>, serde::compat_version<0>> {
+struct disk
+  : serde::envelope<disk, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     ss::sstring path;

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -36,7 +36,7 @@ private:
 // Datapolicy property for v8_engine. In first version it contains only
 // function_name and script_name, in the future it will contain ACLs, geo,
 // e.t.c.
-struct data_policy : public serde::envelope<data_policy, serde::version<0>> {
+struct data_policy : public serde::envelope<data_policy, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t version{1};
 
     data_policy() = default;

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -36,7 +36,9 @@ private:
 // Datapolicy property for v8_engine. In first version it contains only
 // function_name and script_name, in the future it will contain ACLs, geo,
 // e.t.c.
-struct data_policy : public serde::envelope<data_policy, serde::version<0>, serde::compat_version<0>> {
+struct data_policy
+  : public serde::
+      envelope<data_policy, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t version{1};
 
     data_policy() = default;


### PR DESCRIPTION
## Cover letter

This addresses an underlying cause of the bug in https://github.com/redpanda-data/redpanda/pull/7312

Previously, serde defaulted to assuming an envelope
was only compatible with its own latest version, which
caused bugs when the encoding of a structure was updated,
and the developer forgot to add a compat_version indicating
that the struct should still be able to decode the previous version.

## Backport Required

- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

None

## Release notes

* none