### PR TITLE
js: Bump ts-loader to 9.4.1

### DIFF
--- a/src/js/package.json
+++ b/src/js/package.json
@@ -30,7 +30,7 @@
     "mocha": "9.2.2",
     "prettier": "2.7.1",
     "rewire": "5.0.0",
-    "ts-loader": "^8.0.4",
+    "ts-loader": "^9.4.1",
     "ts-node": "^9.0.0",
     "typescript": "3.9.6",
     "webpack": "5.33.2",


### PR DESCRIPTION
## Cover letter

Address a potential security vulnerability in a javascript dependency: http://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3043105

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] issue does not exist in previous branches
- [x] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release notes
* wasm-engine: bump ts-loader dependency to 9.4.1
