### PR TITLE
[v22.3.x] compat decode fixes

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -348,7 +348,9 @@ struct begin_tx_request : serde::envelope<begin_tx_request, serde::version<0>> {
     }
 };
 
-struct begin_tx_reply : serde::envelope<begin_tx_reply, serde::version<1>> {
+struct begin_tx_reply
+  : serde::
+      envelope<begin_tx_reply, serde::version<1>, serde::compat_version<0>> {
     model::ntp ntp;
     model::term_id etag;
     tx_errc ec;
@@ -1226,7 +1228,10 @@ replication_factor parsing_replication_factor(const ss::sstring& value);
 // This class contains updates for topic properties which are replicates not by
 // topic_frontend
 struct incremental_topic_custom_updates
-  : serde::envelope<incremental_topic_custom_updates, serde::version<1>> {
+  : serde::envelope<
+      incremental_topic_custom_updates,
+      serde::version<1>,
+      serde::compat_version<0>> {
     // Data-policy property is replicated by data_policy_frontend and handled by
     // data_policy_manager.
     property_update<std::optional<v8_engine::data_policy>> data_policy;

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -62,7 +62,8 @@ inline std::ostream& operator<<(std::ostream& os, license_type lt) {
     return os;
 }
 
-struct license : serde::envelope<license, serde::version<1>> {
+struct license
+  : serde::envelope<license, serde::version<1>, serde::compat_version<0>> {
     /// Expected encoded contents
     uint8_t format_version;
     license_type type;


### PR DESCRIPTION
## Cover letter

Backport of:
- https://github.com/redpanda-data/redpanda/pull/7316
- https://github.com/redpanda-data/redpanda/pull/7312

These are not `-x` cherry picks because this PR is opened pre-emptively when those PRs haven't merged yet, in order to provide a faster option for getting the fixes onto v22.3.x.