### PR TITLE
conf: remove node ID

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -20,9 +20,6 @@ redpanda:
   # This directory MUST resides on xfs partion.
   data_directory: "/var/lib/redpanda/data"
 
-  # Node ID - must be unique for each node
-  node_id: 1
-
   # The initial cluster nodes addresses
   seed_servers: []
 

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -166,7 +166,6 @@ func TestRedpandaSampleFile(t *testing.T) {
 		t.Errorf("unexpected error while writing sample config file: %s", err)
 		return
 	}
-	id := 1
 	expCfg := &Config{
 		fileLocation: "/etc/redpanda/redpanda.yaml",
 		Redpanda: RedpandaNodeConfig{
@@ -183,7 +182,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    9644,
 			}},
-			ID:            &id,
+			ID:            nil,
 			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
 		},
@@ -216,7 +215,6 @@ func TestRedpandaSampleFile(t *testing.T) {
 	}
 	require.Equal(t, `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 1
     seed_servers: []
     rpc_server:
         address: 0.0.0.0


### PR DESCRIPTION
## Cover letter

This file gets copied into our packages and ends up creating nodes of node_id=1 when the node ID is omitted otherwise.

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release notes
* The default node ID assigned in packages is removed.