### PR TITLE
[v22.3.x] conf: remove node ID

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -20,9 +20,6 @@ redpanda:
   # This directory MUST resides on xfs partion.
   data_directory: "/var/lib/redpanda/data"
 
-  # Node ID - must be unique for each node
-  node_id: 1
-
   # The initial cluster nodes addresses
   seed_servers: []
 

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -166,7 +166,6 @@ func TestRedpandaSampleFile(t *testing.T) {
 		t.Errorf("unexpected error while writing sample config file: %s", err)
 		return
 	}
-	id := 1
 	expCfg := &Config{
 		fileLocation: "/etc/redpanda/redpanda.yaml",
 		Redpanda: RedpandaNodeConfig{
@@ -183,7 +182,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    9644,
 			}},
-			ID:            &id,
+			ID:            nil,
 			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
 		},
@@ -216,7 +215,6 @@ func TestRedpandaSampleFile(t *testing.T) {
 	}
 	require.Equal(t, `redpanda:
     data_directory: /var/lib/redpanda/data
-    node_id: 1
     seed_servers: []
     rpc_server:
         address: 0.0.0.0


### PR DESCRIPTION
## Cover letter
This file gets copied into our packages and ends up creating nodes of node_id=1 when the node ID is omitted otherwise.

Backport of https://github.com/redpanda-data/redpanda/pull/7321

This is not a -x cherry pick because this PR is opened pre-emptively when the PRs hasn't merged yet, in order to provide a faster option for getting the fix onto v22.3.x.
