### PR TITLE
[v22.1.x] rpc/transport: release caller units when timeout occurs

### DIFF
--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -82,7 +82,7 @@ private:
     void dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
-    make_response_handler(netbuf&, const rpc::client_opts&);
+    make_response_handler(netbuf&, const rpc::client_opts&, sequence_t);
 
     ss::semaphore _memory;
     absl::flat_hash_map<uint32_t, std::unique_ptr<internal::response_handler>>


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6738.
Fixes https://github.com/redpanda-data/redpanda/issues/7324,