### PR TITLE
[v21.11.x] Lower log error severity to WARN for errc::shutting_down in k/group

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2148,11 +2148,17 @@ ss::future<error_code> group::remove() {
               "Replicated group delete record {} at offset {}",
               _id,
               result.value().last_offset);
+        } else if (result.error() == raft::errc::shutting_down) {
+            vlog(
+              klog.debug,
+              "Cannot replicate group {} delete records due to shutdown",
+              _id);
         } else {
             vlog(
               klog.error,
-              "Error occured replicating group {} delete records {}",
+              "Error occured replicating group {} delete records {} ({})",
               _id,
+              result.error().message(),
               result.error());
         }
     } catch (const std::exception& e) {


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/7105.
Fixes https://github.com/redpanda-data/redpanda/issues/7328,