### PR TITLE
schema_registry/test: Support JSON custom attributes on fields

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -284,7 +284,7 @@ ExternalProject_Add(ctre
 
 ExternalProject_Add(avro
   GIT_REPOSITORY https://github.com/redpanda-data/avro
-  GIT_TAG 53250636b5223e434a9819a34e7b5b89e829ffb8
+  GIT_TAG 6b2896c2720e799371ea6f35b492d62171872e39
   INSTALL_DIR @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
## Cover letter

Test that #7274 is mitigated.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

* none

## Release notes


### Improvements

* schema_registry: AVRO: Support custom attributes on fields (fix a regression since v22.2.x)