### PR TITLE
[v22.3.x] s3: ensure lifetimes are extended when recovering from error

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -606,7 +606,7 @@ ss::future<> client::put_object(
     auto header = _requestor.make_unsigned_put_object_request(
       name, id, payload_size, tags);
     if (!header) {
-        return body.close().then([&header] {
+        return body.close().then([header] {
             return ss::make_exception_future<>(
               std::system_error(header.error()));
         });


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/7284.
