### PR TITLE
[v22.2.x] rptest: Remove TRACE & DEBUG logs after each successful run

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -49,7 +49,8 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                     # TODO: extend this to cover shutdown logging too, and
                     # clean up redpanda to not log so many errors on shutdown.
                     self.redpanda.raise_on_bad_logs(allow_list=log_allow_list)
-                    return r
+                self.redpanda.trim_logs()
+                return r
 
         # Propagate ducktape markers (e.g. parameterize) to our function
         # wrapper

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1505,6 +1505,17 @@ class RedpandaService(Service):
             # installation to preserve!
             self._installer.reset_current_install([node])
 
+    def trim_logs(self):
+        # Excessive logging may cause disks to fill up quickly.
+        # Call this method to removes TRACE and DEBUG log lines from redpanda logs
+        # Ensure this is only done on tests that have passed
+        def prune(node):
+            node.account.ssh(
+                f"sed -i -E -e '/TRACE|DEBUG/d' {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
+            )
+
+        self._for_nodes(self.nodes, prune, parallel=True)
+
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
 


### PR DESCRIPTION
Backport from pull request: https://github.com/redpanda-data/redpanda/pull/6757.
