### PR TITLE
[v22.2.x] increase golangci-lint-action timeout to 5m

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
+        args: --timeout 5m
         working-directory: src/go/rpk/
 
     - name: Install gofumpt


### PR DESCRIPTION
## Cover letter

Increase the golang-ci-lint action timeout to 5 minutes because this step is starting to take longer than the default limit of 1 minute.

Tried to backport https://github.com/redpanda-data/redpanda/pull/6341#issuecomment-1317857910 but ran into conflicts and don't really need all of the changes in that PR to just bump timeout.

Fixes https://github.com/redpanda-data/devprod/issues/495

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX changes

* none

## Release notes

* none