### PR TITLE
Fix cross-shard allocator manipulation

### DIFF
--- a/src/v/bytes/oncore.h
+++ b/src/v/bytes/oncore.h
@@ -29,7 +29,7 @@ public:
     void verify_shard_source_location(const char* file, int linenum) const;
 
 private:
-    const shard_id_type _owner_shard;
+    shard_id_type _owner_shard;
 };
 
 // Next function should be replace with source_location in c++20 very soon

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -127,11 +127,12 @@ std::ostream& operator<<(std::ostream& o, allocation_node::state s) {
 std::ostream& operator<<(std::ostream& o, const allocation_node& n) {
     fmt::print(
       o,
-      "{{node: {}, max_partitions_per_core: {}, state: {}, partition_capacity: "
-      "{}, weights: [",
+      "{{node: {}, max_partitions_per_core: {}, state: {}, allocated: {}, "
+      "partition_capacity: {}, weights: [",
       n._id,
       n._partitions_per_shard(),
       n._state,
+      n._allocated_partitions,
       n.partition_capacity());
 
     for (auto w : n._weights) {

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/oncore.h"
 #include "cluster/scheduling/allocation_node.h"
 #include "model/metadata.h"
 
@@ -67,10 +68,17 @@ public:
     std::optional<model::rack_id> get_rack_id(model::node_id) const;
 
 private:
+    /**
+     * This function verifies that the current shard matches the shard the
+     * state was originally created on, aborting if not.
+     */
+    void verify_shard() const;
+
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
 
     raft::group_id _highest_group{0};
     underlying_t _nodes;
+    expression_in_debug_mode(oncore _verify_shard;)
 };
 } // namespace cluster

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -53,7 +53,11 @@ public:
         return _state->contains_node(n);
     }
 
-    result<allocation_units> allocate(allocation_request);
+    /**
+     * Return an allocation_units object wrapping the result of the allocating
+     * the given allocation request, or an error if it was not possible.
+     */
+    result<allocation_units::pointer> allocate(allocation_request);
 
     /// Reallocates partition replicas, moving them away from decommissioned
     /// nodes. Replicas on nodes that were left untouched are not changed.

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -60,6 +60,7 @@ allocation_units::allocation_units(
 }
 
 allocation_units::~allocation_units() {
+    oncore_debug_verify(_oncore);
     for (auto& pas : _assignments) {
         for (auto& replica : pas.replicas) {
             if (!_previous.contains(replica)) {

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -136,6 +136,13 @@ struct allocation_constraints {
  * moved into A and so on).
  */
 struct allocation_units {
+    /**
+     * A foreign unique pointer to some units. Given the warning above about
+     * cross-core destruction, it is best to use this pointer class when dealing
+     * with units allocated on another core.
+     */
+    using pointer = ss::foreign_ptr<std::unique_ptr<allocation_units>>;
+
     allocation_units(
       std::vector<partition_assignment>,
       allocation_state*,

--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -37,10 +37,10 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
     std::vector<model::broker_shard> replicas;
     {
         auto vals = std::move(allocator.allocate(std::move(req)).value());
-        replicas = vals.get_assignments().front().replicas;
+        replicas = vals->get_assignments().front().replicas;
         allocator.update_allocation_state(
-          vals.get_assignments().front().replicas,
-          vals.get_assignments().front().group,
+          vals->get_assignments().front().replicas,
+          vals->get_assignments().front().group,
           cluster::partition_allocation_domains::common);
     }
     perf_tests::do_not_optimize(replicas);

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -65,7 +65,7 @@ struct partition_allocator_fixture {
         auto units = allocator.allocate(
           make_allocation_request(max_capacity(), 1));
 
-        for (auto& pas : units.value().get_assignments()) {
+        for (auto& pas : units.value()->get_assignments()) {
             allocator.state().apply_update(
               pas.replicas,
               pas.group,

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -110,7 +110,7 @@ struct partition_balancer_planner_fixture {
         auto pas = workers.allocator.local()
                      .allocate(std::move(req))
                      .value()
-                     .get_assignments();
+                     ->get_assignments();
 
         return {cfg, std::move(pas)};
     }

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -98,7 +98,7 @@ struct topic_table_fixture {
         auto pas = allocator.local()
                      .allocate(std::move(req))
                      .value()
-                     .get_assignments();
+                     ->get_assignments();
 
         return cluster::topic_configuration_assignment(cfg, std::move(pas));
     }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -592,12 +592,12 @@ ss::future<topic_result> topics_frontend::do_create_topic(
 
 ss::future<topic_result> topics_frontend::replicate_create_topic(
   topic_configuration cfg,
-  allocation_units units,
+  allocation_units::pointer units,
   model::timeout_clock::time_point timeout) {
     auto tp_ns = cfg.tp_ns;
     create_topic_cmd cmd(
       tp_ns,
-      topic_configuration_assignment(std::move(cfg), units.get_assignments()));
+      topic_configuration_assignment(std::move(cfg), units->get_assignments()));
 
     for (auto& p_as : cmd.value.assignments) {
         std::shuffle(
@@ -910,7 +910,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
 
     auto tp_ns = p_cfg.tp_ns;
     create_partitions_configuration_assignment payload(
-      std::move(p_cfg), units.value().get_assignments());
+      std::move(p_cfg), units.value()->get_assignments());
     create_partition_cmd cmd = create_partition_cmd(tp_ns, std::move(payload));
 
     try {

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -136,7 +136,9 @@ private:
       custom_assignable_topic_configuration, model::timeout_clock::time_point);
 
     ss::future<topic_result> replicate_create_topic(
-      topic_configuration, allocation_units, model::timeout_clock::time_point);
+      topic_configuration,
+      allocation_units::pointer,
+      model::timeout_clock::time_point);
 
     ss::future<topic_result>
       do_delete_topic(model::topic_namespace, model::timeout_clock::time_point);


### PR DESCRIPTION
This patch series prevents cross-shard manipulation of the allocator state which may cause segfaults and assertion failures.

The main problem is that the destructor for allocation_units maintains a pointer to the state from which it was created, which when moved onto another shard will do a call back to the original shard on destruction: a race condition. Now we use foreign pointer to avoid this: the destructor will be called on the original shard.

Fixes #5558.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
