### PR TITLE
[v22.1.x] Backport: Fixed logging abort_requested_exception with error severity

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -513,6 +513,12 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
               *it);
             stop = true;
             continue;
+        } catch (ss::sleep_aborted const&) {
+            stop = true;
+            continue;
+        } catch (ss::abort_requested_exception const&) {
+            stop = true;
+            continue;
         } catch (...) {
             vlog(
               clusterlog.error,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -113,9 +113,6 @@ CHAOS_LOG_ALLOW_LIST = [
     re.compile(
         "rpc - .*Unable to parse received RPC request payload - std::out_of_range"
     ),
-    re.compile(
-        "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
-    ),
 ]
 
 


### PR DESCRIPTION
Backport of PR #6223 - fixes the failure on the branch the failure occurred on.

https://buildkite.com/redpanda/redpanda/builds/18675#018480f2-d909-4a11-9e9f-8593ac86353a


## UX Changes

* none

## Release Notes
  * none