### PR TITLE
tests: wrap http proxy configs

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -437,6 +437,18 @@ class LoggingConfig:
         return args
 
 
+class ProxyConfig:
+    def __init__(self):
+        self.authn_method: Optional[str] = None
+        self.cache_keep_alive: int = 300000  # Time in ms
+        self.cache_max_size: int = 10
+
+
+class SchemaRegistryConfig:
+    def __init__(self):
+        self.authn_method: Optional[str] = None
+
+
 class RedpandaService(Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -400,7 +400,6 @@ class SecurityConfig:
         self.endpoint_authn_method: Optional[str] = None
         self.tls_provider: Optional[TLSProvider] = None
         self.require_client_auth: bool = True
-        self.pp_authn_method: Optional[str] = None
         self.sr_authn_method: Optional[str] = None
         self.auto_auth: Optional[bool] = None
 
@@ -530,7 +529,6 @@ class RedpandaService(Service):
                  *,
                  extra_rp_conf=None,
                  extra_node_conf=None,
-                 enable_pp=False,
                  enable_sr=False,
                  resource_settings=None,
                  si_settings=None,
@@ -541,17 +539,14 @@ class RedpandaService(Service):
                  node_ready_timeout_s=None,
                  superuser: Optional[SaslCredentials] = None,
                  skip_if_no_redpanda_log: bool = False,
-                 pp_keep_alive: Optional[int] = None,
-                 pp_cache_max_size: Optional[int] = None):
+                 pandaproxy: Optional[ProxyConfig] = None):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._extra_rp_conf = extra_rp_conf or dict()
-        self._enable_pp = enable_pp
         self._enable_sr = enable_sr
-        self._pp_keep_alive = pp_keep_alive
-        self._pp_cache_max_size = pp_cache_max_size
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
+        self._pandaproxy = pandaproxy
 
         if superuser is None:
             superuser = self.SUPERUSER_CREDENTIALS
@@ -689,9 +684,6 @@ class RedpandaService(Service):
 
     def endpoint_authn_method(self):
         return self._security.endpoint_authn_method
-
-    def pp_authn_method(self):
-        return self._security.pp_authn_method
 
     def require_client_auth(self):
         return self._security.require_client_auth
@@ -1797,6 +1789,16 @@ class RedpandaService(Service):
         # exercise code paths that deal with multiple listeners
         node_ip = socket.gethostbyname(node.account.hostname)
 
+        enable_pp = False
+        pp_authn_method = None
+        pp_keep_alive = None
+        pp_cache_max_size = None
+        if self._pandaproxy is not None:
+            enable_pp = True
+            pp_authn_method = self._pandaproxy.authn_method
+            pp_keep_alive = self._pandaproxy.cache_keep_alive
+            pp_cache_max_size = self._pandaproxy.cache_max_size
+
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
@@ -1807,16 +1809,16 @@ class RedpandaService(Service):
                            node_ip=node_ip,
                            kafka_alternate_port=self.KAFKA_ALTERNATE_PORT,
                            admin_alternate_port=self.ADMIN_ALTERNATE_PORT,
-                           enable_pp=self._enable_pp,
+                           enable_pp=enable_pp,
                            enable_sr=self._enable_sr,
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           pp_authn_method=self._security.pp_authn_method,
+                           pp_authn_method=pp_authn_method,
                            sr_authn_method=self._security.sr_authn_method,
                            auto_auth=self._security.auto_auth,
-                           pp_keep_alive=self._pp_keep_alive,
-                           pp_cache_max_size=self._pp_cache_max_size)
+                           pp_keep_alive=pp_keep_alive,
+                           pp_cache_max_size=pp_cache_max_size)
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -16,6 +16,7 @@ from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import ProxyConfig
 
 
 class KafkaStreamsTest(RedpandaTest):
@@ -28,9 +29,9 @@ class KafkaStreamsTest(RedpandaTest):
     # The java program is represented by a wrapper in KafkaStreamExamples.
     Example = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
+    def __init__(self, test_context, proxy_conf, enable_sr):
         super(KafkaStreamsTest, self).__init__(test_context=test_context,
-                                               enable_pp=enable_pp,
+                                               pandaproxy=proxy_conf,
                                                enable_sr=enable_sr)
 
         self._ctx = test_context
@@ -60,9 +61,9 @@ class KafkaStreamsDriverBase(KafkaStreamsTest):
     # wrapper in KafkaStreamExamples.
     Driver = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
+    def __init__(self, test_context, proxy_conf, enable_sr):
         super(KafkaStreamsDriverBase, self).__init__(test_context=test_context,
-                                                     enable_pp=enable_pp,
+                                                     proxy_conf=proxy_conf,
                                                      enable_sr=enable_sr)
 
     @cluster(num_nodes=5)
@@ -97,10 +98,10 @@ class KafkaStreamsProdConsBase(KafkaStreamsTest):
     # The producer should be an extension to KafProducer
     PRODUCER = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
+    def __init__(self, test_context, proxy_conf, enable_sr):
         super(KafkaStreamsProdConsBase,
               self).__init__(test_context=test_context,
-                             enable_pp=enable_pp,
+                             proxy_conf=proxy_conf,
                              enable_sr=enable_sr)
 
     def is_valid_msg(self, msg):
@@ -158,7 +159,7 @@ class KafkaStreamsTopArticles(KafkaStreamsDriverBase):
     def __init__(self, test_context):
         super(KafkaStreamsTopArticles,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             proxy_conf=ProxyConfig(),
                              enable_sr=True)
 
 
@@ -178,7 +179,7 @@ class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
     def __init__(self, test_context):
         super(KafkaStreamsSessionWindow,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             proxy_conf=ProxyConfig(),
                              enable_sr=True)
 
 
@@ -197,7 +198,7 @@ class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
 
     def __init__(self, test_context):
         super(KafkaStreamsJsonToAvro, self).__init__(test_context=test_context,
-                                                     enable_pp=True,
+                                                     proxy_conf=ProxyConfig(),
                                                      enable_sr=True)
 
 
@@ -214,7 +215,7 @@ class KafkaStreamsPageView(RedpandaTest):
 
     def __init__(self, test_context):
         super(KafkaStreamsPageView, self).__init__(test_context=test_context,
-                                                   enable_pp=True,
+                                                   proxy_conf=ProxyConfig(),
                                                    enable_sr=True)
 
         self._timeout = 300
@@ -258,7 +259,7 @@ class KafkaStreamsWikipedia(RedpandaTest):
 
     def __init__(self, test_context):
         super(KafkaStreamsWikipedia, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
+                                                    proxy_conf=ProxyConfig(),
                                                     enable_sr=True)
 
         self._timeout = 300
@@ -305,7 +306,7 @@ class KafkaStreamsSumLambda(KafkaStreamsDriverBase):
 
     def __init__(self, test_context):
         super(KafkaStreamsSumLambda, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
+                                                    proxy_conf=ProxyConfig(),
                                                     enable_sr=True)
 
 
@@ -336,7 +337,7 @@ class KafkaStreamsAnomalyDetection(KafkaStreamsProdConsBase):
     def __init__(self, test_context):
         super(KafkaStreamsAnomalyDetection,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             proxy_conf=ProxyConfig(),
                              enable_sr=True)
 
     def is_valid_msg(self, msg):
@@ -370,7 +371,7 @@ class KafkaStreamsUserRegion(KafkaStreamsProdConsBase):
 
     def __init__(self, test_context):
         super(KafkaStreamsUserRegion, self).__init__(test_context=test_context,
-                                                     enable_pp=True,
+                                                     proxy_conf=ProxyConfig(),
                                                      enable_sr=True)
 
     def is_valid_msg(self, msg):
@@ -405,7 +406,7 @@ class KafkaStreamsWordCount(KafkaStreamsProdConsBase):
 
     def __init__(self, test_context):
         super(KafkaStreamsWordCount, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
+                                                    proxy_conf=ProxyConfig(),
                                                     enable_sr=True)
 
     def is_valid_msg(self, msg):
@@ -431,7 +432,7 @@ class KafkaStreamsMapFunction(KafkaStreamsProdConsBase):
     def __init__(self, test_context):
         super(KafkaStreamsMapFunction,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             proxy_conf=ProxyConfig(),
                              enable_sr=True)
 
     def is_valid_msg(self, msg):

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -16,7 +16,7 @@ from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import ProxyConfig
+from rptest.services.redpanda import ProxyConfig, SchemaRegistryConfig
 
 
 class KafkaStreamsTest(RedpandaTest):
@@ -29,10 +29,10 @@ class KafkaStreamsTest(RedpandaTest):
     # The java program is represented by a wrapper in KafkaStreamExamples.
     Example = None
 
-    def __init__(self, test_context, proxy_conf, enable_sr):
+    def __init__(self, test_context, proxy_conf, registry_conf):
         super(KafkaStreamsTest, self).__init__(test_context=test_context,
                                                pandaproxy=proxy_conf,
-                                               enable_sr=enable_sr)
+                                               schema_registry=registry_conf)
 
         self._ctx = test_context
 
@@ -61,10 +61,11 @@ class KafkaStreamsDriverBase(KafkaStreamsTest):
     # wrapper in KafkaStreamExamples.
     Driver = None
 
-    def __init__(self, test_context, proxy_conf, enable_sr):
-        super(KafkaStreamsDriverBase, self).__init__(test_context=test_context,
-                                                     proxy_conf=proxy_conf,
-                                                     enable_sr=enable_sr)
+    def __init__(self, test_context, proxy_conf, registry_conf):
+        super(KafkaStreamsDriverBase,
+              self).__init__(test_context=test_context,
+                             proxy_conf=proxy_conf,
+                             registry_conf=registry_conf)
 
     @cluster(num_nodes=5)
     def test_kafka_streams(self):
@@ -98,11 +99,11 @@ class KafkaStreamsProdConsBase(KafkaStreamsTest):
     # The producer should be an extension to KafProducer
     PRODUCER = None
 
-    def __init__(self, test_context, proxy_conf, enable_sr):
+    def __init__(self, test_context, proxy_conf, registry_conf):
         super(KafkaStreamsProdConsBase,
               self).__init__(test_context=test_context,
                              proxy_conf=proxy_conf,
-                             enable_sr=enable_sr)
+                             registry_conf=registry_conf)
 
     def is_valid_msg(self, msg):
         raise NotImplementedError("is_valid_msg() undefined.")
@@ -160,7 +161,7 @@ class KafkaStreamsTopArticles(KafkaStreamsDriverBase):
         super(KafkaStreamsTopArticles,
               self).__init__(test_context=test_context,
                              proxy_conf=ProxyConfig(),
-                             enable_sr=True)
+                             registry_conf=SchemaRegistryConfig())
 
 
 class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
@@ -180,7 +181,7 @@ class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
         super(KafkaStreamsSessionWindow,
               self).__init__(test_context=test_context,
                              proxy_conf=ProxyConfig(),
-                             enable_sr=True)
+                             registry_conf=SchemaRegistryConfig())
 
 
 class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
@@ -197,9 +198,10 @@ class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
     Driver = KafkaStreamExamples.KafkaStreamsJsonToAvro
 
     def __init__(self, test_context):
-        super(KafkaStreamsJsonToAvro, self).__init__(test_context=test_context,
-                                                     proxy_conf=ProxyConfig(),
-                                                     enable_sr=True)
+        super(KafkaStreamsJsonToAvro,
+              self).__init__(test_context=test_context,
+                             proxy_conf=ProxyConfig(),
+                             registry_conf=SchemaRegistryConfig())
 
 
 class KafkaStreamsPageView(RedpandaTest):
@@ -214,9 +216,10 @@ class KafkaStreamsPageView(RedpandaTest):
     )
 
     def __init__(self, test_context):
-        super(KafkaStreamsPageView, self).__init__(test_context=test_context,
-                                                   proxy_conf=ProxyConfig(),
-                                                   enable_sr=True)
+        super(KafkaStreamsPageView,
+              self).__init__(test_context=test_context,
+                             pandaproxy=ProxyConfig(),
+                             schema_registry=SchemaRegistryConfig())
 
         self._timeout = 300
 
@@ -258,9 +261,10 @@ class KafkaStreamsWikipedia(RedpandaTest):
     )
 
     def __init__(self, test_context):
-        super(KafkaStreamsWikipedia, self).__init__(test_context=test_context,
-                                                    proxy_conf=ProxyConfig(),
-                                                    enable_sr=True)
+        super(KafkaStreamsWikipedia,
+              self).__init__(test_context=test_context,
+                             pandaproxy=ProxyConfig(),
+                             schema_registry=SchemaRegistryConfig())
 
         self._timeout = 300
 
@@ -305,9 +309,10 @@ class KafkaStreamsSumLambda(KafkaStreamsDriverBase):
     Driver = KafkaStreamExamples.KafkaStreamsSumLambda
 
     def __init__(self, test_context):
-        super(KafkaStreamsSumLambda, self).__init__(test_context=test_context,
-                                                    proxy_conf=ProxyConfig(),
-                                                    enable_sr=True)
+        super(KafkaStreamsSumLambda,
+              self).__init__(test_context=test_context,
+                             proxy_conf=ProxyConfig(),
+                             registry_conf=SchemaRegistryConfig())
 
 
 class AnomalyProducer(KafProducer):
@@ -338,7 +343,7 @@ class KafkaStreamsAnomalyDetection(KafkaStreamsProdConsBase):
         super(KafkaStreamsAnomalyDetection,
               self).__init__(test_context=test_context,
                              proxy_conf=ProxyConfig(),
-                             enable_sr=True)
+                             registry_conf=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -370,9 +375,10 @@ class KafkaStreamsUserRegion(KafkaStreamsProdConsBase):
     PRODUCER = RegionProducer
 
     def __init__(self, test_context):
-        super(KafkaStreamsUserRegion, self).__init__(test_context=test_context,
-                                                     proxy_conf=ProxyConfig(),
-                                                     enable_sr=True)
+        super(KafkaStreamsUserRegion,
+              self).__init__(test_context=test_context,
+                             proxy_conf=ProxyConfig(),
+                             registry_conf=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -405,9 +411,10 @@ class KafkaStreamsWordCount(KafkaStreamsProdConsBase):
     PRODUCER = WordProducer
 
     def __init__(self, test_context):
-        super(KafkaStreamsWordCount, self).__init__(test_context=test_context,
-                                                    proxy_conf=ProxyConfig(),
-                                                    enable_sr=True)
+        super(KafkaStreamsWordCount,
+              self).__init__(test_context=test_context,
+                             proxy_conf=ProxyConfig(),
+                             registry_conf=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -433,7 +440,7 @@ class KafkaStreamsMapFunction(KafkaStreamsProdConsBase):
         super(KafkaStreamsMapFunction,
               self).__init__(test_context=test_context,
                              proxy_conf=ProxyConfig(),
-                             enable_sr=True)
+                             registry_conf=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         value = msg["value"]

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -31,7 +31,6 @@ class RedpandaTest(Test):
                  test_context,
                  num_brokers=None,
                  extra_rp_conf=dict(),
-                 enable_sr=False,
                  si_settings=None,
                  **kwargs):
         """
@@ -56,7 +55,6 @@ class RedpandaTest(Test):
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,
                                         extra_rp_conf=extra_rp_conf,
-                                        enable_sr=enable_sr,
                                         si_settings=self.si_settings,
                                         **kwargs)
         self._client = DefaultClient(self.redpanda)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -31,7 +31,6 @@ class RedpandaTest(Test):
                  test_context,
                  num_brokers=None,
                  extra_rp_conf=dict(),
-                 enable_pp=False,
                  enable_sr=False,
                  si_settings=None,
                  **kwargs):
@@ -57,7 +56,6 @@ class RedpandaTest(Test):
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,
                                         extra_rp_conf=extra_rp_conf,
-                                        enable_pp=enable_pp,
                                         enable_sr=enable_sr,
                                         si_settings=self.si_settings,
                                         **kwargs)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -24,7 +24,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.python_librdkafka_serde_client import SerdeClient, SchemaType
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig
+from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig, ProxyConfig
 
 
 def create_topic_names(count):
@@ -75,11 +75,11 @@ class SchemaRegistryEndpoints(RedpandaTest):
         super(SchemaRegistryEndpoints, self).__init__(
             context,
             num_brokers=3,
-            enable_pp=True,
             enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
             resource_settings=ResourceSettings(num_cpus=1),
             log_config=log_config,
+            pandaproxy=ProxyConfig(),
             **kwargs)
 
         http.client.HTTPConnection.debuglevel = 1


### PR DESCRIPTION
## Cover letter

The number of configs for the http proxy has increased since v22.3.1. So we should put them in a single location to reduce the number of params on RedpandaService.

Fixes #6878 

Changes from force-push `e475198` and `edcb4ae`:
- Add config wrap for the schema registry
- Replace enable_sr with SchemaRegistryConfig
- Typos

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
