### PR TITLE
tests: add basic auth mtls tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -400,7 +400,6 @@ class SecurityConfig:
         self.endpoint_authn_method: Optional[str] = None
         self.tls_provider: Optional[TLSProvider] = None
         self.require_client_auth: bool = True
-        self.sr_authn_method: Optional[str] = None
         self.auto_auth: Optional[bool] = None
 
         # The rules to extract principal from mtls
@@ -556,30 +555,31 @@ class RedpandaService(Service):
         }
     }
 
-    def __init__(self,
-                 context,
-                 num_brokers,
-                 *,
-                 extra_rp_conf=None,
-                 extra_node_conf=None,
-                 enable_sr=False,
-                 resource_settings=None,
-                 si_settings=None,
-                 log_level: Optional[str] = None,
-                 log_config: Optional[LoggingConfig] = None,
-                 environment: Optional[dict[str, str]] = None,
-                 security: SecurityConfig = SecurityConfig(),
-                 node_ready_timeout_s=None,
-                 superuser: Optional[SaslCredentials] = None,
-                 skip_if_no_redpanda_log: bool = False,
-                 pandaproxy_config: Optional[PandaproxyConfig] = None):
+    def __init__(
+            self,
+            context,
+            num_brokers,
+            *,
+            extra_rp_conf=None,
+            extra_node_conf=None,
+            resource_settings=None,
+            si_settings=None,
+            log_level: Optional[str] = None,
+            log_config: Optional[LoggingConfig] = None,
+            environment: Optional[dict[str, str]] = None,
+            security: SecurityConfig = SecurityConfig(),
+            node_ready_timeout_s=None,
+            superuser: Optional[SaslCredentials] = None,
+            skip_if_no_redpanda_log: bool = False,
+            pandaproxy_config: Optional[PandaproxyConfig] = None,
+            schema_registry_config: Optional[SchemaRegistryConfig] = None):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._extra_rp_conf = extra_rp_conf or dict()
-        self._enable_sr = enable_sr
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
         self._pandaproxy_config = pandaproxy_config
+        self._schema_registry_config = schema_registry_config
 
         if superuser is None:
             superuser = self.SUPERUSER_CREDENTIALS
@@ -1844,11 +1844,10 @@ class RedpandaService(Service):
                            kafka_alternate_port=self.KAFKA_ALTERNATE_PORT,
                            admin_alternate_port=self.ADMIN_ALTERNATE_PORT,
                            pandaproxy_config=self._pandaproxy_config,
-                           enable_sr=self._enable_sr,
+                           schema_registry_config=self._schema_registry_config,
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           sr_authn_method=self._security.sr_authn_method,
                            auto_auth=self._security.auto_auth)
 
         if override_cfg_params or self._extra_node_conf[node]:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -437,6 +437,23 @@ class LoggingConfig:
         return args
 
 
+class AuthConfig:
+    def __init__(self):
+        self.authn_method: Optional[str] = None
+
+
+class PandaproxyConfig(AuthConfig):
+    def __init__(self):
+        super(PandaproxyConfig, self).__init__()
+        self.cache_keep_alive_ms: int = 300000
+        self.cache_max_size: int = 10
+
+
+class SchemaRegistryConfig(AuthConfig):
+    def __init__(self):
+        super(SchemaRegistryConfig, self).__init__()
+
+
 class RedpandaService(Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -475,7 +475,10 @@ class PandaproxyConfig(TlsConfig):
         self.cache_max_size: int = 10
 
 
-class SchemaRegistryConfig(AuthConfig):
+class SchemaRegistryConfig(TlsConfig):
+    SR_TLS_CLIENT_KEY_FILE = "/etc/redpanda/sr_client.key"
+    SR_TLS_CLIENT_CRT_FILE = "/etc/redpanda/sr_client.crt"
+
     def __init__(self):
         super(SchemaRegistryConfig, self).__init__()
 
@@ -702,6 +705,9 @@ class RedpandaService(Service):
 
     def set_pandaproxy_settings(self, settings: PandaproxyConfig):
         self._pandaproxy_config = settings
+
+    def set_schema_registry_settings(self, settings: SchemaRegistryConfig):
+        self._schema_registry_config = settings
 
     def _init_tls(self):
         """
@@ -980,6 +986,15 @@ class RedpandaService(Service):
                 self._pandaproxy_config.server_key = RedpandaService.TLS_SERVER_KEY_FILE
                 self._pandaproxy_config.server_crt = RedpandaService.TLS_SERVER_CRT_FILE
                 self._pandaproxy_config.truststore_file = RedpandaService.TLS_CA_CRT_FILE
+
+            if self._schema_registry_config is not None:
+                self._schema_registry_config.maybe_write_client_certs(
+                    node, self.logger,
+                    SchemaRegistryConfig.SR_TLS_CLIENT_KEY_FILE,
+                    SchemaRegistryConfig.SR_TLS_CLIENT_CRT_FILE)
+                self._schema_registry_config.server_key = RedpandaService.TLS_SERVER_KEY_FILE
+                self._schema_registry_config.server_crt = RedpandaService.TLS_SERVER_CRT_FILE
+                self._schema_registry_config.truststore_file = RedpandaService.TLS_CA_CRT_FILE
 
     def security_config(self):
         return self._security_config

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -115,6 +115,15 @@ schema_registry:
 
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc
 
+  {% if schema_registry_config.truststore_file is not none %}
+  schema_registry_api_tls:
+    enabled: true
+    require_client_auth: {{ schema_registry_config.require_client_auth }}
+    key_file: {{ schema_registry_config.server_key }}
+    cert_file: {{ schema_registry_config.server_crt }}
+    truststore_file: {{ schema_registry_config.truststore_file }}
+  {% endif %}
+
 schema_registry_client:
   # kafka-api compatible brokers
   brokers:
@@ -122,6 +131,15 @@ schema_registry_client:
     - address: "{{node.account.hostname}}"
       port: 9092
   {% endfor %}
+
+  {% if schema_registry_config.truststore_file is not none %}
+  broker_tls:
+    enabled: true
+    require_client_auth: {{ schema_registry_config.require_client_auth }}
+    key_file: {{ schema_registry_config.SR_TLS_CLIENT_KEY_FILE }}
+    cert_file: {{ schema_registry_config.SR_TLS_CLIENT_CRT_FILE }}
+    truststore_file: {{ schema_registry_config.truststore_file }}
+  {% endif %}
 
   retries: 10
   retry_base_backoff_ms: 10

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -104,13 +104,13 @@ pandaproxy_client:
   {% endif %}
 {% endif %}
 
-{% if enable_sr %}
+{% if schema_registry_config is not none %}
 schema_registry:
   schema_registry_api:
     address: "{{node.account.hostname}}"
     port: 8081
-    {% if sr_authn_method %}
-    authentication_method: {{ sr_authn_method }}
+    {% if schema_registry_config.authn_method %}
+    authentication_method: {{ schema_registry_config.authn_method }}
     {% endif %}
 
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -69,6 +69,15 @@ pandaproxy:
 
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc
 
+  {% if pandaproxy_config.truststore_file is not none %}
+  pandaproxy_api_tls:
+    enabled: true
+    require_client_auth: {{ pandaproxy_config.require_client_auth }}
+    key_file: {{ pandaproxy_config.server_key }}
+    cert_file: {{ pandaproxy_config.server_crt }}
+    truststore_file: {{ pandaproxy_config.truststore_file }}
+  {% endif %}
+
 pandaproxy_client:
   # kafka-api compatible brokers
   brokers:
@@ -76,6 +85,15 @@ pandaproxy_client:
     - address: "{{node.account.hostname}}"
       port: 9092
   {% endfor %}
+
+  {% if pandaproxy_config.truststore_file is not none %}
+  broker_tls:
+    enabled: true
+    require_client_auth: {{ pandaproxy_config.require_client_auth }}
+    key_file: {{ pandaproxy_config.PP_TLS_CLIENT_KEY_FILE }}
+    cert_file: {{ pandaproxy_config.PP_TLS_CLIENT_CRT_FILE }}
+    truststore_file: {{ pandaproxy_config.truststore_file }}
+  {% endif %}
 
   retries: 10
   retry_base_backoff_ms: 10

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -50,23 +50,18 @@ redpanda:
   {% endfor %}
 {% endif %}
 
-{% if enable_pp %}
+{% if pandaproxy_config is not none %}
 pandaproxy:
   # Pandaproxy transport
   pandaproxy_api:
     address: "0.0.0.0"
     port: 8082
-    {% if pp_authn_method %}
-    authentication_method: {{ pp_authn_method }}
+    {% if pandaproxy_config.authn_method %}
+    authentication_method: {{ pandaproxy_config.authn_method }}
     {% endif %}
 
-  {% if pp_keep_alive %}
-  client_keep_alive: {{ pp_keep_alive }}
-  {% endif %}
-
-  {% if pp_cache_max_size %}
-  client_cache_max_size: {{ pp_cache_max_size }}
-  {% endif %}
+  client_keep_alive: {{ pandaproxy_config.cache_keep_alive_ms }}
+  client_cache_max_size: {{ pandaproxy_config.cache_max_size }}
 
   advertised_pandaproxy_api:
     address: "{{node.account.hostname}}"

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -16,6 +16,7 @@ from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import PandaproxyConfig
 
 
 class KafkaStreamsTest(RedpandaTest):
@@ -28,10 +29,12 @@ class KafkaStreamsTest(RedpandaTest):
     # The java program is represented by a wrapper in KafkaStreamExamples.
     Example = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
-        super(KafkaStreamsTest, self).__init__(test_context=test_context,
-                                               enable_pp=enable_pp,
-                                               enable_sr=enable_sr)
+    def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
+                 enable_sr):
+        super(KafkaStreamsTest,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=pandaproxy_config,
+                             enable_sr=enable_sr)
 
         self._ctx = test_context
 
@@ -60,10 +63,12 @@ class KafkaStreamsDriverBase(KafkaStreamsTest):
     # wrapper in KafkaStreamExamples.
     Driver = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
-        super(KafkaStreamsDriverBase, self).__init__(test_context=test_context,
-                                                     enable_pp=enable_pp,
-                                                     enable_sr=enable_sr)
+    def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
+                 enable_sr):
+        super(KafkaStreamsDriverBase,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=pandaproxy_config,
+                             enable_sr=enable_sr)
 
     @cluster(num_nodes=5)
     def test_kafka_streams(self):
@@ -97,10 +102,11 @@ class KafkaStreamsProdConsBase(KafkaStreamsTest):
     # The producer should be an extension to KafProducer
     PRODUCER = None
 
-    def __init__(self, test_context, enable_pp, enable_sr):
+    def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
+                 enable_sr):
         super(KafkaStreamsProdConsBase,
               self).__init__(test_context=test_context,
-                             enable_pp=enable_pp,
+                             pandaproxy_config=pandaproxy_config,
                              enable_sr=enable_sr)
 
     def is_valid_msg(self, msg):
@@ -158,7 +164,7 @@ class KafkaStreamsTopArticles(KafkaStreamsDriverBase):
     def __init__(self, test_context):
         super(KafkaStreamsTopArticles,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             pandaproxy_config=PandaproxyConfig(),
                              enable_sr=True)
 
 
@@ -178,7 +184,7 @@ class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
     def __init__(self, test_context):
         super(KafkaStreamsSessionWindow,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             pandaproxy_config=PandaproxyConfig(),
                              enable_sr=True)
 
 
@@ -196,9 +202,10 @@ class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
     Driver = KafkaStreamExamples.KafkaStreamsJsonToAvro
 
     def __init__(self, test_context):
-        super(KafkaStreamsJsonToAvro, self).__init__(test_context=test_context,
-                                                     enable_pp=True,
-                                                     enable_sr=True)
+        super(KafkaStreamsJsonToAvro,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
 
 class KafkaStreamsPageView(RedpandaTest):
@@ -213,9 +220,10 @@ class KafkaStreamsPageView(RedpandaTest):
     )
 
     def __init__(self, test_context):
-        super(KafkaStreamsPageView, self).__init__(test_context=test_context,
-                                                   enable_pp=True,
-                                                   enable_sr=True)
+        super(KafkaStreamsPageView,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
         self._timeout = 300
 
@@ -257,9 +265,10 @@ class KafkaStreamsWikipedia(RedpandaTest):
     )
 
     def __init__(self, test_context):
-        super(KafkaStreamsWikipedia, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
-                                                    enable_sr=True)
+        super(KafkaStreamsWikipedia,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
         self._timeout = 300
 
@@ -304,9 +313,10 @@ class KafkaStreamsSumLambda(KafkaStreamsDriverBase):
     Driver = KafkaStreamExamples.KafkaStreamsSumLambda
 
     def __init__(self, test_context):
-        super(KafkaStreamsSumLambda, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
-                                                    enable_sr=True)
+        super(KafkaStreamsSumLambda,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
 
 class AnomalyProducer(KafProducer):
@@ -336,7 +346,7 @@ class KafkaStreamsAnomalyDetection(KafkaStreamsProdConsBase):
     def __init__(self, test_context):
         super(KafkaStreamsAnomalyDetection,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             pandaproxy_config=PandaproxyConfig(),
                              enable_sr=True)
 
     def is_valid_msg(self, msg):
@@ -369,9 +379,10 @@ class KafkaStreamsUserRegion(KafkaStreamsProdConsBase):
     PRODUCER = RegionProducer
 
     def __init__(self, test_context):
-        super(KafkaStreamsUserRegion, self).__init__(test_context=test_context,
-                                                     enable_pp=True,
-                                                     enable_sr=True)
+        super(KafkaStreamsUserRegion,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -404,9 +415,10 @@ class KafkaStreamsWordCount(KafkaStreamsProdConsBase):
     PRODUCER = WordProducer
 
     def __init__(self, test_context):
-        super(KafkaStreamsWordCount, self).__init__(test_context=test_context,
-                                                    enable_pp=True,
-                                                    enable_sr=True)
+        super(KafkaStreamsWordCount,
+              self).__init__(test_context=test_context,
+                             pandaproxy_config=PandaproxyConfig(),
+                             enable_sr=True)
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -431,7 +443,7 @@ class KafkaStreamsMapFunction(KafkaStreamsProdConsBase):
     def __init__(self, test_context):
         super(KafkaStreamsMapFunction,
               self).__init__(test_context=test_context,
-                             enable_pp=True,
+                             pandaproxy_config=PandaproxyConfig(),
                              enable_sr=True)
 
     def is_valid_msg(self, msg):

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -16,7 +16,7 @@ from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import PandaproxyConfig
+from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig
 
 
 class KafkaStreamsTest(RedpandaTest):
@@ -30,11 +30,11 @@ class KafkaStreamsTest(RedpandaTest):
     Example = None
 
     def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
-                 enable_sr):
+                 schema_registry_config: SchemaRegistryConfig):
         super(KafkaStreamsTest,
               self).__init__(test_context=test_context,
                              pandaproxy_config=pandaproxy_config,
-                             enable_sr=enable_sr)
+                             schema_registry_config=schema_registry_config)
 
         self._ctx = test_context
 
@@ -64,11 +64,11 @@ class KafkaStreamsDriverBase(KafkaStreamsTest):
     Driver = None
 
     def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
-                 enable_sr):
+                 schema_registry_config: SchemaRegistryConfig):
         super(KafkaStreamsDriverBase,
               self).__init__(test_context=test_context,
                              pandaproxy_config=pandaproxy_config,
-                             enable_sr=enable_sr)
+                             schema_registry_config=schema_registry_config)
 
     @cluster(num_nodes=5)
     def test_kafka_streams(self):
@@ -103,11 +103,11 @@ class KafkaStreamsProdConsBase(KafkaStreamsTest):
     PRODUCER = None
 
     def __init__(self, test_context, pandaproxy_config: PandaproxyConfig,
-                 enable_sr):
+                 schema_registry_config: SchemaRegistryConfig):
         super(KafkaStreamsProdConsBase,
               self).__init__(test_context=test_context,
                              pandaproxy_config=pandaproxy_config,
-                             enable_sr=enable_sr)
+                             schema_registry_config=schema_registry_config)
 
     def is_valid_msg(self, msg):
         raise NotImplementedError("is_valid_msg() undefined.")
@@ -165,7 +165,7 @@ class KafkaStreamsTopArticles(KafkaStreamsDriverBase):
         super(KafkaStreamsTopArticles,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
 
 class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
@@ -185,7 +185,7 @@ class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
         super(KafkaStreamsSessionWindow,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
 
 class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
@@ -205,7 +205,7 @@ class KafkaStreamsJsonToAvro(KafkaStreamsDriverBase):
         super(KafkaStreamsJsonToAvro,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
 
 class KafkaStreamsPageView(RedpandaTest):
@@ -223,7 +223,7 @@ class KafkaStreamsPageView(RedpandaTest):
         super(KafkaStreamsPageView,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
         self._timeout = 300
 
@@ -268,7 +268,7 @@ class KafkaStreamsWikipedia(RedpandaTest):
         super(KafkaStreamsWikipedia,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
         self._timeout = 300
 
@@ -316,7 +316,7 @@ class KafkaStreamsSumLambda(KafkaStreamsDriverBase):
         super(KafkaStreamsSumLambda,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
 
 class AnomalyProducer(KafProducer):
@@ -347,7 +347,7 @@ class KafkaStreamsAnomalyDetection(KafkaStreamsProdConsBase):
         super(KafkaStreamsAnomalyDetection,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -382,7 +382,7 @@ class KafkaStreamsUserRegion(KafkaStreamsProdConsBase):
         super(KafkaStreamsUserRegion,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -418,7 +418,7 @@ class KafkaStreamsWordCount(KafkaStreamsProdConsBase):
         super(KafkaStreamsWordCount,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         key = msg["key"]
@@ -444,7 +444,7 @@ class KafkaStreamsMapFunction(KafkaStreamsProdConsBase):
         super(KafkaStreamsMapFunction,
               self).__init__(test_context=test_context,
                              pandaproxy_config=PandaproxyConfig(),
-                             enable_sr=True)
+                             schema_registry_config=SchemaRegistryConfig())
 
     def is_valid_msg(self, msg):
         value = msg["value"]

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -31,7 +31,6 @@ class RedpandaTest(Test):
                  test_context,
                  num_brokers=None,
                  extra_rp_conf=dict(),
-                 enable_sr=False,
                  si_settings=None,
                  **kwargs):
         """
@@ -56,7 +55,6 @@ class RedpandaTest(Test):
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,
                                         extra_rp_conf=extra_rp_conf,
-                                        enable_sr=enable_sr,
                                         si_settings=self.si_settings,
                                         **kwargs)
         self._client = DefaultClient(self.redpanda)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -31,7 +31,6 @@ class RedpandaTest(Test):
                  test_context,
                  num_brokers=None,
                  extra_rp_conf=dict(),
-                 enable_pp=False,
                  enable_sr=False,
                  si_settings=None,
                  **kwargs):
@@ -57,7 +56,6 @@ class RedpandaTest(Test):
         self.redpanda = RedpandaService(test_context,
                                         num_brokers,
                                         extra_rp_conf=extra_rp_conf,
-                                        enable_pp=enable_pp,
                                         enable_sr=enable_sr,
                                         si_settings=self.si_settings,
                                         **kwargs)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -24,7 +24,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.python_librdkafka_serde_client import SerdeClient, SchemaType
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig, PandaproxyConfig
+from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig, PandaproxyConfig, SchemaRegistryConfig
 
 
 def create_topic_names(count):
@@ -71,15 +71,18 @@ class SchemaRegistryEndpoints(RedpandaTest):
     """
     Test schema registry against a redpanda cluster.
     """
-    def __init__(self, context, **kwargs):
+    def __init__(self,
+                 context,
+                 schema_registry_config=SchemaRegistryConfig(),
+                 **kwargs):
         super(SchemaRegistryEndpoints, self).__init__(
             context,
             num_brokers=3,
-            enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
             resource_settings=ResourceSettings(num_cpus=1),
             log_config=log_config,
             pandaproxy_config=PandaproxyConfig(),
+            schema_registry_config=schema_registry_config,
             **kwargs)
 
         http.client.HTTPConnection.debuglevel = 1
@@ -1163,10 +1166,14 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = 'sasl'
-        security.sr_authn_method = 'http_basic'
 
-        super(SchemaRegistryBasicAuthTest, self).__init__(context,
-                                                          security=security)
+        schema_registry_config = SchemaRegistryConfig()
+        schema_registry_config.authn_method = 'http_basic'
+
+        super(SchemaRegistryBasicAuthTest,
+              self).__init__(context,
+                             security=security,
+                             schema_registry_config=schema_registry_config)
 
     @cluster(num_nodes=3)
     def test_schemas_types(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -24,7 +24,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.python_librdkafka_serde_client import SerdeClient, SchemaType
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig
+from rptest.services.redpanda import ResourceSettings, SecurityConfig, LoggingConfig, PandaproxyConfig
 
 
 def create_topic_names(count):
@@ -75,11 +75,11 @@ class SchemaRegistryEndpoints(RedpandaTest):
         super(SchemaRegistryEndpoints, self).__init__(
             context,
             num_brokers=3,
-            enable_pp=True,
             enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
             resource_settings=ResourceSettings(num_cpus=1),
             log_config=log_config,
+            pandaproxy_config=PandaproxyConfig(),
             **kwargs)
 
         http.client.HTTPConnection.debuglevel = 1


### PR DESCRIPTION
## Cover Letter

The HTTP Proxy and Schema Registry now support HTTP Basic Authentication since v22.3.1. This PR tests those services when:
1. mTLS is the only authentication method
2. mTLS and Basic Auth are enabled together

Fixes #6763 
Fixes https://github.com/redpanda-data/redpanda/issues/6878

Changes from force-push `8c51d9c`:
- Add mtls tests for the Schema Registry

Changes from force-push `f6b114c` and `6965d04`:
- Adding TLS certs into the new config wrappers should be in their own commit
- Add `_ms` to `cache_keep_alive`
- Rename `ProxyConfig` to `PandaproxyConfig`
- Pass `PandaproxyConfig` and `SchemaRegistryConfig` into the yaml template
- Make variable names more clear

Changes from force-push `2e512f7`:
- Create a base class for writing TLS certs with the HTTP Proxy and Schema Registry
- Add in some type annotations
- Use the new config wrappers directly in redpanda.yaml template
- Typos
- Use default constructored `PandaproxyConfig` and `SchemaRegistryConfig` where applicable
- Stylistic changes for enabling `https`

Changes from force-push `3b19747`:
- Rename `HTTPConfig` to `TlsConfig`
- Put shared members in the appropriate parent classes
- Typos

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none