### PR TITLE
[v22.3.x] tree_wide: add metrics for ops dashboard

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -123,12 +123,20 @@ void server_probe::setup_public_metrics(
 
     mgs.add_group(
       "rpc",
-      {sm::make_counter(
-         "request_errors_total",
-         [this] { return _service_errors; },
-         sm::description("Number of rpc errors"),
-         {server_label(proto)})
-         .aggregate({sm::shard_label})});
+      {
+        sm::make_counter(
+          "request_errors_total",
+          [this] { return _service_errors; },
+          sm::description("Number of rpc errors"),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "active_connections",
+          [this] { return _connections; },
+          sm::description("Count of currently active connections"),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
+      });
 }
 
 std::ostream& operator<<(std::ostream& o, const server_probe& p) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -136,6 +136,7 @@ consensus::consensus(
   , _node_priority_override(voter_priority_override)
   , _append_requests_buffer(*this, 256) {
     setup_metrics();
+    setup_public_metrics();
     update_follower_stats(_configuration_manager.get_latest());
     _vote_timeout.set_callback([this] {
         maybe_step_down();
@@ -175,6 +176,14 @@ void consensus::setup_metrics() {
                          "joint state i.e. configuration is being changed"),
          labels)
          .aggregate(aggregate_labels)});
+}
+
+void consensus::setup_public_metrics() {
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    _probe.setup_public_metrics(_log.config().ntp());
 }
 
 void consensus::do_step_down(std::string_view ctx) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -480,6 +480,7 @@ private:
     absl::flat_hash_map<vnode, follower_req_seq> next_followers_request_seq();
 
     void setup_metrics();
+    void setup_public_metrics();
 
     bytes voted_for_key() const {
         return raft::details::serialize_group_key(

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/fundamental.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -42,6 +43,7 @@ public:
     create_metric_labels(const model::ntp& ntp);
 
     void setup_metrics(const model::ntp& ntp);
+    void setup_public_metrics(const model::ntp& ntp);
 
     void heartbeat_request_error() { ++_heartbeat_request_error; };
     void replicate_request_error() { ++_replicate_request_error; };
@@ -66,5 +68,7 @@ private:
     uint64_t _recovery_request_error = 0;
 
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
 };
 } // namespace raft


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7287
Fixes https://github.com/redpanda-data/redpanda/issues/7364,