### PR TITLE
cloud_storage: Store only materialized segments ...

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -201,7 +201,7 @@ void materialized_segments::trim_readers(size_t target_free) {
           cst_log.debug,
           "trim_readers: {} {} has {} readers",
           st.ntp(),
-          st.offset_key,
+          st.base_rp_offset(),
           st.readers.size());
 
         candidates.insert(std::make_pair(st.readers.size(), std::ref(st)));
@@ -216,7 +216,7 @@ void materialized_segments::trim_readers(size_t target_free) {
           cst_log.debug,
           "Trimming readers from segment {} offset {} ({} refs, {} readers)",
           st.ntp(),
-          st.base_rp_offset,
+          st.base_rp_offset(),
           st.segment.use_count(),
           st.readers.size());
 
@@ -298,12 +298,12 @@ void materialized_segments::maybe_trim_segment(
           cst_log.debug,
           "Materialized segment {} offset {} is stale",
           st.ntp(),
-          st.offset_key);
+          st.base_rp_offset());
         // this will delete and unlink the object from
         // _materialized collection
         if (st.parent) {
             to_offload.push_back(
-              std::make_pair(st.parent.get(), st.base_rp_offset));
+              std::make_pair(st.parent.get(), st.base_rp_offset()));
         } else {
             // This cannot happen, because materialized_segment_state
             // is only instantiated by remote_partition and will
@@ -312,7 +312,7 @@ void materialized_segments::maybe_trim_segment(
               false,
               "materialized_segment_state outlived remote_partition (offset "
               "{})",
-              st.offset_key);
+              st.base_rp_offset());
         }
     } else {
         // We would like to trim this segment, but cannot right now
@@ -326,7 +326,7 @@ void materialized_segments::maybe_trim_segment(
           "Materialized segment {} base-offset {} is not stale: {} "
           "readers={}",
           st.ntp(),
-          st.base_rp_offset,
+          st.base_rp_offset(),
           st.segment.use_count(),
           st.readers.size());
 

--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -304,7 +304,7 @@ void materialized_segments::maybe_trim_segment(
         // this will delete and unlink the object from
         // _materialized collection
         if (st.parent) {
-            to_offload.push_back(std::make_pair(&st, st.offset_key));
+            to_offload.push_back(std::make_pair(&st, st.base_rp_offset));
         } else {
             // This cannot happen, because materialized_segment_state
             // is only instantiated by remote_partition and will

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -138,7 +138,7 @@ private:
 
     // List of segments to offload, accumulated during trim_segments
     using offload_list_t
-      = std::vector<std::pair<materialized_segment_state*, kafka::offset>>;
+      = std::vector<std::pair<materialized_segment_state*, model::offset>>;
 
     void maybe_trim_segment(materialized_segment_state&, offload_list_t&);
 

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage/remote_partition.h"
 #include "cloud_storage/segment_state.h"
 #include "config/property.h"
 #include "random/simple_time_jitter.h"
@@ -138,7 +139,7 @@ private:
 
     // List of segments to offload, accumulated during trim_segments
     using offload_list_t
-      = std::vector<std::pair<materialized_segment_state*, model::offset>>;
+      = std::vector<std::pair<remote_partition*, model::offset>>;
 
     void maybe_trim_segment(materialized_segment_state&, offload_list_t&);
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -19,6 +19,7 @@
 #include "json/istreamwrapper.h"
 #include "json/ostreamwrapper.h"
 #include "json/writer.h"
+#include "model/fundamental.h"
 #include "model/timestamp.h"
 #include "ssx/sformat.h"
 #include "storage/fs_utils.h"
@@ -35,6 +36,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <utility>
 
 namespace fmt {
@@ -270,6 +272,11 @@ partition_manifest::get_start_kafka_offset() const {
         if (iter != _segments.end()) {
             auto delta = iter->second.delta_offset;
             return _start_offset - delta;
+        } else {
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "can't translate start offset {} because the manifest is empty",
+              _start_offset));
         }
     }
     return std::nullopt;
@@ -277,26 +284,15 @@ partition_manifest::get_start_kafka_offset() const {
 
 partition_manifest::const_iterator
 partition_manifest::segment_containing(kafka::offset o) const {
-    /*TODO: remove*/ vlog(
-      cst_log.debug, "Metadata lookup using kafka offset {}", o);
+    vlog(cst_log.debug, "Metadata lookup using kafka offset {}", o);
     // Kafka offset is always <= log offset.
     // To find a segment by its kafka offset we can simply query
     // manifest by log offset and then traverse forward until we
     // will find matching segment.
     auto it = segment_containing(kafka::offset_cast(o));
-    /*TODO: remove*/ vlog(
-      cst_log.debug,
-      "First metadata lookup using kafka offset {}, result {}",
-      o,
-      it->second.base_offset);
     auto prev = end();
     while (it != end()) {
         auto base = it->second.base_offset - it->second.delta_offset;
-        /*TODO: remove*/ vlog(
-          cst_log.debug,
-          "Metadata lookup using kafka offset {} <> {}",
-          o,
-          base);
         if (base > o) {
             // We need to find first element which has greater kafka
             // offset then the target and step back. It is possible
@@ -306,6 +302,20 @@ partition_manifest::segment_containing(kafka::offset o) const {
         }
         prev = it;
         it = std::next(it);
+    }
+    if (it == end() && prev != end()) {
+        if (prev->second.delta_offset_end != model::offset_delta{}) {
+            // In case if 'prev' points to the last segment it's not guaranteed
+            // that the segment contains the required kafka offset. We need an
+            // extra check using delta_offset_end. If the field is not set then
+            // we will return the last segment. This is OK since
+            // delta_offset_end will always be set for new segments.
+            auto m = prev->second.committed_offset
+                     - prev->second.delta_offset_end;
+            if (m < o) {
+                prev = end();
+            }
+        }
     }
     return prev;
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -179,6 +179,7 @@ public:
 
     /// Get starting offset
     std::optional<model::offset> get_start_offset() const;
+    std::optional<kafka::offset> get_start_kafka_offset() const;
 
     /// Get last uploaded compacted offset
     model::offset get_last_uploaded_compacted_offset() const;
@@ -274,6 +275,7 @@ public:
     /// Returns an iterator to the segment containing offset o, such that o >=
     /// segment.base_offset and o <= segment.committed_offset.
     const_iterator segment_containing(model::offset o) const;
+    const_iterator segment_containing(kafka::offset o) const;
 
     // Return collection of segments that were replaced in lightweight format.
     std::vector<partition_manifest::lw_segment_meta>

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -76,7 +76,7 @@ remote_partition::materialize_segment(const segment_meta& meta) {
     auto key_offset = meta.base_offset - meta.delta_offset;
     auto units = materialized().get_segment_units();
     auto st = std::make_unique<materialized_segment_state>(
-      meta.base_offset, key_offset, *this, std::move(units));
+      meta.base_offset, *this, std::move(units));
     auto [iter, ok] = _segments.insert(
       std::make_pair(meta.base_offset, std::move(st)));
     vassert(
@@ -611,7 +611,9 @@ ss::future<> remote_partition::stop() {
 
     for (auto& s : _segments) {
         vlog(
-          _ctxlog.debug, "remote partition stop {}", s.second->base_rp_offset);
+          _ctxlog.debug,
+          "remote partition stop {}",
+          s.second->base_rp_offset());
         co_await s.second->stop();
     }
 

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -45,122 +45,6 @@ using namespace std::chrono_literals;
 class partition_record_batch_reader_impl;
 struct materialized_segment_state;
 
-namespace details {
-
-/// Iterator adapter for absl::btree_map that privides
-/// iterator stability guarantee by caching the key and
-/// doing a lookup on every increment.
-/// This turns iterator increment into O(logN) operation
-/// Deleting from underlying btree_map is not supported.
-template<class TKey, class TVal>
-class btree_map_stable_iterator
-  : public boost::iterator_facade<
-      btree_map_stable_iterator<TKey, TVal>,
-      typename absl::btree_map<TKey, TVal>::value_type,
-      boost::bidirectional_traversal_tag> {
-    using map_t = absl::btree_map<TKey, TVal>;
-    using self_t = btree_map_stable_iterator<TKey, TVal>;
-    using value_t = typename map_t::value_type;
-
-public:
-    /// Creates an iterator that points to the end of the sequence
-    explicit btree_map_stable_iterator(map_t& map)
-      : _key(std::nullopt)
-      , _map(std::ref(map)) {}
-
-    /// Create an iterator that points to the arbitrary element
-    explicit btree_map_stable_iterator(map_t& map, TKey o)
-      : _key(std::nullopt)
-      , _map(std::ref(map)) {
-        // Invariant: the iterator is pointing to end (_map is null) or
-        // _key is initialized using correct value.
-        if (map.empty()) {
-            set_end();
-        }
-        if (auto it = _map.get().find(o); it != _map.get().end()) {
-            _key = it->first;
-        } else {
-            // Same behaviour as map::find, if key can't be found setup
-            // iterator to point to end of key sequence.
-            set_end();
-        }
-    }
-
-    /// Returns true if the element referenced by this iterator
-    /// was removed from the collection.
-    bool is_invalidated() const {
-        if (!_key) {
-            return true;
-        }
-        return _map.get().count(*_key) == 0;
-    }
-
-private:
-    friend class boost::iterator_core_access;
-
-    // Increment iterator if possible.
-    // The _key will be set to next element key or nullopt.
-    void increment() {
-        vassert(
-          _key.has_value(), "btree_map_stable_iterator can't be incremented");
-        auto it = _map.get().find(*_key);
-        // _key should be present since deletions are not supported
-        if (it == _map.get().end()) {
-            // The element referenced by this iterator was
-            // deleted.
-            set_end();
-            return;
-        }
-        ++it;
-        if (it == _map.get().end()) {
-            set_end();
-        } else {
-            _key = it->first;
-        }
-    }
-
-    // Decrement iterator if possible.
-    // The _key will be set to prev element key.
-    void decrement() {
-        if (_key) {
-            auto it = _map.get().find(*_key);
-            if (it == _map.get().end()) {
-                set_end();
-                return;
-            }
-            --it;
-            _key = it->first;
-        } else {
-            if (_map.get().empty()) {
-                return;
-            }
-            auto it = _map.get().end();
-            --it;
-            _key = it->first;
-        }
-    }
-
-    bool equal(const self_t& other) const { return _key == other._key; }
-
-    value_t& dereference() const {
-        vassert(
-          _key.has_value(),
-          "btree_map_stable_iterator doesn't point to an element and can't be "
-          "dereferenced");
-        auto it = _map.get().find(*_key);
-        return *it;
-    }
-
-    void set_end() { _key = std::nullopt; }
-
-    /// Key of the current element, nullopt is iter == end
-    std::optional<TKey> _key;
-    /// Reference to the container
-    std::reference_wrapper<map_t> _map;
-};
-
-} // namespace details
-
 /// Remote partition manintains list of remote segments
 /// and list of active readers. Only one reader can be
 /// maintained per segment. The idea here is that the
@@ -236,29 +120,20 @@ public:
     ss::future<> erase();
 
     /// Hook for materialized_segment to notify us when a segment is evicted
-    void offload_segment(kafka::offset);
+    void offload_segment(model::offset);
 
 private:
-    /// Create new remote_segment instances for all new
-    /// items in the manifest.
-    void maybe_sync_with_manifest();
-
     ss::future<> run_eviction_loop();
 
-    friend struct offloaded_segment_state;
     friend struct materialized_segment_state;
+    friend struct offloaded_segment_state;
 
     using materialized_segment_ptr
       = std::unique_ptr<materialized_segment_state>;
-    using segment_state
-      = std::variant<offloaded_segment_state, materialized_segment_ptr>;
 
-    static_assert(
-      sizeof(segment_state) == sizeof(std::variant<size_t>),
-      "segment_state has unexpected size");
-
-    using iterator
-      = details::btree_map_stable_iterator<kafka::offset, segment_state>;
+    using segment_map_t
+      = absl::btree_map<model::offset, materialized_segment_ptr>;
+    using iterator = segment_map_t::iterator;
 
     /// This is exposed for the benefit of offloaded_segment_state and
     /// materialized_segment_state
@@ -272,19 +147,37 @@ private:
     std::unique_ptr<remote_segment_batch_reader> borrow_reader(
       storage::log_reader_config config,
       kafka::offset offset_key,
-      segment_state& st);
+      materialized_segment_ptr& st);
 
     /// Return reader back to segment_state
-    void return_reader(
-      std::unique_ptr<remote_segment_batch_reader>, segment_state& st);
+    void return_reader(std::unique_ptr<remote_segment_batch_reader>);
 
     /// Iterators used by the partition_record_batch_reader_impl class
-    iterator begin();
-    iterator end();
-    iterator upper_bound(kafka::offset);
     iterator seek_by_timestamp(model::timestamp);
 
-    using segment_map_t = absl::btree_map<kafka::offset, segment_state>;
+    /// The result of the borrow_next_reader method
+    ///
+    struct borrow_result_t {
+        /// The reader (can be set to null)
+        std::unique_ptr<remote_segment_batch_reader> reader;
+        /// The offset of the next segment, default value means that there is no
+        /// next segment yet
+        model::offset next_segment_offset;
+    };
+
+    /// Borrow next reader in a sequence
+    ///
+    /// If the invocation is first the method will use config.start_offset to
+    /// find the target. It can find already materialized segment and reuse the
+    /// reader. Alternatively, it can materialize the segment and create a
+    /// reader.
+    borrow_result_t borrow_next_reader(
+      storage::log_reader_config config, model::offset hint = {});
+
+    /// Materialize new segment
+    /// @return iterator that points to newly added segment (always valid
+    /// iterator)
+    iterator materialize_segment(const segment_meta&);
 
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
@@ -292,7 +185,6 @@ private:
     remote& _api;
     cache& _cache;
     const partition_manifest& _manifest;
-    model::offset _insync_offset;
     s3::bucket_name _bucket;
 
     // Deleting from _segments is not supported.

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -186,9 +186,6 @@ private:
     const partition_manifest& _manifest;
     s3::bucket_name _bucket;
 
-    // Deleting from _segments is not supported.
-    // absl::btree_map doesn't provide a pointer stabilty. We are
-    // using remote_partition::btree_map_stable_iterator to work around this.
     segment_map_t _segments;
     partition_probe _probe;
 };

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -126,7 +126,6 @@ private:
     ss::future<> run_eviction_loop();
 
     friend struct materialized_segment_state;
-    friend struct offloaded_segment_state;
 
     using materialized_segment_ptr
       = std::unique_ptr<materialized_segment_state>;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -240,10 +240,23 @@ public:
     /// Get base offset (redpanda offset)
     model::offset base_rp_offset() const { return _seg->get_base_rp_offset(); }
 
+    kafka::offset base_kafka_offset() const {
+        return _seg->get_base_kafka_offset();
+    }
+
     bool is_eof() const { return _cur_rp_offset > _seg->get_max_rp_offset(); }
 
     void set_eof() {
         _cur_rp_offset = _seg->get_max_rp_offset() + model::offset{1};
+    }
+
+    model::offset current_rp_offset() const { return _cur_rp_offset; }
+    kafka::offset current_kafka_offset() const {
+        return _cur_rp_offset - _cur_delta;
+    }
+
+    bool reads_from_segment(const remote_segment& segm) const {
+        return &segm == _seg.get();
     }
 
 private:

--- a/src/v/cloud_storage/segment_state.cc
+++ b/src/v/cloud_storage/segment_state.cc
@@ -27,14 +27,9 @@ void materialized_segment_state::offload(remote_partition* partition) {
 }
 
 materialized_segment_state::materialized_segment_state(
-  model::offset base_offset,
-  kafka::offset off_key,
-  remote_partition& p,
-  ssx::semaphore_units u)
-  : base_rp_offset(base_offset)
-  , offset_key(off_key)
-  , segment(ss::make_lw_shared<remote_segment>(
-      p._api, p._cache, p._bucket, p._manifest, base_offset, p._rtc))
+  model::offset base_offset, remote_partition& p, ssx::semaphore_units u)
+  : segment(ss::make_lw_shared<remote_segment>(
+    p._api, p._cache, p._bucket, p._manifest, base_offset, p._rtc))
   , atime(ss::lowres_clock::now())
   , parent(p.weak_from_this())
   , _units(std::move(u)) {
@@ -95,6 +90,10 @@ const model::ntp& materialized_segment_state::ntp() const {
         static model::ntp blank;
         return blank;
     }
+}
+
+model::offset materialized_segment_state::base_rp_offset() const {
+    return segment->get_base_rp_offset();
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -32,10 +32,7 @@ class partition_probe;
 /// remote segment.
 struct materialized_segment_state {
     materialized_segment_state(
-      model::offset bo,
-      kafka::offset offk,
-      remote_partition& p,
-      ssx::semaphore_units);
+      model::offset bo, remote_partition& p, ssx::semaphore_units);
 
     void return_reader(std::unique_ptr<remote_segment_batch_reader> reader);
 
@@ -53,9 +50,8 @@ struct materialized_segment_state {
     const model::ntp& ntp() const;
 
     /// Base offsetof the segment
-    model::offset base_rp_offset;
-    /// Key of the segment in _segments collection of the remote_partition
-    kafka::offset offset_key;
+    model::offset base_rp_offset() const;
+
     ss::lw_shared_ptr<remote_segment> segment;
     /// Batch readers that can be used to scan the segment
     std::list<std::unique_ptr<remote_segment_batch_reader>> readers;

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -25,24 +25,6 @@ struct materialized_segment_state;
 class remote_segment_batch_reader;
 class partition_probe;
 
-/// State that have to be materialized before use
-struct offloaded_segment_state {
-    explicit offloaded_segment_state(model::offset bo);
-
-    std::unique_ptr<materialized_segment_state>
-    materialize(remote_partition& p, kafka::offset offset_key);
-
-    ss::future<> stop();
-
-    offloaded_segment_state offload(remote_partition*);
-
-    model::offset base_rp_offset;
-
-    offloaded_segment_state* operator->() { return this; }
-
-    const offloaded_segment_state* operator->() const { return this; }
-};
-
 /// State with materialized segment and cached reader
 ///
 /// The object represent the state in which there is(or was) at
@@ -66,7 +48,7 @@ struct materialized_segment_state {
 
     ss::future<> stop();
 
-    offloaded_segment_state offload(remote_partition* partition);
+    void offload(remote_partition* partition);
 
     const model::ntp& ntp() const;
 

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -2010,6 +2010,21 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(
+  test_remote_partition_scan_incrementally_random_with_overlaps,
+  cloud_storage_fixture) {
+    constexpr int num_segments = 1000;
+    const auto [batch_types, num_data_batches] = generate_segment_layout(
+      num_segments, 42);
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::overlapping_segments);
+    auto base = segments[0].base_offset;
+    auto max = segments.back().max_offset;
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+
+    scan_remote_partition_incrementally(*this, base, max);
+}
+
+FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random_with_duplicates,
   cloud_storage_fixture) {
     constexpr int num_segments = 500;

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -2046,6 +2046,7 @@ FIXTURE_TEST(
 
     scan_remote_partition_incrementally(*this, base, max);
 }
+
 /// This test scans the entire range of offsets
 FIXTURE_TEST(
   test_remote_partition_scan_translate_tx_fence, cloud_storage_fixture) {


### PR DESCRIPTION
in the remote_partition. The commit changes the data structure that remote_partition uses internally. Previously, it stored an element per log segment in the cloud. Each element could be either materialized_segment_ptr or offloaded_segment_state. This was needed to lookup the manifests by their kafka offsets. The high level reader was storing an iterator to this collection and materialized segments while traversing it.

This approach requires extra memory since we're already storing segments in the manifest. Also, it creates some hard problems when the underlying manifest is not immutable. We had to use an iterator wrapper to avoid iterator invalidation between the scheduling points. With mutable manifest we had to do extra checks on this iterator.

This commit makes collection of segments inside remote_partition to store only materialized segments. The key of the _segments collection is now a model::offset. This avoids a problem when two or more segments could potentially have the same base kafka offset if some of them didn't have data batches.

Instead of storing the iterator the remote_partition reader now uses an api that returns a next reader. The logic that was prevoiusly living inside the manifest synchronization procedure is now implemented there (e.g. handling of duplicate base kafka offsets of different segments). This method uses manifest to find segments by the kafka offset. It returns not only a reader but also the log offset of the next segment. The iterator can now use this offset to advance to the next segment when the eof is reached instead of relying on the state of the remote_segment_record_batch_reader. This avoid potential live-lock in some cases (when the segment reader can't reach the end of the segment file so the next offset used to create next reader belongs to the same segment).



## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes



  ### Bug Fixes

  * none

  ### Features

  * none

  ### Improvements

  * Improve memory efficiency of the tiered storage



