### PR TITLE
Fixed rebalancing when multiple nodes are added at once

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -120,6 +120,9 @@ public:
     ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
 
     ss::sharded<storage::api>& get_storage() { return _storage; }
+    ss::sharded<members_backend>& get_members_backend() {
+        return _members_backend;
+    }
 
     bool is_raft0_leader() const {
         vassert(

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -186,6 +186,21 @@
             ]
         },
         {
+            "path": "/v1/partitions/rebalance",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Execute on demand partition rebalance",
+                    "type": "void",
+                    "nickname": "trigger_partitions_rebalance",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/partitions/{namespace}/{topic}/{partition}/unclean_abort_reconfiguration",
             "operations": [
                 {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -17,11 +17,13 @@
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
 #include "cluster/controller_api.h"
+#include "cluster/controller_stm.h"
 #include "cluster/errc.h"
 #include "cluster/feature_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/health_monitor_types.h"
+#include "cluster/members_backend.h"
 #include "cluster/members_frontend.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
@@ -2612,6 +2614,12 @@ void admin_server::register_partition_routes() {
           return set_partition_replicas_handler(std::move(req));
       });
 
+    register_route<superuser>(
+      ss::httpd::partition_json::trigger_partitions_rebalance,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return trigger_on_demand_reconfiguration_handler(std::move(req));
+      });
+
     register_route<user>(
       ss::httpd::partition_json::get_partition_reconfigurations,
       [this](std::unique_ptr<ss::httpd::request>) {
@@ -2638,6 +2646,18 @@ void admin_server::register_partition_routes() {
           }
           return ss::make_ready_future<ss::json::json_return_type>(ret);
       });
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::trigger_on_demand_reconfiguration_handler(
+  std::unique_ptr<ss::httpd::request> req) {
+    auto ec = co_await _controller->get_members_backend().invoke_on(
+      cluster::controller_stm_shard, [](cluster::members_backend& backend) {
+          return backend.request_rebalance();
+      });
+
+    co_await throw_on_error(*req, ec, model::controller_ntp);
+    co_return ss::json::json_return_type(ss::json::json_void());
 }
 
 void admin_server::register_hbadger_routes() {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -25,6 +25,7 @@
 #include <seastar/http/file_handler.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/json_path.hh>
+#include <seastar/json/json_elements.hh>
 #include <seastar/util/log.hh>
 
 #include <absl/container/flat_hash_map.h>
@@ -284,6 +285,9 @@ private:
         std::unique_ptr<ss::httpd::request>);
     ss::future<ss::json::json_return_type>
       set_partition_replicas_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<ss::json::json_return_type>
+      trigger_on_demand_reconfiguration_handler(
+        std::unique_ptr<ss::httpd::request>);
 
     /// Transaction routes
     ss::future<ss::json::json_return_type>

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -476,6 +476,14 @@ class Admin:
         self.redpanda.logger.debug(f"recommissioning {id}")
         return self._request('put', path, node=node)
 
+    def trigger_rebalance(self, node=None):
+        """
+        Trigger on demand partitions rebalancing
+        """
+        path = f"partitions/rebalance"
+
+        return self._request('post', path, node=node)
+
     def list_reconfigurations(self, node=None):
         """
         List pending reconfigurations

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import random
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
@@ -21,58 +22,34 @@ class ScalingUpTest(EndToEndTest):
     Adding nodes to the cluster should result in partition reallocations to new
     nodes
     """
-    @cluster(num_nodes=5)
-    def test_adding_nodes_to_cluster(self):
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf={
-                                            "group_topic_partitions":
-                                            1,
-                                            "partition_autobalancing_mode":
-                                            "node_add"
-                                        })
-        # start single node cluster
-        self.redpanda.start(nodes=[self.redpanda.nodes[0]])
-        # create some topics
-        topics = []
-        # include __consumer_offsets topic replica
-        total_replicas = 1
-        for partition_count in range(1, 5):
-            name = f"topic{len(topics)}"
-            spec = TopicSpec(name=name,
-                             partition_count=partition_count,
-                             replication_factor=1)
-            total_replicas += partition_count
-            topics.append(spec)
 
-        for spec in topics:
-            DefaultClient(self.redpanda).create_topic(spec)
-            self.topic = spec.name
+    group_topic_partitions = 16
 
-        self.start_producer(1)
-        self.start_consumer(1)
-        self.await_startup()
-        # add second node
-        self.redpanda.start_node(self.redpanda.nodes[1])
+    def _replicas_per_node(self):
         kafkacat = KafkaCat(self.redpanda)
+        node_replicas = {}
+        md = kafkacat.metadata()
+        self.redpanda.logger.info(f"metadata: {md}")
+        for topic in md['topics']:
+            for p in topic['partitions']:
+                for r in p['replicas']:
+                    id = r['id']
+                    if id not in node_replicas:
+                        node_replicas[id] = 0
+                    node_replicas[id] += 1
 
-        def _replicas_per_node():
-            node_replicas = {}
-            md = kafkacat.metadata()
-            self.redpanda.logger.info(f"metadata: {md}")
-            for topic in md['topics']:
-                for p in topic['partitions']:
-                    for r in p['replicas']:
-                        id = r['id']
-                        if id not in node_replicas:
-                            node_replicas[id] = 0
-                        node_replicas[id] += 1
+        return node_replicas
 
-            return node_replicas
+    def wait_for_partitions_rebalanced(self, total_replicas, timeout_sec):
+
+        expected_per_node = total_replicas / len(self.redpanda.started_nodes())
+        expected_range = [0.8 * expected_per_node, 1.2 * expected_per_node]
 
         def partitions_rebalanced():
-            per_node = _replicas_per_node()
-            self.redpanda.logger.info(f"replicas per node: {per_node}")
+            per_node = self._replicas_per_node()
+            self.redpanda.logger.info(
+                f"replicas per node: {per_node}, expected range: [{expected_range[0]},{expected_range[1]}]"
+            )
             if len(per_node) < len(self.redpanda.started_nodes()):
                 return False
 
@@ -80,11 +57,86 @@ class ScalingUpTest(EndToEndTest):
             if replicas != total_replicas:
                 return False
 
-            return all(p[1] > 1 for p in per_node.items())
+            return all(expected_range[0] < p[1] < expected_range[1]
+                       for p in per_node.items())
 
-        wait_until(partitions_rebalanced, timeout_sec=30, backoff_sec=1)
+        wait_until(partitions_rebalanced,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=1)
+
+    def create_topics(self, rf):
+        total_replicas = 0
+        topics = []
+        for _ in range(1, 5):
+            partitions = random.randint(10, 20)
+            spec = TopicSpec(partition_count=partitions, replication_factor=rf)
+            total_replicas += partitions * rf
+            topics.append(spec)
+
+        for spec in topics:
+            DefaultClient(self.redpanda).create_topic(spec)
+
+        self.topic = random.choice(topics).name
+
+        return total_replicas
+
+    @cluster(num_nodes=5)
+    def test_adding_nodes_to_cluster(self):
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        extra_rp_conf={
+                                            "group_topic_partitions":
+                                            self.group_topic_partitions,
+                                            "partition_autobalancing_mode":
+                                            "node_add"
+                                        })
+        # start single node cluster
+        self.redpanda.start(nodes=[self.redpanda.nodes[0]])
+        # create some topics
+        total_replicas = self.create_topics(rf=1)
+        # include __consumer_offsets topic replica
+        total_replicas += self.group_topic_partitions
+
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+        # add second node
+        self.redpanda.start_node(self.redpanda.nodes[1])
+        self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
+                                            timeout_sec=30)
         # add third node
         self.redpanda.start_node(self.redpanda.nodes[2])
-        wait_until(partitions_rebalanced, timeout_sec=30, backoff_sec=1)
+        self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
+                                            timeout_sec=30)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
+    @cluster(num_nodes=8)
+    def test_adding_multiple_nodes_to_the_cluster(self):
+
+        self.redpanda = RedpandaService(self.test_context,
+                                        6,
+                                        extra_rp_conf={
+                                            "partition_autobalancing_mode":
+                                            "node_add",
+                                            "group_topic_partitions":
+                                            self.group_topic_partitions
+                                        })
+        # start single node cluster
+        self.redpanda.start(nodes=self.redpanda.nodes[0:3])
+        # create some topics
+        topics = []
+        total_replicas = self.create_topics(rf=3)
+        # add consumer group topic replicas
+        total_replicas += self.group_topic_partitions * 3
+
+        throughput = 100000 if not self.debug_mode else 1000
+        self.start_producer(1, throughput=throughput)
+        self.start_consumer(1)
+        self.await_startup(min_records=15 * throughput, timeout_sec=120)
+        # add three nodes at once
+        for n in self.redpanda.nodes[3:]:
+            self.redpanda.start_node(n)
+
+        self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
+                                            timeout_sec=120)


### PR DESCRIPTION
## Rebalance fix with multiple nodes added at a time

An incorrect condition in `members_backend` caused rebalancing not to
stop when more than one node was added to the cluster in the same time.
The condition assumend that the allocator will always move the partition
to the node that the update is currentlty being processed. This is
incorrect assumption as the allocator should be a source of truth for
partition replica placement decisions.

Changed the conditions to relay only on partition allocator to achieve optimal partition distribution. 

## On demand rebalance API 

Added `POST v1/partitions/rebalance` API to trigger on demand partition rebalancing. 

## Improved partition rebalancing stop condition

When rebalancing partitions it may happen that the partition number isn't even or node are placed in racks so that the balancer will not be able to achieve even number of partitions per node. Added a stop condition based on monitoring the last improvement of unevenness error. If balancing improvement is insignificant then the balancing is stopped. 


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
- fixes automatic partition rebalancing when multiple nodes are added to the cluster before previous rebalancing finished
- Added `POST v1/partitions/rebalance` API to manually trigger partition rebalancing. 