### PR TITLE
Rebalance on demand

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -120,6 +120,9 @@ public:
     ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
 
     ss::sharded<storage::api>& get_storage() { return _storage; }
+    ss::sharded<members_backend>& get_members_backend() {
+        return _members_backend;
+    }
 
     bool is_raft0_leader() const {
         vassert(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -82,6 +82,8 @@ public:
     void start();
     ss::future<> stop();
 
+    ss::future<std::error_code> request_rebalance();
+
 private:
     void start_reconciliation_loop();
     ss::future<> reconcile();
@@ -97,7 +99,7 @@ private:
     void stop_node_addition(model::node_id id);
     void handle_reallocation_finished(model::node_id);
     void reassign_replicas(partition_assignment&, partition_reallocation&);
-    ss::future<> calculate_reallocations_after_node_added(
+    ss::future<> calculate_all_reallocations(
       update_meta&, partition_allocation_domain);
     ss::future<> calculate_reallocations_after_decommissioned(update_meta&);
     ss::future<> calculate_reallocations_after_recommissioned(update_meta&);

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1101,6 +1101,8 @@ operator<<(std::ostream& o, const members_manager::node_update_type& tp) {
         return o << "recommissioned";
     case members_manager::node_update_type::reallocation_finished:
         return o << "reallocation_finished";
+    case members_manager::node_update_type::on_demand:
+        return o << "on_demand_rebalance";
     }
     return o << "unknown";
 }

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -93,6 +93,8 @@ public:
         // (e.g. it's been fully decommissioned, indicating it can no longer be
         // recommissioned).
         reallocation_finished,
+        // on demand update requested manually by user
+        on_demand,
     };
 
     // Node update information to be processed by the members_backend.

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -186,6 +186,21 @@
             ]
         },
         {
+            "path": "/v1/partitions/rebalance",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Execute on demand partition rebalance",
+                    "type": "void",
+                    "nickname": "trigger_partitions_rebalance",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/partitions/{namespace}/{topic}/{partition}/unclean_abort_reconfiguration",
             "operations": [
                 {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -17,11 +17,13 @@
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
 #include "cluster/controller_api.h"
+#include "cluster/controller_stm.h"
 #include "cluster/errc.h"
 #include "cluster/feature_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/health_monitor_types.h"
+#include "cluster/members_backend.h"
 #include "cluster/members_frontend.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
@@ -2612,6 +2614,12 @@ void admin_server::register_partition_routes() {
           return set_partition_replicas_handler(std::move(req));
       });
 
+    register_route<superuser>(
+      ss::httpd::partition_json::trigger_partitions_rebalance,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return trigger_on_demand_reconfiguration_handler(std::move(req));
+      });
+
     register_route<user>(
       ss::httpd::partition_json::get_partition_reconfigurations,
       [this](std::unique_ptr<ss::httpd::request>) {
@@ -2638,6 +2646,19 @@ void admin_server::register_partition_routes() {
           }
           return ss::make_ready_future<ss::json::json_return_type>(ret);
       });
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::trigger_on_demand_reconfiguration_handler(
+  std::unique_ptr<ss::httpd::request> req) {
+    if (!_controller->is_raft0_leader()) {
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+    co_await _controller->get_members_backend().invoke_on(
+      cluster::controller_stm_shard, [](cluster::members_backend& backend) {
+          return backend.request_rebalance();
+      });
+    co_return ss::json::json_return_type(ss::json::json_void());
 }
 
 void admin_server::register_hbadger_routes() {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -25,6 +25,7 @@
 #include <seastar/http/file_handler.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/json_path.hh>
+#include <seastar/json/json_elements.hh>
 #include <seastar/util/log.hh>
 
 #include <absl/container/flat_hash_map.h>
@@ -284,6 +285,9 @@ private:
         std::unique_ptr<ss::httpd::request>);
     ss::future<ss::json::json_return_type>
       set_partition_replicas_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<ss::json::json_return_type>
+      trigger_on_demand_reconfiguration_handler(
+        std::unique_ptr<ss::httpd::request>);
 
     /// Transaction routes
     ss::future<ss::json::json_return_type>

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import random
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
@@ -88,3 +89,74 @@ class ScalingUpTest(EndToEndTest):
         wait_until(partitions_rebalanced, timeout_sec=30, backoff_sec=1)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
+    @cluster(num_nodes=8)
+    def test_adding_multiple_nodes_to_the_cluster(self):
+        group_topic_partitions = 16
+        self.redpanda = RedpandaService(self.test_context,
+                                        6,
+                                        extra_rp_conf={
+                                            "partition_autobalancing_mode":
+                                            "node_add",
+                                            "group_topic_partitions":
+                                            group_topic_partitions
+                                        })
+        # start single node cluster
+        self.redpanda.start(nodes=self.redpanda.nodes[0:3])
+        # create some topics
+        topics = []
+        total_replicas = 0
+        for _ in range(1, 5):
+            partitions = random.randint(10, 20)
+            spec = TopicSpec(partition_count=partitions, replication_factor=3)
+            total_replicas += partitions * 3
+            topics.append(spec)
+
+        total_replicas += group_topic_partitions * 3
+
+        for spec in topics:
+            DefaultClient(self.redpanda).create_topic(spec)
+            self.topic = spec.name
+        throughput = 100000 if not self.debug_mode else 1000
+        self.start_producer(1, throughput=throughput)
+        self.start_consumer(1)
+        self.await_startup(min_records=15 * throughput, timeout_sec=120)
+        # add three nodes at once
+        for n in self.redpanda.nodes[3:]:
+            self.redpanda.start_node(n)
+        kafkacat = KafkaCat(self.redpanda)
+
+        def _replicas_per_node():
+            node_replicas = {}
+            md = kafkacat.metadata()
+            for topic in md['topics']:
+                for p in topic['partitions']:
+                    for r in p['replicas']:
+                        id = r['id']
+                        if id not in node_replicas:
+                            node_replicas[id] = 0
+                        node_replicas[id] += 1
+
+            return node_replicas
+
+        expected_per_node = total_replicas / 6
+        expected_range = [0.8 * expected_per_node, 1.2 * expected_per_node]
+
+        def partitions_rebalanced():
+            per_node = _replicas_per_node()
+            self.redpanda.logger.info(
+                f"replicas per node: {per_node}, expected range: [{expected_range[0]},{expected_range[1]}]"
+            )
+            if len(per_node) < len(self.redpanda.started_nodes()):
+                return False
+
+            replicas = sum(per_node.values())
+            if replicas != total_replicas:
+                return False
+
+            return all(expected_range[0] < p[1] < expected_range[1]
+                       for p in per_node.items())
+
+        wait_until(partitions_rebalanced, timeout_sec=120, backoff_sec=1)
+
+        self.run_validation(enable_idempotence=False, consumer_timeout_sec=120)


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
