### PR TITLE
cloud storage/partition_recovery_manager: pass offset_map by value

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -178,8 +178,6 @@ private:
 
     using offset_map_t = absl::btree_map<model::offset, segment_meta>;
 
-    ss::future<offset_map_t> build_offset_map(const recovery_material& mat);
-
     ss::future<download_part> download_log_with_capped_size(
       offset_map_t offset_map,
       const partition_manifest& manifest,

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -181,13 +181,13 @@ private:
     ss::future<offset_map_t> build_offset_map(const recovery_material& mat);
 
     ss::future<download_part> download_log_with_capped_size(
-      const offset_map_t& offset_map,
+      offset_map_t offset_map,
       const partition_manifest& manifest,
       const std::filesystem::path& prefix,
       size_t max_size);
 
     ss::future<download_part> download_log_with_capped_time(
-      const offset_map_t& offset_map,
+      offset_map_t offset_map,
       const partition_manifest& manifest,
       const std::filesystem::path& prefix,
       model::timestamp_clock::duration retention_time);


### PR DESCRIPTION
following https://github.com/redpanda-data/redpanda/pull/7157#discussion_r1022930410
modify how offset_map is passed to download_log_with_capped_size, to make the usage of iterator across suspension points more future proof 

## Backports Required
- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes

* none
