### PR TITLE
cloud_storage/partition_recovery_manager: some include hygiene

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -12,42 +12,30 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/topic_manifest.h"
 #include "cloud_storage/types.h"
-#include "config/configuration.h"
 #include "hashing/xx.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
-#include "model/record.h"
 #include "model/record_batch_types.h"
 #include "model/timestamp.h"
-#include "s3/client.h"
-#include "s3/error.h"
-#include "storage/log_reader.h"
-#include "storage/logger.h"
 #include "storage/ntp_config.h"
 #include "storage/parser.h"
-#include "storage/segment_appender_utils.h"
 #include "utils/gate_guard.h"
 
 #include <seastar/core/abort_source.hh>
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/file-types.hh>
-#include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/iostream-impl.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
-#include <seastar/core/thread.hh>
 #include <seastar/util/log.hh>
 
 #include <absl/container/btree_map.h>
 #include <boost/algorithm/string/detail/sequence.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <chrono>
 #include <exception>

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -12,22 +12,16 @@
 
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/remote.h"
-#include "cloud_storage/topic_manifest.h"
-#include "cloud_storage/types.h"
 #include "model/metadata.h"
 #include "model/record.h"
 #include "s3/client.h"
 #include "storage/ntp_config.h"
-#include "utils/named_type.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 
-#include <compare>
-#include <iterator>
 #include <vector>
 
 namespace cloud_storage {


### PR DESCRIPTION
a small unused header cleanup on partition_recovery_manager.{h,cc}

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
* none
