### PR TITLE
Tolerate partition deallocation invariant failures from delete_topic_cmd

### DIFF
--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -30,6 +30,7 @@ public:
     enum class state { active, decommissioned, deleted };
     using allocation_capacity
       = named_type<uint32_t, struct allocation_node_slot_tag>;
+    enum class deallocation_error_policy { strict, relaxed };
 
     allocation_node(
       model::node_id,
@@ -122,7 +123,10 @@ public:
 private:
     friend allocation_state;
 
-    void deallocate_on(ss::shard_id core, partition_allocation_domain);
+    void deallocate_on(
+      ss::shard_id core,
+      partition_allocation_domain,
+      deallocation_error_policy);
     void allocate_on(ss::shard_id core, partition_allocation_domain);
 
     model::node_id _id;

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -28,7 +28,8 @@ void allocation_state::rollback(
   const std::vector<model::broker_shard>& v,
   const partition_allocation_domain domain) {
     for (auto& bs : v) {
-        deallocate(bs, domain);
+        deallocate(
+          bs, domain, allocation_node::deallocation_error_policy::strict);
     }
 }
 
@@ -157,9 +158,10 @@ bool allocation_state::is_empty(model::node_id id) const {
 
 void allocation_state::deallocate(
   const model::broker_shard& replica,
-  const partition_allocation_domain domain) {
+  const partition_allocation_domain domain,
+  const allocation_node::deallocation_error_policy error_policy) {
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
-        it->second->deallocate_on(replica.shard, domain);
+        it->second->deallocate_on(replica.shard, domain, error_policy);
     }
 }
 

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -42,7 +42,10 @@ public:
     int16_t available_nodes() const;
 
     // Operations on state
-    void deallocate(const model::broker_shard&, partition_allocation_domain);
+    void deallocate(
+      const model::broker_shard&,
+      partition_allocation_domain,
+      allocation_node::deallocation_error_policy);
     void apply_update(
       std::vector<model::broker_shard>,
       raft::group_id,

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -395,7 +395,8 @@ void partition_allocator::deallocate(
   const partition_allocation_domain domain) {
     for (auto& r : replicas) {
         // find in brokers
-        _state->deallocate(r, domain);
+        _state->deallocate(
+          r, domain, allocation_node::deallocation_error_policy::relaxed);
     }
 }
 
@@ -420,7 +421,8 @@ void partition_allocator::remove_allocations(
   const std::vector<model::broker_shard>& to_remove,
   const partition_allocation_domain domain) {
     for (const auto& bs : to_remove) {
-        _state->deallocate(bs, domain);
+        _state->deallocate(
+          bs, domain, allocation_node::deallocation_error_policy::relaxed);
     }
 }
 

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -63,7 +63,10 @@ allocation_units::~allocation_units() {
     for (auto& pas : _assignments) {
         for (auto& replica : pas.replicas) {
             if (!_previous.contains(replica)) {
-                _state->deallocate(replica, _domain);
+                _state->deallocate(
+                  replica,
+                  _domain,
+                  allocation_node::deallocation_error_policy::strict);
             }
         }
     }


### PR DESCRIPTION
A controller log may possibly end up with the commands sequence that
would deallocate partitions from a node when the node does not have
partitions in the domain. This change relaxes `vassert` to log warning
in deallocation scenarios that directly result from `delete_topic_cmd`
and prevents decreasing pratition counts below zero.

May be a workarond for #7343.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

* none 
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* Automatic recovery from certain controller states causing deletion of non-exiting partitions while replaying

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
