### PR TITLE
cluster: allow seeds-driven bootstrap when empty_seed_starts_cluster=1

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -575,15 +575,6 @@ controller::create_cluster(const bootstrap_cluster_cmd_data cmd_data) {
  */
 ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
     if (co_await discovery.is_cluster_founder()) {
-        if (config::node().empty_seed_starts_cluster()) {
-            vassert(
-              config::node().seed_servers().empty(),
-              "Cluster founder is not the root node");
-            vassert(
-              _raft0->config().brokers().size() == 1,
-              "Root is a cluster founder but joiners are in the cluster alrdy");
-        }
-
         // Full cluster bootstrap
         bootstrap_cluster_cmd_data cmd_data;
         cmd_data.uuid = model::cluster_uuid(uuid_t::create());

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -65,9 +65,12 @@ node_config::node_config() noexcept
   , empty_seed_starts_cluster(
       *this,
       "empty_seed_starts_cluster",
-      "If enabled, requires exactly one node in a cluster-to-be to have its "
-      "seed_servers list empty. Otherwise, seed_servers list cannot be empty, "
-      "and must be the same in each node from that list",
+      "If true, an empty seed_servers list will denote that this node should "
+      "form a cluster. At most one node in the cluster should be configured "
+      "configured with an empty seed_servers list. If no such configured node "
+      "exists, or if configured to false, all nodes denoted by the "
+      "seed_servers list must be identical among those nodes' configurations, "
+      "and those nodes will form the initial cluster.",
       {.visibility = visibility::user},
       true)
   , rpc_server(


### PR DESCRIPTION
Previously, empty_seed_starts_cluster=1 meant that the node was configured to use root-driven bootstrap and that it should expect some singular node in the cluster to have an empty seeds list. This is the default, and was mainly there for compatibility reasons. However, this default is currently explicitly incompatible with seeds-driven bootstrap, and thus is incompatible with having all node configurations in the cluster being identical.

To encourage usage of seeds-driven bootstrap, and to allow homogeneous node configs by default, this commit makes empty_seed_starts_cluster=1 compatible with seeds-driven bootstrap. An empty seed_servers list still indicates that the configured node should be the root node, but seeds-driven bootstrap can be used with empty_seed_starts_cluster=1 if:
- there exists no root node among any of the seeds, and
- all seeds meet the existing requirements to perform seeds-driven bootstrap.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

  ### Improvements

  * The `seed_servers` node configuration may now be identical on each node to form a cluster, even when `empty_seed_starts_cluster` is `true` (the default).
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.


If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
