### PR TITLE
Rate limiting per client groups

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   SRCS
     rest_authn_endpoint.cc
     broker_authn_endpoint.cc
+    client_group_byte_rate_quota.cc
     configuration.cc
     node_config.cc
     base_property.cc

--- a/src/v/config/client_group_byte_rate_quota.cc
+++ b/src/v/config/client_group_byte_rate_quota.cc
@@ -1,0 +1,68 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/client_group_byte_rate_quota.h"
+
+namespace config {
+
+std::ostream& operator<<(std::ostream& os, const client_group_quota& rq) {
+    fmt::print(
+      os,
+      "{{group_name: {}, client_prefix: {}, quota: {}}}",
+      rq.group_name,
+      rq.clients_prefix,
+      rq.quota);
+    return os;
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::client_group_quota>::encode(const type& rhs) {
+    Node node;
+    node["group_name"] = rhs.group_name;
+    node["clients_prefix"] = rhs.clients_prefix;
+    node["quota"] = rhs.quota;
+    return node;
+}
+
+bool convert<config::client_group_quota>::decode(const Node& node, type& rhs) {
+    for (const auto& s : {"group_name", "clients_prefix", "quota"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+    auto group_name = node["group_name"].as<ss::sstring>();
+    auto clients_prefix = node["clients_prefix"].as<ss::sstring>();
+    auto quota = node["quota"].as<int64_t>();
+    rhs = config::client_group_quota{
+      .group_name = std::move(group_name),
+      .clients_prefix = std::move(clients_prefix),
+      .quota = quota};
+    return true;
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::client_group_quota& ep) {
+    w.StartObject();
+    w.Key("group_name");
+    w.String(ep.group_name);
+    w.Key("clients_prefix");
+    w.String(ep.clients_prefix);
+    w.Key("quota");
+    w.Int64(ep.quota);
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/client_group_byte_rate_quota.h
+++ b/src/v/config/client_group_byte_rate_quota.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/property.h"
+#include "json/_include_first.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <yaml-cpp/node/node.h>
+
+#include <iosfwd>
+#include <string>
+
+namespace config {
+
+struct client_group_quota {
+    using key_type = ss::sstring;
+
+    ss::sstring group_name;
+    ss::sstring clients_prefix;
+    int64_t quota;
+
+    static ss::sstring key_name() { return "group_name"; }
+
+    const ss::sstring& key() const { return group_name; }
+
+    friend bool operator==(const client_group_quota&, const client_group_quota&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const client_group_quota& ep);
+};
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<client_group_quota>() {
+    return "config::client_group_quota";
+}
+
+} // namespace detail
+
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::client_group_quota> {
+    using type = config::client_group_quota;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::client_group_quota& ep);
+
+} // namespace json

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -948,6 +948,18 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
+  , kafka_client_group_byte_rate_quota(
+      *this,
+      "kafka_client_group_byte_rate_quota",
+      "Per-group target quota byte rate (bytes per second). "
+      "Client is considered part of the group if client_id contains "
+      "clients_prefix",
+      {.needs_restart = needs_restart::no,
+       .example
+       = R"([{'group_name': 'first_group','clients_prefix': 'group_1','quota': 10240}])",
+       .visibility = visibility::user},
+      {},
+      validate_client_groups_byte_rate_quota)
   , kafka_rpc_server_tcp_recv_buf(
       *this,
       "kafka_rpc_server_tcp_recv_buf",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/bounded_property.h"
 #include "config/broker_endpoint.h"
+#include "config/client_group_byte_rate_quota.h"
 #include "config/config_store.h"
 #include "config/convert.h"
 #include "config/data_directory_path.h"
@@ -197,6 +198,8 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>> kafka_connections_max;
     property<std::optional<uint32_t>> kafka_connections_max_per_ip;
     property<std::vector<ss::sstring>> kafka_connections_max_overrides;
+    one_or_many_map_property<client_group_quota>
+      kafka_client_group_byte_rate_quota;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_recv_buf;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_send_buf;
     bounded_property<std::optional<size_t>> kafka_rpc_server_stream_recv_buf;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -20,6 +20,8 @@
 #include <boost/lexical_cast.hpp>
 #include <yaml-cpp/yaml.h>
 
+#include <unordered_map>
+
 namespace YAML {
 
 template<>
@@ -310,6 +312,42 @@ struct convert<model::partition_autobalancing_mode> {
             return false;
         }
 
+        return true;
+    }
+};
+
+template<typename T>
+concept has_hashable_key_type = requires(T x) {
+    x.key_name();
+    {
+        std::hash<typename T::key_type>{}(x.key())
+        } -> std::convertible_to<std::size_t>;
+};
+
+template<has_hashable_key_type T>
+struct convert<std::unordered_map<typename T::key_type, T>> {
+    using type = std::unordered_map<typename T::key_type, T>;
+    static Node encode(const type& rhs) {
+        Node node;
+        for (const auto& group : rhs) {
+            node.push_back(convert<T>::encode(group.second));
+        }
+        return node;
+    }
+    static bool decode(const Node& node, type& rhs) {
+        rhs = std::unordered_map<typename T::key_type, T>{};
+        if (node.IsSequence()) {
+            for (auto elem : node) {
+                if (!elem[T::key_name()]) {
+                    return false;
+                }
+                auto elem_val = elem.as<T>();
+                rhs.emplace(elem_val.key(), elem_val);
+            }
+        } else {
+            auto elem_val = node.as<T>();
+            rhs.emplace(elem_val.key(), elem_val);
+        }
         return true;
     }
 };

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -371,6 +371,12 @@ concept is_collection = requires(T x) {
 };
 
 template<typename T>
+concept is_pair = requires(T x) {
+    typename T::first_type;
+    typename T::second_type;
+};
+
+template<typename T>
 struct dependent_false : std::false_type {};
 
 template<typename T>
@@ -386,6 +392,8 @@ consteval std::string_view property_type_name() {
         return property_type_name<typename type::value_type>();
     } else if constexpr (is_collection<type>) {
         return property_type_name<typename type::value_type>();
+    } else if constexpr (is_pair<type>) {
+        return property_type_name<typename type::second_type>();
     } else if constexpr (has_type_name<type>) {
         return type::type_name();
     } else if constexpr (std::is_same_v<type, model::compression>) {
@@ -529,6 +537,51 @@ private:
             }
         } else {
             value.push_back(std::move(n.as<T>()));
+        }
+        return value;
+    }
+};
+
+/*
+ * Same as property<std::unordered_map<T::key_type, T>> but will also decode a
+ * single T. This can be useful for dealing with backwards compatibility or
+ * creating easier yaml schemas that have simplified special cases.
+ */
+template<typename T>
+class one_or_many_map_property
+  : public property<std::unordered_map<typename T::key_type, T>> {
+public:
+    using property<std::unordered_map<typename T::key_type, T>>::property;
+
+    bool set_value(YAML::Node n) override {
+        auto value = decode_yaml(std::move(n));
+        return property<std::unordered_map<typename T::key_type, T>>::
+          update_value(std::move(value));
+    }
+
+    std::optional<validation_error> validate(YAML::Node n) const override {
+        std::unordered_map<typename T::key_type, T> value = decode_yaml(
+          std::move(n));
+        return property<std::unordered_map<typename T::key_type, T>>::validate(
+          value);
+    }
+
+private:
+    /**
+     * Given either a single value or a list of values, return
+     * a hash_map of decoded values.
+     **/
+    std::unordered_map<typename T::key_type, T>
+    decode_yaml(const YAML::Node& n) const {
+        std::unordered_map<typename T::key_type, T> value;
+        if (n.IsSequence()) {
+            for (const auto& elem : n) {
+                auto elem_val = elem.as<T>();
+                value.emplace(elem_val.key(), std::move(elem_val));
+            }
+        } else {
+            auto elem_val = n.as<T>();
+            value.emplace(elem_val.key(), std::move(elem_val));
         }
         return value;
     }

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -7,7 +7,8 @@ set(srcs
     tls_config_convert_test.cc
     advertised_kafka_api_test.cc
     seed_server_property_test.cc
-    cloud_credentials_source_test.cc)
+    cloud_credentials_source_test.cc
+    validator_tests.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/config/tests/validator_tests.cc
+++ b/src/v/config/tests/validator_tests.cc
@@ -1,0 +1,69 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/validators.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(test_client_groups_byte_rate_quota_invalid_config) {
+    std::unordered_map<ss::sstring, config::client_group_quota> repeated_group{
+      {"group1", {"group1", "group1", 1}},
+      {"group2", {"group2", "group1", 1}},
+      {"group3", {"group3", "group3", 1}}};
+    auto result = config::validate_client_groups_byte_rate_quota(
+      repeated_group);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(
+      result->find("Group client prefix can not be prefix for another group")
+      != ss::sstring::npos);
+
+    std::unordered_map<ss::sstring, config::client_group_quota> prefix_group{
+      {"group1", {"group1", "group1", 1}},
+      {"special_group", {"special_group", "special_group", 1}},
+      {"group", {"group", "group", 1}}};
+    result = config::validate_client_groups_byte_rate_quota(prefix_group);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(
+      result->find("Group client prefix can not be prefix for another group")
+      != ss::sstring::npos);
+
+    std::unordered_map<ss::sstring, config::client_group_quota> prefix_group_2{
+      {"g", {"g", "g", 1}},
+      {"group1", {"group1", "group1", 1}},
+      {"group2", {"group2", "group2", 1}}};
+    result = config::validate_client_groups_byte_rate_quota(prefix_group_2);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(
+      result->find("Group client prefix can not be prefix for another group")
+      != ss::sstring::npos);
+
+    std::unordered_map<ss::sstring, config::client_group_quota> zero_rate{
+      {"group1", {"group1", "group1", 1}}, {"group2", {"group2", "group2", 0}}};
+    result = config::validate_client_groups_byte_rate_quota(zero_rate);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(
+      result->find("Quota must be a non zero positive number")
+      != ss::sstring::npos);
+
+    std::unordered_map<ss::sstring, config::client_group_quota> negative_rate{
+      {"group1", {"group1", "group1", 1}},
+      {"group2", {"group2", "group2", -10}}};
+    result = config::validate_client_groups_byte_rate_quota(negative_rate);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(
+      result->find("Quota must be a non zero positive number")
+      != ss::sstring::npos);
+
+    std::unordered_map<ss::sstring, config::client_group_quota> valid_config{
+      {"group1", {"group1", "group1", 9223372036854775807}},
+      {"group2", {"group2", "group2", 1073741824}},
+      {"another_group", {"another_group", "another_group", 1}}};
+    result = config::validate_client_groups_byte_rate_quota(valid_config);
+    BOOST_TEST(!result.has_value());
+}

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -11,33 +11,40 @@
 
 #include "config/validators.h"
 
+#include "config/client_group_byte_rate_quota.h"
 #include "net/inet_address_wrapper.h"
 
 #include <absl/container/node_hash_set.h>
 #include <fmt/format.h>
 
 #include <optional>
+#include <unordered_map>
 
 namespace config {
 
 std::optional<std::pair<ss::sstring, int64_t>>
-parse_connection_rate_override(const ss::sstring& raw_option) {
+split_string_int_by_colon(const ss::sstring& raw_option) {
     auto del_pos = raw_option.find(":");
     if (del_pos == ss::sstring::npos || del_pos == raw_option.size() - 1) {
         return std::nullopt;
     }
 
-    auto ip = raw_option.substr(0, del_pos);
-    auto rate_str = raw_option.substr(del_pos + 1);
+    auto str_val = raw_option.substr(0, del_pos);
+    auto int_val = raw_option.substr(del_pos + 1);
 
     std::pair<ss::sstring, int64_t> ans;
-    ans.first = ip;
+    ans.first = str_val;
     try {
-        ans.second = std::stoi(rate_str);
+        ans.second = std::stoll(int_val);
     } catch (...) {
         return std::nullopt;
     }
     return ans;
+}
+
+std::optional<std::pair<ss::sstring, int64_t>>
+parse_connection_rate_override(const ss::sstring& raw_option) {
+    return split_string_int_by_colon(raw_option);
 }
 
 std::optional<ss::sstring>
@@ -61,6 +68,36 @@ validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit) {
         if (!ip_set.insert(addr).second) {
             return fmt::format(
               "Duplicate setting for ip: {}", parsing_setting->first);
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
+  const std::unordered_map<ss::sstring, config::client_group_quota>&
+    groups_with_limit) {
+    for (const auto& gal : groups_with_limit) {
+        if (gal.second.quota <= 0) {
+            return fmt::format(
+              "Quota must be a non zero positive number, got: {}",
+              gal.second.quota);
+        }
+
+        for (const auto& another_group : groups_with_limit) {
+            if (another_group.first == gal.first) {
+                continue;
+            }
+            if (std::string_view(gal.second.clients_prefix)
+                  .starts_with(
+                    std::string_view(another_group.second.clients_prefix))) {
+                return fmt::format(
+                  "Group client prefix can not be prefix for another group "
+                  "name. "
+                  "Violation: {}, {}",
+                  gal.second.clients_prefix,
+                  another_group.second.clients_prefix);
+            }
         }
     }
 

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "config/client_group_byte_rate_quota.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -24,5 +25,8 @@ parse_connection_rate_override(const ss::sstring& raw_option);
 
 std::optional<ss::sstring>
 validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit);
+
+std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
+  const std::unordered_map<ss::sstring, config::client_group_quota>&);
 
 }; // namespace config

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <type_traits>
+#include <unordered_map>
 
 namespace json {
 
@@ -87,6 +88,17 @@ void rjson_serialize(
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
+template<typename T>
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const std::unordered_map<typename T::key_type, T>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e.second);
     }
     w.EndArray();
 }

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -63,9 +63,12 @@ public:
         config::shard_local_cfg().default_num_windows.bind())
       , _default_window_width(
           config::shard_local_cfg().default_window_sec.bind())
-      , _target_tp_rate(config::shard_local_cfg().target_quota_byte_rate.bind())
+      , _default_target_tp_rate(
+          config::shard_local_cfg().target_quota_byte_rate.bind())
       , _target_partition_mutation_quota(
           config::shard_local_cfg().kafka_admin_topic_api_rate.bind())
+      , _target_tp_rate_per_client_group(
+          config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
       , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
       , _max_delay(
           config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
@@ -130,12 +133,19 @@ private:
     underlying_t::iterator maybe_add_and_retrieve_quota(
       const std::optional<std::string_view>&, const clock::time_point&);
 
+    std::optional<std::string_view>
+    get_client_quota(const std::optional<std::string_view>& client_id);
+    int64_t
+    get_client_target_tp_rate(const std::optional<std::string_view>& quota_id);
+
 private:
     config::binding<int16_t> _default_num_windows;
     config::binding<std::chrono::milliseconds> _default_window_width;
 
-    config::binding<uint32_t> _target_tp_rate;
+    config::binding<uint32_t> _default_target_tp_rate;
     config::binding<std::optional<uint32_t>> _target_partition_mutation_quota;
+    config::binding<std::unordered_map<ss::sstring, config::client_group_quota>>
+      _target_tp_rate_per_client_group;
 
     underlying_t _quotas;
 


### PR DESCRIPTION
Adding rate limiting per client group.
Now it is possible to unite clients into groups so clients under one group will have common rate quota.
Group name is any string. Client is part of the group if its client_id prefix is equal to group name.
For Groups we create separate rate limiters. Before we were creating limiter for every client

Potential problem:
Every shard has its own quota

Fixes https://github.com/redpanda-data/core-internal/issues/43


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes

  ### Features

Clients can be united in one group in order to have common rate quota.
