### PR TITLE
Unevenness error stop condition improvements/fixes

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -335,8 +335,8 @@ double members_backend::calculate_unevenness_error() const {
     static const std::vector<partition_allocation_domain> domains{
       partition_allocation_domains::consumer_offsets,
       partition_allocation_domains::common};
-    size_t err = 0;
-    size_t max_err = 0;
+    double err = 0;
+    double max_err = 0;
 
     const auto node_cnt = _allocator.local().state().available_nodes();
     for (auto d : domains) {
@@ -351,18 +351,18 @@ double members_backend::calculate_unevenness_error() const {
           = total_replicas / _allocator.local().state().available_nodes();
         // max error is an error calculated when all replicas are allocated on
         // the same node
-        auto domain_max_err = (total_replicas - target_replicas_per_node)
-                              + target_replicas_per_node * (node_cnt - 1);
+        double domain_max_err = (total_replicas - target_replicas_per_node)
+                                + target_replicas_per_node * (node_cnt - 1);
         // divide by total replicas and node count to make the error independent
         // from number of nodes and number of topics.
-        domain_max_err /= total_replicas;
-        domain_max_err /= node_cnt;
+        domain_max_err /= static_cast<double>(total_replicas);
+        domain_max_err /= static_cast<double>(node_cnt);
 
-        size_t domain_err = 0;
+        double domain_err = 0;
         for (auto& [id, allocation_info] : node_replicas) {
-            int64_t diff = static_cast<int64_t>(target_replicas_per_node)
-                           - static_cast<int64_t>(
-                             allocation_info.allocated_replicas);
+            double diff = static_cast<double>(target_replicas_per_node)
+                          - static_cast<double>(
+                            allocation_info.allocated_replicas);
 
             vlog(
               clusterlog.trace,
@@ -374,12 +374,12 @@ double members_backend::calculate_unevenness_error() const {
               diff);
             domain_err += std::abs(diff);
         }
-        err += domain_err / (total_replicas * node_cnt);
+        err += domain_err / (static_cast<double>(total_replicas) * node_cnt);
         max_err += domain_max_err;
     }
 
     // normalize error to stay in range (0,1)
-    return err / (double)max_err;
+    return err / max_err;
 }
 
 ss::future<> members_backend::calculate_reallocations_for_even_partition_count(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -125,7 +125,7 @@ private:
     bool should_stop_rebalancing_update(double, const update_meta&) const;
 
     static size_t calculate_total_replicas(const node_replicas_map_t&);
-
+    void reset_last_unevenness_error();
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;
     ss::sharded<partition_allocator>& _allocator;
@@ -146,7 +146,8 @@ private:
     ss::condition_variable _new_updates;
     ss::metrics::metric_groups _metrics;
     config::binding<size_t> _max_concurrent_reallocations;
-    double _last_unevenness_error = std::numeric_limits<double>::max();
+    // unevenness error is normalized to be at most 1.0, set to max
+    double _last_unevenness_error = 1.0;
     /**
      * store revision of node decommissioning update, decommissioning command
      * revision is stored when node is being decommissioned, it is used to


### PR DESCRIPTION
Improved handling of stop condition based on lack of partition balance improvement. 

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
