### PR TITLE
[v22.2.x] treewide: Small cleanups for llvm-15

### DIFF
--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -83,12 +83,10 @@ inline iobuf generate_segment(
   model::offset base_offset, const std::vector<batch_t>& batches) {
     auto buff = make_random_batches(base_offset, batches);
     iobuf result;
-    int ix = 0;
     for (auto&& batch : buff) {
         auto hdr = storage::disk_header_to_iobuf(batch.header());
         result.append(std::move(hdr));
         result.append(iobuf_deep_copy(batch.data()));
-        ix++;
     }
     return result;
 }

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -516,15 +516,12 @@ FIXTURE_TEST(updating_nodes_properties, partition_allocator_fixture) {
     register_node(1, 4);
     register_node(2, 7);
 
-    auto capacity = max_capacity();
-
     // change node 1 core coung from 4 to 10
     for (int i = 0; i < 50; ++i) {
         // try to allocate single partition
         auto req = make_allocation_request(1, 1);
         auto res = allocator.allocate(std::move(req));
         if (res) {
-            capacity--;
             for (auto& as : res.value().get_assignments()) {
                 allocator.update_allocation_state(
                   as.replicas,

--- a/src/v/http/tests/framing_test.cc
+++ b/src/v/http/tests/framing_test.cc
@@ -92,7 +92,7 @@ public:
 
 private:
     std::random_device _rnddev;
-    std::uniform_int_distribution<char> _dist;
+    std::uniform_int_distribution<int8_t> _dist;
 };
 
 struct test_case {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7349
