### PR TITLE
rpk clocksource tuner only enabled for amd

### DIFF
--- a/src/go/rpk/pkg/tuners/clocksource.go
+++ b/src/go/rpk/pkg/tuners/clocksource.go
@@ -11,6 +11,7 @@ package tuners
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/executors"
@@ -50,6 +51,10 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 			return NewTuneResult(false)
 		},
 		func() (bool, string) {
+			// tsc clocksource is only available in x86 architectures.
+			if runtime.GOARCH != "amd64" && runtime.GOARCH != "386" {
+				return false, "Clocksource setting not available for this architecture"
+			}
 			content, err := afero.ReadFile(fs,
 				"/sys/devices/system/clocksource/clocksource0/available_clocksource")
 			if err != nil {
@@ -63,7 +68,7 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 				}
 			}
 			return false, fmt.Sprintf(
-				"Preferred clocksource '%s' not avaialable", preferredClkSource)
+				"Preferred clocksource '%s' not available", preferredClkSource)
 		},
 		executor.IsLazy(),
 	)

--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -83,6 +83,18 @@ net                    true     true
 swappiness             true     true       
 transparent_hugepages  true     true       
 '''
+
+        uname = str(node.account.ssh_output("uname -m"))
+        # either x86-64 or i386.
+        is_not_x86 = "86" not in uname
+
+        # Clocksource is only available for x86 architectures.
+        expected = expected.replace(
+            "clocksource            true     true       ",
+            "clocksource            true     false      Clocksource setting not available for this architecture"
+        ) if is_not_x86 else expected
+
         output = rpk.tune("list")
+        self.logger.debug(output)
 
         assert output == expected


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->
Our recommended clocksource is `tsc`, which is only present for x86 architectures

In arch != amd rpk will show that the tuner is not available and print:
```
 Clocksource setting not available for this architecture
```

Instead of:
```
 Preferred clocksource 'tsc' not available
```

This PR also fixes one ducktape test failing in ARM instances, tested in:

**CDT_ARCH=arm64 CDT_INSTANCE_TYPE=is4gen.4xlarge**
```
test_id:    rptest.tests.rpk_tuner_test.RpkTunerTest.test_tune_transparent_hugepages
status:     PASS
run time:   6.403 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_tuner_test.RpkTunerTest.test_tune_prod_all
status:     PASS
run time:   6.484 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_tuner_test.RpkTunerTest.test_tune_list
status:     PASS
run time:   6.643 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_tuner_test.RpkTunerTest.test_tune_fstrim
status:     PASS
run time:   8.271 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------
==============================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2022-11-21--002
run time:         8.296 seconds
tests run:        4
passed:           4
failed:           0
ignored:          0
opassed:          0
ofailed:          0
==============================================================================================================================================================
~
```
Fixes #7403, Fixes #6446


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
### Improvements

* rpk tune clocksource will display a better error message when executed from machines with unsupported architectures.
