### PR TITLE
rpk: add fetch_reads_debounce_timeout to help text

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1070,6 +1070,7 @@ environments:
         * group_topic_partitions: 3
         * storage_min_free_bytes: 10485760 (10MiB)
         * topic_partitions_per_shard: 1000
+        * fetch_reads_debounce_timeout: 10
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`


### PR DESCRIPTION
I added this field to dev-container mode in 0ed8111bd235845c9b1fd7370184f3731879a8d7 but forgot to update the help text.

Doc change: https://github.com/redpanda-data/documentation/pull/837

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
