### PR TITLE
rpk: encourage users to restart nodes on config change if required

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -195,6 +195,15 @@ func importConfig(
 
 	fmt.Printf("Successfully updated configuration. New configuration version is %d.\n", result.ConfigVersion)
 
+	status, err := client.ClusterConfigStatus(ctx, true)
+	out.MaybeDie(err, "unable to check if the cluster needs to be restarted: %v\nCheck the status with 'rpk cluster config status'.", err)
+	for _, value := range status {
+		if value.Restart {
+			fmt.Print("\nCluster needs to be restarted. See more details with 'rpk cluster config status'.\n")
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
@@ -91,6 +91,15 @@ If an empty string is given as the value, the property is reset to its default.`
 
 			out.MaybeDie(err, "error setting property: %v", err)
 			fmt.Printf("Successfully updated configuration. New configuration version is %d.\n", result.ConfigVersion)
+
+			status, err := client.ClusterConfigStatus(cmd.Context(), true)
+			out.MaybeDie(err, "unable to check if the cluster needs to be restarted: %v\nCheck the status with 'rpk cluster config status'.", err)
+			for _, value := range status {
+				if value.Restart {
+					fmt.Print("\nCluster needs to be restarted. See more details with 'rpk cluster config status'.\n")
+					break
+				}
+			}
 		},
 	}
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -634,15 +634,16 @@ class ClusterConfigTest(RedpandaTest):
             file.flush()
             import_stdout = self.rpk.cluster_config_import(file.name, all)
 
-        last_line = import_stdout.strip().split("\n")[-1]
-        m = re.match(r"^.+New configuration version is (\d+).*$", last_line)
+        m = re.match(r"^.+New configuration version is (\d+).*$",
+                     import_stdout,
+                     flags=re.DOTALL)
 
-        self.logger.debug(f"_import status: {last_line}")
+        self.logger.debug(f"_import status: {import_stdout}")
 
         if m is None and allow_noop:
             return None
 
-        assert m is not None, f"Config version not found: {last_line}"
+        assert m is not None, f"Config version not found: {import_stdout}"
         version = int(m.group(1))
         return version
 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/7420

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

Upon completion of `rpk cluster config edit` or `rpk cluster config set`, print the following message if restart is required:

```
Cluster needs to be restarted. See more details with 'rpk cluster config status'
```

