### PR TITLE
Changed rebalancing timeout in scaling up test

### DIFF
--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -24,7 +24,7 @@ class ScalingUpTest(EndToEndTest):
     Adding nodes to the cluster should result in partition reallocations to new
     nodes
     """
-
+    rebalance_timeout = 120
     group_topic_partitions = 16
 
     def _replicas_per_node(self):
@@ -113,11 +113,11 @@ class ScalingUpTest(EndToEndTest):
         # add second node
         self.redpanda.start_node(self.redpanda.nodes[1])
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
-                                            timeout_sec=30)
+                                            timeout_sec=self.rebalance_timeout)
         # add third node
         self.redpanda.start_node(self.redpanda.nodes[2])
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
-                                            timeout_sec=30)
+                                            timeout_sec=self.rebalance_timeout)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
@@ -151,7 +151,7 @@ class ScalingUpTest(EndToEndTest):
             self.redpanda.start_node(n)
 
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
-                                            timeout_sec=120)
+                                            timeout_sec=self.rebalance_timeout)
 
     @cluster(num_nodes=8)
     @matrix(partition_count=[1, 20])
@@ -176,7 +176,8 @@ class ScalingUpTest(EndToEndTest):
         throughput = 100000 if not self.debug_mode else 1000
         self.start_producer(1, throughput=throughput)
         self.start_consumer(1)
-        self.await_startup(min_records=5 * throughput, timeout_sec=120)
+        self.await_startup(min_records=5 * throughput,
+                           timeout_sec=self.rebalance_timeout)
         # add three nodes
         for n in self.redpanda.nodes[3:]:
             self.redpanda.start_node(n)
@@ -192,4 +193,4 @@ class ScalingUpTest(EndToEndTest):
         admin.trigger_rebalance()
 
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
-                                            timeout_sec=120)
+                                            timeout_sec=self.rebalance_timeout)


### PR DESCRIPTION
Scaling up tests was recently parametrized with partition count. For the large partition count it is not enough to wait 30 seconds for the partitions to be rebalanced, especially for the slow debug builds.


Signed-off-by: Michal Maslanka <michal@redpanda.com>

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
