### PR TITLE
Metrics for rack awareness repair

### DIFF
--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -48,10 +48,22 @@ public:
       const std::vector<model::broker_shard>& next);
 
 private:
+    struct probe {
+        explicit probe(const partition_balancer_state&);
+
+        void setup_metrics(ss::metrics::metric_groups&);
+
+        const partition_balancer_state& _parent;
+        ss::metrics::metric_groups _metrics;
+        ss::metrics::metric_groups _public_metrics;
+    };
+
+private:
     topic_table& _topic_table;
     members_table& _members_table;
     partition_allocator& _partition_allocator;
     absl::btree_set<model::ntp> _ntps_with_broken_rack_constraint;
+    probe _probe;
 };
 
 } // namespace cluster


### PR DESCRIPTION
Add a metric named `vectorized_cluster_partition_num_with_broken_rack_constraint` with a value equal to total number of partitions with broken rack awareness constraint.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
### Features
  * Add `vectorized_cluster_partition_num_with_broken_rack_constraint` metric (total number of partitions that don't satisfy the rack awareness constraint)