### PR TITLE
[v22.2.x] rpk clocksource tuner only enabled for amd

### DIFF
--- a/src/go/rpk/pkg/tuners/clocksource.go
+++ b/src/go/rpk/pkg/tuners/clocksource.go
@@ -11,6 +11,7 @@ package tuners
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/executors"
@@ -50,6 +51,10 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 			return NewTuneResult(false)
 		},
 		func() (bool, string) {
+			// tsc clocksource is only available in x86 architectures.
+			if runtime.GOARCH != "amd64" && runtime.GOARCH != "386" {
+				return false, "Clocksource setting not available for this architecture"
+			}
 			content, err := afero.ReadFile(fs,
 				"/sys/devices/system/clocksource/clocksource0/available_clocksource")
 			if err != nil {
@@ -63,7 +68,7 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 				}
 			}
 			return false, fmt.Sprintf(
-				"Preferred clocksource '%s' not avaialable", preferredClkSource)
+				"Preferred clocksource '%s' not available", preferredClkSource)
 		},
 		executor.IsLazy(),
 	)

--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -83,6 +83,18 @@ net                    true     true
 swappiness             true     true       
 transparent_hugepages  true     true       
 '''
+
+        uname = str(node.account.ssh_output("uname -m"))
+        # either x86-64 or i386.
+        is_not_x86 = "86" not in uname
+
+        # Clocksource is only available for x86 architectures.
+        expected = expected.replace(
+            "clocksource            true     true       ",
+            "clocksource            true     false      Clocksource setting not available for this architecture"
+        ) if is_not_x86 else expected
+
         output = rpk.tune("list")
+        self.logger.debug(output)
 
         assert output == expected


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7412
Fixes https://github.com/redpanda-data/redpanda/issues/7442,