### PR TITLE
[v22.3.x] archival: allow scheduler service to stop early in unit tests

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -193,6 +193,11 @@ ss::future<> scheduler_service_impl::start() {
 }
 
 ss::future<> scheduler_service_impl::stop() {
+    if (_stopped) {
+        vlog(_rtclog.info, "Scheduler service is already stopped");
+        co_return;
+    }
+    _stopped = true;
     vlog(_rtclog.info, "Scheduler service stop");
     _timer.cancel();
     co_await _gate.close();

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -33,8 +33,6 @@
 namespace archival {
 namespace internal {
 
-class archiver_replacer;
-
 using namespace std::chrono_literals;
 
 /// Shard-local archiver service.
@@ -48,8 +46,6 @@ using namespace std::chrono_literals;
 /// - Re-upload manifest(s)
 /// - Reset timer
 class scheduler_service_impl {
-    friend class archiver_replacer;
-
 public:
     /// \brief create scheduler service
     ///

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -144,6 +144,13 @@ private:
     ss::lowres_clock::duration _topic_manifest_upload_timeout;
     ss::lowres_clock::duration _initial_backoff;
     ss::scheduling_group _upload_sg;
+
+    // Storing the stopped state allows the scheduler stop method to be called
+    // multiple times safely without triggering assertions in the gate and in
+    // the archivers which have already been stopped. This makes it possible to
+    // stop early in test code where the scheduler has been wired into the
+    // redpanda app which will try to stop scheduler again during test shutdown.
+    bool _stopped{false};
 };
 
 } // namespace internal

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -310,7 +310,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
@@ -380,7 +380,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
@@ -440,7 +440,7 @@ FIXTURE_TEST(
     stm_acc.replace_manifest(misaligned_lco);
     const auto& stm_manifest = part->archival_meta_stm()->manifest();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     mark_segments_as_compacted({0, 1});
 
@@ -477,7 +477,7 @@ FIXTURE_TEST(test_upload_compacted_segments_fill_gap, reupload_fixture) {
 
     const auto& stm_manifest = part->archival_meta_stm()->manifest();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     mark_segments_as_compacted({0});
 
@@ -516,7 +516,7 @@ FIXTURE_TEST(test_upload_compacted_segments_ends_in_gap, reupload_fixture) {
 
     const auto& stm_manifest = part->archival_meta_stm()->manifest();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     mark_segments_as_compacted({0});
 
@@ -554,7 +554,7 @@ FIXTURE_TEST(test_upload_compacted_segments_begins_in_gap, reupload_fixture) {
 
     const auto& stm_manifest = part->archival_meta_stm()->manifest();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     mark_segments_as_compacted({0, 1});
 
@@ -581,7 +581,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
@@ -646,7 +646,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
@@ -721,7 +721,7 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
     initialize(segments, false);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
 
@@ -766,7 +766,7 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // Upload two non compacted segments, no segment is compacted yet.
 
@@ -824,7 +824,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     initialize(segments);
     auto action = ss::defer([this] { archiver->stop().get(); });
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
     // 4 out of 5 segments uploaded due to archiver limit of 4
     archival::ntp_archiver::batch_result expected{{4, 0, 0}, {0, 0, 0}};

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -86,83 +86,8 @@ void log_upload_candidate(const archival::upload_candidate& up) {
       first_source->offsets().dirty_offset);
 }
 
-namespace archival::internal {
-
-/// Replaces the ntp archiver in scheduler with an object which has a remote
-/// connection configured to a port which is not being listened to. The new
-/// archiver does not make any progress, freeing the unit test to create an
-/// archiver of its own and performing actions and making assertions about them
-/// in a clean environment.
-///
-/// We initialize a remote because the newly created archiver expects a
-/// reference to a remote which should remain alive for the duration of the
-/// test. The replacer must be closed before the test ends.
-class archiver_replacer {
-public:
-    explicit archiver_replacer(const cloud_storage::configuration& cfg)
-      : _cfg{with_port_replaced(cfg)}
-      , _remote{
-          _cfg.connection_limit,
-          _cfg.client_config,
-          _cfg.cloud_credentials_source} {}
-
-    void replace_archiver_with_no_op(
-      const model::ntp& ntp,
-      internal::scheduler_service_impl& scheduler,
-      const archival::configuration& aconf) {
-        if (auto it = scheduler._archivers.find(ntp);
-            it != scheduler._archivers.end()) {
-            it->second->stop().get();
-            scheduler._archivers.erase(it);
-        }
-
-        auto [it, ok] = scheduler._archivers.emplace(
-          ntp,
-          ss::make_lw_shared<ntp_archiver>(
-            scheduler._partition_manager.local().log(ntp)->config(),
-            scheduler._partition_manager.local(),
-            aconf,
-            _remote,
-            scheduler._partition_manager.local().get(ntp)));
-        it->second->run_upload_loop();
-    }
-
-    ss::future<> stop() { return _remote.stop(); }
-
-private:
-    // Replace the client configuration port with an adjacent port so that the
-    // remote object constructed can never connect and the associated archiver
-    // can not make progress.
-    static cloud_storage::configuration
-    with_port_replaced(const cloud_storage::configuration& cfg) {
-        auto replaced = cfg;
-        replaced.client_config.server_addr = net::unresolved_address{
-          {archiver_fixture::httpd_host_name.data(),
-           archiver_fixture::httpd_host_name.size()},
-          archiver_fixture::httpd_port_number + 1};
-
-        // Explicitly disable metrics. The archivers created in test may or may
-        // not have metrics disabled. If we do not disable metrics here there
-        // could be double registration which is an error.
-        replaced.client_config.disable_metrics = net::metrics_disabled::yes;
-        replaced.client_config.disable_public_metrics
-          = net::public_metrics_disabled::yes;
-        return replaced;
-    }
-
-    cloud_storage::configuration _cfg;
-    cloud_storage::remote _remote;
-};
-} // namespace archival::internal
-
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
-    auto [arch_conf, remote_conf] = get_configurations();
-    cloud_storage::remote remote(
-      remote_conf.connection_limit,
-      remote_conf.client_config,
-      remote_conf.cloud_credentials_source);
-
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1)},
       {manifest_ntp, model::offset(1000), model::term_id(4)},
@@ -171,18 +96,10 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     vlog(test_log.info, "Initialized, start waiting for partition leadership");
 
     wait_for_partition_leadership(manifest_ntp);
-    archival::internal::archiver_replacer replacer{remote_conf};
-    ss::defer([&replacer] { replacer.stop().get(); });
-
-    replacer.replace_archiver_with_no_op(
-      manifest_ntp, get_scheduler_service(), arch_conf);
-
     auto part = app.partition_manager.local().get(manifest_ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
         return part->last_stable_offset() >= model::offset(1000);
     }).get();
-
-    listen();
 
     vlog(
       test_log.info,
@@ -191,6 +108,12 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       part->committed_offset(),
       *part);
 
+    stop_archiver_scheduler_and_listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    cloud_storage::remote remote(
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
     archival::ntp_archiver archiver(
       get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
@@ -264,11 +187,6 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
      * retention was applied and garbage collection has run, we should
      * see DELETE requests for the old segments being made.
      */
-    auto [arch_conf, remote_conf] = get_configurations();
-    cloud_storage::remote remote(
-      remote_conf.connection_limit,
-      remote_conf.client_config,
-      remote_conf.cloud_credentials_source);
 
     auto old_stamp = model::timestamp{
       model::timestamp::now().value()
@@ -294,11 +212,6 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
     vlog(test_log.info, "Initialized, start waiting for partition leadership");
 
     wait_for_partition_leadership(manifest_ntp);
-    archival::internal::archiver_replacer replacer{remote_conf};
-    ss::defer([&replacer] { replacer.stop().get(); });
-
-    replacer.replace_archiver_with_no_op(
-      manifest_ntp, get_scheduler_service(), arch_conf);
     auto part = app.partition_manager.local().get(manifest_ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
         return part->last_stable_offset() >= model::offset(1);
@@ -311,7 +224,13 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
       part->committed_offset(),
       *part);
 
-    listen();
+    stop_archiver_scheduler_and_listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    cloud_storage::remote remote(
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
     archival::ntp_archiver archiver(
       get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
@@ -381,12 +300,6 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
      * as the backlog size was breached (3 > 2).
      */
 
-    auto [arch_conf, remote_conf] = get_configurations();
-    cloud_storage::remote remote(
-      remote_conf.connection_limit,
-      remote_conf.client_config,
-      remote_conf.cloud_credentials_source);
-
     auto old_stamp = model::timestamp{
       model::timestamp::now().value()
       - std::chrono::milliseconds{10min}.count()};
@@ -410,21 +323,23 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
     init_storage_api_local(segments);
 
     wait_for_partition_leadership(manifest_ntp);
-    archival::internal::archiver_replacer replacer{remote_conf};
-    ss::defer([&replacer] { replacer.stop().get(); });
 
-    replacer.replace_archiver_with_no_op(
-      manifest_ntp, get_scheduler_service(), arch_conf);
     auto part = app.partition_manager.local().get(manifest_ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
         return part->last_stable_offset() >= model::offset(3000);
     }).get();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
     config::shard_local_cfg().delete_retention_ms.set_value(
       std::chrono::milliseconds{1min});
     config::shard_local_cfg()
       .cloud_storage_max_segments_pending_deletion_per_partition(2);
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    cloud_storage::remote remote(
+      remote_conf.connection_limit,
+      remote_conf.client_config,
+      remote_conf.cloud_credentials_source);
     archival::ntp_archiver archiver(
       get_ntp_conf(), app.partition_manager.local(), arch_conf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
@@ -758,13 +673,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       part->committed_offset(),
       *part);
 
-    auto [arch_conf, remote_conf] = get_configurations();
-    archival::internal::archiver_replacer replacer{remote_conf};
-    ss::defer([&replacer] { replacer.stop().get(); });
-
-    replacer.replace_archiver_with_no_op(
-      manifest_ntp, get_scheduler_service(), arch_conf);
-
     auto s1name = archival::segment_name("0-1-v1.log");
     auto s2name = archival::segment_name("1000-4-v1.log");
     auto segment1 = get_segment(manifest_ntp, s1name);
@@ -794,8 +702,9 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       ->add_segments(old_segments, ss::lowres_clock::now() + 1s)
       .get();
 
-    listen();
+    stop_archiver_scheduler_and_listen();
 
+    auto [arch_conf, remote_conf] = get_configurations();
     cloud_storage::remote remote(
       remote_conf.connection_limit,
       remote_conf.client_config,
@@ -938,13 +847,6 @@ static void test_partial_upload_impl(
         return part->last_stable_offset() >= model::offset(1);
     }).get();
 
-    auto [aconf, cconf] = get_configurations();
-    archival::internal::archiver_replacer replacer{cconf};
-    ss::defer([&replacer] { replacer.stop().get(); });
-
-    replacer.replace_archiver_with_no_op(
-      manifest_ntp, test.get_scheduler_service(), aconf);
-
     auto s1name = archival::segment_name("0-1-v1.log");
 
     auto segment1 = test.get_segment(manifest_ntp, s1name);
@@ -1013,21 +915,20 @@ static void test_partial_upload_impl(
       last_uploaded_offset,
       lso);
 
-    test.listen();
-
+    auto [aconf, cconf] = get_configurations();
     cloud_storage::remote remote(
       cconf.connection_limit,
       cconf.client_config,
       cconf.cloud_credentials_source);
 
     aconf.time_limit = segment_time_limit(0s);
+
     archival::ntp_archiver archiver(
       get_ntp_conf(), test.app.partition_manager.local(), aconf, remote, part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     retry_chain_node fib;
-    test.reset_http_call_state();
-
+    test.stop_archiver_scheduler_and_listen();
     auto res = upload_next_with_retries(archiver, lso).get0();
 
     auto non_compacted_result = res.non_compacted_upload_result;

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -183,6 +183,15 @@ public:
       const storage::ntp_config& cfg,
       cloud_storage::partition_manifest manifest);
 
+    /// Stops the scheduler service before listening to incoming HTTP calls.
+    /// Intended to be used in tests which create their own archiver, where
+    /// stopping the scheduler first is necessary so that the built in archiver
+    /// does not interfere with the archiver in test.
+    void stop_archiver_scheduler_and_listen() {
+        get_scheduler_service().stop().get();
+        listen();
+    }
+
 private:
     void initialize_shard(
       storage::api& api,

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -9,7 +9,6 @@
  */
 
 #include "archival/ntp_archiver_service.h"
-#include "archival/service.h"
 #include "archival/tests/service_fixture.h"
 #include "cluster/commands.h"
 #include "net/unresolved_address.h"
@@ -17,13 +16,9 @@
 #include "test_utils/async.h"
 
 #include <seastar/core/deleter.hh>
-#include <seastar/core/file.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/metrics.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/http/request.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
 

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -118,7 +118,7 @@ json::Document parse_json_response(iobuf resp) {
 static ss::future<api_response> make_post_request(
   http::client& client,
   http::client::request_header& req,
-  iobuf&& content,
+  iobuf content,
   std::chrono::milliseconds timeout) {
     req.set(
       boost::beast::http::field::content_length,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7242
Fixes https://github.com/redpanda-data/redpanda/issues/7446,