### PR TITLE
tools: formatted dev_cluster with yapf

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -74,16 +74,19 @@ class Redpanda:
         self.process.terminate()
         return await self.process.wait()
 
+
 async def input_helper(configs):
     def dump_endpoints():
         for config, _ in configs:
-            print("admin endpoint:", f"http://localhost:{config.redpanda.admin.port}")
+            print("admin endpoint:",
+                  f"http://localhost:{config.redpanda.admin.port}")
 
     while True:
         loop = asyncio.get_event_loop()
         content = await loop.run_in_executor(None, sys.stdin.readline)
         if "h" in content:
             dump_endpoints()
+
 
 async def main():
     parser = argparse.ArgumentParser()
@@ -98,7 +101,10 @@ async def main():
                         type=pathlib.Path,
                         help="data directory",
                         default="data")
-    parser.add_argument("--base-rpc-port", type=int, help="rpc port", default=33145)
+    parser.add_argument("--base-rpc-port",
+                        type=int,
+                        help="rpc port",
+                        default=33145)
     parser.add_argument("--base-kafka-port",
                         type=int,
                         help="kafka port",


### PR DESCRIPTION
Fixed `dev_cluster.py` formatting

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
