### PR TITLE
[v22.3.x] Lower log error severity to DEBUG for `errc::shutting_down` in k/group (2)

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2806,11 +2806,17 @@ group::remove_topic_partitions(const std::vector<model::topic_partition>& tps) {
               "Replicated group cleanup record {} at offset {}",
               _id,
               result.value().last_offset);
+        } else if (result.error() == raft::errc::shutting_down) {
+            vlog(
+              klog.debug,
+              "Cannot replicate group {} cleanup records due to shutdown",
+              _id);
         } else {
             vlog(
               klog.error,
-              "Error occured replicating group {} cleanup records {}",
+              "Error occured replicating group {} cleanup records {} ({})",
               _id,
+              result.error().message(),
               result.error());
         }
     } catch (const std::exception& e) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7448
Fixes https://github.com/redpanda-data/redpanda/issues/7452,