### PR TITLE
redpanda: Recommend rpk config set

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -553,7 +553,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
     config_printer("redpanda", config::shard_local_cfg());
 
     vlog(_log.info, "Node configuration properties:");
-    vlog(_log.info, "(use `rpk config set <cfg> <value>` to change)");
+    vlog(_log.info, "(use `rpk redpanda config set <cfg> <value>` to change)");
     config_printer("redpanda", config::node());
 
     if (config["pandaproxy"]) {


### PR DESCRIPTION
Redpanda suggests:
```
INFO  2022-11-23 15:00:11,965 [shard 0] main - application.cc:543 - Node configuration properties:
INFO  2022-11-23 15:00:11,965 [shard 0] main - application.cc:544 - (use `rpk config set <cfg> <value>` to change)
```
When the `rpk config set` is used the following log appears:
```
Command "set" is deprecated, use "rpk redpanda config set" instead
```

## Backports Required

This appears to have been changed a while ago in https://github.com/redpanda-data/redpanda/pull/444

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

* none