### PR TITLE
archival: downgrade upload failure from ERR to WARN

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -209,10 +209,12 @@ ss::future<> ntp_archiver::upload_loop() {
           = co_await upload_next_candidates();
         if (non_compacted_upload_result.num_failed != 0) {
             // The logic in class `remote` already does retries: if we get here,
-            // it means the upload failed after several retries, indicating
-            // something non-transient may be wrong.  Hence error severity.
+            // it means the upload failed after several retries, justifying
+            // a warning to the operator: something non-transient may be wrong,
+            // although we do also see this in practice on AWS S3 occasionally
+            // during normal operation.
             vlog(
-              _rtclog.error,
+              _rtclog.warn,
               "Failed to upload {} segments out of {}",
               non_compacted_upload_result.num_failed,
               non_compacted_upload_result.num_succeeded


### PR DESCRIPTION
Originally it was expected that we would not hit this path on a healthy system, but in practice we do from time to time when running against AWS S3.

This shows up as an occasional failure on various cloud storage tests when running on S3, where the test body succeeds but leaves behind one of these messages in the log, triggering a BadLogLines failure.

Fixes: https://github.com/redpanda-data/redpanda/issues/7208

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

None

## Release Notes

### Improvements
 * An ERROR log message on S3 upload failures is downgraded to WARN, as this situation has been observed to occur transiently in normal operation on AWS.

