### PR TITLE
tests: fix NoSuchBucket failures in ShadowIndexingWhileBusyTest

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -264,7 +264,6 @@ class SISettings:
             cloud_storage_access_key: str = 'panda-user',
             cloud_storage_secret_key: str = 'panda-secret',
             cloud_storage_region: str = 'panda-region',
-            cloud_storage_bucket: Optional[str] = None,
             cloud_storage_api_endpoint: str = 'minio-s3',
             cloud_storage_api_endpoint_port: int = 9000,
             cloud_storage_cache_size: int = 160 * 1000000,
@@ -282,7 +281,7 @@ class SISettings:
         self.cloud_storage_access_key = cloud_storage_access_key
         self.cloud_storage_secret_key = cloud_storage_secret_key
         self.cloud_storage_region = cloud_storage_region
-        self.cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}' if cloud_storage_bucket is None else cloud_storage_bucket
+        self.cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}'
         self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
         self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
         self.cloud_storage_cache_size = cloud_storage_cache_size

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -373,7 +373,6 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
     def __init__(self, test_context: TestContext):
         si_settings = SISettings(log_segment_size=self.segment_size,
                                  cloud_storage_cache_size=20 * 2**30,
-                                 cloud_storage_bucket='while-busy-bucket',
                                  cloud_storage_enable_remote_read=False,
                                  cloud_storage_enable_remote_write=False)
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -51,7 +51,6 @@ class TestReadReplicaService(EndToEndTest):
         # We're adding 'none' as a bucket name without creating
         # an actual bucket with such name.
         self.rr_settings = SISettings(
-            cloud_storage_bucket='none',
             bypass_bucket_creation=True,
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,


### PR DESCRIPTION
If tests specify a bucket name, it becomes unsafe to run parametrized versions of the test in parallel.

Fix the test and remove the ability to do this in general: no tests require it.

Fixes https://github.com/redpanda-data/redpanda/issues/7208

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none