### PR TITLE
tests: make test_restore_with_aborted_tx reliably reproduce transaction read issues(#7043)

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -256,7 +256,10 @@ ss::future<> cache::clean_up_cache() {
                 // leak
                 _access_time_tracker.remove_timestamp(
                   std::string_view(filename_to_remove));
-            } catch (std::exception& e) {
+            } catch (const ss::gate_closed_exception&) {
+                // We are shutting down, stop iterating and propagate
+                throw;
+            } catch (const std::exception& e) {
                 vlog(
                   cst_log.error,
                   "Cache eviction couldn't delete {}: {}.",

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -110,9 +110,14 @@ static ss::future<read_result> read_from_partition(
               result.first_tx_batch_offset.value(),
               result.last_offset,
               std::move(rdr.ot_state));
+            vlog(klog.trace, "fetched aborted_transactions {} {}-{}",
+                 aborted_transactions.size(), result.first_tx_batch_offset, result.last_offset);
+        } else {
+            vlog(klog.trace, "skipping aborted_transactions {} {}", result.first_tx_batch_offset, result.record_count);
         }
 
     } catch (...) {
+        vlog(klog.trace, "exception getting aborted_transactions");
         e = std::current_exception();
     }
 
@@ -266,6 +271,7 @@ static void fill_fetch_responses(
          * According to KIP-74 we have to return first batch even if it would
          * violate max_bytes fetch parameter
          */
+        vlog(klog.trace, "fill_fetch_response[{}]: {} aborted transactions", idx, res.aborted_transactions.size());
         if (
           res.has_data()
           && (octx.bytes_left >= res.data_size_bytes() || octx.response_size == 0)) {

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -215,7 +215,8 @@ replicated_partition::aborted_transactions(
     }
     if (
       _partition->cloud_data_available()
-      && offsets.begin_rp < _partition->start_offset()) {
+      && offsets.begin
+           < _translator->from_log_offset(_partition->start_offset())) {
         // The fetch request was satisfied using shadow indexing.
         auto tx_remote = co_await aborted_transactions_remote(
           offsets, ot_state);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -206,6 +206,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     while ((_logs_list.front().flags & bflags::compacted) == bflags::none) {
         auto& current_log = _logs_list.front();
 
+
         _logs_list.pop_front();
         _logs_list.push_back(current_log);
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -145,8 +145,8 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
     mv /root/go/bin/kcl /usr/local/bin/
 
 # Install the kgo-verifier tool
-RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 3c01706276bb08bed90839d38c5f1e95437d8e78 && \
+RUN git -C /opt clone https://github.com/jcsp/kgo-verifier.git && \
+    cd /opt/kgo-verifier && git reset --hard e07b234a3b7960f0bf531215e99cb7b60539fac4 && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -318,7 +318,10 @@ class RpkTool:
 
     def alter_topic_config(self, topic, set_key, set_value):
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
-        self._run_topic(cmd)
+        out = self._run_topic(cmd)
+        if 'INVALID' in out:
+            raise RpkException(
+                f"Invalid topic config {topic} {set_key}={set_value}")
 
     def delete_topic_config(self, topic, key):
         cmd = ['alter-config', topic, "--delete", key]

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -418,13 +418,15 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
                  max_msgs=None,
                  max_throughput_mb=None,
                  nodes=None,
-                 debug_logs=False):
+                 debug_logs=False,
+                 loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
                              debug_logs)
         self._max_msgs = max_msgs
         self._max_throughput_mb = max_throughput_mb
         self._status = ConsumerStatus()
+        self._loop = loop
 
     @property
     def consumer_status(self):
@@ -434,7 +436,8 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
         if clean:
             self.clean_node(node)
 
-        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --produce_msgs 0 --rand_read_msgs 0 --seq_read=1 --loop --client-name {self.who_am_i()}"
+        loop = "--loop" if self._loop else ""
+        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --produce_msgs 0 --rand_read_msgs 0 --seq_read=1 {loop} --client-name {self.who_am_i()}"
         if self._max_msgs is not None:
             cmd += f" --seq_read_msgs {self._max_msgs}"
         if self._max_throughput_mb is not None:

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -28,7 +28,7 @@ class KgoVerifierService(Service):
     Use ctx.cluster.alloc(ClusterSpec.simple_linux(1)) to allocate node and pass it to constructor
     """
     def __init__(self, context, redpanda, topic, msg_size, custom_node,
-                 debug_logs):
+                 debug_logs, trace_logs):
         self.use_custom_node = custom_node is not None
 
         # We should pass num_nodes to allocate for our service in BackgroundThreadService,
@@ -52,6 +52,7 @@ class KgoVerifierService(Service):
         self._pid = None
         self._remote_port = None
         self._debug_logs = debug_logs
+        self._trace_logs = trace_logs
 
         for node in self.nodes:
             if not hasattr(node, "kgo_verifier_ports"):
@@ -95,7 +96,9 @@ class KgoVerifierService(Service):
 
         self._remote_port = self._select_port(node)
 
-        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {'--debug' if self._debug_logs else ''}> {self.log_path} 2>&1 & echo $!"
+        debug = '--debug' if self._debug_logs else ''
+        trace = '--trace' if self._trace_logs else ''
+        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {debug} {trace}> {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
         pid_str = node.account.ssh_output(wrapped_cmd)
         self.logger.debug(
@@ -419,10 +422,11 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
                  max_throughput_mb=None,
                  nodes=None,
                  debug_logs=False,
+                 trace_logs=False,
                  loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
-                             debug_logs)
+                             debug_logs, trace_logs)
         self._max_msgs = max_msgs
         self._max_throughput_mb = max_throughput_mb
         self._status = ConsumerStatus()
@@ -457,8 +461,10 @@ class KgoVerifierRandomConsumer(KgoVerifierService):
                  rand_read_msgs,
                  parallel,
                  nodes=None,
-                 debug_logs=False):
-        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
+                 debug_logs=False,
+                 trace_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
+                         trace_logs)
         self._rand_read_msgs = rand_read_msgs
         self._parallel = parallel
         self._status = ConsumerStatus()
@@ -489,8 +495,10 @@ class KgoVerifierConsumerGroupConsumer(KgoVerifierService):
                  max_msgs=None,
                  max_throughput_mb=None,
                  nodes=None,
-                 debug_logs=False):
-        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
+                 debug_logs=False,
+                 trace_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
+                         trace_logs)
 
         self._readers = readers
         self._loop = loop
@@ -553,13 +561,14 @@ class KgoVerifierProducer(KgoVerifierService):
                  custom_node=None,
                  batch_max_bytes=None,
                  debug_logs=False,
+                 trace_logs=False,
                  fake_timestamp_ms=None,
                  use_transactions=False,
                  transaction_abort_rate=None,
                  msgs_per_transaction=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
-                             debug_logs)
+                             debug_logs, trace_logs)
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1534,6 +1534,8 @@ class RedpandaService(Service):
             if key.endswith('manifest.json') and manifest_dump_limit > 0:
                 manifests_to_dump.append(key)
                 manifest_dump_limit -= 1
+            elif key.endswith(".tx"):
+                manifests_to_dump.append(key)
 
         archive_basename = "cloud_diagnostics.zip"
         archive_path = os.path.join(

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -23,7 +23,7 @@ import re
 from itertools import zip_longest
 
 from rptest.util import segments_count
-from rptest.utils.si_utils import Producer
+from rptest.utils.si_utils import TxProducer
 
 import confluent_kafka as ck
 
@@ -254,8 +254,8 @@ class EndToEndTopicRecovery(RedpandaTest):
                 "Skipping test in debug mode (requires release build)")
             return
 
-        producer = Producer(self.redpanda.brokers(), "topic-recovery-tx-test",
-                            self.logger)
+        producer = TxProducer(self.redpanda.brokers(),
+                              "topic-recovery-tx-test", self.logger)
 
         def done():
             for _ in range(100):

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -17,7 +17,7 @@ from rptest.util import (
     segments_count,
     wait_for_segments_removal,
 )
-from rptest.utils.si_utils import Producer
+from rptest.utils.si_utils import TxProducer
 
 from ducktape.utils.util import wait_until
 
@@ -62,8 +62,8 @@ class ShadowIndexingTxTest(RedpandaTest):
         when fetching from remote segments."""
         topic = self.topics[0]
 
-        producer = Producer(self.redpanda.brokers(), "shadow-indexing-tx-test",
-                            self.logger)
+        producer = TxProducer(self.redpanda.brokers(),
+                              "shadow-indexing-tx-test", self.logger)
 
         def done():
             for _ in range(100):

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -61,10 +61,9 @@ class Redpanda:
         self.process = None
 
     async def run(self):
-        self.process = await asyncio.create_subprocess_exec(
-            self.binary,
-            "--redpanda-cfg",
-            self.config,
+        log_path = pathlib.Path(os.path.dirname(self.config)) / "redpanda.log"
+        self.process = await asyncio.create_subprocess_shell(
+            f"{self.binary} --redpanda-cfg {self.config} 2>&1 | tee -i {log_path}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT)
 

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -21,11 +21,15 @@ import yaml
 import dataclasses
 import argparse
 import sys
+import os
+import shutil
 
 try:
     from rich import print
 except ImportError:
     pass
+
+BOOTSTRAP_YAML = ".bootstrap.yaml"
 
 
 @dataclasses.dataclass
@@ -158,6 +162,12 @@ async def main():
                       f,
                       indent=2,
                       Dumper=get_config_dumper())
+
+        # If there is a bootstrap file in pwd, propagate it to each node's
+        # directory so that they'll load it on first start
+        if os.path.exists(BOOTSTRAP_YAML):
+            shutil.copyfile(BOOTSTRAP_YAML, node_dir / BOOTSTRAP_YAML)
+
         return config, conf_file
 
     configs = [prepare_node(i) for i in range(args.nodes)]


### PR DESCRIPTION
    tests: improve test_restore_with_aborted_tx
    
    Use KgoVerifierProducer/SeqConsumer, for much higher volume
    of messages, giving much higher chance of hitting issues.  Increasing
    the message count on the python producer made the test very slow.
    
    This reliably reproduces the tx_fence consumer hang from #7043 now.
    
Related: https://github.com/redpanda-data/redpanda/issues/7043

## Backports Required

**Don't merge or backport until we've fixed the bug!**

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
