### PR TITLE
cloud_storage: fix topic recovery size/time limits to use local.target settings

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -179,12 +179,12 @@ ss::future<log_recovery_result> partition_downloader::download_log() {
 
 // Parameters used to exclude data based on total size.
 struct size_bound_deletion_parameters {
-    size_t retention_bytes;
+    size_t bytes;
 };
 
 // Parameters used to exclude data based on time.
 struct time_bound_deletion_parameters {
-    std::chrono::milliseconds retention_duration;
+    std::chrono::milliseconds duration;
 };
 
 // Retention policy that should be used during recovery
@@ -198,10 +198,10 @@ std::ostream& operator<<(std::ostream& o, const retention& r) {
         fmt::print(o, "{{none}}");
     } else if (std::holds_alternative<size_bound_deletion_parameters>(r)) {
         auto p = std::get<size_bound_deletion_parameters>(r);
-        fmt::print(o, "{{size-bytes: {}}}", p.retention_bytes);
+        fmt::print(o, "{{size-bytes: {}}}", p.bytes);
     } else if (std::holds_alternative<time_bound_deletion_parameters>(r)) {
         auto p = std::get<time_bound_deletion_parameters>(r);
-        fmt::print(o, "{{time-ms: {}}}", p.retention_duration.count());
+        fmt::print(o, "{{time-ms: {}}}", p.duration.count());
     }
     return o;
 }
@@ -266,24 +266,24 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
         vlog(
           _ctxlog.info,
           "Size bound retention is used. Size limit: {} bytes.",
-          r.retention_bytes);
+          r.bytes);
         part = co_await download_log_with_capped_size(
           build_offset_map(mat.partition_manifest),
           mat.partition_manifest,
           prefix,
-          r.retention_bytes);
+          r.bytes);
     } else if (std::holds_alternative<time_bound_deletion_parameters>(
                  retention)) {
         auto r = std::get<time_bound_deletion_parameters>(retention);
         vlog(
           _ctxlog.info,
           "Time bound retention is used. Time limit: {}ms.",
-          r.retention_duration.count());
+          r.duration.count());
         part = co_await download_log_with_capped_time(
           build_offset_map(mat.partition_manifest),
           mat.partition_manifest,
           prefix,
-          r.retention_duration);
+          r.duration);
     }
     // Move parts to final destinations
     co_await move_parts(part);

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -213,10 +213,25 @@ get_retention_policy(const storage::ntp_config::default_overrides& prop) {
       flags
       && (flags.value() & model::cleanup_policy_bitflags::deletion)
            == model::cleanup_policy_bitflags::deletion) {
-        if (prop.retention_bytes.has_value()) {
-            return size_bound_deletion_parameters{prop.retention_bytes.value()};
-        } else if (prop.retention_time.has_value()) {
-            return time_bound_deletion_parameters{prop.retention_time.value()};
+        // If a space constraint is set on the topic, use that: otherwise
+        // use time based constraint if present.  If total retention setting
+        // is less than local retention setting, take the smallest.
+        //
+        // This differs from ordinary storage GC, in that we are applying
+        // space _or_ time bounds: not both together.
+        if (prop.retention_local_target_bytes.has_value()) {
+            auto v = prop.retention_local_target_bytes.value();
+
+            if (prop.retention_bytes.has_value()) {
+                v = std::min(prop.retention_bytes.value(), v);
+            }
+            return size_bound_deletion_parameters{v};
+        } else if (prop.retention_local_target_ms.has_value()) {
+            auto v = prop.retention_local_target_ms.value();
+            if (prop.retention_time.has_value()) {
+                v = std::min(prop.retention_time.value(), v);
+            }
+            return time_bound_deletion_parameters{v};
         }
     }
     return std::monostate();

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -146,11 +146,11 @@ class EndToEndTopicRecovery(RedpandaTest):
     def test_restore_with_config_batches(self, num_messages):
         """related to issue 6413: force the creation of remote segments containing only configuration batches,
         check that older data can be nonetheless recovered even if the total download size
-         would exceed the property retention.bytes.
-         in other words, only segments containing at least some data counts towards retention.bytes limit"""
+         would exceed the property retention.local.target.bytes.
+         in other words, only segments containing at least some data counts towards retention.local.target.bytes limit"""
         """1. generate some messages
         2. restart the cluster to generate some config-only remote segments
-        3. restore topic with a small retention.bytes to force redpanda 
+        3. restore topic with a small retention.local.target.bytes to force redpanda 
            to get over the limit and skip over configuration batches"""
         self.logger.info("start")
         self.init_producer(5000, num_messages)
@@ -175,7 +175,8 @@ class EndToEndTopicRecovery(RedpandaTest):
         # Run recovery
         self._start_redpanda_nodes()
         for topic_spec in self.topics:
-            self._restore_topic(topic_spec, {'retention.bytes': 512})
+            self._restore_topic(topic_spec,
+                                {'retention.local.target.bytes': 512})
 
         self.init_consumer(5000)
         self._consumer.start(clean=False)
@@ -186,7 +187,7 @@ class EndToEndTopicRecovery(RedpandaTest):
     @matrix(message_size=[5000],
             num_messages=[100000],
             recovery_overrides=[{}, {
-                'retention.bytes': 1024
+                'retention.local.target.bytes': 1024
             }])
     def test_restore(self, message_size, num_messages, recovery_overrides):
         """Write some data. Remove local data then restore
@@ -233,7 +234,7 @@ class EndToEndTopicRecovery(RedpandaTest):
 
     @cluster(num_nodes=4, log_allow_list=ALLOWED_ERROR_LOG_LINES)
     @matrix(recovery_overrides=[{}, {
-        'retention.bytes': 1024,
+        'retention.local.target.bytes': 1024,
         'redpanda.remote.write': True,
         'redpanda.remote.read': True,
     }])

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -766,9 +766,10 @@ class SizeBasedRetention(BaseCase):
         for topic in self.expected_recovered_topics:
             for _, manifest in topic_manifests:
                 if manifest['topic'] == topic.name:
-                    self._restore_topic(
-                        manifest,
-                        {"retention.bytes": self.restored_size_bytes})
+                    self._restore_topic(manifest, {
+                        "retention.local.target.bytes":
+                        self.restored_size_bytes
+                    })
 
     def validate_cluster(self, baseline, restored):
         """Check size of every partition."""
@@ -904,7 +905,8 @@ class TimeBasedRetention(BaseCase):
             for _, manifest in topic_manifests:
                 if manifest['topic'] == topic.name:
                     # retention - 1 hour
-                    self._restore_topic(manifest, {"retention.ms": 3600000})
+                    self._restore_topic(manifest,
+                                        {"retention.local.target.ms": 3600000})
 
     def validate_cluster(self, baseline, restored):
         """Check that the topic is writeable"""


### PR DESCRIPTION
Topic recovery code uses retention settings as its cue for how much to restore to local disk. These should be changed to respect the local targets rather than the total retention.


Fixes https://github.com/redpanda-data/redpanda/issues/7490

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* Tiered storage topic recovery now uses the `retention.local.target` settings to bound how much data is restored to local disk, rather than the total retention settings.

