### PR TITLE
tests: add script to redact sensitive info

### DIFF
--- a/tests/rptest/redact_info.py
+++ b/tests/rptest/redact_info.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+
+class Redactor:
+    """
+    Redact the sensitive information like aws account info from the
+    ducktape results.
+    """
+    def __init__(self, ducktape_report_json_file) -> None:
+        self.ducktape_report_json_file = ducktape_report_json_file
+
+    def redact_sensitive_info(self):
+
+        with open(self.ducktape_report_json_file) as f:
+            ducktape_report_json = json.load(f)
+
+        if 'session_context' in ducktape_report_json:
+            if '_globals' in ducktape_report_json['session_context']:
+                if 's3_access_key' in ducktape_report_json['session_context'][
+                        '_globals']:
+                    ducktape_report_json['session_context']['_globals'][
+                        's3_access_key'] = '***'
+                if 's3_bucket' in ducktape_report_json['session_context'][
+                        '_globals']:
+                    ducktape_report_json['session_context']['_globals'][
+                        's3_bucket'] = '***'
+                if 's3_region' in ducktape_report_json['session_context'][
+                        '_globals']:
+                    ducktape_report_json['session_context']['_globals'][
+                        's3_region'] = '***'
+                if 's3_secret_key' in ducktape_report_json['session_context'][
+                        '_globals']:
+                    ducktape_report_json['session_context']['_globals'][
+                        's3_secret_key'] = '***'
+
+        with open(self.ducktape_report_json_file, 'w') as f:
+            json.dump(ducktape_report_json, f, indent=2, sort_keys=True)
+
+
+if len(sys.argv) > 1:
+    Redactor(sys.argv[1]).redact_sensitive_info()
+else:
+    Redactor("report.json").redact_sensitive_info()


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/devprod/issues/452

Adds a script to mask sensitive information from the ducktape results.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
