### PR TITLE
[v22.3.x] cluster: allow seeds-driven bootstrap when empty_seed_starts_cluster=1

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -575,15 +575,6 @@ controller::create_cluster(const bootstrap_cluster_cmd_data cmd_data) {
  */
 ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
     if (co_await discovery.is_cluster_founder()) {
-        if (config::node().empty_seed_starts_cluster()) {
-            vassert(
-              config::node().seed_servers().empty(),
-              "Cluster founder is not the root node");
-            vassert(
-              _raft0->config().brokers().size() == 1,
-              "Root is a cluster founder but joiners are in the cluster alrdy");
-        }
-
         // Full cluster bootstrap
         bootstrap_cluster_cmd_data cmd_data;
         cmd_data.uuid = model::cluster_uuid(uuid_t::create());

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -65,9 +65,12 @@ node_config::node_config() noexcept
   , empty_seed_starts_cluster(
       *this,
       "empty_seed_starts_cluster",
-      "If enabled, requires exactly one node in a cluster-to-be to have its "
-      "seed_servers list empty. Otherwise, seed_servers list cannot be empty, "
-      "and must be the same in each node from that list",
+      "If true, an empty seed_servers list will denote that this node should "
+      "form a cluster. At most one node in the cluster should be configured "
+      "configured with an empty seed_servers list. If no such configured node "
+      "exists, or if configured to false, all nodes denoted by the "
+      "seed_servers list must be identical among those nodes' configurations, "
+      "and those nodes will form the initial cluster.",
       {.visibility = visibility::user},
       true)
   , rpc_server(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7390
