### PR TITLE
[v22.1.x] raft: amend error code when leadership transfer can't proceed due to recovery

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2841,7 +2841,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                     _log.offsets().dirty_offset);
 
                   return seastar::make_ready_future<std::error_code>(
-                    make_error_code(errc::timeout));
+                    make_error_code(errc::exponential_backoff));
               }
 
               timeout_now_request req{


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7297
Fixes https://github.com/redpanda-data/redpanda/issues/7503,