### PR TITLE
Fixed incorrectly stopping rebalancing when batch size is small

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -309,6 +309,9 @@ members_backend::calculate_replicas_per_node(
     ret.reserve(_allocator.local().state().allocation_nodes().size());
 
     for (const auto& [id, n] : _allocator.local().state().allocation_nodes()) {
+        if (!n->is_active()) {
+            continue;
+        }
         auto [it, _] = ret.try_emplace(
           id,
           node_replicas{

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -591,12 +591,8 @@ ss::future<> members_backend::reconcile() {
         }
     }
     // remove finished updates
-    auto removed = std::erase_if(
+    std::erase_if(
       _updates, [](const update_meta& meta) { return meta.finished; });
-    // if updates were finished, reset unevenness error
-    if (removed > 0) {
-        reset_last_unevenness_error();
-    }
     if (!_raft0->is_elected_leader() || _updates.empty()) {
         co_return;
     }
@@ -684,7 +680,7 @@ ss::future<> members_backend::reconcile() {
               meta.finished);
             co_return;
         }
-        _last_unevenness_error = current_error;
+        meta.last_unevenness_error = current_error;
     }
 
     // execute reallocations
@@ -778,12 +774,12 @@ bool members_backend::should_stop_rebalancing_update(
     }
     static auto const stop_condition_improvement = 0.05;
 
-    auto improvement = _last_unevenness_error - current_error;
+    auto improvement = meta.last_unevenness_error - current_error;
     vlog(
       clusterlog.info,
       "balance unevenness error - current: {}, previous: {}, improvement: {}",
       current_error,
-      _last_unevenness_error,
+      meta.last_unevenness_error,
       improvement);
 
     return meta.partition_reallocations.empty()
@@ -1011,7 +1007,6 @@ void members_backend::stop_node_decommissioning(model::node_id id) {
 
 void members_backend::stop_node_addition_and_ondemand_rebalance(
   model::node_id id) {
-    reset_last_unevenness_error();
     // remove all pending added updates for current node
     std::erase_if(_updates, [id](update_meta& meta) {
         return !meta.update
@@ -1021,7 +1016,6 @@ void members_backend::stop_node_addition_and_ondemand_rebalance(
 
 void members_backend::handle_reallocation_finished(model::node_id id) {
     // remove all pending added node updates for this node
-    reset_last_unevenness_error();
     std::erase_if(_updates, [id](update_meta& meta) {
         return meta.update && meta.update->id == id
                  && (meta.update->type
@@ -1029,10 +1023,6 @@ void members_backend::handle_reallocation_finished(model::node_id id) {
                || meta.update->type
                     == members_manager::node_update_type::recommissioned);
     });
-}
-
-void members_backend::reset_last_unevenness_error() {
-    _last_unevenness_error = 1.0;
 }
 
 std::ostream&

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -100,6 +100,10 @@ private:
         size_t allocated_replicas;
         size_t max_capacity;
     };
+    struct unevenness_error_info {
+        double e;
+        double e_step;
+    };
     using node_replicas_map_t
       = absl::node_hash_map<model::node_id, members_backend::node_replicas>;
     void start_reconciliation_loop();
@@ -128,7 +132,8 @@ private:
     absl::node_hash_map<model::node_id, node_replicas>
       calculate_replicas_per_node(partition_allocation_domain) const;
 
-    double calculate_unevenness_error(partition_allocation_domain) const;
+    unevenness_error_info
+      calculate_unevenness_error(partition_allocation_domain) const;
     bool should_stop_rebalancing_update(const update_meta&) const;
 
     static size_t calculate_total_replicas(const node_replicas_map_t&);

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -73,6 +73,8 @@ public:
 
         std::vector<partition_reallocation> partition_reallocations;
         bool finished = false;
+        // unevenness error is normalized to be at most 1.0, set to max
+        double last_unevenness_error = 1.0;
     };
 
     members_backend(
@@ -125,7 +127,6 @@ private:
     bool should_stop_rebalancing_update(double, const update_meta&) const;
 
     static size_t calculate_total_replicas(const node_replicas_map_t&);
-    void reset_last_unevenness_error();
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;
     ss::sharded<partition_allocator>& _allocator;
@@ -146,8 +147,7 @@ private:
     ss::condition_variable _new_updates;
     ss::metrics::metric_groups _metrics;
     config::binding<size_t> _max_concurrent_reallocations;
-    // unevenness error is normalized to be at most 1.0, set to max
-    double _last_unevenness_error = 1.0;
+
     /**
      * store revision of node decommissioning update, decommissioning command
      * revision is stored when node is being decommissioned, it is used to

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -76,6 +76,7 @@ public:
         // unevenness error is normalized to be at most 1.0, set to max
         absl::flat_hash_map<partition_allocation_domain, double>
           last_unevenness_error;
+        absl::flat_hash_map<partition_allocation_domain, size_t> last_ntp_index;
     };
 
     members_backend(

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -23,6 +23,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
     NODE_AVAILABILITY_TIMEOUT = 10
     MANY_PARTITIONS = "many_partitions"
     BIG_PARTITIONS = "big_partitions"
+    GROUP_TOPIC_PARTITIONS = 16
 
     def __init__(self, test_context, *args, **kwargs):
         super().__init__(
@@ -36,6 +37,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                 "partition_autobalancing_tick_interval_ms": 5000,
                 "members_backend_retry_ms": 1000,
                 "raft_learner_recovery_rate": 1073741824,
+                "group_topic_partitions": self.GROUP_TOPIC_PARTITIONS
             },
             *args,
             **kwargs)
@@ -87,6 +89,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
         replicas = set()
         for tp_d in topic_descriptions:
             for p in tp_d.partitions:
+                self.logger.debug(f"{tp_d.name}/{p.id} replicas: {p.replicas}")
                 for r in p.replicas:
                     if r == node_id:
                         replicas.add(f'{tp_d.name}/{p}')
@@ -266,12 +269,13 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                                      "seed_servers":
                                      seed_servers_for(to_restart)
                                  })
-        new_node_id = self.redpanda.node_id(to_restart)
-        expected_per_node = partitions_count * replication_factor / len(
-            self.redpanda.nodes)
+        new_node_id = self.redpanda.node_id(to_restart, force_refresh=True)
+        expected_per_node = (partitions_count + self.GROUP_TOPIC_PARTITIONS
+                             ) * replication_factor / len(self.redpanda.nodes)
 
         def partitions_moved_to_new_node():
-            replicas = self.node_replicas([topic.name], new_node_id)
+            replicas = self.node_replicas([topic.name, "__consumer_offsets"],
+                                          new_node_id)
             self.logger.info(
                 f"broker {new_node_id} is a host for {len(replicas)} replicas")
             return len(replicas) > 0.9 * expected_per_node

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -177,6 +177,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             consumers = 1
             partitions_count = 40
             max_concurrent_moves = 5
+            timeout = 80
         elif type == self.MANY_PARTITIONS:
             message_size = 128 * (2 ^ 10)
             message_cnt = 2000000


### PR DESCRIPTION
Refined rebalancing stop condition to make it more reliable when rebalancing batch size is small. 

When there is no improvement of unevenness error after requesting partition rebalancing the iteration stops.

Error is calculated as:


$$ e_{raw}=\sum_{n=0}^{N}{\frac{R-r_n}{TN}}$$
$$ R = \frac{T}{N} $$

Where:

$T$ - total number or replicas in cluster
$R$ - requested replicas per node
$N$- number of nodes in the cluster
$r_{n}$ - number of replicas on the node n

then the error is normalized to be in range $[0,1]$.

To do this we calculate the maximum error:

$$ e_{max} = \frac{(T-R)+\sum\limits_{n=1}^{N}{R}}{TN} $$

normalized error is equal to:

$$ e=\frac{e}{e_{max}} $$


Since the improvement depends on the number of replicas moved in a single batch
we need to calculate the improvement that would moving a single partition
replica introduce. Since single move requested by a balancer moves partition
from node A->B (where A has more than requested number of replicas per
and B should have less than requested number of replicas) we can calculate the
error improvement introduced by single move as:

$$ e_{step}=\frac{2}{NT} $$


Single step error must be normalized as well. We stop the movement if there in
no improvement from at least 10 percents of moves requested in a batch if ten
percent would result in 0 requested moves we require at least one
move to improve the unevenness.

Fixes #7218 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
 - Improved algorithm re balancing partitions after node addition.
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
