### PR TITLE
[v22.1.x] cloud_storage: Make read-path resilient to inconsistencies

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -626,16 +626,30 @@ public:
               "remote_segment_batch_consumer not initialized",
               _parent._seg->get_ntp());
 
-            _parent._cur_ot_state->get().add_gap(
-              header.base_offset, header.last_offset());
-            vlog(
-              _ctxlog.debug,
-              "added offset translation gap [{}-{}], current state: {}",
-              header.base_offset,
-              header.last_offset(),
-              _parent._cur_ot_state);
+            if (
+              _parent._cur_ot_state->get().last_gap_offset()
+              < header.base_offset) {
+                _parent._cur_ot_state->get().add_gap(
+                  header.base_offset, header.last_offset());
+                vlog(
+                  _ctxlog.debug,
+                  "added offset translation gap [{}-{}], current state: {}",
+                  header.base_offset,
+                  header.last_offset(),
+                  _parent._cur_ot_state);
 
-            _parent._cur_delta += header.last_offset_delta + model::offset{1};
+                _parent._cur_delta += header.last_offset_delta
+                                      + model::offset{1};
+            } else {
+                // This can happen if we're dealing with overlapping segments
+                vlog(
+                  _ctxlog.debug,
+                  "offset translation gap [{}-{}] is already added, current "
+                  "state: {}",
+                  header.base_offset,
+                  header.last_offset(),
+                  _parent._cur_ot_state);
+            }
         }
     }
 
@@ -706,7 +720,9 @@ remote_segment_batch_reader::read_some(
             _parser = co_await init_parser();
         }
 
-        if (ot_state.add_absolute_delta(_cur_rp_offset, _cur_delta)) {
+        if (
+          ot_state.empty()
+          && ot_state.add_absolute_delta(_cur_rp_offset, _cur_delta)) {
             vlog(
               _ctxlog.debug,
               "offset translation: add_absolute_delta at offset {}, "


### PR DESCRIPTION
If the manifest has inconsistencies in form of overlapping segments or duplicate offset ranges the read path should be able to work anyway. This commit adds extra tests and fixes the problems that the tests detected.

The code in the `remote_partition` and `remote_segment` expects that segment do not overlap and base offset of the next segment is equal to last offset of the previous one + 1.  If there is an overlap between the segments or some offset range is uploaded twice the single reader may attempt to read the offset range twice. In this case it may invoke `add_absolute_delta` method of the offset translator twice.  The second call will trigger an assertion. The reader may also break invariant of the `add_gap` method by calling it on smaller offset.

The fix is to check the state of the offset translator before invoking its methods. If the reader encounters the same offset range twice (due to overlap or a duplicate) it will skip offsets that it has already seen before. In this case we need to check if the offset of the skipped record batch was seen by OT before.


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

  ### Bug Fixes

  * none

  ### Features

  * none

  ### Improvements

  * Improve tiered-storage reliability in presence of inconsistencies in metadata
