### PR TITLE
rpk: add nil check for maintenance mode

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -108,7 +108,9 @@ leader handles the request.
 			b, err := cl.Broker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			if b.Maintenance.Draining {
+			// Old brokers (< v22.1) don't have maintenance mode, so we must
+			// check if b.Maintenance is not nil.
+			if b.Maintenance != nil && b.Maintenance.Draining {
 				out.Die(`Node cannot be decommissioned while it is in maintenance mode.
 Take the node out of maintenance mode first by running: 
     rpk cluster maintenance disable %v`, broker)


### PR DESCRIPTION
To avoid a segfault, we must check if
b.Maintenance is not nil because a user might try
to decommission a node with an older version that
doesn't have the maintenance mode feature (<v22).

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->
- [ ] v22.3.x
- [ ] v22.2.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
