### PR TITLE
cluster: re-enable partition_moving_test

### DIFF
--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -72,8 +72,7 @@ rp_test(
   SOURCES partition_moving_test.cc
   LIBRARIES v::seastar_testing_main v::application v::storage_test_utils
   DEFINITIONS SEASTAR_TESTING_MAIN
-  # disabled for issue #2909
-  LABELS cluster disable_on_ci
+  LABELS cluster
 )
 
 rp_test(


### PR DESCRIPTION
This test was disabled for a long time.  Much has changed.  It passed in a loop for a couple of hours on my desktop: even if it turns out to still fail sometimes in CI, and we disable it again, that'll be useful information.

Related: https://github.com/redpanda-data/redpanda/issues/2909

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes



  * none

