### PR TITLE
Get cluster health before an update

### DIFF
--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -558,6 +558,12 @@ func (m *mockAdminAPI) DisableMaintenanceMode(_ context.Context, _ int) error {
 	return nil
 }
 
+func (m *mockAdminAPI) GetHealthOverview(_ context.Context) (admin.ClusterHealthOverview, error) {
+	return admin.ClusterHealthOverview{
+		IsHealthy: true,
+	}, nil
+}
+
 //nolint:goerr113 // test code
 func (m *mockAdminAPI) SetBrokerStatus(
 	id int, status admin.MembershipStatus,

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -102,6 +102,8 @@ var _ = BeforeSuite(func(done Done) {
 		}
 		return testAdminAPI, nil
 	}
+	testAdminAPI.SetClusterHealth(true)
+
 	testStore = consolepkg.NewStore(k8sManager.GetClient(), k8sManager.GetScheme())
 	testKafkaAdmin = &mockKafkaAdmin{}
 	testKafkaAdminFactory = func(context.Context, client.Client, *redpandav1alpha1.Cluster, *consolepkg.Store) (consolepkg.KafkaAdminClient, error) {

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -97,6 +97,8 @@ type AdminAPIClient interface {
 
 	EnableMaintenanceMode(ctx context.Context, node int) error
 	DisableMaintenanceMode(ctx context.Context, node int) error
+
+	GetHealthOverview(ctx context.Context) (admin.ClusterHealthOverview, error)
 }
 
 var _ AdminAPIClient = &admin.AdminAPI{}

--- a/src/go/k8s/pkg/admin/mock_admin.go
+++ b/src/go/k8s/pkg/admin/mock_admin.go
@@ -35,6 +35,7 @@ type MockAdminAPI struct {
 	brokers          []admin.Broker
 	monitor          sync.Mutex
 	Log              logr.Logger
+	clusterHealth    bool
 }
 
 var _ AdminAPIClient = &MockAdminAPI{Log: ctrl.Log.WithName("AdminAPIClient").WithName("mockAdminAPI")}
@@ -48,6 +49,12 @@ type unavailableError struct{}
 
 func (*unavailableError) Error() string {
 	return "unavailable"
+}
+
+func (m *MockAdminAPI) SetClusterHealth(health bool) {
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	m.clusterHealth = health
 }
 
 func (m *MockAdminAPI) Config(context.Context, bool) (admin.Config, error) {
@@ -394,7 +401,7 @@ func (m *MockAdminAPI) DisableMaintenanceMode(_ context.Context, _ int) error {
 func (m *MockAdminAPI) GetHealthOverview(_ context.Context) (admin.ClusterHealthOverview, error) {
 	m.Log.WithName("GetHealthOverview").Info("called")
 	return admin.ClusterHealthOverview{
-		IsHealthy: true,
+		IsHealthy: m.clusterHealth,
 	}, nil
 }
 

--- a/src/go/k8s/pkg/admin/mock_admin.go
+++ b/src/go/k8s/pkg/admin/mock_admin.go
@@ -1,0 +1,445 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/configuration"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type MockAdminAPI struct {
+	config           admin.Config
+	schema           admin.ConfigSchema
+	patches          []configuration.CentralConfigurationPatch
+	unavailable      bool
+	invalid          []string
+	unknown          []string
+	directValidation bool
+	brokers          []admin.Broker
+	monitor          sync.Mutex
+	Log              logr.Logger
+}
+
+var _ AdminAPIClient = &MockAdminAPI{Log: ctrl.Log.WithName("AdminAPIClient").WithName("mockAdminAPI")}
+
+type ScopedMockAdminAPI struct {
+	*MockAdminAPI
+	Ordinal int32
+}
+
+type unavailableError struct{}
+
+func (*unavailableError) Error() string {
+	return "unavailable"
+}
+
+func (m *MockAdminAPI) Config(context.Context, bool) (admin.Config, error) {
+	m.Log.WithName("Config").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return admin.Config{}, &unavailableError{}
+	}
+	var res admin.Config
+	makeCopy(m.config, &res)
+	return res, nil
+}
+
+func (m *MockAdminAPI) ClusterConfigStatus(
+	_ context.Context, _ bool,
+) (admin.ConfigStatusResponse, error) {
+	m.Log.WithName("ClusterConfigStatus").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return admin.ConfigStatusResponse{}, &unavailableError{}
+	}
+	node := admin.ConfigStatus{
+		Invalid: append([]string{}, m.invalid...),
+		Unknown: append([]string{}, m.unknown...),
+	}
+	return []admin.ConfigStatus{node}, nil
+}
+
+func (m *MockAdminAPI) ClusterConfigSchema(
+	_ context.Context,
+) (admin.ConfigSchema, error) {
+	m.Log.WithName("ClusterConfigSchema").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return admin.ConfigSchema{}, &unavailableError{}
+	}
+	var res admin.ConfigSchema
+	makeCopy(m.schema, &res)
+	return res, nil
+}
+
+func (m *MockAdminAPI) PatchClusterConfig(
+	_ context.Context, upsert map[string]interface{}, remove []string,
+) (admin.ClusterConfigWriteResult, error) {
+	m.Log.WithName("PatchClusterConfig").WithValues("upsert", upsert, "remove", remove).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return admin.ClusterConfigWriteResult{}, &unavailableError{}
+	}
+	m.patches = append(m.patches, configuration.CentralConfigurationPatch{
+		Upsert: upsert,
+		Remove: remove,
+	})
+	var newInvalid []string
+	var newUnknown []string
+	for k := range upsert {
+		if meta, ok := m.schema[k]; !ok {
+			newUnknown = append(newUnknown, k)
+		} else if meta.Description == "invalid" {
+			newInvalid = append(newInvalid, k)
+		}
+	}
+	invalidRequest := len(newInvalid)+len(newUnknown) > 0
+	if m.directValidation && invalidRequest {
+		return admin.ClusterConfigWriteResult{}, &admin.HTTPResponseError{
+			Method: http.MethodPut,
+			URL:    "/v1/cluster_config",
+			Response: &http.Response{
+				Status:     "Bad Request",
+				StatusCode: 400,
+			},
+			Body: []byte("Mock bad request message"),
+		}
+	}
+	if invalidRequest {
+		m.invalid = addAsSet(m.invalid, newInvalid...)
+		m.unknown = addAsSet(m.unknown, newUnknown...)
+		return admin.ClusterConfigWriteResult{}, nil
+	}
+	if m.config == nil {
+		m.config = make(map[string]interface{})
+	}
+	for k, v := range upsert {
+		m.config[k] = v
+	}
+	for _, k := range remove {
+		delete(m.config, k)
+		for i := range m.invalid {
+			if m.invalid[i] == k {
+				m.invalid = append(m.invalid[0:i], m.invalid[i+1:]...)
+			}
+		}
+		for i := range m.unknown {
+			if m.unknown[i] == k {
+				m.unknown = append(m.unknown[0:i], m.unknown[i+1:]...)
+			}
+		}
+	}
+	return admin.ClusterConfigWriteResult{}, nil
+}
+
+func (m *MockAdminAPI) CreateUser(_ context.Context, _, _, _ string) error {
+	m.Log.WithName("CreateUser").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return &unavailableError{}
+	}
+	return nil
+}
+
+func (m *MockAdminAPI) DeleteUser(_ context.Context, _ string) error {
+	m.Log.WithName("DeleteUser").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return &unavailableError{}
+	}
+	return nil
+}
+
+func (m *MockAdminAPI) Clear() {
+	m.Log.WithName("Clear").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	m.config = nil
+	m.schema = nil
+	m.patches = nil
+	m.unavailable = false
+	m.directValidation = false
+	m.brokers = nil
+}
+
+func (m *MockAdminAPI) GetFeatures(
+	_ context.Context,
+) (admin.FeaturesResponse, error) {
+	m.Log.WithName("GetFeatures").Info("called")
+	return admin.FeaturesResponse{
+		ClusterVersion: 0,
+		Features: []admin.Feature{
+			{
+				Name:      "central_config",
+				State:     admin.FeatureStateActive,
+				WasActive: true,
+			},
+		},
+	}, nil
+}
+
+func (m *MockAdminAPI) SetLicense(_ context.Context, _ interface{}) error {
+	m.Log.WithName("SetLicense").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return &unavailableError{}
+	}
+	return nil
+}
+
+func (m *MockAdminAPI) GetLicenseInfo(_ context.Context) (admin.License, error) {
+	m.Log.WithName("GetLicenseInfo").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.unavailable {
+		return admin.License{}, &unavailableError{}
+	}
+	return admin.License{}, nil
+}
+
+//nolint:gocritic // It's test API
+func (m *MockAdminAPI) RegisterPropertySchema(
+	name string, metadata admin.ConfigPropertyMetadata,
+) {
+	m.Log.WithName("RegisterPropertySchema").WithValues("name", name, "metadata", metadata).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.schema == nil {
+		m.schema = make(map[string]admin.ConfigPropertyMetadata)
+	}
+	m.schema[name] = metadata
+}
+
+func (m *MockAdminAPI) PropertyGetter(name string) func() interface{} {
+	return func() interface{} {
+		m.Log.WithName("PropertyGetter").WithValues("name", name).Info("called")
+		m.monitor.Lock()
+		defer m.monitor.Unlock()
+		return m.config[name]
+	}
+}
+
+func (m *MockAdminAPI) ConfigGetter() func() admin.Config {
+	return func() admin.Config {
+		m.Log.WithName("ConfigGetter").Info("called")
+		m.monitor.Lock()
+		defer m.monitor.Unlock()
+		var res admin.Config
+		makeCopy(m.config, &res)
+		return res
+	}
+}
+
+func (m *MockAdminAPI) PatchesGetter() func() []configuration.CentralConfigurationPatch {
+	return func() []configuration.CentralConfigurationPatch {
+		m.Log.WithName("PatchesGetter(func)").Info("called")
+		m.monitor.Lock()
+		defer m.monitor.Unlock()
+		var res []configuration.CentralConfigurationPatch
+		makeCopy(m.patches, &res)
+		return res
+	}
+}
+
+func (m *MockAdminAPI) NumPatchesGetter() func() int {
+	return func() int {
+		m.Log.WithName("NumPatchesGetter(func)").Info("called")
+		return len(m.PatchesGetter()())
+	}
+}
+
+func (m *MockAdminAPI) SetProperty(key string, value interface{}) {
+	m.Log.WithName("SetProperty").WithValues("key", key, "value", value).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	if m.config == nil {
+		m.config = make(map[string]interface{})
+	}
+	m.config[key] = value
+}
+
+func (m *MockAdminAPI) SetUnavailable(unavailable bool) {
+	m.Log.WithName("SetUnavailable").WithValues("unavailable", unavailable).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	m.unavailable = unavailable
+}
+
+func (m *MockAdminAPI) GetNodeConfig(
+	_ context.Context,
+) (admin.NodeConfig, error) {
+	m.Log.WithName("GetNodeConfig").Info("called")
+	return admin.NodeConfig{}, nil
+}
+
+//nolint:goerr113 // test code
+func (s *ScopedMockAdminAPI) GetNodeConfig(
+	ctx context.Context,
+) (admin.NodeConfig, error) {
+	brokers, err := s.Brokers(ctx)
+	if err != nil {
+		return admin.NodeConfig{}, err
+	}
+	if len(brokers) <= int(s.Ordinal) {
+		return admin.NodeConfig{}, fmt.Errorf("broker not registered")
+	}
+	return admin.NodeConfig{
+		NodeID: brokers[int(s.Ordinal)].NodeID,
+	}, nil
+}
+
+func (m *MockAdminAPI) SetDirectValidationEnabled(directValidation bool) {
+	m.Log.WithName("SetDirectValicationEnabled").WithValues("directValidation", directValidation).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+	m.directValidation = directValidation
+}
+
+func (m *MockAdminAPI) AddBroker(broker admin.Broker) {
+	m.Log.WithName("AddBroker").WithValues("broker", broker).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+
+	m.brokers = append(m.brokers, broker)
+}
+
+func (m *MockAdminAPI) RemoveBroker(id int) bool {
+	m.Log.WithName("RemoveBroker").WithValues("id", id).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+
+	idx := -1
+	for i := range m.brokers {
+		if m.brokers[i].NodeID == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return false
+	}
+	m.brokers = append(m.brokers[:idx], m.brokers[idx+1:]...)
+	return true
+}
+
+func (m *MockAdminAPI) Brokers(_ context.Context) ([]admin.Broker, error) {
+	m.Log.WithName("RemoveBroker").Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+
+	return append([]admin.Broker{}, m.brokers...), nil
+}
+
+func (m *MockAdminAPI) BrokerStatusGetter(
+	id int,
+) func() admin.MembershipStatus {
+	return func() admin.MembershipStatus {
+		m.Log.WithName("BrokerStatusGetter(func)").WithValues("id", id).Info("called")
+		m.monitor.Lock()
+		defer m.monitor.Unlock()
+
+		for i := range m.brokers {
+			if m.brokers[i].NodeID == id {
+				return m.brokers[i].MembershipStatus
+			}
+		}
+		return ""
+	}
+}
+
+func (m *MockAdminAPI) DecommissionBroker(_ context.Context, id int) error {
+	m.Log.WithName("DecommissionBroker").WithValues("id", id).Info("called")
+	return m.SetBrokerStatus(id, admin.MembershipStatusDraining)
+}
+
+func (m *MockAdminAPI) RecommissionBroker(_ context.Context, id int) error {
+	m.Log.WithName("RecommissionBroker").WithValues("id", id).Info("called")
+	return m.SetBrokerStatus(id, admin.MembershipStatusActive)
+}
+
+func (m *MockAdminAPI) EnableMaintenanceMode(_ context.Context, _ int) error {
+	m.Log.WithName("EnableMaintenanceMode").Info("called")
+	return nil
+}
+
+func (m *MockAdminAPI) DisableMaintenanceMode(_ context.Context, _ int) error {
+	m.Log.WithName("DisableMaintenanceMode").Info("called")
+	return nil
+}
+
+func (m *MockAdminAPI) GetHealthOverview(_ context.Context) (admin.ClusterHealthOverview, error) {
+	m.Log.WithName("GetHealthOverview").Info("called")
+	return admin.ClusterHealthOverview{
+		IsHealthy: true,
+	}, nil
+}
+
+//nolint:goerr113 // test code
+func (m *MockAdminAPI) SetBrokerStatus(
+	id int, status admin.MembershipStatus,
+) error {
+	m.Log.WithName("SetBrokerStatus").WithValues("id", id, "status", status).Info("called")
+	m.monitor.Lock()
+	defer m.monitor.Unlock()
+
+	for i := range m.brokers {
+		if m.brokers[i].NodeID == id {
+			m.brokers[i].MembershipStatus = status
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown broker %d", id)
+}
+
+func makeCopy(input, output interface{}) {
+	ser, err := json.Marshal(input)
+	if err != nil {
+		panic(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(ser))
+	decoder.UseNumber()
+	err = decoder.Decode(output)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func addAsSet(sliceSet []string, vals ...string) []string {
+	asSet := make(map[string]bool, len(sliceSet)+len(vals))
+	for _, k := range sliceSet {
+		asSet[k] = true
+	}
+	for _, v := range vals {
+		asSet[v] = true
+	}
+	lst := make([]string, 0, len(asSet))
+	for k := range asSet {
+		lst = append(lst, k)
+	}
+	sort.Strings(lst)
+	return lst
+}

--- a/src/go/k8s/pkg/resources/featuregates/featuregates.go
+++ b/src/go/k8s/pkg/resources/featuregates/featuregates.go
@@ -38,6 +38,12 @@ func CentralizedConfiguration(version string) bool {
 	return atLeastVersion(V22_1, version)
 }
 
+// ClusterHealth feature gate should be removed when the operator
+// will no longer support 21.x or older versions
+func ClusterHealth(version string) bool {
+	return atLeastVersion(V22_1, version)
+}
+
 // MaintenanceMode feature gate should be removed when the operator
 // will no longer support 21.x or older versions
 func MaintenanceMode(version string) bool {

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -17,6 +17,7 @@ import (
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda/src/go/k8s/pkg/admin"
 	res "github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
+	resourcetypes "github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/types"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -110,7 +111,9 @@ func TestEnsure(t *testing.T) {
 					ImagePullPolicy:       "Always",
 				},
 				func(ctx context.Context) (string, error) { return hash, nil },
-				adminutils.NewInternalAdminAPI,
+				func(ctx context.Context, k8sClient client.Reader, redpandaCluster *redpandav1alpha1.Cluster, fqdn string, adminTLSProvider resourcetypes.AdminTLSConfigProvider, ordinals ...int32) (adminutils.AdminAPIClient, error) {
+					return &adminutils.MockAdminAPI{Log: ctrl.Log.WithName("testAdminAPI").WithName("mockAdminAPI")}, nil
+				},
 				time.Second,
 				ctrl.Log.WithName("test"))
 

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -11,6 +11,7 @@ package resources_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -65,17 +66,25 @@ func TestEnsure(t *testing.T) {
 	// Remove shadow-indexing-cache from the volume claim templates
 	stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates = stsWithoutSecondPersistentVolume.Spec.VolumeClaimTemplates[:1]
 
+	unhealthyRedpandaCluster := cluster.DeepCopy()
+
 	tests := []struct {
 		name           string
 		existingObject client.Object
 		pandaCluster   *redpandav1alpha1.Cluster
 		expectedObject *v1.StatefulSet
+		clusterHealth  bool
+		expectedError  error
 	}{
-		{"none existing", nil, cluster, stsResource},
-		{"update resources", stsResource, resourcesUpdatedCluster, resourcesUpdatedSts},
-		{"update redpanda resources", stsResource, resourcesUpdatedRedpandaCluster, resourcesUpdatedSts},
-		{"disabled sidecar", nil, noSidecarCluster, noSidecarSts},
-		{"cluster without shadow index cache dir", stsResource, withoutShadowIndexCacheDirectory, stsWithoutSecondPersistentVolume},
+		{"none existing", nil, cluster, stsResource, true, nil},
+		{"update resources", stsResource, resourcesUpdatedCluster, resourcesUpdatedSts, true, nil},
+		{"update redpanda resources", stsResource, resourcesUpdatedRedpandaCluster, resourcesUpdatedSts, true, nil},
+		{"disabled sidecar", nil, noSidecarCluster, noSidecarSts, true, nil},
+		{"cluster without shadow index cache dir", stsResource, withoutShadowIndexCacheDirectory, stsWithoutSecondPersistentVolume, true, nil},
+		{"update none healthy cluster", stsResource, unhealthyRedpandaCluster, stsResource, false, &res.RequeueAfterError{
+			RequeueAfter: res.RequeueDuration,
+			Msg:          "wait for cluster to become healthy (cluster restarting)",
+		}},
 	}
 
 	for _, tt := range tests {
@@ -112,13 +121,20 @@ func TestEnsure(t *testing.T) {
 				},
 				func(ctx context.Context) (string, error) { return hash, nil },
 				func(ctx context.Context, k8sClient client.Reader, redpandaCluster *redpandav1alpha1.Cluster, fqdn string, adminTLSProvider resourcetypes.AdminTLSConfigProvider, ordinals ...int32) (adminutils.AdminAPIClient, error) {
-					return &adminutils.MockAdminAPI{Log: ctrl.Log.WithName("testAdminAPI").WithName("mockAdminAPI")}, nil
+					health := tt.clusterHealth
+					adminAPI := &adminutils.MockAdminAPI{Log: ctrl.Log.WithName("testAdminAPI").WithName("mockAdminAPI")}
+					adminAPI.SetClusterHealth(health)
+					return adminAPI, nil
 				},
 				time.Second,
 				ctrl.Log.WithName("test"))
 
 			err = sts.Ensure(context.Background())
-			assert.NoError(t, err, tt.name)
+			if tt.expectedError != nil && errors.Is(err, tt.expectedError) {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
 
 			actual := &v1.StatefulSet{}
 			err = c.Get(context.Background(), sts.Key(), actual)

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -457,6 +457,10 @@ func (e *RequeueAfterError) Error() string {
 	return fmt.Sprintf("RequeueAfterError %s", e.Msg)
 }
 
+func (e *RequeueAfterError) Is(target error) bool {
+	return e.Error() == target.Error()
+}
+
 // RequeueError error to requeue using default retry backoff.
 type RequeueError struct {
 	Msg string

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/00-redpanda-cluster.yaml
@@ -22,7 +22,6 @@ spec:
     - port: 9644
       tls:
         enabled: true
-        requireClientAuth: true
     pandaproxyApi:
      - port: 8082
     developerMode: true

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/01-redpanda-cluster-change.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/01-redpanda-cluster-change.yaml
@@ -22,9 +22,10 @@ spec:
     - port: 9644
       tls:
         enabled: true
-        requireClientAuth: true
     pandaproxyApi:
      - port: 8082
+       tls:
+         enabled: true
     developerMode: true
   additionalConfiguration:
     redpanda.segment_appender_flush_timeout_ms: "1003"

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/02-probe.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/02-probe.yaml
@@ -8,10 +8,6 @@ spec:
     spec:
       activeDeadlineSeconds: 90
       volumes:
-        - name: tlsadmin
-          secret:
-            defaultMode: 420
-            secretName: centralized-configuration-tls-admin-api-client
         - name: tlsadminca
           secret:
             defaultMode: 420
@@ -31,14 +27,12 @@ spec:
           args:
             - >
               url=https://centralized-configuration-tls-0.centralized-configuration-tls.$NAMESPACE.svc.cluster.local:9644/v1/config
-              res=$(curl --cacert /etc/tls/certs/admin/ca/ca.crt --cert /etc/tls/certs/admin/tls.crt --key /etc/tls/certs/admin/tls.key --silent -L $url | grep -o '\"segment_appender_flush_timeout_ms\":[^,}]*' | grep -o '[^:]*$') &&
+              res=$(curl --cacert /etc/tls/certs/admin/ca/ca.crt --silent -L $url | grep -o '\"segment_appender_flush_timeout_ms\":[^,}]*' | grep -o '[^:]*$') &&
               echo $res > /dev/termination-log &&
               if [[ "$res" != "1003" ]]; then
                 exit 1;
               fi
           volumeMounts:
-            - mountPath: /etc/tls/certs/admin
-              name: tlsadmin
             - mountPath: /etc/tls/certs/admin/ca
               name: tlsadminca
       restartPolicy: Never

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: centralized-configuration-upgrade
 spec:
   image: "vectorized/redpanda"
-  version: "v21.11.11"
+  version: "v22.1.10"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.16"
+    image: "vectorized/redpanda:v22.1.10"
 status:
   phase: "Running"
 ---
@@ -25,7 +25,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v21.11.16"
+      image: "vectorized/redpanda:v22.1.10"
 status:
   phase: "Running"
 ---

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
@@ -4,7 +4,7 @@ metadata:
   name: centralized-configuration-upgrade
 spec:
   image: "vectorized/redpanda"
-  version: "v21.11.16"
+  version: "v22.1.10"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
@@ -4,7 +4,7 @@ metadata:
   name: centralized-configuration-upgrade
 spec:
   image: "vectorized/redpanda"
-  version: "v22.2.7"
+  version: "v22.2.8"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -58,4 +58,4 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 status:
-  version: "v21.11.1"
+  version: "v22.1.10"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
@@ -23,7 +23,7 @@ metadata:
   name: update-image-cluster-and-node-port
 spec:
   image: "vectorized/redpanda"
-  version: "v21.11.1"
+  version: "v22.1.10"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -14,12 +14,15 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
     - mountPath: /scripts
       name: hook-scripts-dir
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache
@@ -38,12 +41,15 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
     - mountPath: /scripts
       name: hook-scripts-dir
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache
@@ -90,4 +96,4 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 status:
-  version: "v21.11.12"
+  version: "v22.2.8"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  version: "v21.11.12"
+  version: "v22.2.8"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: vectorized/redpanda:v22.2.7
+    image: vectorized/redpanda:v22.3.4
 status:
   phase: "Running"
 
@@ -27,7 +27,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: vectorized/redpanda:v22.2.7
+    image: vectorized/redpanda:v22.3.4
 status:
   phase: "Running"
 
@@ -47,4 +47,4 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 status:
-  version: v22.2.7
+  version: v22.3.4

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-new-image.yaml
@@ -4,4 +4,4 @@ metadata:
   name: update-image-cluster-and-node-port
 spec:
   image: "vectorized/redpanda"
-  version: "v22.2.7"
+  version: "v22.3.4"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.11.1"
+  version: "v22.1.10"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -24,6 +24,9 @@ spec:
       name: tlsadmincert
     - mountPath: /etc/tls/certs/admin/ca
       name: tlsadminca
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache
@@ -42,7 +45,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -52,6 +55,9 @@ spec:
       name: tlsadmincert
     - mountPath: /etc/tls/certs/admin/ca
       name: tlsadminca
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "v21.11.12"
+  version: "v22.2.8"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v22.2.7"
+    image: "vectorized/redpanda:v22.3.4"
 status:
   phase: "Running"
 
@@ -27,7 +27,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v22.2.7"
+    image: "vectorized/redpanda:v22.3.4"
 status:
   phase: "Running"
 

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-new-image.yaml
@@ -4,4 +4,4 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v22.2.7"
+  version: "v22.3.4"

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.11.1"
+  version: "v22.1.10"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -22,6 +22,9 @@ spec:
       name: hook-scripts-dir
     - mountPath: /etc/tls/certs/admin
       name: tlsadmincert
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache
@@ -40,7 +43,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.11.12"
+    image: "vectorized/redpanda:v22.2.8"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -48,6 +51,9 @@ spec:
       name: hook-scripts-dir
     - mountPath: /etc/tls/certs/admin
       name: tlsadmincert
+    - mountPath: /etc/redpanda/.bootstrap.yaml
+      name: configmap-dir
+      subPath: .bootstrap.yaml
     - mountPath: /var/lib/redpanda/data
       name: datadir
     - mountPath: /var/lib/shadow-index-cache

--- a/src/go/k8s/tests/e2e/update-image-tls/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "v21.11.12"
+  version: "v22.2.8"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v22.2.7"
+    image: "vectorized/redpanda:v22.3.4"
 status:
   phase: "Running"
 
@@ -27,7 +27,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v22.2.7"
+    image: "vectorized/redpanda:v22.3.4"
 status:
   phase: "Running"
 

--- a/src/go/k8s/tests/e2e/update-image-tls/02-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-new-image.yaml
@@ -4,4 +4,4 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v22.2.7"
+  version: "v22.3.4"


### PR DESCRIPTION
As per https://github.com/redpanda-data/redpanda/issues/3023 the cluster should
be healthy before starting put node in maintanance mode and after POD is restarted.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->
Internal update logic is improved to not consider update if cluster is not
reporting healthy status via Admin API.

There is one regression that will be addressed later if someone would like
to turn off mTLS from internal Admin API new logic does not now how to
handle correct client certification.

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
### Improvements

* Updates inside kuberntes environment the Redpanda update will be more
  safe as operator now doesn't consider updates if cluster does not report
  healthy status.

### REF

https://github.com/redpanda-data/redpanda/issues/3023