### PR TITLE
k8s: Put brokers in maintenance mode before deleting orphan's pod

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -551,7 +551,7 @@ func (r *ClusterReconciler) fetchAdminNodeID(ctx context.Context, rp *redpandav1
 		return -1, fmt.Errorf("creating pki: %w", err)
 	}
 
-	ordinal, err := strconv.ParseInt(pod.Name[len(rp.Name)+1:], 10, 0)
+	ordinal, err := strconv.ParseInt(getPodOrdinal(pod.Name, rp.Name), 10, 0)
 	if err != nil {
 		return -1, fmt.Errorf("cluster %s: cannot convert pod name (%s) to ordinal: %w", rp.Name, pod.Name, err)
 	}
@@ -565,6 +565,16 @@ func (r *ClusterReconciler) fetchAdminNodeID(ctx context.Context, rp *redpandav1
 		return -1, fmt.Errorf("unable to fetch /v1/node_config from %s: %w", pod.Name, err)
 	}
 	return int32(cfg.NodeID), nil
+}
+
+func getPodOrdinal(podName string, clusterName string) string {
+	// Pod name needs to have at least 2 more characters
+	if len(podName) < len(clusterName)+2 {
+		return ""
+	}
+
+	// The +1 is for the separator between stateful set name and pod ordinal
+	return podName[len(clusterName)+1:]
 }
 
 func (r *ClusterReconciler) reportStatus(

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -551,7 +551,7 @@ func (r *ClusterReconciler) fetchAdminNodeID(ctx context.Context, rp *redpandav1
 		return -1, fmt.Errorf("creating pki: %w", err)
 	}
 
-	ordinal, err := strconv.ParseInt(getPodOrdinal(pod.Name, rp.Name), 10, 0)
+	ordinal, err := utils.GetPodOrdinal(pod.Name, rp.Name)
 	if err != nil {
 		return -1, fmt.Errorf("cluster %s: cannot convert pod name (%s) to ordinal: %w", rp.Name, pod.Name, err)
 	}
@@ -565,16 +565,6 @@ func (r *ClusterReconciler) fetchAdminNodeID(ctx context.Context, rp *redpandav1
 		return -1, fmt.Errorf("unable to fetch /v1/node_config from %s: %w", pod.Name, err)
 	}
 	return int32(cfg.NodeID), nil
-}
-
-func getPodOrdinal(podName string, clusterName string) string {
-	// Pod name needs to have at least 2 more characters
-	if len(podName) < len(clusterName)+2 {
-		return ""
-	}
-
-	// The +1 is for the separator between stateful set name and pod ordinal
-	return podName[len(clusterName)+1:]
 }
 
 func (r *ClusterReconciler) reportStatus(

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -92,6 +92,7 @@ type AdminAPIClient interface {
 	GetLicenseInfo(ctx context.Context) (admin.License, error)
 
 	Brokers(ctx context.Context) ([]admin.Broker, error)
+	Broker(ctx context.Context, nodeID int) (admin.Broker, error)
 	DecommissionBroker(ctx context.Context, node int) error
 	RecommissionBroker(ctx context.Context, node int) error
 

--- a/src/go/k8s/pkg/admin/mock_admin.go
+++ b/src/go/k8s/pkg/admin/mock_admin.go
@@ -25,17 +25,18 @@ import (
 )
 
 type MockAdminAPI struct {
-	config           admin.Config
-	schema           admin.ConfigSchema
-	patches          []configuration.CentralConfigurationPatch
-	unavailable      bool
-	invalid          []string
-	unknown          []string
-	directValidation bool
-	brokers          []admin.Broker
-	monitor          sync.Mutex
-	Log              logr.Logger
-	clusterHealth    bool
+	config            admin.Config
+	schema            admin.ConfigSchema
+	patches           []configuration.CentralConfigurationPatch
+	unavailable       bool
+	invalid           []string
+	unknown           []string
+	directValidation  bool
+	brokers           []admin.Broker
+	monitor           sync.Mutex
+	Log               logr.Logger
+	clusterHealth     bool
+	MaintenanceStatus *admin.MaintenanceStatus
 }
 
 var _ AdminAPIClient = &MockAdminAPI{Log: ctrl.Log.WithName("AdminAPIClient").WithName("mockAdminAPI")}
@@ -420,6 +421,18 @@ func (m *MockAdminAPI) SetBrokerStatus(
 		}
 	}
 	return fmt.Errorf("unknown broker %d", id)
+}
+
+func (m *MockAdminAPI) Broker(_ context.Context, nodeID int) (admin.Broker, error) {
+	t := true
+	return admin.Broker{
+		NodeID:           nodeID,
+		NumCores:         2,
+		MembershipStatus: "",
+		IsAlive:          &t,
+		Version:          "unversioned",
+		Maintenance:      m.MaintenanceStatus,
+	}, nil
 }
 
 func makeCopy(input, output interface{}) {

--- a/src/go/k8s/pkg/resources/statefulset_update_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_update_test.go
@@ -10,12 +10,19 @@
 package resources //nolint:testpackage // needed to test private method
 
 import (
+	"context"
 	"testing"
 
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	adminutils "github.com/redpanda-data/redpanda/src/go/k8s/pkg/admin"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/types"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestShouldUpdate_AnnotationChange(t *testing.T) {
@@ -64,4 +71,79 @@ func TestShouldUpdate_AnnotationChange(t *testing.T) {
 	update, err = ssres.shouldUpdate(false, stsWithAnnotation, stsWithAnnotation)
 	require.NoError(t, err)
 	require.False(t, update)
+}
+
+func TestPutInMaintenanceMode(t *testing.T) {
+	tcs := []struct {
+		name              string
+		maintenanceStatus *admin.MaintenanceStatus
+		errorRequired     error
+	}{
+		{
+			"maintenance finished",
+			&admin.MaintenanceStatus{
+				Finished: true,
+			},
+			nil,
+		},
+		{
+			"maintenance draining",
+			&admin.MaintenanceStatus{
+				Draining: true,
+			},
+			ErrMaintenanceNotFinished,
+		},
+		{
+			"maintenance failed",
+			&admin.MaintenanceStatus{
+				Failed: 1,
+			},
+			ErrMaintenanceNotFinished,
+		},
+		{
+			"maintenance has errors",
+			&admin.MaintenanceStatus{
+				Errors: true,
+			},
+			ErrMaintenanceNotFinished,
+		},
+		{
+			"maintenance did not finished",
+			&admin.MaintenanceStatus{
+				Finished: false,
+			},
+			ErrMaintenanceNotFinished,
+		},
+		{
+			"maintenance was not returned",
+			nil,
+			ErrMaintenanceMissing,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ssres := StatefulSetResource{
+				adminAPIClientFactory: func(
+					ctx context.Context,
+					k8sClient client.Reader,
+					redpandaCluster *redpandav1alpha1.Cluster,
+					fqdn string,
+					adminTLSProvider types.AdminTLSConfigProvider,
+					ordinals ...int32,
+				) (adminutils.AdminAPIClient, error) {
+					return &adminutils.MockAdminAPI{
+						Log:               ctrl.Log.WithName("testAdminAPI").WithName("mockAdminAPI"),
+						MaintenanceStatus: tc.maintenanceStatus,
+					}, nil
+				},
+			}
+			err := ssres.putInMaintenanceMode(context.Background(), 0)
+			if tc.errorRequired == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.errorRequired)
+			}
+		})
+	}
 }

--- a/src/go/k8s/pkg/utils/kubernetes.go
+++ b/src/go/k8s/pkg/utils/kubernetes.go
@@ -9,7 +9,14 @@
 
 package utils
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var ErrInvalidInputParameters = fmt.Errorf("invalid input parameters")
 
 // IsPodReady tells if a given pod is ready looking at its status.
 func IsPodReady(pod *corev1.Pod) bool {
@@ -20,4 +27,19 @@ func IsPodReady(pod *corev1.Pod) bool {
 	}
 
 	return false
+}
+
+func GetPodOrdinal(podName, clusterName string) (int64, error) {
+	// Pod name needs to have at least 2 more characters
+	if len(podName) < len(clusterName)+2 {
+		return -1, fmt.Errorf("pod name (%s) and cluster name (%s): %w", podName, clusterName, ErrInvalidInputParameters)
+	}
+
+	// The +1 is for the separator between stateful set name and pod ordinal
+	ordinalStr := podName[len(clusterName)+1:]
+	ordinal, err := strconv.ParseInt(ordinalStr, 10, 0)
+	if err != nil {
+		return -1, fmt.Errorf("parsing int failed (%s): %w", ordinalStr, err)
+	}
+	return ordinal, nil
 }

--- a/src/go/k8s/pkg/utils/kubernetes_test.go
+++ b/src/go/k8s/pkg/utils/kubernetes_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022-2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPodOrdinal(t *testing.T) {
+	tcs := []struct {
+		podName         string
+		clusterName     string
+		expectedError   bool
+		expectedOrdinal int64
+	}{
+		{"", "", true, -1},
+		{"test", "", true, -1},
+		{"pod-0", "pod", false, 0},
+		{"pod-99", "pod", false, 99},
+		{"", "unexpected longer cluster name", true, -1},
+		{"test+0", "test", false, 0},
+		{"without-ordinal-", "without-ordinal", true, -1},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("pod %s and cluster %s", tc.podName, tc.clusterName), func(t *testing.T) {
+			ordinal, err := utils.GetPodOrdinal(tc.podName, tc.clusterName)
+			if tc.expectedError {
+				require.Error(t, err)
+			}
+			require.Equal(t, tc.expectedOrdinal, ordinal)
+		})
+	}
+}


### PR DESCRIPTION
During rolling update, before this change, Redpanda operator was calculating the difference between running pod specification and stateful set pod template. If the specification did not match the pod was deleted. From release v22.1.1 operator is configuring each broker with pod lifecycle hooks. In the PreStop hook the script will try to put broker into maintenance mode for 120 seconds before POD is terminated. Redpanda could not finish within 120 seconds to put one broker into maintenance mode.

This PR improves the situation by putting maintenance mode before POD is deleted. The `putInMaintenanceMode` function is called multiple times until `Broker` function returns correct status. The assumption is that REST admin API maintenance mode endpoint is idempotent.

When pod is successfully deleted statefulset would reschedule the pod with correct pod specification.

## Ref

https://github.com/redpanda-data/redpanda/pull/4125 
https://github.com/redpanda-data/redpanda/issues/3023

On top of:
https://github.com/redpanda-data/redpanda/pull/7528

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

Before deleting the POD maintenance mode is configured (not within 120 second lifecycle hook).

## Release Notes

### Improvements

  * Before deleting the POD maintenance mode is configured (not within 120 second lifecycle hook)

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
