### PR TITLE
tests: fix bad arg in cloud_storage_compaction_test

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -127,7 +127,6 @@ class CloudStorageCompactionTest(EndToEndTest):
 
     def _init_redpanda_read_replica(self):
         self.rr_si_settings = SISettings(
-            cloud_storage_bucket='none',
             bypass_bucket_creation=True,
             cloud_storage_reconciliation_interval_ms=500,
             cloud_storage_max_connections=5,


### PR DESCRIPTION
This merge-raced with a change that removed the cloud_storage_bucket parameter to SISettings.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
