### PR TITLE
`cluster_bootstrap_tests` test upgrade 22.2 -> 22.3, not -> newest

### DIFF
--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -93,13 +93,17 @@ class ClusterBootstrapNew(RedpandaTest):
             assert expected_node_id == node_id, f"Expected {expected_node_id} but got {node_id}"
 
 
+def ver_str(ver) -> str:
+    return 'v' + '.'.join(str(k) for k in ver)
+
+
 class ClusterBootstrapUpgrade(RedpandaTest):
     """
     Tests verifying upgrade of cluster from a pre-Seed-Driven-Bootstrap version
     """
 
     OLDVER = (22, 2, 7)
-    OLDVER_STR = 'v' + '.'.join(str(k) for k in OLDVER)
+    NEWVER = (22, 3, 4)
 
     def __init__(self, test_context):
         super(ClusterBootstrapUpgrade,
@@ -108,8 +112,6 @@ class ClusterBootstrapUpgrade(RedpandaTest):
         self.admin = self.redpanda._admin
 
     def setUp(self):
-        # NOTE: `rpk redpanda admin brokers list` requires versions v22.1.x and
-        # above.
         self.installer.install(self.redpanda.nodes, self.OLDVER)
         set_seeds_for_cluster(self.redpanda, 3)
         super(ClusterBootstrapUpgrade, self).setUp()
@@ -120,7 +122,7 @@ class ClusterBootstrapUpgrade(RedpandaTest):
                                                     empty_seed_starts_cluster):
         # Upgrade the cluster to begin using the new binary, but don't change
         # any configs yet.
-        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.installer.install(self.redpanda.nodes, self.NEWVER)
         self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
 
         # Now update the configs.
@@ -136,7 +138,7 @@ class ClusterBootstrapUpgrade(RedpandaTest):
     def test_change_bootstrap_configs_during_upgrade(
             self, empty_seed_starts_cluster):
         # Upgrade the cluster as we change the configs node-by-node.
-        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.installer.install(self.redpanda.nodes, self.NEWVER)
         self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
                                             override_cfg_params={
                                                 "empty_seed_starts_cluster":
@@ -164,15 +166,15 @@ class ClusterBootstrapUpgrade(RedpandaTest):
             return u_prev
 
         unique_versions = wait_for_num_versions(self.redpanda, 1)
-        assert self.OLDVER_STR in unique_versions, unique_versions
+        assert ver_str(self.OLDVER) in unique_versions, unique_versions
 
         # Upgrade all but 1 node, verify cluster UUID is not created in 10s
         one_node = [self.redpanda.nodes[0]]
         but_one_node = self.redpanda.nodes[1:]
-        self.installer.install(but_one_node, RedpandaInstaller.HEAD)
+        self.installer.install(but_one_node, self.NEWVER)
         self.redpanda.restart_nodes(but_one_node)
         unique_versions = wait_for_num_versions(self.redpanda, 2)
-        assert self.OLDVER_STR in unique_versions, unique_versions
+        assert ver_str(self.OLDVER) in unique_versions, unique_versions
         try:
             wait_until(lambda: get_cluster_uuid() is not None,
                        timeout_sec=10,
@@ -182,8 +184,8 @@ class ClusterBootstrapUpgrade(RedpandaTest):
             pass
 
         # Upgrade all nodes, verify the cluster has a UUID now
-        self.installer.install(one_node, RedpandaInstaller.HEAD)
+        self.installer.install(one_node, self.NEWVER)
         self.redpanda.restart_nodes(one_node)
         unique_versions = wait_for_num_versions(self.redpanda, 1)
-        assert self.OLDVER_STR not in unique_versions, unique_versions
+        assert ver_str(self.OLDVER) not in unique_versions, unique_versions
         wait_until(lambda: get_cluster_uuid() is not None, timeout_sec=30)


### PR DESCRIPTION
This is to avoid skipping major versions in upgrade tests

Re #7310

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
