### PR TITLE
kafka: update describe configs version

### DIFF
--- a/src/v/kafka/protocol/schemata/describe_configs_request.json
+++ b/src/v/kafka/protocol/schemata/describe_configs_request.json
@@ -16,11 +16,13 @@
 {
   "apiKey": 32,
   "type": "request",
+  "listeners": ["zkBroker", "broker"],
   "name": "DescribeConfigsRequest",
-  // Version 1 adds IncludeSynoyms.
+  // Version 1 adds IncludeSynonyms.
   // Version 2 is the same as version 1.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  // Version 4 enables flexible versions.
+  "validVersions": "0-4",
+  "flexibleVersions": "4+",
   "fields": [
     { "name": "Resources", "type": "[]DescribeConfigsResource", "versions": "0+",
       "about": "The resources whose configurations we want to describe.", "fields": [
@@ -32,6 +34,8 @@
         "about": "The configuration keys to list, or null to list all configuration keys." }
     ]},
     { "name": "IncludeSynonyms", "type": "bool", "versions": "1+", "default": "false", "ignorable": false,
-      "about": "True if we should include all synonyms." }
+      "about": "True if we should include all synonyms." },
+    { "name": "IncludeDocumentation", "type": "bool", "versions": "3+", "default": "false", "ignorable": false,
+      "about": "True if we should include configuration documentation." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/describe_configs_response.json
+++ b/src/v/kafka/protocol/schemata/describe_configs_response.json
@@ -19,8 +19,9 @@
   "name": "DescribeConfigsResponse",
   // Version 1 adds ConfigSource and the synonyms.
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  // Version 4 enables flexible versions.
+  "validVersions": "0-4",
+  "flexibleVersions": "4+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
@@ -59,7 +60,11 @@
             "about": "The synonym value." },
           { "name": "Source", "type": "int8", "versions": "1+",
             "about": "The synonym source." }
-        ]}
+        ]},
+        { "name": "ConfigType", "type": "int8", "versions": "3+", "default": "0", "ignorable": true,
+          "about": "The configuration data type. Type can be one of the following values - BOOLEAN, STRING, INT, SHORT, LONG, DOUBLE, LIST, CLASS, PASSWORD" },
+        { "name": "Documentation", "type": "string", "versions": "3+", "nullableVersions": "0+", "ignorable": true,
+          "about": "The configuration documentation." }
       ]}
     ]}
   ]

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -211,6 +211,7 @@ path_type_map = {
             "ResourceType": ("kafka::config_resource_type", "int8"),
             "Configs": {
                 "ConfigSource": ("kafka::describe_configs_source", "int8"),
+                "ConfigType": ("kafka::describe_configs_type", "int8"),
             },
         },
     },

--- a/src/v/kafka/protocol/types.cc
+++ b/src/v/kafka/protocol/types.cc
@@ -62,8 +62,6 @@ std::ostream& operator<<(std::ostream& os, describe_configs_type t) {
         return os << "{class}";
     case describe_configs_type::password:
         return os << "{password}";
-    case describe_configs_type::not_supported:
-        break;
     }
     return os << "{unsupported type}";
 }

--- a/src/v/kafka/protocol/types.cc
+++ b/src/v/kafka/protocol/types.cc
@@ -40,4 +40,32 @@ std::ostream& operator<<(std::ostream& os, const uuid& u) {
     return os << u.to_string();
 }
 
+std::ostream& operator<<(std::ostream& os, describe_configs_type t) {
+    switch (t) {
+    case describe_configs_type::unknown:
+        return os << "{unknown}";
+    case describe_configs_type::boolean:
+        return os << "{boolean}";
+    case describe_configs_type::string:
+        return os << "{string}";
+    case describe_configs_type::int_type:
+        return os << "{int}";
+    case describe_configs_type::short_type:
+        return os << "{short}";
+    case describe_configs_type::long_type:
+        return os << "{long}";
+    case describe_configs_type::double_type:
+        return os << "{double}";
+    case describe_configs_type::list:
+        return os << "{list}";
+    case describe_configs_type::class_type:
+        return os << "{class}";
+    case describe_configs_type::password:
+        return os << "{password}";
+    case describe_configs_type::not_supported:
+        break;
+    }
+    return os << "{unsupported type}";
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -140,8 +140,7 @@ concept KafkaApi = requires(T request) {
  * Data type of the configuration entry.
  */
 enum class describe_configs_type : int8_t {
-    not_supported = -1,
-    unknown = 0, // This is the default config type
+    unknown = 0,
     boolean = 1,
     string = 2,
     int_type = 3,

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -136,4 +136,23 @@ concept KafkaApi = requires(T request) {
     { T::min_flexible } -> std::convertible_to<const api_version&>;
 };
 
+/*
+ * Data type of the configuration entry.
+ */
+enum class describe_configs_type : int8_t {
+    not_supported = -1,
+    unknown = 0, // This is the default config type
+    boolean = 1,
+    string = 2,
+    int_type = 3,
+    short_type = 4,
+    long_type = 5,
+    double_type = 6,
+    list = 7,
+    class_type = 8,
+    password = 9
+};
+
+std::ostream& operator<<(std::ostream&, describe_configs_type t);
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -22,6 +22,7 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/validation.h"
+#include "reflection/type_traits.h"
 #include "security/acl.h"
 #include "ssx/sformat.h"
 
@@ -33,6 +34,7 @@
 
 #include <charconv>
 #include <string_view>
+#include <type_traits>
 
 namespace kafka {
 
@@ -77,12 +79,83 @@ static ss::sstring describe_as_string(const T& t) {
     return ssx::sformat("{}", t);
 }
 
+// Kafka protocol defines integral types by sizes. See
+// https://kafka.apache.org/protocol.html
+// Therefore we should also use type sizes for integrals and use Java type sizes
+// as a guideline. See
+// https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
+template<typename T>
+constexpr auto num_bits = CHAR_BIT * sizeof(T);
+
+template<typename T>
+constexpr bool is_short
+  = std::is_integral_v<T> && !std::is_same_v<T, bool> && num_bits<T> <= 16;
+
+template<typename T>
+constexpr bool is_int = std::is_integral_v<T>&& num_bits<T> > 16
+                        && num_bits<T> <= 32;
+
+template<typename T>
+constexpr bool is_long = std::is_integral_v<T>&& num_bits<T> > 32
+                         && num_bits<T> <= 64;
+
+// property_config_type maps the datatype for a config property to
+// describe_configs_type. Currently class_type and password are not used in
+// Redpanda so we do not include checks for those types. You may find a similar
+// mapping in Apache Kafka at
+// https://github.com/apache/kafka/blob/be032735b39360df1a6de1a7feea8b4336e5bcc0/core/src/main/scala/kafka/server/ConfigHelper.scala
+template<typename T>
+consteval describe_configs_type property_config_type() {
+    if constexpr (reflection::is_std_optional<T>) {
+        return property_config_type<typename T::value_type>();
+    } else if constexpr (reflection::is_tristate<T>) {
+        return property_config_type<typename T::value_type>();
+    } else if constexpr (std::is_same_v<T, bool>) {
+        return describe_configs_type::boolean;
+    } else if constexpr (std::is_same_v<T, ss::sstring>) {
+        return describe_configs_type::string;
+    } else if constexpr (is_short<T>) {
+        return describe_configs_type::short_type;
+    } else if constexpr (is_int<T>) {
+        return describe_configs_type::int_type;
+    } else if constexpr (is_long<T>) {
+        return describe_configs_type::long_type;
+    } else if constexpr (std::is_floating_point_v<T>) {
+        return describe_configs_type::double_type;
+    } else if constexpr (reflection::is_std_vector<T>) {
+        return describe_configs_type::list;
+    } else if constexpr (std::is_same_v<T, model::compression>) {
+        return describe_configs_type::string;
+    } else if constexpr (std::is_same_v<T, model::cleanup_policy_bitflags>) {
+        return describe_configs_type::string;
+    } else if constexpr (std::is_same_v<T, std::chrono::seconds>) {
+        // Long type since seconds is atleast a 35-bit signed integral
+        // https://en.cppreference.com/w/cpp/chrono/duration
+        return describe_configs_type::long_type;
+    } else if constexpr (std::is_same_v<T, std::chrono::milliseconds>) {
+        // Long type since milliseconds is atleast a 45-bit signed integral
+        // https://en.cppreference.com/w/cpp/chrono/duration
+        return describe_configs_type::long_type;
+    } else if constexpr (std::is_same_v<T, model::timestamp_type>) {
+        return describe_configs_type::string;
+    } else if constexpr (std::is_same_v<T, config::data_directory_path>) {
+        return describe_configs_type::string;
+    } else if constexpr (std::is_same_v<T, v8_engine::data_policy>) {
+        return describe_configs_type::string;
+    } else {
+        static_assert(
+          config::detail::dependent_false<T>::value,
+          "Type name is not supported in describe_configs_type");
+    }
+}
+
 template<typename T, typename Func>
 static void add_broker_config(
   describe_configs_result& result,
   std::string_view name,
   const config::property<T>& property,
   bool include_synonyms,
+  std::optional<ss::sstring> documentation,
   Func&& describe_f) {
     describe_configs_source src
       = property.is_overriden() ? describe_configs_source::static_broker_config
@@ -120,6 +193,8 @@ static void add_broker_config(
       .value = describe_f(property.value()),
       .config_source = src,
       .synonyms = std::move(synonyms),
+      .config_type = property_config_type<T>(),
+      .documentation = documentation,
     });
 }
 
@@ -130,6 +205,7 @@ static void add_broker_config_if_requested(
   std::string_view name,
   const config::property<T>& property,
   bool include_synonyms,
+  std::optional<ss::sstring> documentation,
   Func&& describe_f) {
     if (config_property_requested(resource.configuration_keys, name)) {
         add_broker_config(
@@ -137,6 +213,7 @@ static void add_broker_config_if_requested(
           name,
           property,
           include_synonyms,
+          documentation,
           std::forward<Func>(describe_f));
     }
 }
@@ -149,6 +226,7 @@ static void add_topic_config(
   std::string_view override_name,
   const std::optional<T>& overrides,
   bool include_synonyms,
+  std::optional<ss::sstring> documentation,
   Func&& describe_f) {
     describe_configs_source src = overrides
                                     ? describe_configs_source::topic
@@ -177,6 +255,8 @@ static void add_topic_config(
       .value = describe_f(overrides.value_or(default_value)),
       .config_source = src,
       .synonyms = std::move(synonyms),
+      .config_type = property_config_type<T>(),
+      .documentation = documentation,
     });
 }
 
@@ -208,6 +288,7 @@ static void add_topic_config_if_requested(
   std::string_view override_name,
   const std::optional<T>& overrides,
   bool include_synonyms,
+  std::optional<ss::sstring> documentation,
   Func&& describe_f,
   bool hide_default_override = false) {
     if (config_property_requested(resource.configuration_keys, override_name)) {
@@ -225,7 +306,19 @@ static void add_topic_config_if_requested(
           override_name,
           overrides_val,
           include_synonyms,
+          documentation,
           std::forward<Func>(describe_f));
+    }
+}
+
+template<typename T>
+static ss::sstring maybe_print_tristate(const tristate<T>& tri) {
+    if (tri.is_disabled()) {
+        return "-1";
+    } else if (tri.has_value()) {
+        return ssx::sformat("{}", tri.value());
+    } else {
+        return "-1";
     }
 }
 
@@ -236,22 +329,24 @@ static void add_topic_config(
   const std::optional<T>& default_value,
   std::string_view override_name,
   const tristate<T>& overrides,
-  bool include_synonyms) {
-    std::optional<ss::sstring> override_value;
-    if (overrides.is_disabled()) {
-        override_value = "-1";
-    } else if (overrides.has_value()) {
-        override_value = ssx::sformat("{}", overrides.value());
+  bool include_synonyms,
+  std::optional<ss::sstring> documentation) {
+    // Wrap overrides in an optional because add_topic_config expects
+    // optional<S> where S = tristate<T>
+    std::optional<tristate<T>> override_value;
+    if (overrides.is_disabled() || overrides.has_value()) {
+        override_value = std::make_optional(overrides);
     }
 
     add_topic_config(
       result,
       default_name,
-      default_value ? ssx::sformat("{}", default_value.value()) : "-1",
+      tristate<T>{default_value},
       override_name,
       override_value,
       include_synonyms,
-      [](const ss::sstring& s) { return s; });
+      documentation,
+      &maybe_print_tristate<T>);
 }
 
 template<typename T>
@@ -262,7 +357,8 @@ static void add_topic_config_if_requested(
   const std::optional<T>& default_value,
   std::string_view override_name,
   const tristate<T>& overrides,
-  bool include_synonyms) {
+  bool include_synonyms,
+  std::optional<ss::sstring> documentation) {
     if (config_property_requested(resource.configuration_keys, override_name)) {
         add_topic_config(
           result,
@@ -270,7 +366,8 @@ static void add_topic_config_if_requested(
           default_value,
           override_name,
           overrides,
-          include_synonyms);
+          include_synonyms,
+          documentation);
     }
 }
 
@@ -310,10 +407,17 @@ static ss::sstring kafka_authn_endpoint_format(
     return ssx::sformat("{}", fmt::join(uris, ","));
 }
 
+static inline std::optional<ss::sstring> maybe_make_documentation(
+  bool include_documentation, const std::string_view& docstring) {
+    return include_documentation ? std::make_optional(ss::sstring{docstring})
+                                 : std::nullopt;
+}
+
 static void report_broker_config(
   const describe_configs_resource& resource,
   describe_configs_result& result,
-  bool include_synonyms) {
+  bool include_synonyms,
+  bool include_documentation) {
     if (!result.resource_name.empty()) {
         int32_t broker_id = -1;
         auto res = std::from_chars(
@@ -344,6 +448,8 @@ static void report_broker_config(
       "listeners",
       config::node().kafka_api,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation, config::node().kafka_api.desc()),
       &kafka_authn_endpoint_format);
 
     add_broker_config_if_requested(
@@ -352,6 +458,9 @@ static void report_broker_config(
       "advertised.listeners",
       config::node().advertised_kafka_api_property(),
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::node().advertised_kafka_api_property().desc()),
       &kafka_endpoint_format);
 
     add_broker_config_if_requested(
@@ -360,6 +469,9 @@ static void report_broker_config(
       "log.segment.bytes",
       config::shard_local_cfg().log_segment_size,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().log_segment_size.desc()),
       &describe_as_string<size_t>);
 
     add_broker_config_if_requested(
@@ -368,6 +480,9 @@ static void report_broker_config(
       "log.retention.bytes",
       config::shard_local_cfg().retention_bytes,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().retention_bytes.desc()),
       [](std::optional<size_t> sz) {
           return ssx::sformat("{}", sz ? sz.value() : -1);
       });
@@ -378,6 +493,9 @@ static void report_broker_config(
       "log.retention.ms",
       config::shard_local_cfg().delete_retention_ms,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().delete_retention_ms.desc()),
       [](const std::optional<std::chrono::milliseconds>& ret) {
           return ssx::sformat("{}", ret.value_or(-1ms).count());
       });
@@ -388,6 +506,9 @@ static void report_broker_config(
       "num.partitions",
       config::shard_local_cfg().default_topic_partitions,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().default_topic_partitions.desc()),
       &describe_as_string<int32_t>);
 
     add_broker_config_if_requested(
@@ -396,6 +517,9 @@ static void report_broker_config(
       "default.replication.factor",
       config::shard_local_cfg().default_topic_replication,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().default_topic_replication.desc()),
       &describe_as_string<int16_t>);
 
     add_broker_config_if_requested(
@@ -404,6 +528,8 @@ static void report_broker_config(
       "log.dirs",
       config::node().data_directory,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation, config::node().data_directory.desc()),
       [](const config::data_directory_path& path) {
           return path.as_sstring();
       });
@@ -414,6 +540,9 @@ static void report_broker_config(
       "auto.create.topics.enable",
       config::shard_local_cfg().auto_create_topics_enabled,
       include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().auto_create_topics_enabled.desc()),
       &describe_as_string<bool>);
 }
 
@@ -497,6 +626,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_property_compression,
               topic_config->properties.compression,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().log_compression_type.desc()),
               &describe_as_string<model::compression>);
 
             add_topic_config_if_requested(
@@ -507,8 +639,15 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_property_cleanup_policy,
               topic_config->properties.cleanup_policy_bitflags,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().log_cleanup_policy.desc()),
               &describe_as_string<model::cleanup_policy_bitflags>);
 
+            const std::string_view docstring{
+              topic_config->properties.is_compacted()
+                ? config::shard_local_cfg().compacted_log_segment_size.desc()
+                : config::shard_local_cfg().log_segment_size.desc()};
             add_topic_config_if_requested(
               resource,
               result,
@@ -522,6 +661,8 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_property_segment_size,
               topic_config->properties.segment_size,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation, docstring),
               &describe_as_string<size_t>);
 
             add_topic_config_if_requested(
@@ -531,7 +672,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
               ctx.metadata_cache().get_default_retention_duration(),
               topic_property_retention_duration,
               topic_config->properties.retention_duration,
-              request.data.include_synonyms);
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().delete_retention_ms.desc()));
 
             add_topic_config_if_requested(
               resource,
@@ -540,7 +684,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
               ctx.metadata_cache().get_default_retention_bytes(),
               topic_property_retention_bytes,
               topic_config->properties.retention_bytes,
-              request.data.include_synonyms);
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().retention_bytes.desc()));
 
             add_topic_config_if_requested(
               resource,
@@ -550,6 +697,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_property_timestamp_type,
               topic_config->properties.timestamp_type,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().log_message_timestamp_type.desc()),
               &describe_as_string<model::timestamp_type>);
 
             add_topic_config_if_requested(
@@ -560,6 +710,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
               topic_property_max_message_bytes,
               topic_config->properties.batch_max_bytes,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().kafka_batch_max_bytes.desc()),
               &describe_as_string<uint32_t>);
 
             // Shadow indexing properties
@@ -575,6 +728,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   *topic_config->properties.shadow_indexing))
                 : std::nullopt,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .cloud_storage_enable_remote_read.desc()),
               &describe_as_string<bool>,
               true);
 
@@ -590,6 +747,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   *topic_config->properties.shadow_indexing))
                 : std::nullopt,
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .cloud_storage_enable_remote_write.desc()),
               &describe_as_string<bool>,
               true);
 
@@ -600,7 +761,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
               ctx.metadata_cache().get_default_retention_local_target_bytes(),
               topic_property_retention_local_target_bytes,
               topic_config->properties.retention_local_target_bytes,
-              request.data.include_synonyms);
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .retention_local_target_bytes_default.desc()));
 
             add_topic_config_if_requested(
               resource,
@@ -610,7 +775,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 ctx.metadata_cache().get_default_retention_local_target_ms()),
               topic_property_retention_local_target_ms,
               topic_config->properties.retention_local_target_ms,
-              request.data.include_synonyms);
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .retention_local_target_ms_default.desc()));
 
             if (config_property_requested(
                   resource.configuration_keys, topic_property_remote_delete)) {
@@ -624,6 +793,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
                       topic_config->properties.remote_delete),
                     storage::ntp_config::default_remote_delete),
                   true,
+                  maybe_make_documentation(
+                    request.data.include_documentation,
+                    "Controls whether topic deletion should imply deletion in "
+                    "S3"),
                   [](const bool& b) { return b ? "true" : "false"; });
             }
 
@@ -637,6 +810,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
               property_name,
               ctx.data_policy_table().get_data_policy(topic),
               request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                "Datapolicy property for v8_engine"),
               &describe_as_string<v8_engine::data_policy>);
 
             break;
@@ -648,7 +824,10 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 continue;
             }
             report_broker_config(
-              resource, result, request.data.include_synonyms);
+              resource,
+              result,
+              request.data.include_synonyms,
+              request.data.include_documentation);
             break;
 
         // resource types not yet handled

--- a/src/v/kafka/server/handlers/describe_configs.h
+++ b/src/v/kafka/server/handlers/describe_configs.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using describe_configs_handler
-  = single_stage_handler<describe_configs_api, 0, 2>;
+  = single_stage_handler<describe_configs_api, 0, 4>;
 
 }

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -142,6 +142,24 @@ class KCL:
 
         return self._cmd(cmd, attempts=1)
 
+    def describe_topic(self,
+                       topic: str,
+                       with_docs: bool = False,
+                       with_types: bool = False):
+        """
+        :param topic: the name of the topic to describe
+        :param with_docs: if true, include documention strings in the response
+        :param with_types: if true, include config type information in the reponse
+        :return: stdout string
+        """
+        cmd = ["admin", "configs", "describe", topic, "--type", "topic"]
+        if with_docs:
+            cmd.append("--with-docs")
+        if with_types:
+            cmd.append("--with-types")
+
+        return self._cmd(cmd, attempts=1)
+
     def _cmd(self, cmd, input=None, attempts=5):
         """
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -14,6 +14,20 @@ from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kcl import KCL
+import re
+
+
+class ConfigProperty:
+    def __init__(self,
+                 config_type: str,
+                 value: str,
+                 doc_string: str,
+                 source_type: str = "default_config"):
+        self.config_type = config_type.lower()
+        self.value = value.lower()
+        self.doc_string = doc_string.lower()
+        self.source_type = source_type.lower()
 
 
 class DescribeTopicsTest(RedpandaTest):
@@ -54,3 +68,137 @@ class DescribeTopicsTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=2,
                    err_msg=f"Failed to describe all topics {topics}")
+
+    @cluster(num_nodes=3)
+    def test_describe_topics_with_documentation_and_types(self):
+        tp_spec = TopicSpec()
+
+        self.client().create_topic([tp_spec])
+
+        kcl = KCL(self.redpanda)
+
+        output = kcl.describe_topic(tp_spec.name,
+                                    with_docs=True,
+                                    with_types=True).splitlines()
+
+        assert len(output) >= 26
+
+        # First thirteen lines follow a format
+        property_lines = output[:13]
+        # Lines after that are for documentation
+        documentation_lines = output[13:]
+        self.logger.debug(f"Nyalia\n{property_lines}")
+        self.logger.debug(f"Lui\n{documentation_lines}")
+
+        # All the config properties and their values reported by topic describe
+        properties = {
+            "cleanup.policy":
+            ConfigProperty(config_type="STRING",
+                           value="DELETE",
+                           doc_string="Default topic cleanup policy",
+                           source_type="DYNAMIC_TOPIC_CONFIG"),
+            "compression.type":
+            ConfigProperty(config_type="STRING",
+                           value="producer",
+                           doc_string="Default topic compression type"),
+            "max.message.bytes":
+            ConfigProperty(
+                config_type="INT",
+                value="1048576",
+                doc_string=
+                "Maximum size of a batch processed by server. If batch is compressed the limit applies to compressed batch size"
+            ),
+            "message.timestamp.type":
+            ConfigProperty(config_type="STRING",
+                           value="CreateTime",
+                           doc_string="Default topic messages timestamp type"),
+            "redpanda.datapolicy":
+            ConfigProperty(config_type="STRING",
+                           value="function_name: script_name:",
+                           doc_string="Datapolicy property for v8_engine"),
+            "redpanda.remote.delete":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="true",
+                doc_string=
+                "Controls whether topic deletion should imply deletion in S3"),
+            "redpanda.remote.read":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string="Default remote read config value for new topics"),
+            "redpanda.remote.write":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string="Default remote write value for new topics"),
+            "retention.bytes":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                doc_string=
+                "Default max bytes per partition on disk before triggering a compaction"
+            ),
+            "retention.local.target.bytes":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                doc_string=
+                "Local retention size target for partitions of topics with cloud storage write enabled"
+            ),
+            "retention.local.target.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="86400000",
+                doc_string=
+                "Local retention time target for partitions of topics with cloud storage write enabled"
+            ),
+            "retention.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="604800000",
+                doc_string="delete segments older than this - default 1 week"),
+            "segment.bytes":
+            ConfigProperty(
+                config_type="LONG",
+                value="1073741824",
+                doc_string=
+                "Default log segment size in bytes for topics which do not set segment.bytes"
+            )
+        }
+
+        for line in property_lines:
+            col = line.strip().lower().split()
+            self.logger.debug(col)
+            assert len(col) >= 4
+            name = col[0]
+            config_type = col[1]
+            value = col[2]
+            source_type = col[3]
+
+            # The above .split() also applies to the value for datapolicy
+            # so we need to re-concatenate the string
+            if name == "redpanda.datapolicy":
+                assert len(col) == 5
+                value = f'{col[2]} {col[3]}'
+                source_type = col[4]
+
+            assert name in properties.keys()
+            prop = properties[name]
+            assert config_type == prop.config_type
+            assert value == prop.value
+            assert source_type == prop.source_type
+
+        # The output format follows:
+        # line 1 is empty
+        # line 2 is the property name
+        # line 3 is the property docstring
+        prop = None
+        for i in range(0, len(documentation_lines), 3):
+            # The property names have a colon at the end
+            prop_match = re.match(r"^(?P<name>[A-Za-z.]+?):$", line[1])
+            if prop_match is not None:
+                name = prop_match.group("name").lower()
+                assert name in properties.keys()
+                prop = properties[name]
+                assert line[2].lower() == prop.doc_string


### PR DESCRIPTION
## Cover letter

[KIP-569](https://cwiki.apache.org/confluence/display/KAFKA/KIP-569%3A+DescribeConfigsResponse+-+Update+the+schema+to+include+additional+metadata+information+of+the+field) updated DescribeConfigs to include a `documentation` string and `config type` enum in the response. Therefore this PR updates DescribeConfigs to the new API version with the new fields.

Fixes #4170

Changes from force-push `0e814de`:
-  Group changes to the schemata and generator.py in the same commit and update that commit message the the sourced Kafka version
- Use enum naming schema `int_type` for reserved keywords
- Use the same integral sizes that Java uses
- Use `base_property.desc()` for the documentation text
- Define the mapping from property types -> `describe_config_type`. This is for the `ConfigType` field from KIP-569

Changes from force-push `15ff3eb`:
- Use `reflection::is_std_vector`
- Account for unsigned integral types
- Account for several ADTs such as `model::compression`
- Recursively call `property_config_type` when the type is an optional
- Pass `std::nullopt` into the documentation field when `include_documentation` is unset
- Remove the `make_documentation_string` lambda. Instead pass the `include_documentation` option as an argument
- Edit alter_configs unit test to use the new fields

Changes from force-push `9296d42`:
- Use a different "unknown" string when printing an unknown type
- No need to use a temp var for capturing the result of property_config_type
- Strictly base proeprty_config_type on `typename T`
- Use `std::optional<std::optional<T>>` to capture a `tristate<T>`
- Make documentation a `std::optional` instead of plumbing `include_documentation`
- Change comment placements

Changes from force-push `0c539cb`:
- Resolve conflicts

Changes from force-push `7823436`:
- Split `property_config_type` into `property_config_type_by_type` and `property_config_type_by_name`

Changes from force-push `11b5235`:
- Convert `std::optional` to `tristate` in the tristate overload of `add_topic_config`
- Pass `tristate` to final version of `add_topic_config`

Changes from force-push `ee38f8c`:
- Add ducktape test using KCL

Changes from force-push `bd39be6`:
- Account for disabled state in `tristate<T> overrides` - this was causing DT tests to fail
- Account for all fundamental integral types
- Account for known fundamental char types
- Account for fixed width types
- Default integral type is now `int`

Changes from force-push `16a0ad6`:
- Use `constexpr` for typetraits instead of a monolith function
- Check integral types by size

Changes from force-push `dc87280`:
- Use return type `auto` instead of `int` for `num_bits`
- Formatting
- Add `!is_bool<T>` to integral type traits

Changes from force-push `9f51c67`:
- Use `!is_bool<T>` only for the `is_short<T>` check

Changes from force-push `d186c73`:
- Reword the integral type checking to be less confusing: `short <= 16bits`, `16bits < int <= 32bits`, `32bits < long <= 64bits`
- Update comments to include the Java type sizes
 
## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* DescribeConfigs can now return the config's documentation and indicate the config type

## Release Notes

### Improvements

* Updates DescribeConfigs Kafka API to support KIP-569
