### PR TITLE
transactions: preserve monotonicity of LSO

### DIFF
--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -92,6 +92,17 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, leader_epoch_err);
     }
+
+    auto offset = kafka_partition->high_watermark();
+    if (isolation_lvl == model::isolation_level::read_committed) {
+        auto maybe_lso = kafka_partition->last_stable_offset();
+        if (unlikely(!maybe_lso)) {
+            co_return list_offsets_response::make_partition(
+              ntp.tp.partition, maybe_lso.error());
+        }
+        offset = maybe_lso.value();
+    }
+
     /*
      * the responses for earliest/latest timestamp queries do not require
      * that the actual timestamp be returned. only the offset is required.
@@ -104,25 +115,15 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           kafka_partition->leader_epoch());
 
     } else if (timestamp == list_offsets_request::latest_timestamp) {
-        const auto offset = isolation_lvl
-                                == model::isolation_level::read_committed
-                              ? kafka_partition->last_stable_offset()
-                              : kafka_partition->high_watermark();
-
         co_return list_offsets_response::make_partition(
           ntp.tp.partition,
           model::timestamp(-1),
           offset,
           kafka_partition->leader_epoch());
     }
-    const auto offset_limit = isolation_lvl
-                                  == model::isolation_level::read_committed
-                                ? kafka_partition->last_stable_offset()
-                                : kafka_partition->high_watermark();
-
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
       timestamp,
-      offset_limit,
+      offset,
       kafka_read_priority(),
       {model::record_batch_type::raft_data}});
     auto id = ntp.tp.partition;

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -38,7 +38,7 @@ public:
         return model::next_offset(_partition->dirty_offset());
     }
 
-    model::offset last_stable_offset() const final {
+    checked<model::offset, error_code> last_stable_offset() const final {
         return model::next_offset(_partition->dirty_offset());
     }
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -34,7 +34,8 @@ public:
         virtual const model::ntp& ntp() const = 0;
         virtual model::offset start_offset() const = 0;
         virtual model::offset high_watermark() const = 0;
-        virtual model::offset last_stable_offset() const = 0;
+        virtual checked<model::offset, error_code>
+        last_stable_offset() const = 0;
         virtual kafka::leader_epoch leader_epoch() const = 0;
         virtual std::optional<model::offset>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
@@ -67,7 +68,7 @@ public:
 
     model::offset high_watermark() const { return _impl->high_watermark(); }
 
-    model::offset last_stable_offset() const {
+    checked<model::offset, error_code> last_stable_offset() const {
         return _impl->last_stable_offset();
     }
 

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -191,7 +191,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           *shard, [ntp](cluster::partition_manager& mgr) {
               auto partition = mgr.get(ntp);
               return partition
-                     && partition->committed_offset() >= model::offset(1);
+                     && partition->last_stable_offset() >= model::offset(1);
           });
     }).get();
 

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -200,6 +200,10 @@ inline constexpr model::offset prev_offset(model::offset o) {
     return o - model::offset{1};
 }
 
+// An invalid offset indicating that actual LSO is not yet ready to be returned.
+// Follows the policy that LSO is the next offset of the decided offset.
+static constexpr model::offset invalid_lso{next_offset(model::offset::min())};
+
 struct topic_partition_view {
     topic_partition_view(model::topic_view tp, model::partition_id p)
       : topic(tp)


### PR DESCRIPTION
Kafka clients expect that the LSO monotonically increases. In a normal
operation of the partition this holds true but if there is a change
in leadership with transactions, it may take time for the state machine
to catch up before returning the correct LSO. In that window the broker
is expected to return a retryable error code `offset_not_available`.

Fixes #7521
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * last stable offset returned by the broker now monotonically increases

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
