### PR TITLE
Wait for cluster membership in topic_recovery_test

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1084,6 +1084,7 @@ class TopicRecoveryTest(RedpandaTest):
         for node in self.redpanda.nodes:
             self.logger.info(f"Starting node {node.account.hostname}")
             self.redpanda.start_node(node)
+        self.redpanda.wait_for_membership(first_start=False)
         self._started = True
 
     def _wipe_data(self):
@@ -1237,8 +1238,6 @@ class TopicRecoveryTest(RedpandaTest):
         self._wipe_data()
 
         self._start_redpanda_nodes()
-
-        time.sleep(5)
 
         self.logger.info("Restoring topic data")
         controller_cs = self._collect_controller_log_checksums()


### PR DESCRIPTION
After we erase all files in the data directory and restart redpanda, the cluster has to be re-assembled again (nodes have to re-join etc.). This means that if we don't wait for all nodes to join, clients can get bogus metadata response later in the test (for quite a long time, because health monitor results are cached)

Fixes #7214

## Backports Required

- [x] v22.3.x
- [x] v22.2.x

## UX Changes

none

## Release Notes
* none

