### PR TITLE
cluster: add test for mixing maintenance and decommissioning

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -67,12 +67,6 @@ void partition_balancer_planner::init_per_node_state(
   reallocation_request_state& rrs,
   plan_data& result) const {
     for (const auto& [id, broker] : _state.members().nodes()) {
-        if (
-          broker.state.get_membership_state()
-          == model::membership_state::removed) {
-            continue;
-        }
-
         rrs.all_nodes.push_back(id);
 
         if (

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -133,15 +133,10 @@ struct broker_endpoint final
  *            replicas from given node, node is no longer accepting new
  *            partitions, but can still handle Kafka requests
  *
- * removed - after node is drained and it has no replicas assigned it is finally
- *           marked as removed, at the same time the node is no longer cluster
- *           member and can be shut down.
- *
- * TODO: keep removed nodes in members_state. Currently we keep brokers in raft0
- * configuration and it is our source of information about cluster members,
- * basing on configuration updates we build `cluster::members_table`. It would
- * be ideal to migrate brokers out of the raft configuration and manage them in
- * cluster layer, this way Raft can operate solely on node ids.
+ * removed - DEPRECATED: in older versions, node state was kept around even
+ *           after the node had all its replicas removed and the node was
+ *           removed from cluster, marked with this 'removed' state. Now the
+ *           node is simply removed from in-memory structures.
  */
 enum class membership_state : int8_t { active, draining, removed };
 


### PR DESCRIPTION
Following c1bcf59c057f417288889d344579c29e9c3fef36, we no longer use the `removed` state, and we no longer keep removed nodes in the `members_table::_nodes` container. This means that the check preventing multiple nodes in maintenance mode now correctly ignores removed nodes, allowing us to intermix maintenance mode and decommissioning.

This commit adds a test for this, and adjusts some comments to reflect the existing behavior.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
