### PR TITLE
[v22.3.x] cluster: ignore removed nodes for maintenance commands

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -145,7 +145,10 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     _version = model::revision_id(version());
 
     const auto target = _brokers.find(cmd.key);
-    if (target == _brokers.end()) {
+    if (
+      target == _brokers.end()
+      || target->second->get_membership_state()
+           == model::membership_state::removed) {
         return errc::node_does_not_exists;
     }
     auto& [id, broker] = *target;
@@ -190,7 +193,9 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     const auto other = std::find_if(
       _brokers.cbegin(), _brokers.cend(), [](const auto& b) {
           return b.second->get_maintenance_state()
-                 == model::maintenance_state::active;
+                   == model::maintenance_state::active
+                 && b.second->get_membership_state()
+                      != model::membership_state::removed;
       });
 
     if (other != _brokers.cend()) {

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import random
+from requests.exceptions import HTTPError
 
 from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
@@ -17,6 +18,25 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST
+
+
+def in_maintenance(node, admin):
+    """
+    Use the given Admin to check if the given node is in maintenance mode.
+    """
+    status = admin.maintenance_status(node)
+    if "finished" in status and status["finished"]:
+        return True
+    return status["draining"]
+
+
+def wait_for_maintenance(node, admin):
+    """
+    Use the given Admin to wait until the given node is in maintenance mode.
+    """
+    wait_until(lambda: in_maintenance(node, admin),
+               timeout_sec=10,
+               backoff_sec=1)
 
 
 class NodesDecommissioningTest(EndToEndTest):
@@ -100,6 +120,74 @@ class NodesDecommissioningTest(EndToEndTest):
             return False
 
         wait_until(requested_status, timeout_sec=timeout_sec, backoff_sec=1)
+
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_decommissioning_maintenance_node(self):
+        self.start_redpanda(num_nodes=4)
+        self._create_topics()
+        admin = self.redpanda._admin
+
+        to_decommission = random.choice(self.redpanda.nodes)
+        to_decommission_id = self.redpanda.node_id(to_decommission)
+        survivor_node = self._not_decommissioned_node(to_decommission_id)
+
+        admin.maintenance_start(to_decommission)
+        wait_for_maintenance(to_decommission, admin)
+
+        admin.decommission_broker(to_decommission_id)
+        wait_until(
+            lambda: self._node_removed(to_decommission_id, survivor_node),
+            timeout_sec=120,
+            backoff_sec=2)
+
+        # We should be unable to run further maintenance commands on the
+        # removed node.
+        try:
+            admin.maintenance_stop(to_decommission)
+            assert False, f"Excepted 404 for node {to_decommission_id}"
+        except HTTPError as e:
+            assert "404 Client Error" in repr(e)
+
+        # We should be able to start maintenance on another node, even if we
+        # didn't explicitly stop maintenance on 'to_decommission'.
+        admin.maintenance_start(survivor_node)
+        wait_for_maintenance(survivor_node, admin)
+        assert in_maintenance(to_decommission, admin)
+
+    @cluster(num_nodes=6)
+    def test_recommissioning_maintenance_node(self):
+        self.start_redpanda(num_nodes=4)
+        self._create_topics()
+        admin = self.redpanda._admin
+
+        # Start a workload so partition movement takes some amount of time.
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+
+        to_decommission = random.choice(self.redpanda.nodes)
+        to_decommission_id = self.redpanda.node_id(to_decommission)
+
+        admin.maintenance_start(to_decommission)
+        wait_for_maintenance(to_decommission, admin)
+
+        # Throttle recovery so the node doesn't move its replicas away so
+        # quickly, allowing us to recommission.
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("raft_learner_recovery_rate", str(1))
+
+        admin.decommission_broker(to_decommission_id)
+        self._wait_until_status(to_decommission_id, 'draining')
+
+        # Recommission the broker. Maintenance state should be unaffected.
+        admin.recommission_broker(to_decommission_id)
+        self._wait_until_status(to_decommission_id, 'active')
+        assert in_maintenance(to_decommission, admin)
+
+        # One last sanity check that partitions aren't moving.
+        wait_until(lambda: self._partitions_not_moving(),
+                   timeout_sec=15,
+                   backoff_sec=1)
 
     @cluster(
         num_nodes=6,


### PR DESCRIPTION
Issue #7370 is fixed on dev by a wide refactor that isn't ideal for backporting. This commit is a lighter-weight fix for the issue.

This commit ignores removed nodes when considering whether nodes can be placed into maintenance mode, matching the behavior on dev.

Fixes #7370
Fixes #5601

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes

  * Redpanda will now treat nodes that were decommissioned while in maintenance mode as no longer in maintenance mode, allowing for further nodes to be placed in maintenance mode.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
