### PR TITLE
schema_registry: If _schemas is missing return 500

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -67,7 +67,18 @@ public:
 
         auto units = co_await _os();
         auto guard = gate_guard(_g);
-        co_return co_await _h(std::move(rq), std::move(rp));
+        try {
+            co_return co_await _h(std::move(rq), std::move(rp));
+        } catch (kafka::client::partition_error const& ex) {
+            if (
+              ex.error == kafka::error_code::unknown_topic_or_partition
+              && ex.tp.topic == model::schema_registry_internal_tp.topic) {
+                throw exception(
+                  kafka::error_code::unknown_server_error,
+                  "_schemas topic does not exist");
+            }
+            throw;
+        }
     }
 
 private:


### PR DESCRIPTION
If the `_schemas` topic is deleted during runtime, a 403 is returned. This isn't a good description of the problem.

Instead, return a 500 Internal Server Error with an informative message.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## Release Notes

### Improvements

* schema_registry: If `_schemas` topic is missing, return a 500 status code.
