### PR TITLE
rpk: add `cluster txn` commands

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/cluster.go
+++ b/src/go/rpk/pkg/cli/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/partitions"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/selftest"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/storage"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/txn"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/group"
 	pkgconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
@@ -45,6 +46,7 @@ func NewCommand(fs afero.Fs, p *pkgconfig.Params) *cobra.Command {
 		partitions.NewPartitionsCommand(fs, p),
 		selftest.NewSelfTestCommand(fs, p),
 		storage.NewCommand(fs, p),
+		txn.NewCommand(fs, p),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cluster/txn/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/describe.go
@@ -1,0 +1,146 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package txn
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		format          string
+		printPartitions bool
+	)
+	cmd := &cobra.Command{
+		Use:   "describe [TXN-IDS...]",
+		Short: "Describe transactional IDs",
+		Long: `Describe transactional IDs.
+
+This command, in comparison to 'list', is a more detailed per-transaction view
+of transactional IDs. In addition to the state and producer ID, this command
+also outputs when a transaction started, the epoch of the producer ID, how long
+until the transaction times out, and the partitions currently a part of the
+transaction. For information on what the columns in the output mean, see
+'rpk cluster txn --help'.
+
+By default, all topics in a transaction are merged into one line. To print a
+row per topic, use --format=long. To include partitions with topics, use
+--print-partitions,
+
+If no transactional IDs are requested, all transactional IDs are printed.
+`,
+
+		Run: func(cmd *cobra.Command, txnIDs []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			described, err := adm.DescribeTransactions(cmd.Context(), txnIDs...)
+			out.HandleShardError("DescribeTransactions", err)
+
+			headers := []string{
+				"coordinator",
+				"transactional-id",
+				"producer-id",
+				"producer-epoch",
+				"state",
+				"start-timestamp",
+				"timeout",
+			}
+			common := func(x kadm.DescribedTransaction) []interface{} {
+				return out.StructFields(struct {
+					Coordinator    int32
+					TxnID          string
+					ProducerID     int64
+					ProducerEpoch  int16
+					State          string
+					StartTimestamp string
+					Timeout        time.Duration
+				}{
+					x.Coordinator,
+					x.TxnID,
+					x.ProducerID,
+					x.ProducerEpoch,
+					x.State,
+					time.UnixMilli(x.StartTimestamp).Format(rfc3339Milli),
+					time.Duration(x.TimeoutMillis) * time.Millisecond,
+				})
+			}
+
+			switch format {
+			case "short", "text":
+				tw := out.NewTable(append(headers, "topics")...)
+				defer tw.Flush()
+				for _, x := range described.Sorted() {
+					// Without partitions, we format like "foo,bar,baz".
+					// With partitions, we format "foo[0;1;2],bar[1;2;3]
+					var topics string
+					if printPartitions {
+						var ts []string
+						for _, t := range x.Topics.Sorted() {
+							var ps []string
+							for _, p := range t.Partitions {
+								ps = append(ps, strconv.Itoa(int(p)))
+							}
+							ts = append(ts, fmt.Sprintf("%s[%s]", t.Topic, strings.Join(ps, ";")))
+						}
+						topics = strings.Join(ts, ",")
+					} else {
+						ts := x.Topics.Topics()
+						sort.Strings(ts)
+						topics = strings.Join(ts, ",")
+					}
+					tw.Print(append(common(x), topics))
+				}
+
+			case "long", "wide":
+				if printPartitions {
+					tw := out.NewTable(append(headers, "topic", "partition")...)
+					defer tw.Flush()
+					for _, x := range described.Sorted() {
+						for _, t := range x.Topics.Sorted() {
+							for _, p := range t.Partitions {
+								tw.Print(append(common(x), t.Topic, p))
+							}
+						}
+					}
+				} else {
+					tw := out.NewTable(append(headers, "topic")...)
+					defer tw.Flush()
+					for _, x := range described.Sorted() {
+						for _, t := range x.Topics.Sorted() {
+							tw.Print(append(common(x), t.Topic))
+						}
+					}
+				}
+			default:
+				out.Die("unrecognized format %q", format)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", "text", "Output format (short, long)")
+	cmd.Flags().BoolVarP(&printPartitions, "print-partitions", "p", false, "Include per-topic partitions that are in the transaction")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/txn/describe_producers.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/describe_producers.go
@@ -1,0 +1,140 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package txn
+
+import (
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+func newDescribeProducersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		topics     []string
+		partitions []int32
+		all        bool
+	)
+	cmd := &cobra.Command{
+		Use:   "describe-producers",
+		Short: "Describe transactional producers to partitions",
+		Long: `Describe transactional producers to partitions.
+
+This command describes partitions that active transactional producers are
+producing to. For more information on the producer ID and epoch columns, see
+'rpk cluster txn --help'.
+
+The last timestamp corresponds to the timestamp of the last record that was
+written by the client. The transaction start offset corresponds to the offset
+that the transaction is began at. All consumers configured to read only
+committed records cannot read past the transaction start offset.
+
+The output includes a few advanced fields that can be used for sanity checking:
+the last sequence is the last sequence number that the producer has written,
+and the coordinator epoch is the epoch of the broker that is being written to.
+The last sequence should always go up and then wrap back to 0 at MaxInt32. The
+coordinator epoch should remain fixed, or rarely, increase.
+
+You can query all topics and partitions that have active producers with --all.
+To filter for specific topics, use --topics. You can additionally filter by
+partitions with --partitions.
+`,
+
+		Run: func(cmd *cobra.Command, txnIDs []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			if len(topics) == 0 && len(partitions) > 0 {
+				out.Die("cannot specify partitions without any topics")
+			}
+			if !all && len(topics) == 0 {
+				out.Die("must specify at least one of --all or --topics")
+			}
+			// If the TopicsSet is empty, the request returns all partitions.
+			var s kadm.TopicsSet
+			for _, topic := range topics {
+				s.Add(topic, partitions...)
+			}
+
+			described, err := adm.DescribeProducers(cmd.Context(), s)
+			out.HandleShardError("DescribeProducers", err)
+
+			tw := out.NewTable(
+				"leader",
+				"topic",
+				"partition",
+				"producer-id",
+				"producer-epoch",
+				"last-timestamp",
+				"last-sequence",
+				"coordinator-epoch",
+				"txn-start-offset",
+				"error",
+			)
+			defer tw.Flush()
+
+			type fields struct {
+				Leader           int32
+				Topic            string
+				Partition        int32
+				ProducerID       int64
+				ProducerEpoch    int16
+				LastSequence     int32
+				LastTimestamp    string
+				CoordinatorEpoch int32
+				TxnStartOffset   int64
+				Err              string
+			}
+
+			for _, d := range described.SortedPartitions() {
+				if d.Err != nil {
+					tw.PrintStructFields(fields{
+						Leader:    d.Leader,
+						Topic:     d.Topic,
+						Partition: d.Partition,
+						Err:       d.Err.Error(),
+					})
+				}
+				if len(d.ActiveProducers) == 0 {
+					continue
+				}
+				for _, p := range d.ActiveProducers.Sorted() {
+					tw.PrintStructFields(fields{
+						Leader:           p.Leader,
+						Topic:            p.Topic,
+						Partition:        p.Partition,
+						ProducerID:       p.ProducerID,
+						ProducerEpoch:    p.ProducerEpoch,
+						LastSequence:     p.LastSequence,
+						LastTimestamp:    time.UnixMilli(p.LastTimestamp).Format(rfc3339Milli),
+						CoordinatorEpoch: p.CoordinatorEpoch,
+						TxnStartOffset:   p.CurrentTxnStartOffset,
+					})
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&topics, "topics", "t", nil, "Topic to describe producers for (repeatable)")
+	cmd.Flags().Int32SliceVarP(&partitions, "partitions", "p", nil, "Partitions to describe producers for (repeatable)")
+	cmd.Flags().BoolVarP(&all, "all", "a", false, "Query all producer IDs on any topic")
+
+	cmd.MarkFlagsMutuallyExclusive("topics", "all")
+	cmd.MarkFlagsMutuallyExclusive("partitions", "all")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/txn/list.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/list.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package txn
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List transactions and their current states",
+		Long: `List transactions and their current states
+
+This command lists all known transactions in the cluster, the producer ID for
+the transactional ID, and the and the state of the transaction. For information
+on what the columns in the output mean, see 'rpk cluster txn --help'.
+`,
+
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			listed, err := adm.ListTransactions(cmd.Context(), nil, nil)
+			out.HandleShardError("ListTransactions", err)
+
+			tw := out.NewTable("coordinator", "transactional-id", "producer-id", "state")
+			defer tw.Flush()
+			for _, x := range listed.Sorted() {
+				tw.PrintStructFields(struct {
+					Broker     int32
+					TxnID      string
+					ProducerID int64
+					State      string
+				}{x.Coordinator, x.TxnID, x.ProducerID, x.State})
+			}
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/cluster/txn/list.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/list.go
@@ -17,6 +17,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type listResponse struct {
+	Broker     int32  `json:"broker" yaml:"broker"`
+	TxnID      string `json:"transaction_id" yaml:"transaction_id"`
+	ProducerID int64  `json:"producer_id" yaml:"producer_id"`
+	State      string `json:"state" yaml:"state"`
+}
+
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
@@ -31,6 +38,10 @@ on what the columns in the output mean, see 'rpk cluster txn --help'.
 
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]listResponse{}); ok {
+				out.Exit(h)
+			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
@@ -41,15 +52,23 @@ on what the columns in the output mean, see 'rpk cluster txn --help'.
 			listed, err := adm.ListTransactions(cmd.Context(), nil, nil)
 			out.HandleShardError("ListTransactions", err)
 
+			response := []listResponse{}
+			for _, x := range listed.Sorted() {
+				response = append(response, listResponse{
+					Broker:     x.Coordinator,
+					TxnID:      x.TxnID,
+					ProducerID: x.ProducerID,
+					State:      x.State,
+				})
+			}
+			if isText, _, s, err := f.Format(response); !isText {
+				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+				out.Exit(s)
+			}
 			tw := out.NewTable("coordinator", "transactional-id", "producer-id", "state")
 			defer tw.Flush()
-			for _, x := range listed.Sorted() {
-				tw.PrintStructFields(struct {
-					Broker     int32
-					TxnID      string
-					ProducerID int64
-					State      string
-				}{x.Coordinator, x.TxnID, x.ProducerID, x.State})
+			for _, r := range response {
+				tw.PrintStructFields(r)
 			}
 		},
 	}

--- a/src/go/rpk/pkg/cli/cluster/txn/txn.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/txn.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package txn
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const rfc3339Milli = "2006-01-02T15:04:05.999Z"
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "txn",
+		Aliases: []string{"transaction"},
+		Short:   "Information about transactions and transactional producers",
+		Long: `Information about transactions and transactional producers.
+
+Transactions allow producing, or consume-modifying-producing, to Redpanda.
+The consume-modify-produce loop is also referred to as EOS (exactly once
+semantics). Transactions involve a lot of technical complexity that is largely
+hidden within clients. This command space helps shed a light on what is
+actually happening in clients and brokers while transactions are in use.
+
+TRANSACTIONAL ID
+
+The transactional ID is the string you define in clients when actually using
+transactions.
+
+PRODUCER ID & EPOCH
+
+The producer ID is generated within clients when you transactionally produce.
+The producer ID is a number that maps to your transactional ID, allowing
+requests to be smaller when producing, and allowing some optimizations within
+brokers when managing transactions.
+
+Some clients expose the producer ID, allowing you to track the transactional ID
+that a producer ID maps to. If possible, it is recommended to monitor the
+producer ID used in your applications.
+
+The producer epoch is a number that somewhat "counts" the number of times your
+transaction has been initialized or expired. If you have one client that uses
+a transactional ID, it may receive producer ID 3 epoch 0. Another client that
+uses that same transactional ID will receive producer ID 3 epoch 1. If the
+client starts a transaction but does not finish it in time, the cluster will
+internally bump the epoch to 2. The epoch allows the cluster to "fence"
+clients: if a client attempts to use a producer ID with an old epoch, the
+cluster will reject the client's produce request as stale.
+
+TRANSACTION STATE
+
+The state of a transaction indicates what is currently happening with a
+transaction. A high level overview of transactional states:
+
+  * Empty: the transactional ID is ready but there are no partitions
+           nor groups added to it -- there is no active transaction
+  * Ongoing: the transactional ID is being used in a began transaction
+  * PrepareCommit: a commit is in progress
+  * PrepareAbort: an abort is in progress
+  * PrepareEpochFence: the transactional ID is timing out
+  * Dead: the transactional ID has expired and/or is not in use
+
+LAST STABLE OFFSET
+
+The last stable offset is the offset at which a transaction has begun and
+clients cannot consume past, if the client is configured to read only committed
+offsets. The last stable offset can be seen when describing active transactional
+producers by looking for the earliest transaction start offset per partition.
+`,
+	}
+	p.InstallKafkaFlags(cmd)
+
+	cmd.AddCommand(
+		newDescribeCommand(fs, p),
+		newDescribeProducersCommand(fs, p),
+		newListCommand(fs, p),
+	)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/txn/txn.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/txn.go
@@ -83,5 +83,6 @@ producers by looking for the earliest transaction start offset per partition.
 		newDescribeProducersCommand(fs, p),
 		newListCommand(fs, p),
 	)
+	p.InstallFormatFlag(cmd)
 	return cmd
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1599,3 +1599,38 @@ class RpkTool:
             )
 
         return [transform_from_json(o) for o in loaded]
+
+    def describe_txn_producers(self, topics, partitions, all=False):
+        cmd = [
+            "describe-producers", "--topics", ",".join(topics), "--partitions",
+            ",".join([str(x) for x in partitions])
+        ]
+
+        if all:
+            cmd += ["--all"]
+
+        return self._run_txn(cmd)
+
+    def describe_txn(self, txn_id, print_partitions=False):
+        cmd = ["describe", txn_id]
+
+        if print_partitions:
+            cmd += ["--print-partitions"]
+
+        return self._run_txn(cmd)
+
+    def list_txn(self):
+        return self._run_txn(["list"])
+
+    def _run_txn(self, cmd, stdin=None, timeout=None, output_format="json"):
+        cmd = [
+            self._rpk_binary(),
+            "cluster",
+            "txn",
+            "--format",
+            output_format,
+        ] + self._kafka_conn_settings() + cmd
+
+        out = self._execute(cmd, stdin=stdin, timeout=timeout)
+
+        return json.loads(out) if output_format == "json" else out

--- a/tests/rptest/tests/rpk_transaction_test.py
+++ b/tests/rptest/tests/rpk_transaction_test.py
@@ -1,0 +1,173 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+import confluent_kafka as ck
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+import time
+import json
+
+
+class TxRpkTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=3, replication_factor=3),
+              TopicSpec(partition_count=3, replication_factor=3))
+
+    def __init__(self, test_context):
+        super(TxRpkTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "tx_timeout_delay_ms": 10000000,
+                                 "abort_timed_out_transactions_interval_ms":
+                                 10000000,
+                                 "enable_leader_balancer": False,
+                                 "transaction_coordinator_partitions": 4
+                             })
+
+        self._rpk = RpkTool(self.redpanda)
+
+    def extract_producer(self, tx):
+        return (tx["producer_id"], tx["producer_epoch"], tx["last_sequence"])
+
+    @cluster(num_nodes=3)
+    def test_describe_producers(self):
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer2 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '1',
+        })
+        producer1.init_transactions()
+        producer2.init_transactions()
+        producer1.begin_transaction()
+        producer2.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer1.produce(topic.name, '0', '0', partition)
+                producer2.produce(topic.name, '0', '1', partition)
+
+        producer1.flush()
+        producer2.flush()
+
+        expected_producers = None
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+
+                txs_info = self._rpk.describe_txn_producers([topic.name],
+                                                            [partition])
+                if expected_producers == None:
+                    expected_producers = set(
+                        map(self.extract_producer, txs_info))
+                    assert (len(txs_info) == 2)
+
+                assert (len(expected_producers) == len(txs_info))
+                for producer in txs_info:
+                    assert (self.extract_producer(producer)
+                            in expected_producers)
+
+    @cluster(num_nodes=3)
+    def test_last_timestamp_of_describe_producers(self):
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer1.init_transactions()
+        producer1.begin_transaction()
+
+        for _ in range(2):
+            for topic in self.topics:
+                for partition in range(topic.partition_count):
+                    producer1.produce(topic.name, '0', '0', partition)
+            producer1.flush()
+
+        now_ms = int(time.time() * 1000)
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producers = self._rpk.describe_txn_producers([topic.name],
+                                                             [partition])
+                self.redpanda.logger.debug(json.dumps(producers))
+                for producer in producers:
+                    assert int(producer["last_sequence"]) > 0
+                    # checking that the producer's info was recently updated
+                    assert abs(now_ms -
+                               int(producer["last_timestamp"])) < 120 * 1000
+
+    @cluster(num_nodes=3)
+    def test_describe_transactions(self):
+        tx_id = "0"
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': tx_id,
+        })
+        producer.init_transactions()
+        producer.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer.produce(topic.name, '0', '0', partition)
+
+        producer.flush()
+
+        txn_partition = self._rpk.describe_txn(tx_id)
+        for p in txn_partition:
+            assert p["transaction_id"] == tx_id
+            assert p["timeout"] == 60000
+
+        # Check that we describe every topic-partition combination.
+        for topic in self.topics:
+            tx_filter = [
+                txn for txn in txn_partition if txn['topic'] == topic.name
+            ]
+            assert len(tx_filter) == topic.partition_count
+            for p in range(topic.partition_count):
+                p_filter = [txn for txn in tx_filter if txn['partition'] == p]
+                assert len(p_filter) == 1
+
+    @cluster(num_nodes=3)
+    def test_empty_list_transactions(self):
+        txs_info = self._rpk.list_txn()
+        assert len(txs_info) == 0
+
+    @cluster(num_nodes=3)
+    def test_list_transactions(self):
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer2 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '1',
+        })
+        producer1.init_transactions()
+        producer2.init_transactions()
+        producer1.begin_transaction()
+        producer2.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer1.produce(topic.name, '0', '0', partition)
+                producer2.produce(topic.name, '0', '1', partition)
+
+        producer1.flush()
+        producer2.flush()
+
+        txn_list = self._rpk.list_txn()
+        assert len(txn_list) > 0
+
+        for txn in txn_list:
+            txn_described = self._rpk.describe_txn(txn["transaction_id"])
+            for described in txn_described:
+                assert int(described["producer_id"]) == int(txn["producer_id"])


### PR DESCRIPTION
For #7308 

## UX Changes

Adds:

```
rpk cluster txn 
rpk cluster txn list
rpk cluster txn describe
rpk cluster txn describe-producers
```

## Release Notes

  ### Features

  * rpk now has a `cluster txn` command space