### PR TITLE
[v22.3.x] schema_registry: Explicitly set _schemas topic to retain forever.

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -257,6 +257,7 @@ ss::future<> service::create_internal_topic() {
       replication_factor);
 
     auto make_internal_topic = [replication_factor]() {
+        constexpr std::string_view retain_forever = "-1";
         return kafka::creatable_topic{
           .name{model::schema_registry_internal_tp.topic},
           .num_partitions = 1,
@@ -266,7 +267,17 @@ ss::future<> service::create_internal_topic() {
             {.name{ss::sstring{kafka::topic_property_cleanup_policy}},
              .value{"compact"}},
             {.name{ss::sstring{kafka::topic_property_compression}},
-             .value{ssx::sformat("{}", model::compression::none)}}}};
+             .value{ssx::sformat("{}", model::compression::none)}},
+            {.name{ss::sstring{kafka::topic_property_retention_bytes}},
+             .value{retain_forever}},
+            {.name{ss::sstring{kafka::topic_property_retention_duration}},
+             .value{retain_forever}},
+            {.name{
+               ss::sstring{kafka::topic_property_retention_local_target_bytes}},
+             .value{retain_forever}},
+            {.name{
+               ss::sstring{kafka::topic_property_retention_local_target_ms}},
+             .value{retain_forever}}}};
     };
     auto res = co_await _client.local().create_topic(make_internal_topic());
     if (res.data.topics.size() != 1) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7553
