### PR TITLE
Do not rely on `raft::group_configuration` to drive cluster membership changes

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -150,8 +150,8 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd) {
     }
 
     // Apply initial node UUID to ID map
-    _members_manager.local().apply_initial_node_uuid_map(
-      cmd.value.node_ids_by_uuid);
+    co_await _members_manager.local().set_initial_state(
+      cmd.value.initial_nodes, cmd.value.node_ids_by_uuid);
 
     // Apply cluster version to feature table: this activates features without
     // waiting for feature_manager to come up.

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -172,7 +172,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
               clusterlog.debug,
               "Error registering UUID {}: {}, retrying",
               _node_uuid,
-              r.error());
+              r.error().message());
             continue;
         }
         if (!r.has_value() || !r.value().success) {

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -110,6 +110,9 @@ static constexpr int8_t recommission_node_cmd_type = 1;
 static constexpr int8_t finish_reallocations_cmd_type = 2;
 static constexpr int8_t maintenance_mode_cmd_type = 3;
 static constexpr int8_t register_node_uuid_cmd_type = 4;
+static constexpr int8_t add_node_cmd_type = 5;
+static constexpr int8_t update_node_cmd_type = 6;
+static constexpr int8_t remove_node_cmd_type = 7;
 
 // cluster config commands
 static constexpr int8_t cluster_config_delta_cmd_type = 0;
@@ -270,6 +273,24 @@ using maintenance_mode_cmd = controller_command<
   maintenance_mode_cmd_type,
   model::record_batch_type::node_management_cmd,
   serde_opts::adl_and_serde>;
+
+using add_node_cmd = controller_command<
+  int8_t, // unused
+  model::broker,
+  add_node_cmd_type,
+  model::record_batch_type::node_management_cmd>;
+
+using update_node_cfg_cmd = controller_command<
+  int8_t, // unused
+  model::broker,
+  update_node_cmd_type,
+  model::record_batch_type::node_management_cmd>;
+
+using remove_node_cmd = controller_command<
+  model::node_id,
+  int8_t, // unused,
+  remove_node_cmd_type,
+  model::record_batch_type::node_management_cmd>;
 
 // Cluster configuration deltas
 using cluster_config_delta_cmd = controller_command<

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -127,6 +127,30 @@ std::vector<raft::broker_revision> create_brokers_set(
     return brokers;
 }
 
+static std::vector<raft::vnode> create_vnode_set(
+  const std::vector<model::broker_shard>& replicas,
+  const absl::flat_hash_map<model::node_id, model::revision_id>&
+    replica_revisions) {
+    std::vector<raft::vnode> nodes;
+    nodes.reserve(replicas.size());
+
+    std::transform(
+      std::cbegin(replicas),
+      std::cend(replicas),
+      std::back_inserter(nodes),
+      [&replica_revisions](const model::broker_shard& bs) {
+          auto rev_it = replica_revisions.find(bs.node_id);
+          vassert(
+            rev_it != replica_revisions.end(),
+            "revision for broker {} must be present in replica revisions map. "
+            "revisions map size: {}",
+            bs.node_id,
+            replica_revisions.size());
+          return raft::vnode(bs.node_id, rev_it->second);
+      });
+    return nodes;
+}
+
 std::optional<ss::shard_id> get_target_shard(
   model::node_id id, const std::vector<model::broker_shard>& replicas) {
     auto it = std::find_if(
@@ -244,7 +268,7 @@ std::error_code check_configuration_update(
           "{}",
           partition->ntp(),
           bs,
-          group_cfg.brokers());
+          group_cfg);
         return errc::partition_configuration_differs;
     }
 
@@ -274,6 +298,11 @@ controller_backend::controller_backend(
   , _housekeeping_timer_interval(
       config::shard_local_cfg().controller_backend_housekeeping_interval_ms())
   , _as(as) {}
+
+bool controller_backend::command_based_membership_active() const {
+    return _features.local().is_active(
+      features::feature::membership_change_controller_cmds);
+}
 
 ss::future<> controller_backend::stop() {
     vlog(clusterlog.info, "Stopping Controller Backend...");
@@ -378,14 +407,41 @@ find_interrupting_operation(deltas_t::iterator current_it, deltas_t& deltas) {
       });
 }
 
+ss::future<std::error_code> do_update_replica_set(
+  const model::ntp& ntp,
+  const std::vector<model::broker_shard>& replicas,
+  const topic_table_delta::revision_map_t& replica_revisions,
+  model::revision_id rev,
+  ss::lw_shared_ptr<partition> p,
+  members_table& members,
+  bool command_based_members_update) {
+    vlog(
+      clusterlog.debug,
+      "[{}] updating partition replicas. revision: {}, replicas: {}, using "
+      "vnodes: {}",
+      ntp,
+      rev,
+      replicas,
+      command_based_members_update);
+
+    // when cluster membership updates are driven by controller commands, use
+    // only vnodes to update raft replica set
+    if (likely(command_based_members_update)) {
+        auto nodes = create_vnode_set(replicas, replica_revisions);
+        co_return co_await p->update_replica_set(std::move(nodes), rev);
+    }
+
+    auto brokers = create_brokers_set(replicas, replica_revisions, members);
+    co_return co_await p->update_replica_set(std::move(brokers), rev);
+}
 ss::future<std::error_code> revert_configuration_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
   const topic_table_delta::revision_map_t& replica_revisions,
   model::revision_id rev,
   ss::lw_shared_ptr<partition> p,
-  members_table& members) {
-    auto brokers = create_brokers_set(replicas, replica_revisions, members);
+  members_table& members,
+  bool command_based_members_update) {
     vlog(
       clusterlog.debug,
       "[{}] reverting already finished reconfiguration. Revision: {}, replica "
@@ -393,7 +449,14 @@ ss::future<std::error_code> revert_configuration_update(
       ntp,
       rev,
       replicas);
-    co_return co_await p->update_replica_set(std::move(brokers), rev);
+    return do_update_replica_set(
+      ntp,
+      replicas,
+      replica_revisions,
+      rev,
+      p,
+      members,
+      command_based_members_update);
 }
 
 bool is_finishing_operation(
@@ -1178,10 +1241,14 @@ controller_backend::create_partition_from_remote_shard(
             co_return errc::waiting_for_partition_shutdown;
         }
         initial_revision = x_shard_req->log_revision;
-        std::copy(
-          x_shard_req->initial_configuration.brokers().begin(),
-          x_shard_req->initial_configuration.brokers().end(),
-          std::back_inserter(initial_brokers));
+        const auto all_nodes = x_shard_req->initial_configuration.all_nodes();
+        std::transform(
+          all_nodes.begin(),
+          all_nodes.end(),
+          std::back_inserter(initial_brokers),
+          [this](const raft::vnode& vnode) {
+              return get_node_metadata(_members_table.local(), vnode.id());
+          });
     }
 
     if (!initial_revision) {
@@ -1444,15 +1511,14 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
                         errc::success);
                   }
 
-                  auto brokers = create_brokers_set(
-                    replicas, replica_revisions, _members_table.local());
-                  vlog(
-                    clusterlog.debug,
-                    "[{}] updating replica set with {}",
+                  return do_update_replica_set(
                     ntp,
-                    replicas);
-
-                  return p->update_replica_set(std::move(brokers), rev);
+                    replicas,
+                    replica_revisions,
+                    rev,
+                    std::move(p),
+                    _members_table.local(),
+                    command_based_membership_active());
               } else if (already_moved) {
                   if (likely(_features.local().is_active(
                         features::feature::partition_move_revert_cancel))) {
@@ -1465,7 +1531,8 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
                     replica_revisions,
                     rev,
                     std::move(p),
-                    _members_table.local());
+                    _members_table.local(),
+                    command_based_membership_active());
               }
               return ss::make_ready_future<std::error_code>(
                 errc::waiting_for_recovery);
@@ -1550,7 +1617,8 @@ ss::future<std::error_code> controller_backend::force_abort_replica_set_update(
                     replica_revisions,
                     rev,
                     std::move(p),
-                    _members_table.local());
+                    _members_table.local(),
+                    command_based_membership_active());
               });
         }
         co_return errc::waiting_for_recovery;
@@ -1594,15 +1662,14 @@ ss::future<std::error_code> controller_backend::update_partition_replica_set(
               return ss::make_ready_future<std::error_code>(errc::success);
           }
 
-          auto brokers = create_brokers_set(
-            replicas, replica_revisions, _members_table.local());
-          vlog(
-            clusterlog.debug,
-            "[{}] updating replica set with {}",
+          return do_update_replica_set(
             ntp,
-            replicas);
-
-          return p->update_replica_set(std::move(brokers), rev);
+            replicas,
+            replica_revisions,
+            rev,
+            std::move(p),
+            _members_table.local(),
+            command_based_membership_active());
       });
 }
 

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -372,6 +372,8 @@ private:
 
     void housekeeping();
     void setup_metrics();
+
+    bool command_based_membership_active() const;
     ss::sharded<topic_table>& _topics;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -835,10 +835,8 @@ ss::future<std::error_code> members_backend::reconcile() {
               "[update: {}] decommissioning finished, removing node from "
               "cluster",
               meta.update);
-            // workaround: https://github.com/redpanda-data/redpanda/issues/891
-            std::vector<model::node_id> ids{meta.update->id};
             co_await _raft0
-              ->remove_members(std::move(ids), model::revision_id{0})
+              ->remove_member(meta.update->id, model::revision_id{0})
               .discard_result();
         } else {
             // Decommissioning still in progress

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -42,6 +42,7 @@ public:
     ss::future<std::error_code> decommission_node(model::node_id);
     ss::future<std::error_code> recommission_node(model::node_id);
     ss::future<std::error_code> finish_node_reallocations(model::node_id);
+    ss::future<std::error_code> remove_node(model::node_id);
 
     ss::future<std::error_code>
     set_maintenance_mode(model::node_id, bool enabled);

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -960,8 +960,7 @@ members_manager::handle_join_request(join_node_request const req) {
     // we do not use revisions in raft0 configuration, it is always revision
     // 0 which is perfectly fine. this will work like revision less raft
     // protocol.
-    co_return co_await _raft0
-      ->add_group_members({req.node}, model::revision_id(0))
+    co_return co_await _raft0->add_group_member(req.node, model::revision_id(0))
       .then([broker = req.node](std::error_code ec) {
           if (!ec) {
               return ret_t(join_node_reply{true, broker.id()});

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -71,7 +71,10 @@ public:
       recommission_node_cmd,
       finish_reallocations_cmd,
       maintenance_mode_cmd,
-      register_node_uuid_cmd>{};
+      register_node_uuid_cmd,
+      add_node_cmd,
+      remove_node_cmd,
+      update_node_cfg_cmd>{};
     static constexpr ss::shard_id shard = 0;
     static constexpr size_t max_updates_queue_size = 100;
 
@@ -229,6 +232,12 @@ private:
 
     ss::future<std::error_code>
       apply_raft_configuration_batch(model::record_batch);
+
+    ss::future<std::error_code> do_apply_add_node(add_node_cmd, model::offset);
+    ss::future<std::error_code>
+      do_apply_update_node(update_node_cfg_cmd, model::offset);
+    ss::future<std::error_code>
+      do_apply_remove_node(remove_node_cmd, model::offset);
 
     const std::vector<config::seed_server> _seed_servers;
     const model::broker _self;

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -51,6 +51,9 @@ public:
     std::error_code apply(model::offset, decommission_node_cmd);
     std::error_code apply(model::offset, recommission_node_cmd);
     std::error_code apply(model::offset, maintenance_mode_cmd);
+    std::error_code apply(model::offset, add_node_cmd);
+    std::error_code apply(model::offset, update_node_cfg_cmd);
+    std::error_code apply(model::offset, remove_node_cmd);
 
     model::revision_id version() const { return _version; }
 

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -53,6 +53,8 @@ public:
     std::error_code apply(model::offset, update_node_cfg_cmd);
     std::error_code apply(model::offset, remove_node_cmd);
 
+    void set_initial_brokers(std::vector<model::broker>);
+
     model::revision_id version() const { return _version; }
 
     ss::future<> await_membership(model::node_id id, ss::abort_source& as) {

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -46,8 +46,6 @@ public:
 
     bool contains(model::node_id) const;
 
-    void update_brokers(model::offset, const std::vector<model::broker>&);
-
     std::error_code apply(model::offset, decommission_node_cmd);
     std::error_code apply(model::offset, recommission_node_cmd);
     std::error_code apply(model::offset, maintenance_mode_cmd);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -161,6 +161,10 @@ public:
         return _raft->replace_configuration(
           std::move(brokers), new_revision_id);
     }
+    ss::future<std::error_code> update_replica_set(
+      std::vector<raft::vnode> nodes, model::revision_id new_revision_id) {
+        return _raft->replace_configuration(std::move(nodes), new_revision_id);
+    }
 
     raft::group_configuration group_configuration() const {
         return _raft->config();

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -35,6 +35,9 @@ public:
     // Allocation nodes
     void register_node(node_ptr);
     void update_allocation_nodes(const std::vector<model::broker>&);
+    void upsert_allocation_node(const model::broker&);
+    void remove_allocation_node(model::node_id);
+
     void decommission_node(model::node_id);
     void recommission_node(model::node_id);
     bool is_empty(model::node_id) const;

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -318,7 +318,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         }
         _need_controller_refresh = true;
         co_return ss::stop_iteration::yes;
-    } else if (_raft0->config().brokers().size() == 1) {
+    } else if (_members.node_count() == 1) {
         vlog(clusterlog.trace, "Leadership balancer tick: single node cluster");
         co_return ss::stop_iteration::yes;
     }

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -45,6 +45,14 @@ public:
     void update_allocation_nodes(const std::vector<model::broker>& brokers) {
         _state->update_allocation_nodes(brokers);
     }
+
+    void upsert_allocation_node(const model::broker& broker) {
+        _state->upsert_allocation_node(broker);
+    }
+
+    void remove_allocation_node(model::node_id id) {
+        _state->remove_allocation_node(id);
+    }
     void decommission_node(model::node_id id) { _state->decommission_node(id); }
     void recommission_node(model::node_id id) { _state->recommission_node(id); }
 

--- a/src/v/cluster/tests/feature_barrier_test.cc
+++ b/src/v/cluster/tests/feature_barrier_test.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "cluster/commands.h"
 #include "cluster/feature_manager.h"
 #include "cluster/members_table.h"
 #include "test_utils/async.h"
@@ -58,7 +59,9 @@ struct barrier_fixture {
               std::nullopt,
               model::broker_properties{}));
         }
-        members.update_brokers(model::offset{0}, brokers);
+        for (auto& br : brokers) {
+            members.apply(model::offset(0), cluster::add_node_cmd(br.id(), br));
+        }
     }
 
     void create_node_state(model::node_id id) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/commands.h"
 #include "cluster/members_table.h"
 #include "cluster/partition_balancer_planner.h"
 #include "cluster/partition_balancer_state.h"
@@ -203,8 +204,10 @@ struct partition_balancer_planner_fixture {
                 .available_disk_gb = 100}));
             last_node_idx++;
         }
-
-        members_table.update_brokers(model::offset{}, new_brokers);
+        for (auto& b : new_brokers) {
+            members_table.apply(
+              model::offset{}, cluster::add_node_cmd(b.id(), b));
+        }
     }
 
     cluster::move_partition_replicas_cmd make_move_partition_replicas_cmd(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2333,7 +2333,7 @@ struct user_and_credential
 struct bootstrap_cluster_cmd_data
   : serde::envelope<
       bootstrap_cluster_cmd_data,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -2354,6 +2354,7 @@ struct bootstrap_cluster_cmd_data
     // from this version. Indicates the version of Redpanda of
     // the node that generated the bootstrap record.
     cluster_version founding_version{invalid_version};
+    std::vector<model::broker> initial_nodes;
 };
 
 enum class reconciliation_status : int8_t {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -67,7 +67,8 @@ std::string_view to_string_view(feature f) {
         return "group_offset_retention";
     case feature::rpc_transport_unknown_errc:
         return "rpc_transport_unknown_errc";
-
+    case feature::membership_change_controller_cmds:
+        return "membership_change_controller_cmds";
     /*
      * testing features
      */

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -54,6 +54,7 @@ enum class feature : std::uint64_t {
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     rpc_transport_unknown_errc = 1ULL << 21U,
+    membership_change_controller_cmds = 1ULL << 22U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -237,6 +238,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{9},
     "rpc_transport_unknown_errc",
     feature::rpc_transport_unknown_errc,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "membership_change_controller_cmds",
+    feature::membership_change_controller_cmds,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -130,6 +130,16 @@ public:
      */
     ss::future<std::error_code>
       replace_configuration(std::vector<broker_revision>, model::revision_id);
+
+    /**
+     * New simplified configuration change API, accepting only vnode instead of
+     * full broker object
+     */
+    ss::future<std::error_code> add_group_member(vnode, model::revision_id);
+    ss::future<std::error_code> remove_member(vnode, model::revision_id);
+    ss::future<std::error_code>
+      replace_configuration(std::vector<vnode>, model::revision_id);
+
     // Abort ongoing configuration change - may cause data loss
     ss::future<std::error_code> abort_configuration_change(model::revision_id);
     // Revert current configuration change - this is safe and will never cause

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -117,16 +117,14 @@ public:
 
     ss::future<timeout_now_reply> timeout_now(timeout_now_request&& r);
 
-    /// This method adds multiple members to the group and performs
-    /// configuration update
+    /// This method adds member to a group
     ss::future<std::error_code>
-      add_group_members(std::vector<model::broker>, model::revision_id);
+      add_group_member(model::broker, model::revision_id);
     /// Updates given member configuration
     ss::future<std::error_code> update_group_member(model::broker);
-    // Removes members from group
+    // Removes member from group
     ss::future<std::error_code>
-      remove_members(std::vector<model::node_id>, model::revision_id);
-
+      remove_member(model::node_id, model::revision_id);
     /**
      * Replace configuration, uses revision provided with brokers
      */

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -606,7 +606,7 @@ private:
         return false;
     }
 
-    void maybe_upgrade_configuration(group_configuration&);
+    void maybe_upgrade_configuration_to_v4(group_configuration&);
 
     void update_confirmed_term();
     // args

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -176,19 +176,6 @@ group_configuration::make_change_strategy() {
     }
 }
 
-std::optional<model::broker>
-group_configuration::find_broker(model::node_id id) const {
-    auto it = std::find_if(
-      _brokers.cbegin(), _brokers.cend(), [id](const model::broker& broker) {
-          return id == broker.id();
-      });
-
-    if (it != _brokers.cend()) {
-        return *it;
-    }
-    return std::nullopt;
-}
-
 bool group_configuration::has_voters() const {
     return !(_current.voters.empty() || (_old && _old->voters.empty()));
 }

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -125,24 +125,49 @@ class group_configuration final {
 public:
     using version_t
       = named_type<int8_t, struct raft_group_configuration_version>;
-    static constexpr version_t current_version{4};
+    // classic joint consensus change strategy
+    static constexpr version_t v_3{3};
+    // improved change strategy, fix for availability issue when one replica is
+    // faulty
+    static constexpr version_t v_4{4};
+    // simplified configuration, not serializing brokers field
+    static constexpr version_t v_5{5};
+    static constexpr version_t current_version = v_5;
+
     /**
      * creates a configuration where all provided brokers are current
      * configuration voters
+     *
+     * DEPRECATED: Use vnode accepting constructor instead
      */
     explicit group_configuration(
       std::vector<model::broker>, model::revision_id);
-
     /**
-     * creates joint configuration
+     * creates a configuration where all provided vnodes are current
+     * configuration voters
+     *
+     * Note:
+     * This is preferred constructor for group configuration
+     */
+    group_configuration(std::vector<vnode>, model::revision_id);
+    /**
+     * creates joint configuration, version 4, with brokers
      */
     group_configuration(
       std::vector<model::broker>,
       group_nodes,
       model::revision_id,
       std::optional<configuration_update>,
-      std::optional<group_nodes> = std::nullopt,
-      version_t = current_version);
+      std::optional<group_nodes> = std::nullopt);
+
+    /**
+     * creates joint configuration
+     */
+    group_configuration(
+      group_nodes,
+      model::revision_id,
+      std::optional<configuration_update>,
+      std::optional<group_nodes> = std::nullopt);
 
     group_configuration(const group_configuration&) = default;
     group_configuration(group_configuration&&) = default;
@@ -171,15 +196,19 @@ public:
      * Configuration manipulation API. Each operation cause the configuration to
      * become joint configuration.
      */
-    void add(model::broker, model::revision_id);
-    void remove(model::node_id);
-    void replace(std::vector<broker_revision>, model::revision_id);
-
+    // deprecated: broker based API, only applicable to versions < v_5
+    void add_broker(model::broker, model::revision_id);
+    void replace_brokers(std::vector<broker_revision>, model::revision_id);
+    void remove_broker(model::node_id);
     /**
      * Updating broker configuration. This operation does not require entering
      * joint consensus as it never change majority
      */
     void update(model::broker);
+
+    void add(vnode, model::revision_id);
+    void remove(vnode, model::revision_id);
+    void replace(std::vector<vnode>, model::revision_id);
 
     /**
      * Discards the old configuration, after this operation joint configuration
@@ -214,7 +243,13 @@ public:
 
     const group_nodes& current_config() const { return _current; }
     const std::optional<group_nodes>& old_config() const { return _old; }
-    const std::vector<model::broker>& brokers() const { return _brokers; }
+    const std::vector<model::broker>& brokers() const {
+        vassert(
+          _version < v_5,
+          "brokers API is unsupported in configuration version {}",
+          _version);
+        return _brokers;
+    }
 
     configuration_state get_state() const;
 
@@ -231,6 +266,10 @@ public:
 
     template<typename Func>
     void for_each_learner(Func&& f) const;
+
+    std::vector<vnode> all_nodes() const;
+
+    std::optional<vnode> find_by_node_id(model::node_id) const;
 
     void set_revision(model::revision_id new_revision) {
         vassert(
@@ -298,14 +337,16 @@ public:
          * configuration revision with provided parameter.
          */
         // add
+        // Deprecated: broker based manipulation methods
+        virtual void add_broker(model::broker, model::revision_id) = 0;
         virtual void
-        add(model::broker to_add, model::revision_id new_cfg_revision)
+          replace_brokers(std::vector<broker_revision>, model::revision_id)
           = 0;
-        virtual void remove(model::node_id to_remove) = 0;
-        virtual void replace(
-          std::vector<broker_revision> new_replica_set,
-          model::revision_id new_cfg_revision)
-          = 0;
+        virtual void remove_broker(model::node_id) = 0;
+
+        virtual void add(vnode, model::revision_id) = 0;
+        virtual void remove(vnode, model::revision_id) = 0;
+        virtual void replace(std::vector<vnode>, model::revision_id) = 0;
 
         /**
          * Discards the old configuration, after this operation joint
@@ -334,11 +375,20 @@ public:
 
         virtual ~configuration_change_strategy() = default;
     };
+    /**
+     * Returns true if current configuration contains information about brokers
+     * configuration. Broker information is available in configuration with
+     * versions smaller than 5.
+     **/
+    bool is_with_brokers() const { return _version < v_5; }
 
 private:
     friend class configuration_change_strategy_v3;
 
     friend class configuration_change_strategy_v4;
+
+    friend class configuration_change_strategy_v5;
+
     std::vector<vnode> unique_voter_ids() const;
     std::vector<vnode> unique_learner_ids() const;
     std::unique_ptr<configuration_change_strategy> make_change_strategy();
@@ -392,6 +442,10 @@ bool majority(Predicate&& f, Range&& range) {
 
 template<typename Func>
 void group_configuration::for_each_broker(Func&& f) const {
+    vassert(
+      _version < v_5,
+      "for_each_broker method is not supported in configuration version {}",
+      _version);
     std::for_each(
       std::cbegin(_brokers), std::cend(_brokers), std::forward<Func>(f));
 }

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -152,7 +152,6 @@ public:
 
     bool has_voters() const;
 
-    std::optional<model::broker> find_broker(model::node_id id) const;
     bool contains_broker(model::node_id id) const;
     bool contains_address(const net::unresolved_address& address) const;
 

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -171,8 +171,8 @@ public:
      * Configuration manipulation API. Each operation cause the configuration to
      * become joint configuration.
      */
-    void add(std::vector<model::broker>, model::revision_id);
-    void remove(const std::vector<model::node_id>&);
+    void add(model::broker, model::revision_id);
+    void remove(model::node_id);
     void replace(std::vector<broker_revision>, model::revision_id);
 
     /**
@@ -298,11 +298,10 @@ public:
          * configuration revision with provided parameter.
          */
         // add
-        virtual void add(
-          std::vector<model::broker> to_add,
-          model::revision_id new_cfg_revision)
+        virtual void
+        add(model::broker to_add, model::revision_id new_cfg_revision)
           = 0;
-        virtual void remove(const std::vector<model::node_id>& to_remove) = 0;
+        virtual void remove(model::node_id to_remove) = 0;
         virtual void replace(
           std::vector<broker_revision> new_replica_set,
           model::revision_id new_cfg_revision)

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -86,6 +86,9 @@ private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();
 
+    raft::group_configuration create_initial_configuration(
+      std::vector<model::broker>, model::revision_id) const;
+
     model::node_id _self;
     ss::scheduling_group _raft_sg;
     raft::consensus_client_protocol _client;

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -56,7 +56,8 @@ struct config_manager_fixture {
           raft::group_id(1),
           model::ntp(model::ns("t"), model::topic("t"), model::partition_id(0)))
       , _cfg_mgr(
-          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_configuration(
+            std::vector<raft::vnode>{}, model::revision_id(0)),
           raft::group_id(1),
           _storage,
           _logger) {
@@ -115,7 +116,8 @@ struct config_manager_fixture {
 
     void validate_recovery() {
         raft::configuration_manager recovered(
-          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_configuration(
+            std::vector<raft::vnode>{}, model::revision_id(0)),
           raft::group_id(1),
           _storage,
           _logger);
@@ -248,7 +250,8 @@ FIXTURE_TEST(test_start_write_concurrency, config_manager_fixture) {
     auto configurations = test_configurations();
 
     raft::configuration_manager new_cfg_manager(
-      raft::group_configuration({}, model::revision_id(1)),
+      raft::group_configuration(
+        std::vector<raft::vnode>{}, model::revision_id(1)),
       raft::group_id(1),
       _storage,
       _logger);

--- a/src/v/raft/tests/membership_test.cc
+++ b/src/v/raft/tests/membership_test.cc
@@ -25,37 +25,13 @@ FIXTURE_TEST(add_one_node_to_single_node_cluster, raft_test_fixture) {
     auto new_node = gr.create_new_node(model::node_id(2));
     res = retry_with_leader(gr, 5, 1s, [new_node](raft_node& leader) {
               return leader.consensus
-                ->add_group_members({new_node}, model::revision_id(0))
+                ->add_group_member(new_node, model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
 
     validate_logs_replication(gr);
     auto& leader = gr.get_member(gr.get_leader_id().value());
     BOOST_REQUIRE_EQUAL(leader.consensus->config().brokers().size(), 2);
-};
-
-FIXTURE_TEST(add_two_nodes_to_the_cluster, raft_test_fixture) {
-    raft_group gr = raft_group(raft::group_id(0), 1);
-    gr.enable_all();
-    auto res = replicate_random_batches(gr, 1).get0();
-    BOOST_REQUIRE(res);
-    auto new_node_1 = gr.create_new_node(model::node_id(2));
-    auto new_node_2 = gr.create_new_node(model::node_id(3));
-    res = retry_with_leader(
-            gr,
-            5,
-            1s,
-            [new_node_1, new_node_2](raft_node& leader) {
-                return leader.consensus
-                  ->add_group_members(
-                    {new_node_1, new_node_2}, model::revision_id(0))
-                  .then([](std::error_code ec) { return !ec; });
-            })
-            .get0();
-
-    validate_logs_replication(gr);
-    auto& leader = gr.get_member(gr.get_leader_id().value());
-    BOOST_REQUIRE_EQUAL(leader.consensus->config().brokers().size(), 3);
 };
 
 /**
@@ -114,7 +90,7 @@ FIXTURE_TEST(remove_non_leader, raft_test_fixture) {
                            ->first;
     res = retry_with_leader(gr, 5, 1s, [non_leader_id](raft_node& leader) {
               return leader.consensus
-                ->remove_members({non_leader_id}, model::revision_id(0))
+                ->remove_member(non_leader_id, model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
     BOOST_REQUIRE(res);
@@ -147,7 +123,7 @@ FIXTURE_TEST(remove_current_leader, raft_test_fixture) {
     auto old_leader_id = wait_for_group_leader(gr);
     res = retry_with_leader(gr, 5, 1s, [old_leader_id](raft_node& leader) {
               return leader.consensus
-                ->remove_members({old_leader_id}, model::revision_id(0))
+                ->remove_member(old_leader_id, model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
 
@@ -170,75 +146,6 @@ FIXTURE_TEST(remove_current_leader, raft_test_fixture) {
     gr.disable_node(old_leader_id);
 
     verify_removed_node_is_behind(gr, removed_offset);
-    validate_offset_translation(gr);
-}
-FIXTURE_TEST(remove_multiple_members, raft_test_fixture) {
-    raft_group gr = raft_group(raft::group_id(0), 3);
-    gr.enable_all();
-    auto res = replicate_random_batches(gr, 2).get0();
-    auto old_leader_id = wait_for_group_leader(gr);
-    auto& members = gr.get_members();
-    auto non_leader_id = std::find_if(
-                           members.begin(),
-                           members.end(),
-                           [](raft_group::members_t::value_type& p) {
-                               return !p.second.consensus->is_elected_leader();
-                           })
-                           ->first;
-    res = retry_with_leader(
-            gr,
-            5,
-            1s,
-            [old_leader_id, non_leader_id](raft_node& leader) {
-                return leader.consensus
-                  ->remove_members(
-                    {old_leader_id, non_leader_id}, model::revision_id(0))
-                  .then([](std::error_code ec) { return !ec; });
-            })
-            .get0();
-
-    tests::cooperative_spin_wait_with_timeout(2s, [&gr, old_leader_id] {
-        auto leader_id = gr.get_leader_id();
-        if (!leader_id) {
-            return false;
-        }
-        auto& leader = gr.get_member(*leader_id);
-        return leader.consensus->config().brokers().size() == 1
-               && leader_id != old_leader_id;
-    }).get0();
-
-    res = replicate_random_batches(gr, 2).get0();
-    BOOST_REQUIRE(res);
-    validate_offset_translation(gr);
-}
-
-FIXTURE_TEST(try_remove_all_voters, raft_test_fixture) {
-    raft_group gr = raft_group(raft::group_id(0), 3);
-    gr.enable_all();
-    auto leader_id = wait_for_group_leader(gr);
-    auto leader_raft = gr.get_member(leader_id).consensus;
-    tests::cooperative_spin_wait_with_timeout(
-      std::chrono::seconds(10),
-      [&leader_raft] {
-          return leader_raft->committed_offset()
-                   >= leader_raft->get_latest_configuration_offset()
-                 && leader_raft->config().current_config().voters.size() == 3;
-      })
-      .get0();
-    tests::cooperative_spin_wait_with_timeout(
-      std::chrono::seconds(10),
-      [&leader_raft] {
-          // try removing all voters
-          return leader_raft
-            ->remove_members(
-              {model::node_id(0), model::node_id(1), model::node_id(2)},
-              model::revision_id(0))
-            .then([](std::error_code result) {
-                return result == raft::errc::invalid_configuration_update;
-            });
-      })
-      .get0();
-
     validate_offset_translation(gr);
 }
 

--- a/src/v/raft/tests/membership_test.cc
+++ b/src/v/raft/tests/membership_test.cc
@@ -9,6 +9,7 @@
 
 #include "model/metadata.h"
 #include "raft/errc.h"
+#include "raft/group_configuration.h"
 #include "raft/tests/raft_group_fixture.h"
 #include "storage/api.h"
 #include "test_utils/async.h"
@@ -25,13 +26,15 @@ FIXTURE_TEST(add_one_node_to_single_node_cluster, raft_test_fixture) {
     auto new_node = gr.create_new_node(model::node_id(2));
     res = retry_with_leader(gr, 5, 1s, [new_node](raft_node& leader) {
               return leader.consensus
-                ->add_group_member(new_node, model::revision_id(0))
+                ->add_group_member(
+                  raft::vnode(new_node.id(), model::revision_id(0)),
+                  model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
 
     validate_logs_replication(gr);
     auto& leader = gr.get_member(gr.get_leader_id().value());
-    BOOST_REQUIRE_EQUAL(leader.consensus->config().brokers().size(), 2);
+    BOOST_REQUIRE_EQUAL(leader.consensus->config().all_nodes().size(), 2);
 };
 
 /**
@@ -90,7 +93,9 @@ FIXTURE_TEST(remove_non_leader, raft_test_fixture) {
                            ->first;
     res = retry_with_leader(gr, 5, 1s, [non_leader_id](raft_node& leader) {
               return leader.consensus
-                ->remove_member(non_leader_id, model::revision_id(0))
+                ->remove_member(
+                  raft::vnode(non_leader_id, model::revision_id{0}),
+                  model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
     BOOST_REQUIRE(res);
@@ -101,7 +106,7 @@ FIXTURE_TEST(remove_non_leader, raft_test_fixture) {
             return false;
         }
         auto& leader = gr.get_member(*leader_id);
-        return leader.consensus->config().brokers().size() == 2;
+        return leader.consensus->config().all_nodes().size() == 2;
     }).get0();
 
     auto write_ok = replicate_random_batches(gr, 2).get0();
@@ -123,7 +128,9 @@ FIXTURE_TEST(remove_current_leader, raft_test_fixture) {
     auto old_leader_id = wait_for_group_leader(gr);
     res = retry_with_leader(gr, 5, 1s, [old_leader_id](raft_node& leader) {
               return leader.consensus
-                ->remove_member(old_leader_id, model::revision_id(0))
+                ->remove_member(
+                  raft::vnode(old_leader_id, model::revision_id{0}),
+                  model::revision_id(0))
                 .then([](std::error_code ec) { return !ec; });
           }).get0();
 
@@ -133,7 +140,7 @@ FIXTURE_TEST(remove_current_leader, raft_test_fixture) {
             return false;
         }
         auto& leader = gr.get_member(*leader_id);
-        return leader.consensus->config().brokers().size() == 2
+        return leader.consensus->config().all_nodes().size() == 2
                && leader_id != old_leader_id;
     }).get0();
 
@@ -162,11 +169,9 @@ FIXTURE_TEST(replace_whole_group, raft_test_fixture) {
 
     // all nodes are replaced with new node
     gr.create_new_node(model::node_id(5));
-    std::vector<raft::broker_revision> new_members;
+    std::vector<raft::vnode> new_members;
     new_members.reserve(1);
-    new_members.push_back(raft::broker_revision{
-      .broker = gr.get_member(model::node_id(5)).broker,
-      .rev = model::revision_id(0)});
+    new_members.emplace_back(model::node_id(5), model::revision_id(0));
     info("replacing configuration");
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
               return leader.consensus
@@ -227,7 +232,8 @@ FIXTURE_TEST(replace_whole_group, raft_test_fixture) {
     auto new_leader_id = gr.get_leader_id();
     if (new_leader_id) {
         auto& new_leader = gr.get_member(*new_leader_id);
-        BOOST_REQUIRE_EQUAL(new_leader.consensus->config().brokers().size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          new_leader.consensus->config().all_nodes().size(), 1);
     }
     validate_offset_translation(gr);
 }
@@ -243,10 +249,9 @@ FIXTURE_TEST(
     gr.create_new_node(model::node_id(5));
     auto broker = gr.get_member(model::node_id(5)).broker;
     gr.disable_node(model::node_id(5));
-    std::vector<raft::broker_revision> new_members;
+    std::vector<raft::vnode> new_members;
     new_members.reserve(1);
-    new_members.push_back(
-      raft::broker_revision{.broker = broker, .rev = model::revision_id(0)});
+    new_members.emplace_back(model::node_id(5), model::revision_id(0));
     // replace configuration with other node, the target node is stopped
     // to keep the transient state in which the old node is the only voter in
     // raft group
@@ -280,13 +285,9 @@ FIXTURE_TEST(abort_configuration_change, raft_test_fixture) {
     gr.enable_all();
     auto res = replicate_random_batches(gr, 5).get();
     // try to move raft group to
-    std::vector<raft::broker_revision> new_members;
+    std::vector<raft::vnode> new_members;
     new_members.reserve(1);
-    // replace configuration with the node that does not exists
-    new_members.push_back(raft::broker_revision{
-      .broker = gr.make_broker(model::node_id(10)),
-      .rev = model::revision_id(0)});
-
+    new_members.emplace_back(model::node_id(10), model::revision_id(0));
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
               return leader.consensus
                 ->replace_configuration(new_members, model::revision_id(0))
@@ -312,7 +313,7 @@ FIXTURE_TEST(abort_configuration_change, raft_test_fixture) {
     BOOST_REQUIRE(res);
 
     auto current_cfg = gr.get_member(model::node_id(0)).consensus->config();
-    BOOST_REQUIRE_EQUAL(current_cfg.brokers().size(), 1);
+    BOOST_REQUIRE_EQUAL(current_cfg.all_nodes().size(), 1);
     BOOST_REQUIRE(current_cfg.get_state() == raft::configuration_state::simple);
 
     auto logs_before = gr.read_all_logs();
@@ -332,11 +333,9 @@ FIXTURE_TEST(revert_configuration_change, raft_test_fixture) {
     auto res = replicate_random_batches(gr, 5).get0();
     // all nodes are replaced with new node
     gr.create_new_node(model::node_id(5));
-    std::vector<raft::broker_revision> new_members;
+    std::vector<raft::vnode> new_members;
     new_members.reserve(1);
-    new_members.push_back(raft::broker_revision{
-      .broker = gr.get_member(model::node_id(5)).broker,
-      .rev = model::revision_id(0)});
+    new_members.emplace_back(model::node_id(5), model::revision_id(0));
     info("replacing configuration");
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
               return leader.consensus
@@ -375,7 +374,8 @@ FIXTURE_TEST(revert_configuration_change, raft_test_fixture) {
     auto new_leader_id = gr.get_leader_id();
     if (new_leader_id) {
         auto& new_leader = gr.get_member(*new_leader_id);
-        BOOST_REQUIRE_EQUAL(new_leader.consensus->config().brokers().size(), 3);
+        BOOST_REQUIRE_EQUAL(
+          new_leader.consensus->config().all_nodes().size(), 3);
     }
     validate_offset_translation(gr);
 }

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -434,7 +434,8 @@ struct raft_group {
           ntp,
           broker,
           _id,
-          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_configuration(
+            std::vector<model::broker>{}, model::revision_id(0)),
           raft::timeout_jitter(heartbeat_interval * 10),
           ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -513,7 +513,7 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_roundtrip) {
     BOOST_REQUIRE(
       std::chrono::time_point_cast<std::chrono::milliseconds>(d.cluster_time)
       == std::chrono::time_point_cast<std::chrono::milliseconds>(ct));
-    BOOST_REQUIRE_EQUAL(d.latest_configuration, cfg);
+    BOOST_REQUIRE_EQUAL(d.latest_configuration.all_nodes(), cfg.all_nodes());
     BOOST_REQUIRE_EQUAL(d.log_start_delta, delta);
 }
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -628,6 +628,8 @@ class NodesDecommissioningTest(EndToEndTest):
                                     auto_assign_node_id=True,
                                     omit_seeds_on_idx_one=False)
 
+        self.run_validation(enable_idempotence=False, consumer_timeout_sec=180)
+
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(new_bootstrap=True)
     @parametrize(new_bootstrap=False)

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -624,6 +624,10 @@ class NodesDecommissioningTest(EndToEndTest):
 
                 wait_until(has_partitions, 180, 2)
 
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
+
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(new_bootstrap=True)
     @parametrize(new_bootstrap=False)

--- a/tools/offline_log_viewer/model.py
+++ b/tools/offline_log_viewer/model.py
@@ -85,7 +85,8 @@ def read_raft_config(rdr):
     cfg = {}
 
     cfg['version'] = rdr.read_int8()
-    cfg['brokers'] = rdr.read_vector(read_broker)
+    if cfg['version'] < 5:
+        cfg['brokers'] = rdr.read_vector(read_broker)
     cfg['current_config'] = read_group_nodes(rdr)
     cfg['prev_config'] = rdr.read_optional(read_group_nodes)
     cfg['revision'] = rdr.read_int64()


### PR DESCRIPTION
Removed the need to store `model::broker` objects in `raft::group_configuration` by decoupling cluster membership information from `raft-0` configuration. 

Introduced separate set of node operation commands that are used to drive cluster membership changes. The commands are applied to `controller_stm` and as a result build state in `members_table`. 

## Node on backward compatibility

Since we need to maintain backward compatibility it wasn't possible to remove `mode::broker` completely from  Raft implementation. After the support for previous version ends we should be able to remove a lot of code responsible for keeping the broker information in raft.

RFC: https://docs.google.com/document/d/1xGlwDrn5qI2ZBVtK7UoRw9eoF3iusANj3MLqo2LaliU/edit
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.


 

-->
### Improvements

  * lowered memory footprint of single partition