### PR TITLE
[22.3.x] Backport #7493 (cloud_storage: fix topic recovery size/time limits to use local.target settings)

### DIFF
--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -146,11 +146,11 @@ class EndToEndTopicRecovery(RedpandaTest):
     def test_restore_with_config_batches(self, num_messages):
         """related to issue 6413: force the creation of remote segments containing only configuration batches,
         check that older data can be nonetheless recovered even if the total download size
-         would exceed the property retention.bytes.
-         in other words, only segments containing at least some data counts towards retention.bytes limit"""
+         would exceed the property retention.local.target.bytes.
+         in other words, only segments containing at least some data counts towards retention.local.target.bytes limit"""
         """1. generate some messages
         2. restart the cluster to generate some config-only remote segments
-        3. restore topic with a small retention.bytes to force redpanda 
+        3. restore topic with a small retention.local.target.bytes to force redpanda 
            to get over the limit and skip over configuration batches"""
         self.logger.info("start")
         self.init_producer(5000, num_messages)
@@ -175,7 +175,8 @@ class EndToEndTopicRecovery(RedpandaTest):
         # Run recovery
         self._start_redpanda_nodes()
         for topic_spec in self.topics:
-            self._restore_topic(topic_spec, {'retention.bytes': 512})
+            self._restore_topic(topic_spec,
+                                {'retention.local.target.bytes': 512})
 
         self.init_consumer(5000)
         self._consumer.start(clean=False)
@@ -186,7 +187,7 @@ class EndToEndTopicRecovery(RedpandaTest):
     @matrix(message_size=[5000],
             num_messages=[100000],
             recovery_overrides=[{}, {
-                'retention.bytes': 1024
+                'retention.local.target.bytes': 1024
             }])
     def test_restore(self, message_size, num_messages, recovery_overrides):
         """Write some data. Remove local data then restore
@@ -233,7 +234,7 @@ class EndToEndTopicRecovery(RedpandaTest):
 
     @cluster(num_nodes=4, log_allow_list=ALLOWED_ERROR_LOG_LINES)
     @matrix(recovery_overrides=[{}, {
-        'retention.bytes': 1024,
+        'retention.local.target.bytes': 1024,
         'redpanda.remote.write': True,
         'redpanda.remote.read': True,
     }])

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -766,9 +766,10 @@ class SizeBasedRetention(BaseCase):
         for topic in self.expected_recovered_topics:
             for _, manifest in topic_manifests:
                 if manifest['topic'] == topic.name:
-                    self._restore_topic(
-                        manifest,
-                        {"retention.bytes": self.restored_size_bytes})
+                    self._restore_topic(manifest, {
+                        "retention.local.target.bytes":
+                        self.restored_size_bytes
+                    })
 
     def validate_cluster(self, baseline, restored):
         """Check size of every partition."""
@@ -904,7 +905,8 @@ class TimeBasedRetention(BaseCase):
             for _, manifest in topic_manifests:
                 if manifest['topic'] == topic.name:
                     # retention - 1 hour
-                    self._restore_topic(manifest, {"retention.ms": 3600000})
+                    self._restore_topic(manifest,
+                                        {"retention.local.target.ms": 3600000})
 
     def validate_cluster(self, baseline, restored):
         """Check that the topic is writeable"""


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7493

## Backports Required


- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Improvements

  * Tiered storage topic recovery now uses the retention.local.target settings to bound how much data is restored to local disk, rather than the total retention settings.
