### PR TITLE
operator: do not perform rolling restart when replicas count changes

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -702,6 +702,73 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 
+		It("scaling out does not trigger a rolling restart", func() {
+			const replicas = 3
+			resources := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			}
+			key := types.NamespacedName{
+				Name:      "redpanda-no-restart",
+				Namespace: "default",
+			}
+			redpandaCluster := &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Image:    redpandaContainerImage,
+					Version:  redpandaContainerTag,
+					Replicas: pointer.Int32Ptr(replicas),
+					Configuration: v1alpha1.RedpandaConfig{
+						KafkaAPI: []v1alpha1.KafkaAPI{
+							{
+								Port: kafkaPort,
+							},
+						},
+						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+					},
+					Resources: v1alpha1.RedpandaResourceRequirements{
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits:   resources,
+							Requests: resources,
+						},
+						Redpanda: nil,
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
+
+			By("Creating StatefulSet")
+			var sts appsv1.StatefulSet
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), key, &sts)
+				return err == nil &&
+					*sts.Spec.Replicas == replicas
+			}, timeout, interval).Should(BeTrue())
+
+			// configmap annotation should not change when scaling out cluster replicas
+			// to avoid an unnecessary rolling restart
+			configMapHash := sts.Annotations[res.ConfigMapHashAnnotationKey]
+			var existingCluster v1alpha1.Cluster
+			Expect(k8sClient.Get(context.Background(), key, &existingCluster)).Should(Succeed())
+
+			var newReplicas int32 = replicas + 2
+			existingCluster.Spec.Replicas = &newReplicas
+			Expect(k8sClient.Update(context.Background(), &existingCluster)).Should(Succeed())
+
+			// verify scale-out completed and the configmap hash did not change
+			var newSts appsv1.StatefulSet
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), key, &newSts)
+				return err == nil &&
+					*newSts.Spec.Replicas == newReplicas
+			}, timeout, interval).Should(BeTrue())
+			newConfigMapHash := newSts.Annotations[res.ConfigMapHashAnnotationKey]
+			Expect(newConfigMapHash).Should(Equal(configMapHash))
+		})
+
 		It("Should load license", func() {
 			By("Creating the license Secret")
 			licenseSecret := &corev1.Secret{

--- a/src/go/k8s/pkg/resources/configmap_test.go
+++ b/src/go/k8s/pkg/resources/configmap_test.go
@@ -128,7 +128,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			name:                    "Primitive object in additional configuration",
 			additionalConfiguration: map[string]string{"redpanda.transactional_id_expiration_ms": "25920000000", "rpk.overprovisioned": "true"},
 			expectedStrings:         []string{"transactional_id_expiration_ms: 25920000000"},
-			expectedHash:            "36e2d026bbb0c6fa14c88eb3e1ec3639",
+			expectedHash:            "523b9f16869acb716683f2dc844fe203",
 		},
 		{
 			name:                    "Complex struct in additional configuration",
@@ -138,7 +138,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
         - address: 0.0.0.0
           port: 8081
           name: external`},
-			expectedHash: "2c874d3b253c5beda6835fbd1136c62c",
+			expectedHash: "a5d7af0c3bafb1488e1d147da992cf11",
 		},
 		{
 			name: "shadow index cache directory",
@@ -146,7 +146,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				`cloud_storage_cache_directory: /var/lib/shadow-index-cache`,
 				`cloud_storage_cache_size: "10737418240"`,
 			},
-			expectedHash: "0617766c21c59bce831ce1f1cc99d84b",
+			expectedHash: "3b8a2186bb99ebb9b3db10452cdfd45a",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
Prevents restarts when scaling out from `n` to `m`, where `n > 1`. For example, `3->5` works without a restart. Achieved by ignoring the seeds, panda proxy client, schema registry client fields when computing the hash value (that if different triggers a rolling restart).

The case of `n=1` is special: `1->n` incurs a restart because the operator adds lifecycle hooks only when the `replicas > 1`, so the spec changes and the statefulset restarts as seen under `statefulset.go`. Because of that the `1->n` behavior is not affected by this PR. See comment in snippet below:

```go
// Only multi-replica clusters should use maintenance mode. See: https://github.com/redpanda-data/redpanda/issues/4338
// Startup of a fresh cluster would let the first pod restart, until dynamic hooks are implemented. See: https://github.com/redpanda-data/redpanda/pull/4907
multiReplica := r.pandaCluster.GetCurrentReplicas() > 1
if featuregates.MaintenanceMode(r.pandaCluster.Spec.Version) && r.pandaCluster.IsUsingMaintenanceModeHooks() && multiReplica {
	ss.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
		PreStop:   r.getHook(preStopKey),
		PostStart: r.getHook(postStartKey),
	}
}
```

[Forced push](https://github.com/redpanda-data/redpanda/compare/bdfb8c62b82ae9143a870db3831ebb588cc6dc79..6ee5a6f2eb87d0fd54d5d4c6ee0eaa8685eea292) to clean up and fix controller test

[Forced push 2](https://github.com/redpanda-data/redpanda/compare/6ee5a6f2eb87d0fd54d5d4c6ee0eaa8685eea292..fe8f9545de25a0340c3f226979b3059a5784ddc4) to fix the CI status issue, no changes in the commits of this PR
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

Backporting would roll-restart all clusters managed by the updated operator, so I'm marking this as not impactful enough at the moment.

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
