### PR TITLE
Support path style urls

### DIFF
--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -140,13 +140,16 @@ ss::future<configuration> configuration::get_config() {
     }
     overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
 
+    bool use_path_style_url
+      = config::shard_local_cfg().cloud_storage_use_path_style_url;
     auto s3_conf = co_await s3::configuration::make_configuration(
       access_key,
       secret_key,
       region,
       overrides,
       disable_metrics,
-      disable_public_metrics);
+      disable_public_metrics,
+      use_path_style_url);
 
     configuration cfg{
       .client_config = std::move(s3_conf),

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1135,6 +1135,12 @@ configuration::configuration()
       "Enable re-uploading data for compacted topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_use_path_style_url(
+      *this,
+      "cloud_storage_use_path_style_url",
+      "Enable re-uploading data for compacted topics",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      false)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -234,6 +234,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
+    property<bool> cloud_storage_use_path_style_url;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -40,6 +40,17 @@ struct object_tag {
     ss::sstring value;
 };
 
+struct host_and_target {
+    ss::sstring host;
+    ss::sstring target;
+};
+
+host_and_target build_host_and_target(
+  const access_point_uri& access_point,
+  const bucket_name& bucket,
+  const object_key& key,
+  bool use_path_style_url);
+
 /// Request formatter for AWS S3
 class request_creator {
 public:
@@ -47,8 +58,8 @@ public:
     /// \param conf is a configuration container
     explicit request_creator(
       const configuration& conf,
-      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
-        apply_credentials);
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials,
+      bool use_path_style_url = false);
 
     /// \brief Create unsigned 'PutObject' request header
     /// The payload is unsigned which means that we don't need to calculate
@@ -103,6 +114,7 @@ public:
 
 private:
     access_point_uri _ap;
+    bool _use_path_style_url;
     /// Applies credentials to http requests by adding headers and signing
     /// request payload. Shared pointer so that the credentials can be rotated
     /// through the client pool.

--- a/src/v/s3/configuration.h
+++ b/src/v/s3/configuration.h
@@ -54,6 +54,11 @@ struct configuration : net::base_transport::configuration {
     /// Metrics probe (should be created for every aws account on every shard)
     ss::shared_ptr<client_probe> _probe;
 
+    /// If enabled, directs S3 clients to use path style URL instead of vhost
+    /// style URL
+    /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAPI.html
+    bool use_path_style_url;
+
     /// \brief opinionated configuraiton initialization
     /// Generates uri field from region, initializes credentials for the
     /// transport, resolves the uri to get the server_addr.
@@ -72,7 +77,8 @@ struct configuration : net::base_transport::configuration {
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
       net::public_metrics_disabled disable_public_metrics
-      = net::public_metrics_disabled::yes);
+      = net::public_metrics_disabled::yes,
+      bool use_path_style_url = false);
 
     friend std::ostream& operator<<(std::ostream& o, const configuration& c);
 };


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
