### PR TITLE
ducktape: bump wait timeout for compaction test

### DIFF
--- a/tests/rptest/tests/compaction_end_to_end_test.py
+++ b/tests/rptest/tests/compaction_end_to_end_test.py
@@ -123,9 +123,10 @@ class CompactionEndToEndTest(EndToEndTest):
 
                 return all([predicate(n) for n in segments_per_partition])
 
+            timeout_sec = 300
             # wait for multiple segments to appear in topic partitions
             wait_until(lambda: segment_number_matches(lambda s: s >= 5),
-                       timeout_sec=180,
+                       timeout_sec=timeout_sec,
                        backoff_sec=2)
 
             # enable compaction, if topic isn't compacted
@@ -144,10 +145,8 @@ class CompactionEndToEndTest(EndToEndTest):
             # make compaction frequent
             rpk.cluster_config_set("log_compaction_interval_ms", str(3000))
 
-            # wait for compaction to merge some adjacent segments
-            wait_timeout_sec = 300 if self.debug_mode else 180
             wait_until(lambda: segment_number_matches(lambda s: s < 5),
-                       timeout_sec=wait_timeout_sec,
+                       timeout_sec=timeout_sec,
                        backoff_sec=2)
 
             # enable consumer and validate consumed records


### PR DESCRIPTION
On ARM, the release build is slower too resulting in timeouts. It is making progress however (based on logs), just that it is slow. Relax timeout requirements until we narrow down the root cause

Fixes #7138

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
