### PR TITLE
tests/acls: ensure admin user is created

### DIFF
--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -126,6 +126,8 @@ class AccessControlListTest(RedpandaTest):
         if self.security.sasl_enabled() or enable_authz:
             self.admin.create_user("cluster_describe", self.password,
                                    self.algorithm)
+
+        self.admin.create_user(*self.redpanda.SUPERUSER_CREDENTIALS)
         client = self.get_super_client()
         client.acl_create_allow_cluster("cluster_describe", "describe")
 
@@ -143,7 +145,7 @@ class AccessControlListTest(RedpandaTest):
                 if checkpoint_user not in users:
                     return False
                 elif self.security.sasl_enabled() or enable_authz:
-                    assert "base" in users and "cluster_describe" in users
+                    assert "base" in users and "cluster_describe" in users and "admin" in users
             return True
 
         wait_until(auth_metadata_propagated, timeout_sec=10, backoff_sec=1)


### PR DESCRIPTION
## Cover letter

There is a flaky failure on CDT where we fail to create the superuser before running our permission checks. 
Looking at the logs, we see an error from request_auth around the time of the reported log line

```
WARN  2022-11-27 12:55:22,147 [shard 0] request_auth - request_auth.cc:107 - Client auth failure: user '{admin}' not found

INFO  2022-11-27 12:55:22,550 [shard 0] kafka - protocol.cc:132 - 172.31.42.136:34166 errored, proto: kafka rpc protocol, sasl state: initial - std::__1::system_error (error GnuTLS:-110, The TLS connection was non-properly terminated.)

ERROR 2022-11-27 12:55:22,550 [shard 0] rpc - server.cc:116 - kafka rpc protocol - Error[applying protocol] remote address: 172.31.42.136:34166 - std::__1::system_error (error GnuTLS:-110, The TLS connection was non-properly terminated.)
```

Therefore this PR creates the superuser using the Admin API and includes the superuser in the "user list" check.

Fixes: #7536

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
