### PR TITLE
Add Internal Topic Protection

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -865,6 +865,19 @@ configuration::configuration()
       "limit applies to compressed batch size",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_MiB)
+  , kafka_nodelete_topics(
+      *this,
+      "kafka_nodelete_topics",
+      "Prevents the topics in the list from being deleted via the kafka api",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "_schemas"})
+  , kafka_noproduce_topics(
+      *this,
+      "kafka_noproduce_topics",
+      "Prevents the topics in the list from having message produced to them "
+      "via the kafka api",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {"__audit"})
   , compaction_ctrl_update_interval_ms(
       *this,
       "compaction_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -185,6 +185,9 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;
     property<uint32_t> kafka_request_max_bytes;
     property<uint32_t> kafka_batch_max_bytes;
+    property<std::vector<ss::sstring>> kafka_nodelete_topics;
+    property<std::vector<ss::sstring>> kafka_noproduce_topics;
+
     // Compaction controller
     property<std::chrono::milliseconds> compaction_ctrl_update_interval_ms;
     property<double> compaction_ctrl_p_coeff;

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -352,7 +352,8 @@ class RpkTool:
                 offset=None,
                 partition=None,
                 fetch_max_bytes=None,
-                quiet=False):
+                quiet=False,
+                timeout=None):
         cmd = ["consume", topic]
         if group is not None:
             cmd += ["-g", group]
@@ -369,7 +370,7 @@ class RpkTool:
         if quiet:
             cmd += ["-f", "_\\n"]
 
-        return self._run_topic(cmd)
+        return self._run_topic(cmd, timeout=timeout)
 
     def group_seek_to(self, group, to):
         cmd = ["seek", group, "--to", to]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1377,7 +1377,7 @@ class RedpandaService(Service):
     def set_cluster_config(self,
                            values: dict,
                            expect_restart: bool = False,
-                           admin_client: Admin = None,
+                           admin_client: Optional[Admin] = None,
                            timeout: int = 10):
         """
         Update cluster configuration and wait for all nodes to report that they

--- a/tests/rptest/tests/consumer_group_recovery_tool_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_tool_test.py
@@ -33,6 +33,9 @@ class ConsumerOffsetsRecoveryToolTest(PreallocNodesTest):
             *args,
             # disable leader balancer to make sure that group will not be realoaded because of leadership changes
             extra_rp_conf={
+                # clear topics from the the kafka_nodelete_topics to allow for
+                # __consumer_offsets to be configured in this test.
+                "kafka_nodelete_topics": [],
                 "group_topic_partitions": self.initial_partition_count
             },
             node_prealloc_count=1,

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -1,0 +1,190 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import subprocess
+import time
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.util import expect_exception
+
+from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
+
+
+class InternalTopicProtectionTest(RedpandaTest):
+    """
+    Verify that the `kafka_nodelete_topics` and `kafka_noproduce_topics`
+    configuration properties function as intended.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, extra_rp_conf={}, **kwargs)
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.kafka_cat = KafkaCat(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=3)
+    @parametrize(protect_config="kafka_nodelete_topics")
+    @parametrize(protect_config="kafka_noproduce_topics")
+    def kafka_protections_disable_config_test(
+            self,
+            protect_config,
+            config="retention.ms",
+            original_val=str(4 * 60 * 60 * 60),  # 4 hrs
+            new_val=str(5 * 60 * 60 * 60)  # 5 hrs
+    ):
+
+        test_topic = "test_topic"
+        self.rpk.create_topic(test_topic, 3, config={config: original_val})
+
+        # Protect topic
+        self.redpanda.set_cluster_config({protect_config: [test_topic]})
+
+        # Ensure config of protected topic can't be changed.
+        with expect_exception(
+                RpkException,
+                lambda e: "TOPIC_AUTHORIZATION_FAILED" in str(e)):
+            self.rpk.alter_topic_config(test_topic, config, new_val)
+
+        # Allow time for a potential change to be propagated.
+        time.sleep(10)
+        config_val, _ = self.rpk.describe_topic_configs(test_topic)[config]
+
+        assert config_val == original_val, "Topic config was changed even with protection"
+
+        # Ensure config of protected topic can't be deleted.
+        self.rpk.delete_topic_config(test_topic, config)
+
+        # Allow time for a potential change to be propagated.
+        time.sleep(10)
+        config_val, _ = self.rpk.describe_topic_configs(test_topic)[config]
+
+        assert config_val == original_val, "Topic config was deleted even with protection"
+
+        # Remove topic from protection list and ensure config can be changed
+        self.redpanda.set_cluster_config({protect_config: []})
+        self.rpk.alter_topic_config(test_topic, config, new_val)
+
+        # Allow time for the change to be propagated.
+        time.sleep(10)
+        config_val, _ = self.rpk.describe_topic_configs(test_topic)[config]
+
+        assert config_val == new_val, "Topic config wasn't changed"
+
+    @cluster(num_nodes=3)
+    @parametrize(client_type="rpk")
+    @parametrize(client_type="kafka_tools")
+    def kafka_noproduce_topics_test(self, client_type):
+        def get_hw(topic, partition_id):
+            partition = []
+
+            def has_partition():
+                nonlocal partition
+                partition = [
+                    p for p in self.rpk.describe_topic(topic)
+                    if p.id == partition_id
+                ]
+                return len(partition) == 1
+
+            wait_until(has_partition, timeout_sec=30, backoff_sec=3)
+
+            return partition[0].high_watermark
+
+        if client_type == "rpk":
+            produce_fn = lambda topic, msg: self.rpk.produce(
+                topic, "key", msg, timeout=30)
+            failure_exception_type = RpkException
+
+        elif client_type == "kafka_tools":
+            produce_fn = lambda topic, msg: self.kafka_cat.produce_one(
+                topic, msg)
+            failure_exception_type = subprocess.CalledProcessError
+
+        else:
+            assert False, "Unknown client type"
+
+        test_topic = "noproduce_topic"
+        self.kafka_tools.create_topic_with_config(test_topic, 1, 3, {})
+        partition_id = 0
+
+        wait_until(lambda: test_topic in self.rpk.list_topics(),
+                   timeout_sec=90,
+                   backoff_sec=3)
+
+        # Ensure topic can't be produced to via the Kafka API when
+        # it's in the kafka_noproduce_topics list.
+        self.redpanda.set_cluster_config(
+            {"kafka_noproduce_topics": [test_topic]})
+
+        pre_produce_hw = get_hw(test_topic, partition_id)
+        try:
+            produce_fn(test_topic, "test_msg")
+        except Exception as e:
+            assert type(e) == failure_exception_type
+        else:
+            assert False, "Call to delete topic returned sucess"
+        post_produce_hw = get_hw(test_topic, partition_id)
+
+        assert pre_produce_hw == post_produce_hw, "was able to produce to topic"
+
+        # Check that a topic can be removed from the kafka_noproduce_topics
+        # list then produced to.
+        self.redpanda.set_cluster_config({"kafka_noproduce_topics": []})
+
+        pre_produce_hw = get_hw(test_topic, partition_id)
+        produce_fn(test_topic, "test_msg")
+        post_produce_hw = get_hw(test_topic, partition_id)
+
+        assert pre_produce_hw < post_produce_hw, "wasn't able to produce to topic"
+
+    @cluster(num_nodes=3)
+    @parametrize(client_type="rpk", no_exception_on_delete=True)
+    @parametrize(client_type="kafka_tools", no_exception_on_delete=False)
+    def kafka_nodelete_topics_test(self, client_type, no_exception_on_delete):
+        if client_type == "rpk":
+            client = self.rpk
+        elif client_type == "kafka_tools":
+            client = self.kafka_tools
+        else:
+            assert False, "Unknown client type"
+
+        test_topic = "nodelete_topic"
+        self.kafka_tools.create_topic_with_config(test_topic, 3, 3, {})
+
+        wait_until(lambda: test_topic in client.list_topics(),
+                   timeout_sec=90,
+                   backoff_sec=3)
+
+        # Ensure topic can't be deleted via the Kafka API when it's
+        # in the nodelete list.
+        self.redpanda.set_cluster_config(
+            {"kafka_nodelete_topics": [test_topic]})
+        try:
+            client.delete_topic(test_topic)
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            assert no_exception_on_delete, "Call to delete topic returned sucess"
+
+        # allow time for any erronous deletion to be propagated
+        time.sleep(10)
+        assert test_topic in client.list_topics()
+
+        # Check that topics in the nodelete list can be removed then
+        # deleted.
+        self.redpanda.set_cluster_config({"kafka_nodelete_topics": []})
+        client.delete_topic(test_topic)
+
+        wait_until(lambda: test_topic not in client.list_topics(),
+                   timeout_sec=90,
+                   backoff_sec=3)


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->
This PR adds to additional parameters to Redpanda `kafka_noproduce_topics` and `kafka_nodelete_topics`. Topics that are added to the `kafka_noproduce_topics` list will be unable to have messages produced to them via the Kafka API. Topics added to the `kafka_nodelete_topics` list will not be able to be deleted via the Kafka API.  

Fixes https://github.com/redpanda-data/core-internal/issues/272
## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

See release notes

## Release Notes

### Features

* Certain topics are now protected from being produced to by Kafka clients, using a new `kafka_noproduce_topics` cluster configuration property.  The default value of this property is `['__audit']`
* Certain topics are now protected from deletion and configuration changes by Kafka clients, using a new `kafka_nodelete_topics` cluster configuration property.  The default value of this property is `['__consumer_offsets', '__redpanda_e2e_probe', '_schemas']`