### PR TITLE
cloud_storage: Remove assertion from delete_object

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -679,11 +679,12 @@ ss::future<upload_result> remote::delete_object(
             result = upload_result::failed;
             break;
         case error_outcome::notfound:
-            vassert(
-              false,
-              "Unexpected NoSuchKey error response from DeleteObject {}",
+            vlog(
+              ctxlog.info,
+              "Unexpected NoSuchKey error response from DeleteObject {} will "
+              "be ignored",
               path);
-            break;
+            co_return upload_result::success;
         }
     }
     if (!result) {


### PR DESCRIPTION
In AWS S3 the DeleteObject call never returns NoSuchKey error. Because of that the code in 'cloud_storage::remote' doesn't expect this error code and triggers an assertion. But in GCP the corresponding API call may return NoSuchKey error. This commit removes the assertion and converts NoSuchKey to the successful outcome. This is save because our retention is implemented expect this behavior and may call DeleteObjects more than once for the same object.



  Fixes #7615

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

  * none

