### PR TITLE
cloud_storage: Fix remote_partition randomized test

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -2035,7 +2035,7 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random_with_duplicates,
   cloud_storage_fixture) {
-    constexpr int num_segments = 1000;
+    constexpr int num_segments = 500;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
     auto segments = setup_s3_imposter(


### PR DESCRIPTION
The test uses too much memory because of duplicates. This commit decreases the number of segments generated during the test from 1000 to 500 because the test will generate duplicate for every segment.


  Fixes #7548 #7577


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes


  * none


