### PR TITLE
redpanda: attempt leadership drain during shutdown

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -194,6 +194,9 @@ application::~application() = default;
  * is shutting down.
  */
 void application::maybe_drain_leaderships() {
+    if (_test_mode) {
+        return;
+    }
     auto& health_monitor = controller->get_health_monitor();
 
     // Load cluster health status with a short timeout
@@ -2023,6 +2026,8 @@ void application::start_bootstrap_services() {
 }
 
 void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
+    _test_mode = test_mode;
+
     // Setup the app level abort service
     construct_service(_as).get();
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -89,6 +89,7 @@ public:
     ~application();
 
     void shutdown();
+    void maybe_drain_leaderships();
 
     ss::future<> set_proxy_config(ss::sstring name, std::any val);
     ss::future<> set_proxy_client_config(ss::sstring name, std::any val);

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -282,6 +282,10 @@ private:
     deferred_actions _deferred;
 
     ss::sharded<ss::abort_source> _as;
+
+    // Disable quality of life behaviors like leader transfer on shutdown,
+    // which do not make sense in a unit test.
+    bool _test_mode{false};
 };
 
 namespace debug {


### PR DESCRIPTION
This is helpful to users who are not using tools that do not integrate with maintenance mode: prior to shutdown, attempt to drain leaderships, as much as we can within 5 seconds.  An orderly leadership transfer helps with transactional workloads, and depending on client retry behavior this may result in faster recovery than immediately stopping the kafka listener.  Leadership transfer also takes less time than waiting for raft heartbeat timeouts to trigger an election.

This is skipped if anything in the cluster health status indicates that we are not the only node going down, or the rest of the cluster is unhealthy -- in these cases we bias toward shutting down as promptly as possible.

There are no guarantees here other than that shutdown eventually progresses: external tools should still use maintenance mode and watch the draining status themselves in order to have guarantees on leadership transfers.

Fixes https://github.com/redpanda-data/redpanda/issues/4079

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

See release notes.

## Release Notes

  ### Improvements

  * During shutdown after a SIGTERM or SIGINT signal, Redpanda will wait up to 5 seconds for partition leadership to transfer to peers, before closing its Kafka API socket and proceeding to shut down.