### PR TITLE
rpk: add --max-message-bytes to rpk topic produce

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -31,10 +31,11 @@ func newProduceCommand(fs afero.Fs) *cobra.Command {
 		recHeaders []string
 		partition  int32
 
-		inFormat    string
-		outFormat   string
-		compression string
-		acks        int
+		inFormat        string
+		outFormat       string
+		compression     string
+		acks            int
+		maxMessageBytes int32
 
 		tombstone              bool
 		allowAutoTopicCreation bool
@@ -93,6 +94,9 @@ func newProduceCommand(fs afero.Fs) *cobra.Command {
 			}
 			if partition >= 0 {
 				opts = append(opts, kgo.RecordPartitioner(kgo.ManualPartitioner()))
+			}
+			if maxMessageBytes >= 0 {
+				opts = append(opts, kgo.ProducerBatchMaxBytes(maxMessageBytes))
 			}
 			var defaultTopic string
 			if len(args) == 1 {
@@ -167,6 +171,7 @@ func newProduceCommand(fs afero.Fs) *cobra.Command {
 	cmd.Flags().IntVar(&acks, "acks", -1, "Number of acks required for producing (-1=all, 0=none, 1=leader)")
 	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "Per-record delivery timeout, if non-zero, min 1s")
 	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")
+	cmd.Flags().Int32Var(&maxMessageBytes, "max-message-bytes", 1048576, "Maximum size of a record batch before compression")
 
 	cmd.Flags().StringVarP(&inFormat, "format", "f", "%v\n", "Input record format")
 	cmd.Flags().StringVarP(


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/7641

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

With this change, rpk is able to override the max batch size franz-go enforces behind the scenes.

## Release Notes

### Improvements

* Add `--max-message-bytes` to `rpk topic produce` to be able to override the max batch size franz-go enforces behind the scenes.
