### PR TITLE
ducktape: Change diff for connection_rate_test

### DIFF
--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -123,4 +123,4 @@ class ConnectionRateLimitTest(PreallocNodesTest):
                               self.redpanda.nodes[0], RATE_METRIC, {})
         metrics.evaluate([(RATE_METRIC, lambda a, b: b > 0)])
 
-        assert time2 >= time1 * 1.7, f'Time for first iteration:{time1} Time for second iteration:{time2}'
+        assert time2 >= time1 * 1.6, f'Time for first iteration:{time1} Time for second iteration:{time2}'


### PR DESCRIPTION
## Overview

Connection rate limit test uses constant diff to compare 2 difference times.
This constant was was chosen randomly.

After several month of testing this test failed once on CDT.
The diff between times in this case was 1.65.

So we can adjust expected diff for test and decrease it to 1.6

Fixes #7288 

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

## Release Notes
### Improvements
* Fix const in connection_rate_limit_test 


