### PR TITLE
cloud_storage: Extend tags in AWS S3

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -464,7 +464,9 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest() {
       ctxlog.debug,
       "Uploading manifest, path: {}",
       manifest().get_manifest_path());
-    co_return co_await _remote.upload_manifest(_bucket, manifest(), fib);
+    auto tags = cloud_storage::remote::get_manifest_tags(_ntp, _rev);
+    co_return co_await _remote.upload_manifest(
+      _bucket, manifest(), fib, std::move(tags));
 }
 
 remote_segment_path
@@ -515,13 +517,15 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
             _io_priority));
     };
 
+    auto tags = cloud_storage::remote::get_segment_tags(_ntp, _rev);
     co_return co_await _remote.upload_segment(
       _bucket,
       path,
       candidate.content_length,
       reset_func,
       fib,
-      lazy_abort_source);
+      lazy_abort_source,
+      std::move(tags));
 }
 
 bool ntp_archiver::archiver_lost_leadership(
@@ -564,7 +568,13 @@ ntp_archiver::upload_tx(upload_candidate candidate) {
 
     cloud_storage::tx_range_manifest manifest(path, tx_range);
 
-    co_return co_await _remote.upload_manifest(_bucket, manifest, fib);
+    // Note: tx-manifest is uploaded using 'remote::upload_manifest'
+    // method but it has the same tags as the segment because it has
+    // the same lifetime as corresponding segment and associated with
+    // the segment.
+    auto tags = cloud_storage::remote::get_segment_tags(_ntp, _rev);
+    co_return co_await _remote.upload_manifest(
+      _bucket, manifest, fib, std::move(tags));
 }
 
 // The function turns an array of futures that return an error code into a

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -228,8 +228,9 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               rev);
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
+            auto tags = cloud_storage::remote::get_manifest_tags(topic_ns, rev);
             auto res = co_await _remote.local().upload_manifest(
-              _conf.bucket_name, tm, fib);
+              _conf.bucket_name, tm, fib, std::move(tags));
             uploaded = res == cloud_storage::upload_result::success;
             if (!uploaded) {
                 vlog(ctxlog.warn, "Topic manifest upload timed out: {}", key);

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -14,6 +14,7 @@
 #include "cloud_storage/materialized_segments.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
+#include "model/metadata.h"
 #include "net/connection.h"
 #include "s3/client.h"
 #include "ssx/sformat.h"
@@ -310,13 +311,13 @@ ss::future<download_result> remote::do_download_manifest(
 ss::future<upload_result> remote::upload_manifest(
   const s3::bucket_name& bucket,
   const base_manifest& manifest,
-  retry_chain_node& parent) {
+  retry_chain_node& parent,
+  std::vector<s3::object_tag> tags) {
     gate_guard guard{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
     auto key = manifest.get_manifest_path();
     auto path = s3::object_key(key());
-    std::vector<s3::object_tag> tags = {{"rp-type", "partition-manifest"}};
     auto lease = co_await _pool.acquire();
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Uploading manifest {} to the {}", path, bucket());
@@ -394,11 +395,11 @@ ss::future<upload_result> remote::upload_segment(
   uint64_t content_length,
   const reset_input_stream& reset_str,
   retry_chain_node& parent,
-  lazy_abort_source& lazy_abort_source) {
+  lazy_abort_source& lazy_abort_source,
+  std::vector<s3::object_tag> tags) {
     gate_guard guard{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
-    std::vector<s3::object_tag> tags = {{"rp-type", "segment"}};
     auto permit = fib.retry();
     vlog(
       ctxlog.debug,
@@ -791,5 +792,43 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
       std::nullopt,
       _region_name};
 }
+
+std::vector<s3::object_tag> remote::get_manifest_tags(
+  const model::ntp& ntp, model::initial_revision_id rev) {
+    auto tags = default_partition_manifest_tags;
+    tags.push_back({.key = "rp-ns", .value = ntp.ns()});
+    tags.push_back({.key = "rp-topic", .value = ntp.tp.topic()});
+    tags.push_back(
+      {.key = "rp-part", .value = ssx::sformat("{}", ntp.tp.partition())});
+    tags.push_back({.key = "rp-rev", .value = ssx::sformat("{}", rev)});
+    return tags;
+}
+
+std::vector<s3::object_tag> remote::get_manifest_tags(
+  const model::topic_namespace& tns, model::initial_revision_id rev) {
+    auto tags = default_topic_manifest_tags;
+    tags.push_back({.key = "rp-ns", .value = tns.ns()});
+    tags.push_back({.key = "rp-topic", .value = tns.tp()});
+    tags.push_back({.key = "rp-rev", .value = ssx::sformat("{}", rev)});
+    return tags;
+}
+
+std::vector<s3::object_tag> remote::get_segment_tags(
+  const model::ntp& ntp, model::initial_revision_id rev) {
+    auto tags = default_segment_tags;
+    tags.push_back({.key = "rp-ns", .value = ntp.ns()});
+    tags.push_back({.key = "rp-topic", .value = ntp.tp.topic()});
+    tags.push_back(
+      {.key = "rp-part", .value = ssx::sformat("{}", ntp.tp.partition())});
+    tags.push_back({.key = "rp-rev", .value = ssx::sformat("{}", rev)});
+    return tags;
+}
+
+const std::vector<s3::object_tag> remote::default_segment_tags = {
+  {"rp-type", "segment"}};
+const std::vector<s3::object_tag> remote::default_topic_manifest_tags = {
+  {"rp-type", "topic-manifest"}};
+const std::vector<s3::object_tag> remote::default_partition_manifest_tags = {
+  {"rp-type", "partition-manifest"}};
 
 } // namespace cloud_storage


### PR DESCRIPTION
Currently, redpanda sets one tag to every uploaded object. The tag `rp-type` is set to either `segment` for segments or `parititon-manifest` for everything else.

This PR
- adds new `rp-type` for topic manifests
- adds `rp-ns` tag that contains namespace
- adds `rp-topic` tag for topic name
- adds `rp-part` tag to store partition id
- adds `rp-rev` tag to store revision id

The tags can be used to scan all objects in the bucket that belong to particular topic or partition. This might be useful during the incidents or to perform some tasks (e.g. copy one topic to another bucket, delete particular topic etc)

  Fixes #7650


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

  ### Improvements

  * Add new tags to AWS S3 objects

