### PR TITLE
storage: protect optional access

### DIFF
--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -173,7 +173,9 @@ ss::future<result<offset_to_file_pos_result>> convert_end_offset_to_file_pos(
         vlog(stlog.debug, "The position is not flushed {}", *ix_end);
         auto lookup_offset = ix_end->offset - model::offset(1);
         ix_end = segment->index().find_nearest(lookup_offset);
-        vlog(stlog.debug, "Re-adjusted position {}", *ix_end);
+        if (ix_end) {
+            vlog(stlog.debug, "Re-adjusted position {}", *ix_end);
+        }
     }
 
     size_t scan_from = ix_end ? ix_end->filepos : 0;


### PR DESCRIPTION
A segment index position behind optional is accessed in a log. A check is added in this commit to make sure the access is safe.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

