### PR TITLE
Abort tx admin kafka rpc

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -24,6 +24,7 @@ set(handlers_srcs
   server/handlers/topics/topic_utils.cc
   server/handlers/describe_producers.cc
   server/handlers/describe_transactions.cc
+  server/handlers/write_txn_markers.cc
 )
 
 v_cc_library(

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -73,6 +73,8 @@ set(schemata
   add_offsets_to_txn_response.json
   offset_delete_request.json
   offset_delete_response.json
+  write_txn_markers_request.json
+  write_txn_markers_response.json
   offset_for_leader_epoch_request.json
   offset_for_leader_epoch_response.json
   alter_partition_reassignments_request.json

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -552,6 +552,11 @@ STRUCT_TYPES = [
     "DescribeTransactionState",
     "TopicData",
     "ListTransactionState",
+    "WritableTxnMarker",
+    "WritableTxnMarkerTopic",
+    "WritableTxnMarkerResult",
+    "WritableTxnMarkerTopicResult",
+    "WritableTxnMarkerPartitionResult",
 ]
 
 # a list of struct types which are ineligible to have default-generated

--- a/src/v/kafka/protocol/schemata/write_txn_markers_request.json
+++ b/src/v/kafka/protocol/schemata/write_txn_markers_request.json
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+    "apiKey": 27,
+    "type": "request",
+    "name": "WriteTxnMarkersRequest",
+    // Version 1 enables flexible versions.
+    "validVersions": "0-1",
+    "flexibleVersions": "1+",
+    "fields": [
+      { "name": "Markers", "type": "[]WritableTxnMarker", "versions": "0+",
+        "about": "The transaction markers to be written.", "fields": [
+        { "name": "ProducerId", "type": "int64", "versions": "0+", "entityType": "producerId",
+          "about": "The current producer ID."},
+        { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
+          "about": "The current epoch associated with the producer ID." },
+        { "name": "TransactionResult", "type": "bool", "versions": "0+",
+          "about": "The result of the transaction to write to the partitions (false = ABORT, true = COMMIT)." },
+        { "name": "Topics", "type": "[]WritableTxnMarkerTopic", "versions": "0+",
+          "about": "Each topic that we want to write transaction marker(s) for.", "fields": [
+          { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+            "about": "The topic name." },
+          { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
+            "about": "The indexes of the partitions to write transaction markers for." }
+        ]},
+        { "name": "CoordinatorEpoch", "type": "int32", "versions": "0+",
+          "about": "Epoch associated with the transaction state partition hosted by this transaction coordinator" }
+      ]}
+    ]
+  }

--- a/src/v/kafka/protocol/schemata/write_txn_markers_response.json
+++ b/src/v/kafka/protocol/schemata/write_txn_markers_response.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+    "apiKey": 27,
+    "type": "response",
+    "name": "WriteTxnMarkersResponse",
+    "validVersions": "0-1",
+    // Version 1 enables flexible versions.
+    "flexibleVersions": "1+",
+    "fields": [
+      { "name": "Markers", "type": "[]WritableTxnMarkerResult", "versions": "0+",
+        "about": "The results for writing makers.", "fields": [
+        { "name": "ProducerId", "type": "int64", "versions": "0+", "entityType": "producerId",
+          "about": "The current producer ID in use by the transactional ID." },
+        { "name": "Topics", "type": "[]WritableTxnMarkerTopicResult", "versions": "0+",
+          "about": "The results by topic.", "fields": [
+          { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+            "about": "The topic name." },
+          { "name": "Partitions", "type": "[]WritableTxnMarkerPartitionResult", "versions": "0+",
+            "about": "The results by partition.", "fields": [
+            { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+              "about": "The partition index." },
+            { "name": "ErrorCode", "type": "int16", "versions": "0+",
+              "about": "The error code, or 0 if there was no error." }
+          ]}
+        ]}
+      ]}
+    ]
+  }

--- a/src/v/kafka/protocol/write_txn_markers.h
+++ b/src/v/kafka/protocol/write_txn_markers.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "kafka/protocol/schemata/write_txn_markers_request.h"
+#include "kafka/protocol/schemata/write_txn_markers_response.h"
+
+namespace kafka {
+
+struct write_txn_markers_request final {
+    using api_type = write_txn_markers_api;
+
+    write_txn_markers_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const write_txn_markers_request& r) {
+        return os << r.data;
+    }
+};
+
+struct write_txn_markers_response final {
+    using api_type = write_txn_markers_api;
+
+    write_txn_markers_response_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const write_txn_markers_response& r) {
+        return os << r.data;
+    }
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -49,6 +49,7 @@
 #include "kafka/server/handlers/sasl_handshake.h"
 #include "kafka/server/handlers/sync_group.h"
 #include "kafka/server/handlers/txn_offset_commit.h"
+#include "kafka/server/handlers/write_txn_markers.h"
 
 namespace kafka {
 template<typename... Ts>
@@ -98,7 +99,9 @@ using request_types = make_request_types<
   list_partition_reassignments_handler,
   describe_producers_handler,
   describe_transactions_handler,
-  list_transactions_handler>;
+  list_transactions_handler,
+  write_txn_markers_handler,
+  offset_for_leader_epoch_handler>;
 
 template<typename... RequestTypes>
 static constexpr size_t max_api_key(type_list<RequestTypes...>) {

--- a/src/v/kafka/server/handlers/write_txn_markers.cc
+++ b/src/v/kafka/server/handlers/write_txn_markers.cc
@@ -1,0 +1,114 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/write_txn_markers.h"
+
+#include "cluster/errc.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "cluster/tx_gateway_frontend.h"
+#include "cluster/types.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/write_txn_markers_request.h"
+#include "kafka/protocol/schemata/write_txn_markers_response.h"
+#include "model/record.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace kafka {
+
+namespace {
+
+ss::future<std::error_code> expire_tx_for_ntp(
+  request_context& ctx, const model::ntp& ntp, model::producer_identity pid) {
+    auto& shard_table = ctx.connection()->server().shard_table();
+    auto shard = shard_table.shard_for(ntp);
+
+    if (!shard) {
+        return ss::make_ready_future<std::error_code>(
+          cluster::tx_errc::shard_not_found);
+    }
+
+    auto& partition_manager = ctx.connection()->server().partition_manager();
+
+    return partition_manager.invoke_on(
+      *shard,
+      [pid, ntp](cluster::partition_manager& mgr) mutable
+      -> ss::future<std::error_code> {
+          auto partition = mgr.get(ntp);
+          if (!partition) {
+              return ss::make_ready_future<std::error_code>(
+                cluster::tx_errc::partition_not_found);
+          }
+
+          auto stm = partition->rm_stm();
+
+          if (!stm) {
+              vlog(
+                cluster::txlog.warn,
+                "can't get tx stm of the {}' partition",
+                ntp);
+              return ss::make_ready_future<std::error_code>(
+                cluster::tx_errc::stm_not_found);
+          }
+
+          return stm->mark_expired(pid);
+      });
+}
+
+} // namespace
+
+template<>
+ss::future<response_ptr> write_txn_markers_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
+    write_txn_markers_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    vlog(klog.trace, "Handling request {}", request);
+
+    write_txn_markers_response resp;
+
+    for (const auto& marker : request.data.markers) {
+        model::producer_identity pid;
+        pid.id = marker.producer_id;
+        pid.epoch = marker.producer_epoch;
+
+        writable_txn_marker_result marker_res;
+        marker_res.producer_id = marker.producer_id;
+        for (const auto& topic : marker.topics) {
+            writable_txn_marker_topic_result topic_res;
+            topic_res.name = topic.name;
+            for (const auto& partition : topic.partition_indexes) {
+                model::ntp ntp(model::kafka_namespace, topic.name, partition);
+                auto res = co_await expire_tx_for_ntp(ctx, ntp, pid);
+                writable_txn_marker_partition_result partition_res;
+                partition_res.partition_index = partition;
+                switch (res.value()) {
+                case static_cast<int>(cluster::tx_errc::none):
+                    break;
+                case static_cast<int>(cluster::tx_errc::shard_not_found):
+                case static_cast<int>(cluster::tx_errc::partition_not_found): {
+                    partition_res.error_code
+                      = kafka::error_code::not_leader_for_partition;
+                    break;
+                }
+                default:
+                    partition_res.error_code
+                      = kafka::error_code::unknown_server_error;
+                }
+                topic_res.partitions.emplace_back(std::move(partition_res));
+            }
+            marker_res.topics.emplace_back(std::move(topic_res));
+        }
+        resp.data.markers.emplace_back(std::move(marker_res));
+    }
+
+    co_return co_await ctx.respond(std::move(resp));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/write_txn_markers.h
+++ b/src/v/kafka/server/handlers/write_txn_markers.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/write_txn_markers.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using write_txn_markers_handler
+  = single_stage_handler<write_txn_markers_api, 0, 1>;
+
+}

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -389,6 +389,20 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             tx[info_key[i]] = tx_info
         return tx
 
+    def abort_transaction(self, producer_id, epoch, topic, partition):
+        self._redpanda.logger.debug(
+            "Abort transaction for producer_id %s epoch %s", producer_id, epoch)
+        cmd = [self._script("kafka-transactions.sh")]
+        cmd += ["--bootstrap-server", self._redpanda.brokers()]
+        cmd += ["abort"]
+        cmd += ["--topic", topic]
+        cmd += ["--partition", str(partition)]
+        cmd += ["--producer-id", str(producer_id)]
+        cmd += ["--producer-epoch", str(epoch)]
+        cmd += ["--coordinator-epoch", "0"]
+        res = self._execute(cmd)
+        return res
+
     def _run(self, script, args, classname=None):
         cmd = [self._script(script)]
         if classname is not None:


### PR DESCRIPTION
This pr added support for `WriteTxnMarkersRequest`.
This internal kafka API to abort/commit tx. But tools like `bin/kafka-transactions.sh` and admin_api uses is to force abort expired tx.

Redpanda support only this request with abort flag.
Internal it is the same way like for redpanda's admin_api request: `/v1/partitions/{namespace}/{topic}/{partition}/mark_transaction_expired`

client sends this request directly to partition leader, so we do not need to redirect it.

Kafka KIP: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions

Fixes #9142 


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes


### Features
* Added support for `WriteTxnMarkersRequest` kafka API request

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
