### PR TITLE
archival: Improve AWS S3 object tags

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -19,6 +19,7 @@
 #include "cluster/partition.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "s3/client.h"
 #include "s3/configuration.h"
 #include "storage/fwd.h"
 #include "storage/segment.h"
@@ -330,6 +331,10 @@ private:
 
     loop_state _upload_loop_state{loop_state::initial};
     loop_state _sync_manifest_loop_state{loop_state::initial};
+
+    const s3::object_tag_formatter _segment_tags;
+    const s3::object_tag_formatter _manifest_tags;
+    const s3::object_tag_formatter _tx_tags;
 };
 
 } // namespace archival

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -228,9 +228,10 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               rev);
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
-            auto tags = cloud_storage::remote::get_manifest_tags(topic_ns, rev);
+            auto tags = cloud_storage::remote::make_topic_manifest_tags(
+              topic_ns, rev);
             auto res = co_await _remote.local().upload_manifest(
-              _conf.bucket_name, tm, fib, std::move(tags));
+              _conf.bucket_name, tm, fib, tags);
             uploaded = res == cloud_storage::upload_result::success;
             if (!uploaded) {
                 vlog(ctxlog.warn, "Topic manifest upload timed out: {}", key);

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -107,9 +107,9 @@ private:
 class remote : public ss::peering_sharded_service<remote> {
 public:
     /// Default tags applied to objects
-    static const std::vector<s3::object_tag> default_segment_tags;
-    static const std::vector<s3::object_tag> default_partition_manifest_tags;
-    static const std::vector<s3::object_tag> default_topic_manifest_tags;
+    static const s3::object_tag_formatter default_segment_tags;
+    static const s3::object_tag_formatter default_partition_manifest_tags;
+    static const s3::object_tag_formatter default_topic_manifest_tags;
 
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
@@ -203,7 +203,7 @@ public:
       const s3::bucket_name& bucket,
       const base_manifest& manifest,
       retry_chain_node& parent,
-      std::vector<s3::object_tag> tags = default_partition_manifest_tags);
+      const s3::object_tag_formatter& tags = default_partition_manifest_tags);
 
     /// \brief Upload segment to S3
     ///
@@ -220,7 +220,7 @@ public:
       const reset_input_stream& reset_str,
       retry_chain_node& parent,
       lazy_abort_source& lazy_abort_source,
-      std::vector<s3::object_tag> tags = default_segment_tags);
+      const s3::object_tag_formatter& tags = default_segment_tags);
 
     /// \brief Download segment from S3
     ///
@@ -263,14 +263,17 @@ public:
     materialized_segments& materialized() { return *_materialized; }
 
     /// Add partition manifest tags (includes partition id)
-    static std::vector<s3::object_tag>
-    get_manifest_tags(const model::ntp& ntp, model::initial_revision_id rev);
+    static s3::object_tag_formatter make_partition_manifest_tags(
+      const model::ntp& ntp, model::initial_revision_id rev);
     /// Add topic manifest tags (no partition id)
-    static std::vector<s3::object_tag> get_manifest_tags(
+    static s3::object_tag_formatter make_topic_manifest_tags(
       const model::topic_namespace& ntp, model::initial_revision_id rev);
     /// Add segment level tags
-    static std::vector<s3::object_tag>
-    get_segment_tags(const model::ntp& ntp, model::initial_revision_id rev);
+    static s3::object_tag_formatter
+    make_segment_tags(const model::ntp& ntp, model::initial_revision_id rev);
+    /// Add tags for tx-manifest
+    static s3::object_tag_formatter make_tx_manifest_tags(
+      const model::ntp& ntp, model::initial_revision_id rev);
 
 private:
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -217,7 +217,7 @@ request_creator::make_unsigned_put_object_request(
   bucket_name const& name,
   object_key const& key,
   size_t payload_size_bytes,
-  const std::vector<object_tag>& tags) {
+  const object_tag_formatter& tags) {
     // PUT /my-image.jpg HTTP/1.1
     // Host: myBucket.s3.<Region>.amazonaws.com
     // Date: Wed, 12 Oct 2009 17:50:00 GMT
@@ -242,11 +242,7 @@ request_creator::make_unsigned_put_object_request(
       std::to_string(payload_size_bytes));
 
     if (!tags.empty()) {
-        std::stringstream tstr;
-        for (const auto& [key, val] : tags) {
-            tstr << fmt::format("&{}={}", key, val);
-        }
-        header.insert(aws_header_names::x_amz_tagging, tstr.str().substr(1));
+        header.insert(aws_header_names::x_amz_tagging, tags.str());
     }
 
     auto ec = _apply_credentials->add_auth(header);
@@ -601,7 +597,7 @@ ss::future<> client::put_object(
   object_key const& id,
   size_t payload_size,
   ss::input_stream<char>&& body,
-  const std::vector<object_tag>& tags,
+  const object_tag_formatter& tags,
   const ss::lowres_clock::duration& timeout) {
     auto header = _requestor.make_unsigned_put_object_request(
       name, id, payload_size, tags);


### PR DESCRIPTION
Implement `s3::object_tag_formatter` class that can be used to generate tags in S3 format. 
The formatter is created per `ntp_archiver` when in c-tor. Because the parameters of the partition never change it can be safely cached and reused.

The formatter in `archival::scheduler_service` is created ad-hoc because it's used rarely and the whole thing will go away pretty soon.

Followup for #7654

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes



 
  * none


