### PR TITLE
kafka: support partition reassignments

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -64,6 +64,7 @@ enum class errc : int16_t {
     unknown_update_interruption_error,
     throttling_quota_exceeded,
     cluster_already_exists,
+    no_partition_assignments,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -183,6 +184,8 @@ struct errc_category final : public std::error_category {
         case errc::cluster_already_exists:
             return "Node is a part of a cluster already, new cluster is not "
                    "created";
+        case errc::no_partition_assignments:
+            return "No replica assignments for the requested partition";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -298,4 +298,18 @@ topic_properties metadata_cache::get_default_properties() const {
     return tp;
 }
 
+std::optional<partition_assignment>
+metadata_cache::get_partition_assignment(const model::ntp& ntp) const {
+    return _topics_state.local().get_partition_assignment(ntp);
+}
+
+std::optional<std::vector<model::broker_shard>>
+metadata_cache::get_previous_replica_set(const model::ntp& ntp) const {
+    return _topics_state.local().get_previous_replica_set(ntp);
+}
+
+const topic_table::updates_t& metadata_cache::updates_in_progress() const {
+    return _topics_state.local().updates_in_progress();
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -176,6 +176,11 @@ public:
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;
     topic_properties get_default_properties() const;
+    std::optional<partition_assignment>
+    get_partition_assignment(const model::ntp& ntp) const;
+    std::optional<std::vector<model::broker_shard>>
+    get_previous_replica_set(const model::ntp& ntp) const;
+    const topic_table::updates_t& updates_in_progress() const;
 
 private:
     ss::sharded<topic_table>& _topics_state;

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1284,4 +1284,80 @@ ss::future<std::error_code> topics_frontend::decrease_replication_factor(
       _stm, _features, _as, std::move(cmd), timeout);
 }
 
+allocation_request make_allocation_request(
+  model::ntp ntp,
+  replication_factor tp_replication_factor,
+  const std::vector<model::node_id>& new_replicas) {
+    allocation_request req(
+      get_allocation_domain(model::topic_namespace{ntp.ns, ntp.tp.topic}));
+    req.partitions.reserve(1);
+    allocation_constraints constraints;
+    constraints.hard_constraints.push_back(
+      ss::make_lw_shared<hard_constraint_evaluator>(on_nodes(new_replicas)));
+    req.partitions.emplace_back(
+      ntp.tp.partition, tp_replication_factor, std::move(constraints));
+    return req;
+}
+
+ss::future<result<std::vector<partition_assignment>>>
+topics_frontend::generate_reassignments(
+  model::ntp ntp, std::vector<model::node_id> new_replicas) {
+    auto tp_metadata = _topics.local().get_topic_metadata_ref(
+      model::topic_namespace{ntp.ns, ntp.tp.topic});
+    if (!tp_metadata.has_value()) {
+        co_return errc::topic_not_exists;
+    }
+
+    if (!tp_metadata.value().get().is_topic_replicable()) {
+        co_return errc::topic_operation_error;
+    }
+
+    auto tp_replication_factor
+      = tp_metadata.value().get().get_replication_factor();
+
+    auto units = co_await _allocator.invoke_on(
+      partition_allocator::shard,
+      [ntp, tp_replication_factor, new_replicas{std::move(new_replicas)}](
+        partition_allocator& al) {
+          return al.allocate(
+            make_allocation_request(ntp, tp_replication_factor, new_replicas));
+      });
+
+    if (!units) {
+        co_return units.error();
+    }
+
+    auto assignments = units.value()->get_assignments();
+    if (assignments.empty()) {
+        co_return errc::no_partition_assignments;
+    }
+
+    co_return assignments;
+}
+
+ss::future<std::error_code> topics_frontend::move_partition_replicas(
+  model::ntp ntp,
+  std::vector<model::node_id> new_replica_set,
+  model::timeout_clock::time_point tout,
+  std::optional<model::term_id> term) {
+    auto assignments = co_await generate_reassignments(
+      ntp, std::move(new_replica_set));
+
+    // The return type from generate_reassignments is a
+    // result<vector<partition_assignment>>. So we need to make sure
+    // the result: 1) has a value and 2) the vector should only have one replica
+    // set, so check that the front partition id matches the request.
+
+    if (!assignments) {
+        co_return assignments.error();
+    }
+
+    if (assignments.value().front().id != ntp.tp.partition) {
+        co_return errc::allocation_error;
+    }
+
+    co_return co_await move_partition_replicas(
+      ntp, std::move(assignments.value().front().replicas), tout, term);
+}
+
 } // namespace cluster

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -67,6 +67,17 @@ public:
       model::timeout_clock::time_point,
       std::optional<model::term_id> = std::nullopt);
 
+    /**
+     * This overload of move_partition_replicas will use the partition allocator
+     * to generate a new replica set (i.e., a vector<broker_shard>) based on the
+     * given ntp and list of node ids.
+     */
+    ss::future<std::error_code> move_partition_replicas(
+      model::ntp,
+      std::vector<model::node_id>,
+      model::timeout_clock::time_point,
+      std::optional<model::term_id> = std::nullopt);
+
     ss::future<std::error_code> finish_moving_partition_replicas(
       model::ntp,
       std::vector<model::broker_shard>,
@@ -199,6 +210,11 @@ private:
 
     ss::future<capacity_info> get_health_info(
       model::topic_namespace topic, int32_t partition_count) const;
+
+    // Generates a new partition assignment for a single partition
+    ss::future<result<std::vector<partition_assignment>>>
+    generate_reassignments(
+      model::ntp, std::vector<model::node_id> new_replicas);
 
     model::node_id _self;
     ss::sharded<controller_stm>& _stm;

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -18,6 +18,7 @@ set(handlers_srcs
   server/handlers/delete_acls.cc
   server/handlers/create_partitions.cc
   server/handlers/offset_for_leader_epoch.cc
+  server/handlers/alter_partition_reassignments.cc
   server/handlers/handler_interface.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -19,6 +19,7 @@ set(handlers_srcs
   server/handlers/create_partitions.cc
   server/handlers/offset_for_leader_epoch.cc
   server/handlers/alter_partition_reassignments.cc
+  server/handlers/list_partition_reassignments.cc
   server/handlers/handler_interface.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc

--- a/src/v/kafka/protocol/alter_partition_reassignments.h
+++ b/src/v/kafka/protocol/alter_partition_reassignments.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/schemata/alter_partition_reassignments_request.h"
+#include "kafka/protocol/schemata/alter_partition_reassignments_response.h"
+
+namespace kafka {
+
+struct alter_partition_reassignments_request final {
+    using api_type = alter_partition_reassignments_api;
+
+    alter_partition_reassignments_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+
+    friend std::ostream& operator<<(
+      std::ostream& os, const alter_partition_reassignments_request& r) {
+        return os << r.data;
+    }
+};
+
+struct alter_partition_reassignments_response final {
+    using api_type = alter_partition_reassignments_api;
+
+    alter_partition_reassignments_response_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+
+    friend std::ostream& operator<<(
+      std::ostream& os, const alter_partition_reassignments_response& r) {
+        return os << r.data;
+    }
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -181,6 +181,8 @@ std::string_view error_code_to_str(error_code error) {
         return "preferred_leader_not_available";
     case error_code::group_max_size_reached:
         return "group_max_size_reached";
+    case error_code::no_reassignment_in_progress:
+        return "no_reassignment_in_progress";
     case error_code::fenced_instance_id:
         return "fenced_instance_id";
     case error_code::invalid_record:

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -216,6 +216,8 @@ enum class error_code : int16_t {
     // Consumer group The consumer group has reached its max size. already has
     // the configured maximum number of members.
     group_max_size_reached = 81,
+    // No partition reassignment is in progress
+    no_reassignment_in_progress = 85,
     // The broker rejected this static consumer since another consumer with the
     // same group.instance.id has registered with a different member.id.
     fenced_instance_id = 82,

--- a/src/v/kafka/protocol/list_partition_reassignments.h
+++ b/src/v/kafka/protocol/list_partition_reassignments.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/schemata/list_partition_reassignments_request.h"
+#include "kafka/protocol/schemata/list_partition_reassignments_response.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct list_partition_reassignments_request final {
+    using api_type = list_partition_reassignments_api;
+
+    list_partition_reassignments_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+
+    friend std::ostream& operator<<(
+      std::ostream& os, const list_partition_reassignments_request& r) {
+        return os << r.data;
+    }
+};
+
+struct list_partition_reassignments_response final {
+    using api_type = list_partition_reassignments_api;
+
+    list_partition_reassignments_response_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+
+    friend std::ostream& operator<<(
+      std::ostream& os, const list_partition_reassignments_response& r) {
+        return os << r.data;
+    }
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -68,6 +68,8 @@ set(schemata
   offset_for_leader_epoch_request.json
   offset_for_leader_epoch_response.json
   alter_partition_reassignments_request.json
-  alter_partition_reassignments_response.json)
+  alter_partition_reassignments_response.json
+  list_partition_reassignments_request.json
+  list_partition_reassignments_response.json)
 
 set(schemata ${schemata} PARENT_SCOPE)

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -66,6 +66,8 @@ set(schemata
   add_offsets_to_txn_request.json
   add_offsets_to_txn_response.json
   offset_for_leader_epoch_request.json
-  offset_for_leader_epoch_response.json)
+  offset_for_leader_epoch_response.json
+  alter_partition_reassignments_request.json
+  alter_partition_reassignments_response.json)
 
 set(schemata ${schemata} PARENT_SCOPE)

--- a/src/v/kafka/protocol/schemata/alter_partition_reassignments_request.json
+++ b/src/v/kafka/protocol/schemata/alter_partition_reassignments_request.json
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 45,
+  "type": "request",
+  "listeners": ["broker", "controller", "zkBroker"],
+  "name": "AlterPartitionReassignmentsRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",
+      "about": "The time in ms to wait for the request to complete." },
+    { "name": "Topics", "type": "[]ReassignableTopic", "versions": "0+",
+      "about": "The topics to reassign.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]ReassignablePartition", "versions": "0+",
+        "about": "The partitions to reassign.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "Replicas", "type": "[]int32", "versions": "0+", "nullableVersions": "0+", "default": "null", "entityType": "brokerId",
+          "about": "The replicas to place the partitions on, or null to cancel a pending reassignment for this partition." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/alter_partition_reassignments_response.json
+++ b/src/v/kafka/protocol/schemata/alter_partition_reassignments_response.json
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 45,
+  "type": "response",
+  "name": "AlterPartitionReassignmentsResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The top-level error message, or null if there was no error." },
+    { "name": "Responses", "type": "[]ReassignableTopicResponse", "versions": "0+",
+      "about": "The responses to topics to reassign.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name" },
+      { "name": "Partitions", "type": "[]ReassignablePartitionResponse", "versions": "0+",
+        "about": "The responses to partitions to reassign", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code for this partition, or 0 if there was no error." },
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+          "about": "The error message for this partition, or null if there was no error." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -288,7 +288,23 @@ path_type_map = {
                 "EndOffset": ("model::offset", "int64"),
             }
         }
-    }
+    },
+    "AlterPartitionReassignmentsRequestData": {
+        "TimeoutMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+            },
+        }
+    },
+    "AlterPartitionReassignmentsResponseData": {
+        "ThrottleTimeMs": ("std::chrono::milliseconds", "int32"),
+        "Responses": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+            },
+        }
+    },
 }
 
 # a few kafka field types specify an entity type
@@ -471,6 +487,10 @@ STRUCT_TYPES = [
     "SupportedFeatureKey",
     "FinalizedFeatureKey",
     "DeleteTopicState",
+    "ReassignableTopic",
+    "ReassignablePartition",
+    "ReassignableTopicResponse",
+    "ReassignablePartitionResponse",
 ]
 
 # a list of struct types which are ineligible to have default-generated

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1184,14 +1184,6 @@ if ({{ cond }}) {
 {%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
     return reader.{{ decoder }};
-{%- elif field.nullable() %}
-    {
-        auto tmp = reader.{{ decoder }};
-        if (tmp) {
-            return {{ named_type }}(std::move(*tmp));
-        }
-        return std::nullopt;
-    }
 {%- else %}
     return {{ named_type }}(reader.{{ decoder }});
 {%- endif %}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -305,6 +305,20 @@ path_type_map = {
             },
         }
     },
+    "ListPartitionReassignmentsRequestData": {
+        "TimeoutMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "PartitionIndexes": ("model::partition_id", "int32"),
+        }
+    },
+    "ListPartitionReassignmentsResponseData": {
+        "ThrottleTimeMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+            },
+        }
+    },
 }
 
 # a few kafka field types specify an entity type
@@ -491,6 +505,9 @@ STRUCT_TYPES = [
     "ReassignablePartition",
     "ReassignableTopicResponse",
     "ReassignablePartitionResponse",
+    "ListPartitionReassignmentsTopics",
+    "OngoingTopicReassignment",
+    "OngoingPartitionReassignment",
 ]
 
 # a list of struct types which are ineligible to have default-generated

--- a/src/v/kafka/protocol/schemata/list_partition_reassignments_request.json
+++ b/src/v/kafka/protocol/schemata/list_partition_reassignments_request.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 46,
+  "type": "request",
+  "listeners": ["broker", "controller", "zkBroker"],
+  "name": "ListPartitionReassignmentsRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",
+      "about": "The time in ms to wait for the request to complete." },
+    { "name": "Topics", "type": "[]ListPartitionReassignmentsTopics", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The topics to list partition reassignments for, or null to list everything.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name" },
+      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
+        "about": "The partitions to list partition reassignments for." }
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/list_partition_reassignments_response.json
+++ b/src/v/kafka/protocol/schemata/list_partition_reassignments_response.json
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 46,
+  "type": "response",
+  "name": "ListPartitionReassignmentsResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code, or 0 if there was no error" },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The top-level error message, or null if there was no error." },
+    { "name": "Topics", "type": "[]OngoingTopicReassignment", "versions": "0+",
+      "about": "The ongoing reassignments for each topic.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]OngoingPartitionReassignment", "versions": "0+",
+        "about": "The ongoing reassignments for each partition.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The index of the partition." },
+        { "name": "Replicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+          "about": "The current replica set." },
+        { "name": "AddingReplicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+          "about": "The set of replicas we are currently adding." },
+        { "name": "RemovingReplicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+          "about": "The set of replicas we are currently removing." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -80,6 +80,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::no_update_in_progress:
     case cluster::errc::unknown_update_interruption_error:
     case cluster::errc::cluster_already_exists:
+    case cluster::errc::no_partition_assignments:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -1,0 +1,261 @@
+
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/alter_partition_reassignments.h"
+
+#include "cluster/errc.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/topics_frontend.h"
+#include "config/node_config.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/alter_partition_reassignments_request.h"
+#include "kafka/protocol/schemata/alter_partition_reassignments_response.h"
+#include "kafka/server/errors.h"
+#include "kafka/server/fwd.h"
+#include "kafka/server/protocol_utils.h"
+#include "model/namespace.h"
+#include "model/timeout_clock.h"
+
+#include <absl/container/flat_hash_set.h>
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+namespace kafka {
+
+using partitions_request_iterator
+  = std::vector<reassignable_partition>::iterator;
+
+template<typename ResultIter, typename Predicate>
+partitions_request_iterator validate_replicas(
+  partitions_request_iterator begin,
+  partitions_request_iterator end,
+  ResultIter out_it,
+  error_code ec,
+  const ss::sstring& error_message,
+  Predicate&& p) {
+    auto valid_range_end = std::partition(
+      begin, end, std::forward<Predicate>(p));
+
+    if (valid_range_end != end) {
+        vlog(klog.debug, "Invalid replicas: ec {} - {}", ec, error_message);
+    }
+
+    std::transform(
+      valid_range_end,
+      end,
+      out_it,
+      [ec, &error_message](const reassignable_partition& partition) {
+          return reassignable_partition_response{
+            .partition_index = partition.partition_index,
+            .error_code = ec,
+            .error_message = error_message,
+          };
+      });
+    return valid_range_end;
+}
+
+template<typename ResultIter>
+partitions_request_iterator validate_partitions(
+  partitions_request_iterator begin,
+  partitions_request_iterator end,
+  ResultIter resp_it,
+  reassignable_topic_response topic_response,
+  std::vector<model::node_id> all_node_ids) {
+    // An undefined replicas vector is not an error, see "Replicas" in the
+    // AlterPartitionReassignmentsRequest schemata. Instead of checking for
+    // a null replicas vector in every call to validate_replicas, simply put
+    // those elements first and use iterator magic to run validation on
+    // defined replicas only.
+    auto valid_partitions_end = std::partition(
+      begin, end, [](const reassignable_partition& partition) {
+          return !partition.replicas.has_value();
+      });
+
+    std::vector<reassignable_partition_response> invalid_partitions;
+
+    valid_partitions_end = validate_replicas(
+      valid_partitions_end,
+      end,
+      std::back_inserter(invalid_partitions),
+      error_code::invalid_replica_assignment,
+      "Empty replica list specified in partition reassignment.",
+      [](const reassignable_partition& partition) {
+          return !partition.replicas->empty();
+      });
+
+    valid_partitions_end = validate_replicas(
+      valid_partitions_end,
+      end,
+      std::back_inserter(invalid_partitions),
+      error_code::invalid_replica_assignment,
+      "Duplicate replica ids in partition reassignment replica list",
+      [](const reassignable_partition& partition) {
+          absl::flat_hash_set<model::node_id> replicas_set;
+          for (auto& node_id : *partition.replicas) {
+              auto res = replicas_set.insert(node_id);
+              if (!res.second) {
+                  return false;
+              }
+          }
+          return true;
+      });
+
+    valid_partitions_end = validate_replicas(
+      valid_partitions_end,
+      end,
+      std::back_inserter(invalid_partitions),
+      error_code::invalid_replica_assignment,
+      "Invalid broker id in replica list",
+      [](const reassignable_partition& partition) {
+          auto negative_node_id_it = std::find_if(
+            partition.replicas->begin(),
+            partition.replicas->end(),
+            [](const model::node_id& node_id) { return node_id < 0; });
+          return negative_node_id_it == partition.replicas->end();
+      });
+
+    valid_partitions_end = validate_replicas(
+      valid_partitions_end,
+      end,
+      std::back_inserter(invalid_partitions),
+      error_code::invalid_replica_assignment,
+      "Replica assignment has brokers that are not alive",
+      [&all_node_ids](const reassignable_partition& partition) {
+          auto unkown_broker_id_it = std::find_if(
+            partition.replicas->begin(),
+            partition.replicas->end(),
+            [all_node_ids](const model::node_id& node_id) {
+                return std::find(
+                         all_node_ids.begin(), all_node_ids.end(), node_id)
+                       == all_node_ids.end();
+            });
+          return unkown_broker_id_it == partition.replicas->end();
+      });
+
+    // Store any invalid partitions in the response
+    topic_response.partitions = std::move(invalid_partitions);
+    *resp_it = std::move(topic_response);
+
+    return valid_partitions_end;
+}
+
+template<>
+ss::future<response_ptr> alter_partition_reassignments_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    alter_partition_reassignments_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    log_request(ctx.header(), request);
+    alter_partition_reassignments_response resp;
+
+    if (!ctx.authorized(
+          security::acl_operation::alter, security::default_cluster_name)) {
+        vlog(
+          klog.debug,
+          "Failed cluster authorization. Requires ALTER permissions on the "
+          "cluster.");
+        resp.data.error_code = error_code::cluster_authorization_failed;
+        resp.data.error_message = ss::sstring{
+          error_code_to_str(error_code::cluster_authorization_failed)};
+        co_return co_await ctx.respond(std::move(resp));
+    }
+
+    resp.data.responses.reserve(request.data.topics.size());
+    auto all_node_ids = ctx.metadata_cache().node_ids();
+
+    for (auto& topic : request.data.topics) {
+        reassignable_topic_response topic_response{.name = topic.name};
+
+        auto valid_partitions_end = validate_partitions(
+          topic.partitions.begin(),
+          topic.partitions.end(),
+          std::back_inserter(resp.data.responses),
+          topic_response,
+          all_node_ids);
+
+        for (auto it = topic.partitions.begin(); it != valid_partitions_end;
+             ++it) {
+            const reassignable_partition& partition{*it};
+            model::ntp ntp{
+              model::kafka_namespace, topic.name, partition.partition_index};
+
+            if (partition.replicas.has_value()) {
+                vlog(
+                  klog.debug,
+                  "Request to reassign partitions: ntp {}, replicas {}",
+                  ntp,
+                  *partition.replicas);
+
+                auto errc
+                  = co_await ctx.topics_frontend().move_partition_replicas(
+                    ntp,
+                    std::move(*partition.replicas),
+                    model::timeout_clock::now() + request.data.timeout_ms);
+
+                if (!errc) {
+                    topic_response.partitions.push_back(
+                      reassignable_partition_response{
+                        .partition_index = partition.partition_index});
+                } else {
+                    auto clerr = static_cast<cluster::errc>(errc.value());
+                    vlog(
+                      klog.debug,
+                      "Failed to move partition replicas: ntp {}, ec {}",
+                      ntp,
+                      clerr);
+                    auto kerr = map_topic_error_code(clerr);
+                    topic_response.partitions.push_back(
+                      reassignable_partition_response{
+                        .partition_index = partition.partition_index,
+                        .error_code = kerr,
+                        .error_message = ss::sstring{error_code_to_str(kerr)}});
+                }
+
+            } else {
+                // Otherwise we cancel the pending request
+                vlog(
+                  klog.debug, "Request to cancel pending request: ntp {}", ntp);
+                auto errc = co_await ctx.topics_frontend()
+                              .cancel_moving_partition_replicas(
+                                ntp,
+                                model::timeout_clock::now()
+                                  + request.data.timeout_ms);
+                if (errc) {
+                    auto clerr = static_cast<cluster::errc>(errc.value());
+                    vlog(
+                      klog.debug,
+                      "Failed to cancel pending request: ntp {}, ec {}",
+                      ntp,
+                      clerr);
+                    // Explicitly check for no_update_in_progress here. We could
+                    // change the mapping in map_topic_error_code but that may
+                    // cause a regression since several places call this
+                    // function
+                    auto kerr = clerr == cluster::errc::no_update_in_progress
+                                  ? error_code::no_reassignment_in_progress
+                                  : map_topic_error_code(clerr);
+                    topic_response.partitions.push_back(
+                      reassignable_partition_response{
+                        .partition_index = partition.partition_index,
+                        .error_code = kerr,
+                        .error_message = ss::sstring{error_code_to_str(kerr)}});
+                }
+            }
+        }
+
+        resp.data.responses.push_back(topic_response);
+    }
+
+    co_return co_await ctx.respond(std::move(resp));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.h
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/alter_partition_reassignments.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using alter_partition_reassignments_handler
+  = single_stage_handler<alter_partition_reassignments_api, 0, 0>;
+
+}

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -35,6 +35,7 @@
 #include "kafka/server/handlers/leave_group.h"
 #include "kafka/server/handlers/list_groups.h"
 #include "kafka/server/handlers/list_offsets.h"
+#include "kafka/server/handlers/list_partition_reassignments.h"
 #include "kafka/server/handlers/metadata.h"
 #include "kafka/server/handlers/offset_commit.h"
 #include "kafka/server/handlers/offset_fetch.h"
@@ -88,7 +89,8 @@ using request_types = make_request_types<
   end_txn_handler,
   create_partitions_handler,
   offset_for_leader_epoch_handler,
-  alter_partition_reassignments_handler>;
+  alter_partition_reassignments_handler,
+  list_partition_reassignments_handler>;
 
 template<typename... RequestTypes>
 static constexpr size_t max_api_key(type_list<RequestTypes...>) {

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -13,6 +13,7 @@
 #include "kafka/server/handlers/add_offsets_to_txn.h"
 #include "kafka/server/handlers/add_partitions_to_txn.h"
 #include "kafka/server/handlers/alter_configs.h"
+#include "kafka/server/handlers/alter_partition_reassignments.h"
 #include "kafka/server/handlers/api_versions.h"
 #include "kafka/server/handlers/create_acls.h"
 #include "kafka/server/handlers/create_partitions.h"
@@ -86,7 +87,8 @@ using request_types = make_request_types<
   add_offsets_to_txn_handler,
   end_txn_handler,
   create_partitions_handler,
-  offset_for_leader_epoch_handler>;
+  offset_for_leader_epoch_handler,
+  alter_partition_reassignments_handler>;
 
 template<typename... RequestTypes>
 static constexpr size_t max_api_key(type_list<RequestTypes...>) {

--- a/src/v/kafka/server/handlers/list_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/list_partition_reassignments.cc
@@ -1,0 +1,173 @@
+
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/list_partition_reassignments.h"
+
+#include "cluster/metadata_cache.h"
+#include "cluster/shard_table.h"
+#include "cluster/topics_frontend.h"
+#include "config/node_config.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/list_partition_reassignments_request.h"
+#include "kafka/protocol/schemata/list_partition_reassignments_response.h"
+#include "kafka/server/errors.h"
+#include "kafka/server/fwd.h"
+#include "model/namespace.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace kafka {
+
+namespace {
+bool in_broker_list(
+  const model::broker_shard& bshard,
+  const std::vector<model::broker_shard>& list) {
+    return std::find(list.begin(), list.end(), bshard) != list.end();
+}
+} // namespace
+
+// Returns the partition reassignments for a given partition of a topic
+ongoing_partition_reassignment list_partition_reassignments(
+  cluster::partition_assignment& current_assignment,
+  std::optional<std::vector<model::broker_shard>> previous_replica_set) {
+    ongoing_partition_reassignment reassignments;
+
+    std::for_each(
+      current_assignment.replicas.cbegin(),
+      current_assignment.replicas.cend(),
+      [&reassignments,
+       &previous_replica_set](const model::broker_shard& bshard) {
+          reassignments.replicas.push_back(bshard.node_id);
+          if (previous_replica_set.has_value()) {
+              if (!in_broker_list(bshard, *previous_replica_set)) {
+                  reassignments.adding_replicas.push_back(bshard.node_id);
+              }
+          }
+      });
+
+    if (previous_replica_set.has_value()) {
+        std::for_each(
+          previous_replica_set->cbegin(),
+          previous_replica_set->cend(),
+          [&reassignments,
+           &current_assignment](const model::broker_shard& bshard) {
+              if (!in_broker_list(bshard, current_assignment.replicas)) {
+                  reassignments.removing_replicas.push_back(bshard.node_id);
+              }
+          });
+    }
+
+    return reassignments;
+}
+
+// Returns all reassignments currently in progress
+std::vector<ongoing_topic_reassignment> all_active_partition_reassignments(
+  const cluster::topic_table::updates_t& in_progress) {
+    // The in progress reassignments are in a map: ntp -> list of brokers which
+    // is not suitable to use with the ListPartitionReassignments response. So
+    // we restructure them here.
+    absl::flat_hash_map<model::topic, ongoing_topic_reassignment>
+      reassignments_by_topic;
+
+    for (const auto& [ntp, status] : in_progress) {
+        // Convert list of broker shards to node ids
+        std::vector<model::node_id> replicas;
+        std::for_each(
+          status.get_previous_replicas().begin(),
+          status.get_previous_replicas().end(),
+          [&replicas](const model::broker_shard& bshard) {
+              replicas.push_back(bshard.node_id);
+          });
+
+        ongoing_partition_reassignment partition_reassignment{
+          .partition_index = ntp.tp.partition, .replicas = replicas};
+        if (reassignments_by_topic.contains(ntp.tp.topic)) {
+            reassignments_by_topic[ntp.tp.topic].partitions.push_back(
+              std::move(partition_reassignment));
+        } else {
+            reassignments_by_topic[ntp.tp.topic] = ongoing_topic_reassignment{
+              .name = ntp.tp.topic, .partitions = {partition_reassignment}};
+        }
+    }
+
+    std::vector<ongoing_topic_reassignment> all_active_reassignments;
+    all_active_reassignments.reserve(reassignments_by_topic.size());
+    for (auto& [_, reassignments] : reassignments_by_topic) {
+        all_active_reassignments.push_back(std::move(reassignments));
+    }
+
+    return all_active_reassignments;
+}
+
+template<>
+ss::future<response_ptr> list_partition_reassignments_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    list_partition_reassignments_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    log_request(ctx.header(), request);
+    list_partition_reassignments_response resp;
+
+    if (!ctx.authorized(
+          security::acl_operation::describe, security::default_cluster_name)) {
+        vlog(
+          klog.debug,
+          "Failed cluster authorization. Requires DESCRIBE permissions on the "
+          "cluster.");
+        resp.data.error_code = error_code::cluster_authorization_failed;
+        resp.data.error_message = ss::sstring{
+          error_code_to_str(error_code::cluster_authorization_failed)};
+        co_return co_await ctx.respond(std::move(resp));
+    }
+
+    // If topics is undefined, get all active reassignments
+    if (!request.data.topics.has_value()) {
+        auto all_active_reassignments = all_active_partition_reassignments(
+          ctx.metadata_cache().updates_in_progress());
+        resp.data.topics.reserve(all_active_reassignments.size());
+        std::for_each(
+          all_active_reassignments.begin(),
+          all_active_reassignments.end(),
+          [&resp](const ongoing_topic_reassignment& topic_reassignment) {
+              resp.data.topics.push_back(topic_reassignment);
+          });
+        co_return co_await ctx.respond(std::move(resp));
+    }
+
+    resp.data.topics.reserve(request.data.topics->size());
+    for (const list_partition_reassignments_topics& tp : *request.data.topics) {
+        ongoing_topic_reassignment topic_reassignment{.name = tp.name};
+
+        for (const model::partition_id& pid : tp.partition_indexes) {
+            model::ntp ntp{model::kafka_namespace, tp.name, pid};
+
+            vlog(klog.debug, "Request to list reassignments: ntp {}", ntp);
+
+            // Current replica set is in the current partition assignment
+            auto current_assignment
+              = ctx.metadata_cache().get_partition_assignment(ntp);
+            if (current_assignment.has_value()) {
+                auto reassignments = list_partition_reassignments(
+                  *current_assignment,
+                  ctx.metadata_cache().get_previous_replica_set(ntp));
+                reassignments.partition_index = pid;
+                topic_reassignment.partitions.push_back(
+                  std::move(reassignments));
+            } else {
+                vlog(klog.debug, "No replica set: ntp {}", ntp);
+            }
+        }
+        resp.data.topics.push_back(topic_reassignment);
+    }
+
+    co_return co_await ctx.respond(std::move(resp));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/list_partition_reassignments.h
+++ b/src/v/kafka/server/handlers/list_partition_reassignments.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/list_partition_reassignments.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using list_partition_reassignments_handler
+  = single_stage_handler<list_partition_reassignments_api, 0, 0>;
+
+}

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -239,6 +239,7 @@ std::error_condition make_error_condition(std::error_code ec) {
         case kec::kafka_storage_error:
         case kec::unknown_server_error:
         case kec::unstable_offset_commit:
+        case kec::no_reassignment_in_progress:
             return rec::kafka_error;
         case kec::network_exception:
         case kec::coordinator_load_in_progress:

--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -1,0 +1,202 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+import json
+import re
+
+from ducktape.tests.test import TestLoggerMaker
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
+def get_topics_and_partitions(reassignments: dict):
+    topic_names = []
+    partition_idxs = []
+    for reassignment in reassignments["partitions"]:
+        topic_names.append(reassignment["topic"])
+        partition_idxs.append(reassignment["partition"])
+
+    return topic_names, partition_idxs
+
+
+def check_execute_reassign_partitions(lines: list[str], reassignments: dict,
+                                      logger: TestLoggerMaker):
+    topic_names, partition_idxs = get_topics_and_partitions(reassignments)
+
+    # Output has the following structure
+    # Line 0 - "Current partition replica assignment"
+    # Line 1 - empty
+    # Line 2 - Json structure showing the current replica sets for each partition
+    # Line 3 - empty
+    # Line 4 - "Save this to use as the --reassignment-json-file option during rollback"
+    # Line 5 - "Successfully started partition reassignments for topic1-p0,topic1-p1,...,topic2-p0,topic2-p1,..."
+
+    # Check the output in reverse order
+
+    # The last line should list topic partitions
+    line = lines.pop().strip()
+    assert line.startswith("Successfully started partition reassignments for ")
+    topic_partitions = line.removeprefix(
+        "Successfully started partition reassignments for ").split(',')
+    tp_re = re.compile(r"^(?P<topic>[a-z\-]+?)-(?P<pid>[0-9]+?)$")
+    for tp in topic_partitions:
+        tp_match = tp_re.match(tp)
+        logger.debug(f"topic partition match: {tp}, {tp_match}")
+        assert tp_match is not None
+        assert tp_match.group("topic") in topic_names
+        assert int(tp_match.group("pid")) in partition_idxs
+
+    # The next lines are exact strings
+    assert lines.pop().strip(
+    ) == "Save this to use as the --reassignment-json-file option during rollback"
+    assert len(lines.pop()) == 0
+
+    # Then a json structure
+    current_assignment = json.loads(lines.pop().strip())
+    assert type(current_assignment) == type({}), "Expected JSON object"
+
+    # Then another set of exact strings
+    assert len(lines.pop()) == 0
+    assert lines.pop().strip() == "Current partition replica assignment"
+
+    if len(lines) != 0:
+        raise RuntimeError(f"Unexpected output: {lines}")
+
+
+def check_verify_reassign_partitions(lines: list[str], reassignments: dict,
+                                     rp_node_idxs: list[str],
+                                     logger: TestLoggerMaker):
+
+    topic_names, partition_idxs = get_topics_and_partitions(reassignments)
+
+    # Check output
+    # Output has the following structure
+    # Line 0 - "Status of partition reassignment:"
+    #        - One line for each topic partition
+    #        - Empty string
+    #        - "Clearing broker-level throttles on brokers node_id1,node_id2,..."
+    #        - An InvalidConfigurationException because the kafka script attempts to alter broker configs
+    #          on a per-node basis which Redpanda does not support
+
+    # Reverse the order so we do not have to look at the entire Java exception
+    lines.reverse()
+
+    # First line is an exact string
+    assert lines.pop().strip() == "Status of partition reassignment:"
+
+    # Then there is one line for each topic partition
+    tp_re_complete = re.compile(
+        r"^Reassignment of partition (?P<topic>[a-z\-]+?)-(?P<pid>[0-9]+?) is complete.$"
+    )
+    tp_re_no_active = re.compile(
+        r"^There is no active reassignment of partition (?P<topic>[a-z\-]+?)-(?P<pid>[0-9]+?), but replica set is.*$"
+    )
+
+    def re_match(line):
+        m = tp_re_complete.match(line)
+        if m is not None:
+            return m
+
+        return tp_re_no_active.match(line)
+
+    line = lines.pop().strip()
+    tp_match = re_match(line)
+    logger.debug(f"topic partition match: {line} {tp_match}")
+    while tp_match is not None:
+        assert tp_match.group("topic") in topic_names
+        assert int(tp_match.group("pid")) in partition_idxs
+        line = lines.pop().strip()
+        tp_match = re_match(line)
+        logger.debug(f"topic partition match: {line} {tp_match}")
+
+    # The previous line is an empty string
+    assert len(line) == 0
+
+    # Then a line with each node id
+    line = lines.pop().strip()
+    assert line.startswith("Clearing broker-level throttles on brokers ")
+    node_idxs = line.removeprefix(
+        "Clearing broker-level throttles on brokers ").split(",")
+    node_idxs.sort()
+    rp_node_idxs.sort()
+    logger.debug(f'{node_idxs}  {rp_node_idxs}')
+    assert node_idxs == rp_node_idxs
+
+    # Then check for the expected exception
+    assert "Setting broker properties on named brokers is unsupported" in lines.pop(
+    ).strip()
+
+
+class PartitionReassignmentsTest(RedpandaTest):
+    PARTITION_COUNT = 3
+    topics = [
+        TopicSpec(partition_count=PARTITION_COUNT),
+        TopicSpec(partition_count=PARTITION_COUNT),
+    ]
+
+    def __init__(self, test_context):
+        super(PartitionReassignmentsTest,
+              self).__init__(test_context=test_context, num_brokers=4)
+
+    def get_missing_node_idx(self, lhs: list[int], rhs: list[int]):
+        missing_nodes = set(lhs).difference(set(rhs))
+        assert len(missing_nodes) == 1, "Expected one missing node"
+        return missing_nodes.pop()
+
+    @cluster(num_nodes=4)
+    def test_reassignments(self):
+        initial_assignments = self.client().describe_topics()
+        self.logger.debug(f"Initial assignments: {initial_assignments}")
+
+        all_node_idx = [
+            self.redpanda.node_id(node) for node in self.redpanda.nodes
+        ]
+        self.logger.debug(f"All node idx: { all_node_idx}")
+
+        reassignments_json = {"version": 1, "partitions": []}
+        log_dirs = ["any" for _ in range(self.PARTITION_COUNT)]
+
+        for assignment in initial_assignments:
+            for partition in assignment.partitions:
+                assert len(partition.replicas) == self.PARTITION_COUNT
+                missing_node_idx = self.get_missing_node_idx(
+                    all_node_idx, partition.replicas)
+                # Replace one of the replicas with the missing one
+                new_replica_assignment = partition.replicas
+                new_replica_assignment[0] = missing_node_idx
+                reassignments_json["partitions"].append({
+                    "topic":
+                    assignment.name,
+                    "partition":
+                    partition.id,
+                    "replicas":
+                    new_replica_assignment,
+                    "log_dirs":
+                    log_dirs
+                })
+                self.logger.debug(
+                    f"{assignment.name} partition {partition.id}, new replica assignments: {new_replica_assignment}"
+                )
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+        output = kafka_tools.execute_reassign_partitions(
+            reassignments=reassignments_json)
+        check_execute_reassign_partitions(output, reassignments_json,
+                                          self.logger)
+
+        output = kafka_tools.verify_reassign_partitions(
+            reassignments=reassignments_json)
+        rp_node_idxs = [
+            str(self.redpanda.node_id(node)) for node in self.redpanda.nodes
+        ]
+        check_verify_reassign_partitions(output, reassignments_json,
+                                         rp_node_idxs, self.logger)


### PR DESCRIPTION
## Cover letter

Users can already reassign partitions using the Admin API but users should also have the option to use the Kafka API. Therefore, this PR implements [KIP-455](https://cwiki.apache.org/confluence/display/KAFKA/KIP-455%3A+Create+an+Administrative+API+for+Replica+Reassignment) in our Kafka sub-system.

Fixes: #8191 
Fixes: https://github.com/redpanda-data/core-internal/issues/25

Changes from force-push `234429c`:
- Add request validation: check for valid topic name, negative partition id, negative broker id, existing replica set, empty replica reassignment, node id is in the list of brokers, 
- Add ACLs check
- Put changes in `cluster::topic_frontend` in their own commit
- Use `model::kafka_namespace`
- Add more descriptive error messages

Changes from force-push `8024da1`:
- Choose a shard based on topic metadata
- Add more request validation following Apache's [validateReplicas](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/controller/KafkaController.scala#L1840)
- Make error responses more descriptive

Changes from force-push `83a24d9`:
- Remove method to check for existing replica set on `topics_frontend`
- Add method to generate replica reassignments to `topics_frontend`. The reassignments will have valid core ids
- Remove checks for empty topics vectors
- Remove call to `stm_linearizable_barrier` in `topics_frontend::list_partition_reassignments()`
- Remove offending lines in template generator that caused a compile error
- Use `cluster::errc` instead of `kafka::error_code` in `cluster::partition_reassignments` object
- Remove unnecessary logging and early exits in list_partitions_reassignments.cc

Changes from force-push `3b28625`:
- Move request validation to a helper method
- Add `topics_frontend::all_active_partition_reassignments` that gets all running partition reassignments
- Get all running partition reassignments when the `topics` optional is null in ListPartitionReassignments API
- Add `topic_reassignments` object
- Styling and typo fixes

Changes from force-push `33968fc`:
- Rebased dev to resolve conflicts
- Comment typos 
- Run validation at the partitions level instead of topics level
- Remove new types in `cluster/types.h`
- Move `topics_frontend::list_partition_reassignments` and `topics_frontend::all_active_partition_reassignments` to the kafka handler. There is no need to have them in cluster
- Catch errors if `topics_frontend::generate_reassignments` fails

Changes from force-push `52581c1`:
- Add "arrays do not contain null elements" to the commit that updates the kafka schemata generator
- Change `generate_reassignments` to accept a `model::topic_namespace`
- In `generate_reassignments`, capture `new_replicas` by value instead of by reference
- Use a `absl::flat_hash_set` to detect duplicate replica ids
- Dereference `resp_it` in `validate_partitions`
- Add comments for checking the return value from `generate_reassignments`
- Add debug logging to error handling
- Use `auto` where you can instead of explicit type statements
- Call `std::move` on `*partition.replicas` when generating reassignments
- The error mappings in `src/v/pandaproxy/error.cc` should map `no_reassignment_in_progress` to a non-retriable error
- Return `no_reassignment_in_progress` when a requst to cancel a pending request fails and the cluster reports error `no_update_in_progress`
- Get the `shard_id` for the core that a `ntp` is on
- Use `absl::flat_hash_map` instead of `std::unordered_map`
- Use `conse auto&` for iterating through the `in_progress` map
- Rewrite some code in `all_active_partition_reassignments` to be a oneliner
- Allocate enough space for `all_active_reassignments` based on `reassignments_by_topic`
- Call `std::move` on vectors and other containers when they are not used later

Changes from force-push `d72b0a3`:
- Add check if the node handling the request is the controller

Changes from force-push `49f7d51`:
- Clean up includes list
- Do not check if the node handling the request is the controller because `not_controller` is bubbled up from the controller anyways
- Use `get_replication_factor` from `topic_metadata`
- No need to pass the shard to query `topics_table` because the state is replicated on every core
- Made an overload of `move_partition_replicas` that generates partitions reassignments from a `vector<node_id>`

Changes from force-push `17b45dd`:
- Put output validation of `KafkaCLITools` in `partition_reassignments_test.py`
- Redo error checking in the overload of `move_partition_replicas`

Changes from force-push ` 2a060b2`:
- Call `std::move` on replica sets where applicable
- Parse shell script output in `KafkaCLITool` but do output validation in `partition_reassignments_test.py`

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Enabled AlterPartitionReassignments API and ListPartitionReassignments API

## Release Notes

### Improvements

* Added support for AlterPartitionReassignments API and ListPartitionReassigments API
