### PR TITLE
Fix compaction index size overflow

### DIFF
--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -53,7 +53,7 @@ ss::future<> compacted_index_chunk_reader::verify_integrity() {
         options.io_priority_class = _iopc;
         options.read_ahead = 1;
         return ss::do_with(
-                 int32_t(_footer->size),
+                 int64_t(_footer->size),
                  crc::crc32c{},
                  ss::make_file_input_stream(
                    _handle,
@@ -61,7 +61,7 @@ ss::future<> compacted_index_chunk_reader::verify_integrity() {
                    _file_size.value() - compacted_index::footer_size,
                    std::move(options)),
                  [](
-                   int32_t& max_bytes,
+                   int64_t& max_bytes,
                    crc::crc32c& crc,
                    ss::input_stream<char>& in) {
                      return ss::do_until(
@@ -117,7 +117,8 @@ compacted_index_chunk_reader::load_footer() {
 
     if (!_file_size || _file_size < compacted_index::footer_size) {
         throw std::runtime_error(fmt::format(
-          "Cannot read footer: file {} size is too small ({} bytes)",
+          "Cannot read footer: file {} size is too small ({} bytes). "
+          "Possible cause is old index format.",
           path(),
           _file_size));
     }

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -115,11 +115,11 @@ compacted_index_chunk_reader::load_footer() {
         _file_size = s.st_size;
     }
 
-    if (
-      !_file_size || _file_size == 0
-      || _file_size < compacted_index::footer_size) {
-        throw std::runtime_error(
-          fmt::format("Cannot read footer from empty file: {}", path()));
+    if (!_file_size || _file_size < compacted_index::footer_size) {
+        throw std::runtime_error(fmt::format(
+          "Cannot read footer: file {} size is too small ({} bytes)",
+          path(),
+          _file_size));
     }
 
     ss::file_input_stream_options options;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -299,8 +299,9 @@ do_detect_compaction_index_state(segment_full_path p, compaction_config cfg) {
       .handle_exception([](std::exception_ptr e) {
           vlog(
             stlog.warn,
-            "detected error while attempting recovery, {}. marking as 'needs "
-            "rebuild'. Common situation during crashes or hard shutdowns.",
+            "detected error while attempting compacted index recovery, {}. "
+            "marking as 'needs rebuild'. Common situation during crashes or "
+            "hard shutdowns.",
             e);
           return compacted_index::recovery_state::index_needs_rebuild;
       });

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -192,6 +192,7 @@ ss::future<> spill_key_index::spill(
   compacted_index::entry_type type, bytes_view b, value_type v) {
     constexpr size_t size_reservation = sizeof(uint16_t);
     ++_footer.keys;
+    ++_footer.keys_deprecated;
     iobuf payload;
     // INT16
     auto ph = payload.reserve(size_reservation);
@@ -219,6 +220,7 @@ ss::future<> spill_key_index::spill(
 
     // update internal state
     _footer.size += payload.size_bytes();
+    _footer.size_deprecated = _footer.size;
     for (auto& f : payload) {
         // NOLINTNEXTLINE
         _crc.extend(reinterpret_cast<const uint8_t*>(f.get()), f.size());

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -84,7 +84,7 @@ FIXTURE_TEST(format_verification, compacted_topic_fixture) {
     info("{}", idx);
 
     iobuf data = std::move(index_data).release_iobuf();
-    BOOST_REQUIRE_EQUAL(data.size_bytes(), 1048);
+    BOOST_REQUIRE_EQUAL(data.size_bytes(), 1064);
     iobuf_parser p(data.share(0, data.size_bytes()));
     (void)p.consume_type<uint16_t>(); // SIZE
     (void)p.consume_type<uint8_t>();  // TYPE

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -104,8 +104,7 @@ FIXTURE_TEST(format_verification, compacted_topic_fixture) {
       sizeof(uint16_t) + 1 /*type*/ + 1 /*offset*/ + 2 /*delta*/
         + 1 /*batch_type*/ + 1024 /*key*/);
     BOOST_REQUIRE_EQUAL(
-      footer.version,
-      storage::compacted_index::footer::key_prefixed_with_batch_type);
+      footer.version, storage::compacted_index::footer::current_version);
     BOOST_REQUIRE(footer.crc != 0);
 }
 FIXTURE_TEST(format_verification_max_key, compacted_topic_fixture) {
@@ -157,8 +156,7 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
     auto footer = rdr.load_footer().get0();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
     BOOST_REQUIRE_EQUAL(
-      footer.version,
-      storage::compacted_index::footer::key_prefixed_with_batch_type);
+      footer.version, storage::compacted_index::footer::current_version);
     BOOST_REQUIRE(footer.crc != 0);
     auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);
@@ -184,8 +182,7 @@ FIXTURE_TEST(
     auto footer = rdr.load_footer().get0();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
     BOOST_REQUIRE_EQUAL(
-      footer.version,
-      storage::compacted_index::footer::key_prefixed_with_batch_type);
+      footer.version, storage::compacted_index::footer::current_version);
     BOOST_REQUIRE(footer.crc != 0);
     auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);


### PR DESCRIPTION
As by default max compacted segment size is 5 GiB, compacted index size for large segments can oveflow 32-bit ints. This PR substitutes size and the number of keys in the footer for 64-bit ints. Old 32-bit fields are left for backwards compatibility with the code that doesn't check version number.

Fixes #7647

Additionally a more stringent footer version check is introduced that requires version to be equal to the current one (it is better to rebuild even if the version is greater as the index is probably incompatible anyway).

## Backports Required

- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## Release Notes
### Bug Fixes
* Fix integer overflow in compaction index footer that could lead to hangs when trying to compact large segments.