### PR TITLE
rpk: --max-message-bytes defaults to 1,000,012. Otherwise, if non-negative, overwrite it

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -171,7 +171,7 @@ func newProduceCommand(fs afero.Fs) *cobra.Command {
 	cmd.Flags().IntVar(&acks, "acks", -1, "Number of acks required for producing (-1=all, 0=none, 1=leader)")
 	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "Per-record delivery timeout, if non-zero, min 1s")
 	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")
-	cmd.Flags().Int32Var(&maxMessageBytes, "max-message-bytes", 1048576, "Maximum size of a record batch before compression")
+	cmd.Flags().Int32Var(&maxMessageBytes, "max-message-bytes", -1, "If non-negative, maximum size of a record batch before compression")
 
 	cmd.Flags().StringVarP(&inFormat, "format", "f", "%v\n", "Input record format")
 	cmd.Flags().StringVarP(


### PR DESCRIPTION
A follow-up task per https://github.com/redpanda-data/redpanda/pull/7646#discussion_r1045099166. 

* Making the default value of `--max-message-bytes` is `-1`, which respects franz-go's default.
* If non-negative value is specified, overwrite the default one.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
