### PR TITLE
[v22.1.x] storage: assert out on EIO in read

### DIFF
--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -199,14 +199,23 @@ log_segment_batch_reader::read_some(model::timeout_clock::time_point timeout) {
         _iterator = initialize(timeout, cache_read.next_cached_batch);
     }
     auto ptr = _iterator.get();
-    return ptr->consume().then(
-      [this](result<size_t> bytes_consumed) -> result<records_t> {
+    return ptr->consume()
+      .then([this](result<size_t> bytes_consumed) -> result<records_t> {
           if (!bytes_consumed) {
               return bytes_consumed.error();
           }
           auto tmp = std::exchange(_state, {});
           return result<records_t>(std::move(tmp.buffer));
-      });
+      })
+      .handle_exception_type(
+        [](const std::system_error& ec) -> ss::future<result<records_t>> {
+            if (ec.code().value() == EIO) {
+                vassert(false, "I/O error during read!  Disk failure?");
+            } else {
+                return ss::make_exception_future<result<records_t>>(
+                  std::current_exception());
+            }
+        });
 }
 
 log_reader::log_reader(


### PR DESCRIPTION
(cherry picked from commit 875faa41a0019ce2bf8cec82bc96d656a007494b)

Backport 875faa41a0019ce2bf8cec82bc96d656a007494b

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
