### PR TITLE
Serde split read nested

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -919,15 +919,15 @@ inline void read_nested(
     }
 }
 
-template<typename T>
-void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
-    using Type = std::decay_t<T>;
+template<typename Clock, typename Duration>
+void read_nested(
+  iobuf_parser&,
+  std::chrono::time_point<Clock, Duration>& t,
+  std::size_t const /* bytes_left_limit */) {
     static_assert(
-      !is_chrono_time_point<Type>,
+      !is_chrono_time_point<decltype(t)>,
       "Time point serialization is risky and can have unintended "
       "consequences. Check with Redpanda team before fixing this.");
-    static_assert(are_bytes_and_string_different<Type>);
-    static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 }
 
 template<typename T>

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -666,6 +666,11 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     }
 }
 
+inline void
+read_nested(iobuf_parser& in, bool& t, std::size_t const bytes_left_limit) {
+    t = read_nested<int8_t>(in, bytes_left_limit) != 0;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -676,9 +681,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, bool>) {
-        t = read_nested<int8_t>(in, bytes_left_limit) != 0;
-    } else if constexpr (serde_is_enum_v<Type>) {
+    if constexpr (serde_is_enum_v<Type>) {
         auto const val = read_nested<serde_enum_serialized_t>(
           in, bytes_left_limit);
         if (unlikely(

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -748,6 +748,14 @@ read_nested(iobuf_parser& in, iobuf& t, std::size_t const bytes_left_limit) {
     t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
 }
 
+inline void read_nested(
+  iobuf_parser& in, ss::sstring& t, std::size_t const bytes_left_limit) {
+    auto str = ss::uninitialized_string(
+      read_nested<serde_size_t>(in, bytes_left_limit));
+    in.consume_to(str.size(), str.begin());
+    t = str;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -758,12 +766,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, ss::sstring>) {
-        auto str = ss::uninitialized_string(
-          read_nested<serde_size_t>(in, bytes_left_limit));
-        in.consume_to(str.size(), str.begin());
-        t = str;
-    } else if constexpr (std::is_same_v<Type, bytes>) {
+    if constexpr (std::is_same_v<Type, bytes>) {
         auto str = ss::uninitialized_string<bytes>(
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -735,6 +735,14 @@ void read_nested(
     t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
 }
 
+template<typename Tag>
+void read_nested(
+  iobuf_parser& in,
+  ss::bool_class<Tag>& t,
+  std::size_t const bytes_left_limit) {
+    t = ss::bool_class<Tag>{read_nested<int8_t>(in, bytes_left_limit) != 0};
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -745,9 +753,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_ss_bool_class<Type>) {
-        t = Type{read_nested<int8_t>(in, bytes_left_limit) != 0};
-    } else if constexpr (std::is_same_v<Type, iobuf>) {
+    if constexpr (std::is_same_v<Type, iobuf>) {
         t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
     } else if constexpr (std::is_same_v<Type, ss::sstring>) {
         auto str = ss::uninitialized_string(

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -756,6 +756,14 @@ inline void read_nested(
     t = str;
 }
 
+inline void
+read_nested(iobuf_parser& in, bytes& t, std::size_t const bytes_left_limit) {
+    auto str = ss::uninitialized_string<bytes>(
+      read_nested<serde_size_t>(in, bytes_left_limit));
+    in.consume_to(str.size(), str.begin());
+    t = str;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -766,12 +774,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, bytes>) {
-        auto str = ss::uninitialized_string<bytes>(
-          read_nested<serde_size_t>(in, bytes_left_limit));
-        in.consume_to(str.size(), str.begin());
-        t = str;
-    } else if constexpr (std::is_same_v<Type, uuid_t>) {
+    if constexpr (std::is_same_v<Type, uuid_t>) {
         in.consume_to(uuid_t::length, t.mutable_uuid().begin());
     } else if constexpr (reflection::is_std_optional<Type>) {
         t = read_nested<bool>(in, bytes_left_limit)

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -807,6 +807,22 @@ void read_nested(
 }
 
 template<typename T>
+requires is_absl_node_hash_map<std::decay_t<T>> || is_absl_flat_hash_map<
+  std::decay_t<T>> || is_std_unordered_map<std::decay_t<T>>
+void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<T>;
+
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
+    t.reserve(size);
+    for (auto i = 0U; i < size; ++i) {
+        auto key = read_nested<typename Type::key_type>(in, bytes_left_limit);
+        auto value = read_nested<typename Type::mapped_type>(
+          in, bytes_left_limit);
+        t.emplace(std::move(key), std::move(value));
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -816,27 +832,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        t.reserve(size);
-        for (auto i = 0U; i < size; ++i) {
-            auto key = read_nested<typename Type::key_type>(
-              in, bytes_left_limit);
-            auto value = read_nested<typename Type::mapped_type>(
-              in, bytes_left_limit);
-            t.emplace(std::move(key), std::move(value));
-        }
-    } else if constexpr (is_std_unordered_map<Type>) {
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        t.reserve(size);
-        for (auto i = 0U; i < size; ++i) {
-            auto key = read_nested<typename Type::key_type>(
-              in, bytes_left_limit);
-            auto value = read_nested<typename Type::mapped_type>(
-              in, bytes_left_limit);
-            t.emplace(std::move(key), std::move(value));
-        }
-    } else if constexpr (is_fragmented_vector<Type>) {
+    if constexpr (is_fragmented_vector<Type>) {
         using value_type = typename Type::value_type;
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         for (auto i = 0U; i < size; ++i) {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -764,6 +764,11 @@ read_nested(iobuf_parser& in, bytes& t, std::size_t const bytes_left_limit) {
     t = str;
 }
 
+inline void read_nested(
+  iobuf_parser& in, uuid_t& t, std::size_t const /* bytes_left_limit */) {
+    in.consume_to(uuid_t::length, t.mutable_uuid().begin());
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -774,9 +779,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, uuid_t>) {
-        in.consume_to(uuid_t::length, t.mutable_uuid().begin());
-    } else if constexpr (reflection::is_std_optional<Type>) {
+    if constexpr (reflection::is_std_optional<Type>) {
         t = read_nested<bool>(in, bytes_left_limit)
               ? Type{read_nested<typename Type::value_type>(
                 in, bytes_left_limit)}

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -743,6 +743,11 @@ void read_nested(
     t = ss::bool_class<Tag>{read_nested<int8_t>(in, bytes_left_limit) != 0};
 }
 
+inline void
+read_nested(iobuf_parser& in, iobuf& t, std::size_t const bytes_left_limit) {
+    t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -753,9 +758,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, iobuf>) {
-        t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
-    } else if constexpr (std::is_same_v<Type, ss::sstring>) {
+    if constexpr (std::is_same_v<Type, ss::sstring>) {
         auto str = ss::uninitialized_string(
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -714,6 +714,19 @@ requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>)
 }
 
 template<typename T>
+void read_nested(
+  iobuf_parser& in, std::vector<T>& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    using value_type = typename Type::value_type;
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
+    t.reserve(size);
+    for (auto i = 0U; i < size; ++i) {
+        t.push_back(read_nested<value_type>(in, bytes_left_limit));
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -723,14 +736,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_std_vector<Type>) {
-        using value_type = typename Type::value_type;
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        t.reserve(size);
-        for (auto i = 0U; i < size; ++i) {
-            t.push_back(read_nested<value_type>(in, bytes_left_limit));
-        }
-    } else if constexpr (reflection::is_rp_named_type<Type>) {
+    if constexpr (reflection::is_rp_named_type<Type>) {
         t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
     } else if constexpr (reflection::is_ss_bool_class<Type>) {
         t = Type{read_nested<int8_t>(in, bytes_left_limit) != 0};

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -822,6 +822,21 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     }
 }
 
+template<typename T, size_t fragment_size>
+void read_nested(
+  iobuf_parser& in,
+  fragmented_vector<T, fragment_size>& t,
+  std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    using value_type = typename Type::value_type;
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
+    for (auto i = 0U; i < size; ++i) {
+        t.push_back(read_nested<value_type>(in, bytes_left_limit));
+    }
+    t.shrink_to_fit();
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -832,14 +847,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (is_fragmented_vector<Type>) {
-        using value_type = typename Type::value_type;
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        for (auto i = 0U; i < size; ++i) {
-            t.push_back(read_nested<value_type>(in, bytes_left_limit));
-        }
-        t.shrink_to_fit();
-    } else if constexpr (is_chrono_duration<Type>) {
+    if constexpr (is_chrono_duration<Type>) {
         static_assert(
           !std::is_floating_point_v<typename Type::rep>,
           "Floating point duration conversions are prone to precision and "

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -780,6 +780,33 @@ void read_nested(
 }
 
 template<typename T>
+void read_nested(
+  iobuf_parser& in,
+  absl::node_hash_set<T>& t,
+  std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
+    t.reserve(size);
+    for (auto i = 0U; i < size; ++i) {
+        auto elem = read_nested<typename Type::key_type>(in, bytes_left_limit);
+        t.emplace(std::move(elem));
+    }
+}
+
+template<typename T>
+void read_nested(
+  iobuf_parser& in, absl::btree_set<T>& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
+    for (auto i = 0U; i < size; ++i) {
+        auto elem = read_nested<typename Type::key_type>(in, bytes_left_limit);
+        t.emplace(std::move(elem));
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -789,23 +816,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (is_absl_node_hash_set<Type>) {
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        t.reserve(size);
-        for (auto i = 0U; i < size; ++i) {
-            auto elem = read_nested<typename Type::key_type>(
-              in, bytes_left_limit);
-            t.emplace(std::move(elem));
-        }
-    } else if constexpr (is_absl_btree_set<Type>) {
-        const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
-        for (auto i = 0U; i < size; ++i) {
-            auto elem = read_nested<typename Type::key_type>(
-              in, bytes_left_limit);
-            t.emplace(std::move(elem));
-        }
-    } else if constexpr (
-      is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
+    if constexpr (is_absl_node_hash_map<Type> || is_absl_flat_hash_map<Type>) {
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         t.reserve(size);
         for (auto i = 0U; i < size; ++i) {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -770,6 +770,16 @@ inline void read_nested(
 }
 
 template<typename T>
+void read_nested(
+  iobuf_parser& in, std::optional<T>& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    t = read_nested<bool>(in, bytes_left_limit)
+          ? Type{read_nested<typename Type::value_type>(in, bytes_left_limit)}
+          : std::nullopt;
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -779,12 +789,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_std_optional<Type>) {
-        t = read_nested<bool>(in, bytes_left_limit)
-              ? Type{read_nested<typename Type::value_type>(
-                in, bytes_left_limit)}
-              : std::nullopt;
-    } else if constexpr (is_absl_node_hash_set<Type>) {
+    if constexpr (is_absl_node_hash_set<Type>) {
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         t.reserve(size);
         for (auto i = 0U; i < size; ++i) {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -689,6 +689,31 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
 }
 
 template<typename T>
+requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>) void read_nested(
+  iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<T>;
+
+    if (unlikely(in.bytes_left() - bytes_left_limit < sizeof(Type))) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "reading type {} of size {}: {} bytes left",
+          type_str<Type>(),
+          sizeof(Type),
+          in.bytes_left()));
+    }
+
+    if constexpr (sizeof(Type) == 1) {
+        t = in.consume_type<Type>();
+    } else if constexpr (std::is_same_v<float, Type>) {
+        t = bit_cast<float>(le32toh(in.consume_type<uint32_t>()));
+    } else if constexpr (std::is_same_v<double, Type>) {
+        t = bit_cast<double>(le64toh(in.consume_type<uint64_t>()));
+    } else {
+        t = ss::le_to_cpu(in.consume_type<Type>());
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -698,26 +723,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_scalar_v<Type>) {
-        if (unlikely(in.bytes_left() < sizeof(Type))) {
-            throw serde_exception(fmt_with_ctx(
-              ssx::sformat,
-              "reading type {} of size {}: {} bytes left",
-              type_str<Type>(),
-              sizeof(Type),
-              in.bytes_left()));
-        }
-
-        if constexpr (sizeof(Type) == 1) {
-            t = in.consume_type<Type>();
-        } else if constexpr (std::is_same_v<float, Type>) {
-            t = bit_cast<float>(le32toh(in.consume_type<uint32_t>()));
-        } else if constexpr (std::is_same_v<double, Type>) {
-            t = bit_cast<double>(le64toh(in.consume_type<uint64_t>()));
-        } else {
-            t = ss::le_to_cpu(in.consume_type<Type>());
-        }
-    } else if constexpr (reflection::is_std_vector<Type>) {
+    if constexpr (reflection::is_std_vector<Type>) {
         using value_type = typename Type::value_type;
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         t.reserve(size);


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
