### PR TITLE
gha: workflow to render pr body release notes

### DIFF
--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+name: Render PR Body Release Notes
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl rpchangelog
+        run: |
+          mkdir -v -p rpchangelog
+          curl -s -S -f -L -o rpchangelog/requirements.txt https://vectorized-public.s3.us-west-2.amazonaws.com/rpchangelog/requirements.txt
+          curl -s -S -f -L -o rpchangelog/rpchangelog.py https://vectorized-public.s3.us-west-2.amazonaws.com/rpchangelog/rpchangelog.py
+          chmod +x rpchangelog/rpchangelog.py
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip3 install -r ./rpchangelog/requirements.txt
+      - name: Render PR body release notes to job summary
+        env:
+          PR_NUM: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./rpchangelog/rpchangelog.py --log-level=DEBUG --github-owner="$GITHUB_REPOSITORY_OWNER" pr "$PR_NUM" >> "$GITHUB_STEP_SUMMARY"
+          LINK_TO_SUMMARY="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          FINAL_MSG="View rendered release notes of PR #$PR_NUM in the job summary: $LINK_TO_SUMMARY"
+          if grep -q '## Unclear' "$GITHUB_STEP_SUMMARY"; then
+             echo '❌ Release Notes Unclear'
+             echo $FINAL_MSG
+             exit 1
+          else
+             echo '✔ Release Notes Clear'
+             echo $FINAL_MSG
+          fi


### PR DESCRIPTION
To validate the PR bodies have structured release notes that can be parsed, this PR will add a workflow to lint the release notes section. The workflow will show up as a PR check `Render PR Body Release Notes`.

This workflow will render the markdown release notes of the PR to the job summary using `rpchangelog.py` script. If the script is unable to render the markdown, it will be marked as "Unclear" and the job will fail. The expected format for the release notes section is summarized in the [pull_request_template.md](https://github.com/redpanda-data/redpanda/blob/dev/.github/pull_request_template.md?plain=1).

This PR works around the issue of retrieving the `rpchangelog.py` script from a private repo in PR #7590 (which was reverted in PR #7616).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

* none