### PR TITLE
rpk: do not modify redpanda.rpc_server_tls field

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_linux.go
@@ -461,7 +461,6 @@ func saveConfig(ps *stepParams, conf *config.Config) step {
 		// We want to redact any blindly decoded parameters.
 		redactOtherMap(conf.Other)
 		redactOtherMap(conf.Redpanda.Other)
-		redactServerTLSSlice(conf.Redpanda.RPCServerTLS)
 		redactServerTLSSlice(conf.Redpanda.KafkaAPITLS)
 		redactServerTLSSlice(conf.Redpanda.AdminAPITLS)
 		if conf.SchemaRegistry != nil {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -67,7 +67,6 @@ type RedpandaNodeConfig struct {
 	EmptySeedStartsCluster     *bool                     `yaml:"empty_seed_starts_cluster,omitempty" json:"empty_seed_starts_cluster,omitempty"`
 	SeedServers                []SeedServer              `yaml:"seed_servers" json:"seed_servers"`
 	RPCServer                  SocketAddress             `yaml:"rpc_server,omitempty" json:"rpc_server"`
-	RPCServerTLS               []ServerTLS               `yaml:"rpc_server_tls,omitempty" json:"rpc_server_tls"`
 	KafkaAPI                   []NamedAuthNSocketAddress `yaml:"kafka_api,omitempty" json:"kafka_api"`
 	KafkaAPITLS                []ServerTLS               `yaml:"kafka_api_tls,omitempty" json:"kafka_api_tls"`
 	AdminAPI                   []NamedSocketAddress      `yaml:"admin,omitempty" json:"admin"`

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -12,8 +12,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -325,6 +327,9 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
+// once is used to ensure that we only print the rpc_server_tls bug warning once.
+var once sync.Once
+
 func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
 		Directory                  weakString                `yaml:"data_directory"`
@@ -333,7 +338,6 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		EmptySeedStartsCluster     *weakBool                 `yaml:"empty_seed_starts_cluster"`
 		SeedServers                seedServers               `yaml:"seed_servers"`
 		RPCServer                  SocketAddress             `yaml:"rpc_server"`
-		RPCServerTLS               serverTLSArray            `yaml:"rpc_server_tls"`
 		KafkaAPI                   namedAuthNSocketAddresses `yaml:"kafka_api"`
 		KafkaAPITLS                serverTLSArray            `yaml:"kafka_api_tls"`
 		AdminAPI                   namedSocketAddresses      `yaml:"admin"`
@@ -352,13 +356,21 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	if err := n.Decode(&internal); err != nil {
 		return err
 	}
+
+	// redpanda won't recognize rpc_server_tls if is a list.
+	v := reflect.ValueOf(internal.Other["rpc_server_tls"])
+	if v.Kind() == reflect.Slice {
+		once.Do(func() {
+			fmt.Fprintf(os.Stderr, "WARNING: Due to an old rpk bug, your redpanda.yaml's redpanda.rpc_server_tls property is an array, and redpanda reads the field as a struct. rpk cannot automatically fix this: brokers would not be able to rejoin the cluster during a rolling upgrade. To enable TLS on broker RPC ports, you must turn off your cluster, switch the redpanda.rpc_server_tls field to a struct, and then turn your cluster back on. To switch from a list to a struct, replace the single dash under redpanda.rpc_server_tls with a space. This message will continue to appear while redpanda.rpc_server_tls exists and is an array\n")
+		})
+	}
+
 	rpc.Directory = string(internal.Directory)
 	rpc.ID = (*int)(internal.ID)
 	rpc.Rack = string(internal.Rack)
 	rpc.EmptySeedStartsCluster = (*bool)(internal.EmptySeedStartsCluster)
 	rpc.SeedServers = internal.SeedServers
 	rpc.RPCServer = internal.RPCServer
-	rpc.RPCServerTLS = internal.RPCServerTLS
 	rpc.KafkaAPI = internal.KafkaAPI
 	rpc.KafkaAPITLS = internal.KafkaAPITLS
 	rpc.AdminAPI = internal.AdminAPI

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -996,10 +996,7 @@ rpk:
 					AdminAPITLS: []ServerTLS{
 						{Enabled: false, CertFile: "certs/tls-cert.pem"},
 					},
-					RPCServer: SocketAddress{"0.0.0.0", 33145},
-					RPCServerTLS: []ServerTLS{
-						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
-					},
+					RPCServer:        SocketAddress{"0.0.0.0", 33145},
 					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
 					KafkaAPI: []NamedAuthNSocketAddress{
 						{"0.0.0.0", 9092, "internal", nil},
@@ -1018,6 +1015,13 @@ rpk:
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
+						// This one is a slice
+						"rpc_server_tls": []interface{}{
+							map[string]interface{}{
+								"require_client_auth": false,
+								"truststore_file":     "certs/tls-ca.pem",
+							},
+						},
 					},
 				},
 				Pandaproxy: &Pandaproxy{
@@ -1146,10 +1150,7 @@ redpanda:
 					AdminAPITLS: []ServerTLS{
 						{Enabled: false, CertFile: "certs/tls-cert.pem"},
 					},
-					RPCServer: SocketAddress{"0.0.0.0", 33145},
-					RPCServerTLS: []ServerTLS{
-						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
-					},
+					RPCServer:        SocketAddress{"0.0.0.0", 33145},
 					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
 					KafkaAPI: []NamedAuthNSocketAddress{
 						{"0.0.0.0", 9092, "internal", nil},
@@ -1168,6 +1169,13 @@ redpanda:
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
+						// This one is a slice
+						"rpc_server_tls": []interface{}{
+							map[string]interface{}{
+								"require_client_auth": false,
+								"truststore_file":     "certs/tls-ca.pem",
+							},
+						},
 					},
 				},
 			},
@@ -1318,10 +1326,7 @@ rpk:
 					AdminAPITLS: []ServerTLS{
 						{Enabled: false, CertFile: "certs/tls-cert.pem"},
 					},
-					RPCServer: SocketAddress{"0.0.0.0", 33145},
-					RPCServerTLS: []ServerTLS{
-						{RequireClientAuth: false, TruststoreFile: "certs/tls-ca.pem"},
-					},
+					RPCServer:        SocketAddress{"0.0.0.0", 33145},
 					AdvertisedRPCAPI: &SocketAddress{"0.0.0.0", 33145},
 					KafkaAPI: []NamedAuthNSocketAddress{
 						{"0.0.0.0", 9092, "internal", nil},
@@ -1342,6 +1347,10 @@ rpk:
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
+						"rpc_server_tls": map[string]interface{}{
+							"require_client_auth": false,
+							"truststore_file":     "certs/tls-ca.pem",
+						},
 					},
 				},
 				Pandaproxy: &Pandaproxy{

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1497,6 +1497,15 @@ class RedpandaService(Service):
         self.start_service(node, start_rp)
         self._started.append(node)
 
+        # We need to manually read the config from the file and add it
+        # to _node_configs since we use rpk to write the file instead of
+        # the write_node_conf_file method.
+        with tempfile.TemporaryDirectory() as d:
+            node.account.copy_from(RedpandaService.NODE_CONFIG_FILE, d)
+            with open(os.path.join(d, "redpanda.yaml")) as f:
+                actual_config = yaml.full_load(f.read())
+                self._node_configs[node] = actual_config
+
     def _log_node_process_state(self, node):
         """
         For debugging issues around starting and stopping processes: log

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -9,10 +9,12 @@
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.services.redpanda import RedpandaService
+from rptest.services import tls
 
+import json
 import os
 import yaml
 import tempfile
@@ -27,6 +29,38 @@ class RpkRedpandaStartTest(RedpandaTest):
     def setUp(self):
         # Skip starting redpanda, so that test can explicitly start it
         pass
+
+    def write_tls_cert(self, node, tls_manager):
+        cert = tls_manager.create_cert(node.name)
+
+        self.logger.info(
+            f"Writing Redpanda node tls key file: {RedpandaService.TLS_SERVER_KEY_FILE}"
+        )
+        node.account.mkdirs(
+            os.path.dirname(RedpandaService.TLS_SERVER_KEY_FILE))
+        node.account.copy_to(cert.key, RedpandaService.TLS_SERVER_KEY_FILE)
+
+        self.logger.info(
+            f"Writing Redpanda node tls cert file: {RedpandaService.TLS_SERVER_CRT_FILE}"
+        )
+        node.account.mkdirs(
+            os.path.dirname(RedpandaService.TLS_SERVER_CRT_FILE))
+        node.account.copy_to(cert.crt, RedpandaService.TLS_SERVER_CRT_FILE)
+
+        self.logger.info(
+            f"Writing Redpanda node tls ca cert file: {RedpandaService.TLS_CA_CRT_FILE}"
+        )
+        node.account.mkdirs(os.path.dirname(RedpandaService.TLS_CA_CRT_FILE))
+        node.account.copy_to(tls_manager.ca.crt,
+                             RedpandaService.TLS_CA_CRT_FILE)
+
+    def rpc_server_tls(self):
+        return json.dumps({
+            "cert_file": RedpandaService.TLS_SERVER_CRT_FILE,
+            "enabled": True,
+            "key_file": RedpandaService.TLS_SERVER_KEY_FILE,
+            "truststore_file": RedpandaService.TLS_CA_CRT_FILE
+        })
 
     @cluster(num_nodes=1)
     def test_simple_start(self):
@@ -203,3 +237,195 @@ class RpkRedpandaStartTest(RedpandaTest):
         # This was the original issue:
         assert not self.redpanda.search_log_any(
             f"\-\-abort-on-seastar-bad-alloc=true")
+
+    @cluster(num_nodes=3)
+    def test_rpc_tls_start(self):
+        """
+        Starts redpanda via rpk with rpc_server_tls and verify
+        that rpk treat the config file properly and we can produce
+        and consume from the cluster.
+        """
+
+        tls_manager = tls.TLSCertManager(self.logger)
+
+        # clean the node and write the redpanda.yaml with the
+        # rpc_server_tls configuration _before_ starting rp.
+        def setup_cluster(node):
+            self.redpanda.clean_node(node)
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+            rpk = RpkRemoteTool(self.redpanda, node)
+            rpk.mode_set("production")
+            rpk.config_set("redpanda.rpc_server_tls", self.rpc_server_tls())
+            self.write_tls_cert(node, tls_manager)
+
+            # We need to increase the upper limit of instances to avoid hitting
+            # the limits when TLS is enabled.
+            node.account.ssh("sysctl fs.inotify.max_user_instances=512")
+
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 setup_cluster,
+                                 parallel=True)
+
+        seeds_str = ",".join(
+            [f"{n.account.hostname}" for n in self.redpanda.nodes])
+
+        # We start a 3 nodes cluster using the flags for rpk redpanda start.
+        def start_cluster(node):
+            base_args = f"--rpc-addr={node.account.hostname} --kafka-addr=dnslistener://{node.account.hostname}"
+            seeds_arg = f"--seeds={seeds_str}"
+            if self.redpanda.idx(node) == 1:
+                seeds_arg = ""
+            args = f"{base_args} {seeds_arg}"
+            self.redpanda.start_node_with_rpk(node, args, clean_node=False)
+
+            # We check that rpc_server_tls is enabled on start:
+            assert self.redpanda.search_log_node(
+                node, "redpanda.rpc_server_tls:{ enabled: 1")
+
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 start_cluster,
+                                 parallel=True)
+
+        # To validate that everything works fine we check that
+        # formed a cluster and we can produce and consume from it
+        # even after restarting.
+        try:
+            nodes = self.rpk.cluster_info()
+            assert len(nodes) == 3
+
+            topic = "test-rpc"
+            self.rpk.create_topic(topic)
+
+            for i in range(50):
+                self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
+        except RpkException:
+            pass
+
+        self.redpanda.stop()
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 start_cluster,
+                                 parallel=True)
+        try:
+            for i in range(50, 100):
+                self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
+
+            out = self.rpk.consume(topic, n=100)
+            assert "k-99" in out
+        except RpkException:
+            pass
+
+    @cluster(num_nodes=3)
+    def test_rpc_tls_list(self):
+        """
+        Starts redpanda via rpk with rpc_server_tls as a list
+        and check if rpk prints the warning in the logs
+        """
+        def setup_and_start(node):
+            self.redpanda.clean_node(node)
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+            rpk = RpkRemoteTool(self.redpanda, node)
+            rpk.mode_set("production")
+            # We add [] so rpk picks it up as a list.
+            rpk.config_set("redpanda.rpc_server_tls",
+                           f"[{self.rpc_server_tls()}]")
+
+            self.redpanda.start_node_with_rpk(node, clean_node=False)
+
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 setup_and_start,
+                                 parallel=True)
+
+        # Check that we don't enable rpc and print a warning
+        assert self.redpanda.search_log_all(
+            "redpanda.rpc_server_tls:{ enabled: 0", self.redpanda.nodes)
+        assert self.redpanda.search_log_all(
+            "WARNING: Due to an old rpk bug, your redpanda.yaml's redpanda.rpc_server_tls property is an array",
+            self.redpanda.nodes)
+
+    @cluster(num_nodes=3)
+    def test_rpc_tls_enable(self):
+        """
+        Starts redpanda via rpk with rpc_server_tls as a list
+        (i.e no TLS) and test the process of enabling TLS and
+        restarting the cluster
+        """
+
+        # First we setup the cluster with rpc_server_tls as a list.
+        def setup_cluster(node):
+            self.redpanda.clean_node(node)
+            node.account.mkdirs(
+                os.path.dirname(RedpandaService.NODE_CONFIG_FILE))
+
+            rpk = RpkRemoteTool(self.redpanda, node)
+            rpk.mode_set("production")
+            rpk.config_set("redpanda.rpc_server_tls",
+                           f"[{self.rpc_server_tls()}]")
+            node.account.ssh("sysctl fs.inotify.max_user_instances=512")
+
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 setup_cluster,
+                                 parallel=True)
+
+        seeds_str = ",".join(
+            [f"{n.account.hostname}" for n in self.redpanda.nodes])
+
+        def start_cluster(node):
+            base_args = f"--rpc-addr={node.account.hostname} --kafka-addr=dnslistener://{node.account.hostname}"
+            seeds_arg = f"--seeds={seeds_str}"
+            if self.redpanda.idx(node) == 1:
+                seeds_arg = ""
+            args = f"{base_args} {seeds_arg}"
+            self.redpanda.start_node_with_rpk(node, args, clean_node=False)
+
+        # On first start we validate that TLS is disabled and produce
+        # to a topic.
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 start_cluster,
+                                 parallel=True)
+        assert self.redpanda.search_log_all(
+            "redpanda.rpc_server_tls:{ enabled: 0", self.redpanda.nodes)
+
+        try:
+            nodes = self.rpk.cluster_info()
+            assert len(nodes) == 3
+
+            topic = "test-rpc"
+            self.rpk.create_topic(topic)
+
+            for i in range(50):
+                self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
+        except RpkException:
+            pass
+
+        # Now we create the certs + write the correct config.
+        tls_manager = tls.TLSCertManager(self.logger)
+
+        for node in self.redpanda.nodes:
+            rpk = RpkRemoteTool(self.redpanda, node)
+            rpk.config_set("redpanda.rpc_server_tls", self.rpc_server_tls())
+            self.write_tls_cert(node, tls_manager)
+
+        # Restart and validate rpc_server_tls is enabled.
+        self.redpanda.stop()
+        self.redpanda._for_nodes(self.redpanda.nodes,
+                                 start_cluster,
+                                 parallel=True)
+        assert self.redpanda.search_log_all(
+            "redpanda.rpc_server_tls:{ enabled: 1", self.redpanda.nodes)
+
+        try:
+            nodes = self.rpk.cluster_info()
+            assert len(nodes) == 3
+
+            for i in range(50, 100):
+                self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
+
+            out = self.rpk.consume(topic, n=100)
+            assert "k-10" in out
+            assert "k-99" in out
+        except RpkException:
+            pass


### PR DESCRIPTION
rpk now will treat this field like an unmanaged field, which means that we can have either a list, or an element, and rpk will respect that.

rpk will print a warning if the element is a list and will let the user know that TLS won't be enabled as it is.

Fixes #7644 

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


  ### Bug Fixes

  * rpk will not modify `redpanda.rpc_server_tls` property when decoding the redpanda.yaml, which means that it will leave the field as a list or as an element depending on what the user has configured before executing rpk commands.
