### PR TITLE
rpk/pkg: bring back linux build and tweak the archive name template

### DIFF
--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -1,6 +1,6 @@
 project_name: rpk
 builds:
-  - id: rpk-windows
+  - id: windows-and-linux
     main: ./cmd/rpk
     binary: rpk
     ldflags:
@@ -11,11 +11,12 @@ builds:
       - CGO_ENABLED=0
     goos:
       - windows
+      - linux
     goarch:
       - amd64
       - arm64
   # we need separate build for darwin to sign/notarize using quill
-  - id: rpk-darwin
+  - id: darwin
     main: ./cmd/rpk
     binary: rpk
     ldflags:

--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -40,6 +40,13 @@ builds:
         - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
           env:
             - QUILL_LOG_FILE=dist/quill-{{ .Target }}.log
+archives:
+  - id: rpk
+    builds:
+      - windows-and-linux
+      - darwin
+    format: zip
+    name_template: "rpk-{{ .Os }}-{{ .Arch }}"
 release:
   github:
     owner: redpanda-data


### PR DESCRIPTION
After the move to goreleaser for packaging rpk, linux was removed. This PR is bringing it back.

fixes https://github.com/redpanda-data/homebrew-tap/issues/9

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
