### PR TITLE
c/feature_table: fixed the tx_stm_cache feature flag

### DIFF
--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -30,26 +30,26 @@ namespace features {
 struct feature_table_snapshot;
 
 enum class feature : std::uint64_t {
-    central_config = 0x1,
-    consumer_offsets = 0x2,
-    maintenance_mode = 0x4,
-    mtls_authentication = 0x8,
-    rm_stm_kafka_cache = 0x10,
-    serde_raft_0 = 0x20,
-    license = 0x40,
-    raft_improved_configuration = 0x80,
-    transaction_ga = 0x100,
-    raftless_node_status = 0x200,
-    rpc_v2_by_default = 0x400,
-    cloud_retention = 0x800,
-    node_id_assignment = 0x1000,
-    replication_factor_change = 0x2000,
-    ephemeral_secrets = 0x4000,
-    seeds_driven_bootstrap_capable = 0x8000,
-    tm_stm_cache = 0x10000,
+    central_config = 1ULL,
+    consumer_offsets = 1ULL << 1U,
+    maintenance_mode = 1ULL << 2U,
+    mtls_authentication = 1ULL << 3U,
+    rm_stm_kafka_cache = 1ULL << 4U,
+    serde_raft_0 = 1ULL << 5U,
+    license = 1ULL << 6U,
+    raft_improved_configuration = 1ULL << 7U,
+    transaction_ga = 1ULL << 8U,
+    raftless_node_status = 1ULL << 9U,
+    rpc_v2_by_default = 1ULL << 10U,
+    cloud_retention = 1ULL << 11U,
+    node_id_assignment = 1ULL << 12U,
+    replication_factor_change = 1ULL << 13U,
+    ephemeral_secrets = 1ULL << 14U,
+    seeds_driven_bootstrap_capable = 1ULL << 15U,
+    tm_stm_cache = 1ULL << 16U,
 
     // Dummy features for testing only
-    test_alpha = uint64_t(1) << 63,
+    test_alpha = 1ULL << 63U,
 };
 
 /**

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -46,7 +46,7 @@ enum class feature : std::uint64_t {
     replication_factor_change = 0x2000,
     ephemeral_secrets = 0x4000,
     seeds_driven_bootstrap_capable = 0x8000,
-    tm_stm_cache = 0x16000,
+    tm_stm_cache = 0x10000,
 
     // Dummy features for testing only
     test_alpha = uint64_t(1) << 63,

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -224,3 +224,16 @@ FIXTURE_TEST(feature_table_preparing, feature_table_fixture) {
     BOOST_REQUIRE(f_active.available());
     f_active.get();
 }
+
+FIXTURE_TEST(feature_uniqueness, feature_table_fixture) {
+    for (const auto& schema : feature_schema) {
+        feature current_feature = schema.bits;
+        for (const auto& other : feature_schema) {
+            BOOST_REQUIRE(
+              (static_cast<uint64_t>(other.bits)
+               & static_cast<uint64_t>(current_feature))
+                == 0
+              || other.bits == current_feature);
+        }
+    }
+}


### PR DESCRIPTION
Since features are intended to be used as a bit mask each feature must set only one bit. Fixed the value for `tx_stm_cache` feature.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
  * none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
