### PR TITLE
cluster: wait for leadership with auto create

### DIFF
--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -260,7 +260,8 @@ ss::future<response_ptr> create_topics_handler::handle(
       .create_topics(std::move(to_create), to_timeout(request.data.timeout_ms))
       .then([&ctx, tout = to_timeout(request.data.timeout_ms)](
               std::vector<cluster::topic_result> c_res) mutable {
-          return wait_for_topics(c_res, ctx.controller_api(), tout)
+          return wait_for_topics(
+                   ctx.metadata_cache(), c_res, ctx.controller_api(), tout)
             .then([c_res = std::move(c_res)]() mutable { return c_res; });
       })
       .then([&ctx,

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -170,6 +170,7 @@ create_topic(request_context& ctx, model::topic&& topic) {
           }
 
           return wait_for_topics(
+                   md_cache,
                    res,
                    ctx.controller_api(),
                    tout + model::timeout_clock::now())

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -58,21 +58,28 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
 }
 
 ss::future<> wait_for_topics(
+  cluster::metadata_cache& md_cache,
   std::vector<cluster::topic_result> results,
   cluster::controller_api& api,
   model::timeout_clock::time_point timeout) {
     return ss::do_with(
       std::move(results),
-      [&api, timeout](std::vector<cluster::topic_result>& results) {
+      [&md_cache, &api, timeout](std::vector<cluster::topic_result>& results) {
           return ss::parallel_for_each(
-            results, [&api, timeout](cluster::topic_result& r) {
-                if (r.ec != cluster::errc::success) {
-                    return ss::now();
-                }
-                // we discard return here, we do not want to return error even
-                // if waiting for topic wasn't successfull, it was already
-                // created
-                return api.wait_for_topic(r.tp_ns, timeout).discard_result();
+                   results,
+                   [&api, timeout](cluster::topic_result& r) {
+                       if (r.ec != cluster::errc::success) {
+                           return ss::now();
+                       }
+                       // we discard return here, we do not want to return error
+                       // even if waiting for topic wasn't successfull, it was
+                       // already created
+                       return api.wait_for_topic(r.tp_ns, timeout)
+                         .discard_result();
+                   })
+            .then([&md_cache, &results, timeout]() {
+                return wait_for_leaders(md_cache, results, timeout)
+                  .discard_result();
             });
       });
 }

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -184,6 +184,7 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
   model::timeout_clock::time_point);
 
 ss::future<> wait_for_topics(
+  cluster::metadata_cache&,
   std::vector<cluster::topic_result>,
   cluster::controller_api&,
   model::timeout_clock::time_point);


### PR DESCRIPTION
With newly created topics via auto creation,
the patch additionally waits for the leaders
to be assigned before handing of the control to the
caller (with a timeout).

Typically auto creation is used in conjunction with
a produce which immediately runs after the creation
returns the control only to see that the newly
created partitions are leader-less. This is a
common pattern when unit testing with redpanda
(as well as regular use cases) and is a bad UX.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Improvements

* Better UX when auto creating topics, creation waits for the topic leaders to be assigned and ready to accept requests.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
