### PR TITLE
kafka/client: Improve connection error handling

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -12,6 +12,7 @@
 #include "cluster/cluster_utils.h"
 #include "kafka/client/logger.h"
 #include "kafka/client/sasl_client.h"
+#include "net/connection.h"
 #include "net/dns.h"
 
 #include <seastar/core/coroutine.hh>
@@ -45,9 +46,7 @@ ss::future<shared_broker_t> make_broker(
             });
       })
       .handle_exception_type([node_id](const std::system_error& ex) {
-          if (
-            ex.code() == std::errc::host_unreachable
-            || ex.code() == std::errc::connection_refused) {
+          if (net::is_reconnect_error(ex)) {
               return ss::make_exception_future<shared_broker_t>(
                 broker_error(node_id, error_code::network_exception));
           }

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -191,9 +191,7 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
           } catch (const ss::gate_closed_exception&) {
               vlog(kclog.debug, "gate_closed_exception");
           } catch (const std::system_error& ex) {
-              if (
-                ex.code() == std::errc::broken_pipe
-                || ex.code() == std::errc::timed_out) {
+              if (net::is_reconnect_error(ex)) {
                   vlog(kclog.debug, "system_error: {}", ex);
                   return _wait_or_start_update_metadata();
               } else {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1191,6 +1191,38 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 check_connection(n.account.hostname)
             restart_leader()
 
+    @cluster(num_nodes=3)
+    def test_move_leader(self):
+        admin = Admin(self.redpanda)
+
+        def check_connection(hostname: str):
+            result_raw = self._get_subjects(hostname=hostname)
+            self.logger.info(result_raw.status_code)
+            self.logger.info(result_raw.json())
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json() == []
+
+        def get_leader():
+            return admin.get_partition_leader(namespace="kafka",
+                                              topic="_schemas",
+                                              partition=0)
+
+        def move_leader():
+            leader = get_leader()
+            self.logger.info(f"Transferring leadership from node: {leader}")
+            admin.partition_transfer_leadership(namespace="kafka",
+                                                topic="_schemas",
+                                                partition=0)
+            wait_until(lambda: get_leader() != leader,
+                       timeout_sec=10,
+                       backoff_sec=1,
+                       err_msg="Leadership did not stabilize")
+
+        for _ in range(20):
+            for n in self.redpanda.nodes:
+                check_connection(n.account.hostname)
+            move_leader()
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Several known connection errors were not being mitigated. This can result in Schema Registry or Pandaproxy failing to retry requests when there are connection errors.

Handle all connection errors by checking against `net::is_reconnection_error`, and refreshing metadata for any of them.

This is a much more complete version of https://github.com/redpanda-data/redpanda/pull/6687

Additionally do not call `client::mitigate_error` during connect, as that can result in an infinite (recursive) loop. Instead call only `_external_mitigate` so that pandaproxy and schema registry can handle ephemeral credentials.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x


## Release Notes

### Bug Fixes

* Improve robustness of Schema Registry and HTTP Proxy under several connection errors.
