### PR TITLE
schema_registry: Don't batch writes unless explictly configured to

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -119,20 +119,16 @@ static void set_local_kafka_client_config(
     }
 }
 
-static void set_sr_local_kafka_client_config(
-  std::optional<kafka::client::configuration>& client_config,
-  const config::node_config& config) {
-    set_local_kafka_client_config(client_config, config);
-    if (client_config.has_value()) {
-        if (!client_config->produce_batch_delay.is_overriden()) {
-            client_config->produce_batch_delay.set_value(0ms);
-        }
-        if (!client_config->produce_batch_record_count.is_overriden()) {
-            client_config->produce_batch_record_count.set_value(int32_t(0));
-        }
-        if (!client_config->produce_batch_size_bytes.is_overriden()) {
-            client_config->produce_batch_size_bytes.set_value(int32_t(0));
-        }
+static void
+set_sr_kafka_client_defaults(kafka::client::configuration& client_config) {
+    if (!client_config.produce_batch_delay.is_overriden()) {
+        client_config.produce_batch_delay.set_value(0ms);
+    }
+    if (!client_config.produce_batch_record_count.is_overriden()) {
+        client_config.produce_batch_record_count.set_value(int32_t(0));
+    }
+    if (!client_config.produce_batch_size_bytes.is_overriden()) {
+        client_config.produce_batch_size_bytes.set_value(int32_t(0));
     }
 }
 
@@ -575,9 +571,10 @@ void application::hydrate_config(const po::variables_map& cfg) {
         if (config["schema_registry_client"]) {
             _schema_reg_client_config.emplace(config["schema_registry_client"]);
         } else {
-            set_sr_local_kafka_client_config(
+            set_local_kafka_client_config(
               _schema_reg_client_config, config::node());
         }
+        set_sr_kafka_client_defaults(*_schema_reg_client_config);
         config_printer("schema_registry", *_schema_reg_config);
         config_printer("schema_registry_client", *_schema_reg_client_config);
     }


### PR DESCRIPTION
This was supposed to be fixed in #2156, but the case where `schema_registry_client` has been set still chose the bad defaults.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## Release Notes

### Improvements

* Schema Registry: Improve performance by disabling batching unless explicitly set
