### PR TITLE
rpk: support reading array of structs from files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install gofumpt
       env:
-        GOFUMPT_VER: 0.3.1
+        GOFUMPT_VER: 0.4.0
       run: |
         mkdir -v -p "$HOME/.local/bin"
         wget -O "$HOME/.local/bin/gofumpt" "https://github.com/mvdan/gofumpt/releases/download/v${GOFUMPT_VER}/gofumpt_v${GOFUMPT_VER}_linux_amd64"
@@ -49,7 +49,7 @@ jobs:
 
     - name: Run gofumpt
       run: |
-        find src/go -type f -name '*.go' | xargs -n1 gofumpt -w -lang=1.17
+        find src/go -type f -name '*.go' | xargs -n1 gofumpt -w -lang=1.19
         git diff --exit-code
 
   js:

--- a/src/go/rpk/pkg/out/in.go
+++ b/src/go/rpk/pkg/out/in.go
@@ -1,0 +1,139 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+// ParseFileArray parses the given file and returns the array of values within
+// it. The file can be keyed yaml, keyed json, or raw-value tab/space delimited
+// lines in a text file. Files with no extension are assumed to be text files.
+// The input type must be a struct with public fields. As an example,
+//
+//	ParseFileArray[struct{
+//		F1 string `json:"f1" yaml:"f1"`
+//		F2 int    `json:"f2" yaml:"f2"`
+//	}]
+//
+// For text files, if the line is empty or begins with "// ", the line is
+// skipped.
+func ParseFileArray[T any](fs afero.Fs, file string) ([]T, error) {
+	var unmarshal func([]byte, interface{}) error
+	switch ext := filepath.Ext(file); ext {
+	case ".txt", "":
+		f, err := fs.Open(file)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open %q: %v", file, err)
+		}
+		defer f.Close()
+		vs, err := parseSpaceLines[T](f)
+		if err != nil {
+			return nil, fmt.Errorf("unable to process file %q: %v", file, err)
+		}
+		return vs, nil
+	case ".yml", ".yaml":
+		unmarshal = yaml.Unmarshal
+	case ".json":
+		unmarshal = json.Unmarshal
+	default:
+		return nil, fmt.Errorf("unable to handle file %q extension %s", file, ext)
+	}
+
+	raw, err := afero.ReadFile(fs, file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file %q: %v", file, err)
+	}
+	var vs []T
+	if err := unmarshal(raw, &vs); err != nil {
+		return nil, fmt.Errorf("unable to process file %q: %v", file, err)
+	}
+	return vs, nil
+}
+
+func parseSpaceLines[T any](r io.Reader) ([]T, error) {
+	var typ reflect.Type
+	{
+		var v T
+		typ = reflect.TypeOf(v)
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, errors.New("internal type to decode into is not a struct")
+	}
+
+	var vs []T
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		if len(line) == 0 || strings.HasPrefix(line, "// ") {
+			continue
+		}
+		fields := strings.Split(line, " ")
+		if len(fields) != typ.NumField() {
+			fields = strings.Split(line, "\t")
+			if len(fields) != typ.NumField() {
+				return nil, fmt.Errorf("short line: saw %d out of %d fields", len(fields), typ.NumField())
+			}
+		}
+
+		var v T
+		val := reflect.Indirect(reflect.ValueOf(&v))
+		for i := 0; i < typ.NumField(); i++ {
+			sf := val.Field(i)
+			f := fields[i]
+			switch {
+			case sf.Type().Kind() == reflect.String:
+				sf.SetString(f)
+			case sf.Type().Kind() == reflect.Bool:
+				p, err := strconv.ParseBool(f)
+				if err != nil {
+					return nil, fmt.Errorf("unable to decode %s as a bool", f)
+				}
+				sf.SetBool(p)
+			case sf.CanInt():
+				p, err := strconv.ParseInt(f, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("unable to decode %s as an int", f)
+				}
+				sf.SetInt(p)
+			case sf.CanUint():
+				p, err := strconv.ParseUint(f, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("unable to decode %s as a uint", f)
+				}
+				sf.SetUint(p)
+			case sf.CanFloat():
+				p, err := strconv.ParseFloat(f, 64)
+				if err != nil {
+					return nil, fmt.Errorf("unable to decode %s as a float", f)
+				}
+				sf.SetFloat(p)
+			default:
+				return nil, fmt.Errorf("internal type to decode into has unhandled field type %v", sf.Type().Kind())
+			}
+		}
+		vs = append(vs, v)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return vs, nil
+}

--- a/src/go/rpk/pkg/out/in_test.go
+++ b/src/go/rpk/pkg/out/in_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/testfs"
+)
+
+func TestParseFileArray(t *testing.T) {
+	fs := testfs.FromMap(map[string]testfs.Fmode{
+		"/t1": {
+			Mode: 0o666,
+			Contents: `first 3 fields true 12 0
+
+second 4 str false 4.4 2
+// comment line
+third 5 s2 true 3 0
+`,
+		},
+
+		"/t2.txt": {
+			Mode:     0o666,
+			Contents: `text	0	file	false	3.2	3`,
+		},
+
+		"/t3.json": {
+			Mode: 0o666,
+			Contents: `[{
+	"f1": "json",
+	"f3": "file",
+	"f6": 1,
+	"f4": true
+}, {
+	"f2": 3
+}]`,
+		},
+
+		"/t4.yaml": {
+			Mode: 0o666,
+			Contents: `
+- f1: yaml
+  f3: easier
+- f5: 3.2
+  f3: yamly
+  f6: 9
+ `,
+		},
+
+		"/t5": {
+			Mode:     0o666,
+			Contents: "short line\n",
+		},
+		"/t6": {
+			Mode:     0o666,
+			Contents: "nonbool 4 str FAIL 4.4 2\n",
+		},
+		"/t7": {
+			Mode:     0o666,
+			Contents: "nonint FAIL str false 4.4 2\n",
+		},
+		"/t8": {
+			Mode:     0o666,
+			Contents: "nonuint 3 str false 4.4 FAIL\n",
+		},
+		"/t9": {
+			Mode:     0o666,
+			Contents: "nonfloat 3 str false FAIL 3\n",
+		},
+	})
+
+	type S struct {
+		F1 string  `json:"f1" yaml:"f1"`
+		F2 int     `json:"f2" yaml:"f2"`
+		F3 string  `json:"f3" yaml:"f3"`
+		F4 bool    `json:"f4" yaml:"f4"`
+		F5 float32 `json:"f5" yaml:"f5"`
+		F6 uint32  `json:"f6" yaml:"f6"`
+	}
+
+	for _, test := range []struct {
+		file   string
+		exp    []S
+		expErr bool
+	}{
+		{
+			file: "/t1",
+			exp: []S{
+				{"first", 3, "fields", true, 12, 0},
+				{"second", 4, "str", false, 4.4, 2},
+				{"third", 5, "s2", true, 3, 0},
+			},
+		},
+		{
+			file: "/t2.txt",
+			exp: []S{
+				{"text", 0, "file", false, 3.2, 3},
+			},
+		},
+		{
+			file: "/t3.json",
+			exp: []S{
+				{"json", 0, "file", true, 0, 1},
+				{"", 3, "", false, 0, 0},
+			},
+		},
+		{
+			file: "/t4.yaml",
+			exp: []S{
+				{"yaml", 0, "easier", false, 0, 0},
+				{"", 0, "yamly", false, 3.2, 9},
+			},
+		},
+
+		{file: "/t5", expErr: true},
+		{file: "/t6", expErr: true},
+		{file: "/t7", expErr: true},
+		{file: "/t8", expErr: true},
+		{file: "/t9", expErr: true},
+	} {
+		t.Run(test.file, func(t *testing.T) {
+			got, err := ParseFileArray[S](fs, test.file)
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("got err? %v, exp err? %v", gotErr, test.expErr)
+			}
+			if gotErr || test.expErr {
+				return
+			}
+			if !reflect.DeepEqual(got, test.exp) {
+				t.Errorf("got %#v != exp %#v", got, test.exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We sometimes want to read input from files. We already do this for `rpk group seek`, and we are adding it to `rpk acl users create`.

This adds the ability to read json, yaml, or tab/space delimited files directly into types. For json and yaml, the types need struct tags and the files will have keyed structs.

## Release notes

* none