### PR TITLE
tools/dev_cluster.py improvements

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -61,10 +61,9 @@ class Redpanda:
         self.process = None
 
     async def run(self):
-        self.process = await asyncio.create_subprocess_exec(
-            self.binary,
-            "--redpanda-cfg",
-            self.config,
+        log_path = pathlib.Path(os.path.dirname(self.config)) / "redpanda.log"
+        self.process = await asyncio.create_subprocess_shell(
+            f"{self.binary} --redpanda-cfg {self.config} 2>&1 | tee -i {log_path}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT)
 

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -21,11 +21,15 @@ import yaml
 import dataclasses
 import argparse
 import sys
+import os
+import shutil
 
 try:
     from rich import print
 except ImportError:
     pass
+
+BOOTSTRAP_YAML = ".bootstrap.yaml"
 
 
 @dataclasses.dataclass
@@ -158,6 +162,12 @@ async def main():
                       f,
                       indent=2,
                       Dumper=get_config_dumper())
+
+        # If there is a bootstrap file in pwd, propagate it to each node's
+        # directory so that they'll load it on first start
+        if os.path.exists(BOOTSTRAP_YAML):
+            shutil.copyfile(BOOTSTRAP_YAML, node_dir / BOOTSTRAP_YAML)
+
         return config, conf_file
 
     configs = [prepare_node(i) for i in range(args.nodes)]


### PR DESCRIPTION

- Enable it to handle a .bootstrap.yaml file: that's how I configure tiered storage backend/bucket when doing local development
- Take each node's log into a separate file with a `tee` attached to each one.  Doing a shell-style subprocess is a little kludgy, but writing line by line from the python is a bit inefficient and also would require an extra library to do it async.

## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
