### PR TITLE
[v22.3.x] cloud_storage: handle infinite retention tristates

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -62,7 +62,6 @@ enum class errc : int16_t {
     invalid_request,
     no_update_in_progress,
     unknown_update_interruption_error,
-    invalid_retention_configuration,
     throttling_quota_exceeded,
     cluster_already_exists,
 };
@@ -179,10 +178,6 @@ struct errc_category final : public std::error_category {
             return "Partition configuration is not being updated";
         case errc::unknown_update_interruption_error:
             return "Error while cancelling partition reconfiguration";
-        case errc::invalid_retention_configuration:
-            return "retention.bytes and retention.ms must be greater or equal "
-                   "than retention.local.target.bytes and "
-                   "retention.local.target.ms respectively";
         case errc::throttling_quota_exceeded:
             return "Request declined due to exceeded requests quotas";
         case errc::cluster_already_exists:

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -478,24 +478,6 @@ errc topics_frontend::validate_topic_configuration(
         }
     }
 
-    const auto& properties = assignable_config.cfg.properties;
-
-    if (
-      properties.retention_bytes.has_value()
-      && properties.retention_local_target_bytes.has_value()
-      && properties.retention_bytes.value()
-           < properties.retention_local_target_bytes.value()) {
-        return errc::invalid_retention_configuration;
-    }
-
-    if (
-      properties.retention_duration.has_value()
-      && properties.retention_local_target_ms.has_value()
-      && properties.retention_duration.value()
-           < properties.retention_local_target_ms.value()) {
-        return errc::invalid_retention_configuration;
-    }
-
     return errc::success;
 }
 

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -19,7 +19,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::success:
         return error_code::none;
     case cluster::errc::topic_invalid_config:
-    case cluster::errc::invalid_retention_configuration:
         return error_code::invalid_config;
     case cluster::errc::topic_invalid_partitions:
         return error_code::invalid_partitions;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -157,19 +157,31 @@ public:
     }
 
     std::optional<size_t> retention_bytes() const {
-        if (!_overrides || !_overrides->retention_bytes.has_value()) {
-            return config::shard_local_cfg().retention_bytes();
+        if (_overrides) {
+            // Handle the special "-1" case.
+            if (_overrides->retention_bytes.is_disabled()) {
+                return std::nullopt;
+            }
+            if (_overrides->retention_bytes.has_value()) {
+                return _overrides->retention_bytes.value();
+            }
+            // If no value set, fall through and use the cluster-wide default.
         }
-
-        return _overrides->retention_bytes.value();
+        return config::shard_local_cfg().retention_bytes();
     }
 
     std::optional<std::chrono::milliseconds> retention_duration() const {
-        if (!_overrides || !_overrides->retention_time.has_value()) {
-            return config::shard_local_cfg().delete_retention_ms();
+        if (_overrides) {
+            // Handle the special "-1" case.
+            if (_overrides->retention_time.is_disabled()) {
+                return std::nullopt;
+            }
+            if (_overrides->retention_time.has_value()) {
+                return _overrides->retention_time.value();
+            }
+            // If no value set, fall through and use the cluster-wide default.
         }
-
-        return _overrides->retention_time.value();
+        return config::shard_local_cfg().delete_retention_ms();
     }
 
     bool is_archival_enabled() const {

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -71,6 +71,10 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             ]
         if spec.segment_bytes is not None:
             args += ["--config", f"segment.bytes={spec.segment_bytes}"]
+        if spec.retention_bytes:
+            args += ["--config", f"retention.bytes={spec.retention_bytes}"]
+        if spec.retention_ms:
+            args += ["--config", f"retention.ms={spec.retention_ms}"]
         return self._run("kafka-topics.sh", args)
 
     def create_topic_partitions(self, topic, partitions):

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from time import sleep
 from ducktape.errors import TimeoutError
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
@@ -439,6 +440,98 @@ class ShadowIndexingRetentionTest(RedpandaTest):
 
         # Test that the size of the cloud log is below the retention threshold
         # by querying the manifest.
+        wait_until(lambda: cloud_log_size() <= retention_bytes,
+                   timeout_sec=10,
+                   backoff_sec=2,
+                   err_msg=f"Too many bytes in the cloud")
+
+    @cluster(num_nodes=1)
+    def test_cloud_size_based_retention_application(self):
+        """
+        Test that retention is enforced when applied to topics that initially
+        have all SI settings disabled.
+        """
+        total_bytes = 20 * self.segment_size
+        retention_bytes = 10 * self.segment_size
+        cs_housekeeping_interval = 100
+
+        topic = TopicSpec(name=self.topic_name,
+                          partition_count=1,
+                          replication_factor=1,
+                          cleanup_policy=TopicSpec.CLEANUP_DELETE)
+
+        # Cluster-wide settings have remote_read & remote_write enabled
+        self.redpanda.set_cluster_config(
+            {
+                "cloud_storage_enable_remote_write": True,
+                "cloud_storage_enable_remote_read": True,
+                "cloud_storage_housekeeping_interval_ms":
+                cs_housekeeping_interval
+            },
+            expect_restart=True)
+
+        # However, topic settings have main SI functionality disabled
+        self.rpk.create_topic(topic=topic.name,
+                              partitions=topic.partition_count,
+                              replicas=topic.replication_factor,
+                              config={
+                                  "cleanup.policy": topic.cleanup_policy,
+                                  "redpanda.remote.write": "false",
+                                  "redpanda.remote.read": "false",
+                              })
+
+        before_alter = self.rpk.describe_topic_configs(topic.name)
+        assert before_alter['redpanda.remote.write'][0] == 'false'
+        assert before_alter['redpanda.remote.read'][0] == 'false'
+
+        # Write some data to the topic, and assert that nothing has been
+        # written out to S3
+        produce_total_bytes(self.redpanda,
+                            topic=self.topic_name,
+                            partition_index=0,
+                            bytes_to_produce=total_bytes)
+
+        def ntp_in_manifest() -> int:
+            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+                                     self.s3_bucket_name, self.logger)
+            return s3_snapshot.is_ntp_in_manifest(topic.name, 0)
+
+        # Sleep for 4 cloud_storage_housekeeping_interval_ms, then assert ntp does
+        # not exist in manifest
+        sleep(4 * cs_housekeeping_interval * 0.001)
+        assert not ntp_in_manifest(
+        ), "Segment uploaded, when it should not exist"
+
+        # Now modify topic properties to enable SI read/write for the topic
+        self.rpk.alter_topic_config(topic.name, "redpanda.remote.write",
+                                    "true")
+        self.rpk.alter_topic_config(topic.name, "redpanda.remote.read", "true")
+        after_alter = self.rpk.describe_topic_configs(topic.name)
+        assert after_alter['redpanda.remote.write'][0] == 'true'
+        assert after_alter['redpanda.remote.read'][0] == 'true'
+
+        # Wait for upload to occur first
+        wait_until(lambda: ntp_in_manifest(), timeout_sec=10)
+
+        def cloud_log_size() -> int:
+            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+                                     self.s3_bucket_name, self.logger)
+            cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
+            self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
+            return cloud_log_size
+
+        # Wait for everything to be uploaded to the cloud.
+        wait_until(lambda: cloud_log_size() >= total_bytes,
+                   timeout_sec=10,
+                   backoff_sec=2,
+                   err_msg=f"Segments not uploaded")
+
+        # Modify retention settings
+        self.client().alter_topic_configs(
+            topic.name, {TopicSpec.PROPERTY_RETENTION_BYTES: retention_bytes})
+
+        # Assert that retention policy has kicked in and with the desired
+        # effect, i.e. total bytes is <= retention settings applied
         wait_until(lambda: cloud_log_size() <= retention_bytes,
                    timeout_sec=10,
                    backoff_sec=2,

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -454,6 +454,13 @@ class S3Snapshot:
             self.logger.info(f'error {e} while checking if {o} is a segment')
             return False
 
+    def is_ntp_in_manifest(self,
+                           topic: str,
+                           partition: int,
+                           ns: str = "kafka") -> bool:
+        ntp = NTP(ns, topic, partition)
+        return ntp in self.partition_manifests
+
     def manifest_for_ntp(self,
                          topic: str,
                          partition: int,


### PR DESCRIPTION
Manual backport of #7747. No functional changes were required for the backport.

## Release Notes

  ### Bug Fixes

  * Redpanda will now correctly honor negative values to mean an infinite value for the `retention.ms` and `retention.bytes` topic configurations.
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.


  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
