### PR TITLE
tests: ClusterConfigUpgradeTest clean on start

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -54,6 +54,12 @@ class ClusterConfigUpgradeTest(RedpandaTest):
         node = self.redpanda.nodes[0]
         admin = Admin(self.redpanda)
 
+        # Since we skip RedpandaService.start, must clean node explicitly
+        self.redpanda.clean_node(node)
+
+        # Start node outside of the usual RedpandaService.start, so that we
+        # skip writing out bootstrap.yaml files (the presence of which disables
+        # the upgrade import of values from redpanda.yaml)
         self.redpanda.start_node(
             node, override_cfg_params={'delete_retention_ms': '9876'})
 


### PR DESCRIPTION
This test was vulnerable to failing if other tests had left a node in a bad state.

Fixes https://github.com/redpanda-data/redpanda/issues/7755

## Backports Required

Backporting just one hop, because if this was an issue in practice on older branches I would expect to have seen it before.

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
