### PR TITLE
sr: add /restart endpoint

### DIFF
--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -70,4 +70,9 @@ ss::future<> api::stop() {
     }
 }
 
+ss::future<> api::restart() {
+    co_await stop();
+    co_await start();
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -42,6 +42,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> restart();
 
 private:
     model::node_id _node_id;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -11,7 +11,8 @@ set(swags
   transaction
   cluster
   debug
-  shadow_indexing)
+  shadow_indexing
+  redpanda_services_restart)
 
 set(swag_files)
 foreach(swag ${swags})

--- a/src/v/redpanda/admin/api-doc/redpanda_services_restart.json
+++ b/src/v/redpanda/admin/api-doc/redpanda_services_restart.json
@@ -1,0 +1,31 @@
+"/v1/redpanda-services/restart": {
+  "put": {
+    "summary": "Restart a redpanda service.",
+    "operationId": "redpanda_services_restart",
+    "parameters": [
+      {
+        "name": "service",
+        "in": "query",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "Restart success"
+      },
+      "400": {
+        "description": "Service name is required"
+      },
+      "404": {
+        "description": "Service not found"
+      },
+      "500": {
+        "description": "Internal Server error"
+      }
+    }
+  }
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -639,7 +639,8 @@ void application::configure_admin_server() {
       std::ref(metadata_cache),
       std::ref(_connection_cache),
       std::ref(node_status_table),
-      std::ref(self_test_frontend))
+      std::ref(self_test_frontend),
+      _schema_registry.get())
       .get();
 }
 

--- a/src/v/redpanda/rp_services.h
+++ b/src/v/redpanda/rp_services.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/string_switch.h"
+
+#include <type_traits>
+
+enum class service_kind {
+    schema_registry,
+};
+
+constexpr std::string_view to_string_view(service_kind kind) {
+    switch (kind) {
+    case service_kind::schema_registry:
+        return "schema-registry";
+    }
+    return "invalid";
+}
+
+template<typename E>
+std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
+  from_string_view(std::string_view);
+
+template<>
+constexpr std::optional<service_kind>
+from_string_view<service_kind>(std::string_view sv) {
+    return string_switch<std::optional<service_kind>>(sv)
+      .match(
+        to_string_view(service_kind::schema_registry),
+        service_kind::schema_registry)
+      .default_match(std::nullopt);
+}

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -785,3 +785,8 @@ class Admin:
 
     def self_test_status(self):
         return self._request("GET", "debug/self_test/status").json()
+
+    def redpanda_services_restart(self, rp_service: Optional[str] = None):
+        service_param = f"service={rp_service if rp_service is not None else ''}"
+        return self._request("PUT",
+                             f"redpanda-services/restart?{service_param}")

--- a/tests/rptest/tests/restart_services_test.py
+++ b/tests/rptest/tests/restart_services_test.py
@@ -1,0 +1,62 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import requests
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.redpanda import ResourceSettings, LoggingConfig, SchemaRegistryConfig
+
+log_config = LoggingConfig('info',
+                           logger_levels={
+                               'admin_api_server': 'trace',
+                               'security': 'trace',
+                               'pandaproxy': 'trace',
+                               'kafka/client': 'trace'
+                           })
+
+
+class RestartServicesTest(RedpandaTest):
+    #
+    # Smoke test the redpanda-services/restart Admin API endpoint
+    #
+    def __init__(self, context, **kwargs):
+        super(RestartServicesTest, self).__init__(
+            context,
+            extra_rp_conf={"auto_create_topics_enabled": False},
+            resource_settings=ResourceSettings(num_cpus=1),
+            log_config=log_config,
+            schema_registry_config=SchemaRegistryConfig(),
+            **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_restart_services(self):
+        admin = Admin(self.redpanda)
+
+        # Failure checks
+        self.logger.debug("Check restart with no service name")
+        try:
+            admin.redpanda_services_restart()
+        except requests.exceptions.HTTPError as ex:
+            self.logger.debug(ex)
+            assert ex.response.status_code == requests.codes.bad_request
+
+        self.logger.debug("Check restart with invalid service name")
+        try:
+            admin.redpanda_services_restart(rp_service='foobar')
+        except requests.exceptions.HTTPError as ex:
+            self.logger.debug(ex)
+            assert ex.response.status_code == requests.codes.not_found
+
+        self.logger.debug("Check schema registry restart")
+        result_raw = admin.redpanda_services_restart(
+            rp_service='schema-registry')
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok


### PR DESCRIPTION
## Cover letter

Adds a new endpoint that manually triggers a restart of the in-memory schema store. To accomplish this, first we stop the Kafka client, wipe the store contents, restart the client, and finally re-fill the store with the data held in the _schemas topic.

Fixes #7656

Changes from force-push `ce0b3e3`:
- Fix DT test typos
- Use `put` instead of `get`
- Rename `/restart` to `/redpanda/admin/restart_schema_store`
- Return `no_content` instead of `ok` status
- No need to check `is_empty` on the schema store internal structures
- No need to skip topic creation
- Just reset `_is_started` to false
- Reset `_next_schema_id` as well

Changes from force-push `599d9da`:
- Resolve merge conflicts
- Clear sequence writer state
- Clear kafka client state
- Pass the service name as a query param (e.g., `admin/redpanda-services/restart?service=schema-registry`)

Changes from force-push `27b0866`:
- Split the commits so they are more clear
- Use `request` object to access the schema registry `service::mittigate_error` method

Changes from force-push `649c202`:
- Support Basic Auth in `remote_script/schema_registry_test_helper.py`
- Using the `concurrent_writes` test to generate some load before and after issuing the restart

Changes from force-push `8f629b7`:
- Move the endpoint to the Admin API
- Return 404 when the service is incorrect
- Typos

Changes from force-push `722da04`:
- Edit `redpanda_services_restart.json` to follow correct swagger syntax
- Remove `service_kind::none`
- Check for empty service name in DT test
- Improve DT test to check schema values before and after restart

Changes from force-push `3f095c1`:
- Move failure tests into their own DT test file
- Do not associate schema Id with subject version
- Add 400 status to swagger json file
- Remove redundant checks
- Typos
- Log the service name in more places

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Users can now restart the schema registry by issuing a PUT request to `admin/redpanda-services/restart?service=schema-registry`. This request will wipe schema registry state.

## Release Notes

### Improvements

* Adds a new endpoint to the schema registry that clears the in-memory data.