### PR TITLE
[v22.2.x] kafka/client: Improve connection error handling

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -12,6 +12,7 @@
 #include "cluster/cluster_utils.h"
 #include "kafka/client/logger.h"
 #include "kafka/client/sasl_client.h"
+#include "net/connection.h"
 #include "net/dns.h"
 
 #include <seastar/core/coroutine.hh>
@@ -45,9 +46,7 @@ ss::future<shared_broker_t> make_broker(
             });
       })
       .handle_exception_type([node_id](const std::system_error& ex) {
-          if (
-            ex.code() == std::errc::host_unreachable
-            || ex.code() == std::errc::connection_refused) {
+          if (net::is_reconnect_error(ex)) {
               return ss::make_exception_future<shared_broker_t>(
                 broker_error(node_id, error_code::network_exception));
           }

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -196,9 +196,7 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     } catch (const ss::gate_closed_exception&) {
         vlog(kclog.debug, "gate_closed_exception");
     } catch (const std::system_error& ex) {
-        if (
-          ex.code() == std::errc::broken_pipe
-          || ex.code() == std::errc::timed_out) {
+        if (net::is_reconnect_error(ex)) {
             vlog(kclog.debug, "system_error: {}", ex);
             return _wait_or_start_update_metadata();
         } else {

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -11,7 +11,44 @@
 
 #include "rpc/service.h"
 
+#include <gnutls/gnutls.h>
+
 namespace net {
+
+/**
+ * Identify error cases that should be quickly retried, e.g.
+ * TCP disconnects, timeouts. Network errors may also show up
+ * indirectly as errors from the TLS layer.
+ */
+bool is_reconnect_error(const std::system_error& e) {
+    auto v = e.code().value();
+
+    // The name() of seastar's gnutls_error_category class
+    constexpr std::string_view gnutls_category_name{"GnuTLS"};
+
+    if (e.code().category().name() == gnutls_category_name) {
+        switch (v) {
+        case GNUTLS_E_PUSH_ERROR:
+        case GNUTLS_E_PULL_ERROR:
+        case GNUTLS_E_PREMATURE_TERMINATION:
+            return true;
+        default:
+            return false;
+        }
+    } else {
+        switch (v) {
+        case ECONNREFUSED:
+        case ENETUNREACH:
+        case ETIMEDOUT:
+        case ECONNRESET:
+        case EPIPE:
+            return true;
+        default:
+            return false;
+        }
+    }
+    __builtin_unreachable();
+}
 
 /**
  * If the exception is a "boring" disconnection case, then populate this with

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -28,6 +28,7 @@
  */
 namespace net {
 
+bool is_reconnect_error(const std::system_error& e);
 std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr);
 
 class connection : public boost::intrusive::list_base_hook<> {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -187,10 +187,11 @@ class SchemaRegistryTest(RedpandaTest):
                              f"schemas/ids/{id}/versions",
                              headers=headers)
 
-    def _get_subjects(self, deleted=False, headers=HTTP_GET_HEADERS):
+    def _get_subjects(self, deleted=False, headers=HTTP_GET_HEADERS, **kwargs):
         return self._request("GET",
                              f"subjects{'?deleted=true' if deleted else ''}",
-                             headers=headers)
+                             headers=headers,
+                             **kwargs)
 
     def _post_subjects_subject(self,
                                subject,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7735

Added a commit from #7212
Conflict in client.cc (indentation)
Skipped the commit for ephemeral_credentials (_external_mitigate)
Add a tiny commit to pass args for the tests
Minor conflict in the ducktape tests
Dropped the test for moving partition leader as it isn't correct on this branch.