### PR TITLE
[v22.1.x] kafka/client: Improve connection error handling

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_storage/logger.h"
 #include "cloud_storage/types.h"
+#include "net/connection.h"
 #include "s3/client.h"
 #include "ssx/sformat.h"
 #include "utils/intrusive_list_helpers.h"
@@ -106,17 +107,14 @@ static error_outcome categorize_error(
         // - any filesystem error
         // - broken-pipe
         // - any other network error (no memory, bad socket, etc)
-        if (auto code = cerr.code();
-            code.value() != ECONNREFUSED && code.value() != ENETUNREACH
-            && code.value() != ETIMEDOUT && code.value() != ECONNRESET
-            && code.value() != EPIPE) {
-            vlog(ctxlog.error, "System error {}", cerr);
-            result = error_outcome::fail;
-        } else {
+        if (net::is_reconnect_error(cerr)) {
             vlog(
               ctxlog.warn,
               "System error susceptible for retry {}",
               cerr.what());
+        } else {
+            vlog(ctxlog.error, "System error {}", cerr);
+            result = error_outcome::fail;
         }
     } catch (const ss::timed_out_error& terr) {
         // This should happen when the connection pool was disconnected

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -12,6 +12,7 @@
 #include "cluster/cluster_utils.h"
 #include "kafka/client/logger.h"
 #include "kafka/client/sasl_client.h"
+#include "net/connection.h"
 #include "net/dns.h"
 
 #include <seastar/core/coroutine.hh>
@@ -43,9 +44,7 @@ ss::future<shared_broker_t> make_broker(
             });
       })
       .handle_exception_type([node_id](const std::system_error& ex) {
-          if (
-            ex.code() == std::errc::host_unreachable
-            || ex.code() == std::errc::connection_refused) {
+          if (net::is_reconnect_error(ex)) {
               return ss::make_exception_future<shared_broker_t>(
                 broker_error(node_id, error_code::network_exception));
           }

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -196,9 +196,7 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     } catch (const ss::gate_closed_exception&) {
         vlog(kclog.debug, "gate_closed_exception");
     } catch (const std::system_error& ex) {
-        if (
-          ex.code() == std::errc::broken_pipe
-          || ex.code() == std::errc::timed_out) {
+        if (net::is_reconnect_error(ex)) {
             vlog(kclog.debug, "system_error: {}", ex);
             return _wait_or_start_update_metadata();
         } else {

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -28,6 +28,8 @@
  */
 namespace net {
 
+bool is_reconnect_error(const std::system_error& e);
+
 class connection : public boost::intrusive::list_base_hook<> {
 public:
     connection(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -187,10 +187,11 @@ class SchemaRegistryTest(RedpandaTest):
                              f"schemas/ids/{id}/versions",
                              headers=headers)
 
-    def _get_subjects(self, deleted=False, headers=HTTP_GET_HEADERS):
+    def _get_subjects(self, deleted=False, headers=HTTP_GET_HEADERS, **kwargs):
         return self._request("GET",
                              f"subjects{'?deleted=true' if deleted else ''}",
-                             headers=headers)
+                             headers=headers,
+                             **kwargs)
 
     def _post_subjects_subject(self,
                                subject,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7735

Added a commit from #7212
Conflict in client.cc (indentation)
Skipped the commit for ephemeral_credentials (_external_mitigate)
Add a tiny commit to pass args for the tests
Minor conflict in the ducktape tests
Dropped the test for moving partition leader