### PR TITLE
Fix quadratic behavior in notify_waiters

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -650,22 +650,16 @@ void topic_table::notify_waiters() {
     /// function_ptrs stored in \ref notifications, without consuming all
     /// pending_deltas for when a subsequent waiter does arrive
 
-    std::vector<delta> changes;
-
     // \ref notify_waiters is called after every apply. Hence for the most
     // part there should only be a few items towards the end of \ref
     // _pending_deltas that need to be sent to callbacks in \ref
     // notifications. \ref _last_consumed_by_notifier_offset allows us to
     // skip ahead to the items added since the last \ref notify_waiters
     // call.
-    auto starting_iter = _pending_deltas.begin()
+    auto starting_iter = _pending_deltas.cbegin()
                          + _last_consumed_by_notifier_offset;
 
-    std::copy_if(
-      starting_iter,
-      _pending_deltas.end(),
-      std::back_inserter(changes),
-      [this](const delta& d) { return d.offset > _last_consumed_by_notifier; });
+    std::span changes{starting_iter, _pending_deltas.cend()};
 
     if (!changes.empty()) {
         for (auto& cb : _notifications) {

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -647,23 +647,40 @@ void topic_table::notify_waiters() {
     /// If by invocation of this method there are no waiters, notify
     /// function_ptrs stored in \ref notifications, without consuming all
     /// pending_deltas for when a subsequent waiter does arrive
+
     std::vector<delta> changes;
+
+    // \ref notify_waiters is called after every apply. Hence for the most
+    // part there should only be a few items towards the end of \ref
+    // _pending_deltas that need to be sent to callbacks in \ref
+    // notifications. \ref _last_consumed_by_notifier_offset allows us to
+    // skip ahead to the items added since the last \ref notify_waiters
+    // call.
+    auto starting_iter = _pending_deltas.begin()
+                         + _last_consumed_by_notifier_offset;
+
     std::copy_if(
-      _pending_deltas.begin(),
+      starting_iter,
       _pending_deltas.end(),
       std::back_inserter(changes),
       [this](const delta& d) { return d.offset > _last_consumed_by_notifier; });
-    for (auto& cb : _notifications) {
-        cb.second(changes);
-    }
+
     if (!changes.empty()) {
+        for (auto& cb : _notifications) {
+            cb.second(changes);
+        }
+
         _last_consumed_by_notifier = changes.back().offset;
     }
+
+    _last_consumed_by_notifier_offset = _pending_deltas.end()
+                                        - _pending_deltas.begin();
 
     /// Consume all pending deltas
     if (!_waiters.empty()) {
         changes.clear();
         changes.swap(_pending_deltas);
+        _last_consumed_by_notifier_offset = 0;
         std::vector<std::unique_ptr<waiter>> active_waiters;
         active_waiters.swap(_waiters);
         for (auto& w : active_waiters) {
@@ -678,6 +695,11 @@ topic_table::wait_for_changes(ss::abort_source& as) {
     if (!_pending_deltas.empty()) {
         ret_t ret;
         ret.swap(_pending_deltas);
+        // \ref notify_waiters uses this member to skip ahead in \ref
+        // _pending_deltas to items not yet sent to callbacks in \ref
+        // _notifications. Since we are clearing \ref _pending_deltas here we
+        // need to clear this member too.
+        _last_consumed_by_notifier_offset = 0;
         return ss::make_ready_future<ret_t>(std::move(ret));
     }
     auto w = std::make_unique<waiter>(_waiter_id++);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -23,6 +23,8 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
 
+#include <span>
+
 namespace cluster {
 
 /// Topic table represent all topics configuration and partition assignments.
@@ -170,8 +172,7 @@ public:
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
 
-    using delta_cb_t
-      = ss::noncopyable_function<void(const std::vector<delta>&)>;
+    using delta_cb_t = ss::noncopyable_function<void(std::span<const delta>)>;
 
     explicit topic_table()
       : _probe(*this){};

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -413,6 +413,7 @@ private:
     uint64_t _waiter_id{0};
     model::offset _last_consumed_by_notifier{
       model::model_limits<model::offset>::min()};
+    std::vector<delta>::difference_type _last_consumed_by_notifier_offset{0};
     topic_table_probe _probe;
 };
 

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -72,7 +72,7 @@ private:
     ss::future<> add_to_shard_table(
       model::ntp ntp, ss::shard_id shard, model::revision_id revision);
 
-    void enqueue_events(std::vector<update_t>);
+    void enqueue_events(std::span<const update_t>);
     ss::future<> process_loop();
 
     bool stale_create_non_replicable_partition_request(

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -93,7 +93,7 @@ ss::future<> group_manager::start() {
      */
     _topic_table_notify_handle
       = _topic_table.local().register_delta_notification(
-        [this](const std::vector<cluster::topic_table::delta>& deltas) {
+        [this](std::span<const cluster::topic_table::delta> deltas) {
             handle_topic_delta(deltas);
         });
 
@@ -213,7 +213,7 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
 }
 
 void group_manager::handle_topic_delta(
-  const std::vector<cluster::topic_table_delta>& deltas) {
+  std::span<const cluster::topic_table_delta> deltas) {
     // topic-partition deletions in the kafka namespace are the only deltas that
     // are relevant to the group manager
     std::vector<model::topic_partition> tps;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -41,6 +41,8 @@
 #include <absl/container/node_hash_map.h>
 #include <cluster/partition_manager.h>
 
+#include <span>
+
 namespace kafka {
 
 /*
@@ -219,7 +221,7 @@ private:
       ss::lw_shared_ptr<cluster::partition>,
       std::optional<model::node_id>);
 
-    void handle_topic_delta(const std::vector<cluster::topic_table_delta>&);
+    void handle_topic_delta(std::span<const cluster::topic_table_delta>);
 
     ss::future<> cleanup_removed_topic_partitions(
       const std::vector<model::topic_partition>&);


### PR DESCRIPTION
From issue 7665; 

> Consider when recovering a large topic with many deltas and when _waiters is empty. The deltas are applied from the log one-by-one and notify_waiters is called after each addition. Then the copy_if will traverse the entire pending deltas every time, so we have O(n^2) behavior in the number of deltas.

This PR reduces the behavior to O(n) by storing the last sent index of `_pending_deltas`

Fixes #7665
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
none