### PR TITLE
rpk: set group_initial_rebalance_delay=0 in dev-container

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1043,6 +1043,7 @@ func setContainerModeCfgFields(cfg *config.Config) {
 	cfg.Redpanda.Other["storage_min_free_bytes"] = 10485760
 	cfg.Redpanda.Other["topic_partitions_per_shard"] = 1000
 	cfg.Redpanda.Other["fetch_reads_debounce_timeout"] = 10
+	cfg.Redpanda.Other["group_initial_rebalance_delay"] = 0
 }
 
 func getOrFindInstallDir(fs afero.Fs, installDir string) (string, error) {
@@ -1071,6 +1072,7 @@ environments:
         * storage_min_free_bytes: 10485760 (10MiB)
         * topic_partitions_per_shard: 1000
         * fetch_reads_debounce_timeout: 10
+        * group_initial_rebalance_delay: 0
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -244,11 +244,12 @@ func TestStartCommand(t *testing.T) {
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 
 			conf, err := new(config.Params).Load(fs)
@@ -1484,11 +1485,12 @@ func TestStartCommand(t *testing.T) {
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},
@@ -1534,11 +1536,12 @@ func TestStartCommand(t *testing.T) {
 
 			// Config:
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
@@ -1577,9 +1580,10 @@ func TestStartCommand(t *testing.T) {
 				"auto_create_topics_enabled": false,
 				"group_topic_partitions":     1,
 				// rest of --mode dev-container cfg fields
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Exactly(st, expectedClusterFields, conf.Redpanda.Other)
 		},

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -139,7 +139,8 @@ class RpkRedpandaStartTest(RedpandaTest):
             "group_topic_partitions": "3",
             "storage_min_free_bytes": "10485760",
             "topic_partitions_per_shard": "1000",
-            "fetch_reads_debounce_timeout": "10"
+            "fetch_reads_debounce_timeout": "10",
+            "group_initial_rebalance_delay": "0"
         }
 
         for p in expected_cluster_properties:


### PR DESCRIPTION
Fixes: #7761

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Improvements

* Set group_initial_rebalance_delay=0 in dev container mode. The default setting adds a 3s delay when using consumers groups in unit tests and is a bad UX.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
