### PR TITLE
[v22.3.x] rpk: set group_initial_rebalance_delay=0 in dev-container

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1043,6 +1043,7 @@ func setContainerModeCfgFields(cfg *config.Config) {
 	cfg.Redpanda.Other["storage_min_free_bytes"] = 10485760
 	cfg.Redpanda.Other["topic_partitions_per_shard"] = 1000
 	cfg.Redpanda.Other["fetch_reads_debounce_timeout"] = 10
+	cfg.Redpanda.Other["group_initial_rebalance_delay"] = 0
 }
 
 func getOrFindInstallDir(fs afero.Fs, installDir string) (string, error) {
@@ -1071,6 +1072,7 @@ environments:
         * storage_min_free_bytes: 10485760 (10MiB)
         * topic_partitions_per_shard: 1000
         * fetch_reads_debounce_timeout: 10
+        * group_initial_rebalance_delay: 0
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -244,11 +244,12 @@ func TestStartCommand(t *testing.T) {
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 
 			conf, err := new(config.Params).Load(fs)
@@ -1484,11 +1485,12 @@ func TestStartCommand(t *testing.T) {
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},
@@ -1534,11 +1536,12 @@ func TestStartCommand(t *testing.T) {
 
 			// Config:
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled":   true,
-				"group_topic_partitions":       3,
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
@@ -1577,9 +1580,10 @@ func TestStartCommand(t *testing.T) {
 				"auto_create_topics_enabled": false,
 				"group_topic_partitions":     1,
 				// rest of --mode dev-container cfg fields
-				"storage_min_free_bytes":       10485760,
-				"topic_partitions_per_shard":   1000,
-				"fetch_reads_debounce_timeout": 10,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"fetch_reads_debounce_timeout":  10,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Exactly(st, expectedClusterFields, conf.Redpanda.Other)
 		},

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -137,7 +137,8 @@ class RpkRedpandaStartTest(RedpandaTest):
             "group_topic_partitions": "3",
             "storage_min_free_bytes": "10485760",
             "topic_partitions_per_shard": "1000",
-            "fetch_reads_debounce_timeout": "10"
+            "fetch_reads_debounce_timeout": "10",
+            "group_initial_rebalance_delay": "0"
         }
 
         for p in expected_cluster_properties:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7784
Fixes https://github.com/redpanda-data/redpanda/issues/7785,