### PR TITLE
cloud_storage: avoid double stop on remote_segment

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -66,7 +66,15 @@ ss::future<> materialized_segments::stop() {
     // Do the last pass over the eviction list to stop remaining items returned
     // from readers after the eviction loop stopped.
     for (auto& rs : _eviction_list) {
-        co_await std::visit([](auto&& rs) { return rs->stop(); }, rs);
+        co_await std::visit(
+          [](auto&& rs) {
+              if (!rs->is_stopped()) {
+                  return rs->stop();
+              } else {
+                  return ss::make_ready_future<>();
+              }
+          },
+          rs);
     }
 }
 ss::future<> materialized_segments::start() {

--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -89,8 +89,13 @@ private:
 
         ss::future<> stop() {
             promise.set_value();
+            stopped = true;
             return ss::now();
         }
+
+        bool stopped{false};
+
+        bool is_stopped() const { return stopped; }
     };
 
     using evicted_resource_t = std::variant<

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1062,6 +1062,14 @@ size_t remote_segment_batch_reader::produce(model::record_batch batch) {
 }
 
 ss::future<> remote_segment_batch_reader::stop() {
+    if (_stopped) {
+        vlog(
+          _ctxlog.warn,
+          "remote_segment_batch_reader::stop called when reader already "
+          "stopped");
+        co_return;
+    }
+
     vlog(_ctxlog.debug, "remote_segment_batch_reader::stop");
     co_await _gate.close();
     if (_parser) {

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -153,6 +153,11 @@ const kafka::offset remote_segment::get_base_kafka_offset() const {
 const model::term_id remote_segment::get_term() const { return _term; }
 
 ss::future<> remote_segment::stop() {
+    if (_stopped) {
+        vlog(_ctxlog.warn, "remote segment {} already stopped", _path);
+        co_return;
+    }
+
     vlog(_ctxlog.debug, "remote segment stop");
     _bg_cvar.broken();
     co_await _gate.close();
@@ -163,6 +168,8 @@ ss::future<> remote_segment::stop() {
                 _ctxlog.error, "Error '{}' while closing the '{}'", err, _path);
           });
     }
+
+    _stopped = true;
 }
 
 ss::future<storage::segment_reader_handle>

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -188,6 +188,7 @@ private:
     simple_time_jitter<ss::lowres_clock> _cache_backoff_jitter;
 
     bool _compacted{false};
+    bool _stopped{false};
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -123,6 +123,8 @@ public:
         return _path;
     }
 
+    bool is_stopped() const { return _stopped; }
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available
@@ -261,6 +263,8 @@ public:
     bool reads_from_segment(const remote_segment& segm) const {
         return &segm == _seg.get();
     }
+
+    bool is_stopped() const { return _stopped; }
 
 private:
     friend class single_record_consumer;


### PR DESCRIPTION
When a remote segment is stopped, a flag is set. If there is another call to stop the segment, the flag prevents attempting to stop resources in the segment twice.

Another option would be to just protect stopping of the segment gate with the flag, allowing the rest of the stop method to run as before, but this becomes hard to manage if the code in stop() grows with more resources.

Fixes #7799 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes


  * none

## Release Notes

  * none
