### PR TITLE
rpk: set group_initial_rebalance_delay=0 in dev-container

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1100,6 +1100,7 @@ func setContainerModeCfgFields(cfg *config.Config) {
 	cfg.Redpanda.Other["group_topic_partitions"] = 3
 	cfg.Redpanda.Other["storage_min_free_bytes"] = 10485760
 	cfg.Redpanda.Other["topic_partitions_per_shard"] = 1000
+	cfg.Redpanda.Other["group_initial_rebalance_delay"] = 0
 }
 
 const helpMode = `Mode uses well-known configuration properties for development or tests 
@@ -1116,6 +1117,7 @@ environments:
         * group_topic_partitions: 3
         * storage_min_free_bytes: 10485760 (10MiB)
         * topic_partitions_per_shard: 1000
+        * group_initial_rebalance_delay: 0
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -244,10 +244,11 @@ func TestStartCommand(t *testing.T) {
 			// We are adding now this cluster properties as default with
 			// redpanda.developer_mode: true.
 			c.Redpanda.Other = map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"group_initial_rebalance_delay": 0,
 			}
 
 			conf, err := new(config.Params).Load(fs)
@@ -1403,10 +1404,11 @@ func TestStartCommand(t *testing.T) {
 			require.Equal(st, 0, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},
@@ -1452,10 +1454,11 @@ func TestStartCommand(t *testing.T) {
 
 			// Config:
 			expectedClusterFields := map[string]interface{}{
-				"auto_create_topics_enabled": true,
-				"group_topic_partitions":     3,
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"auto_create_topics_enabled":    true,
+				"group_topic_partitions":        3,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Equal(st, 0, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
@@ -1494,8 +1497,9 @@ func TestStartCommand(t *testing.T) {
 				"auto_create_topics_enabled": false,
 				"group_topic_partitions":     1,
 				// rest of --mode dev-container cfg fields
-				"storage_min_free_bytes":     10485760,
-				"topic_partitions_per_shard": 1000,
+				"storage_min_free_bytes":        10485760,
+				"topic_partitions_per_shard":    1000,
+				"group_initial_rebalance_delay": 0,
 			}
 			require.Exactly(st, expectedClusterFields, conf.Redpanda.Other)
 		},


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
### Improvements

* Set group_initial_rebalance_delay=0 in dev container mode. The default setting adds a 3s delay when using consumers groups in unit tests and is a bad UX.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
