### PR TITLE
Fix InvalidTxnState on adding partition or group

### DIFF
--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -172,6 +172,7 @@ protected:
     ss::future<> handle_eviction() override;
 
 private:
+    std::optional<tm_transaction> find_tx(kafka::transactional_id);
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
 


### PR DESCRIPTION
Before we introduced fetch_tx the state of the ongoing tx lived only in memory so RP was querying only the stm's transient memory and not the log. Now RP may rehydrate the state from the previous leader and correct a tx's etag by writing to log. As a result we should check not only the transient memory and the state rebuild from the log too

Fixes https://github.com/redpanda-data/redpanda-jepsen/issues/23

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

### Bug Fixes

  * Fixes occasional InvalidTxnState on adding partition or group