### PR TITLE
archival: set test reconciliation interval

### DIFF
--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -214,6 +214,11 @@ public:
         aconf.segment_upload_timeout = 1s;
         aconf.manifest_upload_timeout = 1s;
         aconf.time_limit = std::nullopt;
+        // Set the archiver reconciliation interval to be longer than the
+        // duration of any sensible unit test. Unit tests request reconciliation
+        // manually by calling into the scheduler service.
+        // TODO: Remove in PR#7547
+        aconf.reconciliation_interval = 1h;
         return aconf;
     }
 


### PR DESCRIPTION
Previously, the archiver reconciliation interval was default initialised to 0ms. This led to race conditions in tests that called directly into the archiver (e.g. test_reconciliation_drop_ntp) as, generally, it's not safe to call into the scheduler service concurrently.

This PR set the archiver reconciliation interval to be longer than the duration of any sensible unit test. The race condition
reproduced in my local env fairly reliably and the fix works locally.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [X] v22.2.x
- [X] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
